### PR TITLE
Replace mlkit with zxing QR scanner

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -133,28 +133,18 @@ dependencies {
 
     // For QR generation
     implementation 'com.google.zxing:core:3.5.1'
-    implementation "androidx.camera:camera-camera2:1.2.1"
-    implementation 'androidx.camera:camera-lifecycle:1.2.1'
-    implementation 'androidx.camera:camera-view:1.2.1'
+    implementation 'com.journeyapps:zxing-android-embedded:4.3.0'
 
     // Markdown
     implementation "com.halilibo.compose-richtext:richtext-ui:0.16.0"
     implementation "com.halilibo.compose-richtext:richtext-ui-material:0.16.0"
     implementation "com.halilibo.compose-richtext:richtext-commonmark:0.16.0"
 
-    // For QR Scanning
-    implementation 'com.google.mlkit:vision-common:17.3.0'
-
-    // Local Barcode Scanning model
-    // The idea is to make it work for degoogled phones
-    implementation 'com.google.mlkit:barcode-scanning:17.0.3'
-
     // Local model for language identification
     implementation 'com.google.mlkit:language-id:17.0.4'
 
     // Google services model the translate text
     implementation 'com.google.mlkit:translate:17.0.1'
-
 
     // Automatic memory leak detection
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.10'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
         android:theme="@style/Theme.Amethyst"
         android:largeHeap="true"
         android:usesCleartextTraffic="true"
+        android:hardwareAccelerated="true"
         tools:targetApi="33">
         <activity
             android:name=".ui.MainActivity"
@@ -45,6 +46,11 @@
                 android:name="android.app.lib_name"
                 android:value="" />
         </activity>
+
+        <activity
+            android:name="com.journeyapps.barcodescanner.CaptureActivity"
+            android:screenOrientation="fullSensor"
+            tools:replace="screenOrientation" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/qrcode/QrCodeDrawer.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/qrcode/QrCodeDrawer.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -34,13 +33,13 @@ fun QrCodeDrawer(contents: String, modifier: Modifier = Modifier) {
         createQrCode(contents = contents)
     }
 
-    val foregroundColor = MaterialTheme.colors.onSurface
+    val foregroundColor = Color.Black
 
     Box(
         modifier = modifier
             .defaultMinSize(48.dp, 48.dp)
             .aspectRatio(1f)
-            .background(MaterialTheme.colors.background)
+            .background(Color.White)
     ) {
         Canvas(modifier = Modifier.fillMaxSize()) {
             // Calculate the height and width of each column/row

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/qrcode/QrCodeDrawer.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/qrcode/QrCodeDrawer.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -33,13 +34,13 @@ fun QrCodeDrawer(contents: String, modifier: Modifier = Modifier) {
         createQrCode(contents = contents)
     }
 
-    val foregroundColor = Color.Black
+    val foregroundColor = MaterialTheme.colors.onSurface
 
     Box(
         modifier = modifier
             .defaultMinSize(48.dp, 48.dp)
             .aspectRatio(1f)
-            .background(Color.White)
+            .background(MaterialTheme.colors.background)
     ) {
         Canvas(modifier = Modifier.fillMaxSize()) {
             // Calculate the height and width of each column/row

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/qrcode/QrCodeScanner.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/qrcode/QrCodeScanner.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
+import com.google.zxing.client.android.Intents
 import com.journeyapps.barcodescanner.ScanContract
 import com.journeyapps.barcodescanner.ScanOptions
 import com.vitorpamplona.amethyst.R
@@ -48,6 +49,7 @@ fun QrCodeScanner(onScan: (String?) -> Unit) {
         setPrompt(stringResource(id = R.string.point_to_the_qr_code))
         setBeepEnabled(false)
         setOrientationLocked(false)
+        addExtra(Intents.Scan.SCAN_TYPE, Intents.Scan.MIXED_SCAN)
     }
 
     DisposableEffect(lifecycleOwner) {

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/qrcode/QrCodeScanner.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/qrcode/QrCodeScanner.kt
@@ -1,156 +1,57 @@
 package com.vitorpamplona.amethyst.ui.qrcode
-import android.Manifest
-import android.content.pm.PackageManager
+
 import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
-import androidx.camera.core.CameraSelector
-import androidx.camera.core.ImageAnalysis
-import androidx.camera.core.ImageProxy
-import androidx.camera.core.Preview
-import androidx.camera.lifecycle.ProcessCameraProvider
-import androidx.camera.view.PreviewView
-import androidx.compose.foundation.layout.Column
-import androidx.compose.runtime.*
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.content.ContextCompat
-import androidx.lifecycle.LifecycleOwner
-import com.google.mlkit.vision.barcode.BarcodeScannerOptions
-import com.google.mlkit.vision.barcode.BarcodeScanning
-import com.google.mlkit.vision.barcode.common.Barcode
-import com.google.mlkit.vision.common.InputImage
+import androidx.compose.ui.res.stringResource
+import com.journeyapps.barcodescanner.ScanContract
+import com.journeyapps.barcodescanner.ScanOptions
+import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.service.nip19.Nip19
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
 
 @Composable
-fun QrCodeScanner(onScan: (String) -> Unit) {
-    val context = LocalContext.current
+fun QrCodeScanner(onScan: (String?) -> Unit) {
     val lifecycleOwner = LocalLifecycleOwner.current
-    val cameraProviderFuture = remember { ProcessCameraProvider.getInstance(context) }
 
-    val cameraExecutor = Executors.newSingleThreadExecutor()
+    val parseQrResult = { it: String ->
+        try {
+            val nip19 = Nip19.uriToRoute(it)
+            val startingPage = when (nip19?.type) {
+                Nip19.Type.USER -> "User/${nip19.hex}"
+                Nip19.Type.NOTE -> "Note/${nip19.hex}"
+                else -> null
+            }
 
-    var hasCameraPermission by remember {
-        mutableStateOf(
-            ContextCompat.checkSelfPermission(
-                context,
-                Manifest.permission.CAMERA
-            ) == PackageManager.PERMISSION_GRANTED
-        )
+            if (startingPage != null) {
+                onScan(startingPage)
+            } else {
+                onScan(null)
+            }
+        } catch (e: Throwable) {
+            // QR can be anything, do not throw errors.
+            onScan(null)
+        }
     }
 
-    val launcher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestPermission(),
-        onResult = { granted ->
-            hasCameraPermission = granted
-        }
-    )
-
-    val analyzer = QRCodeAnalyzer { result ->
-        result?.let {
-            try {
-                val nip19 = Nip19.uriToRoute(it)
-                val startingPage = when (nip19?.type) {
-                    Nip19.Type.USER -> "User/${nip19.hex}"
-                    Nip19.Type.NOTE -> "Note/${nip19.hex}"
-                    else -> null
-                }
-
-                if (startingPage != null) {
-                    onScan(startingPage)
-                }
-            } catch (e: Throwable) {
-                // QR can be anythign. do not throw errors.
+    val qrLauncher =
+        rememberLauncherForActivityResult(ScanContract()) {
+            if (it.contents != null) {
+                parseQrResult(it.contents)
+            } else {
+                onScan(null)
             }
         }
+
+    val scanOptions = ScanOptions().apply {
+        setDesiredBarcodeFormats(ScanOptions.QR_CODE)
+        setPrompt(stringResource(id = R.string.point_to_the_qr_code))
+        setBeepEnabled(false)
+        setOrientationLocked(false)
     }
 
-    DisposableEffect(key1 = true) {
-        launcher.launch(Manifest.permission.CAMERA)
-        onDispose() {
-            cameraProviderFuture.get().unbindAll()
-            cameraExecutor.shutdown()
-        }
-    }
-
-    Column() {
-        if (hasCameraPermission) {
-            AndroidView(
-                factory = { context ->
-                    val previewView = PreviewView(context)
-
-                    cameraProviderFuture.addListener({
-                        val cameraProvider = cameraProviderFuture.get()
-                        bindPreview(analyzer, previewView, cameraExecutor, cameraProvider, lifecycleOwner)
-                    }, ContextCompat.getMainExecutor(context))
-
-                    return@AndroidView previewView
-                },
-                modifier = Modifier.weight(1f)
-            )
-        }
-    }
-}
-
-fun bindPreview(
-    analyzer: ImageAnalysis.Analyzer,
-    previewView: PreviewView,
-    cameraExecutor: ExecutorService,
-    cameraProvider: ProcessCameraProvider,
-    lifecycleOwner: LifecycleOwner
-) {
-    val preview = Preview.Builder().build()
-
-    val selector = CameraSelector.Builder()
-        .requireLensFacing(CameraSelector.LENS_FACING_BACK)
-        .build()
-
-    preview.setSurfaceProvider(previewView.surfaceProvider)
-
-    val imageAnalysis = ImageAnalysis.Builder()
-        .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
-        .build()
-
-    imageAnalysis.setAnalyzer(
-        cameraExecutor,
-        analyzer
-    )
-
-    cameraProvider.bindToLifecycle(
-        lifecycleOwner,
-        selector,
-        imageAnalysis,
-        preview
-    )
-}
-
-class QRCodeAnalyzer(
-    private val onQrCodeScanned: (result: String?) -> Unit
-) : ImageAnalysis.Analyzer {
-
-    private val scanningOptions = BarcodeScannerOptions.Builder().setBarcodeFormats(Barcode.FORMAT_QR_CODE).build()
-
-    fun scanBarcodes(inputImage: InputImage) {
-        BarcodeScanning.getClient(scanningOptions).process(inputImage)
-            .addOnSuccessListener { barcodes ->
-                if (barcodes.isNotEmpty()) {
-                    onQrCodeScanned(barcodes[0].displayValue)
-                }
-            }
-            .addOnFailureListener {
-                it.printStackTrace()
-            }
-    }
-
-    @androidx.annotation.OptIn(androidx.camera.core.ExperimentalGetImage::class)
-    override fun analyze(imageProxy: ImageProxy) {
-        imageProxy.image?.let { image ->
-            val inputImage = InputImage.fromMediaImage(image, imageProxy.imageInfo.rotationDegrees)
-            scanBarcodes(inputImage)
-        }
-        imageProxy.close()
+    DisposableEffect(lifecycleOwner) {
+        qrLauncher.launch(scanOptions)
+        onDispose { }
     }
 }

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/qrcode/ShowQRDialog.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/qrcode/ShowQRDialog.kt
@@ -59,7 +59,9 @@ fun ShowQRDialog(user: User, onScan: (String) -> Unit, onClose: () -> Unit) {
                     .fillMaxSize()
             ) {
                 Row(
-                    modifier = Modifier.fillMaxWidth().padding(10.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(10.dp),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
@@ -67,13 +69,17 @@ fun ShowQRDialog(user: User, onScan: (String) -> Unit, onClose: () -> Unit) {
                 }
 
                 Column(
-                    modifier = Modifier.fillMaxSize().padding(horizontal = 10.dp),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 10.dp),
                     verticalArrangement = Arrangement.SpaceBetween
                 ) {
                     if (presenting) {
                         Row(
                             horizontalArrangement = Arrangement.Center,
-                            modifier = Modifier.fillMaxWidth().padding(horizontal = 30.dp, vertical = 10.dp)
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 30.dp, vertical = 10.dp)
                         ) {
                         }
 
@@ -107,7 +113,9 @@ fun ShowQRDialog(user: User, onScan: (String) -> Unit, onClose: () -> Unit) {
 
                             Row(
                                 horizontalArrangement = Arrangement.Center,
-                                modifier = Modifier.fillMaxWidth().padding(horizontal = 35.dp, vertical = 10.dp)
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 35.dp, vertical = 10.dp)
                             ) {
                                 QrCodeDrawer("nostr:${user.pubkeyNpub()}")
                             }
@@ -115,7 +123,9 @@ fun ShowQRDialog(user: User, onScan: (String) -> Unit, onClose: () -> Unit) {
 
                         Row(
                             horizontalArrangement = Arrangement.Center,
-                            modifier = Modifier.fillMaxWidth().padding(horizontal = 30.dp, vertical = 10.dp)
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 30.dp, vertical = 10.dp)
                         ) {
                             Button(
                                 onClick = { presenting = false },
@@ -132,38 +142,11 @@ fun ShowQRDialog(user: User, onScan: (String) -> Unit, onClose: () -> Unit) {
                             }
                         }
                     } else {
-                        Row(horizontalArrangement = Arrangement.Center, modifier = Modifier.fillMaxWidth()) {
-                            Text(
-                                stringResource(R.string.point_to_the_qr_code),
-                                modifier = Modifier.padding(top = 7.dp),
-                                fontWeight = FontWeight.Bold,
-                                fontSize = 25.sp
-                            )
-                        }
-
-                        Row(
-                            horizontalArrangement = Arrangement.Center,
-                            modifier = Modifier.fillMaxWidth().padding(30.dp)
-                        ) {
-                            QrCodeScanner(onScan)
-                        }
-
-                        Row(
-                            horizontalArrangement = Arrangement.Center,
-                            modifier = Modifier.fillMaxWidth().padding(horizontal = 30.dp, vertical = 10.dp)
-                        ) {
-                            Button(
-                                onClick = { presenting = true },
-                                shape = RoundedCornerShape(35.dp),
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(50.dp),
-                                colors = ButtonDefaults
-                                    .buttonColors(
-                                        backgroundColor = MaterialTheme.colors.primary
-                                    )
-                            ) {
-                                Text(text = stringResource(R.string.show_qr))
+                        QrCodeScanner {
+                            if (it.isNullOrEmpty()) {
+                                presenting = true
+                            } else {
+                                onScan(it)
                             }
                         }
                     }


### PR DESCRIPTION
I wanted to give this as an option for #54. It works fine for me on the few devices I've tested, and the scanner documentation says it supports SDK 24+ by default, so there shouldn't be any problems. True, the interface is not quite as polished as the mlkit version, but for scanning a QR it's probably not a big deal.

This does not completely solve the file size issue. A large part of that is in RoboHash images, which would be fixed with my [svg branch](https://github.com/maxmoney21m/amethyst/tree/215-robohash-identicons) (needs a little work for PR). The other part of it would be doing a split APK for each platform. With this PR, replacing bitmap with svg robohash, and doing a split APK, the file size should go down to under 30 MB.