### PR TITLE
Tiny change to profile page:

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/ProfileScreen.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/ProfileScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ScrollableTabRow
 import androidx.compose.material.Surface
 import androidx.compose.material.Tab
 import androidx.compose.material.TabRow
@@ -121,14 +122,15 @@ fun ProfileScreen(userId: String?, accountViewModel: AccountViewModel, navContro
             val coroutineScope = rememberCoroutineScope()
 
             Column(modifier = Modifier.padding()) {
-                TabRow(
-                    selectedTabIndex = pagerState.currentPage,
-                    indicator = { tabPositions ->
-                        TabRowDefaults.Indicator(
-                            Modifier.pagerTabIndicatorOffset(pagerState, tabPositions),
-                            color = MaterialTheme.colors.primary
-                        )
-                    },
+                ScrollableTabRow(
+                        selectedTabIndex = pagerState.currentPage,
+                        indicator = { tabPositions ->
+                            TabRowDefaults.Indicator(
+                                Modifier.pagerTabIndicatorOffset(pagerState, tabPositions),
+                                color = MaterialTheme.colors.primary
+                            )
+                        },
+                        edgePadding = 8.dp
                 ) {
                     Tab(
                         selected = pagerState.currentPage == 0,


### PR DESCRIPTION
[Use]([url](url)) scrollable tabs instead of fixed tab to avoid bad text wrap.

# BEFORE 
<img width="462" alt="Screenshot 2023-02-05 at 2 04 12 AM" src="https://user-images.githubusercontent.com/5253171/216806255-9aaa98e9-bf0a-4cb8-beb8-93e7eaf9f38e.png">

# AFTER
<img width="475" alt="Screenshot 2023-02-05 at 2 04 17 AM" src="https://user-images.githubusercontent.com/5253171/216806253-6b8edf65-a313-420a-aff6-fc9580ecd19c.png">


