### PR TITLE
Fix hidden notes when hidden words is empty

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/model/Note.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/model/Note.kt
@@ -766,7 +766,7 @@ open class Note(
         }
 
         if (thisEvent is BaseTextNoteEvent) {
-            if (thisEvent.content.containsAny(accountChoices.hiddenWordsCase)) {
+            if (accountChoices.hiddenWordsCase.isNotEmpty() && thisEvent.content.containsAny(accountChoices.hiddenWordsCase)) {
                 return true
             }
         }


### PR DESCRIPTION
Don't know if we should check this here or change the containsAny function