### PR TITLE
introduce zap types, implemented non-zaps in custom zap dialog

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/service/model/LnZapEvent.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/model/LnZapEvent.kt
@@ -69,4 +69,11 @@ class LnZapEvent(
     companion object {
         const val kind = 9735
     }
+
+    enum class ZapType() {
+        PUBLIC,
+        PRIVATE, // not implemented
+        ANONYMOUS, // not implemented
+        NONZAP
+    }
 }

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/note/PollNote.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/note/PollNote.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.window.Popup
 import androidx.navigation.NavController
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.Note
+import com.vitorpamplona.amethyst.service.model.LnZapEvent
 import com.vitorpamplona.amethyst.ui.components.TranslatableRichTextViewer
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.theme.BitcoinOrange
@@ -251,7 +252,8 @@ fun ZapVote(
                                 scope.launch(Dispatchers.Main) {
                                     zappingProgress = it
                                 }
-                            }
+                            },
+                            type = LnZapEvent.ZapType.PUBLIC
                         )
                     }
                 } else {
@@ -378,7 +380,8 @@ fun FilteredZapAmountChoicePopup(
                                 zapMessage,
                                 context,
                                 onError,
-                                onProgress
+                                onProgress,
+                                LnZapEvent.ZapType.PUBLIC
                             )
                             onDismiss()
                         }
@@ -403,7 +406,8 @@ fun FilteredZapAmountChoicePopup(
                                         zapMessage,
                                         context,
                                         onError,
-                                        onProgress
+                                        onProgress,
+                                        LnZapEvent.ZapType.PUBLIC
                                     )
                                     onDismiss()
                                 }
@@ -495,7 +499,8 @@ fun ZapVoteAmountChoicePopup(
                                 "",
                                 context,
                                 onError,
-                                onProgress
+                                onProgress,
+                                LnZapEvent.ZapType.PUBLIC
                             )
                             onDismiss()
                         }
@@ -520,7 +525,8 @@ fun ZapVoteAmountChoicePopup(
                                         "",
                                         context,
                                         onError,
-                                        onProgress
+                                        onProgress,
+                                        LnZapEvent.ZapType.PUBLIC
                                     )
                                     onDismiss()
                                 }

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
@@ -55,6 +55,7 @@ import coil.request.CachePolicy
 import coil.request.ImageRequest
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.Note
+import com.vitorpamplona.amethyst.service.model.LnZapEvent
 import com.vitorpamplona.amethyst.ui.actions.NewPostView
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.theme.BitcoinOrange
@@ -363,7 +364,8 @@ fun ZapReaction(
                                     scope.launch(Dispatchers.Main) {
                                         zappingProgress = it
                                     }
-                                }
+                                },
+                                type = LnZapEvent.ZapType.PUBLIC
                             )
                         }
                     } else if (account.zapAmountChoices.size > 1) {
@@ -559,7 +561,8 @@ fun ZapAmountChoicePopup(
                                 zapMessage,
                                 context,
                                 onError,
-                                onProgress
+                                onProgress,
+                                LnZapEvent.ZapType.PUBLIC
                             )
                             onDismiss()
                         }
@@ -584,7 +587,8 @@ fun ZapAmountChoicePopup(
                                         zapMessage,
                                         context,
                                         onError,
-                                        onProgress
+                                        onProgress,
+                                        LnZapEvent.ZapType.PUBLIC
                                     )
                                     onDismiss()
                                 }

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapCustomDialog.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapCustomDialog.kt
@@ -5,12 +5,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -27,15 +22,16 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.Note
+import com.vitorpamplona.amethyst.service.model.LnZapEvent
 import com.vitorpamplona.amethyst.ui.actions.CloseButton
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.TextSpinner
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class ZapOptionstViewModel : ViewModel() {
     private var account: Account? = null
-
-    var customAmount by mutableStateOf(TextFieldValue("1000"))
+    var customAmount by mutableStateOf(TextFieldValue("21"))
     var customMessage by mutableStateOf(TextFieldValue(""))
 
     fun load(account: Account) {
@@ -63,10 +59,20 @@ fun ZapCustomDialog(onClose: () -> Unit, account: Account, accountViewModel: Acc
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val postViewModel: ZapOptionstViewModel = viewModel()
-
+    postViewModel.load(account)
     LaunchedEffect(account) {
         postViewModel.load(account)
     }
+
+    var zappingProgress by remember { mutableStateOf(0f) }
+
+    val zapTypes = listOf(
+        Pair(LnZapEvent.ZapType.PUBLIC, "Public"),
+        Pair(LnZapEvent.ZapType.NONZAP, "Non-Zap")
+    )
+
+    val zapOptions = zapTypes.map { it.second }
+    var selectedZapType by remember { mutableStateOf(zapTypes[0]) }
 
     Dialog(
         onDismissRequest = { onClose() },
@@ -98,6 +104,7 @@ fun ZapCustomDialog(onClose: () -> Unit, account: Account, accountViewModel: Acc
                                 postViewModel.customMessage.text,
                                 context,
                                 onError = {
+                                    zappingProgress = 0f
                                     scope.launch {
                                         Toast
                                             .makeText(context, it, Toast.LENGTH_SHORT).show()
@@ -105,8 +112,10 @@ fun ZapCustomDialog(onClose: () -> Unit, account: Account, accountViewModel: Acc
                                 },
                                 onProgress = {
                                     scope.launch(Dispatchers.Main) {
+                                        zappingProgress = it
                                     }
-                                }
+                                },
+                                type = selectedZapType.first
                             )
                         }
                         onClose()
@@ -174,6 +183,15 @@ fun ZapCustomDialog(onClose: () -> Unit, account: Account, accountViewModel: Acc
                             .weight(1f)
                     )
                 }
+                TextSpinner(
+                    label = "Zap Type",
+                    placeholder = "Public",
+                    options = zapOptions,
+                    onSelect = {
+                        selectedZapType = zapTypes[it]
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                )
             }
         }
     }

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -14,6 +14,7 @@ import com.vitorpamplona.amethyst.model.AccountState
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.lnurl.LightningAddressResolver
+import com.vitorpamplona.amethyst.service.model.LnZapEvent
 import com.vitorpamplona.amethyst.service.model.ReportEvent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -52,7 +53,7 @@ class AccountViewModel(private val account: Account) : ViewModel() {
         account.delete(account.boostsTo(note))
     }
 
-    fun zap(note: Note, amount: Long, pollOption: Int?, message: String, context: Context, onError: (String) -> Unit, onProgress: (percent: Float) -> Unit) {
+    fun zap(note: Note, amount: Long, pollOption: Int?, message: String, context: Context, onError: (String) -> Unit, onProgress: (percent: Float) -> Unit, type: LnZapEvent.ZapType) {
         val lud16 = note.author?.info?.lud16?.trim() ?: note.author?.info?.lud06?.trim()
 
         if (lud16.isNullOrBlank()) {
@@ -60,7 +61,12 @@ class AccountViewModel(private val account: Account) : ViewModel() {
             return
         }
 
-        val zapRequest = account.createZapRequestFor(note, pollOption, message)
+        var zapRequest = account.createZapRequestFor(note, pollOption, message)
+        var zapRequestJson = zapRequest?.toJson()
+
+        if (type == LnZapEvent.ZapType.NONZAP) {
+            zapRequestJson = ""
+        }
 
         onProgress(0.10f)
 
@@ -68,7 +74,7 @@ class AccountViewModel(private val account: Account) : ViewModel() {
             lud16,
             amount,
             message,
-            zapRequest?.toJson(),
+            zapRequestJson,
             onSuccess = {
                 onProgress(0.7f)
                 if (account.hasWalletConnectSetup()) {


### PR DESCRIPTION
Zaptype is Public by default both in ReactionsRow and CustomZapDialog.

Custom Zap Dialog offers additional Options Public and Non-Zap.
Non-Zaps allow to tip the author of a note without using the zap mechanism (no record on the note, no notification)

Besides these two, additional Zap types supported in other Clients are Private and Anonymous. (Todo)