### PR TITLE
Extend NIP93 Profile Gallery with Nip68 Events

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -1962,6 +1962,7 @@ class Account(
         if (isImage) {
             PictureEvent.create(
                 url = url,
+                msg = alt,
                 mimeType = headerInfo.mimeType,
                 hash = headerInfo.hash,
                 size = headerInfo.size.toLong(),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/VideoView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/VideoView.kt
@@ -250,6 +250,7 @@ fun VideoView(
     onControllerVisibilityChanged: ((Boolean) -> Unit)? = null,
     accountViewModel: AccountViewModel,
     alwaysShowVideo: Boolean = false,
+    showControls: Boolean = true,
 ) {
     val defaultToStart by remember(videoUri) { mutableStateOf(DEFAULT_MUTED_SETTING.value) }
 
@@ -337,6 +338,7 @@ fun VideoView(
                     onControllerVisibilityChanged = onControllerVisibilityChanged,
                     onDialog = onDialog,
                     accountViewModel = accountViewModel,
+                    showControls = showControls,
                 )
             }
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
@@ -27,6 +27,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.InlineTextContent
@@ -222,7 +223,7 @@ fun GalleryContentView(
             }
         is MediaUrlVideo ->
             SensitivityWarning(content.contentWarning != null, accountViewModel) {
-                Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     VideoView(
                         videoUri = content.url,
                         mimeType = content.mimeType,
@@ -230,11 +231,13 @@ fun GalleryContentView(
                         artworkUri = content.artworkUri,
                         borderModifier = MaterialTheme.colorScheme.videoGalleryModifier,
                         authorName = content.authorName,
-                        dimensions = content.dim,
+                        dimensions = Dimension(1, 1), // fit video in 1:1 ratio
                         blurhash = content.blurhash,
                         isFiniteHeight = isFiniteHeight,
                         nostrUriCallback = content.uri,
                         accountViewModel = accountViewModel,
+                        alwaysShowVideo = true,
+                        showControls = false,
                     )
                 }
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/UserProfileGalleryFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/UserProfileGalleryFeedFilter.kt
@@ -26,7 +26,9 @@ import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.quartz.events.MuteListEvent
 import com.vitorpamplona.quartz.events.PeopleListEvent
+import com.vitorpamplona.quartz.events.PictureEvent
 import com.vitorpamplona.quartz.events.ProfileGalleryEntryEvent
+import com.vitorpamplona.quartz.events.VideoEvent
 
 class UserProfileGalleryFeedFilter(
     val user: User,
@@ -65,7 +67,7 @@ class UserProfileGalleryFeedFilter(
     ): Boolean {
         val noteEvent = it.event
         return (
-            (it.event?.pubKey() == user.pubkeyHex && noteEvent is ProfileGalleryEntryEvent) && noteEvent.hasUrl() && noteEvent.hasFromEvent() // && noteEvent.isOneOf(SUPPORTED_VIDEO_FEED_MIME_TYPES_SET))
+            (it.event?.pubKey() == user.pubkeyHex && (noteEvent is PictureEvent || noteEvent is VideoEvent || (noteEvent is ProfileGalleryEntryEvent) && noteEvent.hasUrl() && noteEvent.hasFromEvent())) // && noteEvent.isOneOf(SUPPORTED_VIDEO_FEED_MIME_TYPES_SET))
         ) &&
             params.match(noteEvent) &&
             account.isAcceptable(it)

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -285,7 +285,7 @@
     <string name="quick_action_unfollow">Unfollow</string>
     <string name="quick_action_follow">Follow</string>
     <string name="quick_action_request_deletion_gallery_title">Delete from Gallery</string>
-    <string name="quick_action_request_deletion_gallery_alert_body">Remove this media from your Gallery, you can readd it later</string>
+    <string name="quick_action_request_deletion_gallery_alert_body">Remove this media from your Gallery.</string>
     <string name="quick_action_request_deletion_alert_title">Request Deletion</string>
     <string name="quick_action_request_deletion_alert_body">Amethyst will request that your note be deleted from the relays you are currently connected to. There is no guarantee that your note will be permanently deleted from those relays, or from other relays where it may be stored.</string>
     <string name="quick_action_block_dialog_btn">Block</string>


### PR DESCRIPTION
This is an alternative PR to #1208 

It keeps the user gallery as before (including kind 1163 events) but it also adds NIP68 Kind 20 events. These will be added when posting via the multimedia tab, or on other clients like Olas.

This way users with already large galleries, keep their entries. Users might opt to use the multimedia feed in the future.
(Add to media gallery on images is still there but could be deprecated in the future in favor of kind 20)

Additionally, same as in the other PR:
- Fixes content not being posted with kind 20 event
- Fixes videos in gallery not clickable
