### PR TITLE
fix signed byte used for array slice with + added test

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/service/nip19/Tlv.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/nip19/Tlv.kt
@@ -21,7 +21,7 @@ object Tlv {
         var rest = data
         while (rest.isNotEmpty()) {
             val t = rest[0]
-            val l = rest[1]
+            val l = rest[1].toUByte().toInt()
             val v = rest.sliceArray(IntRange(2, (2 + l) - 1))
             rest = rest.sliceArray(IntRange(2 + l, rest.size - 1))
             if (v.size < l) continue

--- a/app/src/test/java/com/vitorpamplona/amethyst/NIP19ParserTest.kt
+++ b/app/src/test/java/com/vitorpamplona/amethyst/NIP19ParserTest.kt
@@ -116,6 +116,15 @@ class NIP19ParserTest {
     }
 
     @Test
+    fun nEventParser3() {
+        val result = Nip19.uriToRoute("nostr:nevent1qqsg6gechd3dhzx38n4z8a2lylzgsmmgeamhmtzz72m9ummsnf0xjfspsdmhxue69uhkummn9ekx7mpvwaehxw309ahx7um5wghx77r5wghxgetk93mhxue69uhhyetvv9ujumn0wd68ytnzvuk8wumn8ghj7mn0wd68ytn9d9h82mny0fmkzmn6d9njuumsv93k2trhwden5te0wfjkccte9ehx7um5wghxyctwvsk8wumn8ghj7un9d3shjtnyv9kh2uewd9hs3kqsdn")
+
+        assertEquals(Nip19.Type.EVENT, result?.type)
+        assertEquals("8d2338bb62db88d13cea23f55f27c4886f68cf777dac42f2b65e6f709a5e6926", result?.hex)
+        assertEquals("wss://nos.lol,wss://nostr.oxtr.dev,wss://relay.nostr.bg,wss://nostr.einundzwanzig.space,wss://relay.nostr.band,wss://relay.damus.io", result?.relay)
+    }
+
+    @Test
     fun nEventParserInvalidChecksum() {
         val result = Nip19.uriToRoute("nostr:nevent1qqsyxq8v0730nz38dupnjzp5jegkyz4gu2ptwcps4v32hjnrap0q0espz3mhxue69uhhyetvv9ujuerpd46hxtnfdupzq3svyhng9ld8sv44950j957j9vchdktj7cxumsep9mvvjthc2pjuqvzqqqqqqyn3t9gj")
 


### PR DESCRIPTION
In case L was above 127 it would be signed int and ArrayIndexOutOfBoundsException would be thrown on the slice array.
Added test with nevent1 to reproduce and fix with .toUByte().toInt()