### PR TITLE
fix bug in nip47 scheme check

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/service/Nip47.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/Nip47.kt
@@ -14,7 +14,7 @@ object Nip47 {
 
         val url = Uri.parse(uri)
 
-        if (url.scheme != "nostrwalletconnect" || url.scheme != "nostr+walletconnect") {
+        if (url.scheme != "nostrwalletconnect" && url.scheme != "nostr+walletconnect") {
             throw IllegalArgumentException("Not a Wallet Connect QR Code")
         }
 


### PR DESCRIPTION
Current version is broken and does not recognize the old scheme as valid because of a mistake related to [De Morgan's laws](https://en.wikipedia.org/wiki/De_Morgan%27s_laws).