### PR TITLE
Account backup qr codes

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/DrawerContent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/DrawerContent.kt
@@ -539,7 +539,7 @@ fun ListContent(
         MediaServersListView({ editMediaServers = false }, accountViewModel = accountViewModel, nav = nav)
     }
     if (backupDialogOpen) {
-        AccountBackupDialog(accountViewModel, nav, onClose = { backupDialogOpen = false })
+        AccountBackupDialog(accountViewModel, onClose = { backupDialogOpen = false })
     }
     if (conectOrbotDialogOpen) {
         ConnectTorDialog(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/DrawerContent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/DrawerContent.kt
@@ -539,7 +539,7 @@ fun ListContent(
         MediaServersListView({ editMediaServers = false }, accountViewModel = accountViewModel, nav = nav)
     }
     if (backupDialogOpen) {
-        AccountBackupDialog(accountViewModel, onClose = { backupDialogOpen = false })
+        AccountBackupDialog(accountViewModel, nav, onClose = { backupDialogOpen = false })
     }
     if (conectOrbotDialogOpen) {
         ConnectTorDialog(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountBackupDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountBackupDialog.kt
@@ -101,7 +101,6 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.qrcode.QrCodeDrawer
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.ButtonBorder
 import com.vitorpamplona.amethyst.ui.theme.ButtonPadding
-import com.vitorpamplona.amethyst.ui.theme.Size10dp
 import com.vitorpamplona.amethyst.ui.theme.ThemeComparisonRow
 import com.vitorpamplona.amethyst.ui.theme.placeholderText
 import com.vitorpamplona.quartz.crypto.CryptoUtils
@@ -493,27 +492,30 @@ private fun ShowKeyQRDialog(
         properties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
         Surface {
-            Column {
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(10.dp),
+            ) {
+                // Back button at the top
                 Row(
-                    modifier = Modifier.padding(10.dp),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     BackButton(onPress = onClose)
                 }
 
+                // QR Code content
                 Column(
-                    modifier = Modifier.fillMaxSize().padding(horizontal = 10.dp),
-                    verticalArrangement = Arrangement.SpaceAround,
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(vertical = 10.dp),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
-                    Column {
-                        Row(
-                            horizontalArrangement = Arrangement.Center,
-                            modifier = Modifier.fillMaxWidth().padding(horizontal = Size10dp),
-                        ) {
-                            QrCodeDrawer(qrCode ?: "error")
-                        }
-                    }
+                    QrCodeDrawer(qrCode ?: "error")
                 }
             }
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountBackupDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountBackupDialog.kt
@@ -301,96 +301,6 @@ private fun DialogContents(
 }
 
 @Composable
-private fun QrCodeButton(accountViewModel: AccountViewModel) {
-    val context = LocalContext.current
-
-    // store the dialog open or close state
-    var dialogOpen by remember { mutableStateOf(false) }
-
-    val keyguardLauncher =
-        rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
-            if (result.resultCode == Activity.RESULT_OK) {
-                dialogOpen = true
-            }
-        }
-
-    IconButton(
-        onClick = {
-            authenticate(
-                title = stringRes(context, R.string.copy_my_secret_key),
-                context = context,
-                keyguardLauncher = keyguardLauncher,
-                onApproved = { dialogOpen = true },
-                onError = { title, message -> accountViewModel.toast(title, message) },
-            )
-        },
-    ) {
-        Icon(
-            painter = painterResource(R.drawable.ic_qrcode),
-            contentDescription = stringRes(id = R.string.show_npub_as_a_qr_code),
-            modifier = Modifier.size(24.dp),
-            tint = MaterialTheme.colorScheme.primary,
-        )
-    }
-
-    if (dialogOpen) {
-        ShowKeyQRDialog(
-            accountViewModel.account.settings.keyPair.privKey
-                ?.toNsec(),
-            onClose = { dialogOpen = false },
-        )
-    }
-}
-
-@Composable
-private fun QrCodeButtonEncrypted(
-    accountViewModel: AccountViewModel,
-    password: MutableState<TextFieldValue>,
-) {
-    val context = LocalContext.current
-
-    // store the dialog open or close state
-    var dialogOpen by remember { mutableStateOf(false) }
-
-    val keyguardLauncher =
-        rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
-            if (result.resultCode == Activity.RESULT_OK) {
-                dialogOpen = true
-            }
-        }
-
-    IconButton(
-        enabled = password.value.text.isNotBlank(),
-        onClick = {
-            authenticate(
-                title = stringRes(context, R.string.copy_my_secret_key),
-                context = context,
-                keyguardLauncher = keyguardLauncher,
-                onApproved = { dialogOpen = true },
-                onError = { title, message -> accountViewModel.toast(title, message) },
-            )
-        },
-    ) {
-        Icon(
-            painter = painterResource(R.drawable.ic_qrcode),
-            contentDescription = stringRes(id = R.string.show_npub_as_a_qr_code),
-            modifier = Modifier.size(24.dp),
-        )
-    }
-
-    if (dialogOpen) {
-        val key =
-            accountViewModel.account.settings.keyPair.privKey
-                ?.toHexKey()
-                ?.let { CryptoUtils.encryptNIP49(it, password.value.text) }
-        ShowKeyQRDialog(
-            key,
-            onClose = { dialogOpen = false },
-        )
-    }
-}
-
-@Composable
 private fun NSecCopyButton(accountViewModel: AccountViewModel) {
     val clipboardManager = LocalClipboardManager.current
     val context = LocalContext.current
@@ -556,6 +466,96 @@ private fun encryptCopyNSec(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun QrCodeButton(accountViewModel: AccountViewModel) {
+    val context = LocalContext.current
+
+    // store the dialog open or close state
+    var dialogOpen by remember { mutableStateOf(false) }
+
+    val keyguardLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
+            if (result.resultCode == Activity.RESULT_OK) {
+                dialogOpen = true
+            }
+        }
+
+    IconButton(
+        onClick = {
+            authenticate(
+                title = stringRes(context, R.string.copy_my_secret_key),
+                context = context,
+                keyguardLauncher = keyguardLauncher,
+                onApproved = { dialogOpen = true },
+                onError = { title, message -> accountViewModel.toast(title, message) },
+            )
+        },
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_qrcode),
+            contentDescription = stringRes(id = R.string.show_npub_as_a_qr_code),
+            modifier = Modifier.size(24.dp),
+            tint = MaterialTheme.colorScheme.primary,
+        )
+    }
+
+    if (dialogOpen) {
+        ShowKeyQRDialog(
+            accountViewModel.account.settings.keyPair.privKey
+                ?.toNsec(),
+            onClose = { dialogOpen = false },
+        )
+    }
+}
+
+@Composable
+private fun QrCodeButtonEncrypted(
+    accountViewModel: AccountViewModel,
+    password: MutableState<TextFieldValue>,
+) {
+    val context = LocalContext.current
+
+    // store the dialog open or close state
+    var dialogOpen by remember { mutableStateOf(false) }
+
+    val keyguardLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
+            if (result.resultCode == Activity.RESULT_OK) {
+                dialogOpen = true
+            }
+        }
+
+    IconButton(
+        enabled = password.value.text.isNotBlank(),
+        onClick = {
+            authenticate(
+                title = stringRes(context, R.string.copy_my_secret_key),
+                context = context,
+                keyguardLauncher = keyguardLauncher,
+                onApproved = { dialogOpen = true },
+                onError = { title, message -> accountViewModel.toast(title, message) },
+            )
+        },
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_qrcode),
+            contentDescription = stringRes(id = R.string.show_npub_as_a_qr_code),
+            modifier = Modifier.size(24.dp),
+        )
+    }
+
+    if (dialogOpen) {
+        val key =
+            accountViewModel.account.settings.keyPair.privKey
+                ?.toHexKey()
+                ?.let { CryptoUtils.encryptNIP49(it, password.value.text) }
+        ShowKeyQRDialog(
+            key,
+            onClose = { dialogOpen = false },
+        )
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountBackupDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountBackupDialog.kt
@@ -192,30 +192,14 @@ private fun DialogContents(
 
                 Spacer(modifier = Modifier.height(20.dp))
 
-                NSecCopyButton(accountViewModel)
+                Row {
+                    Column {
+                        NSecCopyButton(accountViewModel)
+                    }
 
-                // store the dialog open or close state
-                var dialogOpen by remember { mutableStateOf(false) }
-                IconButton(
-                    onClick = {
-                        dialogOpen = true
-                        nav.closeDrawer()
-                    },
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.ic_qrcode),
-                        contentDescription = stringRes(id = R.string.show_npub_as_a_qr_code),
-                        modifier = Modifier.size(24.dp),
-                        tint = MaterialTheme.colorScheme.primary,
-                    )
-                }
-
-                if (dialogOpen) {
-                    ShowKeyQRDialog(
-                        accountViewModel.account.settings.keyPair.privKey
-                            ?.toNsec(),
-                        onClose = { dialogOpen = false },
-                    )
+                    Column {
+                        QrCodeButton(nav, accountViewModel)
+                    }
                 }
 
                 Spacer(modifier = Modifier.height(30.dp))
@@ -318,6 +302,37 @@ private fun DialogContents(
                 Spacer(modifier = Modifier.height(30.dp))
             }
         }
+    }
+}
+
+@Composable
+private fun QrCodeButton(
+    nav: INav,
+    accountViewModel: AccountViewModel,
+) {
+    // store the dialog open or close state
+    var dialogOpen by remember { mutableStateOf(false) }
+
+    IconButton(
+        onClick = {
+            dialogOpen = true
+            nav.closeDrawer()
+        },
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_qrcode),
+            contentDescription = stringRes(id = R.string.show_npub_as_a_qr_code),
+            modifier = Modifier.size(24.dp),
+            tint = MaterialTheme.colorScheme.primary,
+        )
+    }
+
+    if (dialogOpen) {
+        ShowKeyQRDialog(
+            accountViewModel.account.settings.keyPair.privKey
+                ?.toNsec(),
+            onClose = { dialogOpen = false },
+        )
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountBackupDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountBackupDialog.kt
@@ -128,8 +128,7 @@ fun DialogContentsPreview() {
     ThemeComparisonRow {
         DialogContents(
             mockAccountViewModel(),
-            {},
-        )
+        ) {}
     }
 }
 
@@ -251,7 +250,7 @@ private fun DialogContents(
                     },
                     keyboardOptions =
                         KeyboardOptions(
-                            autoCorrect = false,
+                            autoCorrectEnabled = false,
                             keyboardType = KeyboardType.Password,
                             imeAction = ImeAction.Go,
                         ),
@@ -474,6 +473,7 @@ private fun encryptCopyNSec(
 private fun QrCodeButtonBase(
     accountViewModel: AccountViewModel,
     isEnabled: Boolean = true,
+    contentDescription: Int,
     onDialogShow: () -> String?,
 ) {
     val context = LocalContext.current
@@ -502,7 +502,7 @@ private fun QrCodeButtonBase(
     ) {
         Icon(
             painter = painterResource(R.drawable.ic_qrcode),
-            contentDescription = stringRes(id = R.string.show_npub_as_a_qr_code),
+            contentDescription = stringRes(id = contentDescription),
             modifier = Modifier.size(24.dp),
             tint = if (isEnabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.grayText,
         )
@@ -520,6 +520,7 @@ private fun QrCodeButtonBase(
 private fun QrCodeButton(accountViewModel: AccountViewModel) {
     QrCodeButtonBase(
         accountViewModel = accountViewModel,
+        contentDescription = R.string.show_private_key_qr_code,
         onDialogShow = {
             accountViewModel.account.settings.keyPair.privKey
                 ?.toNsec()
@@ -535,6 +536,7 @@ private fun QrCodeButtonEncrypted(
     QrCodeButtonBase(
         accountViewModel = accountViewModel,
         isEnabled = password.value.text.isNotBlank(),
+        contentDescription = R.string.show_encrypted_private_key_qr_code,
         onDialogShow = {
             accountViewModel.account.settings.keyPair.privKey
                 ?.toHexKey()

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -153,6 +153,8 @@
     <string name="lightning_address">Lightning Address</string>
     <string name="copies_the_nsec_id_your_password_to_the_clipboard_for_backup">Copies the Nsec ID (your password) to the clipboard for backup</string>
     <string name="copy_private_key_to_the_clipboard">Copy Secret Key to the Clipboard</string>
+    <string name="show_private_key_qr_code">Show private key QR code</string>
+    <string name="show_encrypted_private_key_qr_code">Show encrypted private key QR code</string>
     <string name="copies_the_public_key_to_the_clipboard_for_sharing">Copies the public key to the clipboard for sharing</string>
     <string name="copy_public_key_npub_to_the_clipboard">Copy Public Key (NPub) to the Clipboard</string>
     <string name="send_a_direct_message">Send a Direct Message</string>


### PR DESCRIPTION
Amethyst has a great QR code scanning feature in login screen but I didn't see a way to export keys as QR code.

New fucntionality:
- Show QR code for private key. The QR code can be scanned by a different device to allow for quick account import.
- Show QR code for private key or for encrypted private key. You can print the QR code of encrypted private key and keep as backup and scan at a later date and provide password to allow import.

https://github.com/user-attachments/assets/d9c31eb5-b482-4073-bd62-853ebb740352

