### PR TITLE
Fix slightly broken following icon background on UserPicture

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteCompose.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteCompose.kt
@@ -1,41 +1,14 @@
 package com.vitorpamplona.amethyst.ui.note
 
-import android.widget.Space
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.*
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.Divider
-import androidx.compose.material.DropdownMenu
-import androidx.compose.material.DropdownMenuItem
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.*
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -512,14 +485,12 @@ fun UserPicture(
                 contentAlignment = Alignment.Center
             ) {
                 // Background for the transparent checkmark
-                Text(
-                    "x",
+                Box(
                     Modifier
-                        .padding(4.dp)
-                        .fillMaxSize()
+                        .clip(CircleShape)
+                        .fillMaxSize(0.6f)
                         .align(Alignment.Center)
                         .background(MaterialTheme.colors.background)
-                        .clip(shape = CircleShape)
                 )
 
                 Icon(


### PR DESCRIPTION
There is an issue with the following icon background on the user picture. It is rectangular, and its corners are visible behind the icon (at least on my screen). It also has a strange black tip at the check start.

This fix makes it pretty.

<p float="left">
<img src="https://user-images.githubusercontent.com/5675681/220669698-fd341537-be90-4707-9a0e-0b26a7027c11.png" width=300 />
<img src="https://user-images.githubusercontent.com/5675681/220669751-0be33418-d009-4dec-9168-d51dcf5a16d7.png" width=300 />
</p>