### PR TITLE
add notifications for users of amber

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
@@ -43,6 +43,7 @@ class EventNotificationConsumer(private val applicationContext: Context) {
     private suspend fun consumeIfMatchesAccount(pushWrappedEvent: GiftWrapEvent, account: Account) {
         val key = account.keyPair.privKey
         if (account.loginWithExternalSigner) {
+            ExternalSignerUtils.account = account
             var cached = ExternalSignerUtils.cachedDecryptedContent[pushWrappedEvent.id]
             if (cached == null) {
                 ExternalSignerUtils.decrypt(

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/notifications/RegisterAccounts.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/notifications/RegisterAccounts.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.vitorpamplona.amethyst.AccountInfo
 import com.vitorpamplona.amethyst.BuildConfig
 import com.vitorpamplona.amethyst.LocalPreferences
+import com.vitorpamplona.amethyst.service.ExternalSignerUtils
 import com.vitorpamplona.amethyst.service.HttpClient
 import com.vitorpamplona.quartz.events.RelayAuthEvent
 import kotlinx.coroutines.Dispatchers
@@ -23,7 +24,10 @@ class RegisterAccounts(
     ): List<RelayAuthEvent> {
         return accounts.mapNotNull {
             val acc = LocalPreferences.loadFromEncryptedStorage(it.npub)
-            if (acc != null && acc.isWriteable()) {
+            if (acc != null && (acc.isWriteable() || acc.loginWithExternalSigner)) {
+                if (acc.loginWithExternalSigner) {
+                    ExternalSignerUtils.account = acc
+                }
                 val relayToUse = acc.activeRelays()?.firstOrNull { it.read }
                 if (relayToUse != null) {
                     acc.createAuthEvent(relayToUse, notificationToken)
@@ -66,5 +70,6 @@ class RegisterAccounts(
         postRegistrationEvent(
             signEventsToProveControlOfAccounts(accounts, notificationToken)
         )
+        PushNotificationUtils.hasInit = true
     }
 }


### PR DESCRIPTION
This just works if the user checked the remember my choice for decrypting nip44
I havent found a way to open amber when amethyst is in background. Seems to be a limitation since android 10