### PR TITLE
Fixed long usernames in profile

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/ProfileScreen.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/ProfileScreen.kt
@@ -430,12 +430,13 @@ private fun DrawAdditionalInfo(baseUser: User, account: Account, accountViewMode
                 fontSize = 25.sp
             )
         }
-
+    }
+    Row(verticalAlignment = Alignment.CenterVertically) {
         user.bestUsername()?.let {
             Text(
                 "@$it",
                 color = MaterialTheme.colors.onSurface.copy(alpha = 0.32f),
-                modifier = Modifier.padding(top = 1.dp, bottom = 1.dp, start = 5.dp)
+                modifier = Modifier.padding(top = 1.dp, bottom = 1.dp)
             )
         }
     }


### PR DESCRIPTION
Fixed usernames being displayed weird in profile when name is long

Previous:
![image](https://user-images.githubusercontent.com/1097224/228480955-1a551e64-f0c5-4267-be22-75f3693e74e9.png)
Now:
![Screenshot 2023-03-29 at 10 53 44](https://user-images.githubusercontent.com/1097224/228481164-20e074fa-8c48-4f1d-8713-c5dcdefc1070.png)
