### PR TITLE
add leak canary to detect memory leaks in debug builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -136,6 +136,9 @@ dependencies {
     implementation 'com.google.mlkit:language-id:17.0.4'
     implementation 'com.google.android.gms:play-services-mlkit-language-id:17.0.0'
 
+    // Automatic memory leak detection
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.10'
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'


### PR DESCRIPTION
this library does automatic memory leak detection only in debug builds. It's useful particularly because I've heard there were previous issues with OutOfMemory errors