### PR TITLE
Display amounts up to 4 digits without abbreviation

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
@@ -1438,13 +1438,14 @@ fun showCount(count: Int?): String {
     return when {
         count >= 1000000000 -> "${(count / 1000000000f).roundToInt()}G"
         count >= 1000000 -> "${(count / 1000000f).roundToInt()}M"
-        count >= 1000 -> "${(count / 1000f).roundToInt()}k"
+        count >= 10000 -> "${(count / 1000f).roundToInt()}k"
         else -> "$count"
     }
 }
 
 val OneGiga = BigDecimal(1000000000)
 val OneMega = BigDecimal(1000000)
+val TenKilo = BigDecimal(10000)
 val OneKilo = BigDecimal(1000)
 
 var dfG: DecimalFormat = DecimalFormat("#.0G")
@@ -1457,9 +1458,9 @@ fun showAmount(amount: BigDecimal?): String {
     if (amount.abs() < BigDecimal(0.01)) return ""
 
     return when {
-        amount >= OneGiga -> dfG.format(amount.div(OneGiga).setScale(1, RoundingMode.HALF_UP))
-        amount >= OneMega -> dfM.format(amount.div(OneMega).setScale(1, RoundingMode.HALF_UP))
-        amount >= OneKilo -> dfK.format(amount.div(OneKilo).setScale(1, RoundingMode.HALF_UP))
+        amount >= OneGiga -> dfG.format(amount.div(OneGiga).setScale(0, RoundingMode.HALF_UP))
+        amount >= OneMega -> dfM.format(amount.div(OneMega).setScale(0, RoundingMode.HALF_UP))
+        amount >= TenKilo -> dfK.format(amount.div(OneKilo).setScale(0, RoundingMode.HALF_UP))
         else -> dfN.format(amount)
     }
 }

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/NotificationScreen.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/NotificationScreen.kt
@@ -53,6 +53,7 @@ import com.vitorpamplona.amethyst.ui.navigation.Route
 import com.vitorpamplona.amethyst.ui.note.OneGiga
 import com.vitorpamplona.amethyst.ui.note.OneKilo
 import com.vitorpamplona.amethyst.ui.note.OneMega
+import com.vitorpamplona.amethyst.ui.note.TenKilo
 import com.vitorpamplona.amethyst.ui.note.UserReactionsRow
 import com.vitorpamplona.amethyst.ui.note.UserReactionsViewModel
 import com.vitorpamplona.amethyst.ui.note.showAmount
@@ -289,7 +290,7 @@ fun showAmountAxis(amount: BigDecimal?): String {
     return when {
         amount >= OneGiga -> dfG.format(amount.div(OneGiga).setScale(0, RoundingMode.HALF_UP))
         amount >= OneMega -> dfM.format(amount.div(OneMega).setScale(0, RoundingMode.HALF_UP))
-        amount >= OneKilo -> dfK.format(amount.div(OneKilo).setScale(0, RoundingMode.HALF_UP))
+        amount >= TenKilo -> dfK.format(amount.div(OneKilo).setScale(0, RoundingMode.HALF_UP))
         else -> dfN.format(amount)
     }
 }


### PR DESCRIPTION
When viewing reactions, it would be helpful to see up to 4 characters/digits of zap amounts. This changes the rounding to start at 10000 sats vs 1000, as most zap amounts are under that threshold.

See sample result from this change.  On the left is before the change. On the right is after. The value 1337 is shown instead of 1000, and 2100 instead of 2k among others.

![2023-11-10-amethyst-before-and-after-4digit](https://github.com/vitorpamplona/amethyst/assets/88121568/d038402e-cc57-4731-8f98-c8942ceeb196)