### PR TITLE
Fixed a bug in Japanese string display

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/service/CachedRichTextParser.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/CachedRichTextParser.kt
@@ -70,8 +70,7 @@ class RichTextParser() {
             } else if (it.originalUrl.contains("。")) {
                 null
             } else {
-                val pattern = "^(http|https)://([A-Z0-9][A-Z0-9_-]*(?:.[A-Z0-9][A-Z0-9_-]*)+):?(d+)?/?".toRegex(RegexOption.IGNORE_CASE)
-                if (pattern.matches(it.originalUrl)) {
+                if (Patterns.WEB_URL.matcher(it.originalUrl).matches()) {
                     it.originalUrl
                 } else {
                     null

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/CachedRichTextParser.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/CachedRichTextParser.kt
@@ -52,7 +52,8 @@ val shortDatePattern: Pattern = Pattern.compile("^\\d{2}-\\d{2}-\\d{2}$")
 val numberPattern: Pattern = Pattern.compile("^(-?[\\d.]+)([a-zA-Z%]*)$")
 
 // Group 1 = url, group 4 additional chars
-val noProtocolUrlValidator = Pattern.compile("(([\\w\\d-]+\\.)*[a-zA-Z][\\w-]+[\\.\\:]\\w+([\\/\\?\\=\\&\\#\\.]?[\\w-]+)*\\/?)(.*)")
+//val noProtocolUrlValidator = Pattern.compile("(([\\w\\d-]+\\.)*[a-zA-Z][\\w-]+[\\.\\:]\\w+([\\/\\?\\=\\&\\#\\.]?[\\w-]+)*\\/?)(.*)")
+val noProtocolUrlValidator = Pattern.compile("(([\\w\\d-]+\\.)*[a-zA-Z][\\w-]+[\\.\\:]\\w+([\\/\\?\\=\\&\\#\\.]?[\\w-]*[^\\p{IsHan}\\p{IsHiragana}\\p{IsKatakana}])*\\/?)(.*)")
 
 class RichTextParser() {
     fun parseText(
@@ -70,7 +71,8 @@ class RichTextParser() {
             } else if (it.originalUrl.contains("。")) {
                 null
             } else {
-                if (Patterns.WEB_URL.matcher(it.originalUrl).matches()) {
+                val pattern = "^((http|https)://)?([A-Za-z0-9-]+(\\.[A-Za-z0-9]+)+)(:[0-9]+)?(/[^?#]*)?(\\?[^#]*)?(#.*)?".toRegex(RegexOption.IGNORE_CASE)
+                if (pattern.matches(it.originalUrl)) {
                     it.originalUrl
                 } else {
                     null
@@ -178,7 +180,8 @@ class RichTextParser() {
         } else if (schemelessMatcher.find()) {
             val url = schemelessMatcher.group(1) // url
             val additionalChars = schemelessMatcher.group(4) // additional chars
-            if (url != null) {
+            val pattern = "^([A-Za-z0-9-]+(\\.[A-Za-z0-9]+)+)(:[0-9]+)?(/[^?#]*)?(\\?[^#]*)?(#.*)?".toRegex(RegexOption.IGNORE_CASE)
+            if (pattern.matches(word)) {
                 SchemelessUrlSegment(word, url, additionalChars)
             } else {
                 RegularTextSegment(word)

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/CachedRichTextParser.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/CachedRichTextParser.kt
@@ -23,6 +23,8 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.collections.immutable.toImmutableSet
 import java.util.regex.Pattern
+import java.net.URI
+import java.net.URISyntaxException
 
 @Immutable
 data class RichTextViewerState(
@@ -67,8 +69,15 @@ class RichTextParser() {
                 null
             } else if (isNumber(it.originalUrl)) {
                 null
+            } else if (it.originalUrl.contains("。")) {
+                null
             } else {
-                it.originalUrl
+                val pattern = "^(http|https)://([A-Z0-9][A-Z0-9_-]*(?:.[A-Z0-9][A-Z0-9_-]*)+):?(d+)?/?".toRegex(RegexOption.IGNORE_CASE)
+                if (pattern.matches(it.originalUrl)) {
+                    it.originalUrl
+                } else {
+                    null
+                }
             }
         }
 

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/CachedRichTextParser.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/CachedRichTextParser.kt
@@ -52,7 +52,7 @@ val shortDatePattern: Pattern = Pattern.compile("^\\d{2}-\\d{2}-\\d{2}$")
 val numberPattern: Pattern = Pattern.compile("^(-?[\\d.]+)([a-zA-Z%]*)$")
 
 // Group 1 = url, group 4 additional chars
-//val noProtocolUrlValidator = Pattern.compile("(([\\w\\d-]+\\.)*[a-zA-Z][\\w-]+[\\.\\:]\\w+([\\/\\?\\=\\&\\#\\.]?[\\w-]+)*\\/?)(.*)")
+// val noProtocolUrlValidator = Pattern.compile("(([\\w\\d-]+\\.)*[a-zA-Z][\\w-]+[\\.\\:]\\w+([\\/\\?\\=\\&\\#\\.]?[\\w-]+)*\\/?)(.*)")
 val noProtocolUrlValidator = Pattern.compile("(([\\w\\d-]+\\.)*[a-zA-Z][\\w-]+[\\.\\:]\\w+([\\/\\?\\=\\&\\#\\.]?[\\w-]*[^\\p{IsHan}\\p{IsHiragana}\\p{IsKatakana}])*\\/?)(.*)")
 
 class RichTextParser() {

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/CachedRichTextParser.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/CachedRichTextParser.kt
@@ -23,8 +23,6 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.collections.immutable.toImmutableSet
 import java.util.regex.Pattern
-import java.net.URI
-import java.net.URISyntaxException
 
 @Immutable
 data class RichTextViewerState(


### PR DESCRIPTION
Nice to meet you. I am an engineer in Japan, usually making web applications, etc.

I was wondering about the bug in issue #390 and thought I would fix it.

The following images are before and after the fix.

[before 1]
![](https://imgproxy.snort.social/aYvtfYu_xqHyeGACBnMAMynwuUrqLUNsGQxwXr3e_FE//aHR0cHM6Ly9ub3N0ci5idWlsZC9pL2FkNzFjZWQyMmU2OTM0OWFhMWNkZDg1ZTQ4ODMyNjA4MDYxOTk4NzkzMjlkYjZkMGZhMTU0YjZhMDE5NDQxMzAuanBn)

[after 1]
![](https://imgproxy.snort.social/49yEhG0L04nY7UpZG4QmDmNRuSYTN9k57lUGZILB9dA//aHR0cHM6Ly9ub3N0ci5idWlsZC9pL2FiYmI5YjY2NWNhMzY2NDAxODNhYTBiZmQ2ODQyOWJlYzliZTRkMDQ2NTY3ZTg2MjAxMTMyZDhiNWZjYzg0Y2QuanBn)

[before 2]
![](https://imgproxy.snort.social/vIRKokF4XtZoSGi-BXKhnMtvlK_KVQHitA-aPWyX3ro//aHR0cHM6Ly9ub3N0ci5idWlsZC9pLzk5NTA5ZDQwNTIyNzkyN2M0ZDBiYmIzNjYxMmQ2Y2Y0NTEzYjU1OThkMjkwZjA4ZDA3NTdlZTBjYjdkZDE4MzcuanBn)

[after 2]
![](https://imgproxy.snort.social/ya4li6y_YjvpVB-OZGh-wwMqPh3fpXtztGqYdAusnCg//aHR0cHM6Ly9ub3N0ci5idWlsZC9pLzM4YmEwNjU4NjNkMWU5MzAyOWFiMTI5OGI3MjIwN2M4NjE3NmNhY2JmZmU1YzljZjkxYWY1NWU2MDczMzljMGEuanBn)

The fix is to make it more strict to determine if it is a URL or not.
First of all, "." is used. is mistaken for Japanese ". is now corrected by hard-coding.
In addition, URLs without a scheme are now allowed to use the characters used in URLs.

Note that this fix affects all users of the timeline.
We have prepared a pre-built APK so that you can check it before release.

https://drive.google.com/drive/folders/1vTfyPIsvP58_X3Xx26nSc8aGfRX6XonN?usp=sharing

The other day I was looking at the Amethyst timeline and saw a bug where a Japanese string was interpreted as a URL.

About 6 hours ago, I saw it posted and decided to fix it.

nevent1qqsdu79vq5wradvquk32upfd5amgrla448v4vv69sa3sr4dy6w6j0vcpz9mhxue69uhkummnw3ezuamfdejj7qf9waehxw309a6ku6tkv4e8xefwdehhxarjd93kstnvv9hxgteld3skueeadfsslwjtwm