### PR TITLE
Disable android backup as this app uses EncryptedSharedPrefs. Usage o…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
     <uses-permission android:name="android.permission.CAMERA" />
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@drawable/amethyst"


### PR DESCRIPTION
Disable android backup as this app uses EncryptedSharedPrefs. Usage of EncryptedSharedPrefs can cause crashes if it's not properly excluded from backup.

https://stackoverflow.com/questions/61751264/autobackup-with-encryptedsharedpreferences-failing-to-restore