### PR TITLE
Fix #83

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/ProfileScreen.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/ProfileScreen.kt
@@ -177,12 +177,9 @@ fun ProfileScreen(userId: String?, accountViewModel: AccountViewModel, navContro
                     HorizontalPager(
                         count = 4,
                         state = pagerState,
-                        modifier = Modifier.then(with(LocalDensity.current) {
-                            Modifier.size(
-                                width = columnSize.width.toDp(),
-                                height = (columnSize.height - tabsSize.height).toDp(),
-                            )
-                        })
+                        modifier = with(LocalDensity.current) {
+                            Modifier.height((columnSize.height - tabsSize.height).toDp())
+                        }
                     ) {
                         when (pagerState.currentPage) {
                             0 -> TabNotes(baseUser, accountViewModel, navController)


### PR DESCRIPTION
This pull request fixes the issue #83 by making the profile header scrollable and hideable. Tabs, however, remain fixed

<img src="https://user-images.githubusercontent.com/5675681/216977137-0b20c648-60c2-4866-b8c4-339d3054489f.gif" width=300 />

I used nested scrolling callback for this. Maybe there is a better way