### PR TITLE
Fix poll options behavior

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewPostView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewPostView.kt
@@ -629,17 +629,21 @@ private fun BottomRowActions(postViewModel: NewPostViewModel) {
 
 @Composable
 private fun PollField(postViewModel: NewPostViewModel) {
+    val optionsList = postViewModel.pollOptions
     Column(
         modifier = Modifier.fillMaxWidth(),
     ) {
-        postViewModel.pollOptions.values.forEachIndexed { index, _ ->
-            NewPollOption(postViewModel, index)
+        optionsList.forEach { value ->
+            NewPollOption(postViewModel, value.key)
         }
 
         NewPollVoteValueRange(postViewModel)
 
         Button(
-            onClick = { postViewModel.pollOptions[postViewModel.pollOptions.size] = "" },
+            onClick = {
+                // postViewModel.pollOptions[postViewModel.pollOptions.size] = ""
+                optionsList[optionsList.size] = ""
+            },
             border =
                 BorderStroke(
                     1.dp,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewPostViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewPostViewModel.kt
@@ -1296,9 +1296,6 @@ open class NewPostViewModel : ViewModel() {
         val newEntries = keyList.zip(elementList) { key, content -> Pair(key, content) }
         this.clear()
         this.putAll(newEntries)
-
-        println("Keys collection size(after deletion) :${keys.size}")
-        println("Values collection size(after deletion) :${values.size}")
     }
 
     fun updatePollOption(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewPostViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewPostViewModel.kt
@@ -1278,8 +1278,27 @@ open class NewPostViewModel : ViewModel() {
     }
 
     fun removePollOption(optionIndex: Int) {
-        pollOptions.remove(optionIndex)
+        pollOptions.removeOrdered(optionIndex)
         saveDraft()
+    }
+
+    private fun MutableMap<Int, String>.removeOrdered(index: Int) {
+        val keyList = keys
+        val elementList = values.toMutableList()
+        run stop@{
+            for (i in index until elementList.size) {
+                val nextIndex = i + 1
+                if (nextIndex == elementList.size) return@stop
+                elementList[i] = elementList[nextIndex].also { elementList[nextIndex] = "null" }
+            }
+        }
+        elementList.removeLast()
+        val newEntries = keyList.zip(elementList) { key, content -> Pair(key, content) }
+        this.clear()
+        this.putAll(newEntries)
+
+        println("Keys collection size(after deletion) :${keys.size}")
+        println("Values collection size(after deletion) :${values.size}")
     }
 
     fun updatePollOption(


### PR DESCRIPTION
Fixes #532 .
As observed by both @davotoula and I, the poll state becomes inconsistent when an item, which is not the last item, is deleted, and persists even when adding items back. This PR aims to solve that issue.