### PR TITLE
Fix contact link in relay information dialog

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/actions/RelayInformationDialog.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/actions/RelayInformationDialog.kt
@@ -111,7 +111,15 @@ fun RelayInformationDialog(
                 Section(stringResource(R.string.contact))
 
                 Box(modifier = Modifier.padding(start = 10.dp)) {
-                    ClickableEmail(relayInfo.contact ?: "")
+                    relayInfo.contact?.let {
+                        if (it.startsWith("https:")) {
+                            ClickableUrl(urlText = it, url = it)
+                        } else if (it.startsWith("mailto:") || it.contains('@')) {
+                            ClickableEmail(it)
+                        } else {
+                            SectionContent(it)
+                        }
+                    }
                 }
 
                 Section(stringResource(R.string.supports))

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/components/ClickableEmail.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/components/ClickableEmail.kt
@@ -13,11 +13,12 @@ import androidx.compose.ui.text.AnnotatedString
 
 @Composable
 fun ClickableEmail(email: String) {
+    val stripped = email.replaceFirst("mailto:", "")
     val context = LocalContext.current
 
     ClickableText(
-        text = remember { AnnotatedString(email) },
-        onClick = { runCatching { context.sendMail(email) } },
+        text = remember { AnnotatedString(stripped) },
+        onClick = { runCatching { context.sendMail(stripped) } },
         style = LocalTextStyle.current.copy(color = MaterialTheme.colors.primary)
     )
 }


### PR DESCRIPTION
- Added specific handling for the `https:` schema
- Stop making the text clickable if it is neither of a `https:` URL nor an email address
- Strip `mailto:` schema from email addresses