### PR TITLE
Add support for non-english hashtags too

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/components/RichTextViewer.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/components/RichTextViewer.kt
@@ -59,7 +59,7 @@ val noProtocolUrlValidator = Pattern.compile("(([\\w\\d-]+\\.)*[a-zA-Z][\\w-]+[\
 val tagIndex = Pattern.compile("\\#\\[([0-9]+)\\](.*)")
 
 val mentionsPattern: Pattern = Pattern.compile("@([A-Za-z0-9_\\-]+)")
-val hashTagsPattern: Pattern = Pattern.compile("#([a-z0-9_\\-]+)(.*)", Pattern.CASE_INSENSITIVE)
+val hashTagsPattern: Pattern = Pattern.compile("#([^\\s!@#\$%^&*()=+./,\\[{\\]};:'\"?><]+)(.*)", Pattern.CASE_INSENSITIVE)
 val urlPattern: Pattern = Patterns.WEB_URL
 
 fun isValidURL(url: String?): Boolean {


### PR DESCRIPTION
**Background:**
Right now, we can use only english hashtags.  This can be limiting for non-english users.

Example:
![image](https://user-images.githubusercontent.com/2035886/234917289-ebdcdb2b-6e58-41f0-9bb6-a1221dc3792e.png)


**Screenshot after fix:**

![image](https://user-images.githubusercontent.com/2035886/234916726-c96e7f65-b49a-4c0f-8dac-12d9ddfcab28.png)

Edit: I took the solution from https://stackoverflow.com/a/27343333 
