### PR TITLE
Refactor UserProfileZapsFeedFilter

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -159,6 +159,7 @@ dependencies {
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.10'
 
     testImplementation 'junit:junit:4.13.2'
+    testImplementation "io.mockk:mockk:1.13.4"
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_ui_version"

--- a/app/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -415,7 +415,7 @@ class Account(
 
       event.plainContent(loggedIn.privKey!!, pubkeyToUse.toByteArray())
     } else {
-      event?.content
+      event?.content()
     }
   }
 

--- a/app/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -192,7 +192,7 @@ object LocalCache {
 
     note.loadEvent(event, author, mentions, replyTo)
 
-    //Log.d("TN", "New Note (${notes.size},${users.size}) ${note.author?.toBestDisplayName()} ${note.event?.content?.take(100)} ${formattedDateTime(event.createdAt)}")
+    //Log.d("TN", "New Note (${notes.size},${users.size}) ${note.author?.toBestDisplayName()} ${note.event?.content()?.take(100)} ${formattedDateTime(event.createdAt)}")
 
     // Prepares user's profile view.
     author.addNote(note)
@@ -223,7 +223,7 @@ object LocalCache {
     }
 
     // Already processed this event.
-    if (note.event?.id == event.id) return
+    if (note.event?.id() == event.id) return
 
     if (antiSpam.isSpam(event)) {
       relay?.let {
@@ -594,7 +594,7 @@ object LocalCache {
 
     note.loadEvent(event, author, mentions, replyTo)
 
-    //Log.d("CM", "New Note (${notes.size},${users.size}) ${note.author?.toBestDisplayName()} ${note.event?.content} ${formattedDateTime(event.createdAt)}")
+    //Log.d("CM", "New Note (${notes.size},${users.size}) ${note.author?.toBestDisplayName()} ${note.event?.content()} ${formattedDateTime(event.createdAt)}")
 
     // Adds notifications to users.
     mentions.forEach {
@@ -700,8 +700,8 @@ object LocalCache {
 
   fun findNotesStartingWith(text: String): List<Note> {
     return notes.values.filter {
-           (it.event is TextNoteEvent && it.event?.content?.contains(text, true) ?: false)
-        || (it.event is ChannelMessageEvent && it.event?.content?.contains(text, true) ?: false)
+           (it.event is TextNoteEvent && it.event?.content()?.contains(text, true) ?: false)
+        || (it.event is ChannelMessageEvent && it.event?.content()?.contains(text, true) ?: false)
         || it.idHex.startsWith(text, true)
         || it.idNote().startsWith(text, true)
     } + addressables.values.filter {
@@ -770,7 +770,7 @@ object LocalCache {
 
     val toBeRemoved = notes
       .filter {
-        (it.value.author == null || it.value.author!! !in followSet) && it.value.event?.kind == TextNoteEvent.kind && it.value.liveSet?.isInUse() != true
+        (it.value.author == null || it.value.author!! !in followSet) && it.value.event?.kind() == TextNoteEvent.kind && it.value.liveSet?.isInUse() != true
       }
 
     toBeRemoved.forEach {

--- a/app/src/main/java/com/vitorpamplona/amethyst/model/ThreadAssembler.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/model/ThreadAssembler.kt
@@ -11,7 +11,7 @@ class ThreadAssembler {
 
     testedNotes.add(note)
 
-    val markedAsRoot = note.event?.tags?.firstOrNull { it[0] == "e" && it.size > 3 && it[3] == "root" }?.getOrNull(1)
+    val markedAsRoot = note.event?.tags()?.firstOrNull { it[0] == "e" && it.size > 3 && it[3] == "root" }?.getOrNull(1)
     if (markedAsRoot != null) return LocalCache.checkGetOrCreateNote(markedAsRoot)
 
     val hasNoReplyTo = note.replyTo?.firstOrNull { it.replyTo?.isEmpty() == true }

--- a/app/src/main/java/com/vitorpamplona/amethyst/model/UrlCachedPreviewer.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/model/UrlCachedPreviewer.kt
@@ -54,7 +54,7 @@ object UrlCachedPreviewer {
   }
 
   fun preloadPreviewsFor(note: Note) {
-    note.event?.content?.let {
+    note.event?.content()?.let {
       findUrlsInMessage(it).forEach {
         val removedParamsFromUrl = it.split("?")[0].lowercase()
         if (imageExtension.matcher(removedParamsFromUrl).matches()) {

--- a/app/src/main/java/com/vitorpamplona/amethyst/model/User.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/model/User.kt
@@ -61,6 +61,8 @@ class User(val pubkeyHex: String) {
     fun pubkeyNpub() = pubkey().toNpub()
     fun pubkeyDisplayHex() = pubkeyNpub().toShortenHex()
 
+    override fun toString(): String = pubkeyHex
+
     fun toBestDisplayName(): String {
         return bestDisplayName() ?: bestUsername() ?: pubkeyDisplayHex()
     }

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/model/EventInterface.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/model/EventInterface.kt
@@ -1,0 +1,25 @@
+package com.vitorpamplona.amethyst.service.model
+
+import com.vitorpamplona.amethyst.model.HexKey
+
+interface EventInterface {
+  fun id(): HexKey
+
+  fun pubKey(): HexKey
+
+  fun createdAt(): Long
+
+  fun kind(): Int
+
+  fun tags(): List<List<String>>
+
+  fun content(): String
+
+  fun sig(): HexKey
+
+  fun toJson(): String
+
+  fun checkSignature()
+
+  fun hasValidSignature(): Boolean
+}

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/model/LnZapEvent.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/model/LnZapEvent.kt
@@ -3,36 +3,54 @@ package com.vitorpamplona.amethyst.service.model
 import com.vitorpamplona.amethyst.model.HexKey
 import com.vitorpamplona.amethyst.service.lnurl.LnInvoiceUtil
 import com.vitorpamplona.amethyst.service.relays.Client
+import java.math.BigDecimal
 
-class LnZapEvent (
+class LnZapEvent(
   id: HexKey,
   pubKey: HexKey,
   createdAt: Long,
   tags: List<List<String>>,
   content: String,
   sig: HexKey
-): Event(id, pubKey, createdAt, kind, tags, content, sig) {
+): LnZapEventInterface, Event(id, pubKey, createdAt, kind, tags, content, sig) {
 
-  fun zappedPost() = tags.filter { it.firstOrNull() == "e" }.mapNotNull { it.getOrNull(1) }
-  fun zappedAuthor() = tags.filter { it.firstOrNull() == "p" }.mapNotNull { it.getOrNull(1) }
+  override fun zappedPost() = tags
+    .filter { it.firstOrNull() == "e" }
+    .mapNotNull { it.getOrNull(1) }
 
-  fun taggedAddresses() = tags.filter { it.firstOrNull() == "a" }.mapNotNull { it.getOrNull(1) }.mapNotNull { ATag.parse(it) }
+  override fun zappedAuthor() = tags
+    .filter { it.firstOrNull() == "p" }
+    .mapNotNull { it.getOrNull(1) }
 
-  fun lnInvoice() = tags.filter { it.firstOrNull() == "bolt11" }.mapNotNull { it.getOrNull(1) }.firstOrNull()
-  fun preimage() = tags.filter { it.firstOrNull() == "preimage" }.mapNotNull { it.getOrNull(1) }.firstOrNull()
+  override fun taggedAddresses(): List<ATag> = tags
+    .filter { it.firstOrNull() == "a" }
+    .mapNotNull { it.getOrNull(1) }
+    .mapNotNull { ATag.parse(it) }
 
-  fun description() = tags.filter { it.firstOrNull() == "description" }.mapNotNull { it.getOrNull(1) }.firstOrNull()
+  override fun amount(): BigDecimal? {
+    return lnInvoice()?.let { LnInvoiceUtil.getAmountInSats(it) }
+  }
 
   // Keeps this as a field because it's a heavier function used everywhere.
   val amount = lnInvoice()?.let { LnInvoiceUtil.getAmountInSats(it) }
 
-  fun containedPost() = try {
+  override fun containedPost(): Event? = try {
     description()?.let {
       fromJson(it, Client.lenient)
     }
   } catch (e: Exception) {
     null
   }
+
+  private fun lnInvoice(): String? = tags
+    .filter { it.firstOrNull() == "bolt11" }
+    .mapNotNull { it.getOrNull(1) }
+    .firstOrNull()
+
+  private fun description(): String? = tags
+    .filter { it.firstOrNull() == "description" }
+    .mapNotNull { it.getOrNull(1) }
+    .firstOrNull()
 
   companion object {
     const val kind = 9735

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/model/LnZapEventInterface.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/model/LnZapEventInterface.kt
@@ -1,0 +1,16 @@
+package com.vitorpamplona.amethyst.service.model
+
+import java.math.BigDecimal
+
+interface LnZapEventInterface: EventInterface {
+
+  fun zappedPost(): List<String>
+
+  fun zappedAuthor(): List<String>
+
+  fun taggedAddresses(): List<ATag>
+
+  fun amount(): BigDecimal?
+
+  fun containedPost(): Event?
+}

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/model/LnZapRequestEvent.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/model/LnZapRequestEvent.kt
@@ -21,12 +21,12 @@ class LnZapRequestEvent (
   companion object {
     const val kind = 9734
 
-    fun create(originalNote: Event, relays: Set<String>, privateKey: ByteArray, createdAt: Long = Date().time / 1000): LnZapRequestEvent {
+    fun create(originalNote: EventInterface, relays: Set<String>, privateKey: ByteArray, createdAt: Long = Date().time / 1000): LnZapRequestEvent {
       val content = ""
       val pubKey = Utils.pubkeyCreate(privateKey).toHexKey()
       var tags = listOf(
-        listOf("e", originalNote.id),
-        listOf("p", originalNote.pubKey),
+        listOf("e", originalNote.id()),
+        listOf("p", originalNote.pubKey()),
         listOf("relays") + relays
       )
       if (originalNote is LongTextNoteEvent) {

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/model/ReactionEvent.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/model/ReactionEvent.kt
@@ -22,18 +22,18 @@ class ReactionEvent (
   companion object {
     const val kind = 7
 
-    fun createWarning(originalNote: Event, privateKey: ByteArray, createdAt: Long = Date().time / 1000): ReactionEvent {
+    fun createWarning(originalNote: EventInterface, privateKey: ByteArray, createdAt: Long = Date().time / 1000): ReactionEvent {
       return create("\u26A0\uFE0F", originalNote, privateKey, createdAt)
     }
 
-    fun createLike(originalNote: Event, privateKey: ByteArray, createdAt: Long = Date().time / 1000): ReactionEvent {
+    fun createLike(originalNote: EventInterface, privateKey: ByteArray, createdAt: Long = Date().time / 1000): ReactionEvent {
       return create("+", originalNote, privateKey, createdAt)
     }
 
-    fun create(content: String, originalNote: Event, privateKey: ByteArray, createdAt: Long = Date().time / 1000): ReactionEvent {
+    fun create(content: String, originalNote: EventInterface, privateKey: ByteArray, createdAt: Long = Date().time / 1000): ReactionEvent {
       val pubKey = Utils.pubkeyCreate(privateKey).toHexKey()
 
-      var tags = listOf( listOf("e", originalNote.id), listOf("p", originalNote.pubKey))
+      var tags = listOf( listOf("e", originalNote.id()), listOf("p", originalNote.pubKey()))
       if (originalNote is LongTextNoteEvent) {
         tags = tags + listOf( listOf("a", originalNote.address().toTag()) )
       }

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/model/ReportEvent.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/model/ReportEvent.kt
@@ -53,11 +53,11 @@ class ReportEvent (
   companion object {
     const val kind = 1984
 
-    fun create(reportedPost: Event, type: ReportType, privateKey: ByteArray, createdAt: Long = Date().time / 1000): ReportEvent {
+    fun create(reportedPost: EventInterface, type: ReportType, privateKey: ByteArray, createdAt: Long = Date().time / 1000): ReportEvent {
       val content = ""
 
-      val reportPostTag = listOf("e", reportedPost.id, type.name.lowercase())
-      val reportAuthorTag = listOf("p", reportedPost.pubKey, type.name.lowercase())
+      val reportPostTag = listOf("e", reportedPost.id(), type.name.lowercase())
+      val reportAuthorTag = listOf("p", reportedPost.pubKey(), type.name.lowercase())
 
       val pubKey = Utils.pubkeyCreate(privateKey).toHexKey()
       var tags:List<List<String>> = listOf(reportPostTag, reportAuthorTag)

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/model/RepostEvent.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/model/RepostEvent.kt
@@ -29,14 +29,14 @@ class RepostEvent (
   companion object {
     const val kind = 6
 
-    fun create(boostedPost: Event, privateKey: ByteArray, createdAt: Long = Date().time / 1000): RepostEvent {
+    fun create(boostedPost: EventInterface, privateKey: ByteArray, createdAt: Long = Date().time / 1000): RepostEvent {
       val content = boostedPost.toJson()
 
-      val replyToPost = listOf("e", boostedPost.id)
-      val replyToAuthor = listOf("p", boostedPost.pubKey)
+      val replyToPost = listOf("e", boostedPost.id())
+      val replyToAuthor = listOf("p", boostedPost.pubKey())
 
       val pubKey = Utils.pubkeyCreate(privateKey).toHexKey()
-      var tags:List<List<String>> = boostedPost.tags.plus(listOf(replyToPost, replyToAuthor))
+      var tags:List<List<String>> = boostedPost.tags().plus(listOf(replyToPost, replyToAuthor))
 
       if (boostedPost is LongTextNoteEvent) {
         tags = tags + listOf( listOf("a", boostedPost.address().toTag()) )

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/model/zaps/UserZaps.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/model/zaps/UserZaps.kt
@@ -1,0 +1,16 @@
+package com.vitorpamplona.amethyst.service.model.zaps
+
+import com.vitorpamplona.amethyst.model.Note
+import com.vitorpamplona.amethyst.service.model.LnZapEvent
+
+object UserZaps {
+  fun groupByUser(zaps: Map<Note, Note?>?): List<Pair<Note, Note>> {
+    if (zaps == null) return emptyList()
+
+    return (zaps
+      .filter { it.value != null }
+      .toList()
+      .sortedBy { (it.second?.event as? LnZapEvent)?.amount }
+      .reversed()) as List<Pair<Note, Note>>
+  }
+}

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/model/zaps/UserZaps.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/model/zaps/UserZaps.kt
@@ -4,7 +4,7 @@ import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.service.model.LnZapEventInterface
 
 object UserZaps {
-  fun groupByUser(zaps: Map<Note, Note?>?): List<Pair<Note, Note>> {
+  fun forProfileFeed(zaps: Map<Note, Note?>?): List<Pair<Note, Note>> {
     if (zaps == null) return emptyList()
 
     return (zaps

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/model/zaps/UserZaps.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/model/zaps/UserZaps.kt
@@ -1,7 +1,7 @@
 package com.vitorpamplona.amethyst.service.model.zaps
 
 import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.service.model.LnZapEvent
+import com.vitorpamplona.amethyst.service.model.LnZapEventInterface
 
 object UserZaps {
   fun groupByUser(zaps: Map<Note, Note?>?): List<Pair<Note, Note>> {
@@ -10,7 +10,7 @@ object UserZaps {
     return (zaps
       .filter { it.value != null }
       .toList()
-      .sortedBy { (it.second?.event as? LnZapEvent)?.amount }
+      .sortedBy { (it.second?.event as? LnZapEventInterface)?.amount() }
       .reversed()) as List<Pair<Note, Note>>
   }
 }

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/relays/Client.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/relays/Client.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import com.vitorpamplona.amethyst.service.model.Event
+import com.vitorpamplona.amethyst.service.model.EventInterface
 
 /**
  * The Nostr Client manages multiple personae the user may switch between. Events are received and
@@ -62,7 +63,7 @@ object Client: RelayPool.Listener {
         RelayPool.sendFilterOnlyIfDisconnected()
     }
 
-    fun send(signedEvent: Event) {
+    fun send(signedEvent: EventInterface) {
         RelayPool.send(signedEvent)
     }
 

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/relays/Relay.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/relays/Relay.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.google.gson.JsonElement
 import java.util.Date
 import com.vitorpamplona.amethyst.service.model.Event
+import com.vitorpamplona.amethyst.service.model.EventInterface
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -193,7 +194,7 @@ class Relay(
         }
     }
 
-    fun send(signedEvent: Event) {
+    fun send(signedEvent: EventInterface) {
         if (write) {
             socket?.send("""["EVENT",${signedEvent.toJson()}]""")
             eventUploadCounter++

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/relays/RelayPool.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/relays/RelayPool.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import com.vitorpamplona.amethyst.service.model.Event
+import com.vitorpamplona.amethyst.service.model.EventInterface
 
 /**
  * RelayPool manages the connection to multiple Relays and lets consumers deal with simple events.
@@ -54,7 +55,7 @@ object RelayPool: Relay.Listener {
         relays.forEach { it.sendFilterOnlyIfDisconnected() }
     }
 
-    fun send(signedEvent: Event) {
+    fun send(signedEvent: EventInterface) {
         relays.forEach { it.send(signedEvent) }
     }
 

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/dal/UserProfileZapsFeedFilter.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/dal/UserProfileZapsFeedFilter.kt
@@ -13,6 +13,6 @@ object UserProfileZapsFeedFilter: FeedFilter<Pair<Note, Note>>() {
   }
 
   override fun feed(): List<Pair<Note, Note>> {
-    return UserZaps.groupByUser(user?.zaps)
+    return UserZaps.forProfileFeed(user?.zaps)
   }
 }

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/dal/UserProfileZapsFeedFilter.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/dal/UserProfileZapsFeedFilter.kt
@@ -3,7 +3,7 @@ package com.vitorpamplona.amethyst.ui.dal
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
-import com.vitorpamplona.amethyst.service.model.LnZapEvent
+import com.vitorpamplona.amethyst.service.model.zaps.UserZaps
 
 object UserProfileZapsFeedFilter: FeedFilter<Pair<Note, Note>>() {
   var user: User? = null
@@ -13,10 +13,6 @@ object UserProfileZapsFeedFilter: FeedFilter<Pair<Note, Note>>() {
   }
 
   override fun feed(): List<Pair<Note, Note>> {
-    return (user?.zaps
-      ?.filter { it.value != null }
-      ?.toList()
-      ?.sortedBy { (it.second?.event as? LnZapEvent)?.amount }
-      ?.reversed() ?: emptyList()) as List<Pair<Note, Note>>
+    return UserZaps.groupByUser(user?.zaps)
   }
 }

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/note/ChatroomCompose.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/note/ChatroomCompose.kt
@@ -77,7 +77,7 @@ fun ChatroomCompose(baseNote: Note, accountViewModel: AccountViewModel, navContr
         } else if (noteEvent is ChannelMetadataEvent) {
             "${stringResource(R.string.channel_information_changed_to)} "
         } else {
-            noteEvent?.content
+            noteEvent?.content()
         }
         channel?.let { channel ->
             var hasNewMessages by remember { mutableStateOf<Boolean>(false) }
@@ -127,7 +127,7 @@ fun ChatroomCompose(baseNote: Note, accountViewModel: AccountViewModel, navContr
 
             LaunchedEffect(key1 = notificationCache, key2 = note) {
                 noteEvent?.let {
-                    hasNewMessages = it.createdAt > notificationCache.cache.load("Room/${userToComposeOn.pubkeyHex}", context)
+                    hasNewMessages = it.createdAt() > notificationCache.cache.load("Room/${userToComposeOn.pubkeyHex}", context)
                 }
             }
 

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/note/ChatroomMessageCompose.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/note/ChatroomMessageCompose.kt
@@ -265,7 +265,7 @@ fun ChatroomMessageCompose(
                                             eventContent,
                                             canPreview,
                                             Modifier,
-                                            note.event?.tags,
+                                            note.event?.tags(),
                                             backgroundBubbleColor,
                                             accountViewModel,
                                             navController
@@ -275,7 +275,7 @@ fun ChatroomMessageCompose(
                                             stringResource(R.string.could_not_decrypt_the_message),
                                             true,
                                             Modifier,
-                                            note.event?.tags,
+                                            note.event?.tags(),
                                             backgroundBubbleColor,
                                             accountViewModel,
                                             navController

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteCompose.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteCompose.kt
@@ -370,7 +370,7 @@ fun NoteCompose(
                                 eventContent,
                                 canPreview = canPreview && !makeItShort,
                                 Modifier.fillMaxWidth(),
-                                noteEvent.tags,
+                                noteEvent.tags(),
                                 backgroundColor,
                                 accountViewModel,
                                 navController

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/ChatroomListFeedView.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/ChatroomListFeedView.kt
@@ -119,7 +119,7 @@ private fun FeedLoaded(
                         route = "Room/${userToComposeOn.pubkeyHex}"
                     }
 
-                    notificationCache.cache.markAsRead(route, it.createdAt, context)
+                    notificationCache.cache.markAsRead(route, it.createdAt(), context)
                 }
             }
             markAsRead.value = false

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/ThreadFeedView.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/ThreadFeedView.kt
@@ -307,7 +307,7 @@ fun NoteMaster(baseNote: Note,
 
             Row(modifier = Modifier.padding(horizontal = 12.dp)) {
                 Column() {
-                    val eventContent = note.event?.content
+                    val eventContent = note.event?.content()
 
                     val canPreview = note.author == account.userProfile()
                       || (note.author?.let { account.userProfile().isFollowing(it) } ?: true )
@@ -318,7 +318,7 @@ fun NoteMaster(baseNote: Note,
                             eventContent,
                             canPreview,
                             Modifier.fillMaxWidth(),
-                            note.event?.tags,
+                            note.event?.tags(),
                             MaterialTheme.colors.background,
                             accountViewModel,
                             navController

--- a/app/src/test/java/com/vitorpamplona/amethyst/service/zaps/UserZapsTest.kt
+++ b/app/src/test/java/com/vitorpamplona/amethyst/service/zaps/UserZapsTest.kt
@@ -42,6 +42,29 @@ class UserZapsTest {
     )
   }
 
+  @Test
+  fun aggregate_zap_amount_group_by_user() {
+    val zaps: Map<Note, Note?> = mapOf(
+      mockk<Note>() to mockZapNoteWith("user-1", amount = 100),
+      mockk<Note>() to mockZapNoteWith("user-1", amount = 200),
+      mockk<Note>() to mockZapNoteWith("user-2", amount = 400),
+    )
+
+    val actual = UserZaps.groupByUser(zaps)
+
+    Assert.assertEquals(2, actual.count())
+
+    Assert.assertEquals(
+      BigDecimal(300),
+      (actual[0].second.event as LnZapEventInterface).amount()
+    )
+
+    Assert.assertEquals(
+      BigDecimal(400),
+      (actual[1].second.event as LnZapEventInterface).amount()
+    )
+  }
+
   private fun mockZapNoteWith(pubkey: HexKey, amount: Int): Note {
 
     val lnZapEvent = mockk<LnZapEventInterface>()

--- a/app/src/test/java/com/vitorpamplona/amethyst/service/zaps/UserZapsTest.kt
+++ b/app/src/test/java/com/vitorpamplona/amethyst/service/zaps/UserZapsTest.kt
@@ -18,7 +18,7 @@ class UserZapsTest {
 
   @Test
   fun user_without_zaps() {
-    val actual = UserZaps.groupByUser(zaps = null)
+    val actual = UserZaps.forProfileFeed(zaps = null)
 
     Assert.assertEquals(emptyList<Pair<Note, Note>>(), actual)
   }
@@ -32,36 +32,13 @@ class UserZapsTest {
       zapRequest to mockZapNoteWith("user-1", amount = 200),
     )
 
-    val actual = UserZaps.groupByUser(zaps)
+    val actual = UserZaps.forProfileFeed(zaps)
 
     Assert.assertEquals(1, actual.count())
     Assert.assertEquals(zapRequest, actual.first().first)
     Assert.assertEquals(
       BigDecimal(200),
       (actual.first().second.event as LnZapEventInterface).amount()
-    )
-  }
-
-  @Test
-  fun aggregate_zap_amount_group_by_user() {
-    val zaps: Map<Note, Note?> = mapOf(
-      mockk<Note>() to mockZapNoteWith("user-1", amount = 100),
-      mockk<Note>() to mockZapNoteWith("user-1", amount = 200),
-      mockk<Note>() to mockZapNoteWith("user-2", amount = 400),
-    )
-
-    val actual = UserZaps.groupByUser(zaps)
-
-    Assert.assertEquals(2, actual.count())
-
-    Assert.assertEquals(
-      BigDecimal(300),
-      (actual[0].second.event as LnZapEventInterface).amount()
-    )
-
-    Assert.assertEquals(
-      BigDecimal(400),
-      (actual[1].second.event as LnZapEventInterface).amount()
     )
   }
 

--- a/app/src/test/java/com/vitorpamplona/amethyst/service/zaps/UserZapsTest.kt
+++ b/app/src/test/java/com/vitorpamplona/amethyst/service/zaps/UserZapsTest.kt
@@ -1,0 +1,56 @@
+package com.vitorpamplona.amethyst.service.zaps
+
+import com.vitorpamplona.amethyst.model.Note
+import com.vitorpamplona.amethyst.service.model.EventInterface
+import com.vitorpamplona.amethyst.service.model.zaps.UserZaps
+import io.mockk.*
+import org.junit.Assert
+import org.junit.Test
+
+class UserZapsTest {
+  @Test
+  fun nothing() {
+    Assert.assertEquals(1, 1)
+  }
+
+  @Test
+  fun user_without_zaps() {
+    val actual = UserZaps.groupByUser(zaps = null)
+
+    Assert.assertEquals(emptyList<Pair<Note, Note>>(), actual)
+  }
+
+  @Test
+  fun group_by_user_with_just_one_user() {
+    val u1 = mockk<Note>()
+    val z1 = mockk<Note>()
+    val z2 = mockk<Note>()
+    val zaps: Map<Note, Note?> = mapOf(u1 to z1, u1 to z2)
+    val actual = UserZaps.groupByUser(zaps)
+
+    Assert.assertEquals(listOf(Pair(u1, z2)), actual)
+  }
+
+  @Test
+  fun group_by_user() {
+    // FIXME: not working yet...
+//    IDEA:
+//    [ (u1 -> z1) (u1 -> z2) (u2 -> z3) ]
+//    [ (u1 -> z1 + z2) (u2 -> z3)]
+    val u1 = mockk<Note>()
+    val u2 = mockk<Note>()
+
+    val z1 = mockk<Note>()
+    val z2 = mockk<Note>()
+    val z3 = mockk<Note>()
+    every { z3.event } returns mockk<EventInterface>()
+
+    val zaps: Map<Note, Note?> = mapOf(u1 to z1, u1 to z2, u2 to z3)
+    val actual = UserZaps.groupByUser(zaps)
+
+    Assert.assertEquals(
+      listOf(Pair(u1, z1), Pair(u1, z2), Pair(u2, z3)),
+      actual
+    )
+  }
+}


### PR DESCRIPTION
## 🤔   Background

Extract the logic from `UserProfileZapsFeedFilter` into an isolated class, so we can write unit tests for it. 

This is inspired/related to https://github.com/vitorpamplona/amethyst/issues/159 . In this PR I didn't solve that issue, but we are getting closer to make it happen.

## 💡 Goal

Make the code more testable and add more automated tests.

## 📖 Changes

- Move the logic from the `UserProfileZapsFeedFilter` to a separated class `UserZaps.forProfileFeed()`
- Create `EventInterface` and `LnZapEventInterface`
  - Using the interface methods instead of the event's public values let the code behaving the same way as before
- Install "[mockk](https://mockk.io/)" to create mocks in kotlin test
- Added some characterization tests for `UserZapsTest`

The creation of the interfaces (`EventInterface`, `LnZapEventInterface`) is important in order to invert the dependencies and mock the `Secp256k1` behaviour [See Event:143]:

```kotlin
private val secp256k1 = Secp256k1.get()
```