### PR TITLE
Make changes to reduce the release APK/app bundle size.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,7 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+# For the Secp256k1 library
+-keep class fr.acinq.secp256k1.jni.** { *; }
+# For the NostrPostr library
+-keep class nostr.postr.** { *; }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.enableR8.fullMode=true


### PR DESCRIPTION
Testing against the current changes and release(0.9.2), the modification cut the AAB size by ~49% and the APK size by ~75%.