### PR TITLE
remove trailing slash from relay URI

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewRelayListView.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewRelayListView.kt
@@ -421,8 +421,9 @@ fun EditableServerConfig(relayToAdd: String, onNewRelay: (NewRelayListViewModel.
 
         Button(
             onClick = {
-                if (url.isNotBlank()) {
+                if (url.isNotBlank() && url != "/") {
                     val addedWSS = if (!url.startsWith("wss://")) "wss://$url" else url
+                    if (url.endsWith("/")) addedWSS = addedWSS.dropLast(1)
                     onNewRelay(NewRelayListViewModel.Relay(addedWSS, read, write, feedTypes = FeedType.values().toSet()))
                     url = ""
                     write = true


### PR DESCRIPTION
Remove trailing slash from relay URI to be added to

- prevent relays with duplicate URIs from being registered
- unify the appearance of URIs in the relay list