### PR TITLE
Public relay name change

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/service/relays/Constants.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/relays/Constants.kt
@@ -14,7 +14,7 @@ object Constants {
 
   val defaultRelays = arrayOf(
     // Free relays
-    NewRelayListViewModel.Relay("wss://nostr.bitcoiner.social", read = true, write = true, feedTypes = activeTypes),
+    NewRelayListViewModel.Relay("wss://offchain.pub", read = true, write = true, feedTypes = activeTypes),
     NewRelayListViewModel.Relay("wss://relay.nostr.bg", read = true, write = true, feedTypes = activeTypes),
     NewRelayListViewModel.Relay("wss://relay.snort.social", read = true, write = true, feedTypes = activeTypes),
     NewRelayListViewModel.Relay("wss://relay.damus.io", read = true, write = true, feedTypes = activeTypes),


### PR DESCRIPTION
nostr.bitcoiner.social -> offchain.pub

[note1zpgy9f8tlwdwhhwtzy50vpl72qkunzhmy57p4f5xaf8h57pfvwpschwe74](https://snort.social/e/note1zpgy9f8tlwdwhhwtzy50vpl72qkunzhmy57p4f5xaf8h57pfvwpschwe74)

> Before I deployed the new pay-to-relay server, I ran a public relay under a "nostr" subdomain. I've since renamed my public relay to wss://offchain.pub. Much cooler name. Better represents how nostr isn't something this domain handles on the side, it's the primary purpose. Raison d'etre.
> 
> Both offchain.pub and the "nostr" subdomain will work concurrently for awhile, pointing to the same public relay server. But I'll eventually deprecate the "nostr" subdomain and redirect requests to the new offchain.pub name.