### PR TITLE
Add user-agent header to OkHttpClient requests

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/service/Nip05Verifier.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/Nip05Verifier.kt
@@ -42,7 +42,10 @@ class Nip05Verifier {
 
         withContext(Dispatchers.IO) {
             try {
-                val request: Request = Request.Builder().url(url).build()
+                val request = Request.Builder()
+                    .header("User-Agent", "Amethyst")
+                    .url(url)
+                    .build()
 
                 client.newCall(request).enqueue(object : Callback {
                     override fun onResponse(call: Call, response: Response) {

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/lnurl/LightningAddressResolver.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/lnurl/LightningAddressResolver.kt
@@ -51,7 +51,10 @@ class LightningAddressResolver {
         }
 
         withContext(Dispatchers.IO) {
-            val request: Request = Request.Builder().url(url).build()
+            val request: Request = Request.Builder()
+                .header("User-Agent", "Amethyst")
+                .url(url)
+                .build()
 
             client.newCall(request).enqueue(object : Callback {
                 override fun onResponse(call: Call, response: Response) {
@@ -91,7 +94,10 @@ class LightningAddressResolver {
                 url += "&nostr=$encodedNostrRequest"
             }
 
-            val request: Request = Request.Builder().url(url).build()
+            val request: Request = Request.Builder()
+                .header("User-Agent", "Amethyst")
+                .url(url)
+                .build()
 
             client.newCall(request).enqueue(object : Callback {
                 override fun onResponse(call: Call, response: Response) {

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/relays/Relay.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/relays/Relay.kt
@@ -55,7 +55,10 @@ class Relay(
         if (socket != null) return
 
         try {
-            val request = Request.Builder().url(url.trim()).build()
+            val request = Request.Builder()
+                .header("User-Agent", "Amethyst")
+                .url(url.trim())
+                .build()
             val listener = object : WebSocketListener() {
 
                 override fun onOpen(webSocket: WebSocket, response: Response) {

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/actions/ImageSaver.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/actions/ImageSaver.kt
@@ -31,6 +31,7 @@ object ImageSaver {
         val client = OkHttpClient.Builder().build()
 
         val request = Request.Builder()
+            .header("User-Agent", "Amethyst")
             .get()
             .url(url)
             .build()

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/actions/ImageUploader.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/actions/ImageUploader.kt
@@ -43,8 +43,9 @@ object ImageUploader {
             .build()
 
         val request: Request = Request.Builder()
-            .url("https://api.imgur.com/3/image")
             .header("Authorization", "Client-ID e6aea87296f3f96")
+            .header("User-Agent", "Amethyst")
+            .url("https://api.imgur.com/3/image")
             .post(requestBody)
             .build()
 


### PR DESCRIPTION
I added `Amethyst` but you could change it to whatever string you want, really.

Some web servers (like apache) need this header or they give a 403. This fixes #259, which is actually not the first time I saw this problem, so I got suspicious when the reporter said he had set the CORS headers properly. Confirmed with logging interceptor to be a result of missing UA header.