### PR TITLE
Require biometric with device lock fallback to copy nsec

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,6 +73,9 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-livedata:$lifecycle_version"
 
+    // Biometrics
+    implementation "androidx.biometric:biometric-ktx:1.2.0-alpha05"
+
     // Swipe Refresh
     implementation 'com.google.accompanist:accompanist-swiperefresh:0.29.1-alpha'
 

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/MainActivity.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/MainActivity.kt
@@ -2,12 +2,12 @@ package com.vitorpamplona.amethyst.ui
 
 import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.ui.Modifier
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.Coil
 import coil.ImageLoader
@@ -22,7 +22,7 @@ import com.vitorpamplona.amethyst.ui.screen.AccountScreen
 import com.vitorpamplona.amethyst.ui.screen.AccountStateViewModel
 import com.vitorpamplona.amethyst.ui.theme.AmethystTheme
 
-class MainActivity : ComponentActivity() {
+class MainActivity : FragmentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,4 +181,6 @@
         \n- **Do** keep a secure backup of your secret key for account recovery. We recommend using a password manager.
     </string>
     <string name="secret_key_copied_to_clipboard">Secret key (nsec) copied to clipboard</string>
+    <string name="copy_my_secret_key">Copy my secret key</string>
+    <string name="biometric_authentication_failed">Authentication failed</string>
 </resources>


### PR DESCRIPTION
Following on #182, this PR prompts the user to authenticate after they click the "Copy nsec" button on the backup dialog.

- If user has fingerprint enabled, authenticate by fingerprint, otherwise by device lock
- From fingerprint screen, user can switch to device lock (PIN etc) if desired
- If fingerprint doesn't work, it falls back to PIN after the standard number of failures
- If no fingerprint or device lock mechanisms are in place, just copy the key anyway