### PR TITLE
fix #407 correct non-english hashtags

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/SearchScreen.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/SearchScreen.kt
@@ -335,7 +335,7 @@ private fun SearchBar(accountViewModel: AccountViewModel, navController: NavCont
     }
 }
 
-val hashtagSearch = Pattern.compile("(?:\\s|\\A)#([A-Za-z0-9_\\-]+)")
+val hashtagSearch = Pattern.compile("(?:\\s|\\A)#([^\\s!@#\$%^&*()=+./,\\[{\\]};:'\"?><]+)")
 
 fun findHashtags(content: String): List<String> {
     val matcher = hashtagSearch.matcher(content)


### PR DESCRIPTION
**Fix Approach**
Identical to the one in https://github.com/vitorpamplona/amethyst/pull/381/files

**How did I verify the fix?**
I created a new event with similar text as the one in the issue #407 , using the new code.

New Event ID: nevent1qqs03v7fw77s0sfwdxx50gwgh0gm6wx9x238d2pn05fvv8xaa8qzswgjrqetp

**New Event JSON**

```json
{
  "content": "Now in #amethyst .. Retesting international hashtags. Please ignore.\n\n\n#ಕನ್ನಡ is in Kannada\n#தமிழ் is in Tamil\n#сообщество is in Russian\n#漫画 is in Japanese\n#समाज is in Hindi",
  "created_at": 1684087070,
  "id": "f8b3c977bd07c12e698d47a1c8bbd1bd38c532a276a8337d12c61cdde9c02839",
  "kind": 1,
  "pubkey": "facdaf1ce758bdf04cdf1a1fa32a3564a608d4abc2481a286ffc178f86953ef0",
  "sig": "96aa4b5b6ba913a5db656fa2c80018fc54b4313dfb45509ee1bc749f69bac60397d2ba3f980ca13e435ccfd5b71c39e7462f8bd465764fed000cf0c2d7b0d329",
  "tags": [
    [
      "t",
      "amethyst"
    ],
    [
      "t",
      "ಕನ್ನಡ"
    ],
    [
      "t",
      "தமிழ்"
    ],
    [
      "t",
      "сообщество"
    ],
    [
      "t",
      "漫画"
    ],
    [
      "t",
      "समाज"
    ]
  ]
}
```

**Screenshot of JSON Diff**
![image](https://github.com/vitorpamplona/amethyst/assets/2035886/a986ef50-b0cb-4168-ade7-e3eed943a8ec)


