### PR TITLE
Failed to save the image

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
@@ -43,6 +43,7 @@ import okio.IOException
 import okio.buffer
 import okio.sink
 import okio.source
+import okio.use
 import java.io.File
 import java.util.UUID
 
@@ -124,8 +125,8 @@ object MediaSaverToDisk {
                                 checkNotNull(contentType) { "Can't find out the content type" }
 
                                 val realType =
-                                    if (mimeType != null && contentType == "application/octet-stream") {
-                                        mimeType
+                                    if (contentType == "application/octet-stream") {
+                                        mimeType ?: getMimeTypeFromExtension(url)
                                     } else {
                                         contentType
                                     }
@@ -153,6 +154,11 @@ object MediaSaverToDisk {
                 },
             )
     }
+
+    private fun getMimeTypeFromExtension(fileName: String): String =
+        fileName.substringAfterLast('.', "").lowercase().let {
+            MimeTypeMap.getSingleton().getMimeTypeFromExtension(it).orEmpty()
+        }
 
     fun save(
         localFile: File,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
@@ -43,7 +43,6 @@ import okio.IOException
 import okio.buffer
 import okio.sink
 import okio.source
-import okio.use
 import java.io.File
 import java.util.UUID
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
@@ -56,10 +56,10 @@ object MediaSaverToDisk {
         onSuccess: () -> Any?,
         onError: (Throwable) -> Any?,
     ) {
-        if (videoUri != null) {
-            if (!videoUri.startsWith("file")) {
+        videoUri?.let { theVideoUri ->
+            if (!theVideoUri.startsWith("file")) {
                 downloadAndSave(
-                    url = videoUri,
+                    url = theVideoUri,
                     mimeType = mimeType,
                     context = localContext,
                     forceProxy = forceProxy,
@@ -68,7 +68,7 @@ object MediaSaverToDisk {
                 )
             } else {
                 save(
-                    localFile = videoUri.toUri().toFile(),
+                    localFile = theVideoUri.toUri().toFile(),
                     mimeType = mimeType,
                     context = localContext,
                     onSuccess = onSuccess,
@@ -181,7 +181,7 @@ object MediaSaverToDisk {
                 )
             } else {
                 saveContentDefault(
-                    fileName = UUID.randomUUID().toString() + ".$extension",
+                    fileName = "${UUID.randomUUID()}.$extension",
                     contentSource = buffer,
                     context = context,
                 )
@@ -212,10 +212,9 @@ object MediaSaverToDisk {
             }
 
         val masterUri =
-            if (contentType.startsWith("image")) {
-                MediaStore.Images.Media.EXTERNAL_CONTENT_URI
-            } else {
-                MediaStore.Video.Media.EXTERNAL_CONTENT_URI
+            when {
+                contentType.startsWith("image") -> MediaStore.Images.Media.EXTERNAL_CONTENT_URI
+                else -> MediaStore.Video.Media.EXTERNAL_CONTENT_URI
             }
 
         val uri = contentResolver.insert(masterUri, contentValues)


### PR DESCRIPTION
A web server can return media with contentType application/octet-stream and missing mime type.

Eg: https://smartflowsocial.s3.us-east-1.amazonaws.com/clients/cm7kdrwdk0000qyu6fwtd96ui/cc408b84-689f-4403-875b-ff91ba077a28.jpg

Currently the app will then set mime type to application/octet-stream. This breaks the download as application/octet-stream is not a valid mime type to be saved.

This fix uses the file extension to try and guess the mime type.

Another solution would have been to use magic number in file header but hopefully this fix is sufficient.

Testing 

On >=Q and < Q
Image with null mimetype and content type application/octet-stream
Video with null mimetype and content type application/octet-stream

