### PR TITLE
Update strings.xml

### DIFF
--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -161,7 +161,7 @@
     <string name="to">naar</string>
     <string name="show_in">Laten zien in</string>
     <string name="first">eerste</string>
-    <string name="always_translate_to">Altijd vertalen naar</string>
+    <string name="always_translate_to">Altijd vertalen naar </string>
     <string name="nip_05" translatable="false">NIP-05</string>
     <string name="lnurl" translatable="false">LNURL...</string>
     <string name="never">nooit</string>


### PR DESCRIPTION
A small addition I don't know how to properly correct in the file wrt the translation of the 'auto-translation pop-up'. 
Referring specifically to line 162 and 163, "Laten zien in" and "eerste".

In English: "Show in [language] first" = grammatically ok
In Dutch: "Laten zien in [language] eerste" = grammatically wrong  **--> should be "Eerst laten zien in [language]"**