### PR TITLE
Use KeyboardType.Password for login text field

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedOff/LoginScreen.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedOff/LoginScreen.kt
@@ -100,7 +100,7 @@ fun LoginPage(accountViewModel: AccountStateViewModel) {
                 onValueChange = { key.value = it },
                 keyboardOptions = KeyboardOptions(
                     autoCorrect = false,
-                    keyboardType = KeyboardType.Ascii,
+                    keyboardType = KeyboardType.Password,
                     imeAction = ImeAction.Go
                 ),
                 placeholder = {


### PR DESCRIPTION
KeyboardType.Ascii is unsafe for entering the private key, as it can be remembered by the keyboard, probably even sent to Google's servers.