### PR TITLE
add a button to cashu preview to redeem on external wallet

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/components/CashuRedeem.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/components/CashuRedeem.kt
@@ -175,58 +175,47 @@ fun CashuPreview(token: CashuToken, accountViewModel: AccountViewModel) {
                         LoadingAnimation()
                     }
 
-                    Spacer(modifier = StdHorzSpacer)
-
                     Text(
-                        "⚡",
+                        "⚡ Send to Zap Wallet",
                         color = Color.White,
                         fontSize = 16.sp
                     )
                 }
-
-                Spacer(modifier = StdHorzSpacer)
-                Button(
-                    onClick = {
-                        try {
-                            val intent = Intent(Intent.ACTION_VIEW, Uri.parse("cashu://$token"))
-                            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-
-                            startActivity(context, intent, null)
-                        } catch (e: Exception) {
-                            accountViewModel.toast("Cashu", context.getString(R.string.cashu_no_wallet_found))
-                        }
-                    },
-                    shape = QuoteBorder,
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.primary
-                    )
-                ) {
-                    Spacer(modifier = StdHorzSpacer)
-                    Text("\uD83E\uDD5C", color = Color.White, fontSize = 16.sp)
-                }
-                Spacer(modifier = StdHorzSpacer)
-
-                Button(
-                    onClick = {
-                        if (useWebService) {
-                            // In case we want to use the cashu.me webservice
-                            val url = "https://redeem.cashu.me?token=$token&lightning=$lud16&autopay=false"
-                            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-                            startActivity(context, intent, null)
-                        } else {
-                            // Copying the token to clipboard for now
-                            clipboardManager.setText(AnnotatedString(token.token))
-                        }
-                    },
-                    shape = QuoteBorder,
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.primary
-                    )
-                ) {
-                    Text("⎘", color = Color.White, fontSize = 18.sp)
-                }
-                Spacer(modifier = StdHorzSpacer)
             }
+
+            Spacer(modifier = StdHorzSpacer)
+            Button(
+                onClick = {
+                    try {
+                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("cashu://$token"))
+                        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+
+                        startActivity(context, intent, null)
+                    } catch (e: Exception) {
+                        accountViewModel.toast("Cashu", context.getString(R.string.cashu_no_wallet_found))
+                    }
+                },
+                shape = QuoteBorder,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary
+                )
+            ) {
+                Text("\uD83E\uDD5C Open in Cashu Wallet", color = Color.White, fontSize = 16.sp)
+            }
+            Spacer(modifier = StdHorzSpacer)
+            Button(
+                onClick = {
+                    // Copying the token to clipboard
+                    clipboardManager.setText(AnnotatedString(token.token))
+                },
+                shape = QuoteBorder,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary
+                )
+            ) {
+                Text("⎘ Copy ", color = Color.White, fontSize = 16.sp)
+            }
+            Spacer(modifier = StdHorzSpacer)
         }
     }
 }

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/components/CashuRedeem.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/components/CashuRedeem.kt
@@ -178,12 +178,32 @@ fun CashuPreview(token: CashuToken, accountViewModel: AccountViewModel) {
                     Spacer(modifier = StdHorzSpacer)
 
                     Text(
-                        stringResource(R.string.cashu_redeem),
+                        "⚡",
                         color = Color.White,
-                        fontSize = 18.sp
+                        fontSize = 16.sp
                     )
                 }
 
+                Spacer(modifier = StdHorzSpacer)
+                Button(
+                    onClick = {
+                        try {
+                            val intent = Intent(Intent.ACTION_VIEW, Uri.parse("cashu://$token"))
+                            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+
+                            startActivity(context, intent, null)
+                        } catch (e: Exception) {
+                            accountViewModel.toast("Cashu", context.getString(R.string.cashu_no_wallet_found))
+                        }
+                    },
+                    shape = QuoteBorder,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary
+                    )
+                ) {
+                    Spacer(modifier = StdHorzSpacer)
+                    Text("\uD83E\uDD5C", color = Color.White, fontSize = 16.sp)
+                }
                 Spacer(modifier = StdHorzSpacer)
 
                 Button(
@@ -205,6 +225,7 @@ fun CashuPreview(token: CashuToken, accountViewModel: AccountViewModel) {
                 ) {
                     Text("⎘", color = Color.White, fontSize = 18.sp)
                 }
+                Spacer(modifier = StdHorzSpacer)
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -629,6 +629,7 @@
 
     <string name="cashu_sucessful_redemption">Cashu Received</string>
     <string name="cashu_sucessful_redemption_explainer">%1$s sats were sent to your wallet. (Fees: %2$s sats)</string>
+    <string name="cashu_no_wallet_found">No compatible Cashu wallet found on system</string>
 
     <string name="error_unable_to_fetch_invoice">Unable to fetch invoice from receiver\'s servers</string>
 


### PR DESCRIPTION
Cashu preview would allow to 1) Melt to user's Ln address 2) (new) Deeplink to Cashu Wallet App on phone 3) copy cashu token

![cashu](https://github.com/vitorpamplona/amethyst/assets/1097224/e0929f57-5c8c-4cc5-b73a-b9130c05f419)
