### PR TITLE
corrected profile picture border colour

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/theme/Theme.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/theme/Theme.kt
@@ -278,14 +278,14 @@ val darkLargeProfilePictureModifier =
         .width(120.dp)
         .height(120.dp)
         .clip(shape = CircleShape)
-        .border(3.dp, DarkColorPalette.background, CircleShape)
+        .border(3.dp, DarkColorPalette.onBackground, CircleShape)
 
 val lightLargeProfilePictureModifier =
     Modifier
         .width(120.dp)
         .height(120.dp)
         .clip(shape = CircleShape)
-        .border(3.dp, LightColorPalette.background, CircleShape)
+        .border(3.dp, LightColorPalette.onBackground, CircleShape)
 
 val RichTextDefaults = RichTextStyle().resolveDefaults()
 


### PR DESCRIPTION
regression: circle around profile pic was not visible because new modifier in theme was accidentally set to `background` rather than `onBackground`.

@vitorpamplona Should we also add a circle around logo in
1. AppDrawer?
2. TopBar?
3. AccountSwitch?