### PR TITLE
Fixes/improvements to external signer

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/components/InvoiceRequest.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/components/InvoiceRequest.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.Account
+import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.service.lnurl.LightningAddressResolver
 import com.vitorpamplona.amethyst.ui.theme.QuoteBorder
 import com.vitorpamplona.amethyst.ui.theme.placeholderText
@@ -170,6 +171,7 @@ fun InvoiceRequest(
                     )
                 } else {
                     account.createZapRequestFor(toUserPubKeyHex, message, account.defaultZapType) { zapRequest ->
+                        LocalCache.justConsume(zapRequest, null)
                         LightningAddressResolver().lnAddressInvoice(
                             lud16,
                             amount * 1000,

--- a/quartz/src/main/java/com/vitorpamplona/quartz/signers/NostrSignerExternal.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/signers/NostrSignerExternal.kt
@@ -34,17 +34,33 @@ class NostrSignerExternal(
         )
 
         launcher.openSigner(event) { signature ->
-            (EventFactory.create(
-                event.id,
-                event.pubKey,
-                event.createdAt,
-                event.kind,
-                event.tags,
-                event.content,
-                signature
-            ) as? T?)?.let {
-                onReady(it)
+            if (signature.startsWith("{")) {
+                val localEvent = Event.fromJson(signature)
+                (EventFactory.create(
+                    localEvent.id,
+                    localEvent.pubKey,
+                    localEvent.createdAt,
+                    localEvent.kind,
+                    localEvent.tags,
+                    localEvent.content,
+                    localEvent.sig
+                ) as? T?)?.let {
+                    onReady(it)
+                }
+            } else {
+                (EventFactory.create(
+                    event.id,
+                    event.pubKey,
+                    event.createdAt,
+                    event.kind,
+                    event.tags,
+                    event.content,
+                    signature
+                ) as? T?)?.let {
+                    onReady(it)
+                }
             }
+
         }
     }
 


### PR DESCRIPTION
- [x] Fix sending zaps
- [x] Send some default permissions on login (need a new version of Amber not released yet)
- [x] Save the external signer package name on login (need a new version of Amber not released yet)
- [x] Test all events
- [ ] Test in graphene os
- [x] Test old version of Amber and Amethyst
- [ ] Support for signing multiple events simultaneous
- [ ] Support for sending the account metadata

Some screenshots:

![Screenshot_20231120_150154](https://github.com/vitorpamplona/amethyst/assets/115044884/8e971319-bdc5-4eb1-aeea-5987456ca352)

![Screenshot_20231120_150212](https://github.com/vitorpamplona/amethyst/assets/115044884/c9380995-c54c-4b65-910d-06cc03f15053)
