### PR TITLE
Prioritise search results with user name starting with search term

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/search/SearchBarViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/search/SearchBarViewModel.kt
@@ -74,8 +74,13 @@ class SearchBarViewModel(
         _searchResultsUsers.emit(
             LocalCache
                 .findUsersStartingWith(searchValue)
-                .sortedWith(compareBy({ account.isFollowing(it) }, { it.toBestDisplayName() }))
-                .reversed(),
+                .sortedWith(
+                    compareBy(
+                        { it.toBestDisplayName().startsWith(searchValue, true) },
+                        { account.isFollowing(it) },
+                        { it.toBestDisplayName() },
+                    ),
+                ).reversed(),
         )
         _searchResultsNotes.emit(
             LocalCache


### PR DESCRIPTION
It was a bit frustrating that user profiles with the search term anywhere in the description (eg lightning address) were mixed with users with user name same as search term.

Added comparison between search term and display name to comparator to prioritise results with search term in name.

Before:
![before](https://github.com/user-attachments/assets/f424aa7b-1589-48de-bbd8-078e08fdbc3d)

After:
![after](https://github.com/user-attachments/assets/06252cfa-7ec8-4b2e-9be9-313f3153621b)
