### PR TITLE
allow relay selection dialog to pick any relays

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -2435,6 +2435,10 @@ class Account(
         return (activeRelays() ?: convertLocalRelays()).filter { it.write }
     }
 
+    fun activeAllRelays(): List<Relay> {
+        return ((activeRelays() ?: convertLocalRelays()).toList())
+    }
+
     fun isAllHidden(users: Set<HexKey>): Boolean {
         return users.all { isHidden(it) }
     }

--- a/app/src/main/java/com/vitorpamplona/amethyst/service/relays/RelayPool.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/relays/RelayPool.kt
@@ -150,11 +150,15 @@ object RelayPool : Relay.Listener {
         list: List<Relay>,
         signedEvent: EventInterface,
     ) {
-        list.forEach { relay -> relays.filter { it.url == relay.url }.forEach { it.send(signedEvent) } }
+        list.forEach { relay -> relays.filter { it.url == relay.url }.forEach { it.sendOverride(signedEvent) } }
     }
 
     fun send(signedEvent: EventInterface) {
         relays.forEach { it.send(signedEvent) }
+    }
+
+    fun sendOverride(signedEvent: EventInterface) {
+        relays.forEach { it.sendOverride(signedEvent) }
     }
 
     fun close(subscriptionId: String) {

--- a/app/src/main/java/com/vitorpamplona/amethyst/ui/actions/RelaySelectionDialog.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/ui/actions/RelaySelectionDialog.kt
@@ -78,7 +78,7 @@ fun RelaySelectionDialog(
 
     var relays by remember {
         mutableStateOf(
-            accountViewModel.account.activeWriteRelays().map {
+            accountViewModel.account.activeAllRelays().map {
                 RelayList(
                     relay = it,
                     relayInfo = RelayBriefInfoCache.RelayBriefInfo(it.url),


### PR DESCRIPTION
Currently, the relay selection dialog only shows "write" relays.  This change allows you to select from any of the relays and override the relay posting engine to allow the messages through.