### PR TITLE
Fix AppTopBar background color

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppTopBar.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppTopBar.kt
@@ -99,6 +99,7 @@ fun MainTopBar(scaffoldState: ScaffoldState, accountViewModel: AccountViewModel)
     Column() {
         TopAppBar(
             elevation = 0.dp,
+            backgroundColor = MaterialTheme.colors.surface,
             title = {
                 Column(
                     modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
Accidentally removed in previous PR. (I thought the default was `surface`, but its `primarySurface` which was some purple color in light mode.)