### PR TITLE
Hide drafts from other accounts on device

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/ThreadFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/ThreadFeedView.kt
@@ -274,7 +274,6 @@ fun RenderThreadFeed(
             val modifier =
                 Modifier
                     .drawReplyLevel(
-                        note = item,
                         level = level,
                         color = MaterialTheme.colorScheme.placeholderText,
                         selected =
@@ -322,7 +321,6 @@ fun RenderThreadFeed(
 
 // Creates a Zebra pattern where each bar is a reply level.
 fun Modifier.drawReplyLevel(
-    note: Note,
     level: State<Int>,
     color: Color,
     selected: Color,
@@ -662,9 +660,8 @@ private fun FullBleedNoteCompose(
             }
         }
 
-        val noteEvent = baseNote.event
-        val zapSplits = remember(noteEvent) { noteEvent?.hasZapSplitSetup() ?: false }
-        if (zapSplits && noteEvent != null) {
+        val zapSplits = remember(noteEvent) { noteEvent.hasZapSplitSetup() }
+        if (zapSplits) {
             Spacer(modifier = DoubleVertSpacer)
             Row(
                 modifier = Modifier.padding(horizontal = 12.dp),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/ThreadFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/ThreadFeedView.kt
@@ -242,9 +242,9 @@ fun RenderThreadFeed(
         // In that case, this screen will open with 0-1 items, and the scrollToItem below
         // will not change the state of the screen (too few items, scroll is not available)
         // as the app loads the reaming of the thread the position of the reply changes
-        // and becuase there wasn't a possibility to scroll before and now there is one,
+        // and because there wasn't a possibility to scroll before and now there is one,
         // the screen stays at the top. Once the thread has enough replies, the lazy column
-        // updates with new items correctly. It just needs a few items to start the scrool.
+        // updates with new items correctly. It just needs a few items to start the scroll.
         //
         // This hack allows the list 1 second to fill up with more
         // records before setting up the position on the feed.
@@ -482,14 +482,22 @@ private fun FullBleedNoteCompose(
 
         Spacer(modifier = Modifier.height(10.dp))
 
-        if (noteEvent is BadgeDefinitionEvent) {
-            BadgeDisplay(baseNote = baseNote)
-        } else if (noteEvent is LongTextNoteEvent) {
-            RenderLongFormHeaderForThread(noteEvent)
-        } else if (noteEvent is WikiNoteEvent) {
-            RenderWikiHeaderForThread(noteEvent, accountViewModel, nav)
-        } else if (noteEvent is ClassifiedsEvent) {
-            RenderClassifiedsReaderForThread(noteEvent, baseNote, accountViewModel, nav)
+        when (noteEvent) {
+            is BadgeDefinitionEvent -> {
+                BadgeDisplay(baseNote = baseNote)
+            }
+
+            is LongTextNoteEvent -> {
+                RenderLongFormHeaderForThread(noteEvent)
+            }
+
+            is WikiNoteEvent -> {
+                RenderWikiHeaderForThread(noteEvent, accountViewModel, nav)
+            }
+
+            is ClassifiedsEvent -> {
+                RenderClassifiedsReaderForThread(noteEvent, baseNote, accountViewModel, nav)
+            }
         }
 
         Row(
@@ -510,11 +518,11 @@ private fun FullBleedNoteCompose(
                         nav = nav,
                     )
                 } else if (noteEvent is VideoEvent) {
-                    VideoDisplay(baseNote, false, true, backgroundColor, false, accountViewModel, nav)
+                    VideoDisplay(baseNote, makeItShort = false, canPreview = true, backgroundColor = backgroundColor, isFiniteHeight = false, accountViewModel = accountViewModel, nav = nav)
                 } else if (noteEvent is FileHeaderEvent) {
-                    FileHeaderDisplay(baseNote, true, false, accountViewModel)
+                    FileHeaderDisplay(baseNote, roundedCorner = true, isFiniteHeight = false, accountViewModel = accountViewModel)
                 } else if (noteEvent is FileStorageHeaderEvent) {
-                    FileStorageHeaderDisplay(baseNote, true, false, accountViewModel)
+                    FileStorageHeaderDisplay(baseNote, roundedCorner = true, isFiniteHeight = false, accountViewModel = accountViewModel)
                 } else if (noteEvent is PeopleListEvent) {
                     DisplayPeopleList(baseNote, backgroundColor, accountViewModel, nav)
                 } else if (noteEvent is AudioTrackEvent) {
@@ -561,9 +569,9 @@ private fun FullBleedNoteCompose(
                 } else if (noteEvent is GitRepositoryEvent) {
                     RenderGitRepositoryEvent(baseNote, accountViewModel, nav)
                 } else if (noteEvent is GitPatchEvent) {
-                    RenderGitPatchEvent(baseNote, false, true, quotesLeft = 3, backgroundColor, accountViewModel, nav)
+                    RenderGitPatchEvent(baseNote, makeItShort = false, canPreview = true, quotesLeft = 3, backgroundColor = backgroundColor, accountViewModel = accountViewModel, nav = nav)
                 } else if (noteEvent is GitIssueEvent) {
-                    RenderGitIssueEvent(baseNote, false, true, quotesLeft = 3, backgroundColor, accountViewModel, nav)
+                    RenderGitIssueEvent(baseNote, makeItShort = false, canPreview = true, quotesLeft = 3, backgroundColor = backgroundColor, accountViewModel = accountViewModel, nav = nav)
                 } else if (noteEvent is AppDefinitionEvent) {
                     RenderAppDefinition(baseNote, accountViewModel, nav)
                 } else if (noteEvent is DraftEvent) {
@@ -670,7 +678,7 @@ private fun FullBleedNoteCompose(
             }
         }
 
-        ReactionsRow(baseNote, true, true, editState, accountViewModel, nav)
+        ReactionsRow(baseNote, showReactionDetail = true, addPadding = true, editState = editState, accountViewModel = accountViewModel, nav = nav)
     }
 }
 
@@ -922,14 +930,14 @@ private fun RenderWikiHeaderForThreadPreview() {
                 RenderWikiHeaderForThread(noteEvent = event, accountViewModel = accountViewModel, nav)
                 RenderTextEvent(
                     baseNote!!,
-                    false,
-                    true,
+                    makeItShort = false,
+                    canPreview = true,
                     quotesLeft = 3,
                     unPackReply = false,
-                    backgroundColor,
-                    editState,
-                    accountViewModel,
-                    nav,
+                    backgroundColor = backgroundColor,
+                    editState = editState,
+                    accountViewModel = accountViewModel,
+                    nav = nav,
                 )
             }
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/ThreadFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/ThreadFeedView.kt
@@ -268,7 +268,7 @@ fun RenderThreadFeed(
         contentPadding = FeedPadding,
         state = listState,
     ) {
-        itemsIndexed(items.list.filter { !it.isDraft() || (it.author?.pubkeyHex == accountViewModel.account.userProfile().pubkeyHex) }, key = { _, item -> item.idHex }) { index, item ->
+        itemsIndexed(items.list, key = { _, item -> item.idHex }) { index, item ->
             val level = viewModel.levelFlowForItem(item).collectAsStateWithLifecycle(0)
 
             val modifier =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/ThreadFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/ThreadFeedView.kt
@@ -268,7 +268,7 @@ fun RenderThreadFeed(
         contentPadding = FeedPadding,
         state = listState,
     ) {
-        itemsIndexed(items.list, key = { _, item -> item.idHex }) { index, item ->
+        itemsIndexed(items.list.filter { !it.isDraft() || (it.author?.pubkeyHex == accountViewModel.account.userProfile().pubkeyHex) }, key = { _, item -> item.idHex }) { index, item ->
             val level = viewModel.levelFlowForItem(item).collectAsStateWithLifecycle(0)
 
             val modifier =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/ThreadFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/ThreadFeedView.kt
@@ -483,21 +483,10 @@ private fun FullBleedNoteCompose(
         Spacer(modifier = Modifier.height(10.dp))
 
         when (noteEvent) {
-            is BadgeDefinitionEvent -> {
-                BadgeDisplay(baseNote = baseNote)
-            }
-
-            is LongTextNoteEvent -> {
-                RenderLongFormHeaderForThread(noteEvent)
-            }
-
-            is WikiNoteEvent -> {
-                RenderWikiHeaderForThread(noteEvent, accountViewModel, nav)
-            }
-
-            is ClassifiedsEvent -> {
-                RenderClassifiedsReaderForThread(noteEvent, baseNote, accountViewModel, nav)
-            }
+            is BadgeDefinitionEvent -> BadgeDisplay(baseNote = baseNote)
+            is LongTextNoteEvent -> RenderLongFormHeaderForThread(noteEvent)
+            is WikiNoteEvent -> RenderWikiHeaderForThread(noteEvent, accountViewModel, nav)
+            is ClassifiedsEvent -> RenderClassifiedsReaderForThread(noteEvent, baseNote, accountViewModel, nav)
         }
 
         Row(


### PR DESCRIPTION
Bug: #1172

This solution filters out drafts from other accounts on device before displaying a thread (draft content from other accounts was never visible due to encryption).

First commit ffd43e448bc1687cd4847f1589f37091748a4e37 has the actual functionality change the other commits are code cleanup.

Maybe another solution would be to clear drafts when switching accounts but then drafts would always have to be fetched again when switching back. With this solution drafts remain in cache and are just filtered out if they are not your drafts.

Comment count is incorrect as it includes the hidden comments. This issue is already present due to hidden comments by mute and anti spam so maybe it can be fixed all together in another feature.

User one is logged in and sees 2 comments on user Twoo post and three comments on his own post.
![a1](https://github.com/user-attachments/assets/8ce66225-d0bb-4e63-a8c7-ddae32230de3)

User one sees three draft comments on his own post
![a2](https://github.com/user-attachments/assets/50c30502-3272-4dd6-a3d3-4ee29746c837)

User one sees no drafts on user Twoooo post
![a3](https://github.com/user-attachments/assets/2443227a-18bd-44e4-bd19-964362e6823a)

