### PR TITLE
Use lowercase() instead of toLowerCase() [deprecated]

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/model/UrlCachedPreviewer.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/model/UrlCachedPreviewer.kt
@@ -56,7 +56,7 @@ object UrlCachedPreviewer {
   fun preloadPreviewsFor(note: Note) {
     note.event?.content?.let {
       findUrlsInMessage(it).forEach {
-        val removedParamsFromUrl = it.split("?")[0].toLowerCase()
+        val removedParamsFromUrl = it.split("?")[0].lowercase()
         if (imageExtension.matcher(removedParamsFromUrl).matches()) {
           // Preload Images? Isn't this too heavy?
         } else if (videoExtension.matcher(removedParamsFromUrl).matches()) {

--- a/app/src/main/java/com/vitorpamplona/amethyst/model/User.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/model/User.kt
@@ -259,7 +259,7 @@ class User(val pubkeyHex: String) {
         info?.latestMetadata = latestMetadata
         info?.updatedMetadataAt = latestMetadata.createdAt
 
-        if (newUserInfo.lud16.isNullOrBlank() && newUserInfo.lud06?.toLowerCase()?.startsWith("lnurl") == true) {
+        if (newUserInfo.lud16.isNullOrBlank() && newUserInfo.lud06?.lowercase()?.startsWith("lnurl") == true) {
             try {
                 val url = String(Bech32.decodeBytes(newUserInfo.lud06!!, false).second)
 

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/lnurl/LightningAddressResolver.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/lnurl/LightningAddressResolver.kt
@@ -24,7 +24,7 @@ class LightningAddressResolver {
       return "https://${parts[1]}/.well-known/lnurlp/${parts[0]}"
     }
 
-    if (lnaddress.toLowerCase().startsWith("lnurl")) {
+    if (lnaddress.lowercase().startsWith("lnurl")) {
       return try {
         String(Bech32.decodeBytes(lnaddress, false).second)
       } catch (e: Exception) {

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/lnurl/LnInvoiceUtil.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/lnurl/LnInvoiceUtil.kt
@@ -128,7 +128,7 @@ object LnInvoiceUtil {
   }
 
   private fun multiplier(multiplier: String): BigDecimal {
-    return when (multiplier.toLowerCase()) {
+    return when (multiplier.lowercase()) {
       "m" -> BigDecimal("0.001")
       "u" -> BigDecimal("0.000001")
       "n" -> BigDecimal("0.000000001")

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/model/ReportEvent.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/model/ReportEvent.kt
@@ -56,8 +56,8 @@ class ReportEvent (
     fun create(reportedPost: Event, type: ReportType, privateKey: ByteArray, createdAt: Long = Date().time / 1000): ReportEvent {
       val content = ""
 
-      val reportPostTag = listOf("e", reportedPost.id, type.name.toLowerCase())
-      val reportAuthorTag = listOf("p", reportedPost.pubKey, type.name.toLowerCase())
+      val reportPostTag = listOf("e", reportedPost.id, type.name.lowercase())
+      val reportAuthorTag = listOf("p", reportedPost.pubKey, type.name.lowercase())
 
       val pubKey = Utils.pubkeyCreate(privateKey).toHexKey()
       var tags:List<List<String>> = listOf(reportPostTag, reportAuthorTag)
@@ -74,7 +74,7 @@ class ReportEvent (
     fun create(reportedUser: String, type: ReportType, privateKey: ByteArray, createdAt: Long = Date().time / 1000): ReportEvent {
       val content = ""
 
-      val reportAuthorTag = listOf("p", reportedUser, type.name.toLowerCase())
+      val reportAuthorTag = listOf("p", reportedUser, type.name.lowercase())
 
       val pubKey = Utils.pubkeyCreate(privateKey).toHexKey()
       val tags:List<List<String>> = listOf(reportAuthorTag)

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/relays/TypedFilter.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/relays/TypedFilter.kt
@@ -22,7 +22,7 @@ class TypedFilter(
   }
 
   fun typesToJson(types: Set<FeedType>): JsonArray {
-    return JsonArray().apply { types.forEach { add(it.name.toLowerCase()) } }
+    return JsonArray().apply { types.forEach { add(it.name.lowercase()) } }
   }
 
   fun filterToJson(filter: JsonFilter): JsonObject {

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewPostView.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewPostView.kt
@@ -155,7 +155,7 @@ fun NewPostView(onClose: () -> Unit, baseReplyTo: Note? = null, quote: Note? = n
                                 Row(modifier = Modifier.padding(top = 5.dp)) {
                                     if (isValidURL(myUrlPreview)) {
                                         val removedParamsFromUrl =
-                                            myUrlPreview.split("?")[0].toLowerCase()
+                                            myUrlPreview.split("?")[0].lowercase()
                                         if (imageExtension.matcher(removedParamsFromUrl).matches()) {
                                             AsyncImage(
                                                 model = myUrlPreview,

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/components/RichTextViewer.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/components/RichTextViewer.kt
@@ -141,7 +141,7 @@ fun RichTextViewer(
               if (lnInvoice != null) {
                 InvoicePreview(lnInvoice)
               } else if (isValidURL(word)) {
-                val removedParamsFromUrl = word.split("?")[0].toLowerCase()
+                val removedParamsFromUrl = word.split("?")[0].lowercase()
                 if (imageExtension.matcher(removedParamsFromUrl).matches()) {
                   ZoomableImageView(word)
                 } else if (videoExtension.matcher(removedParamsFromUrl).matches()) {


### PR DESCRIPTION
## 📚 Description

The method `String.toLowerCase()` is deprecated in favor of `lowercase()`.

<img width="1065" alt="Screenshot 2023-03-04 at 11 26 53" src="https://user-images.githubusercontent.com/5256287/222894616-d4ba49f3-e899-47e1-a5ef-7fa4f2728bad.png">
