### PR TITLE
Bugfix:  add to gallery and copy note id to clipboard missing after clicking "show more"  #993

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/RichTextViewer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/RichTextViewer.kt
@@ -431,7 +431,7 @@ private fun RenderWordWithPreview(
     nav: (String) -> Unit,
 ) {
     when (word) {
-        is ImageSegment -> ZoomableContentView(word.segmentText, state, accountViewModel)
+        is ImageSegment -> ZoomableContentView(word.segmentText, state, callbackUri, accountViewModel)
         is LinkSegment -> LoadUrlPreview(word.segmentText, word.segmentText, callbackUri, accountViewModel)
         is EmojiSegment -> RenderCustomEmoji(word.segmentText, state)
         is InvoiceSegment -> MayBeInvoicePreview(word.segmentText, accountViewModel)
@@ -493,11 +493,14 @@ fun ImageFromBase64(base64String: String) {
 private fun ZoomableContentView(
     word: String,
     state: RichTextViewerState,
+    callbackUri: String?,
     accountViewModel: AccountViewModel,
 ) {
     state.imagesForPager[word]?.let {
+        val contentwithuri = it
+        contentwithuri.uri = callbackUri
         Box(modifier = HalfVertPadding) {
-            ZoomableContentView(it, state.imageList, roundedCorner = true, isFiniteHeight = false, accountViewModel)
+            ZoomableContentView(contentwithuri, state.imageList, roundedCorner = true, isFiniteHeight = false, accountViewModel)
         }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/ProfileScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/ProfileScreen.kt
@@ -364,7 +364,7 @@ fun ProfileScreen(
         val observer =
             LifecycleEventObserver { _, event ->
                 if (event == Lifecycle.Event.ON_RESUME) {
-                    println("Profidle Start")
+                    println("Profile Start")
                     NostrUserProfileDataSource.loadUserProfile(baseUser)
                     NostrUserProfileDataSource.start()
                 }

--- a/commons/src/main/java/com/vitorpamplona/amethyst/commons/richtext/MediaContentModels.kt
+++ b/commons/src/main/java/com/vitorpamplona/amethyst/commons/richtext/MediaContentModels.kt
@@ -37,7 +37,7 @@ abstract class MediaUrlContent(
     val hash: String? = null,
     dim: String? = null,
     blurhash: String? = null,
-    val uri: String? = null,
+    var uri: String? = null,
     val mimeType: String? = null,
 ) : BaseMediaContent(description, dim, blurhash)
 


### PR DESCRIPTION
As pointed out in issue #993. when clicking the "show more" button on longer notes, media could not be added to the gallery (nor could the note id be copied). This fix adds the uri when ImageSegment is fetched from the Richtextviewer renderer