### PR TITLE
Correct identity claim for mastodon

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/service/model/MetadataEvent.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/model/MetadataEvent.kt
@@ -128,7 +128,7 @@ class MastodonIdentity(
                 if (proofUrl.isBlank()) return null
                 val path = proofUrl.removePrefix("https://").split("?")[0].split("/")
 
-                return MastodonIdentity(path[0], path[1])
+                return MastodonIdentity("${path[0]}/${path[1]}", path[2])
             } catch (e: Exception) {
                 null
             }


### PR DESCRIPTION
This change corrects the identity (`<instance>/@<username>`) and proof (`post ID`) of mastodon to comply with NIP-39.
