### PR TITLE
1037 tor setting reset to off after switching away

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -252,7 +252,7 @@ class AccountSettings(
         portNumber: String,
     ) {
         val port = portNumber.toIntOrNull() ?: return
-        if (proxyPort != port && isProxyEnabled() != enabled) {
+        if (proxyPort != port || isProxyEnabled() != enabled) {
             proxyPort = portNumber.toInt()
             proxy = HttpClientManager.initProxy(enabled, "127.0.0.1", proxyPort)
             saveAccountSettings()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedOff/LoginScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedOff/LoginScreen.kt
@@ -472,43 +472,42 @@ fun LoginPage(
                         },
                     ),
             )
+        }
+        Spacer(modifier = Modifier.height(10.dp))
 
-            Spacer(modifier = Modifier.height(10.dp))
+        if (PackageUtils.isOrbotInstalled(context)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Checkbox(
+                    checked = useProxy.value,
+                    onCheckedChange = {
+                        if (it) {
+                            connectOrbotDialogOpen = true
+                        }
+                    },
+                )
 
-            if (PackageUtils.isOrbotInstalled(context)) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Checkbox(
-                        checked = useProxy.value,
-                        onCheckedChange = {
-                            if (it) {
-                                connectOrbotDialogOpen = true
-                            }
-                        },
-                    )
+                Text(stringRes(R.string.connect_via_tor))
+            }
 
-                    Text(stringRes(R.string.connect_via_tor))
-                }
-
-                if (connectOrbotDialogOpen) {
-                    ConnectOrbotDialog(
-                        onClose = { connectOrbotDialogOpen = false },
-                        onPost = {
-                            connectOrbotDialogOpen = false
-                            useProxy.value = true
-                        },
-                        onError = {
-                            scope.launch {
-                                Toast
-                                    .makeText(
-                                        context,
-                                        it,
-                                        Toast.LENGTH_LONG,
-                                    ).show()
-                            }
-                        },
-                        proxyPort,
-                    )
-                }
+            if (connectOrbotDialogOpen) {
+                ConnectOrbotDialog(
+                    onClose = { connectOrbotDialogOpen = false },
+                    onPost = {
+                        connectOrbotDialogOpen = false
+                        useProxy.value = true
+                    },
+                    onError = {
+                        scope.launch {
+                            Toast
+                                .makeText(
+                                    context,
+                                    it,
+                                    Toast.LENGTH_LONG,
+                                ).show()
+                        }
+                    },
+                    proxyPort,
+                )
             }
         }
 


### PR DESCRIPTION
The changed proxy state wasn't being saved in account settings and thus app restarted with tor disabled.

I changed the logic of saving proxy state from "changed port AND changed proxy state" to "changed port OR changed proxy state".

I also noticed the orbot option had been removed from login screen. I assume by a single misplaced if bracket but the diff looks bigger due to white spaces changes.

Before
![tor_not_visible](https://github.com/user-attachments/assets/2a5abbbe-3731-4ea9-8bc0-348439ba0525)

After
![tor_visible](https://github.com/user-attachments/assets/8718a57c-3e27-452f-9fb2-562bd0e83861)

#1037 