### PR TITLE
Sniff content type from extension when empty in response headers

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
@@ -120,8 +120,8 @@ object MediaSaverToDisk {
                             check(response.isSuccessful)
 
                             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                                val contentType = response.header("Content-Type")
-                                checkNotNull(contentType) { "Can't find out the content type" }
+                                val contentType = response.header("Content-Type") ?: getMimeTypeFromExtension(url)
+                                check(contentType.isNotBlank()) { "Can't find out the content type" }
 
                                 val realType =
                                     if (contentType == "application/octet-stream") {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
@@ -55,25 +55,25 @@ object MediaSaverToDisk {
         onSuccess: () -> Any?,
         onError: (Throwable) -> Any?,
     ) {
-        videoUri?.let { theVideoUri ->
-            if (!theVideoUri.startsWith("file")) {
-                downloadAndSave(
-                    url = theVideoUri,
-                    mimeType = mimeType,
-                    context = localContext,
-                    forceProxy = forceProxy,
-                    onSuccess = onSuccess,
-                    onError = onError,
-                )
-            } else {
+        when {
+            videoUri.isNullOrBlank() -> return
+            videoUri.startsWith("file") ->
                 save(
-                    localFile = theVideoUri.toUri().toFile(),
+                    localFile = videoUri.toUri().toFile(),
                     mimeType = mimeType,
                     context = localContext,
                     onSuccess = onSuccess,
                     onError = onError,
                 )
-            }
+            else ->
+                downloadAndSave(
+                    url = videoUri,
+                    mimeType = mimeType,
+                    forceProxy = forceProxy,
+                    context = localContext,
+                    onSuccess = onSuccess,
+                    onError = onError,
+                )
         }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
@@ -120,7 +120,7 @@ object MediaSaverToDisk {
                             check(response.isSuccessful)
 
                             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                                val contentType = response.header("Content-Type") ?: getMimeTypeFromExtension(url)
+                                val contentType = response.header("Content-Type") ?: getMimeTypeFromExtension(trimInlineMetaData(url))
                                 check(contentType.isNotBlank()) { "Can't find out the content type" }
 
                                 val realType =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
@@ -240,11 +240,9 @@ object MediaSaverToDisk {
             File(
                 Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES),
                 PICTURES_SUBDIRECTORY,
-            )
-
-        if (!subdirectory.exists()) {
-            subdirectory.mkdirs()
-        }
+            ).apply {
+                if (!exists()) mkdirs()
+            }
 
         val outputFile = File(subdirectory, fileName)
 


### PR DESCRIPTION
One more edge case when downloading media: missing content-type in response. Eg:
`nostr:nevent1qqszdanpy86lgq0mxrj7wahds38dhr6sy6j6pdc06xfxyvmy8kx833qpzamhxue69uhhyetvv9ujumn0wd68ytnzv9hxgtczyzhkan3acaxevrkrn64h3a7awm4lm9wle3cnwdrzsk7lknv7yyywyqcyqqqqqqg45ha4r`

Fix: attempt to sniff content type from file extension

Testing:

- On below-Q and above-Q:
- Media with missing content type
- Media with media type application/octet-stream
- DM media clear text
- DM media encrypted


