### PR TITLE
Add media compression level uncompressed

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/Nip05NostrAddressVerifier.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/Nip05NostrAddressVerifier.kt
@@ -126,7 +126,7 @@ class Nip05NostrAddressVerifier {
                 val hexKey = nip05url?.get("names")?.get(user)?.asText()
 
                 if (hexKey == null) {
-                    onError("Username not found in the NIP05 JSON")
+                    onError("Username not found in the NIP05 JSON [$nip05]")
                 } else {
                     onSuccess(hexKey)
                 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewMediaView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewMediaView.kt
@@ -210,7 +210,7 @@ fun NewMediaView(
                                     text = stringRes(context, R.string.media_compression_quality_explainer),
                                     style = MaterialTheme.typography.bodySmall,
                                     color = Color.Gray,
-                                    maxLines = 4,
+                                    maxLines = 5,
                                     overflow = TextOverflow.Ellipsis,
                                 )
                             }
@@ -227,7 +227,7 @@ fun NewMediaView(
                                                 0 -> stringRes(R.string.media_compression_quality_low)
                                                 1 -> stringRes(R.string.media_compression_quality_medium)
                                                 2 -> stringRes(R.string.media_compression_quality_high)
-                                                3 -> "UNCOMPRESSED"
+                                                3 -> stringRes(R.string.media_compression_quality_uncompressed)
                                                 else -> stringRes(R.string.media_compression_quality_medium)
                                             },
                                         modifier = Modifier.align(Alignment.Center),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewMediaView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewMediaView.kt
@@ -105,7 +105,9 @@ fun NewMediaView(
 
     var showRelaysDialog by remember { mutableStateOf(false) }
     var relayList = remember { accountViewModel.account.activeWriteRelays().toImmutableList() }
-    var mediaQualitySlider by remember { mutableIntStateOf(1) } // 0 = Low, 1 = Medium, 2 = High
+
+    // 0 = Low, 1 = Medium, 2 = High, 3=UNCOMPRESSED
+    var mediaQualitySlider by remember { mutableIntStateOf(1) }
 
     Dialog(
         onDismissRequest = { onClose() },
@@ -225,6 +227,7 @@ fun NewMediaView(
                                                 0 -> stringRes(R.string.media_compression_quality_low)
                                                 1 -> stringRes(R.string.media_compression_quality_medium)
                                                 2 -> stringRes(R.string.media_compression_quality_high)
+                                                3 -> "UNCOMPRESSED"
                                                 else -> stringRes(R.string.media_compression_quality_medium)
                                             },
                                         modifier = Modifier.align(Alignment.Center),
@@ -234,8 +237,8 @@ fun NewMediaView(
                                 Slider(
                                     value = mediaQualitySlider.toFloat(),
                                     onValueChange = { mediaQualitySlider = it.toInt() },
-                                    valueRange = 0f..2f,
-                                    steps = 1,
+                                    valueRange = 0f..3f,
+                                    steps = 2,
                                 )
                             }
                         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewPostView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewPostView.kt
@@ -1937,7 +1937,7 @@ fun ImageVideoDescription(
                         text = stringRes(R.string.media_compression_quality_explainer),
                         style = MaterialTheme.typography.bodySmall,
                         color = Color.Gray,
-                        maxLines = 4,
+                        maxLines = 5,
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
@@ -1955,7 +1955,7 @@ fun ImageVideoDescription(
                                     0 -> stringRes(R.string.media_compression_quality_low)
                                     1 -> stringRes(R.string.media_compression_quality_medium)
                                     2 -> stringRes(R.string.media_compression_quality_high)
-                                    3 -> "UNCOMPRESSED"
+                                    3 -> stringRes(R.string.media_compression_quality_uncompressed)
                                     else -> stringRes(R.string.media_compression_quality_medium)
                                 },
                             modifier = Modifier.align(Alignment.Center),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewPostView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewPostView.kt
@@ -1735,7 +1735,9 @@ fun ImageVideoDescription(
     }
     var message by remember { mutableStateOf("") }
     var sensitiveContent by remember { mutableStateOf(false) }
-    var mediaQualitySlider by remember { mutableIntStateOf(1) } // 0 = Low, 1 = Medium, 2 = High
+
+    // 0 = Low, 1 = Medium, 2 = High, 3=UNCOMPRESSED
+    var mediaQualitySlider by remember { mutableIntStateOf(1) }
 
     Column(
         modifier =
@@ -1953,6 +1955,7 @@ fun ImageVideoDescription(
                                     0 -> stringRes(R.string.media_compression_quality_low)
                                     1 -> stringRes(R.string.media_compression_quality_medium)
                                     2 -> stringRes(R.string.media_compression_quality_high)
+                                    3 -> "UNCOMPRESSED"
                                     else -> stringRes(R.string.media_compression_quality_medium)
                                 },
                             modifier = Modifier.align(Alignment.Center),
@@ -1962,8 +1965,8 @@ fun ImageVideoDescription(
                     Slider(
                         value = mediaQualitySlider.toFloat(),
                         onValueChange = { mediaQualitySlider = it.toInt() },
-                        valueRange = 0f..2f,
-                        steps = 1,
+                        valueRange = 0f..3f,
+                        steps = 2,
                     )
                 }
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/MediaCompressor.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/MediaCompressor.kt
@@ -49,99 +49,113 @@ class MediaCompressor {
         onError: (Int) -> Unit,
         mediaQuality: CompressorQuality,
     ) {
-        checkNotInMainThread()
+        if (mediaQuality != CompressorQuality.UNCOMPRESSED) {
+            checkNotInMainThread()
 
-        if (contentType?.startsWith("video", true) == true) {
-            val videoQuality =
-                when (mediaQuality) {
-                    CompressorQuality.VERY_LOW -> VideoQuality.VERY_LOW
-                    CompressorQuality.LOW -> VideoQuality.LOW
-                    CompressorQuality.MEDIUM -> VideoQuality.MEDIUM
-                    CompressorQuality.HIGH -> VideoQuality.HIGH
-                    CompressorQuality.VERY_HIGH -> VideoQuality.VERY_HIGH
-                }
-            Log.d("MediaCompressor", "Using video compression $mediaQuality")
-            VideoCompressor.start(
-                // => This is required
-                context = applicationContext,
-                // => Source can be provided as content uris
-                uris = listOf(uri),
-                isStreamable = false,
-                // THIS STORAGE
-                // sharedStorageConfiguration = SharedStorageConfiguration(
-                //    saveAt = SaveLocation.movies, // => default is movies
-                //    videoName = "compressed_video" // => required name
-                // ),
-                // OR AND NOT BOTH
-                appSpecificStorageConfiguration = AppSpecificStorageConfiguration(),
-                configureWith =
-                    Configuration(
-                        quality = videoQuality,
-                        // => required name
-                        videoNames = listOf(UUID.randomUUID().toString()),
-                    ),
-                listener =
-                    object : CompressionListener {
-                        override fun onProgress(
-                            index: Int,
-                            percent: Float,
-                        ) {}
-
-                        override fun onStart(index: Int) {
-                            // Compression start
-                        }
-
-                        override fun onSuccess(
-                            index: Int,
-                            size: Long,
-                            path: String?,
-                        ) {
-                            if (path != null) {
-                                onReady(Uri.fromFile(File(path)), contentType, size)
-                            } else {
-                                onError(R.string.compression_returned_null)
-                            }
-                        }
-
-                        override fun onFailure(
-                            index: Int,
-                            failureMessage: String,
-                        ) {
-                            // keeps going with original video
-                            onReady(uri, contentType, null)
-                        }
-
-                        override fun onCancelled(index: Int) {
-                            onError(R.string.compression_cancelled)
-                        }
-                    },
-            )
-        } else if (
-            contentType?.startsWith("image", true) == true &&
-            !contentType.contains("gif") &&
-            !contentType.contains("svg")
-        ) {
-            val imageQuality =
-                when (mediaQuality) {
-                    CompressorQuality.VERY_LOW -> 40
-                    CompressorQuality.LOW -> 50
-                    CompressorQuality.MEDIUM -> 60
-                    CompressorQuality.HIGH -> 80
-                    CompressorQuality.VERY_HIGH -> 90
-                }
-            try {
-                Log.d("MediaCompressor", "Using image compression $mediaQuality")
-                val compressedImageFile =
-                    Compressor.compress(applicationContext, from(uri, contentType, applicationContext)) {
-                        default(width = 640, format = Bitmap.CompressFormat.JPEG, quality = imageQuality)
+            if (contentType?.startsWith("video", true) == true) {
+                val videoQuality =
+                    when (mediaQuality) {
+                        CompressorQuality.VERY_LOW -> VideoQuality.VERY_LOW
+                        CompressorQuality.LOW -> VideoQuality.LOW
+                        CompressorQuality.MEDIUM -> VideoQuality.MEDIUM
+                        CompressorQuality.HIGH -> VideoQuality.HIGH
+                        CompressorQuality.VERY_HIGH -> VideoQuality.VERY_HIGH
+                        else -> VideoQuality.MEDIUM // dodgy
                     }
-                onReady(compressedImageFile.toUri(), contentType, compressedImageFile.length())
-            } catch (e: Exception) {
-                if (e is CancellationException) throw e
-                e.printStackTrace()
+                Log.d("MediaCompressor", "Using video compression $mediaQuality")
+                VideoCompressor.start(
+                    // => This is required
+                    context = applicationContext,
+                    // => Source can be provided as content uris
+                    uris = listOf(uri),
+                    isStreamable = false,
+                    // THIS STORAGE
+                    // sharedStorageConfiguration = SharedStorageConfiguration(
+                    //    saveAt = SaveLocation.movies, // => default is movies
+                    //    videoName = "compressed_video" // => required name
+                    // ),
+                    // OR AND NOT BOTH
+                    appSpecificStorageConfiguration = AppSpecificStorageConfiguration(),
+                    configureWith =
+                        Configuration(
+                            quality = videoQuality,
+                            // => required name
+                            videoNames = listOf(UUID.randomUUID().toString()),
+                        ),
+                    listener =
+                        object : CompressionListener {
+                            override fun onProgress(
+                                index: Int,
+                                percent: Float,
+                            ) {
+                            }
+
+                            override fun onStart(index: Int) {
+                                // Compression start
+                            }
+
+                            override fun onSuccess(
+                                index: Int,
+                                size: Long,
+                                path: String?,
+                            ) {
+                                if (path != null) {
+                                    Log.d("MediaCompressor", "Video compression success. Compressed size [$size]")
+                                    onReady(Uri.fromFile(File(path)), contentType, size)
+                                } else {
+                                    Log.d("MediaCompressor", "Video compression successful, but returned null path")
+                                    onError(R.string.compression_returned_null)
+                                }
+                            }
+
+                            override fun onFailure(
+                                index: Int,
+                                failureMessage: String,
+                            ) {
+                                // keeps going with original video
+                                Log.d("MediaCompressor", "Video compression failed: $failureMessage")
+                                onReady(uri, contentType, null)
+                            }
+
+                            override fun onCancelled(index: Int) {
+                                onError(R.string.compression_cancelled)
+                            }
+                        },
+                )
+            } else if (
+                contentType?.startsWith("image", true) == true &&
+                !contentType.contains("gif") &&
+                !contentType.contains("svg")
+            ) {
+                val imageQuality =
+                    when (mediaQuality) {
+                        CompressorQuality.VERY_LOW -> 40
+                        CompressorQuality.LOW -> 50
+                        CompressorQuality.MEDIUM -> 60
+                        CompressorQuality.HIGH -> 80
+                        CompressorQuality.VERY_HIGH -> 90
+                        else -> 60
+                    }
+                try {
+                    Log.d("MediaCompressor", "Using image compression $mediaQuality")
+                    val tempFile = from(uri, contentType, applicationContext)
+                    val compressedImageFile =
+                        Compressor.compress(applicationContext, tempFile) {
+                            default(width = 640, format = Bitmap.CompressFormat.JPEG, quality = imageQuality)
+                        }
+                    Log.d("MediaCompressor", "Image compression success. Original size [${tempFile.length()}], new size [${compressedImageFile.length()}]")
+                    onReady(compressedImageFile.toUri(), contentType, compressedImageFile.length())
+                } catch (e: Exception) {
+                    Log.d("MediaCompressor", "Image compression failed: ${e.message}")
+                    if (e is CancellationException) throw e
+                    e.printStackTrace()
+                    onReady(uri, contentType, null)
+                }
+            } else {
                 onReady(uri, contentType, null)
             }
         } else {
+            Log.d("MediaCompressor", "UNCOMPRESSED quality selected, skip compression and continue with original media.")
             onReady(uri, contentType, null)
         }
     }
@@ -188,6 +202,7 @@ class MediaCompressor {
             0 -> CompressorQuality.LOW
             1 -> CompressorQuality.MEDIUM
             2 -> CompressorQuality.HIGH
+            3 -> CompressorQuality.UNCOMPRESSED
             else -> CompressorQuality.MEDIUM
         }
 
@@ -196,6 +211,7 @@ class MediaCompressor {
             CompressorQuality.LOW -> 0
             CompressorQuality.MEDIUM -> 1
             CompressorQuality.HIGH -> 2
+            CompressorQuality.UNCOMPRESSED -> 3
             else -> 1
         }
 }
@@ -206,4 +222,5 @@ enum class CompressorQuality {
     MEDIUM,
     HIGH,
     VERY_HIGH,
+    UNCOMPRESSED,
 }

--- a/amethyst/src/main/res/values-cs/strings.xml
+++ b/amethyst/src/main/res/values-cs/strings.xml
@@ -667,10 +667,11 @@
     <string name="compression_cancelled">Komprese zrušena</string>
     <string name="compression_returned_null">Komprese se nepodařilo vrátit soubor</string>
     <string name="media_compression_quality_label">Kvalita médií</string>
-    <string name="media_compression_quality_explainer">Vyberte Nízkou kvalitu pro kompresi médií na menší soubor s nižší kvalitou, nebo vyberte Vysokou kvalitu pro kompresi na větší soubor s vyšší kvalitou.</string>
+    <string name="media_compression_quality_explainer">Vyberte Nízkou kvalitu pro kompresi médií na menší soubor s nižší kvalitou, Vysokou kvalitu pro kompresi na větší soubor s vyšší kvalitou, nebo "Bez komprese" pro nahrání médií bez komprese.</string>
     <string name="media_compression_quality_low">Nízká</string>
     <string name="media_compression_quality_medium">Střední</string>
     <string name="media_compression_quality_high">Vysoká</string>
+    <string name="media_compression_quality_uncompressed">Bez komprese</string>
     <string name="edit_draft">Upravit koncept</string>
     <string name="login_with_qr_code">Přihlášení pomocí QR kódu</string>
     <string name="route">Trasa</string>

--- a/amethyst/src/main/res/values-de/strings.xml
+++ b/amethyst/src/main/res/values-de/strings.xml
@@ -672,10 +672,11 @@ anz der Bedingungen ist erforderlich</string>
     <string name="compression_cancelled">Komprimierung abgebrochen</string>
     <string name="compression_returned_null">Komprimierung fehlgeschlagen eine Datei zurückzugeben</string>
     <string name="media_compression_quality_label">Medienqualität</string>
-    <string name="media_compression_quality_explainer">Wählen Sie Niedrige Qualität, um Ihre Medien in eine kleinere Datei mit geringerer Qualität zu komprimieren, oder wählen Sie Hohe Qualität, um sie in eine größere Datei mit höherer Qualität zu komprimieren.</string>
+    <string name="media_compression_quality_explainer">Wählen Sie Niedrige Qualität, um Ihre Medien in eine kleinere Datei mit geringerer Qualität zu komprimieren, Hohe Qualität, um sie in eine größere Datei mit höherer Qualität zu komprimieren, oder "Ohne Kompression", um die Medien ohne Kompression hochzuladen.</string>
     <string name="media_compression_quality_low">Niedrig</string>
     <string name="media_compression_quality_medium">Mittel</string>
     <string name="media_compression_quality_high">Hoch</string>
+    <string name="media_compression_quality_uncompressed">Ohne Kompression</string>
     <string name="edit_draft">Entwurf bearbeiten</string>
     <string name="login_with_qr_code">Einloggen mit QR-Code</string>
     <string name="route">Route</string>

--- a/amethyst/src/main/res/values-pt-rBR/strings.xml
+++ b/amethyst/src/main/res/values-pt-rBR/strings.xml
@@ -667,10 +667,11 @@
     <string name="compression_cancelled">Compressão cancelada</string>
     <string name="compression_returned_null">Compressão falhou ao retornar um arquivo</string>
     <string name="media_compression_quality_label">Qualidade de Mídia</string>
-    <string name="media_compression_quality_explainer">Selecione Baixa qualidade para comprimir sua mídia para um arquivo menor com menor qualidade ou selecione Alta qualidade para comprimir para um arquivo maior com maior qualidade.</string>
+    <string name="media_compression_quality_explainer">Selecione Baixa qualidade para comprimir sua mídia para um arquivo menor com menor qualidade, Alta qualidade para comprimir para um arquivo maior com maior qualidade ou "Sem compressão" para carregar a mídia sem compressão.</string>
     <string name="media_compression_quality_low">Baixa</string>
     <string name="media_compression_quality_medium">Média</string>
     <string name="media_compression_quality_high">Alta</string>
+    <string name="media_compression_quality_uncompressed">Sem compressão</string>
     <string name="edit_draft">Editar rascunho</string>
     <string name="login_with_qr_code">Entrar com Código QR</string>
     <string name="route">Rota</string>

--- a/amethyst/src/main/res/values-sv-rSE/strings.xml
+++ b/amethyst/src/main/res/values-sv-rSE/strings.xml
@@ -666,10 +666,11 @@
     <string name="compression_cancelled">Komprimering avbruten</string>
     <string name="compression_returned_null">Komprimering misslyckades att returnera en fil</string>
     <string name="media_compression_quality_label">Mediakvalitet</string>
-    <string name="media_compression_quality_explainer">Välj Låg kvalitet för att komprimera ditt media till en mindre fil med lägre kvalitet, eller välj Hög kvalitet för att komprimera till en större fil med högre kvalitet.</string>
+    <string name="media_compression_quality_explainer">Välj Låg kvalitet för att komprimera ditt media till en mindre fil med lägre kvalitet, Hög kvalitet för att komprimera till en större fil med högre kvalitet eller Okomprimerad för att ladda upp media utan kompression.</string>
     <string name="media_compression_quality_low">Låg</string>
     <string name="media_compression_quality_medium">Medel</string>
     <string name="media_compression_quality_high">Hög</string>
+    <string name="media_compression_quality_uncompressed">Okomprimerad</string>
     <string name="edit_draft">Redigera utkast</string>
     <string name="login_with_qr_code">Logga in med QR-kod</string>
     <string name="route">Rutt</string>

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -794,10 +794,11 @@
     <string name="compression_returned_null">Compression failed to return a file</string>
 
     <string name="media_compression_quality_label">Media Quality</string>
-    <string name="media_compression_quality_explainer">Select Low quality to compress your media to a smaller file with less quality or select High quality to compress to a larger file with higher quality.</string>
+    <string name="media_compression_quality_explainer">Select Low quality to compress your media to a smaller file with less quality, High quality to compress to a larger file with higher quality or Uncompressed to upload the media without compression.</string>
     <string name="media_compression_quality_low">Low</string>
     <string name="media_compression_quality_medium">Medium</string>
     <string name="media_compression_quality_high">High</string>
+    <string name="media_compression_quality_uncompressed">Uncompressed</string>
 
     <string name="edit_draft">Edit draft</string>
 


### PR DESCRIPTION
Added Uncompressed media quality level. Skips compression completely and just continues with original media.

[Screen_recording_20240911_173255.webm](https://github.com/user-attachments/assets/2edbeac5-4847-44d4-bc3c-9ce69a9b59a9)
