### PR TITLE
fixing global relays selection

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -1478,6 +1478,12 @@ class Account(
         }.toTypedArray()
     }
 
+    fun convertGlobalRelays(): Array<String> {
+        return localRelays.filter { it.feedTypes.contains(FeedType.GLOBAL) }
+            .map { it.url }
+            .toTypedArray()
+    }
+
     fun reconnectIfRelaysHaveChanged() {
         val newRelaySet = activeRelays() ?: convertLocalRelays()
         if (!Client.isSameRelaySetConfig(newRelaySet)) {


### PR DESCRIPTION
Global feed was not filtering by relay global toggle settings.  This patch fixes that.  Now when you have relays set to Global feed, the feed only displays messages from those relays.  Tested and working, I'm a kotlin noob so I don't know if this is the best way to fix it but it works!