### PR TITLE
Bugfix case sensitive nip05

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/service/Nip05Verifier.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/Nip05Verifier.kt
@@ -76,13 +76,13 @@ class Nip05Verifier() {
             nip05,
             onSuccess = {
                 val nip05url = try {
-                    mapper.readTree(it)
+                    mapper.readTree(it.lowercase())
                 } catch (t: Throwable) {
                     onError("Error Parsing JSON from Lightning Address. Check the user's lightning setup")
                     null
                 }
 
-                val user = nip05.split("@")[0]
+                val user = nip05.split("@")[0].lowercase()
 
                 val hexKey = nip05url?.get("names")?.get(user)?.asText()
 

--- a/app/src/test/java/com/vitorpamplona/amethyst/service/Nip05VerifierTest.kt
+++ b/app/src/test/java/com/vitorpamplona/amethyst/service/Nip05VerifierTest.kt
@@ -6,6 +6,7 @@ import io.mockk.impl.annotations.SpyK
 import io.mockk.unmockkAll
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
@@ -89,5 +90,32 @@ class Nip05VerifierTest {
     @After
     fun tearDown() {
         unmockkAll()
+    }
+
+    @Test
+    fun `test assmble url with invalid value returns null`() {
+        // given
+        val nip05address = "this@that@that.com"
+
+        // when
+        val actualValue = nip05Verifier.assembleUrl(nip05address)
+
+        // then
+        assertNull(actualValue)
+    }
+
+    @Test
+    fun `test assmble url with valid value returns user url`() {
+        // given
+        val userName = "TheUser"
+        val domain = "domain.com"
+        val nip05address = "$userName@$domain"
+        val expectedValue = "https://$domain/.well-known/nostr.json?name=$userName"
+
+        // when
+        val actualValue = nip05Verifier.assembleUrl(nip05address)
+
+        // then
+        assertEquals(expectedValue, actualValue)
     }
 }

--- a/app/src/test/java/com/vitorpamplona/amethyst/service/Nip05VerifierTest.kt
+++ b/app/src/test/java/com/vitorpamplona/amethyst/service/Nip05VerifierTest.kt
@@ -1,0 +1,93 @@
+package com.vitorpamplona.amethyst.service
+
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.SpyK
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+
+class Nip05VerifierTest {
+    private val ALL_UPPER_CASE_USER_NAME = "ONETWO"
+    private val ALL_LOWER_CASE_USER_NAME = "onetwo"
+
+    @SpyK
+    var nip05Verifier = Nip05Verifier()
+
+    @Before
+    fun setUp() = MockKAnnotations.init(this)
+
+    @Test
+    fun `test with matching case on user name`() {
+        // Set-up
+        val userNameToTest = ALL_UPPER_CASE_USER_NAME
+        val expectedPubKey = "ca29c211f1c72d5b6622268ff43d2288ea2b2cb5b9aa196ff9f1704fc914b71b"
+
+        val nostrJson = "{\n" +
+            "  \"names\": {\n" +
+            "    \"$userNameToTest\": \"$expectedPubKey\" \n" +
+            "  }\n" +
+            "}"
+
+        every { nip05Verifier.fetchNip05Json(any(), any(), any()) } answers {
+            secondArg<(String) -> Unit>().invoke(nostrJson)
+        }
+
+        val nip05 = "$userNameToTest@domain.com"
+        var actualPubkeyHex = ""
+
+        // Execution
+        nip05Verifier.verifyNip05(
+            nip05,
+            onSuccess = {
+                actualPubkeyHex = it
+            },
+            onError = {
+                fail("Test failure")
+            }
+        )
+
+        // Verification
+        assertEquals(expectedPubKey, actualPubkeyHex)
+    }
+
+    @Test
+    fun `test with NOT matching case on user name`() {
+        // Set-up
+        val expectedPubKey = "ca29c211f1c72d5b6622268ff43d2288ea2b2cb5b9aa196ff9f1704fc914b71b"
+
+        val nostrJson = "{\n" +
+            "  \"names\": {\n" +
+            "    \"$ALL_UPPER_CASE_USER_NAME\": \"$expectedPubKey\" \n" +
+            "  }\n" +
+            "}"
+        every { nip05Verifier.fetchNip05Json(any(), any(), any()) } answers {
+            secondArg<(String) -> Unit>().invoke(nostrJson)
+        }
+
+        val nip05 = "$ALL_LOWER_CASE_USER_NAME@domain.com"
+        var actualPubkeyHex = ""
+
+        // Execution
+        nip05Verifier.verifyNip05(
+            nip05,
+            onSuccess = {
+                actualPubkeyHex = it
+            },
+            onError = {
+                fail("Test failure")
+            }
+        )
+
+        // Verification
+        assertEquals(expectedPubKey, actualPubkeyHex)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+}

--- a/app/src/test/java/com/vitorpamplona/amethyst/service/Nip05VerifierTest.kt
+++ b/app/src/test/java/com/vitorpamplona/amethyst/service/Nip05VerifierTest.kt
@@ -93,7 +93,7 @@ class Nip05VerifierTest {
     }
 
     @Test
-    fun `test assmble url with invalid value returns null`() {
+    fun `execute assemble url with invalid value returns null`() {
         // given
         val nip05address = "this@that@that.com"
 
@@ -105,7 +105,7 @@ class Nip05VerifierTest {
     }
 
     @Test
-    fun `test assmble url with valid value returns user url`() {
+    fun `execute assemble url with valid value returns nip05 url`() {
         // given
         val userName = "TheUser"
         val domain = "domain.com"


### PR DESCRIPTION
I've been helping users to get their nip05 verification valid. I noticed a few profiles that were ok in other Nostr clients but failing in Amethyst.

Turns out it was due to different case for their user name in their nostr.json file and their nip05 url.

I've looked at the NIP05 specification and it clearly says that case insensitive matching should be used.

From https://github.com/nostr-protocol/nips/blob/master/05.md: 
"NIP-05 assumes the <local-part> part will be restricted to the characters a-z0-9-_., case-insensitive."

Here is a simple fix and a test to verify it.