### PR TITLE
Change NewPostView to NewPostScreen to make it route based

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/EditPostView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/EditPostView.kt
@@ -97,6 +97,9 @@ import com.vitorpamplona.amethyst.ui.components.VideoView
 import com.vitorpamplona.amethyst.ui.navigation.INav
 import com.vitorpamplona.amethyst.ui.note.NoteCompose
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.CloseButton
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.ImageVideoDescription
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.PostButton
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.search.UserLine
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.BitcoinOrange

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/JoinUserOrChannelView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/JoinUserOrChannelView.kt
@@ -80,6 +80,7 @@ import com.vitorpamplona.amethyst.ui.note.ClickableUserPicture
 import com.vitorpamplona.amethyst.ui.note.SearchIcon
 import com.vitorpamplona.amethyst.ui.note.UsernameDisplay
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.CloseButton
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chatrooms.ChannelName
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.search.SearchBarViewModel
 import com.vitorpamplona.amethyst.ui.stringRes

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewChannelView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewChannelView.kt
@@ -47,6 +47,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.PublicChatChannel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.CloseButton
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.PostButton
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.placeholderText
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewMediaView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewMediaView.kt
@@ -73,6 +73,9 @@ import com.vitorpamplona.amethyst.service.Nip96MediaServers
 import com.vitorpamplona.amethyst.ui.components.VideoView
 import com.vitorpamplona.amethyst.ui.navigation.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.CloseButton
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.PostButton
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.SettingSwitchItem
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.TextSpinner
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.TitleExplainer
 import com.vitorpamplona.amethyst.ui.stringRes

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewUserMetadataView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewUserMetadataView.kt
@@ -46,6 +46,8 @@ import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.CloseButton
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.SaveButton
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.placeholderText
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/RelaySelectionDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/RelaySelectionDialog.kt
@@ -50,6 +50,8 @@ import com.vitorpamplona.amethyst.service.Nip11Retriever
 import com.vitorpamplona.amethyst.ui.actions.relays.RelayInformationDialog
 import com.vitorpamplona.amethyst.ui.navigation.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.CloseButton
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.SaveButton
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.FeedPadding
 import com.vitorpamplona.ammolite.relays.RelayBriefInfoCache

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/mediaServers/MediaServersLIstView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/mediaServers/MediaServersLIstView.kt
@@ -55,11 +55,11 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.service.Nip96MediaServers
-import com.vitorpamplona.amethyst.ui.actions.CloseButton
-import com.vitorpamplona.amethyst.ui.actions.SaveButton
 import com.vitorpamplona.amethyst.ui.actions.relays.SettingsCategoryWithButton
 import com.vitorpamplona.amethyst.ui.navigation.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.CloseButton
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.SaveButton
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.DoubleVertPadding
 import com.vitorpamplona.amethyst.ui.theme.FeedPadding

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/relays/AddDMRelayListDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/relays/AddDMRelayListDialog.kt
@@ -42,10 +42,10 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.ui.actions.CloseButton
-import com.vitorpamplona.amethyst.ui.actions.SaveButton
 import com.vitorpamplona.amethyst.ui.navigation.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.CloseButton
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.SaveButton
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.StdHorzSpacer
 import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/relays/AddSearchRelayListDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/relays/AddSearchRelayListDialog.kt
@@ -42,10 +42,10 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.ui.actions.CloseButton
-import com.vitorpamplona.amethyst.ui.actions.SaveButton
 import com.vitorpamplona.amethyst.ui.navigation.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.CloseButton
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.SaveButton
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.StdHorzSpacer
 import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/relays/AllRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/relays/AllRelayListView.kt
@@ -49,11 +49,11 @@ import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.ui.actions.CloseButton
-import com.vitorpamplona.amethyst.ui.actions.SaveButton
 import com.vitorpamplona.amethyst.ui.navigation.INav
 import com.vitorpamplona.amethyst.ui.navigation.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.CloseButton
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.SaveButton
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.FeedPadding
 import com.vitorpamplona.amethyst.ui.theme.MinHorzSpacer

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/relays/RelayInformationDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/relays/RelayInformationDialog.kt
@@ -50,7 +50,6 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.FeatureSetType
-import com.vitorpamplona.amethyst.ui.actions.CloseButton
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.components.ClickableEmail
 import com.vitorpamplona.amethyst.ui.components.ClickableUrl
@@ -61,6 +60,7 @@ import com.vitorpamplona.amethyst.ui.note.RenderRelayIcon
 import com.vitorpamplona.amethyst.ui.note.UserCompose
 import com.vitorpamplona.amethyst.ui.note.timeAgo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.CloseButton
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chatrooms.LoadUser
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.DoubleHorzSpacer

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -52,6 +52,7 @@ import com.vitorpamplona.amethyst.ui.screen.SharedPreferencesViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountSwitcherAndLeftDrawerLayout
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.LoadRedirectScreen
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.NewPostScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarks.BookmarkListScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chatrooms.ChannelScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chatrooms.ChatroomListScreen
@@ -278,6 +279,32 @@ fun AppNavigation(
                 val nip47 = it.arguments?.getString("nip47")
 
                 NIP47SetupScreen(accountViewModel, nav, nip47)
+            }
+
+            composable(
+                Route.NewPost.route,
+                Route.NewPost.arguments,
+                enterTransition = { slideInHorizontallyFromEnd },
+                exitTransition = { scaleOut },
+                popEnterTransition = { scaleIn },
+                popExitTransition = { slideOutHorizontallyToEnd },
+            ) {
+                val baseReplyTo = it.arguments?.getString("baseReplyTo")
+                val quote = it.arguments?.getString("quote")
+                val fork = it.arguments?.getString("fork")
+                val version = it.arguments?.getString("version")
+                val draft = it.arguments?.getString("draft")
+                val enableMessageInterface = it.arguments?.getBoolean("enableMessageInterface") ?: false
+                NewPostScreen(
+                    baseReplyTo = baseReplyTo?.let { hex -> accountViewModel.getNoteIfExists(hex) },
+                    quote = quote?.let { hex -> accountViewModel.getNoteIfExists(hex) },
+                    fork = fork?.let { hex -> accountViewModel.getNoteIfExists(hex) },
+                    version = version?.let { hex -> accountViewModel.getNoteIfExists(hex) },
+                    draft = draft?.let { hex -> accountViewModel.getNoteIfExists(hex) },
+                    enableMessageInterface = enableMessageInterface,
+                    accountViewModel = accountViewModel,
+                    nav = nav,
+                )
             }
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/Routes.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/Routes.kt
@@ -220,6 +220,21 @@ sealed class Route(
                     },
                 ).toImmutableList(),
         )
+
+    object NewPost :
+        Route(
+            route = "NewPost?baseReplyTo={baseReplyTo}&quote={quote}&fork={fork}&version={version}&draft={draft}&enableMessageInterface={enableMessageInterface}",
+            icon = R.drawable.ic_moments,
+            arguments =
+                listOf(
+                    navArgument("baseReplyTo") { type = NavType.StringType },
+                    navArgument("quote") { type = NavType.StringType },
+                    navArgument("fork") { type = NavType.StringType },
+                    navArgument("version") { type = NavType.StringType },
+                    navArgument("draft") { type = NavType.StringType },
+                    navArgument("enableMessageInterface") { type = NavType.BoolType },
+                ).toImmutableList(),
+        )
 }
 
 fun getRouteWithArguments(navController: NavHostController): String? {
@@ -270,3 +285,19 @@ private fun getRouteWithArguments(
     }
     return route
 }
+
+fun buildNewPostRoute(
+    baseReplyTo: String? = null,
+    quote: String? = null,
+    fork: String? = null,
+    version: String? = null,
+    draft: String? = null,
+    enableMessageInterface: Boolean = false,
+): String =
+    "NewPost?" +
+        "baseReplyTo=${baseReplyTo ?: ""}&" +
+        "quote=${quote ?: ""}&" +
+        "fork=${fork ?: ""}&" +
+        "version=${version ?: ""}&" +
+        "draft=${draft ?: ""}&" +
+        "enableMessageInterface=$enableMessageInterface"

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteQuickActionMenu.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteQuickActionMenu.kt
@@ -85,10 +85,10 @@ import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.AddressableNote
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
-import com.vitorpamplona.amethyst.ui.actions.NewPostView
 import com.vitorpamplona.amethyst.ui.components.SelectTextDialog
 import com.vitorpamplona.amethyst.ui.navigation.EmptyNav
 import com.vitorpamplona.amethyst.ui.navigation.INav
+import com.vitorpamplona.amethyst.ui.navigation.buildNewPostRoute
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.ReportNoteDialog
 import com.vitorpamplona.amethyst.ui.stringRes
@@ -201,24 +201,16 @@ fun NoteQuickActionMenu(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    val editDraftDialog = remember { mutableStateOf(false) }
-
-    if (editDraftDialog.value) {
-        NewPostView(
-            onClose = {
-                onDismiss()
-                editDraftDialog.value = false
-            },
-            accountViewModel = accountViewModel,
-            draft = note,
-            nav = EmptyNav,
-        )
-    }
-
     NoteQuickActionMenu(
         note = note,
         onDismiss = onDismiss,
-        onWantsToEditDraft = { editDraftDialog.value = true },
+        onWantsToEditDraft = {
+            val route =
+                buildNewPostRoute(
+                    draft = note.idHex,
+                )
+            nav.nav(route)
+        },
         accountViewModel = accountViewModel,
         nav = nav,
     )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
@@ -103,11 +103,11 @@ import com.vitorpamplona.amethyst.model.FeatureSetType
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.service.ZapPaymentHandler
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
-import com.vitorpamplona.amethyst.ui.actions.NewPostView
 import com.vitorpamplona.amethyst.ui.components.ClickableBox
 import com.vitorpamplona.amethyst.ui.components.GenericLoadable
 import com.vitorpamplona.amethyst.ui.components.InLineIconRenderer
 import com.vitorpamplona.amethyst.ui.navigation.INav
+import com.vitorpamplona.amethyst.ui.navigation.buildNewPostRoute
 import com.vitorpamplona.amethyst.ui.navigation.routeToMessage
 import com.vitorpamplona.amethyst.ui.note.types.EditState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -563,14 +563,17 @@ private fun BoostWithDialog(
     var wantsToFork by remember { mutableStateOf<Note?>(null) }
 
     if (wantsToQuote != null) {
-        NewPostView(
-            onClose = { wantsToQuote = null },
-            baseReplyTo = null,
-            quote = wantsToQuote,
-            version = (editState.value as? GenericLoadable.Loaded)?.loaded?.modificationToShow?.value,
-            accountViewModel = accountViewModel,
-            nav = nav,
-        )
+        val route =
+            buildNewPostRoute(
+                quote = wantsToQuote?.idHex,
+                version =
+                    (editState.value as? GenericLoadable.Loaded)
+                        ?.loaded
+                        ?.modificationToShow
+                        ?.value
+                        ?.idHex,
+            )
+        nav.nav(route)
     }
 
     if (wantsToFork != null) {
@@ -585,14 +588,19 @@ private fun BoostWithDialog(
                 }
             }
 
-        NewPostView(
-            onClose = { wantsToFork = null },
-            baseReplyTo = replyTo,
-            fork = wantsToFork,
-            version = (editState.value as? GenericLoadable.Loaded)?.loaded?.modificationToShow?.value,
-            accountViewModel = accountViewModel,
-            nav = nav,
-        )
+        val route =
+            buildNewPostRoute(
+                quote = wantsToQuote?.idHex,
+                baseReplyTo = replyTo?.idHex,
+                fork = wantsToFork?.idHex,
+                version =
+                    (editState.value as? GenericLoadable.Loaded)
+                        ?.loaded
+                        ?.modificationToShow
+                        ?.value
+                        ?.idHex,
+            )
+        nav.nav(route)
     }
 
     BoostReaction(
@@ -614,13 +622,12 @@ private fun ReplyReactionWithDialog(
     var wantsToReplyTo by remember { mutableStateOf<Note?>(null) }
 
     if (wantsToReplyTo != null) {
-        NewPostView(
-            onClose = { wantsToReplyTo = null },
-            baseReplyTo = wantsToReplyTo,
-            quote = null,
-            accountViewModel = accountViewModel,
-            nav = nav,
-        )
+        val route =
+            buildNewPostRoute(
+                baseReplyTo = wantsToReplyTo?.idHex,
+                quote = null,
+            )
+        nav.nav(route)
     }
 
     ReplyReaction(baseNote, grayTint, accountViewModel) { wantsToReplyTo = baseNote }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/UpdateReactionTypeDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/UpdateReactionTypeDialog.kt
@@ -77,13 +77,13 @@ import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.AccountSettings
 import com.vitorpamplona.amethyst.model.AddressableNote
 import com.vitorpamplona.amethyst.service.firstFullChar
-import com.vitorpamplona.amethyst.ui.actions.CloseButton
-import com.vitorpamplona.amethyst.ui.actions.SaveButton
 import com.vitorpamplona.amethyst.ui.components.InLineIconRenderer
 import com.vitorpamplona.amethyst.ui.navigation.INav
 import com.vitorpamplona.amethyst.ui.navigation.routeFor
 import com.vitorpamplona.amethyst.ui.note.types.RenderEmojiPack
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.CloseButton
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.SaveButton
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.ButtonBorder
 import com.vitorpamplona.amethyst.ui.theme.placeholderText

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/UpdateZapAmountDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/UpdateZapAmountDialog.kt
@@ -86,9 +86,9 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.AccountSettings
-import com.vitorpamplona.amethyst.ui.actions.CloseButton
-import com.vitorpamplona.amethyst.ui.actions.SaveButton
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.CloseButton
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.SaveButton
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.TextSpinner
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.TitleExplainer
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.getFragmentActivity

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapCustomDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapCustomDialog.kt
@@ -73,8 +73,8 @@ import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.service.ZapPaymentHandler
-import com.vitorpamplona.amethyst.ui.actions.CloseButton
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.CloseButton
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.TextSpinner
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.TitleExplainer
 import com.vitorpamplona.amethyst.ui.stringRes

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DisplayReward.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DisplayReward.kt
@@ -61,13 +61,13 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.ui.actions.CloseButton
-import com.vitorpamplona.amethyst.ui.actions.PostButton
 import com.vitorpamplona.amethyst.ui.navigation.INav
 import com.vitorpamplona.amethyst.ui.note.ZapIcon
 import com.vitorpamplona.amethyst.ui.note.ZappedIcon
 import com.vitorpamplona.amethyst.ui.note.showAmount
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.CloseButton
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.PostButton
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.Size20Modifier
 import com.vitorpamplona.amethyst.ui.theme.placeholderText

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DropDownMenu.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DropDownMenu.kt
@@ -43,10 +43,10 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.actions.EditPostView
-import com.vitorpamplona.amethyst.ui.actions.NewPostView
 import com.vitorpamplona.amethyst.ui.components.ClickableBox
 import com.vitorpamplona.amethyst.ui.components.GenericLoadable
 import com.vitorpamplona.amethyst.ui.navigation.INav
+import com.vitorpamplona.amethyst.ui.navigation.buildNewPostRoute
 import com.vitorpamplona.amethyst.ui.note.VerticalDotsIcon
 import com.vitorpamplona.amethyst.ui.note.externalLinkForNote
 import com.vitorpamplona.amethyst.ui.note.types.EditState
@@ -124,11 +124,6 @@ fun NoteDropDownMenu(
             mutableStateOf(false)
         }
 
-    val wantsToEditDraft =
-        remember {
-            mutableStateOf(false)
-        }
-
     if (wantsToEditPost.value) {
         // avoids changing while drafting a note and a new event shows up.
         val versionLookingAt =
@@ -144,18 +139,6 @@ fun NoteDropDownMenu(
             edit = note,
             versionLookingAt = versionLookingAt,
             accountViewModel = accountViewModel,
-            nav = nav,
-        )
-    }
-
-    if (wantsToEditDraft.value) {
-        NewPostView(
-            onClose = {
-                onDismiss()
-                wantsToEditDraft.value = false
-            },
-            accountViewModel = accountViewModel,
-            draft = note,
             nav = nav,
         )
     }
@@ -243,7 +226,11 @@ fun NoteDropDownMenu(
             DropdownMenuItem(
                 text = { Text(stringRes(R.string.edit_draft)) },
                 onClick = {
-                    wantsToEditDraft.value = true
+                    val route =
+                        buildNewPostRoute(
+                            draft = note.idHex,
+                        )
+                    nav.nav(route)
                 },
             )
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/NewPostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/NewPostScreen.kt
@@ -18,7 +18,7 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.actions
+package com.vitorpamplona.amethyst.ui.screen.loggedIn
 
 import android.Manifest
 import android.graphics.Bitmap
@@ -78,7 +78,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
@@ -119,8 +118,6 @@ import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -134,6 +131,15 @@ import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.Nip96MediaServers
 import com.vitorpamplona.amethyst.service.NostrSearchEventOrUserDataSource
+import com.vitorpamplona.amethyst.ui.actions.LoadingAnimation
+import com.vitorpamplona.amethyst.ui.actions.NewPollOption
+import com.vitorpamplona.amethyst.ui.actions.NewPollVoteValueRange
+import com.vitorpamplona.amethyst.ui.actions.NewPostViewModel
+import com.vitorpamplona.amethyst.ui.actions.RelaySelectionDialog
+import com.vitorpamplona.amethyst.ui.actions.ServerOption
+import com.vitorpamplona.amethyst.ui.actions.UploadFromGallery
+import com.vitorpamplona.amethyst.ui.actions.UrlUserTagTransformation
+import com.vitorpamplona.amethyst.ui.actions.getPhotoUri
 import com.vitorpamplona.amethyst.ui.components.BechLink
 import com.vitorpamplona.amethyst.ui.components.CreateTextWithEmoji
 import com.vitorpamplona.amethyst.ui.components.InvoiceRequest
@@ -150,9 +156,6 @@ import com.vitorpamplona.amethyst.ui.note.PollIcon
 import com.vitorpamplona.amethyst.ui.note.RegularPostIcon
 import com.vitorpamplona.amethyst.ui.note.UsernameDisplay
 import com.vitorpamplona.amethyst.ui.note.ZapSplitIcon
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.TextSpinner
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.TitleExplainer
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chatrooms.MyTextField
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chatrooms.ShowUserSuggestionList
 import com.vitorpamplona.amethyst.ui.stringRes
@@ -190,8 +193,7 @@ import java.lang.Math.round
 
 @OptIn(ExperimentalMaterial3Api::class, FlowPreview::class)
 @Composable
-fun NewPostView(
-    onClose: () -> Unit,
+fun NewPostScreen(
     baseReplyTo: Note? = null,
     quote: Note? = null,
     fork: Note? = null,
@@ -240,21 +242,66 @@ fun NewPostView(
             NostrSearchEventOrUserDataSource.stop()
         }
     }
+    DisappearingScaffold(
+        isInvertedLayout = false,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Spacer(modifier = StdHorzSpacer)
 
-    Dialog(
-        onDismissRequest = {
-            scope.launch {
-                postViewModel.sendDraftSync(relayList = relayList)
-                onClose()
-            }
+                        Box {
+                            IconButton(
+                                modifier = Modifier.align(Alignment.Center),
+                                onClick = { showRelaysDialog = true },
+                            ) {
+                                Icon(
+                                    painter = painterResource(R.drawable.relays),
+                                    contentDescription = stringRes(id = R.string.relay_list_selector),
+                                    modifier = Modifier.height(25.dp),
+                                    tint = MaterialTheme.colorScheme.onBackground,
+                                )
+                            }
+                        }
+                        PostButton(
+                            onPost = {
+                                postViewModel.sendPost(relayList = relayList)
+                                scope.launch {
+                                    delay(100)
+                                    nav.popBack()
+                                }
+                            },
+                            isActive = postViewModel.canPost(),
+                        )
+                    }
+                },
+                navigationIcon = {
+                    Row {
+                        Spacer(modifier = StdHorzSpacer)
+                        CloseButton(
+                            onPress = {
+                                scope.launch {
+                                    postViewModel.sendDraftSync(relayList = relayList)
+                                    postViewModel.cancel()
+                                    delay(100)
+                                    nav.popBack()
+                                }
+                            },
+                        )
+                    }
+                },
+                colors =
+                    TopAppBarDefaults.topAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.surface,
+                    ),
+            )
         },
-        properties =
-            DialogProperties(
-                usePlatformDefaultWidth = false,
-                dismissOnClickOutside = false,
-                decorFitsSystemWindows = false,
-            ),
-    ) {
+        accountViewModel = accountViewModel,
+    ) { pad ->
         if (showRelaysDialog) {
             RelaySelectionDialog(
                 preSelectedList = relayList,
@@ -264,308 +311,263 @@ fun NewPostView(
                 nav = nav,
             )
         }
-
-        Scaffold(
-            topBar = {
-                TopAppBar(
-                    title = {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Spacer(modifier = StdHorzSpacer)
-
-                            Box {
-                                IconButton(
-                                    modifier = Modifier.align(Alignment.Center),
-                                    onClick = { showRelaysDialog = true },
-                                ) {
-                                    Icon(
-                                        painter = painterResource(R.drawable.relays),
-                                        contentDescription = stringRes(id = R.string.relay_list_selector),
-                                        modifier = Modifier.height(25.dp),
-                                        tint = MaterialTheme.colorScheme.onBackground,
-                                    )
-                                }
-                            }
-                            PostButton(
-                                onPost = {
-                                    postViewModel.sendPost(relayList = relayList)
-                                    scope.launch {
-                                        delay(100)
-                                        onClose()
-                                    }
-                                },
-                                isActive = postViewModel.canPost(),
-                            )
-                        }
-                    },
-                    navigationIcon = {
-                        Row {
-                            Spacer(modifier = StdHorzSpacer)
-                            CloseButton(
-                                onPress = {
-                                    scope.launch {
-                                        postViewModel.sendDraftSync(relayList = relayList)
-                                        postViewModel.cancel()
-                                        delay(100)
-                                        onClose()
-                                    }
-                                },
-                            )
-                        }
-                    },
-                    colors =
-                        TopAppBarDefaults.topAppBarColors(
-                            containerColor = MaterialTheme.colorScheme.surface,
-                        ),
-                )
-            },
-        ) { pad ->
-            Surface(
+        Surface(
+            modifier =
+                Modifier
+                    .padding(
+                        start = Size10dp,
+                        top = pad.calculateTopPadding(),
+                        end = Size10dp,
+                        bottom = pad.calculateBottomPadding(),
+                    ).fillMaxSize(),
+        ) {
+            Column(
                 modifier =
                     Modifier
-                        .padding(
-                            start = Size10dp,
-                            top = pad.calculateTopPadding(),
-                            end = Size10dp,
-                            bottom = pad.calculateBottomPadding(),
-                        ).fillMaxSize(),
+                        .fillMaxWidth()
+                        .fillMaxHeight(),
             ) {
                 Column(
                     modifier =
                         Modifier
-                            .fillMaxWidth()
-                            .fillMaxHeight(),
+                            .imePadding()
+                            .weight(1f),
                 ) {
-                    Column(
+                    Row(
                         modifier =
                             Modifier
-                                .imePadding()
+                                .fillMaxWidth()
                                 .weight(1f),
                     ) {
-                        Row(
+                        Column(
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
-                                    .weight(1f),
+                                    .verticalScroll(scrollState),
                         ) {
-                            Column(
-                                modifier =
-                                    Modifier
-                                        .fillMaxWidth()
-                                        .verticalScroll(scrollState),
+                            postViewModel.originalNote?.let {
+                                Row {
+                                    NoteCompose(
+                                        baseNote = it,
+                                        modifier = MaterialTheme.colorScheme.replyModifier,
+                                        isQuotedNote = true,
+                                        unPackReply = false,
+                                        makeItShort = true,
+                                        quotesLeft = 1,
+                                        accountViewModel = accountViewModel,
+                                        nav = nav,
+                                    )
+                                    Spacer(modifier = StdVertSpacer)
+                                }
+                            }
+
+                            Row {
+                                Notifying(postViewModel.pTags?.toImmutableList()) {
+                                    postViewModel.removeFromReplyList(it)
+                                }
+                            }
+
+                            if (postViewModel.wantsDirectMessage) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier.padding(vertical = Size5dp, horizontal = Size10dp),
+                                ) {
+                                    SendDirectMessageTo(postViewModel = postViewModel)
+                                }
+                            }
+
+                            if (postViewModel.wantsProduct) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier.padding(vertical = Size5dp, horizontal = Size10dp),
+                                ) {
+                                    SellProduct(postViewModel = postViewModel)
+                                }
+                            }
+
+                            Row(
+                                modifier = Modifier.padding(vertical = Size10dp),
                             ) {
-                                postViewModel.originalNote?.let {
-                                    Row(Modifier.heightIn(max = 200.dp)) {
-                                        NoteCompose(
-                                            baseNote = it,
-                                            modifier = MaterialTheme.colorScheme.replyModifier,
-                                            isQuotedNote = true,
-                                            unPackReply = false,
-                                            makeItShort = true,
+                                BaseUserPicture(
+                                    accountViewModel.userProfile(),
+                                    Size35dp,
+                                    accountViewModel = accountViewModel,
+                                )
+                                MessageField(postViewModel)
+                            }
+
+                            if (postViewModel.wantsPoll) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier.padding(vertical = Size5dp, horizontal = Size10dp),
+                                ) {
+                                    PollField(postViewModel)
+                                }
+                            }
+
+                            val myUrlPreview = postViewModel.urlPreview
+                            if (myUrlPreview != null) {
+                                Row(modifier = Modifier.padding(vertical = Size5dp, horizontal = Size10dp)) {
+                                    if (RichTextParser.isValidURL(myUrlPreview)) {
+                                        if (RichTextParser.isImageUrl(myUrlPreview)) {
+                                            AsyncImage(
+                                                model = myUrlPreview,
+                                                contentDescription = myUrlPreview,
+                                                contentScale = ContentScale.FillWidth,
+                                                modifier =
+                                                    Modifier
+                                                        .padding(top = 4.dp)
+                                                        .fillMaxWidth()
+                                                        .clip(shape = QuoteBorder)
+                                                        .border(
+                                                            1.dp,
+                                                            MaterialTheme.colorScheme.subtleBorder,
+                                                            QuoteBorder,
+                                                        ),
+                                            )
+                                        } else if (RichTextParser.isVideoUrl(myUrlPreview)) {
+                                            VideoView(
+                                                myUrlPreview,
+                                                mimeType = null,
+                                                roundedCorner = true,
+                                                isFiniteHeight = false,
+                                                accountViewModel = accountViewModel,
+                                            )
+                                        } else {
+                                            LoadUrlPreview(myUrlPreview, myUrlPreview, null, accountViewModel)
+                                        }
+                                    } else if (RichTextParser.startsWithNIP19Scheme(myUrlPreview)) {
+                                        val bgColor = MaterialTheme.colorScheme.background
+                                        val backgroundColor = remember { mutableStateOf(bgColor) }
+
+                                        BechLink(
+                                            word = myUrlPreview,
+                                            canPreview = true,
                                             quotesLeft = 1,
+                                            backgroundColor = backgroundColor,
                                             accountViewModel = accountViewModel,
                                             nav = nav,
                                         )
-                                        Spacer(modifier = StdVertSpacer)
-                                    }
-                                }
-
-                                Row {
-                                    Notifying(postViewModel.pTags?.toImmutableList()) {
-                                        postViewModel.removeFromReplyList(it)
-                                    }
-                                }
-
-                                if (postViewModel.wantsDirectMessage) {
-                                    Row(
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        modifier = Modifier.padding(vertical = Size5dp, horizontal = Size10dp),
-                                    ) {
-                                        SendDirectMessageTo(postViewModel = postViewModel)
-                                    }
-                                }
-
-                                if (postViewModel.wantsProduct) {
-                                    Row(
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        modifier = Modifier.padding(vertical = Size5dp, horizontal = Size10dp),
-                                    ) {
-                                        SellProduct(postViewModel = postViewModel)
-                                    }
-                                }
-
-                                Row(
-                                    modifier = Modifier.padding(vertical = Size10dp),
-                                ) {
-                                    BaseUserPicture(
-                                        accountViewModel.userProfile(),
-                                        Size35dp,
-                                        accountViewModel = accountViewModel,
-                                    )
-                                    MessageField(postViewModel)
-                                }
-
-                                if (postViewModel.wantsPoll) {
-                                    Row(
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        modifier = Modifier.padding(vertical = Size5dp, horizontal = Size10dp),
-                                    ) {
-                                        PollField(postViewModel)
-                                    }
-                                }
-
-                                val myUrlPreview = postViewModel.urlPreview
-                                if (myUrlPreview != null) {
-                                    Row(modifier = Modifier.padding(vertical = Size5dp, horizontal = Size10dp)) {
-                                        if (RichTextParser.isValidURL(myUrlPreview)) {
-                                            if (RichTextParser.isImageUrl(myUrlPreview)) {
-                                                AsyncImage(
-                                                    model = myUrlPreview,
-                                                    contentDescription = myUrlPreview,
-                                                    contentScale = ContentScale.FillWidth,
-                                                    modifier =
-                                                        Modifier
-                                                            .padding(top = 4.dp)
-                                                            .fillMaxWidth()
-                                                            .clip(shape = QuoteBorder)
-                                                            .border(
-                                                                1.dp,
-                                                                MaterialTheme.colorScheme.subtleBorder,
-                                                                QuoteBorder,
-                                                            ),
-                                                )
-                                            } else if (RichTextParser.isVideoUrl(myUrlPreview)) {
-                                                VideoView(
-                                                    myUrlPreview,
-                                                    mimeType = null,
-                                                    roundedCorner = true,
-                                                    isFiniteHeight = false,
-                                                    accountViewModel = accountViewModel,
-                                                )
-                                            } else {
-                                                LoadUrlPreview(myUrlPreview, myUrlPreview, null, accountViewModel)
-                                            }
-                                        } else if (RichTextParser.startsWithNIP19Scheme(myUrlPreview)) {
-                                            val bgColor = MaterialTheme.colorScheme.background
-                                            val backgroundColor = remember { mutableStateOf(bgColor) }
-
-                                            BechLink(
-                                                word = myUrlPreview,
-                                                canPreview = true,
-                                                quotesLeft = 1,
-                                                backgroundColor = backgroundColor,
-                                                accountViewModel = accountViewModel,
-                                                nav = nav,
-                                            )
-                                        } else if (RichTextParser.isUrlWithoutScheme(myUrlPreview)) {
-                                            LoadUrlPreview("https://$myUrlPreview", myUrlPreview, null, accountViewModel)
-                                        }
-                                    }
-                                }
-
-                                if (postViewModel.wantsToMarkAsSensitive) {
-                                    Row(
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        modifier = Modifier.padding(vertical = Size5dp, horizontal = Size10dp),
-                                    ) {
-                                        ContentSensitivityExplainer(postViewModel)
-                                    }
-                                }
-
-                                if (postViewModel.wantsToAddGeoHash) {
-                                    Row(
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        modifier = Modifier.padding(vertical = Size5dp, horizontal = Size10dp),
-                                    ) {
-                                        LocationAsHash(postViewModel)
-                                    }
-                                }
-
-                                if (postViewModel.wantsForwardZapTo) {
-                                    Row(
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        modifier = Modifier.padding(top = Size5dp, bottom = Size5dp, start = Size10dp),
-                                    ) {
-                                        FowardZapTo(postViewModel, accountViewModel)
-                                    }
-                                }
-
-                                val url = postViewModel.contentToAddUrl
-                                if (url != null) {
-                                    Row(
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        modifier = Modifier.padding(vertical = Size5dp, horizontal = Size10dp),
-                                    ) {
-                                        ImageVideoDescription(
-                                            url,
-                                            accountViewModel.account.settings.defaultFileServer,
-                                            onAdd = { alt, server, sensitiveContent, mediaQuality ->
-                                                postViewModel.upload(url, alt, sensitiveContent, mediaQuality, false, server, accountViewModel::toast, context)
-                                                if (!server.isNip95) {
-                                                    accountViewModel.account.settings.changeDefaultFileServer(server.server)
-                                                }
-                                            },
-                                            onCancel = { postViewModel.contentToAddUrl = null },
-                                            onError = { scope.launch { Toast.makeText(context, context.resources.getText(it), Toast.LENGTH_SHORT).show() } },
-                                            accountViewModel = accountViewModel,
-                                        )
-                                    }
-                                }
-
-                                if (postViewModel.wantsInvoice) {
-                                    postViewModel.lnAddress()?.let { lud16 ->
-                                        Row(
-                                            verticalAlignment = Alignment.CenterVertically,
-                                            modifier = Modifier.padding(vertical = Size5dp, horizontal = Size10dp),
-                                        ) {
-                                            Column(Modifier.fillMaxWidth()) {
-                                                InvoiceRequest(
-                                                    lud16,
-                                                    accountViewModel.account.userProfile().pubkeyHex,
-                                                    accountViewModel,
-                                                    stringRes(id = R.string.lightning_invoice),
-                                                    stringRes(id = R.string.lightning_create_and_add_invoice),
-                                                    onSuccess = {
-                                                        postViewModel.insertAtCursor(it)
-                                                        postViewModel.wantsInvoice = false
-                                                    },
-                                                    onClose = { postViewModel.wantsInvoice = false },
-                                                    onError = { title, message -> accountViewModel.toast(title, message) },
-                                                )
-                                            }
-                                        }
-                                    }
-                                }
-
-                                if (postViewModel.wantsZapraiser && postViewModel.hasLnAddress()) {
-                                    Row(
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        modifier = Modifier.padding(vertical = Size5dp, horizontal = Size10dp),
-                                    ) {
-                                        ZapRaiserRequest(
-                                            stringRes(id = R.string.zapraiser),
-                                            postViewModel,
-                                        )
+                                    } else if (RichTextParser.isUrlWithoutScheme(myUrlPreview)) {
+                                        LoadUrlPreview("https://$myUrlPreview", myUrlPreview, null, accountViewModel)
                                     }
                                 }
                             }
+
+                            if (postViewModel.wantsToMarkAsSensitive) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier.padding(vertical = Size5dp, horizontal = Size10dp),
+                                ) {
+                                    ContentSensitivityExplainer(postViewModel)
+                                }
+                            }
+
+                            if (postViewModel.wantsToAddGeoHash) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier.padding(vertical = Size5dp, horizontal = Size10dp),
+                                ) {
+                                    LocationAsHash(postViewModel)
+                                }
+                            }
+
+                            if (postViewModel.wantsForwardZapTo) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier.padding(top = Size5dp, bottom = Size5dp, start = Size10dp),
+                                ) {
+                                    FowardZapTo(postViewModel, accountViewModel)
+                                }
+                            }
+
+                            val url = postViewModel.contentToAddUrl
+                            if (url != null) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier.padding(vertical = Size5dp, horizontal = Size10dp),
+                                ) {
+                                    ImageVideoDescription(
+                                        url,
+                                        accountViewModel.account.settings.defaultFileServer,
+                                        onAdd = { alt, server, sensitiveContent, mediaQuality ->
+                                            postViewModel.upload(url, alt, sensitiveContent, mediaQuality, false, server, accountViewModel::toast, context)
+                                            if (!server.isNip95) {
+                                                accountViewModel.account.settings.changeDefaultFileServer(server.server)
+                                            }
+                                        },
+                                        onCancel = { postViewModel.contentToAddUrl = null },
+                                        onError = { scope.launch { Toast.makeText(context, context.resources.getText(it), Toast.LENGTH_SHORT).show() } },
+                                        accountViewModel = accountViewModel,
+                                    )
+                                }
+                            }
+
+                            if (postViewModel.wantsInvoice) {
+                                postViewModel.lnAddress()?.let { lud16 ->
+                                    Row(
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        modifier = Modifier.padding(vertical = Size5dp, horizontal = Size10dp),
+                                    ) {
+                                        Column(Modifier.fillMaxWidth()) {
+                                            InvoiceRequest(
+                                                lud16,
+                                                accountViewModel.account.userProfile().pubkeyHex,
+                                                accountViewModel,
+                                                stringRes(id = R.string.lightning_invoice),
+                                                stringRes(id = R.string.lightning_create_and_add_invoice),
+                                                onSuccess = {
+                                                    postViewModel.insertAtCursor(it)
+                                                    postViewModel.wantsInvoice = false
+                                                },
+                                                onClose = { postViewModel.wantsInvoice = false },
+                                                onError = { title, message -> accountViewModel.toast(title, message) },
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+
+                            if (postViewModel.wantsZapraiser && postViewModel.hasLnAddress()) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier.padding(vertical = Size5dp, horizontal = Size10dp),
+                                ) {
+                                    ZapRaiserRequest(
+                                        stringRes(id = R.string.zapraiser),
+                                        postViewModel,
+                                    )
+                                }
+                            }
                         }
-
-                        ShowUserSuggestionList(
-                            postViewModel,
-                            accountViewModel,
-                            modifier = Modifier.heightIn(0.dp, 300.dp),
-                        )
-
-                        BottomRowActions(postViewModel)
                     }
+
+                    ShowUserSuggestionList(
+                        postViewModel,
+                        accountViewModel,
+                        modifier = Modifier.heightIn(0.dp, 300.dp),
+                    )
+
+                    BottomRowActions(postViewModel)
                 }
             }
         }
     }
+//    Dialog(
+//        onDismissRequest = {
+//            scope.launch {
+//                postViewModel.sendDraftSync(relayList = relayList)
+//                onClose()
+//            }
+//        },
+//        properties =
+//        DialogProperties(
+//            usePlatformDefaultWidth = false,
+//            dismissOnClickOutside = false,
+//            decorFitsSystemWindows = false,
+//        ),
+//    ) {
+//    }
 }
 
 @Composable

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chatrooms/ChannelFabColumn.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chatrooms/ChannelFabColumn.kt
@@ -49,8 +49,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.ui.actions.NewChannelView
-import com.vitorpamplona.amethyst.ui.actions.NewPostView
 import com.vitorpamplona.amethyst.ui.navigation.INav
+import com.vitorpamplona.amethyst.ui.navigation.buildNewPostRoute
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.Font12SP
@@ -63,23 +63,10 @@ fun ChannelFabColumn(
 ) {
     var isOpen by remember { mutableStateOf(false) }
 
-    var wantsToSendNewMessage by remember { mutableStateOf(false) }
-
     var wantsToCreateChannel by remember { mutableStateOf(false) }
 
     if (wantsToCreateChannel) {
         NewChannelView({ wantsToCreateChannel = false }, accountViewModel = accountViewModel)
-    }
-
-    if (wantsToSendNewMessage) {
-        NewPostView(
-            onClose = { wantsToSendNewMessage = false },
-            enableMessageInterface = true,
-            accountViewModel = accountViewModel,
-            nav = nav,
-        )
-        // JoinUserOrChannelView({ wantsToJoinChannelOrUser = false }, accountViewModel =
-        // accountViewModel, nav = nav)
     }
 
     Column {
@@ -91,7 +78,11 @@ fun ChannelFabColumn(
             Column {
                 FloatingActionButton(
                     onClick = {
-                        wantsToSendNewMessage = true
+                        val route =
+                            buildNewPostRoute(
+                                enableMessageInterface = true,
+                            )
+                        nav.nav(route)
                         isOpen = false
                     },
                     modifier = Size55Modifier,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chatrooms/ChatroomScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chatrooms/ChatroomScreen.kt
@@ -85,10 +85,8 @@ import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.NostrChatroomDataSource
-import com.vitorpamplona.amethyst.ui.actions.CloseButton
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.actions.NewPostViewModel
-import com.vitorpamplona.amethyst.ui.actions.PostButton
 import com.vitorpamplona.amethyst.ui.actions.ServerOption
 import com.vitorpamplona.amethyst.ui.actions.UploadFromGallery
 import com.vitorpamplona.amethyst.ui.actions.UrlUserTagTransformation
@@ -107,7 +105,9 @@ import com.vitorpamplona.amethyst.ui.note.elements.ObserveRelayListForDMs
 import com.vitorpamplona.amethyst.ui.note.elements.ObserveRelayListForDMsAndDisplayIfNotFound
 import com.vitorpamplona.amethyst.ui.screen.NostrChatroomFeedViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.CloseButton
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.DisappearingScaffold
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.PostButton
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.search.UserLine
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.BottomTopHeight

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/communities/NewCommunityNoteButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/communities/NewCommunityNoteButton.kt
@@ -27,8 +27,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -36,9 +34,9 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.ui.actions.NewPostView
 import com.vitorpamplona.amethyst.ui.components.LoadNote
 import com.vitorpamplona.amethyst.ui.navigation.INav
+import com.vitorpamplona.amethyst.ui.navigation.buildNewPostRoute
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.Size55Modifier
@@ -60,14 +58,14 @@ fun NewCommunityNoteButton(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    var wantsToPost by remember { mutableStateOf(false) }
-
-    if (wantsToPost) {
-        NewPostView({ wantsToPost = false }, note, accountViewModel = accountViewModel, nav = nav)
-    }
-
     FloatingActionButton(
-        onClick = { wantsToPost = true },
+        onClick = {
+            val route =
+                buildNewPostRoute(
+                    baseReplyTo = note.idHex,
+                )
+            nav.nav(route)
+        },
         modifier = Size55Modifier,
         shape = CircleShape,
         containerColor = MaterialTheme.colorScheme.primary,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/NewNoteButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/NewNoteButton.kt
@@ -27,16 +27,14 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.ui.actions.NewPostView
 import com.vitorpamplona.amethyst.ui.navigation.INav
+import com.vitorpamplona.amethyst.ui.navigation.buildNewPostRoute
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.Size55Modifier
@@ -46,14 +44,11 @@ fun NewNoteButton(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    var wantsToPost by remember { mutableStateOf(false) }
-
-    if (wantsToPost) {
-        NewPostView({ wantsToPost = false }, accountViewModel = accountViewModel, nav = nav)
-    }
-
     FloatingActionButton(
-        onClick = { wantsToPost = true },
+        onClick = {
+            val route = buildNewPostRoute()
+            nav.nav(route)
+        },
         modifier = Size55Modifier,
         shape = CircleShape,
         containerColor = MaterialTheme.colorScheme.primary,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/NIP47SetupScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/NIP47SetupScreen.kt
@@ -33,13 +33,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.ui.actions.SaveButton
 import com.vitorpamplona.amethyst.ui.navigation.INav
 import com.vitorpamplona.amethyst.ui.navigation.rememberHeightDecreaser
 import com.vitorpamplona.amethyst.ui.note.ArrowBackIcon
 import com.vitorpamplona.amethyst.ui.note.UpdateZapAmountContent
 import com.vitorpamplona.amethyst.ui.note.UpdateZapAmountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.SaveButton
 import com.vitorpamplona.amethyst.ui.stringRes
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/VideoScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/VideoScreen.kt
@@ -56,7 +56,6 @@ import com.vitorpamplona.amethyst.model.FeatureSetType
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.service.NostrVideoDataSource
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
-import com.vitorpamplona.amethyst.ui.actions.NewPostView
 import com.vitorpamplona.amethyst.ui.components.ClickableBox
 import com.vitorpamplona.amethyst.ui.components.ObserveDisplayNip05Status
 import com.vitorpamplona.amethyst.ui.feeds.FeedContentState
@@ -70,6 +69,7 @@ import com.vitorpamplona.amethyst.ui.feeds.WatchScrollToTop
 import com.vitorpamplona.amethyst.ui.navigation.AppBottomBar
 import com.vitorpamplona.amethyst.ui.navigation.INav
 import com.vitorpamplona.amethyst.ui.navigation.Route
+import com.vitorpamplona.amethyst.ui.navigation.buildNewPostRoute
 import com.vitorpamplona.amethyst.ui.navigation.routeFor
 import com.vitorpamplona.amethyst.ui.note.BoostReaction
 import com.vitorpamplona.amethyst.ui.note.CheckHiddenFeedWatchBlockAndReport
@@ -391,29 +391,29 @@ fun ReactionsColumn(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    var wantsToReplyTo by remember { mutableStateOf<Note?>(null) }
+//    var wantsToReplyTo by remember { mutableStateOf<Note?>(null) }
 
-    var wantsToQuote by remember { mutableStateOf<Note?>(null) }
+//    var wantsToQuote by remember { mutableStateOf<Note?>(null) }
 
-    if (wantsToReplyTo != null) {
-        NewPostView(
-            onClose = { wantsToReplyTo = null },
-            baseReplyTo = wantsToReplyTo,
-            quote = null,
-            accountViewModel = accountViewModel,
-            nav = nav,
-        )
-    }
+//    if (wantsToReplyTo != null) {
+//        NewPostView(
+//            onClose = { wantsToReplyTo = null },
+//            baseReplyTo = wantsToReplyTo,
+//            quote = null,
+//            accountViewModel = accountViewModel,
+//            nav = nav,
+//        )
+//    }
 
-    if (wantsToQuote != null) {
-        NewPostView(
-            onClose = { wantsToQuote = null },
-            baseReplyTo = null,
-            quote = wantsToQuote,
-            accountViewModel = accountViewModel,
-            nav = nav,
-        )
-    }
+//    if (wantsToQuote != null) {
+//        NewPostView(
+//            onClose = { wantsToQuote = null },
+//            baseReplyTo = null,
+//            quote = wantsToQuote,
+//            accountViewModel = accountViewModel,
+//            nav = nav,
+//        )
+//    }
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -437,7 +437,12 @@ fun ReactionsColumn(
             iconSizeModifier = Size40Modifier,
             iconSize = Size40dp,
             onQuotePress = {
-                wantsToQuote = baseNote
+//                wantsToQuote = baseNote
+                val route =
+                    buildNewPostRoute(
+                        quote = baseNote.idHex,
+                    )
+                nav.nav(route)
             },
             onForkPress = {
             },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorSettingsDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorSettingsDialog.kt
@@ -48,8 +48,8 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.ui.actions.CloseButton
-import com.vitorpamplona.amethyst.ui.actions.SaveButton
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.CloseButton
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.SaveButton
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.TitleExplainer
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.SettingsRow
 import com.vitorpamplona.amethyst.ui.stringRes


### PR DESCRIPTION
As discussed in #1119

Changes:
- Moved NewPostView to NewPostScreen and replaced Dialog with DisappearingScaffold
- Previous conditional call to NewPostView now start the navigation to the route passing the hexid of the baseReplyTo, quote, fork, version and draft parameters
- accountViewModel.getNoteIfExists(hex) is called to retrieve the parameters
- Fixed imports which used stuff from the NewPostView file