### PR TITLE
Fix for notifications when using amber

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
@@ -24,6 +24,7 @@ import android.app.NotificationManager
 import android.content.Context
 import android.util.Log
 import androidx.core.content.ContextCompat
+import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.LocalPreferences
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.AccountSettings
@@ -42,6 +43,7 @@ import com.vitorpamplona.quartz.events.LnZapRequestEvent
 import com.vitorpamplona.quartz.events.PrivateDmEvent
 import com.vitorpamplona.quartz.events.SealedGossipEvent
 import com.vitorpamplona.quartz.signers.NostrSigner
+import com.vitorpamplona.quartz.signers.NostrSignerExternal
 import com.vitorpamplona.quartz.utils.TimeUtils
 import java.math.BigDecimal
 import kotlin.coroutines.cancellation.CancellationException
@@ -84,6 +86,12 @@ class EventNotificationConsumer(
         // TODO: Modify the external launcher to launch as different users.
         // Right now it only registers if Amber has already approved this signature
         val signer = account.createSigner()
+        if (signer is NostrSignerExternal) {
+            signer.launcher.registerLauncher(
+                launcher = { },
+                contentResolver = Amethyst.instance::contentResolverFn,
+            )
+        }
 
         pushWrappedEvent.unwrapThrowing(signer) { notificationEvent ->
             val consumed = LocalCache.hasConsumed(notificationEvent)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/RegisterAccounts.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/RegisterAccounts.kt
@@ -22,11 +22,13 @@ package com.vitorpamplona.amethyst.service.notifications
 
 import android.util.Log
 import com.vitorpamplona.amethyst.AccountInfo
+import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.BuildConfig
 import com.vitorpamplona.amethyst.LocalPreferences
 import com.vitorpamplona.amethyst.model.AccountSettings
 import com.vitorpamplona.ammolite.service.HttpClientManager
 import com.vitorpamplona.quartz.events.RelayAuthEvent
+import com.vitorpamplona.quartz.signers.NostrSignerExternal
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -71,6 +73,12 @@ class RegisterAccounts(
                                     val signer = accountRelayPair.first.createSigner()
                                     // TODO: Modify the external launcher to launch as different users.
                                     // Right now it only registers if Amber has already approved this signature
+                                    if (signer is NostrSignerExternal) {
+                                        signer.launcher.registerLauncher(
+                                            launcher = { },
+                                            contentResolver = Amethyst.instance::contentResolverFn,
+                                        )
+                                    }
                                     RelayAuthEvent.create(accountRelayPair.second, notificationToken, signer) { result ->
                                         continuation.resume(result)
                                     }


### PR DESCRIPTION
We still have to change this later to work when using multiple accounts and the events are not allowed in amber but for now this fixes the notifications when amethyst is allowed to sign events in background