### PR TITLE
Add support for per-app languange preferences

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,7 @@ android {
         vectorDrawables {
             useSupportLibrary true
         }
+        resConfigs("ar", "cs", "eo", "es", "fa", "fr", "hu", "night", "nl", "pt-rBR", "ru", "sv-rSE", "ta", "tr", "uk", "zh", "sh-rHK", "zh-rTW" )
     }
 
     buildTypes {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
         android:largeHeap="true"
         android:usesCleartextTraffic="true"
         android:hardwareAccelerated="true"
+        android:localeConfig="@xml/locales_config"
         tools:targetApi="33">
         <activity
             android:name=".ui.MainActivity"

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="ar"/>
+    <locale android:name="cs"/>
+    <locale android:name="eo"/>
+    <locale android:name="es"/>
+    <locale android:name="fa"/>
+    <locale android:name="fr"/>
+    <locale android:name="hu"/>
+    <locale android:name="night"/>
+    <locale android:name="nl"/>
+    <locale android:name="pr-rBR"/>
+    <locale android:name="ru"/>
+    <locale android:name="sv-rSE"/>
+    <locale android:name="ta"/>
+    <locale android:name="tr"/>
+    <locale android:name="uk"/>
+    <locale android:name="zh"/>
+    <locale android:name="zh-rHK"/>
+    <locale android:name="zh-rTW"/>
+    <locale android:name="en"/>
+    <locale android:name="en-GB"/>
+</locale-config>


### PR DESCRIPTION
The new locales_config.xml adds the per-app language support for Amethyst on Android 13+

The new resConfigs was recommended by Android developer guidelines. I _think_  it allows for updating translations only without the rest of the app?

<details>
<summary>Screenshots from Android 13+ UI</summary>
<br>
User can select specific language for the Amethyst app:
<br>
<img src="https://i.imgur.com/HBexTdB.png" width="250"/>
<img src="https://i.imgur.com/zevHteP.png" width="250"/>
<img src="https://i.imgur.com/1MkmFOA.png" width="250"/>
</details>

<details>
<summary>Screenshots from Android 8.0 UI (no changes)</summary>
<br>
User cannot select a specific language for the Amethyst app. Have to change the system language:
<br>
<img src="https://i.imgur.com/t9GLT7A.png" width="250"/>
<img src="https://i.imgur.com/BoEkZYt.png" width="250"/>
<img src="https://i.imgur.com/Jo5qEOO.png" width="250"/>
</details>