### PR TITLE
Keep note state across LazyColumns recompositions

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ExpandableRichTextViewer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ExpandableRichTextViewer.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -70,7 +71,7 @@ fun ExpandableRichTextViewer(
     nav: INav,
 ) {
     var showFullText by
-        remember {
+        rememberSaveable {
             val cached = ShowFullTextCache.cache[id]
             if (cached == null) {
                 ShowFullTextCache.cache.put(id, false)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
@@ -71,6 +71,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.Center
@@ -169,7 +170,7 @@ fun ReactionsRow(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    val wantsToSeeReactions = remember(baseNote) { mutableStateOf(false) }
+    val wantsToSeeReactions = rememberSaveable(baseNote) { mutableStateOf(false) }
 
     InnerReactionRow(baseNote, showReactionDetail, addPadding, wantsToSeeReactions, editState, accountViewModel, nav)
 


### PR DESCRIPTION
Fixes #1203 
The same problem happens with the "show more" state when the note contains enough text.
This is because the LazyColumn in RenderThreadFeed removes items from memory when they are no longer visible. Changing the variables that maintain the state in ReactionsRow and ExpandableRichTextViewer to use rememberSaveable instead of remember seems to fix this problem.