### PR TITLE
Do not show notes with the creation time exceeding the current time

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/dal/GlobalFeedFilter.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/dal/GlobalFeedFilter.kt
@@ -27,6 +27,10 @@ object GlobalFeedFilter : FeedFilter<Note>() {
                     (it.author?.pubkeyHex !in followUsers)
             }
             .filter { account.isAcceptable(it) }
+            .filter {
+                // Do not show notes with the creation time exceeding the current time, as they will always stay at the top of the global feed, which is cheating.
+                it.createdAt()!! <= System.currentTimeMillis() / 1000
+            }
             .toList()
 
         val longFormNotes = LocalCache.addressables.values
@@ -41,6 +45,10 @@ object GlobalFeedFilter : FeedFilter<Note>() {
                     (it.author?.pubkeyHex !in followUsers)
             }
             .filter { account.isAcceptable(it) }
+            .filter {
+                // Do not show notes with the creation time exceeding the current time, as they will always stay at the top of the global feed, which is cheating.
+                it.createdAt()!! <= System.currentTimeMillis() / 1000
+            }
             .toList()
 
         return (notes + longFormNotes)

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -5,7 +5,7 @@
     <string name="scan_qr">扫描二维码</string>
     <string name="show_anyway">一直显示</string>
     <string name="post_was_flagged_as_inappropriate_by">帖文被标记为不当</string>
-    <string name="post_not_found">未找到帖子</string>
+    <string name="post_not_found">未找到帖文</string>
     <string name="channel_image">频道图片</string>
     <string name="referenced_event_not_found">未找到相关事件</string>
     <string name="could_not_decrypt_the_message">无法解密消息</string>
@@ -21,7 +21,10 @@
     <string name="copy_user_pubkey">复制作者@npub</string>
     <string name="copy_note_id">复制笔记ID</string>
     <string name="broadcast">广播</string>
-    <string name="block_hide_user"><![CDATA[阻止并隐藏用户]]></string>
+    <string name="request_deletion">请求删除</string>
+    <string name="block_hide_user">
+		<![CDATA[阻止并隐藏用户]]>
+	</string>
     <string name="report_spam_scam">举报垃圾邮件/诈骗</string>
     <string name="report_impersonation">举报冒充</string>
     <string name="report_explicit_content">举报明确内容</string>
@@ -46,12 +49,12 @@
     <string name="followers">" 粉丝"</string>
     <string name="profile">个人档案</string>
     <string name="security_filters">安全过滤器</string>
-    <string name="log_out">登出</string>
+    <string name="log_out">退出</string>
     <string name="show_more">显示更多</string>
-    <string name="lightning_invoice">闪电网络发票</string>
+    <string name="lightning_invoice">闪电发票</string>
     <string name="pay">付款</string>
     <string name="lightning_tips">闪电小费</string>
-    <string name="note_to_receiver">聪给收款方的留言</string>
+    <string name="note_to_receiver">给收款方的留言</string>
     <string name="thank_you_so_much">非常感谢！</string>
     <string name="amount_in_sats">聪数量</string>
     <string name="send_sats">发送聪</string>
@@ -71,6 +74,7 @@
     <string name="failed_to_upload_the_image">上传图片失败</string>
     <string name="relay_address">中继器地址</string>
     <string name="posts">帖文</string>
+    <string name="bytes">字节</string>
     <string name="errors">错误</string>
     <string name="home_feed">主页</string>
     <string name="private_message_feed">私信</string>
@@ -93,10 +97,10 @@
     <string name="upload_image">上传图片</string>
     <string name="uploading">上传中…</string>
     <string name="user_does_not_have_a_lightning_address_setup_to_receive_sats">用户尚未设置闪电地址以接收聪</string>
-    <string name="reply_here">"回复这里.. "</string>
+    <string name="reply_here">"🔏这里回复.. "</string>
     <string name="copies_the_note_id_to_the_clipboard_for_sharing">复制笔记ID到剪贴板，供分享</string>
     <string name="copy_channel_id_note_to_the_clipboard">复制频道ID（笔记）到剪贴板</string>
-    <string name="edits_the_channel_metadata">编辑频道元数据</string>
+    <string name="edits_the_channel_metadata">修改频道元数据</string>
     <string name="join">加入</string>
     <string name="known">私聊</string>
     <string name="new_requests">新请求</string>
@@ -121,9 +125,9 @@
     <string name="unblock">不隐藏</string>
     <string name="copy_user_id">复制用户ID</string>
     <string name="unblock_user">隐藏该用户</string>
-    <string name="npub_hex_username">npub，hex，用户名 </string>
+    <string name="npub_hex_username">npub，hex，用户名</string>
     <string name="clear">清除</string>
-    <string name="app_logo">应用标志</string>
+    <string name="app_logo">应用图标</string>
     <string name="nsec_npub_hex_private_key">nsec/ npub/ hex 私钥</string>
     <string name="show_password">显示密码</string>
     <string name="hide_password">隐藏密码</string>
@@ -160,10 +164,10 @@
     <string name="translations_never_translate_from_lang">不再翻译 %1$s</string>
     <string name="never">从不</string>
     <string name="now">现在</string>
-    <string name="h">小时</string>
+    <string name="h">时</string>
     <string name="m">分</string>
     <string name="d">天</string>
-    <string name="nudity">裸体</string>
+    <string name="nudity">裸露</string>
     <string name="profanity_hateful_speech">不文雅的言辞 / 敌意言论</string>
     <string name="report_hateful_speech">举报敌意言论</string>
     <string name="report_nudity_porn">举报裸体 / 情色内容</string>
@@ -171,13 +175,12 @@
     <string name="mark_all_known_as_read">将所有已知内容标记为已读</string>
     <string name="mark_all_new_as_read">将所有新内容标记为已读</string>
     <string name="mark_all_as_read">将所有内容标记为已读</string>
-    <string name="account_backup_tips_md" tools:ignore="Typos">
-        ## 备份与安全提示
+    <string name="backup_keys">备份密匙</string>
+    <string name="account_backup_tips_md" tools:ignore="Typos">## 备份与安全提示
         \n\n您的帐户由一个私人密钥保护。 密钥是以**nsec1**开头的长随机字符串。任何拥有您的私人密钥的人都可以使用您的身份发布内容。
         \n\n- **不要**将您的私人密钥添加到您不信任的任何网站或软件，亦不要在网上公开。
         \n- Amethyst 开发人员**永远不会**要求您提供私人密钥。
-        \n- **请**保留您的私人密钥的安全备份，以备帐户恢复。 我们建议使用密码管理器。
-    </string>
+        \n- **请**保留您的私人密钥的安全备份，以备帐户恢复。 我们建议使用密码管理器。</string>
     <string name="secret_key_copied_to_clipboard">私人密钥（nsec）已复制到剪贴板</string>
     <string name="copy_my_secret_key">复制我的私人密钥</string>
     <string name="biometric_authentication_failed">身份验证失败</string>
@@ -190,6 +193,15 @@
     <string name="copied_user_id_to_clipboard" tools:ignore="Typos">复制作者的 @npub 到剪贴板</string>
     <string name="copied_note_id_to_clipboard" tools:ignore="Typos">复制文章ID (@note1) 到剪贴板</string>
     <string name="select_text_dialog_top">选择文本</string>
+    <string name="private_conversation_notification">"&lt;无法解密私人消息&gt;\n\n您被%1$s和%2$s之间的私人/加密会话引用。"</string>
+    <string name="account_switch_add_account_dialog_title">添加新账户</string>
+    <string name="drawer_accounts">账户</string>
+    <string name="account_switch_select_account">选择账户</string>
+    <string name="account_switch_add_account_btn">添加新账户</string>
+    <string name="account_switch_active_account">活跃账户</string>
+    <string name="account_switch_has_private_key">具有私钥</string>
+    <string name="account_switch_pubkey_only">只读，无私钥</string>
+    <string name="back">返回</string>
     <string name="quick_action_select">选择</string>
     <string name="quick_action_share_browser_link">分享浏览网址</string>
     <string name="quick_action_share">分享</string>
@@ -201,4 +213,41 @@
     <string name="quick_action_follow">关注</string>
     <string name="quick_action_request_deletion_alert_title">请求删贴</string>
     <string name="quick_action_request_deletion_alert_body">Amethyst 将请求您的记录从当前连接的中继器中删除。不能保证您发布的笔记将被永久从那些中继器或其他存储笔记的中继器中删除。</string>
+    <string name="quick_action_block_dialog_btn">阻止</string>
+    <string name="quick_action_delete_dialog_btn">删除</string>
+    <string name="quick_action_block">隐藏</string>
+    <string name="quick_action_report">举报</string>
+    <string name="quick_action_delete_button">删除</string>
+    <string name="quick_action_dont_show_again_button">不再次显示</string>
+    <string name="report_dialog_spam">垃圾信息或诈骗</string>
+    <string name="report_dialog_profanity">不文明用语或仇恨行为</string>
+    <string name="report_dialog_impersonation">恶意冒充</string>
+    <string name="report_dialog_nudity">暴露裸露或恶心内容</string>
+    <string name="report_dialog_illegal">违规行为</string>
+    <string name="report_dialog_blocking_a_user">阻止一位用户将会隐藏他/她的内容在您的应用中。您的记录仍然是公开可见的，包括被您阻止的用户。阻止的用户将会列在安全过滤器屏幕上。</string>
+    <string name="report_dialog_block_hide_user_btn">
+		<![CDATA[阻止并隐藏用户]]>
+	</string>
+    <string name="report_dialog_report_btn">违规报告</string>
+    <string name="report_dialog_reminder_public">所有举报都将被公开可见</string>
+    <string name="report_dialog_additional_reason_placeholder">可选择提供关于您的举报的额外背景...</string>
+    <string name="report_dialog_additional_reason_label">其他背景</string>
+    <string name="report_dialog_select_reason_label">理由</string>
+    <string name="report_dialog_select_reason_placeholder">选择一个理由...</string>
+    <string name="report_dialog_post_report_btn">发布举报</string>
+    <string name="report_dialog_title">阻止与举报</string>
+    <string name="block_only">仅阻止</string>
+    <string name="bookmarks">书签</string>
+    <string name="private_bookmarks">私人书签</string>
+    <string name="public_bookmarks">公开书签</string>
+    <string name="add_to_private_bookmarks">添加到私人书签</string>
+    <string name="add_to_public_bookmarks">添加到公开书签</string>
+    <string name="remove_from_private_bookmarks">从私人书签中移除</string>
+    <string name="remove_from_public_bookmarks">从公开书签中移除</string>
+    <string name="wallet_connect_service">钱包绑定服务</string>
+    <string name="wallet_connect_service_explainer">使用您的私钥在不离开应用程序的情况下支付 zaps。 任何具有访问 Nostr 私钥的人都可以使用您的钱包余额。要保留您的资金避免损失，如果可能，请使用私人中继器。中继器操作员可以看到您的付款元数据。</string>
+    <string name="wallet_connect_service_pubkey">钱包绑定公钥</string>
+    <string name="wallet_connect_service_relay">钱包绑定中继</string>
+    <string name="pledge_amount_in_sats">聪数量</string>
+    <string name="looking_for_event">“正在查找事件%1$s”</string>
 </resources>


### PR DESCRIPTION
Do not show notes with the creation time exceeding the current time, as they will always stay at the top of the global feed, which is cheating.