### PR TITLE
changing externa sharing service for text notes to njump.me

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteQuickActionMenu.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteQuickActionMenu.kt
@@ -99,7 +99,7 @@ val externalLinkForNote = { note: Note ->
         if (note.event is FileHeaderEvent) {
             "https://filestr.vercel.app/e/${note.toNEvent()}"
         } else {
-            "https://snort.social/e/${note.toNEvent()}"
+            "https://njump.me/${note.toNEvent()}"
         }
     }
 }


### PR DESCRIPTION
Changed "https://snort.social/e/" to "https://njump.me/"

Benefits of this change are the link previews that njump.me generates for shared content. The snort social links are just the url root and a long nevent, making different shares difficult to tell apart, and a bit scary to click on for some.

More benefits of njump.me listed on https://njump.me/, hosted by fiatjaf. The included nostr onboarding paired with client agnosticism is also beneficial.