### PR TITLE
fix amber trying to signing events with wrong user

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/ServiceManager.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ServiceManager.kt
@@ -11,7 +11,6 @@ import coil.disk.DiskCache
 import coil.util.DebugLogger
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.service.ExternalSignerUtils
 import com.vitorpamplona.amethyst.service.HttpClient
 import com.vitorpamplona.amethyst.service.NostrAccountDataSource
 import com.vitorpamplona.amethyst.service.NostrChannelDataSource
@@ -45,7 +44,6 @@ object ServiceManager {
 
     private fun start(account: Account) {
         this.account = account
-        ExternalSignerUtils.account = account
         start()
     }
 

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/ExternalSignerUtils.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/ExternalSignerUtils.kt
@@ -11,16 +11,16 @@ import androidx.activity.result.contract.ActivityResultContracts
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.ServiceManager
-import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.ui.MainActivity
 import com.vitorpamplona.quartz.encoders.HexKey
-import com.vitorpamplona.quartz.encoders.toNpub
 import com.vitorpamplona.quartz.events.EventInterface
 import com.vitorpamplona.quartz.events.LnZapRequestEvent
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import java.util.Timer
+import kotlin.concurrent.schedule
 
 enum class SignerType {
     SIGN_EVENT,
@@ -33,20 +33,19 @@ enum class SignerType {
 }
 
 object ExternalSignerUtils {
-    val content = LruCache<String, String>(10)
+    val content = LruCache<String, String?>(10)
     var isActivityRunning: Boolean = false
     val cachedDecryptedContent = mutableMapOf<HexKey, String>()
-    lateinit var account: Account
-    private lateinit var activityResultLauncher: ActivityResultLauncher<Intent>
-    private lateinit var decryptResultLauncher: ActivityResultLauncher<Intent>
-    private lateinit var blockListResultLauncher: ActivityResultLauncher<Intent>
+    lateinit var activityResultLauncher: ActivityResultLauncher<Intent>
+    lateinit var decryptResultLauncher: ActivityResultLauncher<Intent>
+    lateinit var blockListResultLauncher: ActivityResultLauncher<Intent>
 
     @OptIn(DelicateCoroutinesApi::class)
     fun requestRejectedToast() {
         GlobalScope.launch(Dispatchers.Main) {
             Toast.makeText(
-                Amethyst.instance,
-                Amethyst.instance.getString(R.string.sign_request_rejected),
+                Amethyst.instance.applicationContext,
+                Amethyst.instance.applicationContext.getString(R.string.sign_request_rejected),
                 Toast.LENGTH_SHORT
             ).show()
         }
@@ -54,15 +53,16 @@ object ExternalSignerUtils {
 
     @OptIn(DelicateCoroutinesApi::class)
     fun default() {
-        isActivityRunning = false
-        ServiceManager.shouldPauseService = true
-        GlobalScope.launch(Dispatchers.IO) {
+        Timer().schedule(200) {
             isActivityRunning = false
             ServiceManager.shouldPauseService = true
+            GlobalScope.launch(Dispatchers.IO) {
+                isActivityRunning = false
+                ServiceManager.shouldPauseService = true
+            }
         }
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
     fun start(activity: MainActivity) {
         activityResultLauncher = activity.registerForActivityResult(
             ActivityResultContracts.StartActivityForResult()
@@ -105,13 +105,14 @@ object ExternalSignerUtils {
                 val id = it.data?.getStringExtra("id") ?: ""
                 if (id.isNotBlank()) {
                     cachedDecryptedContent[id] = decryptedContent
-                    account.live.invalidateData()
                 }
             }
             default()
         }
     }
+}
 
+class ExternalSigner(val npub: String) {
     @OptIn(DelicateCoroutinesApi::class)
     fun openSigner(
         data: String,
@@ -136,7 +137,7 @@ object ExternalSignerUtils {
             intent.putExtra("pubKey", pubKey)
             intent.putExtra("id", id)
             if (type !== SignerType.GET_PUBLIC_KEY) {
-                intent.putExtra("current_user", account.keyPair.pubKey.toNpub())
+                intent.putExtra("current_user", npub)
             }
             intent.`package` = "com.greenart7c3.nostrsigner"
             intentResult.launch(intent)
@@ -144,8 +145,8 @@ object ExternalSignerUtils {
             Log.e("Signer", "Error opening Signer app", e)
             GlobalScope.launch(Dispatchers.Main) {
                 Toast.makeText(
-                    Amethyst.instance,
-                    Amethyst.instance.getString(R.string.error_opening_external_signer),
+                    Amethyst.instance.applicationContext,
+                    Amethyst.instance.applicationContext.getString(R.string.error_opening_external_signer),
                     Toast.LENGTH_SHORT
                 ).show()
             }
@@ -158,47 +159,47 @@ object ExternalSignerUtils {
         val result = getDataFromResolver(SignerType.SIGN_EVENT, arrayOf(event.toJson(), event.pubKey()), columnName)
         if (result == null) {
             ServiceManager.shouldPauseService = false
-            isActivityRunning = true
+            ExternalSignerUtils.isActivityRunning = true
             openSigner(
                 event.toJson(),
                 SignerType.SIGN_EVENT,
-                activityResultLauncher,
+                ExternalSignerUtils.activityResultLauncher,
                 "",
                 event.id()
             )
-            while (isActivityRunning) {
+            while (ExternalSignerUtils.isActivityRunning) {
                 Thread.sleep(100)
             }
         } else {
-            content.put(event.id(), result)
+            ExternalSignerUtils.content.put(event.id(), result)
         }
     }
 
     fun decryptBlockList(encryptedContent: String, pubKey: HexKey, id: String, signerType: SignerType = SignerType.NIP04_DECRYPT) {
         val result = getDataFromResolver(signerType, arrayOf(encryptedContent, pubKey))
         if (result == null) {
-            isActivityRunning = true
+            ExternalSignerUtils.isActivityRunning = true
             openSigner(
                 encryptedContent,
                 signerType,
-                blockListResultLauncher,
+                ExternalSignerUtils.blockListResultLauncher,
                 pubKey,
                 id
             )
         } else {
-            content.put(id, result)
-            cachedDecryptedContent[id] = result
+            ExternalSignerUtils.content.put(id, result)
+            ExternalSignerUtils.cachedDecryptedContent[id] = result
         }
     }
 
     fun getDataFromResolver(signerType: SignerType, data: Array<out String>, columnName: String = "signature"): String? {
         val localData = if (signerType !== SignerType.GET_PUBLIC_KEY) {
-            data.toList().plus(account.keyPair.pubKey.toNpub()).toTypedArray()
+            data.toList().plus(npub).toTypedArray()
         } else {
             data
         }
 
-        Amethyst.instance.contentResolver.query(
+        Amethyst.instance.applicationContext.contentResolver.query(
             Uri.parse("content://com.greenart7c3.nostrsigner.$signerType"),
             localData,
             null,
@@ -223,20 +224,20 @@ object ExternalSignerUtils {
     fun decrypt(encryptedContent: String, pubKey: HexKey, id: String, signerType: SignerType = SignerType.NIP04_DECRYPT) {
         val result = getDataFromResolver(signerType, arrayOf(encryptedContent, pubKey))
         if (result == null) {
-            isActivityRunning = true
+            ExternalSignerUtils.isActivityRunning = true
             openSigner(
                 encryptedContent,
                 signerType,
-                decryptResultLauncher,
+                ExternalSignerUtils.decryptResultLauncher,
                 pubKey,
                 id
             )
-            while (isActivityRunning) {
+            while (ExternalSignerUtils.isActivityRunning) {
                 // do nothing
             }
         } else {
-            content.put(id, result)
-            cachedDecryptedContent[id] = result
+            ExternalSignerUtils.content.put(id, result)
+            ExternalSignerUtils.cachedDecryptedContent[id] = result
         }
     }
 
@@ -246,13 +247,13 @@ object ExternalSignerUtils {
             openSigner(
                 encryptedContent,
                 signerType,
-                decryptResultLauncher,
+                ExternalSignerUtils.decryptResultLauncher,
                 pubKey,
                 id
             )
         } else {
-            content.put(id, result)
-            cachedDecryptedContent[id] = result
+            ExternalSignerUtils.content.put(id, result)
+            ExternalSignerUtils.cachedDecryptedContent[id] = result
         }
     }
 
@@ -262,34 +263,34 @@ object ExternalSignerUtils {
             openSigner(
                 encryptedContent,
                 signerType,
-                decryptResultLauncher,
+                ExternalSignerUtils.decryptResultLauncher,
                 pubKey,
                 id
             )
         } else {
-            content.put(id, result)
-            cachedDecryptedContent[id] = result
+            ExternalSignerUtils.content.put(id, result)
+            ExternalSignerUtils.cachedDecryptedContent[id] = result
         }
     }
 
     fun encrypt(decryptedContent: String, pubKey: HexKey, id: String, signerType: SignerType = SignerType.NIP04_ENCRYPT) {
-        content.remove(id)
-        cachedDecryptedContent.remove(id)
+        ExternalSignerUtils.content.remove(id)
+        ExternalSignerUtils.cachedDecryptedContent.remove(id)
         val result = getDataFromResolver(signerType, arrayOf(decryptedContent, pubKey))
         if (result == null) {
-            isActivityRunning = true
+            ExternalSignerUtils.isActivityRunning = true
             openSigner(
                 decryptedContent,
                 signerType,
-                activityResultLauncher,
+                ExternalSignerUtils.activityResultLauncher,
                 pubKey,
                 id
             )
-            while (isActivityRunning) {
+            while (ExternalSignerUtils.isActivityRunning) {
                 Thread.sleep(100)
             }
         } else {
-            content.put(id, result)
+            ExternalSignerUtils.content.put(id, result)
         }
     }
 
@@ -299,13 +300,13 @@ object ExternalSignerUtils {
             openSigner(
                 event.toJson(),
                 SignerType.DECRYPT_ZAP_EVENT,
-                decryptResultLauncher,
+                ExternalSignerUtils.decryptResultLauncher,
                 event.pubKey,
                 event.id
             )
         } else {
-            content.put(event.id, result)
-            cachedDecryptedContent[event.id] = result
+            ExternalSignerUtils.content.put(event.id, result)
+            ExternalSignerUtils.cachedDecryptedContent[event.id] = result
         }
     }
 }

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/NostrAccountDataSource.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/NostrAccountDataSource.kt
@@ -166,7 +166,7 @@ object NostrAccountDataSource : NostrDataSource("AccountData") {
                 } else if (account.loginWithExternalSigner) {
                     var cached = ExternalSignerUtils.cachedDecryptedContent[event.id]
                     if (cached == null) {
-                        ExternalSignerUtils.decrypt(
+                        account.externalSigner.decrypt(
                             event.content,
                             event.pubKey,
                             event.id,
@@ -189,7 +189,7 @@ object NostrAccountDataSource : NostrDataSource("AccountData") {
                 } else if (account.loginWithExternalSigner) {
                     var cached = ExternalSignerUtils.cachedDecryptedContent[event.id]
                     if (cached == null) {
-                        ExternalSignerUtils.decrypt(
+                        account.externalSigner.decrypt(
                             event.content,
                             event.pubKey,
                             event.id,

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
@@ -44,10 +44,9 @@ class EventNotificationConsumer(private val applicationContext: Context) {
     private suspend fun consumeIfMatchesAccount(pushWrappedEvent: GiftWrapEvent, account: Account) {
         val key = account.keyPair.privKey
         if (account.loginWithExternalSigner) {
-            ExternalSignerUtils.account = account
             var cached = ExternalSignerUtils.cachedDecryptedContent[pushWrappedEvent.id]
             if (cached == null) {
-                ExternalSignerUtils.decrypt(
+                account.externalSigner.decrypt(
                     pushWrappedEvent.content,
                     pushWrappedEvent.pubKey,
                     pushWrappedEvent.id,
@@ -101,7 +100,7 @@ class EventNotificationConsumer(private val applicationContext: Context) {
                 } else if (account.loginWithExternalSigner) {
                     var cached = ExternalSignerUtils.cachedDecryptedContent[event.id]
                     if (cached == null) {
-                        ExternalSignerUtils.decrypt(
+                        account.externalSigner.decrypt(
                             event.content,
                             event.pubKey,
                             event.id,
@@ -127,7 +126,7 @@ class EventNotificationConsumer(private val applicationContext: Context) {
                 } else if (account.loginWithExternalSigner) {
                     var cached = ExternalSignerUtils.cachedDecryptedContent[event.id]
                     if (cached == null) {
-                        ExternalSignerUtils.decrypt(
+                        account.externalSigner.decrypt(
                             event.content,
                             event.pubKey,
                             event.id,

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/notifications/RegisterAccounts.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/notifications/RegisterAccounts.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import com.vitorpamplona.amethyst.AccountInfo
 import com.vitorpamplona.amethyst.BuildConfig
 import com.vitorpamplona.amethyst.LocalPreferences
-import com.vitorpamplona.amethyst.service.ExternalSignerUtils
 import com.vitorpamplona.amethyst.service.HttpClient
 import com.vitorpamplona.quartz.events.RelayAuthEvent
 import kotlinx.coroutines.Dispatchers
@@ -25,10 +24,6 @@ class RegisterAccounts(
         return accounts.mapNotNull {
             val acc = LocalPreferences.loadCurrentAccountFromEncryptedStorage(it.npub)
             if (acc != null && (acc.isWriteable() || acc.loginWithExternalSigner)) {
-                if (acc.loginWithExternalSigner) {
-                    ExternalSignerUtils.account = acc
-                }
-
                 val readRelays = acc.userProfile().latestContactList?.relays() ?: acc.backupContactList?.relays()
 
                 val relayToUse = readRelays?.firstNotNullOfOrNull { if (it.value.read) it.key else null }

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/dal/BookmarkPrivateFeedFilter.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/dal/BookmarkPrivateFeedFilter.kt
@@ -21,7 +21,7 @@ object BookmarkPrivateFeedFilter : FeedFilter<Note>() {
             if (id != null) {
                 val decryptedContent = ExternalSignerUtils.cachedDecryptedContent[id]
                 if (decryptedContent == null) {
-                    ExternalSignerUtils.decryptBookmark(
+                    account.externalSigner.decryptBookmark(
                         bookmarks.content,
                         account.keyPair.pubKey.toHexKey(),
                         id

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/note/UserProfilePicture.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/note/UserProfilePicture.kt
@@ -504,7 +504,7 @@ fun NoteDropDownMenu(note: Note, popupExpanded: MutableState<Boolean>, accountVi
                     scope.launch(Dispatchers.IO) {
                         if (accountViewModel.loggedInWithExternalSigner()) {
                             val bookmarks = accountViewModel.userProfile().latestBookmarkList
-                            ExternalSignerUtils.decrypt(
+                            accountViewModel.account.externalSigner.decrypt(
                                 bookmarks?.content ?: "",
                                 accountViewModel.account.keyPair.pubKey.toHexKey(),
                                 bookmarks?.id ?: ""
@@ -527,7 +527,7 @@ fun NoteDropDownMenu(note: Note, popupExpanded: MutableState<Boolean>, accountVi
                     scope.launch(Dispatchers.IO) {
                         if (accountViewModel.loggedInWithExternalSigner()) {
                             val bookmarks = accountViewModel.userProfile().latestBookmarkList
-                            ExternalSignerUtils.decrypt(
+                            accountViewModel.account.externalSigner.decrypt(
                                 bookmarks?.content ?: "",
                                 accountViewModel.account.keyPair.pubKey.toHexKey(),
                                 bookmarks?.id ?: ""
@@ -551,7 +551,7 @@ fun NoteDropDownMenu(note: Note, popupExpanded: MutableState<Boolean>, accountVi
                     scope.launch(Dispatchers.IO) {
                         if (accountViewModel.loggedInWithExternalSigner()) {
                             val bookmarks = accountViewModel.userProfile().latestBookmarkList
-                            ExternalSignerUtils.decrypt(
+                            accountViewModel.account.externalSigner.decrypt(
                                 bookmarks?.content ?: "",
                                 accountViewModel.account.keyPair.pubKey.toHexKey(),
                                 bookmarks?.id ?: ""
@@ -577,7 +577,7 @@ fun NoteDropDownMenu(note: Note, popupExpanded: MutableState<Boolean>, accountVi
                     scope.launch(Dispatchers.IO) {
                         if (accountViewModel.loggedInWithExternalSigner()) {
                             val bookmarks = accountViewModel.userProfile().latestBookmarkList
-                            ExternalSignerUtils.decrypt(
+                            accountViewModel.account.externalSigner.decrypt(
                                 bookmarks?.content ?: "",
                                 accountViewModel.account.keyPair.pubKey.toHexKey(),
                                 bookmarks?.id ?: ""

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedOff/LoginScreen.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedOff/LoginScreen.kt
@@ -69,6 +69,7 @@ import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.ServiceManager
+import com.vitorpamplona.amethyst.service.ExternalSigner
 import com.vitorpamplona.amethyst.service.ExternalSignerUtils
 import com.vitorpamplona.amethyst.service.PackageUtils
 import com.vitorpamplona.amethyst.service.SignerType
@@ -141,7 +142,7 @@ fun LoginPage(
 
     LaunchedEffect(loginWithExternalSigner) {
         if (loginWithExternalSigner) {
-            ExternalSignerUtils.openSigner(
+            ExternalSigner("").openSigner(
                 "",
                 SignerType.GET_PUBLIC_KEY,
                 activity,
@@ -400,7 +401,7 @@ fun LoginPage(
                                 return@Button
                             }
 
-                            val result = ExternalSignerUtils.getDataFromResolver(SignerType.GET_PUBLIC_KEY, arrayOf("login"))
+                            val result = ExternalSigner("").getDataFromResolver(SignerType.GET_PUBLIC_KEY, arrayOf("login"))
                             if (result == null) {
                                 loginWithExternalSigner = true
                                 return@Button


### PR DESCRIPTION
This also fixes a crash when you create a new account and reject the event after changing your relays and a loop in the auth event because onresume is executed after we set the shouldPauseService variable.
