### PR TITLE
Cover URL preview case with property name with no value

### DIFF
--- a/commons/src/androidTest/java/com/vitorpamplona/amethyst/commons/preview/MetaTagsParserTest.kt
+++ b/commons/src/androidTest/java/com/vitorpamplona/amethyst/commons/preview/MetaTagsParserTest.kt
@@ -78,4 +78,36 @@ class MetaTagsParserTest {
             }
         }
     }
+
+    @Test
+    fun testParseExtraAttributeInMetaTag() {
+        val input =
+            """<html>
+            |  <head>
+            |    <meta data-preact-helmet property="og:title" content="What are your most treasured cookbooks?">
+            |    <meta property="og:description" content='description'>
+            |    <meta data-preact-helmet property="second" data-preact-helmet content="What are your most">
+            |  </head>
+            |  <body>
+            |    <meta name="ignore meta tags in body">
+            |  </body>
+            |</html>
+            """.trimMargin()
+
+        val exp =
+            listOf(
+                listOf("property" to "og:title", "content" to "What are your most treasured cookbooks?"),
+                listOf("property" to "og:description", "content" to "description"),
+                listOf("property" to "second", "content" to "What are your most"),
+            )
+
+        val metaTags = MetaTagsParser.parse(input).toList()
+        println(metaTags)
+        assertEquals(exp.size, metaTags.size)
+        metaTags.zip(exp).forEach { (meta, expAttrs) ->
+            expAttrs.forEach { (name, expValue) ->
+                assertEquals(expValue, meta.attr(name))
+            }
+        }
+    }
 }

--- a/commons/src/main/java/com/vitorpamplona/amethyst/commons/preview/MetaTagsParser.kt
+++ b/commons/src/main/java/com/vitorpamplona/amethyst/commons/preview/MetaTagsParser.kt
@@ -248,6 +248,12 @@ object MetaTagsParser {
                         }
 
                         c.isWhitespace() -> {}
+                        c.isLetter() -> {
+                            // If we find a letter instead of EQ we probably passed a property with no value
+                            // so lets reset to state NAME and continue
+                            nameBegin = i
+                            state = State.NAME
+                        }
                         else -> return null
                     }
                 }


### PR DESCRIPTION
Cover case with property name with no value, eg:

`<meta data-preact-helmet property="og:title" content="Some fancy title">`

Result:
![Screenshot_20240916_155223](https://github.com/user-attachments/assets/8b0ab775-b791-4be0-bf2b-d5bde3f94655)



#1084 