### PR TITLE
Bugfix mute feed is always empty

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/dal/HomeConversationsFeedFilter.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/dal/HomeConversationsFeedFilter.kt
@@ -13,12 +13,14 @@ import com.vitorpamplona.quartz.utils.TimeUtils
 
 class HomeConversationsFeedFilter(val account: Account) : AdditiveFeedFilter<Note>() {
 
+    private val regex = ("30000:[a-f0-9]+:" + PeopleListEvent.blockList).toRegex(RegexOption.IGNORE_CASE)
+
     override fun feedKey(): String {
         return account.userProfile().pubkeyHex + "-" + account.defaultHomeFollowList
     }
 
     override fun showHiddenKey(): Boolean {
-        return account.defaultHomeFollowList.endsWith(PeopleListEvent.blockList)
+        return regex.matches(account.defaultHomeFollowList)
     }
 
     override fun feed(): List<Note> {

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/dal/HomeConversationsFeedFilter.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/dal/HomeConversationsFeedFilter.kt
@@ -13,14 +13,12 @@ import com.vitorpamplona.quartz.utils.TimeUtils
 
 class HomeConversationsFeedFilter(val account: Account) : AdditiveFeedFilter<Note>() {
 
-    private val regex = ("30000:[a-f0-9]+:" + PeopleListEvent.blockList).toRegex(RegexOption.IGNORE_CASE)
-
     override fun feedKey(): String {
         return account.userProfile().pubkeyHex + "-" + account.defaultHomeFollowList
     }
 
     override fun showHiddenKey(): Boolean {
-        return regex.matches(account.defaultHomeFollowList)
+        return account.defaultHomeFollowList == "30000:${account.userProfile().pubkeyHex}:${PeopleListEvent.blockList}"
     }
 
     override fun feed(): List<Note> {

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/dal/HomeConversationsFeedFilter.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/dal/HomeConversationsFeedFilter.kt
@@ -18,7 +18,7 @@ class HomeConversationsFeedFilter(val account: Account) : AdditiveFeedFilter<Not
     }
 
     override fun showHiddenKey(): Boolean {
-        return account.defaultHomeFollowList == PeopleListEvent.blockList
+        return account.defaultHomeFollowList.endsWith(PeopleListEvent.blockList)
     }
 
     override fun feed(): List<Note> {

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/dal/HomeNewThreadFeedFilter.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/dal/HomeNewThreadFeedFilter.kt
@@ -22,7 +22,7 @@ class HomeNewThreadFeedFilter(val account: Account) : AdditiveFeedFilter<Note>()
     }
 
     override fun showHiddenKey(): Boolean {
-        return account.defaultHomeFollowList == PeopleListEvent.blockList
+        return account.defaultHomeFollowList.endsWith(PeopleListEvent.blockList)
     }
 
     override fun feed(): List<Note> {

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/dal/HomeNewThreadFeedFilter.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/dal/HomeNewThreadFeedFilter.kt
@@ -17,12 +17,15 @@ import com.vitorpamplona.quartz.events.TextNoteEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 class HomeNewThreadFeedFilter(val account: Account) : AdditiveFeedFilter<Note>() {
+
+    private val regex = ("30000:[a-f0-9]+:" + PeopleListEvent.blockList).toRegex(RegexOption.IGNORE_CASE)
+
     override fun feedKey(): String {
         return account.userProfile().pubkeyHex + "-" + account.defaultHomeFollowList
     }
 
     override fun showHiddenKey(): Boolean {
-        return account.defaultHomeFollowList.endsWith(PeopleListEvent.blockList)
+        return regex.matches(account.defaultHomeFollowList)
     }
 
     override fun feed(): List<Note> {

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/dal/HomeNewThreadFeedFilter.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/dal/HomeNewThreadFeedFilter.kt
@@ -18,14 +18,12 @@ import com.vitorpamplona.quartz.utils.TimeUtils
 
 class HomeNewThreadFeedFilter(val account: Account) : AdditiveFeedFilter<Note>() {
 
-    private val regex = ("30000:[a-f0-9]+:" + PeopleListEvent.blockList).toRegex(RegexOption.IGNORE_CASE)
-
     override fun feedKey(): String {
         return account.userProfile().pubkeyHex + "-" + account.defaultHomeFollowList
     }
 
     override fun showHiddenKey(): Boolean {
-        return regex.matches(account.defaultHomeFollowList)
+        return account.defaultHomeFollowList == "30000:${account.userProfile().pubkeyHex}:${PeopleListEvent.blockList}"
     }
 
     override fun feed(): List<Note> {


### PR DESCRIPTION
In noticed that Home feed new threads and conversations when mute list is selected at some point stopped showing.

It seems that the mute list changed at some point from simple "mute" to a combination of event code, user hex and mute.

This is a simple fix to bring back the mute list.

I noticed similar issue in chat feed, community feed, live feed and video feed but I haven't fixed it there.

See:
https://github.com/vitorpamplona/amethyst/issues/626
