### PR TITLE
fix url regex pattern.

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/service/CachedRichTextParser.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/CachedRichTextParser.kt
@@ -59,7 +59,7 @@ val noProtocolUrlValidator = try {
     Pattern.compile("(([\\w\\d-]+\\.)*[a-zA-Z][\\w-]+[\\.\\:]\\w+([\\/\\?\\=\\&\\#\\.]?[\\w-]+)*\\/?)(.*)")
 }
 
-val HTTPRegex = "^((http|https)://)?([A-Za-z0-9-]+(\\.[A-Za-z0-9]+)+)(:[0-9]+)?(/[^?#]*)?(\\?[^#]*)?(#.*)?".toRegex(RegexOption.IGNORE_CASE)
+val HTTPRegex = "^((http|https)://)?([A-Za-z0-9-_]+(\\.[A-Za-z0-9-_]+)+)(:[0-9]+)?(/[^?#]*)?(\\?[^#]*)?(#.*)?".toRegex(RegexOption.IGNORE_CASE)
 
 class RichTextParser() {
     fun parseText(
@@ -183,7 +183,7 @@ class RichTextParser() {
         } else if (word.contains(".") && schemelessMatcher.find()) {
             val url = schemelessMatcher.group(1) // url
             val additionalChars = schemelessMatcher.group(4) // additional chars
-            val pattern = "^([A-Za-z0-9-_]+(\\.[A-Za-z0-9-_]+)+)(:[0-9]+)?(/[^?#]*)?(\\?[^#]*)?(#.*)?".toRegex(RegexOption.IGNORE_CASE)
+            val pattern = """^([A-Za-z0-9-_]+(\.[A-Za-z0-9-_]+)+)(:[0-9]+)?(/[^?#]*)?(\?[^#]*)?(#.*)?""".toRegex(RegexOption.IGNORE_CASE)
             if (pattern.find(word) != null) {
                 SchemelessUrlSegment(word, url, additionalChars)
             } else {


### PR DESCRIPTION
Fixed in response to issue #536.
Two screenshots are attached to the evidence.

![before](https://cdn.nostr.build/i/1a0684bd6965ef62aa83649d818c67cf2c3b73340df8545b0933e48b7ce3eb68.jpg)

![after](https://cdn.nostr.build/i/d9320516bd930e62fb5f67b1fc2e3d6798c1d6d071f9794950d16349a6a944de.jpg)

My npub is here.
npub1l60d6h2uvdwa9yq0r7r2suhgrnsadcst6nsx2j03xwhxhu2cjyascejxe5