### PR TITLE
Trim meta data from file name before saving file to disk

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
@@ -131,14 +131,14 @@ object MediaSaverToDisk {
                                     }
 
                                 saveContentQ(
-                                    displayName = File(url).nameWithoutExtension,
+                                    displayName = File(trimInlineMetaData(url)).nameWithoutExtension,
                                     contentType = realType,
                                     contentSource = response.body.source(),
                                     contentResolver = context.contentResolver,
                                 )
                             } else {
                                 saveContentDefault(
-                                    fileName = File(url).name,
+                                    fileName = File(trimInlineMetaData(url)).name,
                                     contentSource = response.body.source(),
                                     context = context,
                                 )
@@ -202,7 +202,7 @@ object MediaSaverToDisk {
     ) {
         val contentValues =
             ContentValues().apply {
-                put(MediaStore.MediaColumns.DISPLAY_NAME, trimInlineMetaData(displayName))
+                put(MediaStore.MediaColumns.DISPLAY_NAME, displayName)
                 put(MediaStore.MediaColumns.MIME_TYPE, contentType)
                 put(
                     MediaStore.MediaColumns.RELATIVE_PATH,
@@ -246,7 +246,7 @@ object MediaSaverToDisk {
             subdirectory.mkdirs()
         }
 
-        val outputFile = File(subdirectory, trimInlineMetaData(fileName))
+        val outputFile = File(subdirectory, fileName)
 
         outputFile.outputStream().use { contentSource.readAll(it.sink()) }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
@@ -202,7 +202,7 @@ object MediaSaverToDisk {
     ) {
         val contentValues =
             ContentValues().apply {
-                put(MediaStore.MediaColumns.DISPLAY_NAME, displayName)
+                put(MediaStore.MediaColumns.DISPLAY_NAME, trimInlineMetaData(displayName))
                 put(MediaStore.MediaColumns.MIME_TYPE, contentType)
                 put(
                     MediaStore.MediaColumns.RELATIVE_PATH,
@@ -246,7 +246,7 @@ object MediaSaverToDisk {
             subdirectory.mkdirs()
         }
 
-        val outputFile = File(subdirectory, fileName)
+        val outputFile = File(subdirectory, trimInlineMetaData(fileName))
 
         outputFile.outputStream().use { contentSource.readAll(it.sink()) }
 
@@ -254,6 +254,8 @@ object MediaSaverToDisk {
         // appears in the gallery faster.
         MediaScannerConnection.scanFile(context, arrayOf(outputFile.toString()), null, null)
     }
+
+    private fun trimInlineMetaData(url: String): String = url.substringBefore("#")
 
     private const val PICTURES_SUBDIRECTORY = "Amethyst"
 }


### PR DESCRIPTION
Dots can appear in URL fragments such as inline meta-data.

A dot towards the end of a long url will break the usage of nameWithoutExtension which simply does substringBeforeLast(".").

Attempting to save a file using the long URL as file name fails (both on <Q and =>Q) 

This fix removes # and anything after it before saving local file.

Fix for #1297 