### PR TITLE
Enable unfollow in note dropdown

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DropDownMenu.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DropDownMenu.kt
@@ -169,6 +169,16 @@ fun NoteDropDownMenu(
                 },
             )
             HorizontalDivider(thickness = DividerThickness)
+        } else {
+            DropdownMenuItem(
+                text = { Text(stringRes(R.string.unfollow)) },
+                onClick = {
+                    val author = note.author ?: return@DropdownMenuItem
+                    accountViewModel.unfollow(author)
+                    onDismiss()
+                },
+            )
+            HorizontalDivider(thickness = DividerThickness)
         }
         DropdownMenuItem(
             text = { Text(stringRes(R.string.copy_text)) },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DropDownMenu.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DropDownMenu.kt
@@ -107,7 +107,7 @@ fun NoteDropDownMenu(
     var reportDialogShowing by remember { mutableStateOf(false) }
 
     var state by remember {
-        mutableStateOf<DropDownParams>(
+        mutableStateOf(
             DropDownParams(
                 isFollowingAuthor = false,
                 isPrivateBookmarkNote = false,


### PR DESCRIPTION
Just noticed this when working on something else.

Any reason why "unfollow" wasn't in the dropdown like the "follow" is?