### PR TITLE
Set redirects to false for httpclient used during nip05

### DIFF
--- a/app/src/main/java/com/vitorpamplona/amethyst/service/Nip05NostrAddressVerifier.kt
+++ b/app/src/main/java/com/vitorpamplona/amethyst/service/Nip05NostrAddressVerifier.kt
@@ -64,8 +64,8 @@ class Nip05NostrAddressVerifier() {
                     .header("User-Agent", "Amethyst/${BuildConfig.VERSION_NAME}")
                     .url(url)
                     .build()
-
-            HttpClientManager.getHttpClient()
+            // Fetchers MUST ignore any HTTP redirects given by the /.well-known/nostr.json endpoint.
+            HttpClientManager.getHttpClient().newBuilder().followRedirects(false).build()
                 .newCall(request)
                 .enqueue(
                     object : Callback {


### PR DESCRIPTION
Change OkHttpClient used for NIP05 verification to not follow redirects.

I verified that this change fails NIP05 verifications with a redirect.

After reading the OkHttpClient docs I'm comfortable this will not create unnecessary resources.

> Customize Your Client With newBuilder()
> You can customize a shared OkHttpClient instance with newBuilder. This builds a client that shares the same connection pool, thread pools, and configuration. Use the builder methods to add configuration to the derived client for a specific purpose.

Fix for https://github.com/vitorpamplona/amethyst/issues/915