### PR TITLE
change branding from NIP-05 to Nostr address

### DIFF
--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -158,7 +158,7 @@
     <string name="translations_to">al</string>
     <string name="translations_show_in_lang_first">Montri en %1$s unua</string>
     <string name="translations_always_translate_to_lang">Ĉiam traduki al</string>
-    <string name="nip_05" translatable="false">NIP-05</string>
+    <string name="nip_05" translatable="false">Nostr Address</string>
     <string name="lnurl" translatable="false">LNURL...</string>
     <string name="never">neniam</string>
     <string name="now">nun</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -164,7 +164,7 @@
     <string name="translations_show_in_lang_first">ابتدا به  نشان بده %1$s</string>
     <string name="translations_always_translate_to_lang">همیشه به  ترجمه کن %1$s</string>
     <string name="translations_never_translate_from_lang">هرگز به  ترجمه نکن %1$s</string>
-    <string name="nip_05" translatable="false">NIP-05</string>
+    <string name="nip_05" translatable="false">Nostr address</string>
     <string name="lnurl" translatable="false">LNURL...</string>
     <string name="never">هرگز</string>
     <string name="now">اکنون</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -161,7 +161,7 @@
     <string name="translations_show_in_lang_first">Eerst laten zien in %1$s</string>
     <string name="translations_always_translate_to_lang">Altijd vertalen naar %1$s</string>
     <string name="translations_never_translate_from_lang">Nooit vertalen vanuit %1$s</string>
-    <string name="nip_05" translatable="false">NIP-05</string>
+    <string name="nip_05" translatable="false">Nostr address</string>
     <string name="lnurl" translatable="false">LNURL...</string>
     <string name="never">nooit</string>
     <string name="now">nu</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -167,7 +167,7 @@
     <string name="translations_show_in_lang_first">Show in %1$s first</string>
     <string name="translations_always_translate_to_lang">Always translate to %1$s</string>
     <string name="translations_never_translate_from_lang">Never translate from %1$s</string>
-    <string name="nip_05" translatable="false">NIP-05</string>
+    <string name="nip_05" translatable="false">Nostr address</string>
     <string name="lnurl" translatable="false">LNURL...</string>
     <string name="never">never</string>
     <string name="now">now</string>


### PR DESCRIPTION
This changes the string values from "NIP-05" to "Nostr address" to reflect a less technical and more user friendly branding for users that wish to edit this field.