### PR TITLE
Simplify the object RoboHashCache

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/RoboHashCache.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/RoboHashCache.kt
@@ -25,7 +25,11 @@ object RoboHashCache {
         if (!this::robots.isInitialized) {
             robots = MyRoboHash(context)
 
-            defaultAvatar = robots.imageForHandle(robots.calculateHandleFromUUID(UUID.nameUUIDFromBytes("aaaa".toByteArray()))).asImageBitmap()
+            defaultAvatar = robots.imageForHandle(
+                robots.calculateHandleFromUUID(
+                    UUID.nameUUIDFromBytes("aaaa".toByteArray())
+                )
+            ).asImageBitmap()
         }
 
         return defaultAvatar

--- a/app/src/main/java/com/vitorpamplona/amethyst/RoboHashCache.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/RoboHashCache.kt
@@ -21,7 +21,7 @@ object RoboHashCache {
     lateinit var defaultAvatar: ImageBitmap
 
     @Synchronized
-    fun get(context: Context, hash: String): ImageBitmap {
+    fun get(context: Context): ImageBitmap {
         if (!this::robots.isInitialized) {
             robots = MyRoboHash(context)
 

--- a/app/src/main/java/com/vitorpamplona/amethyst/RoboHashCache.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/RoboHashCache.kt
@@ -15,10 +15,11 @@ import name.neuhalfen.projects.android.robohash.repository.ImageRepository
 import java.util.UUID
 
 object RoboHashCache {
+    private const val DEFAULT_AVATAR_HASH = "aaaa"
 
-    lateinit var robots: MyRoboHash
+    private lateinit var robots: MyRoboHash
 
-    lateinit var defaultAvatar: ImageBitmap
+    private lateinit var defaultAvatar: ImageBitmap
 
     @Synchronized
     fun get(context: Context): ImageBitmap {
@@ -27,7 +28,7 @@ object RoboHashCache {
 
             defaultAvatar = robots.imageForHandle(
                 robots.calculateHandleFromUUID(
-                    UUID.nameUUIDFromBytes("aaaa".toByteArray())
+                    UUID.nameUUIDFromBytes(DEFAULT_AVATAR_HASH.toByteArray())
                 )
             ).asImageBitmap()
         }

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppTopBar.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppTopBar.kt
@@ -199,9 +199,9 @@ fun MainTopBar(scaffoldState: ScaffoldState, accountViewModel: AccountViewModel)
                 ) {
                     AsyncImageProxy(
                         model = ResizeImage(accountUser.profilePicture(), 34.dp),
-                        placeholder = BitmapPainter(RoboHashCache.get(ctx, accountUser.pubkeyHex)),
-                        fallback = BitmapPainter(RoboHashCache.get(ctx, accountUser.pubkeyHex)),
-                        error = BitmapPainter(RoboHashCache.get(ctx, accountUser.pubkeyHex)),
+                        placeholder = BitmapPainter(RoboHashCache.get(ctx)),
+                        fallback = BitmapPainter(RoboHashCache.get(ctx)),
+                        error = BitmapPainter(RoboHashCache.get(ctx)),
                         contentDescription = stringResource(id = R.string.profile_image),
                         modifier = Modifier
                             .width(34.dp)

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/navigation/DrawerContent.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/navigation/DrawerContent.kt
@@ -138,9 +138,9 @@ fun ProfileContent(baseAccountUser: User, modifier: Modifier = Modifier, scaffol
             AsyncImageProxy(
                 model = ResizeImage(accountUser.profilePicture(), 100.dp),
                 contentDescription = stringResource(id = R.string.profile_image),
-                placeholder = BitmapPainter(RoboHashCache.get(ctx, accountUser.pubkeyHex)),
-                fallback = BitmapPainter(RoboHashCache.get(ctx, accountUser.pubkeyHex)),
-                error = BitmapPainter(RoboHashCache.get(ctx, accountUser.pubkeyHex)),
+                placeholder = BitmapPainter(RoboHashCache.get(ctx)),
+                fallback = BitmapPainter(RoboHashCache.get(ctx)),
+                error = BitmapPainter(RoboHashCache.get(ctx)),
                 modifier = Modifier
                     .width(100.dp)
                     .height(100.dp)

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/note/ChatroomCompose.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/note/ChatroomCompose.kt
@@ -100,10 +100,7 @@ fun ChatroomCompose(
             ChannelName(
                 channelPicture = channel.profilePicture(),
                 channelPicturePlaceholder = BitmapPainter(
-                    RoboHashCache.get(
-                        context,
-                        channel.idHex
-                    )
+                    RoboHashCache.get(context)
                 ),
                 channelTitle = {
                     Text(

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/note/ChatroomMessageCompose.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/note/ChatroomMessageCompose.kt
@@ -197,9 +197,9 @@ fun ChatroomMessageCompose(
                                 ) {
                                     AsyncImageProxy(
                                         model = ResizeImage(author.profilePicture(), 25.dp),
-                                        placeholder = BitmapPainter(RoboHashCache.get(context, author.pubkeyHex)),
-                                        fallback = BitmapPainter(RoboHashCache.get(context, author.pubkeyHex)),
-                                        error = BitmapPainter(RoboHashCache.get(context, author.pubkeyHex)),
+                                        placeholder = BitmapPainter(RoboHashCache.get(context)),
+                                        fallback = BitmapPainter(RoboHashCache.get(context)),
+                                        error = BitmapPainter(RoboHashCache.get(context)),
                                         contentDescription = stringResource(id = R.string.profile_image),
                                         modifier = Modifier
                                             .width(25.dp)
@@ -367,9 +367,9 @@ private fun RelayBadges(baseNote: Note) {
             ) {
                 AsyncImage(
                     model = "https://$url/favicon.ico",
-                    placeholder = BitmapPainter(RoboHashCache.get(ctx, url)),
-                    fallback = BitmapPainter(RoboHashCache.get(ctx, url)),
-                    error = BitmapPainter(RoboHashCache.get(ctx, url)),
+                    placeholder = BitmapPainter(RoboHashCache.get(ctx)),
+                    fallback = BitmapPainter(RoboHashCache.get(ctx)),
+                    error = BitmapPainter(RoboHashCache.get(ctx)),
                     contentDescription = stringResource(id = R.string.relay_icon),
                     colorFilter = ColorFilter.colorMatrix(ColorMatrix().apply { setToSaturation(0f) }),
                     modifier = Modifier

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteCompose.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteCompose.kt
@@ -219,9 +219,9 @@ fun NoteCompose(
                                     ) {
                                         AsyncImageProxy(
                                             model = ResizeImage(channel.profilePicture(), 30.dp),
-                                            placeholder = BitmapPainter(RoboHashCache.get(context, channel.idHex)),
-                                            fallback = BitmapPainter(RoboHashCache.get(context, channel.idHex)),
-                                            error = BitmapPainter(RoboHashCache.get(context, channel.idHex)),
+                                            placeholder = BitmapPainter(RoboHashCache.get(context)),
+                                            fallback = BitmapPainter(RoboHashCache.get(context)),
+                                            error = BitmapPainter(RoboHashCache.get(context)),
                                             contentDescription = stringResource(R.string.group_picture),
                                             modifier = Modifier
                                                 .width(30.dp)
@@ -604,9 +604,9 @@ private fun RelayBadges(baseNote: Note) {
             ) {
                 AsyncImage(
                     model = "https://$url/favicon.ico",
-                    placeholder = BitmapPainter(RoboHashCache.get(ctx, url)),
-                    fallback = BitmapPainter(RoboHashCache.get(ctx, url)),
-                    error = BitmapPainter(RoboHashCache.get(ctx, url)),
+                    placeholder = BitmapPainter(RoboHashCache.get(ctx)),
+                    fallback = BitmapPainter(RoboHashCache.get(ctx)),
+                    error = BitmapPainter(RoboHashCache.get(ctx)),
                     contentDescription = stringResource(R.string.relay_icon),
                     colorFilter = ColorFilter.colorMatrix(ColorMatrix().apply { setToSaturation(0f) }),
                     modifier = Modifier
@@ -677,7 +677,7 @@ fun NoteAuthorPicture(
     ) {
         if (author == null) {
             Image(
-                painter = BitmapPainter(RoboHashCache.get(ctx, "ohnothisauthorisnotfound")),
+                painter = BitmapPainter(RoboHashCache.get(ctx)),
                 contentDescription = stringResource(R.string.unknown_author),
                 modifier = pictureModifier
                     .fillMaxSize(1f)
@@ -726,9 +726,9 @@ fun UserPicture(
         AsyncImageProxy(
             model = ResizeImage(user.profilePicture(), size),
             contentDescription = stringResource(id = R.string.profile_image),
-            placeholder = BitmapPainter(RoboHashCache.get(ctx, user.pubkeyHex)),
-            fallback = BitmapPainter(RoboHashCache.get(ctx, user.pubkeyHex)),
-            error = BitmapPainter(RoboHashCache.get(ctx, user.pubkeyHex)),
+            placeholder = BitmapPainter(RoboHashCache.get(ctx)),
+            fallback = BitmapPainter(RoboHashCache.get(ctx)),
+            error = BitmapPainter(RoboHashCache.get(ctx)),
             modifier = pictureModifier
                 .fillMaxSize(1f)
                 .clip(shape = CircleShape)

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/qrcode/ShowQRDialog.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/qrcode/ShowQRDialog.kt
@@ -81,9 +81,9 @@ fun ShowQRDialog(user: User, onScan: (String) -> Unit, onClose: () -> Unit) {
                             Row(horizontalArrangement = Arrangement.Center, modifier = Modifier.fillMaxWidth()) {
                                 AsyncImageProxy(
                                     model = ResizeImage(user.profilePicture(), 100.dp),
-                                    placeholder = BitmapPainter(RoboHashCache.get(ctx, user.pubkeyHex)),
-                                    fallback = BitmapPainter(RoboHashCache.get(ctx, user.pubkeyHex)),
-                                    error = BitmapPainter(RoboHashCache.get(ctx, user.pubkeyHex)),
+                                    placeholder = BitmapPainter(RoboHashCache.get(ctx)),
+                                    fallback = BitmapPainter(RoboHashCache.get(ctx)),
+                                    error = BitmapPainter(RoboHashCache.get(ctx)),
                                     contentDescription = stringResource(R.string.profile_image),
                                     modifier = Modifier
                                         .width(100.dp)

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/ChannelScreen.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/ChannelScreen.kt
@@ -225,9 +225,9 @@ fun ChannelHeader(baseChannel: Channel, account: Account, navController: NavCont
             Row(verticalAlignment = Alignment.CenterVertically) {
                 AsyncImageProxy(
                     model = ResizeImage(channel.profilePicture(), 35.dp),
-                    placeholder = BitmapPainter(RoboHashCache.get(context, channel.idHex)),
-                    fallback = BitmapPainter(RoboHashCache.get(context, channel.idHex)),
-                    error = BitmapPainter(RoboHashCache.get(context, channel.idHex)),
+                    placeholder = BitmapPainter(RoboHashCache.get(context)),
+                    fallback = BitmapPainter(RoboHashCache.get(context)),
+                    error = BitmapPainter(RoboHashCache.get(context)),
                     contentDescription = context.getString(R.string.profile_image),
                     modifier = Modifier
                         .width(35.dp)

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/ChatroomScreen.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/ChatroomScreen.kt
@@ -215,9 +215,9 @@ fun ChatroomHeader(baseUser: User, accountViewModel: AccountViewModel, navContro
 
                 AsyncImageProxy(
                     model = ResizeImage(author.profilePicture(), 35.dp),
-                    placeholder = BitmapPainter(RoboHashCache.get(ctx, author.pubkeyHex)),
-                    fallback = BitmapPainter(RoboHashCache.get(ctx, author.pubkeyHex)),
-                    error = BitmapPainter(RoboHashCache.get(ctx, author.pubkeyHex)),
+                    placeholder = BitmapPainter(RoboHashCache.get(ctx)),
+                    fallback = BitmapPainter(RoboHashCache.get(ctx)),
+                    error = BitmapPainter(RoboHashCache.get(ctx)),
                     contentDescription = stringResource(id = R.string.profile_image),
                     modifier = Modifier
                         .width(35.dp)

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/ProfileScreen.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/ProfileScreen.kt
@@ -581,7 +581,7 @@ fun BadgeThumb(
     ) {
         if (image == null) {
             Image(
-                painter = BitmapPainter(RoboHashCache.get(ctx, "ohnothisauthorisnotfound")),
+                painter = BitmapPainter(RoboHashCache.get(ctx)),
                 contentDescription = stringResource(R.string.unknown_author),
                 modifier = pictureModifier
                     .fillMaxSize(1f)
@@ -591,9 +591,9 @@ fun BadgeThumb(
             AsyncImage(
                 model = image,
                 contentDescription = stringResource(id = R.string.profile_image),
-                placeholder = BitmapPainter(RoboHashCache.get(ctx, note.idHex)),
-                fallback = BitmapPainter(RoboHashCache.get(ctx, note.idHex)),
-                error = BitmapPainter(RoboHashCache.get(ctx, note.idHex)),
+                placeholder = BitmapPainter(RoboHashCache.get(ctx)),
+                fallback = BitmapPainter(RoboHashCache.get(ctx)),
+                error = BitmapPainter(RoboHashCache.get(ctx)),
                 modifier = pictureModifier
                     .fillMaxSize(1f)
                     .clip(shape = CircleShape)

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/SearchScreen.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/SearchScreen.kt
@@ -247,7 +247,7 @@ private fun SearchBar(accountViewModel: AccountViewModel, navController: NavCont
             itemsIndexed(searchResultsChannels.value, key = { _, item -> "c" + item.idHex }) { index, item ->
                 ChannelName(
                     channelPicture = item.profilePicture(),
-                    channelPicturePlaceholder = BitmapPainter(RoboHashCache.get(ctx, item.idHex)),
+                    channelPicturePlaceholder = BitmapPainter(RoboHashCache.get(ctx)),
                     channelTitle = {
                         Text(
                             "${item.info.name}",


### PR DESCRIPTION
## 📚 Description

The 2nd parameter `hash: String` from `RoboHashCache.get()` wasn't used at all. For this reason, I thought about removing it to simplify the code without changing the original behaviour.