### PR TITLE
Store additional File Metadata in Gallery Entries

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -2251,21 +2251,25 @@ class Account(
         idHex: String,
         url: String,
         relay: String?,
+        blurhash: String?,
+        dim: String?,
+        hash: String?,
+        mimeType: String?,
     ) {
         if (!isWriteable()) return
         ProfileGalleryEntryEvent.create(
             url = url,
             eventid = idHex,
             relayhint = relay,
+            blurhash = blurhash,
+            hash = hash,
+            dimensions = dim,
+            mimeType = mimeType,
             /*magnetUri = magnetUri,
-            mimeType = headerInfo.mimeType,
-            hash = headerInfo.hash,
             size = headerInfo.size.toString(),
             dimensions = headerInfo.dim,
-            blurhash = headerInfo.blurHash,
             alt = alt,
-            originalHash = originalHash,
-            sensitiveContent = sensitiveContent, */
+            originalHash = originalHash, */
             signer = signer,
         ) { event ->
             Client.send(event)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/VideoView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/VideoView.kt
@@ -824,7 +824,7 @@ private fun RenderVideoPlayer(
             }
 
             AnimatedShareButton(controllerVisible, Modifier.align(Alignment.TopEnd).padding(end = Size165dp)) { popupExpanded, toggle ->
-                ShareImageAction(accountViewModel = accountViewModel, popupExpanded, videoUri, nostrUriCallback, toggle)
+                ShareImageAction(accountViewModel = accountViewModel, popupExpanded, videoUri, null, null, null, null, nostrUriCallback, toggle)
             }
         } else {
             controller.volume = 0f

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
@@ -605,6 +605,10 @@ fun ShareImageAction(
             popupExpanded = popupExpanded,
             videoUri = content.url,
             postNostrUri = content.uri,
+            blurhash = content.blurhash,
+            dim = content.dim,
+            hash = content.hash,
+            mimeType = content.mimeType,
             onDismiss = onDismiss,
         )
     } else if (content is MediaPreloadedContent) {
@@ -613,6 +617,10 @@ fun ShareImageAction(
             popupExpanded = popupExpanded,
             videoUri = content.localFile?.toUri().toString(),
             postNostrUri = content.uri,
+            blurhash = content.blurhash,
+            dim = content.dim,
+            hash = null,
+            mimeType = content.mimeType,
             onDismiss = onDismiss,
         )
     }
@@ -625,6 +633,10 @@ fun ShareImageAction(
     popupExpanded: MutableState<Boolean>,
     videoUri: String?,
     postNostrUri: String?,
+    blurhash: String?,
+    dim: String?,
+    hash: String?,
+    mimeType: String?,
     onDismiss: () -> Unit,
 ) {
     DropdownMenu(
@@ -660,7 +672,7 @@ fun ShareImageAction(
                     if (videoUri != null) {
                         var n19 = Nip19Bech32.uriToRoute(postNostrUri)?.entity as? Nip19Bech32.NEvent
                         if (n19 != null) {
-                            accountViewModel.addMediaToGallery(n19.hex, videoUri, n19.relay[0]) // TODO Whole list or first?
+                            accountViewModel.addMediaToGallery(n19.hex, videoUri, n19.relay[0], blurhash, dim, hash, mimeType) // TODO Whole list or first?
                             accountViewModel.toast(R.string.image_saved_to_the_gallery, R.string.image_saved_to_the_gallery)
                         }
                     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -673,8 +673,12 @@ class AccountViewModel(
         hex: String,
         url: String,
         relay: String?,
+        blurhash: String?,
+        dim: String?,
+        hash: String?,
+        mimeType: String?,
     ) {
-        viewModelScope.launch(Dispatchers.IO) { account.addToGallery(hex, url, relay) }
+        viewModelScope.launch(Dispatchers.IO) { account.addToGallery(hex, url, relay, blurhash, dim, hash, mimeType) }
     }
 
     fun removefromMediaGallery(note: Note) {


### PR DESCRIPTION
NIP93 (not merged yet) allows for optional File Metadata. This PR adds information like blurhash, filehash, and dimension to Kind 1163 events to help clients with rendering Gallery Entries. (They are currently not used on Amethyst's side right now, but it could probably be nice to render the blurhash while entries are loading)