### PR TITLE
Append server type to lazy column index to make it unique

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/mediaServers/AllMediaServersLIstView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/mediaServers/AllMediaServersLIstView.kt
@@ -219,7 +219,7 @@ fun MediaServersListView(
                         itemsIndexed(
                             it,
                             key = { index: Int, server: ServerName ->
-                                server.baseUrl
+                                server.type.name + server.baseUrl
                             },
                         ) { index, server ->
                             MediaServerEntry(
@@ -263,7 +263,7 @@ fun LazyListScope.renderMediaServerList(
         itemsIndexed(
             mediaServersState,
             key = { index: Int, server: ServerName ->
-                server.baseUrl
+                server.type.name + server.baseUrl
             },
         ) { index, entry ->
             MediaServerEntry(


### PR DESCRIPTION
Fix for #1186

Currently the app allows entering same media server as nip96 and blossom.

The server name is used as key for LazyColumn and this breaks LazyColumn as it doesn't allow duplicate key.

This fix prepends server type before serve name when used as key which makes it unique. This will prevent crash for any users that have already entered duplicate media servers.

Going forward do we want allow same media server as both nip96 and blossom or should we prevent it?

If we allow a media server as both nip96 and blossom should we make that clear on upload (not part of this pull request):
![Screenshot_20241122_164540](https://github.com/user-attachments/assets/1b08660c-78be-44ba-b7bc-565cc7aecb56)
