### PR TITLE
Bugfix: Reset feedfilter accounts when switching accounts

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/HomeScreen.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/HomeScreen.kt
@@ -25,6 +25,8 @@ import com.google.accompanist.pager.PagerState
 import com.google.accompanist.pager.pagerTabIndicatorOffset
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.service.NostrHomeDataSource
+import com.vitorpamplona.amethyst.ui.dal.HomeConversationsFeedFilter
+import com.vitorpamplona.amethyst.ui.dal.HomeNewThreadFeedFilter
 import com.vitorpamplona.amethyst.ui.navigation.Route
 import com.vitorpamplona.amethyst.ui.screen.FeedView
 import com.vitorpamplona.amethyst.ui.screen.NostrHomeFeedViewModel
@@ -43,10 +45,12 @@ fun HomeScreen(
     scrollToTop: Boolean = false
 ) {
     val coroutineScope = rememberCoroutineScope()
+    val account = accountViewModel.accountLiveData.value?.account ?: return
 
     LaunchedEffect(accountViewModel) {
+        HomeNewThreadFeedFilter.account = account
+        HomeConversationsFeedFilter.account = account
         NostrHomeDataSource.resetFilters()
-
         homeFeedViewModel.refresh()
         repliesFeedViewModel.refresh()
     }

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/SearchScreen.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/SearchScreen.kt
@@ -54,6 +54,7 @@ import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.NostrGlobalDataSource
 import com.vitorpamplona.amethyst.service.NostrSearchEventOrUserDataSource
+import com.vitorpamplona.amethyst.ui.dal.GlobalFeedFilter
 import com.vitorpamplona.amethyst.ui.note.ChannelName
 import com.vitorpamplona.amethyst.ui.note.NoteCompose
 import com.vitorpamplona.amethyst.ui.note.UserCompose
@@ -81,8 +82,11 @@ fun SearchScreen(
     scrollToTop: Boolean = false
 ) {
     val lifeCycleOwner = LocalLifecycleOwner.current
+    val account = accountViewModel.accountLiveData.value?.account ?: return
 
     LaunchedEffect(accountViewModel) {
+        GlobalFeedFilter.account = account
+        NostrGlobalDataSource.resetFilters()
         feedViewModel.refresh()
     }
 


### PR DESCRIPTION
In 0.25.0 there is an issue of notes from Account 1 follows list showing in the Conversations tab after switching to Account 2. Resetting the FeedFilter accounts when the accountViewModel changes fixes this.