### PR TITLE
add option for 2 profile gallery views

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Settings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Settings.kt
@@ -35,6 +35,7 @@ data class Settings(
     val dontShowPushNotificationSelector: Boolean = false,
     val dontAskForNotificationPermissions: Boolean = false,
     val featureSet: FeatureSetType = FeatureSetType.SIMPLIFIED,
+    val gallerySet: ProfileGalleryType = ProfileGalleryType.CLASSIC,
 )
 
 enum class ThemeType(
@@ -75,6 +76,14 @@ enum class FeatureSetType(
     PERFORMANCE(2, R.string.ui_feature_set_type_performance),
 }
 
+enum class ProfileGalleryType(
+    val screenCode: Int,
+    val resourceId: Int,
+) {
+    CLASSIC(0, R.string.gallery_type_classic),
+    MODERN(1, R.string.gallery_type_modern),
+}
+
 fun parseConnectivityType(code: Boolean?): ConnectivityType =
     when (code) {
         ConnectivityType.ALWAYS.prefCode -> ConnectivityType.ALWAYS
@@ -102,6 +111,15 @@ fun parseFeatureSetType(screenCode: Int): FeatureSetType =
         FeatureSetType.PERFORMANCE.screenCode -> FeatureSetType.PERFORMANCE
         else -> {
             FeatureSetType.COMPLETE
+        }
+    }
+
+fun parseGalleryType(screenCode: Int): ProfileGalleryType =
+    when (screenCode) {
+        ProfileGalleryType.CLASSIC.screenCode -> ProfileGalleryType.CLASSIC
+        ProfileGalleryType.MODERN.screenCode -> ProfileGalleryType.MODERN
+        else -> {
+            ProfileGalleryType.CLASSIC
         }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/SharedPreferencesViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/SharedPreferencesViewModel.kt
@@ -38,6 +38,7 @@ import com.vitorpamplona.amethyst.LocalPreferences
 import com.vitorpamplona.amethyst.model.BooleanType
 import com.vitorpamplona.amethyst.model.ConnectivityType
 import com.vitorpamplona.amethyst.model.FeatureSetType
+import com.vitorpamplona.amethyst.model.ProfileGalleryType
 import com.vitorpamplona.amethyst.model.Settings
 import com.vitorpamplona.amethyst.model.ThemeType
 import kotlinx.coroutines.Dispatchers
@@ -56,6 +57,7 @@ class SettingsState {
     var dontShowPushNotificationSelector by mutableStateOf<Boolean>(false)
     var dontAskForNotificationPermissions by mutableStateOf<Boolean>(false)
     var featureSet by mutableStateOf(FeatureSetType.SIMPLIFIED)
+    var gallerySet by mutableStateOf(ProfileGalleryType.CLASSIC)
 
     var isOnMobileData: State<Boolean> = mutableStateOf(false)
 
@@ -68,6 +70,14 @@ class SettingsState {
                 ConnectivityType.WIFI_ONLY -> !isOnMobileData.value
                 ConnectivityType.NEVER -> false
                 ConnectivityType.ALWAYS -> true
+            }
+        }
+
+    val modernGalleryStyle =
+        derivedStateOf {
+            when (gallerySet) {
+                ProfileGalleryType.CLASSIC -> false
+                ProfileGalleryType.MODERN -> true
             }
         }
 
@@ -117,6 +127,7 @@ class SharedPreferencesViewModel : ViewModel() {
             sharedPrefs.automaticallyShowProfilePictures = savedSettings.automaticallyShowProfilePictures
             sharedPrefs.dontShowPushNotificationSelector = savedSettings.dontShowPushNotificationSelector
             sharedPrefs.dontAskForNotificationPermissions = savedSettings.dontAskForNotificationPermissions
+            sharedPrefs.gallerySet = savedSettings.gallerySet
             sharedPrefs.featureSet = savedSettings.featureSet
 
             updateLanguageInTheUI()
@@ -191,6 +202,13 @@ class SharedPreferencesViewModel : ViewModel() {
         }
     }
 
+    fun updateGallerySetType(newgalleryType: ProfileGalleryType) {
+        if (sharedPrefs.gallerySet != newgalleryType) {
+            sharedPrefs.gallerySet = newgalleryType
+            saveSharedSettings()
+        }
+    }
+
     fun dontShowPushNotificationSelector() {
         if (sharedPrefs.dontShowPushNotificationSelector == false) {
             sharedPrefs.dontShowPushNotificationSelector = true
@@ -237,6 +255,7 @@ class SharedPreferencesViewModel : ViewModel() {
                     sharedPrefs.dontShowPushNotificationSelector,
                     sharedPrefs.dontAskForNotificationPermissions,
                     sharedPrefs.featureSet,
+                    sharedPrefs.gallerySet,
                 ),
             )
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/gallery/GalleryCardCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/gallery/GalleryCardCompose.kt
@@ -46,6 +46,7 @@ fun GalleryCardCompose(
     modifier: Modifier = Modifier,
     accountViewModel: AccountViewModel,
     nav: INav,
+    ratio: Float = 1.0f,
 ) {
     WatchNoteEvent(baseNote = baseNote, accountViewModel = accountViewModel, shortPreview = true) {
         CheckHiddenFeedWatchBlockAndReport(
@@ -74,6 +75,7 @@ fun GalleryCardCompose(
                             modifier = modifier,
                             accountViewModel = accountViewModel,
                             nav = nav,
+                            ratio = ratio,
                         )
                     } else {
                         RedirectableGalleryCard(
@@ -82,6 +84,7 @@ fun GalleryCardCompose(
                             modifier = modifier,
                             accountViewModel = accountViewModel,
                             nav = nav,
+                            ratio = ratio,
                         )
                     }
                 }
@@ -92,6 +95,7 @@ fun GalleryCardCompose(
                     modifier = modifier,
                     accountViewModel = accountViewModel,
                     nav = nav,
+                    ratio = ratio,
                 )
             }
         }
@@ -105,6 +109,7 @@ fun RedirectableGalleryCard(
     modifier: Modifier = Modifier,
     accountViewModel: AccountViewModel,
     nav: INav,
+    ratio: Float = 1.0f,
 ) {
     QuickActionGallery(baseNote = galleryNote, accountViewModel = accountViewModel) { showPopup ->
         ClickableNote(
@@ -123,7 +128,7 @@ fun RedirectableGalleryCard(
                 note = galleryNote,
                 accountViewModel = accountViewModel,
             ) {
-                GalleryThumbnail(galleryNote, accountViewModel, nav)
+                GalleryThumbnail(galleryNote, accountViewModel, nav, ratio = ratio)
             }
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/gallery/GalleryThumb.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/gallery/GalleryThumb.kt
@@ -77,6 +77,7 @@ fun GalleryThumbnail(
     baseNote: Note,
     accountViewModel: AccountViewModel,
     nav: INav,
+    ratio: Float = 1.0f,
 ) {
     val noteState by baseNote.live().metadata.observeAsState()
     val noteEvent = noteState?.note?.event ?: return
@@ -134,7 +135,7 @@ fun GalleryThumbnail(
             emptyList()
         }
 
-    InnerRenderGalleryThumb(content, baseNote, accountViewModel)
+    InnerRenderGalleryThumb(content, baseNote, accountViewModel, ratio)
 }
 
 @Composable
@@ -142,9 +143,10 @@ fun InnerRenderGalleryThumb(
     content: List<MediaUrlContent>,
     note: Note,
     accountViewModel: AccountViewModel,
+    ratio: Float = 1.0f,
 ) {
     if (content.isNotEmpty()) {
-        GalleryContentView(content, accountViewModel)
+        GalleryContentView(content, accountViewModel, ratio = ratio)
     } else {
         DisplayGalleryAuthorBanner(note)
     }
@@ -162,16 +164,17 @@ fun DisplayGalleryAuthorBanner(note: Note) {
 fun GalleryContentView(
     contentList: List<MediaUrlContent>,
     accountViewModel: AccountViewModel,
+    ratio: Float = 1.0f,
 ) {
     AutoNonlazyGrid(contentList.size) { contentIndex ->
         when (val content = contentList[contentIndex]) {
             is MediaUrlImage ->
                 SensitivityWarning(content.contentWarning != null, accountViewModel) {
-                    UrlImageView(content, accountViewModel)
+                    UrlImageView(content, accountViewModel, ratio = ratio)
                 }
             is MediaUrlVideo ->
                 SensitivityWarning(content.contentWarning != null, accountViewModel) {
-                    UrlVideoView(content, accountViewModel)
+                    UrlVideoView(content, accountViewModel, ratio = ratio)
                 }
         }
     }
@@ -182,8 +185,9 @@ fun UrlImageView(
     content: MediaUrlImage,
     accountViewModel: AccountViewModel,
     alwayShowImage: Boolean = false,
+    ratio: Float = 1.0f,
 ) {
-    val defaultModifier = Modifier.fillMaxSize().aspectRatio(1f)
+    val defaultModifier = Modifier.fillMaxSize().aspectRatio(ratio)
 
     val showImage =
         remember {
@@ -250,8 +254,9 @@ fun UrlImageView(
 fun UrlVideoView(
     content: MediaUrlVideo,
     accountViewModel: AccountViewModel,
+    ratio: Float = 1.0f,
 ) {
-    val defaultModifier = Modifier.fillMaxSize().aspectRatio(1f)
+    val defaultModifier = Modifier.fillMaxSize().aspectRatio(ratio)
 
     val automaticallyStartPlayback =
         remember(content) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/gallery/ProfileGalleryFeed.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/gallery/ProfileGalleryFeed.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.feeds.FeedEmpty
 import com.vitorpamplona.amethyst.ui.feeds.FeedError
@@ -40,6 +41,7 @@ import com.vitorpamplona.amethyst.ui.feeds.FeedState
 import com.vitorpamplona.amethyst.ui.feeds.LoadingFeed
 import com.vitorpamplona.amethyst.ui.navigation.INav
 import com.vitorpamplona.amethyst.ui.screen.FeedViewModel
+import com.vitorpamplona.amethyst.ui.screen.SharedPreferencesViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.theme.FeedPadding
 
@@ -87,6 +89,14 @@ private fun GalleryFeedLoaded(
     nav: INav,
 ) {
     val items by loaded.feed.collectAsStateWithLifecycle()
+    val sharedPreferencesViewModel: SharedPreferencesViewModel = viewModel()
+
+    sharedPreferencesViewModel.init()
+
+    var ratio = 1.0f
+    if (sharedPreferencesViewModel.sharedPrefs.modernGalleryStyle.value) {
+        ratio = 0.8f
+    }
 
     LazyVerticalGrid(
         columns = GridCells.Fixed(3),
@@ -100,11 +110,12 @@ private fun GalleryFeedLoaded(
                 baseNote = item,
                 modifier =
                     Modifier
-                        .aspectRatio(1f)
+                        .aspectRatio(ratio)
                         .fillMaxSize()
                         .animateItem(),
                 accountViewModel = accountViewModel,
                 nav = nav,
+                ratio = ratio,
             )
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
@@ -48,10 +48,12 @@ import androidx.core.os.LocaleListCompat
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.ConnectivityType
 import com.vitorpamplona.amethyst.model.FeatureSetType
+import com.vitorpamplona.amethyst.model.ProfileGalleryType
 import com.vitorpamplona.amethyst.model.ThemeType
 import com.vitorpamplona.amethyst.model.parseBooleanType
 import com.vitorpamplona.amethyst.model.parseConnectivityType
 import com.vitorpamplona.amethyst.model.parseFeatureSetType
+import com.vitorpamplona.amethyst.model.parseGalleryType
 import com.vitorpamplona.amethyst.model.parseThemeType
 import com.vitorpamplona.amethyst.ui.components.PushNotificationSettingsRow
 import com.vitorpamplona.amethyst.ui.navigation.INav
@@ -187,6 +189,12 @@ fun SettingsScreen(sharedPreferencesViewModel: SharedPreferencesViewModel) {
             TitleExplainer(stringRes(FeatureSetType.PERFORMANCE.resourceId)),
         )
 
+    val galleryItems =
+        persistentListOf(
+            TitleExplainer(stringRes(ProfileGalleryType.CLASSIC.resourceId)),
+            TitleExplainer(stringRes(ProfileGalleryType.MODERN.resourceId)),
+        )
+
     val showImagesIndex = sharedPreferencesViewModel.sharedPrefs.automaticallyShowImages.screenCode
     val videoIndex = sharedPreferencesViewModel.sharedPrefs.automaticallyStartPlayback.screenCode
     val linkIndex = sharedPreferencesViewModel.sharedPrefs.automaticallyShowUrlPreview.screenCode
@@ -204,6 +212,8 @@ fun SettingsScreen(sharedPreferencesViewModel: SharedPreferencesViewModel) {
 
     val featureSetIndex =
         sharedPreferencesViewModel.sharedPrefs.featureSet.screenCode
+    val galleryIndex =
+        sharedPreferencesViewModel.sharedPrefs.gallerySet.screenCode
 
     Column(
         Modifier
@@ -295,8 +305,18 @@ fun SettingsScreen(sharedPreferencesViewModel: SharedPreferencesViewModel) {
         ) {
             sharedPreferencesViewModel.updateFeatureSetType(parseFeatureSetType(it))
         }
+        Spacer(modifier = HalfVertSpacer)
 
         Spacer(modifier = HalfVertSpacer)
+
+        SettingsRow(
+            R.string.gallery_style,
+            R.string.gallery_style_description,
+            galleryItems,
+            galleryIndex,
+        ) {
+            sharedPreferencesViewModel.updateGallerySetType(parseGalleryType(it))
+        }
 
         PushNotificationSettingsRow(sharedPreferencesViewModel)
     }

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -634,6 +634,9 @@
     <string name="ui_feature_set_type_simplified">Simplified</string>
     <string name="ui_feature_set_type_performance">Performance</string>
 
+    <string name="gallery_type_classic">Classic</string>
+    <string name="gallery_type_modern">Modern</string>
+
     <string name="system">System</string>
     <string name="light">Light</string>
     <string name="dark">Dark</string>
@@ -649,6 +652,9 @@
 
     <string name="ui_style">UI Mode</string>
     <string name="ui_style_description">Choose the post style</string>
+
+    <string name="gallery_style">Profile Gallery Style</string>
+    <string name="gallery_style_description">Choose the gallery style</string>
 
     <string name="load_image">Load Image</string>
 


### PR DESCRIPTION
This PR introduces two different ways to look at profile galleries.

The "classic" view as it was used by social media apps for most of the time, and as is used currently in Amethyst (squares)
The "modern" view that is a 4:5 grid and is currently used by almost all popular social media apps. 

There's an option so users can choose the one they prefer. Default is classic.