### PR TITLE
Keep feed position while navigating different screens

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,9 +80,6 @@ dependencies {
     // Biometrics
     implementation "androidx.biometric:biometric-ktx:1.2.0-alpha05"
 
-    // Swipe Refresh
-    implementation 'com.google.accompanist:accompanist-swiperefresh:0.29.1-alpha'
-
     // Bitcoin secp256k1 bindings to Android
     implementation 'fr.acinq.secp256k1:secp256k1-kmp-jni-android:0.7.1'
 

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppBottomBar.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppBottomBar.kt
@@ -83,7 +83,7 @@ fun keyboardAsState(): State<Keyboard> {
 
 @Composable
 fun AppBottomBar(navController: NavHostController, accountViewModel: AccountViewModel) {
-    val currentRoute = currentRoute(navController)
+    val currentRoute = currentRoute(navController)?.substringBefore("?")
     val coroutineScope = rememberCoroutineScope()
 
     val isKeyboardOpen by keyboardAsState()
@@ -101,10 +101,10 @@ fun AppBottomBar(navController: NavHostController, accountViewModel: AccountView
                 bottomNavigationItems.forEach { item ->
                     BottomNavigationItem(
                         icon = { NotifiableIcon(item, currentRoute, accountViewModel) },
-                        selected = currentRoute == item.route,
+                        selected = currentRoute == item.base,
                         onClick = {
                             coroutineScope.launch {
-                                if (currentRoute != item.route) {
+                                if (currentRoute != item.base) {
                                     navController.navigate(item.route) {
                                         navController.graph.startDestinationRoute?.let { start ->
                                             popUpTo(start)
@@ -114,8 +114,7 @@ fun AppBottomBar(navController: NavHostController, accountViewModel: AccountView
                                         restoreState = true
                                     }
                                 } else {
-                                    // TODO: Make it scrool to the top
-                                    navController.navigate(item.route) {
+                                    navController.navigate("${item.base}?forceRefresh=${true}") {
                                         navController.graph.startDestinationRoute?.let { start ->
                                             popUpTo(start) { inclusive = item.route == Route.Home.route }
                                             restoreState = true
@@ -136,12 +135,12 @@ fun AppBottomBar(navController: NavHostController, accountViewModel: AccountView
 
 @Composable
 private fun NotifiableIcon(item: Route, currentRoute: String?, accountViewModel: AccountViewModel) {
-    Box(Modifier.size(if ("Home" == item.route) 25.dp else 23.dp)) {
+    Box(Modifier.size(if ("Home" == item.base) 25.dp else 23.dp)) {
         Icon(
             painter = painterResource(id = item.icon),
             null,
-            modifier = Modifier.size(if ("Home" == item.route) 24.dp else 20.dp),
-            tint = if (currentRoute == item.route) MaterialTheme.colors.primary else Color.Unspecified
+            modifier = Modifier.size(if ("Home" == item.base) 24.dp else 20.dp),
+            tint = if (currentRoute == item.base) MaterialTheme.colors.primary else Color.Unspecified
         )
 
         val accountState by accountViewModel.accountLiveData.observeAsState()

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -1,11 +1,17 @@
 package com.vitorpamplona.amethyst.ui.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import com.vitorpamplona.amethyst.ui.dal.GlobalFeedFilter
 import com.vitorpamplona.amethyst.ui.screen.AccountStateViewModel
+import com.vitorpamplona.amethyst.ui.screen.NostrGlobalFeedViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.SearchScreen
 
 @Composable
 fun AppNavigation(
@@ -14,9 +20,28 @@ fun AppNavigation(
     accountStateViewModel: AccountStateViewModel,
     nextPage: String? = null
 ) {
+    val accountState by accountViewModel.accountLiveData.observeAsState()
+    val account = accountState?.account ?: return
+
+    GlobalFeedFilter.account = account
+    val globalFeedViewModel: NostrGlobalFeedViewModel = viewModel()
+
     NavHost(navController, startDestination = Route.Home.route) {
+        Route.Search.let { route ->
+            composable(route.route, route.arguments, content = {
+                SearchScreen(
+                    accountViewModel = accountViewModel,
+                    feedViewModel = globalFeedViewModel,
+                    navController = navController,
+                    scrollToTop = it.arguments?.getBoolean("scrollToTop") ?: false
+                )
+            })
+        }
+
         Routes.forEach {
-            composable(it.route, it.arguments, content = it.buildScreen(accountViewModel, accountStateViewModel, navController))
+            it.buildScreen?.let { fn ->
+                composable(it.route, it.arguments, content = fn(accountViewModel, accountStateViewModel, navController))
+            }
         }
     }
 

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -7,9 +7,15 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import com.google.accompanist.pager.ExperimentalPagerApi
+import com.google.accompanist.pager.rememberPagerState
 import com.vitorpamplona.amethyst.ui.dal.GlobalFeedFilter
+import com.vitorpamplona.amethyst.ui.dal.HomeConversationsFeedFilter
+import com.vitorpamplona.amethyst.ui.dal.HomeNewThreadFeedFilter
 import com.vitorpamplona.amethyst.ui.screen.AccountStateViewModel
 import com.vitorpamplona.amethyst.ui.screen.NostrGlobalFeedViewModel
+import com.vitorpamplona.amethyst.ui.screen.NostrHomeFeedViewModel
+import com.vitorpamplona.amethyst.ui.screen.NostrHomeRepliesFeedViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.ChannelScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.ChatroomListScreen
@@ -21,6 +27,7 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.ProfileScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.SearchScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.ThreadScreen
 
+@OptIn(ExperimentalPagerApi::class)
 @Composable
 fun AppNavigation(
     navController: NavHostController,
@@ -32,7 +39,13 @@ fun AppNavigation(
     val account = accountState?.account ?: return
 
     GlobalFeedFilter.account = account
+    HomeNewThreadFeedFilter.account = account
+    HomeConversationsFeedFilter.account = account
+
     val globalFeedViewModel: NostrGlobalFeedViewModel = viewModel()
+    val homeFeedViewModel: NostrHomeFeedViewModel = viewModel()
+    val homeRepliesFeedViewModel: NostrHomeRepliesFeedViewModel = viewModel()
+    val homePagerState = rememberPagerState()
 
     NavHost(navController, startDestination = Route.Home.route) {
         Route.Search.let { route ->
@@ -51,6 +64,9 @@ fun AppNavigation(
                 HomeScreen(
                     accountViewModel = accountViewModel,
                     navController = navController,
+                    homeFeedViewModel = homeFeedViewModel,
+                    repliesFeedViewModel = homeRepliesFeedViewModel,
+                    pagerState = homePagerState,
                     scrollToTop = it.arguments?.getBoolean("scrollToTop") ?: false
                 )
             })

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -11,7 +11,15 @@ import com.vitorpamplona.amethyst.ui.dal.GlobalFeedFilter
 import com.vitorpamplona.amethyst.ui.screen.AccountStateViewModel
 import com.vitorpamplona.amethyst.ui.screen.NostrGlobalFeedViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.ChannelScreen
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.ChatroomListScreen
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.ChatroomScreen
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.FiltersScreen
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.HomeScreen
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.NotificationScreen
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.ProfileScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.SearchScreen
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.ThreadScreen
 
 @Composable
 fun AppNavigation(
@@ -38,10 +46,59 @@ fun AppNavigation(
             })
         }
 
-        Routes.forEach {
-            it.buildScreen?.let { fn ->
-                composable(it.route, it.arguments, content = fn(accountViewModel, accountStateViewModel, navController))
-            }
+        Route.Home.let { route ->
+            composable(route.route, route.arguments, content = {
+                HomeScreen(
+                    accountViewModel = accountViewModel,
+                    navController = navController,
+                    scrollToTop = it.arguments?.getBoolean("scrollToTop") ?: false
+                )
+            })
+        }
+
+        composable(Route.Message.route, content = { ChatroomListScreen(accountViewModel, navController) })
+        composable(Route.Notification.route, content = { NotificationScreen(accountViewModel, navController) })
+        composable(Route.Filters.route, content = { FiltersScreen(accountViewModel, navController) })
+
+        Route.Profile.let { route ->
+            composable(route.route, route.arguments, content = {
+                ProfileScreen(
+                    userId = it.arguments?.getString("id"),
+                    accountViewModel = accountViewModel,
+                    navController = navController
+                )
+            })
+        }
+
+        Route.Note.let { route ->
+            composable(route.route, route.arguments, content = {
+                ThreadScreen(
+                    noteId = it.arguments?.getString("id"),
+                    accountViewModel = accountViewModel,
+                    navController = navController
+                )
+            })
+        }
+
+        Route.Room.let { route ->
+            composable(route.route, route.arguments, content = {
+                ChatroomScreen(
+                    userId = it.arguments?.getString("id"),
+                    accountViewModel = accountViewModel,
+                    navController = navController
+                )
+            })
+        }
+
+        Route.Channel.let { route ->
+            composable(route.route, route.arguments, content = {
+                ChannelScreen(
+                    channelId = it.arguments?.getString("id"),
+                    accountViewModel = accountViewModel,
+                    accountStateViewModel = accountStateViewModel,
+                    navController = navController
+                )
+            })
         }
     }
 

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/navigation/Routes.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/navigation/Routes.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.navigation.NamedNavArgument
-import androidx.navigation.NavBackStackEntry
-import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -16,35 +14,21 @@ import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.ui.dal.ChatroomListKnownFeedFilter
 import com.vitorpamplona.amethyst.ui.dal.HomeNewThreadFeedFilter
 import com.vitorpamplona.amethyst.ui.dal.NotificationFeedFilter
-import com.vitorpamplona.amethyst.ui.screen.AccountStateViewModel
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.ChannelScreen
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.ChatroomListScreen
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.ChatroomScreen
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.FiltersScreen
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.HomeScreen
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.NotificationScreen
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.ProfileScreen
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.ThreadScreen
 
 sealed class Route(
     val route: String,
     val icon: Int,
     val hasNewItems: (Account, NotificationCache, Context) -> Boolean = { _, _, _ -> false },
-    val arguments: List<NamedNavArgument> = emptyList(),
-    val buildScreen: ((AccountViewModel, AccountStateViewModel, NavController) -> @Composable (NavBackStackEntry) -> Unit)? = null
+    val arguments: List<NamedNavArgument> = emptyList()
 ) {
     val base: String
         get() = route.substringBefore("?")
 
     object Home : Route(
-        "Home?scrollToTop={scrollToTop}",
-        R.drawable.ic_home,
+        route = "Home?scrollToTop={scrollToTop}",
+        icon = R.drawable.ic_home,
         arguments = listOf(navArgument("scrollToTop") { type = NavType.BoolType; defaultValue = false }),
-        hasNewItems = { accountViewModel, cache, context -> homeHasNewItems(accountViewModel, cache, context) },
-        buildScreen = { accountViewModel, _, navController ->
-            { HomeScreen(accountViewModel, navController, it.arguments?.getBoolean("scrollToTop", false) ?: false) }
-        }
+        hasNewItems = { accountViewModel, cache, context -> homeHasNewItems(accountViewModel, cache, context) }
     )
 
     object Search : Route(
@@ -58,9 +42,6 @@ sealed class Route(
         icon = R.drawable.ic_notifications,
         hasNewItems = { accountViewModel, cache, context ->
             notificationHasNewItems(accountViewModel, cache, context)
-        },
-        buildScreen = { accountViewModel, _, navController ->
-            { NotificationScreen(accountViewModel, navController) }
         }
     )
 
@@ -69,78 +50,38 @@ sealed class Route(
         icon = R.drawable.ic_dm,
         hasNewItems = { accountViewModel, cache, context ->
             messagesHasNewItems(accountViewModel, cache, context)
-        },
-        buildScreen = { accountViewModel, _, navController ->
-            { ChatroomListScreen(accountViewModel, navController) }
         }
     )
 
     object Filters : Route(
         route = "Filters",
-        icon = R.drawable.ic_security,
-        buildScreen = { accountViewModel, _, navController ->
-            { FiltersScreen(accountViewModel, navController) }
-        }
+        icon = R.drawable.ic_security
     )
 
     object Profile : Route(
         route = "User/{id}",
         icon = R.drawable.ic_profile,
-        arguments = listOf(navArgument("id") { type = NavType.StringType }),
-        buildScreen = { accountViewModel, _, navController ->
-            { ProfileScreen(it.arguments?.getString("id"), accountViewModel, navController) }
-        }
+        arguments = listOf(navArgument("id") { type = NavType.StringType })
     )
 
     object Note : Route(
         route = "Note/{id}",
         icon = R.drawable.ic_moments,
-        arguments = listOf(navArgument("id") { type = NavType.StringType }),
-        buildScreen = { accountViewModel, _, navController ->
-            { ThreadScreen(it.arguments?.getString("id"), accountViewModel, navController) }
-        }
+        arguments = listOf(navArgument("id") { type = NavType.StringType })
     )
 
     object Room : Route(
         route = "Room/{id}",
         icon = R.drawable.ic_moments,
-        arguments = listOf(navArgument("id") { type = NavType.StringType }),
-        buildScreen = { accountViewModel, _, navController ->
-            { ChatroomScreen(it.arguments?.getString("id"), accountViewModel, navController) }
-        }
+        arguments = listOf(navArgument("id") { type = NavType.StringType })
     )
 
     object Channel : Route(
         route = "Channel/{id}",
         icon = R.drawable.ic_moments,
-        arguments = listOf(navArgument("id") { type = NavType.StringType }),
-        buildScreen = { accountViewModel, accountStateViewModel, navController ->
-            {
-                ChannelScreen(
-                    it.arguments?.getString("id"),
-                    accountViewModel,
-                    accountStateViewModel,
-                    navController
-                )
-            }
-        }
+        arguments = listOf(navArgument("id") { type = NavType.StringType })
     )
 }
-
-val Routes = listOf(
-    // bottom
-    Route.Home,
-    Route.Message,
-    Route.Search,
-    Route.Notification,
-
-    // drawer
-    Route.Profile,
-    Route.Note,
-    Route.Room,
-    Route.Channel,
-    Route.Filters
-)
 
 // **
 // *  Functions below only exist because we have not broken the datasource classes into backend and frontend.

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/navigation/Routes.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/navigation/Routes.kt
@@ -35,17 +35,32 @@ sealed class Route(
     val arguments: List<NamedNavArgument> = emptyList(),
     val buildScreen: (AccountViewModel, AccountStateViewModel, NavController) -> @Composable (NavBackStackEntry) -> Unit
 ) {
+    val base: String
+        get() = route.substringBefore("?")
+
     object Home : Route(
-        "Home",
+        "Home?forceRefresh={forceRefresh}",
         R.drawable.ic_home,
+        arguments = listOf(navArgument("forceRefresh") { type = NavType.BoolType; defaultValue = false }),
         hasNewItems = { acc, cache, ctx -> homeHasNewItems(acc, cache, ctx) },
-        buildScreen = { acc, accSt, nav -> { _ -> HomeScreen(acc, nav) } }
+        buildScreen = { acc, accSt, nav ->
+            { backStackEntry ->
+                HomeScreen(acc, nav, backStackEntry.arguments?.getBoolean("forceRefresh", false))
+            }
+        }
     )
+
     object Search : Route(
-        "Search",
+        "Search?forceRefresh={forceRefresh}",
         R.drawable.ic_globe,
-        buildScreen = { acc, accSt, nav -> { _ -> SearchScreen(acc, nav) } }
+        arguments = listOf(navArgument("forceRefresh") { type = NavType.BoolType; defaultValue = false }),
+        buildScreen = { acc, accSt, nav ->
+            { backStackEntry ->
+                SearchScreen(acc, nav, backStackEntry.arguments?.getBoolean("forceRefresh", false))
+            }
+        }
     )
+
     object Notification : Route(
         "Notification",
         R.drawable.ic_notifications,

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/navigation/Routes.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/navigation/Routes.kt
@@ -45,7 +45,7 @@ sealed class Route(
         hasNewItems = { accountViewModel, cache, context -> homeHasNewItems(accountViewModel, cache, context) },
         buildScreen = { accountViewModel, _, navController ->
             { backStackEntry ->
-                HomeScreen(accountViewModel, navController, backStackEntry.arguments?.getBoolean("forceRefresh", false))
+                HomeScreen(accountViewModel, navController, backStackEntry.arguments?.getBoolean("forceRefresh", false) ?: false)
             }
         }
     )
@@ -56,7 +56,7 @@ sealed class Route(
         arguments = listOf(navArgument("forceRefresh") { type = NavType.BoolType; defaultValue = false }),
         buildScreen = { acc, _, navController ->
             { backStackEntry ->
-                SearchScreen(acc, navController, backStackEntry.arguments?.getBoolean("forceRefresh", false))
+                SearchScreen(acc, navController, backStackEntry.arguments?.getBoolean("forceRefresh", false) ?: false)
             }
         }
     )

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/ChatroomFeedView.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/ChatroomFeedView.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -21,12 +20,12 @@ import com.vitorpamplona.amethyst.ui.note.ChatroomMessageCompose
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
 @Composable
-fun ChatroomFeedView(viewModel: FeedViewModel, accountViewModel: AccountViewModel, navController: NavController, routeForLastRead: String?, onWantsToReply: (Note) -> Unit) {
+fun ChatroomFeedView(viewModel: FeedViewModel, accountViewModel: AccountViewModel, navController: NavController, routeForLastRead: String, onWantsToReply: (Note) -> Unit) {
     val feedState by viewModel.feedContent.collectAsState()
 
     var isRefreshing by remember { mutableStateOf(false) }
 
-    val listState = rememberLazyListState()
+    val listState = rememberForeverLazyListState(routeForLastRead)
 
     LaunchedEffect(isRefreshing) {
         if (isRefreshing) {

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/ChatroomFeedView.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/ChatroomFeedView.kt
@@ -62,8 +62,7 @@ fun ChatroomFeedView(viewModel: FeedViewModel, accountViewModel: AccountViewMode
                         reverseLayout = true,
                         state = listState
                     ) {
-                        var previousDate: String = ""
-                        itemsIndexed(state.feed.value, key = { index, item -> item.idHex }) { index, item ->
+                        itemsIndexed(state.feed.value, key = { _, item -> item.idHex }) { _, item ->
                             ChatroomMessageCompose(item, routeForLastRead, accountViewModel = accountViewModel, navController = navController, onWantsToReply = onWantsToReply)
                         }
                     }

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/ChatroomListFeedView.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/ChatroomListFeedView.kt
@@ -2,11 +2,16 @@ package com.vitorpamplona.amethyst.ui.screen
 
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
@@ -14,18 +19,18 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
-import com.google.accompanist.swiperefresh.SwipeRefresh
-import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import com.vitorpamplona.amethyst.NotificationCache
 import com.vitorpamplona.amethyst.ui.note.ChatroomCompose
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun ChatroomListFeedView(
     viewModel: FeedViewModel,
@@ -35,24 +40,11 @@ fun ChatroomListFeedView(
 ) {
     val feedState by viewModel.feedContent.collectAsStateWithLifecycle()
 
-    var isRefreshing by remember { mutableStateOf(false) }
-    val swipeRefreshState = rememberSwipeRefreshState(isRefreshing)
+    var refreshing by remember { mutableStateOf(false) }
+    val refresh = { refreshing = true; viewModel.refresh(); refreshing = false }
+    val pullRefreshState = rememberPullRefreshState(refreshing, onRefresh = refresh)
 
-    val coroutineScope = rememberCoroutineScope()
-
-    LaunchedEffect(isRefreshing) {
-        if (isRefreshing) {
-            viewModel.refresh()
-            isRefreshing = false
-        }
-    }
-
-    SwipeRefresh(
-        state = swipeRefreshState,
-        onRefresh = {
-            isRefreshing = true
-        }
-    ) {
+    Box(Modifier.pullRefresh(pullRefreshState)) {
         Column() {
             Crossfade(
                 targetState = feedState,
@@ -61,17 +53,18 @@ fun ChatroomListFeedView(
                 when (state) {
                     is FeedState.Empty -> {
                         FeedEmpty {
-                            isRefreshing = true
+                            refreshing = true
                         }
                     }
 
                     is FeedState.FeedError -> {
                         FeedError(state.errorMessage) {
-                            isRefreshing = true
+                            refreshing = true
                         }
                     }
 
                     is FeedState.Loaded -> {
+                        refreshing = false
                         FeedLoaded(state, accountViewModel, navController, markAsRead)
                     }
 
@@ -81,6 +74,8 @@ fun ChatroomListFeedView(
                 }
             }
         }
+
+        PullRefreshIndicator(refreshing, pullRefreshState, Modifier.align(Alignment.TopCenter))
     }
 }
 
@@ -103,11 +98,9 @@ private fun FeedLoaded(
         if (markAsRead.value) {
             for (note in state.feed.value) {
                 note.event?.let {
-                    var route = ""
                     val channel = note.channel()
-
-                    if (channel != null) {
-                        route = "Channel/${channel.idHex}"
+                    val route = if (channel != null) {
+                        "Channel/${channel.idHex}"
                     } else {
                         val replyAuthorBase = note.mentions?.first()
                         var userToComposeOn = note.author!!
@@ -116,7 +109,7 @@ private fun FeedLoaded(
                                 userToComposeOn = replyAuthorBase
                             }
                         }
-                        route = "Room/${userToComposeOn.pubkeyHex}"
+                        "Room/${userToComposeOn.pubkeyHex}"
                     }
 
                     notificationCache.cache.markAsRead(route, it.createdAt(), context)
@@ -136,7 +129,7 @@ private fun FeedLoaded(
         itemsIndexed(
             state.feed.value,
             key = { index, item -> if (index == 0) index else item.idHex }
-        ) { index, item ->
+        ) { _, item ->
             ChatroomCompose(
                 item,
                 accountViewModel = accountViewModel,

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/FeedView.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/FeedView.kt
@@ -3,6 +3,7 @@ package com.vitorpamplona.amethyst.ui.screen
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -11,10 +12,13 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Button
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -25,12 +29,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
-import com.google.accompanist.swiperefresh.SwipeRefresh
-import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.ui.note.NoteCompose
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun FeedView(
     viewModel: FeedViewModel,
@@ -41,36 +44,31 @@ fun FeedView(
 ) {
     val feedState by viewModel.feedContent.collectAsState()
 
-    var isRefreshing by remember { mutableStateOf(false) }
-    val swipeRefreshState = rememberSwipeRefreshState(isRefreshing)
+    var refreshing by remember { mutableStateOf(false) }
+    val refresh = { refreshing = true; viewModel.refresh(); refreshing = false }
+    val pullRefreshState = rememberPullRefreshState(refreshing, onRefresh = refresh)
 
-    LaunchedEffect(isRefreshing) {
-        if (isRefreshing) {
-            viewModel.refresh()
-            isRefreshing = false
-        }
-    }
-
-    SwipeRefresh(
-        state = swipeRefreshState,
-        onRefresh = {
-            isRefreshing = true
-        }
-    ) {
-        Column() {
-            Crossfade(targetState = feedState, animationSpec = tween(durationMillis = 100)) { state ->
+    Box(Modifier.pullRefresh(pullRefreshState)) {
+        Column {
+            Crossfade(
+                targetState = feedState,
+                animationSpec = tween(durationMillis = 100)
+            ) { state ->
                 when (state) {
                     is FeedState.Empty -> {
                         FeedEmpty {
-                            isRefreshing = true
+                            refreshing = true
                         }
                     }
+
                     is FeedState.FeedError -> {
                         FeedError(state.errorMessage) {
-                            isRefreshing = true
+                            refreshing = true
                         }
                     }
+
                     is FeedState.Loaded -> {
+                        refreshing = false
                         FeedLoaded(
                             state,
                             routeForLastRead,
@@ -79,12 +77,15 @@ fun FeedView(
                             scrollStateKey
                         )
                     }
+
                     is FeedState.Loading -> {
                         LoadingFeed()
                     }
                 }
             }
         }
+
+        PullRefreshIndicator(refreshing, pullRefreshState, Modifier.align(Alignment.TopCenter))
     }
 }
 
@@ -109,7 +110,7 @@ private fun FeedLoaded(
         ),
         state = listState
     ) {
-        itemsIndexed(state.feed.value, key = { _, item -> item.idHex }) { index, item ->
+        itemsIndexed(state.feed.value, key = { _, item -> item.idHex }) { _, item ->
             NoteCompose(
                 item,
                 isBoostedNote = false,

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/FeedView.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/FeedView.kt
@@ -42,11 +42,11 @@ fun FeedView(
     navController: NavController,
     routeForLastRead: String?,
     scrollStateKey: String? = null,
-    forceRefresh: Boolean = false
+    scrollToTop: Boolean = false
 ) {
     val feedState by viewModel.feedContent.collectAsState()
 
-    var refreshing by remember { mutableStateOf(forceRefresh) }
+    var refreshing by remember { mutableStateOf(false) }
     val refresh = { refreshing = true; viewModel.refresh(); refreshing = false }
     val pullRefreshState = rememberPullRefreshState(refreshing, onRefresh = refresh)
 
@@ -77,7 +77,7 @@ fun FeedView(
                             accountViewModel,
                             navController,
                             scrollStateKey,
-                            forceRefresh
+                            scrollToTop
                         )
                     }
 
@@ -99,7 +99,7 @@ private fun FeedLoaded(
     accountViewModel: AccountViewModel,
     navController: NavController,
     scrollStateKey: String?,
-    forceRefresh: Boolean = false
+    scrollToTop: Boolean = false
 ) {
     val listState = if (scrollStateKey != null) {
         rememberForeverLazyListState(scrollStateKey)
@@ -107,9 +107,9 @@ private fun FeedLoaded(
         rememberLazyListState()
     }
 
-    if (forceRefresh) {
+    if (scrollToTop) {
         LaunchedEffect(Unit) {
-            listState.animateScrollToItem(0)
+            listState.scrollToItem(index = 0)
         }
     }
 

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/FeedView.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/FeedView.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -40,11 +41,12 @@ fun FeedView(
     accountViewModel: AccountViewModel,
     navController: NavController,
     routeForLastRead: String?,
-    scrollStateKey: String? = null
+    scrollStateKey: String? = null,
+    forceRefresh: Boolean? = false
 ) {
     val feedState by viewModel.feedContent.collectAsState()
 
-    var refreshing by remember { mutableStateOf(false) }
+    var refreshing by remember { mutableStateOf(forceRefresh!!) }
     val refresh = { refreshing = true; viewModel.refresh(); refreshing = false }
     val pullRefreshState = rememberPullRefreshState(refreshing, onRefresh = refresh)
 
@@ -74,7 +76,8 @@ fun FeedView(
                             routeForLastRead,
                             accountViewModel,
                             navController,
-                            scrollStateKey
+                            scrollStateKey,
+                            forceRefresh!!
                         )
                     }
 
@@ -95,12 +98,19 @@ private fun FeedLoaded(
     routeForLastRead: String?,
     accountViewModel: AccountViewModel,
     navController: NavController,
-    scrollStateKey: String?
+    scrollStateKey: String?,
+    forceRefresh: Boolean = false
 ) {
     val listState = if (scrollStateKey != null) {
         rememberForeverLazyListState(scrollStateKey)
     } else {
         rememberLazyListState()
+    }
+
+    if (forceRefresh) {
+        LaunchedEffect(Unit) {
+            listState.animateScrollToItem(0)
+        }
     }
 
     LazyColumn(

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/FeedView.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/FeedView.kt
@@ -36,7 +36,8 @@ fun FeedView(
     viewModel: FeedViewModel,
     accountViewModel: AccountViewModel,
     navController: NavController,
-    routeForLastRead: String?
+    routeForLastRead: String?,
+    scrollStateKey: String? = null
 ) {
     val feedState by viewModel.feedContent.collectAsState()
 
@@ -74,7 +75,8 @@ fun FeedView(
                             state,
                             routeForLastRead,
                             accountViewModel,
-                            navController
+                            navController,
+                            scrollStateKey
                         )
                     }
                     is FeedState.Loading -> {
@@ -91,9 +93,14 @@ private fun FeedLoaded(
     state: FeedState.Loaded,
     routeForLastRead: String?,
     accountViewModel: AccountViewModel,
-    navController: NavController
+    navController: NavController,
+    scrollStateKey: String?
 ) {
-    val listState = rememberLazyListState()
+    val listState = if (scrollStateKey != null) {
+        rememberForeverLazyListState(scrollStateKey)
+    } else {
+        rememberLazyListState()
+    }
 
     LazyColumn(
         contentPadding = PaddingValues(

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/FeedView.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/FeedView.kt
@@ -42,11 +42,11 @@ fun FeedView(
     navController: NavController,
     routeForLastRead: String?,
     scrollStateKey: String? = null,
-    forceRefresh: Boolean? = false
+    forceRefresh: Boolean = false
 ) {
     val feedState by viewModel.feedContent.collectAsState()
 
-    var refreshing by remember { mutableStateOf(forceRefresh!!) }
+    var refreshing by remember { mutableStateOf(forceRefresh) }
     val refresh = { refreshing = true; viewModel.refresh(); refreshing = false }
     val pullRefreshState = rememberPullRefreshState(refreshing, onRefresh = refresh)
 
@@ -77,7 +77,7 @@ fun FeedView(
                             accountViewModel,
                             navController,
                             scrollStateKey,
-                            forceRefresh!!
+                            forceRefresh
                         )
                     }
 

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/LazyListState.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/LazyListState.kt
@@ -1,0 +1,34 @@
+package com.vitorpamplona.amethyst.ui.screen
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.saveable.rememberSaveable
+
+private val savedScrollStates = mutableMapOf<String, ScrollState>()
+private data class ScrollState(val index: Int, val scrollOffset: Int)
+
+@Composable
+fun rememberForeverLazyListState(
+    key: String,
+    initialFirstVisibleItemIndex: Int = 0,
+    initialFirstVisibleItemScrollOffset: Int = 0
+): LazyListState {
+    val scrollState = rememberSaveable(saver = LazyListState.Saver) {
+        val savedValue = savedScrollStates[key]
+        val savedIndex = savedValue?.index ?: initialFirstVisibleItemIndex
+        val savedOffset = savedValue?.scrollOffset ?: initialFirstVisibleItemScrollOffset
+        LazyListState(
+            savedIndex,
+            savedOffset
+        )
+    }
+    DisposableEffect(Unit) {
+        onDispose {
+            val lastIndex = scrollState.firstVisibleItemIndex
+            val lastOffset = scrollState.firstVisibleItemScrollOffset
+            savedScrollStates[key] = ScrollState(lastIndex, lastOffset)
+        }
+    }
+    return scrollState
+}

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/LazyListState.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/LazyListState.kt
@@ -4,9 +4,16 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.saveable.rememberSaveable
+import com.vitorpamplona.amethyst.ui.navigation.Route
 
 private val savedScrollStates = mutableMapOf<String, ScrollState>()
 private data class ScrollState(val index: Int, val scrollOffset: Int)
+
+object ScrollStateKeys {
+    const val GLOBAL_SCREEN = "Global"
+    val HOME_FOLLOWS = Route.Home.base + "Follows"
+    val HOME_REPLIES = Route.Home.base + "FollowsReplies"
+}
 
 @Composable
 fun rememberForeverLazyListState(

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/LnZapFeedView.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/LnZapFeedView.kt
@@ -2,59 +2,54 @@ package com.vitorpamplona.amethyst.ui.screen
 
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
-import com.google.accompanist.swiperefresh.SwipeRefresh
-import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import com.vitorpamplona.amethyst.ui.note.ZapNoteCompose
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun LnZapFeedView(viewModel: LnZapFeedViewModel, accountViewModel: AccountViewModel, navController: NavController) {
     val feedState by viewModel.feedContent.collectAsState()
 
-    var isRefreshing by remember { mutableStateOf(false) }
-    val swipeRefreshState = rememberSwipeRefreshState(isRefreshing)
+    var refreshing by remember { mutableStateOf(false) }
+    val refresh = { refreshing = true; viewModel.refresh(); refreshing = false }
+    val pullRefreshState = rememberPullRefreshState(refreshing, onRefresh = refresh)
 
-    LaunchedEffect(isRefreshing) {
-        if (isRefreshing) {
-            viewModel.refresh()
-            isRefreshing = false
-        }
-    }
-
-    SwipeRefresh(
-        state = swipeRefreshState,
-        onRefresh = {
-            isRefreshing = true
-        }
-    ) {
+    Box(Modifier.pullRefresh(pullRefreshState)) {
         Column() {
             Crossfade(targetState = feedState, animationSpec = tween(durationMillis = 100)) { state ->
                 when (state) {
                     is LnZapFeedState.Empty -> {
                         FeedEmpty {
-                            isRefreshing = true
+                            refreshing = true
                         }
                     }
                     is LnZapFeedState.FeedError -> {
                         FeedError(state.errorMessage) {
-                            isRefreshing = true
+                            refreshing = true
                         }
                     }
                     is LnZapFeedState.Loaded -> {
+                        refreshing = false
                         LnZapFeedLoaded(state, accountViewModel, navController)
                     }
                     is LnZapFeedState.Loading -> {
@@ -63,6 +58,8 @@ fun LnZapFeedView(viewModel: LnZapFeedViewModel, accountViewModel: AccountViewMo
                 }
             }
         }
+
+        PullRefreshIndicator(refreshing, pullRefreshState, Modifier.align(Alignment.TopCenter))
     }
 }
 

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/ThreadFeedView.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/ThreadFeedView.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -16,12 +17,16 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Divider
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -44,8 +49,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import coil.compose.AsyncImage
-import com.google.accompanist.swiperefresh.SwipeRefresh
-import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.service.model.BadgeDefinitionEvent
@@ -65,42 +68,33 @@ import com.vitorpamplona.amethyst.ui.note.timeAgo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import kotlinx.coroutines.delay
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun ThreadFeedView(noteId: String, viewModel: FeedViewModel, accountViewModel: AccountViewModel, navController: NavController) {
     val feedState by viewModel.feedContent.collectAsState()
 
-    var isRefreshing by remember { mutableStateOf(false) }
-    val swipeRefreshState = rememberSwipeRefreshState(isRefreshing)
-
     val listState = rememberLazyListState()
 
-    LaunchedEffect(isRefreshing) {
-        if (isRefreshing) {
-            viewModel.refresh()
-            isRefreshing = false
-        }
-    }
+    var refreshing by remember { mutableStateOf(false) }
+    val refresh = { refreshing = true; viewModel.refresh(); refreshing = false }
+    val pullRefreshState = rememberPullRefreshState(refreshing, onRefresh = refresh)
 
-    SwipeRefresh(
-        state = swipeRefreshState,
-        onRefresh = {
-            isRefreshing = true
-        }
-    ) {
+    Box(Modifier.pullRefresh(pullRefreshState)) {
         Column() {
             Crossfade(targetState = feedState, animationSpec = tween(durationMillis = 100)) { state ->
                 when (state) {
                     is FeedState.Empty -> {
                         FeedEmpty {
-                            isRefreshing = true
+                            refreshing = true
                         }
                     }
                     is FeedState.FeedError -> {
                         FeedError(state.errorMessage) {
-                            isRefreshing = true
+                            refreshing = true
                         }
                     }
                     is FeedState.Loaded -> {
+                        refreshing = false
                         LaunchedEffect(noteId) {
                             // waits to load the thread to scroll to item.
                             delay(100)
@@ -163,6 +157,8 @@ fun ThreadFeedView(noteId: String, viewModel: FeedViewModel, accountViewModel: A
                 }
             }
         }
+
+        PullRefreshIndicator(refreshing, pullRefreshState, Modifier.align(Alignment.TopCenter))
     }
 }
 

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/UserFeedView.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/UserFeedView.kt
@@ -2,59 +2,54 @@ package com.vitorpamplona.amethyst.ui.screen
 
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
-import com.google.accompanist.swiperefresh.SwipeRefresh
-import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import com.vitorpamplona.amethyst.ui.note.UserCompose
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun UserFeedView(viewModel: UserFeedViewModel, accountViewModel: AccountViewModel, navController: NavController) {
     val feedState by viewModel.feedContent.collectAsState()
 
-    var isRefreshing by remember { mutableStateOf(false) }
-    val swipeRefreshState = rememberSwipeRefreshState(isRefreshing)
+    var refreshing by remember { mutableStateOf(false) }
+    val refresh = { refreshing = true; viewModel.refresh(); refreshing = false }
+    val pullRefreshState = rememberPullRefreshState(refreshing, onRefresh = refresh)
 
-    LaunchedEffect(isRefreshing) {
-        if (isRefreshing) {
-            viewModel.refresh()
-            isRefreshing = false
-        }
-    }
-
-    SwipeRefresh(
-        state = swipeRefreshState,
-        onRefresh = {
-            isRefreshing = true
-        }
-    ) {
+    Box(Modifier.pullRefresh(pullRefreshState)) {
         Column() {
             Crossfade(targetState = feedState, animationSpec = tween(durationMillis = 100)) { state ->
                 when (state) {
                     is UserFeedState.Empty -> {
                         FeedEmpty {
-                            isRefreshing = true
+                            refreshing = true
                         }
                     }
                     is UserFeedState.FeedError -> {
                         FeedError(state.errorMessage) {
-                            isRefreshing = true
+                            refreshing = true
                         }
                     }
                     is UserFeedState.Loaded -> {
+                        refreshing = false
                         FeedLoaded(state, accountViewModel, navController)
                     }
                     is UserFeedState.Loading -> {
@@ -63,6 +58,8 @@ fun UserFeedView(viewModel: UserFeedViewModel, accountViewModel: AccountViewMode
                 }
             }
         }
+
+        PullRefreshIndicator(refreshing, pullRefreshState, Modifier.align(Alignment.TopCenter))
     }
 }
 

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/HomeScreen.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/HomeScreen.kt
@@ -39,7 +39,7 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalPagerApi::class)
 @Composable
-fun HomeScreen(accountViewModel: AccountViewModel, navController: NavController, forceRefresh: Boolean = false) {
+fun HomeScreen(accountViewModel: AccountViewModel, navController: NavController, scrollToTop: Boolean = false) {
     val accountState by accountViewModel.accountLiveData.observeAsState()
     val account = accountState?.account ?: return
 
@@ -107,7 +107,7 @@ fun HomeScreen(accountViewModel: AccountViewModel, navController: NavController,
             }
             HorizontalPager(count = 2, state = pagerState) {
                 when (pagerState.currentPage) {
-                    0 -> FeedView(feedViewModel, accountViewModel, navController, Route.Home.base + "Follows", ScrollStateKeys.HOME_FOLLOWS, forceRefresh)
+                    0 -> FeedView(feedViewModel, accountViewModel, navController, Route.Home.base + "Follows", ScrollStateKeys.HOME_FOLLOWS, scrollToTop)
                     1 -> FeedView(feedViewModelReplies, accountViewModel, navController, Route.Home.base + "FollowsReplies", ScrollStateKeys.HOME_REPLIES)
                 }
             }

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/HomeScreen.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/HomeScreen.kt
@@ -106,8 +106,8 @@ fun HomeScreen(accountViewModel: AccountViewModel, navController: NavController)
             }
             HorizontalPager(count = 2, state = pagerState) {
                 when (pagerState.currentPage) {
-                    0 -> FeedView(feedViewModel, accountViewModel, navController, Route.Home.route + "Follows")
-                    1 -> FeedView(feedViewModelReplies, accountViewModel, navController, Route.Home.route + "FollowsReplies")
+                    0 -> FeedView(feedViewModel, accountViewModel, navController, Route.Home.route + "Follows", Route.Home.route + "Follows")
+                    1 -> FeedView(feedViewModelReplies, accountViewModel, navController, Route.Home.route + "FollowsReplies", Route.Home.route + "FollowsReplies")
                 }
             }
         }

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/HomeScreen.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/HomeScreen.kt
@@ -34,11 +34,12 @@ import com.vitorpamplona.amethyst.ui.navigation.Route
 import com.vitorpamplona.amethyst.ui.screen.FeedView
 import com.vitorpamplona.amethyst.ui.screen.NostrHomeFeedViewModel
 import com.vitorpamplona.amethyst.ui.screen.NostrHomeRepliesFeedViewModel
+import com.vitorpamplona.amethyst.ui.screen.ScrollStateKeys
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalPagerApi::class)
 @Composable
-fun HomeScreen(accountViewModel: AccountViewModel, navController: NavController) {
+fun HomeScreen(accountViewModel: AccountViewModel, navController: NavController, forceRefresh: Boolean? = false) {
     val accountState by accountViewModel.accountLiveData.observeAsState()
     val account = accountState?.account ?: return
 
@@ -106,8 +107,8 @@ fun HomeScreen(accountViewModel: AccountViewModel, navController: NavController)
             }
             HorizontalPager(count = 2, state = pagerState) {
                 when (pagerState.currentPage) {
-                    0 -> FeedView(feedViewModel, accountViewModel, navController, Route.Home.route + "Follows", Route.Home.route + "Follows")
-                    1 -> FeedView(feedViewModelReplies, accountViewModel, navController, Route.Home.route + "FollowsReplies", Route.Home.route + "FollowsReplies")
+                    0 -> FeedView(feedViewModel, accountViewModel, navController, Route.Home.base + "Follows", ScrollStateKeys.HOME_FOLLOWS, forceRefresh)
+                    1 -> FeedView(feedViewModelReplies, accountViewModel, navController, Route.Home.base + "FollowsReplies", ScrollStateKeys.HOME_REPLIES)
                 }
             }
         }

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/HomeScreen.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/HomeScreen.kt
@@ -11,8 +11,6 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLifecycleOwner
@@ -20,16 +18,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
+import com.google.accompanist.pager.PagerState
 import com.google.accompanist.pager.pagerTabIndicatorOffset
-import com.google.accompanist.pager.rememberPagerState
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.service.NostrHomeDataSource
-import com.vitorpamplona.amethyst.ui.dal.HomeConversationsFeedFilter
-import com.vitorpamplona.amethyst.ui.dal.HomeNewThreadFeedFilter
 import com.vitorpamplona.amethyst.ui.navigation.Route
 import com.vitorpamplona.amethyst.ui.screen.FeedView
 import com.vitorpamplona.amethyst.ui.screen.NostrHomeFeedViewModel
@@ -39,33 +34,30 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalPagerApi::class)
 @Composable
-fun HomeScreen(accountViewModel: AccountViewModel, navController: NavController, scrollToTop: Boolean = false) {
-    val accountState by accountViewModel.accountLiveData.observeAsState()
-    val account = accountState?.account ?: return
-
-    HomeNewThreadFeedFilter.account = account
-    HomeConversationsFeedFilter.account = account
-
-    val feedViewModel: NostrHomeFeedViewModel = viewModel()
-    val feedViewModelReplies: NostrHomeRepliesFeedViewModel = viewModel()
-
-    val pagerState = rememberPagerState()
+fun HomeScreen(
+    accountViewModel: AccountViewModel,
+    navController: NavController,
+    homeFeedViewModel: NostrHomeFeedViewModel,
+    repliesFeedViewModel: NostrHomeRepliesFeedViewModel,
+    pagerState: PagerState,
+    scrollToTop: Boolean = false
+) {
     val coroutineScope = rememberCoroutineScope()
 
     LaunchedEffect(accountViewModel) {
         NostrHomeDataSource.resetFilters()
 
-        feedViewModel.refresh()
-        feedViewModelReplies.refresh()
+        homeFeedViewModel.refresh()
+        repliesFeedViewModel.refresh()
     }
 
     val lifeCycleOwner = LocalLifecycleOwner.current
     DisposableEffect(accountViewModel) {
-        val observer = LifecycleEventObserver { source, event ->
+        val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
                 NostrHomeDataSource.resetFilters()
-                feedViewModel.refresh()
-                feedViewModelReplies.refresh()
+                homeFeedViewModel.refresh()
+                repliesFeedViewModel.refresh()
             }
         }
 
@@ -107,8 +99,8 @@ fun HomeScreen(accountViewModel: AccountViewModel, navController: NavController,
             }
             HorizontalPager(count = 2, state = pagerState) {
                 when (pagerState.currentPage) {
-                    0 -> FeedView(feedViewModel, accountViewModel, navController, Route.Home.base + "Follows", ScrollStateKeys.HOME_FOLLOWS, scrollToTop)
-                    1 -> FeedView(feedViewModelReplies, accountViewModel, navController, Route.Home.base + "FollowsReplies", ScrollStateKeys.HOME_REPLIES)
+                    0 -> FeedView(homeFeedViewModel, accountViewModel, navController, Route.Home.base + "Follows", ScrollStateKeys.HOME_FOLLOWS, scrollToTop)
+                    1 -> FeedView(repliesFeedViewModel, accountViewModel, navController, Route.Home.base + "FollowsReplies", ScrollStateKeys.HOME_REPLIES, scrollToTop)
                 }
             }
         }

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/HomeScreen.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/HomeScreen.kt
@@ -39,7 +39,7 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalPagerApi::class)
 @Composable
-fun HomeScreen(accountViewModel: AccountViewModel, navController: NavController, forceRefresh: Boolean? = false) {
+fun HomeScreen(accountViewModel: AccountViewModel, navController: NavController, forceRefresh: Boolean = false) {
     val accountState by accountViewModel.accountLiveData.observeAsState()
     val account = accountState?.account ?: return
 

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/MainScreen.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/MainScreen.kt
@@ -61,7 +61,7 @@ fun MainScreen(accountViewModel: AccountViewModel, accountStateViewModel: Accoun
 fun FloatingButton(navController: NavHostController, accountViewModel: AccountStateViewModel) {
     val accountState by accountViewModel.accountContent.collectAsState()
 
-    if (currentRoute(navController) == Route.Home.route) {
+    if (currentRoute(navController)?.substringBefore("?") == Route.Home.base) {
         Crossfade(targetState = accountState, animationSpec = tween(durationMillis = 100)) { state ->
             when (state) {
                 is AccountState.LoggedInViewOnly -> {
@@ -77,7 +77,7 @@ fun FloatingButton(navController: NavHostController, accountViewModel: AccountSt
         }
     }
 
-    if (currentRoute(navController) == Route.Message.route) {
+    if (currentRoute(navController) == Route.Message.base) {
         Crossfade(targetState = accountState, animationSpec = tween(durationMillis = 100)) { state ->
             when (state) {
                 is AccountState.LoggedInViewOnly -> {

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/SearchScreen.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/SearchScreen.kt
@@ -79,7 +79,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.channels.Channel as CoroutineChannel
 
 @Composable
-fun SearchScreen(accountViewModel: AccountViewModel, navController: NavController, forceRefresh: Boolean? = false) {
+fun SearchScreen(accountViewModel: AccountViewModel, navController: NavController, forceRefresh: Boolean = false) {
     val accountState by accountViewModel.accountLiveData.observeAsState()
     val account = accountState?.account ?: return
 

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/SearchScreen.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/SearchScreen.kt
@@ -47,7 +47,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.RoboHashCache
@@ -58,14 +57,13 @@ import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.NostrGlobalDataSource
 import com.vitorpamplona.amethyst.service.NostrSearchEventOrUserDataSource
-import com.vitorpamplona.amethyst.ui.dal.GlobalFeedFilter
 import com.vitorpamplona.amethyst.ui.note.ChannelName
 import com.vitorpamplona.amethyst.ui.note.NoteCompose
 import com.vitorpamplona.amethyst.ui.note.UserCompose
 import com.vitorpamplona.amethyst.ui.note.UserPicture
 import com.vitorpamplona.amethyst.ui.note.UsernameDisplay
 import com.vitorpamplona.amethyst.ui.screen.FeedView
-import com.vitorpamplona.amethyst.ui.screen.NostrGlobalFeedViewModel
+import com.vitorpamplona.amethyst.ui.screen.FeedViewModel
 import com.vitorpamplona.amethyst.ui.screen.ScrollStateKeys
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
@@ -79,12 +77,12 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.channels.Channel as CoroutineChannel
 
 @Composable
-fun SearchScreen(accountViewModel: AccountViewModel, navController: NavController, forceRefresh: Boolean = false) {
-    val accountState by accountViewModel.accountLiveData.observeAsState()
-    val account = accountState?.account ?: return
-
-    GlobalFeedFilter.account = account
-    val feedViewModel: NostrGlobalFeedViewModel = viewModel()
+fun SearchScreen(
+    accountViewModel: AccountViewModel,
+    feedViewModel: FeedViewModel,
+    navController: NavController,
+    scrollToTop: Boolean = false
+) {
     val lifeCycleOwner = LocalLifecycleOwner.current
 
     LaunchedEffect(accountViewModel) {
@@ -115,7 +113,7 @@ fun SearchScreen(accountViewModel: AccountViewModel, navController: NavControlle
             modifier = Modifier.padding(vertical = 0.dp)
         ) {
             SearchBar(accountViewModel, navController)
-            FeedView(feedViewModel, accountViewModel, navController, null, ScrollStateKeys.GLOBAL_SCREEN, forceRefresh)
+            FeedView(feedViewModel, accountViewModel, navController, null, ScrollStateKeys.GLOBAL_SCREEN, scrollToTop)
         }
     }
 }

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/SearchScreen.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/SearchScreen.kt
@@ -66,6 +66,7 @@ import com.vitorpamplona.amethyst.ui.note.UserPicture
 import com.vitorpamplona.amethyst.ui.note.UsernameDisplay
 import com.vitorpamplona.amethyst.ui.screen.FeedView
 import com.vitorpamplona.amethyst.ui.screen.NostrGlobalFeedViewModel
+import com.vitorpamplona.amethyst.ui.screen.ScrollStateKeys
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.collectLatest
@@ -78,7 +79,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.channels.Channel as CoroutineChannel
 
 @Composable
-fun SearchScreen(accountViewModel: AccountViewModel, navController: NavController) {
+fun SearchScreen(accountViewModel: AccountViewModel, navController: NavController, forceRefresh: Boolean? = false) {
     val accountState by accountViewModel.accountLiveData.observeAsState()
     val account = accountState?.account ?: return
 
@@ -114,7 +115,7 @@ fun SearchScreen(accountViewModel: AccountViewModel, navController: NavControlle
             modifier = Modifier.padding(vertical = 0.dp)
         ) {
             SearchBar(accountViewModel, navController)
-            FeedView(feedViewModel, accountViewModel, navController, null, "Global")
+            FeedView(feedViewModel, accountViewModel, navController, null, ScrollStateKeys.GLOBAL_SCREEN, forceRefresh)
         }
     }
 }

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/SearchScreen.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/SearchScreen.kt
@@ -114,7 +114,7 @@ fun SearchScreen(accountViewModel: AccountViewModel, navController: NavControlle
             modifier = Modifier.padding(vertical = 0.dp)
         ) {
             SearchBar(accountViewModel, navController)
-            FeedView(feedViewModel, accountViewModel, navController, null)
+            FeedView(feedViewModel, accountViewModel, navController, null, "Global")
         }
     }
 }


### PR DESCRIPTION
This PR does not persist feed positions across opening/closing the app, just across navigating different screens. Prevents things from jumping around so much. Currently applies only go Global, Home, and Chatrooms, but can apply to anything that uses a LazyListState. We just store a keyed map of index/offset and look them up when loading the lazy list state.

The second 2 commits replace SwipeRefresh (deprecated) with PullRefresh (replacement), just to remove some deprecation warnings and simplify the code a tiny bit. They are not related to keeping the feed position, and you can use the first 2 commits independently if you don't want this change.