### PR TITLE
Scroll Perf Improvements.

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/service/relays/RelayPool.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/relays/RelayPool.kt
@@ -13,6 +13,9 @@ import nostr.postr.events.Event
  * RelayPool manages the connection to multiple Relays and lets consumers deal with simple events.
  */
 object RelayPool: Relay.Listener {
+
+    val scope = CoroutineScope(Job() + Dispatchers.IO)
+
     private var relays = listOf<Relay>()
     private var listeners = setOf<Listener>()
 
@@ -116,7 +119,6 @@ object RelayPool: Relay.Listener {
     val live: RelayPoolLiveData = RelayPoolLiveData(this)
 
     private fun refreshObservers() {
-        val scope = CoroutineScope(Job() + Dispatchers.Main)
         scope.launch {
             live.refresh()
         }


### PR DESCRIPTION
There are very visible perf issues during app usage and scrolling that clearly indicates that the app is doing too much on the main thread. After digging for instances where Dispatchers.Main is used, it's an easy fix to switch to Dispatchers.IO, which visibility improve perf.
A few thoughts about perf considerations

1. There is no need to force Dispatchers.Main for data that is consumed as state by compose, since flows consumed as state will always flow on main, so we can use a background thread to guarantee best performance.

2. Using Dispatchers.IO is appropriate for disk/network operations to have a device-constrained thread pool that will avoid draining IO-related device resources. Using Dispatchers.Default is more appropriate for computational tasks (bitmap manipulation, delays, etc..)

3. There are a few instances of methods creating coroutine scopes in their body just to launch something that will delay. This is creating a lot of loose scopes, and you can avoid this by just moving scope creation to a class-level field and reusing it, or better yet, make your method suspending so that scope is controlled by the caller.