### PR TITLE
Fix system-localized strings

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,6 +14,8 @@ android {
         versionCode 65
         versionName "0.17.9"
 
+        resConfigs "en"
+
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
             useSupportLibrary true

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/MainActivity.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/MainActivity.kt
@@ -21,6 +21,7 @@ import com.vitorpamplona.amethyst.service.relays.Client
 import com.vitorpamplona.amethyst.ui.screen.AccountScreen
 import com.vitorpamplona.amethyst.ui.screen.AccountStateViewModel
 import com.vitorpamplona.amethyst.ui.theme.AmethystTheme
+import java.util.*
 
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -61,6 +62,8 @@ class MainActivity : ComponentActivity() {
     }
 
     Client.lenient = true
+
+    Locale.setDefault(Locale.ENGLISH)
   }
 
   override fun onResume() {


### PR DESCRIPTION
In this pull request, I've forced the app locale to be `ENGLISH`, as it is currently the only supported language. This fixes seeing system-localized strings, like in the post time, when the device locale is not English. I've also added the `resConfigs` build directive to leave only English resources in the build, which saves ~1 MB of the APK size.

<p float="left">
<img src="https://user-images.githubusercontent.com/5675681/221038071-6cedc015-7597-4779-aadd-ee1648d64f15.png" width=300 />
<img src="https://user-images.githubusercontent.com/5675681/221037707-78e023aa-21de-4bd1-9c05-9d1376ad5ea6.png" width=300 />
</p>