### PR TITLE
Biometric support down to app's minimum SDK level 26, fixes #204

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -187,7 +187,7 @@
     <string name="secret_key_copied_to_clipboard">Secret key (nsec) copied to clipboard</string>
     <string name="copy_my_secret_key">Copy my secret key</string>
     <string name="biometric_authentication_failed">Authentication failed</string>
-
+    <string name="biometric_error">Error</string>
     <string name="badge_created_by">"Created by %1$s"</string>
     <string name="badge_award_image_for">"Badge award image for %1$s"</string>
     <string name="new_badge_award_notif">You Received a new Badge Award</string>


### PR DESCRIPTION
Needed to add a fallback to the `KeyguardManager` to support SDK below level 30 (Android 9 and below).

Fingerprint with PIN unlock and PIN-only (no fingerprint set) tested and working on emulators for SDKs 26, 28, 29, 30, 33.