### PR TITLE
Fix relay set event.

### DIFF
--- a/quartz/src/main/java/com/vitorpamplona/quartz/events/RelaySetEvent.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/events/RelaySetEvent.kt
@@ -39,7 +39,7 @@ class RelaySetEvent(
     fun description() = tags.firstOrNull { it.size > 1 && it[0] == "description" }?.get(1)
 
     companion object {
-        const val KIND = 30022
+        const val KIND = 30002
         const val ALT = "Relay list"
 
         fun create(


### PR DESCRIPTION
According to NIP-51, a relay set event is kind 30002, instead of 30022. 

A probable consequence might be lots of events published with this kind might need to be migrated(?), unless there is little to no usage.