### PR TITLE
fix redundant android:label in AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,7 +24,6 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="33">
         <activity
-            android:label="@string/app_name"
             android:name=".ui.MainActivity"
             android:exported="true"
             android:windowSoftInputMode="adjustResize"


### PR DESCRIPTION
the android:label in the activity is redundant since it already exists in the application which contains the activity.