### PR TITLE
Alternate mark all as read implementation

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/ChatroomListFeedView.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/ChatroomListFeedView.kt
@@ -4,21 +4,31 @@ import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.google.accompanist.swiperefresh.SwipeRefresh
 import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
+import com.vitorpamplona.amethyst.NotificationCache
+import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.ui.note.ChatroomCompose
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
@@ -77,19 +87,70 @@ private fun FeedLoaded(
 ) {
     val listState = rememberLazyListState()
 
-    LazyColumn(
-        contentPadding = PaddingValues(
-            top = 10.dp,
-            bottom = 10.dp
-        ),
-        state = listState
-    ) {
-        itemsIndexed(state.feed.value, key = { index, item -> if (index == 0) index else item.idHex }) { index, item ->
-            ChatroomCompose(
-                item,
-                accountViewModel = accountViewModel,
-                navController = navController
-            )
+    val accountState by accountViewModel.accountLiveData.observeAsState()
+    val account = accountState?.account
+
+    val context = LocalContext.current.applicationContext
+
+    fun markAllAsRead() {
+        state.feed.value.forEach { note ->
+            val routeForLastRead = if (note.event == null) {
+                return@forEach
+            } else if (note.channel != null) {
+                note.channel?.let {
+                    "Channel/${it.idHex}"
+                }
+
+            } else {
+                account?.let {
+                    val replyAuthorBase = note.mentions?.first()
+
+                    var userToComposeOn = note.author!!
+
+                    if (replyAuthorBase != null) {
+                        if (note.author == account.userProfile()) {
+                            userToComposeOn = replyAuthorBase
+                        }
+                    }
+
+                    "Room/${userToComposeOn.pubkeyHex}"
+                }
+            }
+
+            routeForLastRead?.let {
+                val createdAt = note.event?.createdAt
+                if (createdAt != null) {
+                    NotificationCache.markAsRead(it, createdAt, context)
+                }
+            }
         }
     }
+
+
+    Column {
+        TextButton(
+            modifier = Modifier.fillMaxWidth(),
+            shape = MaterialTheme.shapes.large,
+            onClick = { markAllAsRead() }
+        ) {
+            Text(stringResource(R.string.mark_all_as_read))
+        }
+
+        LazyColumn(
+            contentPadding = PaddingValues(
+                top = 10.dp,
+                bottom = 10.dp
+            ),
+            state = listState
+        ) {
+            itemsIndexed(state.feed.value, key = { index, item -> if (index == 0) index else item.idHex }) { index, item ->
+                ChatroomCompose(
+                    item,
+                    accountViewModel = accountViewModel,
+                    navController = navController
+                )
+            }
+        }
+    }
+
 }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -173,4 +173,5 @@
     <string name="report_hateful_speech">أبلغ عن كلام يحض على الكراهية</string>
     <string name="report_nudity_porn">الإبلاغ عن عُري / إباحي</string>
     <string name="others">آخرون</string>
+    <string name="mark_all_as_read">Mark All As Read</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -173,4 +173,5 @@
     <string name="report_hateful_speech">Denunciar discurso de ódio</string>
     <string name="report_nudity_porn">Denunciar nudez / pornografia</string>
     <string name="others">outros</string>
+    <string name="mark_all_as_read">Mark All As Read</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -177,4 +177,5 @@
     <string name="report_hateful_speech">Report Hateful speech</string>
     <string name="report_nudity_porn">Report Nudity / Porn</string>
     <string name="others">others</string>
+    <string name="mark_all_as_read">Mark All As Read</string>
 </resources>


### PR DESCRIPTION
This implementation attempts to mark all as read outside of the composable context.

This pull request seems to change the behavior (for the better?) causing the messages view to automatically refresh when there is a new message in any of your chats, updating it with the unread dot.

#172 