### PR TITLE
Re-enable translations for all languages button in application settings

### DIFF
--- a/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/ui/components/SelectNotificationProvider.kt
+++ b/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/ui/components/SelectNotificationProvider.kt
@@ -194,7 +194,7 @@ fun PushNotificationSettingsRow(sharedPreferencesViewModel: SharedPreferencesVie
         SettingsRow(
             R.string.push_server_title,
             R.string.push_server_explainer,
-            selectedItens = readableListWithExplainer,
+            selectedItems = readableListWithExplainer,
             selectedIndex = list.indexOf(currentDistributor),
         ) { index ->
             if (list[index] == "None") {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -1068,6 +1068,11 @@ class Account(
         sendNewAppSpecificData()
     }
 
+    fun resetDontTranslateFrom() {
+        settings.resetDontTranslateFrom()
+        sendNewAppSpecificData()
+    }
+
     fun updateTranslateTo(languageCode: Locale) {
         if (settings.updateTranslateTo(languageCode)) {
             sendNewAppSpecificData()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -248,6 +248,11 @@ class AccountSettings(
         saveAccountSettings()
     }
 
+    fun resetDontTranslateFrom() {
+        syncedSettings.languages.resetDontTranslateFrom()
+        saveAccountSettings()
+    }
+
     fun translateToContains(languageCode: Locale) = syncedSettings.languages.translateTo.contains(languageCode.language)
 
     fun updateTranslateTo(languageCode: Locale): Boolean {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettings.kt
@@ -143,6 +143,10 @@ class AccountLanguagePreferences(
         }
     }
 
+    fun resetDontTranslateFrom() {
+        dontTranslateFrom = emptySet()
+    }
+
     fun translateToContains(languageCode: Locale) = translateTo.contains(languageCode.language)
 
     fun updateTranslateTo(languageCode: Locale): Boolean {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -900,6 +900,12 @@ class AccountViewModel(
         account.markDonatedInThisVersion()
     }
 
+    fun resetDontTranslateFrom() {
+        viewModelScope.launch(Dispatchers.IO) {
+            account.resetDontTranslateFrom()
+        }
+    }
+
     fun dontTranslateFrom() = account.settings.syncedSettings.languages.dontTranslateFrom
 
     fun translateTo() = account.settings.syncedSettings.languages.translateTo

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.os.LocaleListCompat
+import com.vitorpamplona.amethyst.BuildConfig
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.ConnectivityType
 import com.vitorpamplona.amethyst.model.FeatureSetType
@@ -168,14 +169,14 @@ fun SettingsScreen(
     sharedPreferencesViewModel: SharedPreferencesViewModel,
     accountViewModel: AccountViewModel,
 ) {
-    val selectedItens =
+    val selectedItems =
         persistentListOf(
             TitleExplainer(stringRes(ConnectivityType.ALWAYS.resourceId)),
             TitleExplainer(stringRes(ConnectivityType.WIFI_ONLY.resourceId)),
             TitleExplainer(stringRes(ConnectivityType.NEVER.resourceId)),
         )
 
-    val themeItens =
+    val themeItems =
         persistentListOf(
             TitleExplainer(stringRes(ThemeType.SYSTEM.resourceId)),
             TitleExplainer(stringRes(ThemeType.LIGHT.resourceId)),
@@ -234,7 +235,7 @@ fun SettingsScreen(
         SettingsRow(
             R.string.theme,
             R.string.theme_description,
-            themeItens,
+            themeItems,
             themeIndex,
         ) {
             sharedPreferencesViewModel.updateTheme(parseThemeType(it))
@@ -245,7 +246,7 @@ fun SettingsScreen(
         SettingsRow(
             R.string.automatically_load_images_gifs,
             R.string.automatically_load_images_gifs_description,
-            selectedItens,
+            selectedItems,
             showImagesIndex,
         ) {
             sharedPreferencesViewModel.updateAutomaticallyShowImages(parseConnectivityType(it))
@@ -256,7 +257,7 @@ fun SettingsScreen(
         SettingsRow(
             R.string.automatically_play_videos,
             R.string.automatically_play_videos_description,
-            selectedItens,
+            selectedItems,
             videoIndex,
         ) {
             sharedPreferencesViewModel.updateAutomaticallyStartPlayback(parseConnectivityType(it))
@@ -267,7 +268,7 @@ fun SettingsScreen(
         SettingsRow(
             R.string.automatically_show_url_preview,
             R.string.automatically_show_url_preview_description,
-            selectedItens,
+            selectedItems,
             linkIndex,
         ) {
             sharedPreferencesViewModel.updateAutomaticallyShowUrlPreview(parseConnectivityType(it))
@@ -276,7 +277,7 @@ fun SettingsScreen(
         SettingsRow(
             R.string.automatically_show_profile_picture,
             R.string.automatically_show_profile_picture_description,
-            selectedItens,
+            selectedItems,
             profilePictureIndex,
         ) {
             sharedPreferencesViewModel.updateAutomaticallyShowProfilePicture(parseConnectivityType(it))
@@ -303,26 +304,12 @@ fun SettingsScreen(
         ) {
             sharedPreferencesViewModel.updateFeatureSetType(parseFeatureSetType(it))
         }
-        Spacer(modifier = DoubleVertSpacer)
-        Button(
-            onClick = {
-                accountViewModel.resetDontTranslateFrom()
-            },
-            colors =
-                ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.primary,
-                ),
-            modifier = Modifier.align(Alignment.CenterHorizontally),
-        ) {
-            Text(stringRes(R.string.reset_translated_languages), color = Color.White)
+
+        if (BuildConfig.FLAVOR == "play") {
+            Spacer(modifier = DoubleVertSpacer)
+            ResetTranslatedLanguagesButton(accountViewModel)
         }
-        Text(
-            text = stringRes(R.string.reset_translated_languages_description),
-            style = MaterialTheme.typography.bodySmall,
-            color = Color.Gray,
-            maxLines = 4,
-            overflow = TextOverflow.Ellipsis,
-        )
+
         Spacer(modifier = HalfVertSpacer)
 
         PushNotificationSettingsRow(sharedPreferencesViewModel)
@@ -333,15 +320,15 @@ fun SettingsScreen(
 fun SettingsRow(
     name: Int,
     description: Int,
-    selectedItens: ImmutableList<TitleExplainer>,
+    selectedItems: ImmutableList<TitleExplainer>,
     selectedIndex: Int,
     onSelect: (Int) -> Unit,
 ) {
     SettingsRow(name, description) {
         TextSpinner(
             label = "",
-            placeholder = selectedItens[selectedIndex].title,
-            options = selectedItens,
+            placeholder = selectedItems[selectedIndex].title,
+            options = selectedItems,
             onSelect = onSelect,
             modifier = Modifier.windowInsetsPadding(WindowInsets(0.dp, 0.dp, 0.dp, 0.dp)),
         )
@@ -384,4 +371,26 @@ fun SettingsRow(
             content()
         }
     }
+}
+
+@Composable
+fun ResetTranslatedLanguagesButton(accountViewModel: AccountViewModel) {
+    Button(
+        onClick = {
+            accountViewModel.resetDontTranslateFrom()
+        },
+        colors =
+            ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+            ),
+    ) {
+        Text(stringRes(R.string.reset_translated_languages), color = Color.White)
+    }
+    Text(
+        text = stringRes(R.string.reset_translated_languages_description),
+        style = MaterialTheme.typography.bodySmall,
+        color = Color.Gray,
+        maxLines = 4,
+        overflow = TextOverflow.Ellipsis,
+    )
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
@@ -32,6 +32,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -42,7 +44,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.os.LocaleListCompat
 import com.vitorpamplona.amethyst.R
@@ -61,12 +62,10 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.DisappearingScaffold
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.TextSpinner
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.TitleExplainer
-import com.vitorpamplona.amethyst.ui.screen.mockSharedPreferencesViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.HalfVertSpacer
 import com.vitorpamplona.amethyst.ui.theme.Size10dp
 import com.vitorpamplona.amethyst.ui.theme.Size20dp
-import com.vitorpamplona.amethyst.ui.theme.ThemeComparisonRow
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.persistentListOf
@@ -144,22 +143,16 @@ fun SettingsScreen(
         accountViewModel = accountViewModel,
     ) {
         Column(Modifier.padding(it)) {
-            SettingsScreen(sharedPreferencesViewModel)
+            SettingsScreen(sharedPreferencesViewModel, accountViewModel)
         }
     }
 }
 
-@Preview(device = "spec:width=2160px,height=2340px,dpi=440")
 @Composable
-fun SettingsScreenPreview() {
-    val sharedPreferencesViewModel = mockSharedPreferencesViewModel()
-    ThemeComparisonRow {
-        SettingsScreen(sharedPreferencesViewModel)
-    }
-}
-
-@Composable
-fun SettingsScreen(sharedPreferencesViewModel: SharedPreferencesViewModel) {
+fun SettingsScreen(
+    sharedPreferencesViewModel: SharedPreferencesViewModel,
+    accountViewModel: AccountViewModel,
+) {
     val selectedItens =
         persistentListOf(
             TitleExplainer(stringRes(ConnectivityType.ALWAYS.resourceId)),
@@ -295,7 +288,20 @@ fun SettingsScreen(sharedPreferencesViewModel: SharedPreferencesViewModel) {
         ) {
             sharedPreferencesViewModel.updateFeatureSetType(parseFeatureSetType(it))
         }
+        Spacer(modifier = HalfVertSpacer)
 
+        Button(
+            onClick = {
+                accountViewModel.resetDontTranslateFrom()
+            },
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                ),
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        ) {
+            Text("Reset translations configuration", color = Color.White)
+        }
         Spacer(modifier = HalfVertSpacer)
 
         PushNotificationSettingsRow(sharedPreferencesViewModel)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
@@ -122,12 +122,13 @@ fun getLanguageIndex(
     sharedPreferencesViewModel: SharedPreferencesViewModel,
 ): Int {
     val language = sharedPreferencesViewModel.sharedPrefs.language
-    var languageIndex = -1
-    if (language != null) {
-        languageIndex = languageEntries.values.toTypedArray().indexOf(language)
-    } else {
-        languageIndex = languageEntries.values.toTypedArray().indexOf(Locale.current.toLanguageTag())
-    }
+    var languageIndex: Int
+    languageIndex =
+        if (language != null) {
+            languageEntries.values.toTypedArray().indexOf(language)
+        } else {
+            languageEntries.values.toTypedArray().indexOf(Locale.current.toLanguageTag())
+        }
     if (languageIndex == -1) {
         languageIndex = languageEntries.values.toTypedArray().indexOf(Locale.current.language)
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
@@ -378,6 +378,7 @@ fun ResetTranslatedLanguagesButton(accountViewModel: AccountViewModel) {
     Button(
         onClick = {
             accountViewModel.resetDontTranslateFrom()
+            accountViewModel.toast(R.string.reset_translated_languages, R.string.reset_translated_languages_toast)
         },
         colors =
             ButtonDefaults.buttonColors(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
@@ -66,6 +66,7 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.TitleExplainer
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.mockAccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.mockSharedPreferencesViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.amethyst.ui.theme.DoubleVertSpacer
 import com.vitorpamplona.amethyst.ui.theme.HalfVertSpacer
 import com.vitorpamplona.amethyst.ui.theme.Size10dp
 import com.vitorpamplona.amethyst.ui.theme.Size20dp
@@ -302,8 +303,7 @@ fun SettingsScreen(
         ) {
             sharedPreferencesViewModel.updateFeatureSetType(parseFeatureSetType(it))
         }
-        Spacer(modifier = HalfVertSpacer)
-
+        Spacer(modifier = DoubleVertSpacer)
         Button(
             onClick = {
                 accountViewModel.resetDontTranslateFrom()
@@ -314,8 +314,15 @@ fun SettingsScreen(
                 ),
             modifier = Modifier.align(Alignment.CenterHorizontally),
         ) {
-            Text("Reset translations configuration", color = Color.White)
+            Text(stringRes(R.string.reset_translated_languages), color = Color.White)
         }
+        Text(
+            text = stringRes(R.string.reset_translated_languages_description),
+            style = MaterialTheme.typography.bodySmall,
+            color = Color.Gray,
+            maxLines = 4,
+            overflow = TextOverflow.Ellipsis,
+        )
         Spacer(modifier = HalfVertSpacer)
 
         PushNotificationSettingsRow(sharedPreferencesViewModel)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.os.LocaleListCompat
 import com.vitorpamplona.amethyst.R
@@ -62,10 +63,13 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.DisappearingScaffold
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.TextSpinner
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.TitleExplainer
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.mockAccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.mockSharedPreferencesViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.HalfVertSpacer
 import com.vitorpamplona.amethyst.ui.theme.Size10dp
 import com.vitorpamplona.amethyst.ui.theme.Size20dp
+import com.vitorpamplona.amethyst.ui.theme.ThemeComparisonRow
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.persistentListOf
@@ -145,6 +149,16 @@ fun SettingsScreen(
         Column(Modifier.padding(it)) {
             SettingsScreen(sharedPreferencesViewModel, accountViewModel)
         }
+    }
+}
+
+@Preview(device = "spec:width=2160px,height=2340px,dpi=440")
+@Composable
+fun SettingsScreenPreview() {
+    val sharedPreferencesViewModel = mockSharedPreferencesViewModel()
+    val accountViewModel = mockAccountViewModel()
+    ThemeComparisonRow {
+        SettingsScreen(sharedPreferencesViewModel, accountViewModel)
     }
 }
 

--- a/amethyst/src/main/res/values-cs/strings.xml
+++ b/amethyst/src/main/res/values-cs/strings.xml
@@ -875,4 +875,8 @@
     <string name="torrent_no_apps">Pro otevření a stažení souboru nejsou nainstalovány žádné torrent aplikace.</string>
     <string name="select_list_to_filter">Vyberte seznam pro filtrování kanálu</string>
     <string name="temporary_account">Odhlásit se na zámek zařízení</string>
+
+    <string name="reset_translated_languages">Obnovit přeložené jazyky</string>
+    <string name="reset_translated_languages_description">Tím se obnoví dříve vybrané jazyky \'Nikdy nepřekládat z\' a všechny jazyky budou znovu přeloženy.</string>
+
 </resources>

--- a/amethyst/src/main/res/values-cs/strings.xml
+++ b/amethyst/src/main/res/values-cs/strings.xml
@@ -878,5 +878,5 @@
 
     <string name="reset_translated_languages">Obnovit přeložené jazyky</string>
     <string name="reset_translated_languages_description">Tím se obnoví dříve vybrané jazyky \'Nikdy nepřekládat z\' a všechny jazyky budou znovu přeloženy.</string>
-
+    <string name="reset_translated_languages_toast">Přeložené jazyky byly obnovený.</string>
 </resources>

--- a/amethyst/src/main/res/values-de/strings.xml
+++ b/amethyst/src/main/res/values-de/strings.xml
@@ -880,4 +880,8 @@ anz der Bedingungen ist erforderlich</string>
     <string name="torrent_no_apps">Keine Torrent-Apps installiert, um die Datei zu öffnen und herunterzuladen.</string>
     <string name="select_list_to_filter">Liste zum Filtern des Feeds auswählen</string>
     <string name="temporary_account">Beim Sperren des Geräts abmelden</string>
+
+    <string name="reset_translated_languages">Übersetzte Sprachen zurücksetzen</string>
+    <string name="reset_translated_languages_description">Dies wird die zuvor ausgewählten \'Nie übersetzen von\'-Sprachen zurücksetzen, und alle Sprachen werden erneut übersetzt.</string>
+
 </resources>

--- a/amethyst/src/main/res/values-de/strings.xml
+++ b/amethyst/src/main/res/values-de/strings.xml
@@ -883,5 +883,5 @@ anz der Bedingungen ist erforderlich</string>
 
     <string name="reset_translated_languages">Übersetzte Sprachen zurücksetzen</string>
     <string name="reset_translated_languages_description">Dies wird die zuvor ausgewählten \'Nie übersetzen von\'-Sprachen zurücksetzen, und alle Sprachen werden erneut übersetzt.</string>
-
+    <string name="reset_translated_languages_toast">Übersetzte Sprachen wurden zurückgesetzt.</string>
 </resources>

--- a/amethyst/src/main/res/values-pt-rBR/strings.xml
+++ b/amethyst/src/main/res/values-pt-rBR/strings.xml
@@ -878,5 +878,5 @@
 
     <string name="reset_translated_languages">Redefinir idiomas traduzidos</string>
     <string name="reset_translated_languages_description">Isso redefinirá os idiomas selecionados anteriormente em \'Nunca traduzir de\' e todos os idiomas serão traduzidos novamente.</string>
-
+    <string name="reset_translated_languages_toast">Idiomas traduzidos foram redefinidos.</string>
 </resources>

--- a/amethyst/src/main/res/values-pt-rBR/strings.xml
+++ b/amethyst/src/main/res/values-pt-rBR/strings.xml
@@ -875,4 +875,8 @@
     <string name="torrent_no_apps">Nenhum aplicativo torrent instalado para abrir e baixar o arquivo.</string>
     <string name="select_list_to_filter">Selecione uma lista para filtrar o feed</string>
     <string name="temporary_account">Terminar sessão no bloqueio do dispositivo</string>
+
+    <string name="reset_translated_languages">Redefinir idiomas traduzidos</string>
+    <string name="reset_translated_languages_description">Isso redefinirá os idiomas selecionados anteriormente em \'Nunca traduzir de\' e todos os idiomas serão traduzidos novamente.</string>
+
 </resources>

--- a/amethyst/src/main/res/values-sv-rSE/strings.xml
+++ b/amethyst/src/main/res/values-sv-rSE/strings.xml
@@ -874,4 +874,8 @@
     <string name="torrent_no_apps">Inga torrent-appar installerade för att öppna och ladda ner filen.</string>
     <string name="select_list_to_filter">Välj en lista för att filtrera flödet</string>
     <string name="temporary_account">Logga ut när enheten låses</string>
+
+    <string name="reset_translated_languages">Återställ översatta språk</string>
+    <string name="reset_translated_languages_description">Detta kommer att återställa tidigare valda språk under \'Översätt aldrig från\', och alla språk kommer att översättas igen.</string>
+
 </resources>

--- a/amethyst/src/main/res/values-sv-rSE/strings.xml
+++ b/amethyst/src/main/res/values-sv-rSE/strings.xml
@@ -877,5 +877,5 @@
 
     <string name="reset_translated_languages">Återställ översatta språk</string>
     <string name="reset_translated_languages_description">Detta kommer att återställa tidigare valda språk under \'Översätt aldrig från\', och alla språk kommer att översättas igen.</string>
-
+    <string name="reset_translated_languages_toast">Översatta språk har återställts.</string>
 </resources>

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -625,6 +625,7 @@
 
     <string name="reset_translated_languages">Reset translated languages</string>
     <string name="reset_translated_languages_description">This will reset the previously selected \'Never translate from\' languages and all languages will be translated again.</string>
+    <string name="reset_translated_languages_toast">Translated languages have been reset.</string>
 
     <string name="load_image">Load Image</string>
 

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -623,6 +623,9 @@
     <string name="ui_style">UI Mode</string>
     <string name="ui_style_description">Choose the post style</string>
 
+    <string name="reset_translated_languages">Reset translated languages</string>
+    <string name="reset_translated_languages_description">This will reset the previously selected \'Never translate from\' languages and all languages will be translated again.</string>
+
     <string name="load_image">Load Image</string>
 
     <string name="spamming_users">Spammers</string>


### PR DESCRIPTION
Several users have reported (#684) that once you set a language as "never translate from" it's not possible to revert it.

This is a simple solution by adding a button in the application preferences to reset ALL languages to be translated again.

Changes:

- Add a button to applications settings for Play version only
- Reset dontTranslateFrom field by setting it to an empty set
- Added translations

Testing:

- emulator (play/fdroid)
- Pixel 7 (play/fdroid)

It's not pretty but UI is not my forte:
![button_in_settings](https://github.com/user-attachments/assets/d5f74314-733d-4464-bb86-bd93be227b2a)

A different approach would be to allow a reset of a specific language via the note drop-down. I didn't see a straightforward way to pass the note language code to the dropdown so didn't choose this approach.
