### PR TITLE
Fix LN invoice in expandable text component

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/service/lnurl/LnInvoiceUtil.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/lnurl/LnInvoiceUtil.kt
@@ -152,4 +152,22 @@ object LnInvoiceUtil {
             null
         }
     }
+
+    /**
+     * If the string contains an LN invoice, returns a Pair of the start and end
+     * positions of the invoice in the string. Otherwise, returns (0, 0). This is
+     * used to ensure we don't accidentally cut an invoice in the middle when taking
+     * only a portion of the available text.
+     */
+    fun locateInvoice(input: String?): Pair<Int, Int> {
+        if (input == null) {
+            return Pair(0, 0)
+        }
+        val matcher = invoicePattern.matcher(input)
+        return if (matcher.find()) {
+            Pair(matcher.start(), matcher.end())
+        } else {
+            Pair(0, 0)
+        }
+    }
 }

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/components/ExpandableRichTextViewer.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/components/ExpandableRichTextViewer.kt
@@ -26,7 +26,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.service.lnurl.LnInvoiceUtil
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+
+const val SHORT_TEXT_LENGTH = 350
 
 @Composable
 fun ExpandableRichTextViewer(
@@ -40,7 +43,16 @@ fun ExpandableRichTextViewer(
 ) {
     var showFullText by remember { mutableStateOf(false) }
 
-    val text = if (showFullText) content else content.take(350)
+    val text = if (showFullText) {
+        content
+    } else {
+        val (lnStart, lnEnd) = LnInvoiceUtil.locateInvoice(content)
+        if (lnStart < SHORT_TEXT_LENGTH && lnEnd > 0) {
+            content.take(lnEnd)
+        } else {
+            content.take(SHORT_TEXT_LENGTH)
+        }
+    }
 
     Box(contentAlignment = Alignment.BottomCenter) {
         // CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {


### PR DESCRIPTION
The original text extraction function in the unexpanded version of the ExpandableRichTextViewer blindly pulled 350 characters out of the string. This fix does a pre-check for an invoice before extracting characters. If an index is found within the first 350 characters, we make sure to include the whole invoice.

Original problem was reproducible. Fix tested with Zeus in emulator.