### PR TITLE
Fix token sanitization when using gcompatup

### DIFF
--- a/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/service/notifications/PushMessageReceiver.kt
+++ b/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/service/notifications/PushMessageReceiver.kt
@@ -84,7 +84,7 @@ class PushMessageReceiver : MessagingReceiver() {
         endpoint: String,
         instance: String,
     ) {
-        val sanitizedEndpoint = endpoint.dropLast(5)
+        val sanitizedEndpoint = if (endpoint.endsWith("?up=1")) endpoint.dropLast(5) else endpoint
         if (sanitizedEndpoint != pushHandler.getSavedEndpoint()) {
             Log.d(TAG, "New endpoint provided:- $endpoint for Instance: $instance ${pushHandler.getSavedEndpoint()} $sanitizedEndpoint")
             pushHandler.setEndpoint(sanitizedEndpoint)


### PR DESCRIPTION
@vitorpamplona 
This is one of the reasons some people are not receiving notifications
You need to increase the size of the token field in the notification server too if you are still using the 255
The token was 257 here
This happens when using [gcompat-up](https://play.google.com/store/apps/details?id=org.unifiedpush.distributor.fcm) for notifications