### PR TITLE
Fix string resource mapping when like clicked

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
@@ -932,7 +932,7 @@ private fun likeClick(
             Toast
                 .makeText(
                     context,
-                    context.getString(R.string.login_with_a_private_key_to_be_able_to_send_zaps),
+                    context.getString(R.string.login_with_a_private_key_to_like_posts),
                     Toast.LENGTH_SHORT
                 )
                 .show()


### PR DESCRIPTION
A message about zap was displayed instead of a message about like when clicking a like button when logging in with pubkey.