### PR TITLE
Update EncryptedStorage

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/EncryptedStorage.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/EncryptedStorage.kt
@@ -2,18 +2,20 @@ package com.vitorpamplona.amethyst
 
 import android.content.Context
 import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKeys
+import androidx.security.crypto.MasterKey
 
 class EncryptedStorage {
+    private val preferencesName = "secret_keeper"
 
     fun preferences(context: Context): EncryptedSharedPreferences {
-        val secretKey: String = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
-        val preferencesName = "secret_keeper"
+        val masterKey: MasterKey = MasterKey.Builder(context, MasterKey.DEFAULT_MASTER_KEY_ALIAS)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
 
         return EncryptedSharedPreferences.create(
-            preferencesName,
-            secretKey,
             context,
+            preferencesName,
+            masterKey,
             EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
             EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
         ) as EncryptedSharedPreferences

--- a/app/src/main/java/com/vitorpamplona/amethyst/EncryptedStorage.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/EncryptedStorage.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 
-class EncryptedStorage {
-    private val preferencesName = "secret_keeper"
+object EncryptedStorage {
+    private const val PREFERENCES_NAME = "secret_keeper"
 
     fun preferences(context: Context): EncryptedSharedPreferences {
         val masterKey: MasterKey = MasterKey.Builder(context, MasterKey.DEFAULT_MASTER_KEY_ALIAS)
@@ -14,7 +14,7 @@ class EncryptedStorage {
 
         return EncryptedSharedPreferences.create(
             context,
-            preferencesName,
+            PREFERENCES_NAME,
             masterKey,
             EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
             EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM

--- a/app/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
@@ -29,7 +29,7 @@ class LocalPreferences(context: Context) {
         val LAST_READ: (String) -> String = { route -> "last_read_route_$route" }
     }
 
-    private val encryptedPreferences = EncryptedStorage().preferences(context)
+    private val encryptedPreferences = EncryptedStorage.preferences(context)
     private val gson = GsonBuilder().create()
 
     fun clearEncryptedStorage() {


### PR DESCRIPTION
## 📚 Description

- The `EncryptedStorage` was using a deprecated `MasterKeys`
  - Instead, we should use  `MasterKey.Builder`

<img width="689" alt="Screenshot 2023-03-09 at 21 41 07" src="https://user-images.githubusercontent.com/5256287/224166447-179de605-561d-4383-a518-678efb8188ff.png">

> How to fix it? https://stackoverflow.com/questions/62498977/how-to-create-masterkey-after-masterkeys-deprecated-in-android


### 🏗️  How did I find this?

When running `./gradlew assembleDebug` the output mentioned (and still does mention) a lot of potential improvements. So I plan to work on them step by step. This PR is to fix the first warnings related to the `EncryptedStorage.kt`

<img width="1267" alt="Screenshot 2023-03-09 at 21 46 35" src="https://user-images.githubusercontent.com/5256287/224167519-9e0e7c7d-320b-4a38-ae3a-fa7cfc74b5a1.png">

