### PR TITLE
Exclude file header events from search results

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -1845,6 +1845,21 @@ object LocalCache {
         )
     }
 
+    /**
+     * Will return true if supplied note is one of events to be excluded from
+     * search results.
+     */
+    private fun excludeNoteEventFromSearchResults(note: Note): Boolean =
+        (
+            note.event is GenericRepostEvent ||
+                note.event is RepostEvent ||
+                note.event is CommunityPostApprovalEvent ||
+                note.event is ReactionEvent ||
+                note.event is LnZapEvent ||
+                note.event is LnZapRequestEvent ||
+                note.event is FileHeaderEvent
+        )
+
     fun findNotesStartingWith(
         text: String,
         forAccount: Account,
@@ -1855,30 +1870,13 @@ object LocalCache {
 
         if (key != null) {
             val note = getNoteIfExists(key)
-            if ((note != null) &&
-                !(
-                    note.event is GenericRepostEvent ||
-                        note.event is RepostEvent ||
-                        note.event is CommunityPostApprovalEvent ||
-                        note.event is ReactionEvent ||
-                        note.event is LnZapEvent ||
-                        note.event is LnZapRequestEvent ||
-                        note.event is FileHeaderEvent
-                )
-            ) {
+            if ((note != null) && !excludeNoteEventFromSearchResults(note)) {
                 return listOfNotNull(note)
             }
         }
 
         return notes.filter { _, note ->
-            if (note.event is GenericRepostEvent ||
-                note.event is RepostEvent ||
-                note.event is CommunityPostApprovalEvent ||
-                note.event is ReactionEvent ||
-                note.event is LnZapEvent ||
-                note.event is LnZapRequestEvent ||
-                note.event is FileHeaderEvent
-            ) {
+            if (excludeNoteEventFromSearchResults(note)) {
                 return@filter false
             }
 
@@ -1903,14 +1901,7 @@ object LocalCache {
             return@filter false
         } +
             addressables.filter { _, addressable ->
-                if (addressable.event is GenericRepostEvent ||
-                    addressable.event is RepostEvent ||
-                    addressable.event is CommunityPostApprovalEvent ||
-                    addressable.event is ReactionEvent ||
-                    addressable.event is LnZapEvent ||
-                    addressable.event is LnZapRequestEvent ||
-                    addressable.event is FileHeaderEvent
-                ) {
+                if (excludeNoteEventFromSearchResults(addressable)) {
                     return@filter false
                 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -1855,7 +1855,17 @@ object LocalCache {
 
         if (key != null) {
             val note = getNoteIfExists(key)
-            if (note != null) {
+            if ((note != null) &&
+                !(
+                    note.event is GenericRepostEvent ||
+                        note.event is RepostEvent ||
+                        note.event is CommunityPostApprovalEvent ||
+                        note.event is ReactionEvent ||
+                        note.event is LnZapEvent ||
+                        note.event is LnZapRequestEvent ||
+                        note.event is FileHeaderEvent
+                )
+            ) {
                 return listOfNotNull(note)
             }
         }
@@ -1866,7 +1876,8 @@ object LocalCache {
                 note.event is CommunityPostApprovalEvent ||
                 note.event is ReactionEvent ||
                 note.event is LnZapEvent ||
-                note.event is LnZapRequestEvent
+                note.event is LnZapRequestEvent ||
+                note.event is FileHeaderEvent
             ) {
                 return@filter false
             }
@@ -1897,7 +1908,8 @@ object LocalCache {
                     addressable.event is CommunityPostApprovalEvent ||
                     addressable.event is ReactionEvent ||
                     addressable.event is LnZapEvent ||
-                    addressable.event is LnZapRequestEvent
+                    addressable.event is LnZapRequestEvent ||
+                    addressable.event is FileHeaderEvent
                 ) {
                     return@filter false
                 }


### PR DESCRIPTION
Exclude FileHeaderEvent from note search results as they crash the app due to large content size. 

In Direct note id search and in free text search

#1258 