### PR TITLE
Prepend clickable text with @ or link emoji

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ClickableRoute.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ClickableRoute.kt
@@ -282,7 +282,7 @@ private fun DisplayAddress(
 }
 
 @Composable
-public fun DisplayUser(
+fun DisplayUser(
     userHex: HexKey,
     originalNip19: String,
     additionalChars: String?,
@@ -319,7 +319,7 @@ public fun DisplayUser(
 }
 
 @Composable
-public fun RenderUserAsClickableText(
+fun RenderUserAsClickableText(
     baseUser: User,
     additionalChars: String?,
     nav: INav,
@@ -327,7 +327,7 @@ public fun RenderUserAsClickableText(
     val userState by baseUser.live().userMetadataInfo.observeAsState()
 
     CreateClickableTextWithEmoji(
-        clickablePart = userState?.bestName() ?: ("@" + baseUser.pubkeyDisplayHex()),
+        clickablePart = "@" + (userState?.bestName() ?: baseUser.pubkeyDisplayHex()),
         suffix = additionalChars?.ifBlank { null },
         maxLines = 1,
         route = remember(baseUser) { routeFor(baseUser) },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/markdown/MarkdownMediaRenderer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/markdown/MarkdownMediaRenderer.kt
@@ -75,11 +75,7 @@ class MarkdownMediaRenderer(
         uri: String,
     ): Boolean =
         if (canPreview && uri.startsWith("http")) {
-            if (title.isNullOrBlank() || title == uri) {
-                true
-            } else {
-                false
-            }
+            title.isNullOrBlank() || title == uri
         } else {
             false
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/markdown/MarkdownMediaRenderer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/markdown/MarkdownMediaRenderer.kt
@@ -189,7 +189,7 @@ class MarkdownMediaRenderer(
         richTextStringBuilder: RichTextString.Builder,
     ) {
         val tagWithoutHash = tag.removePrefix("#")
-        renderAsCompleteLink(tag, "nostr:nashtag?id=$tagWithoutHash", richTextStringBuilder)
+        renderAsCompleteLink(tag, "nostr:hashtag?id=$tagWithoutHash", richTextStringBuilder)
 
         val hashtagIcon: HashtagIcon? = checkForHashtagWithIcon(tagWithoutHash)
         if (hashtagIcon != null) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/markdown/RenderContentAsMarkdown.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/markdown/RenderContentAsMarkdown.kt
@@ -71,6 +71,7 @@ fun RenderContentAsMarkdown(
     nav: INav,
 ) {
     val uri = LocalUriHandler.current
+    val modifiedContent = prependEmojiToLinks(content)
     val onClick =
         remember {
             { link: String ->
@@ -86,12 +87,12 @@ fun RenderContentAsMarkdown(
 
     ProvideTextStyle(MarkdownTextStyle) {
         val astNode =
-            remember(content) {
-                CommonmarkAstNodeParser(MarkdownParseOptions.MarkdownWithLinks).parse(content)
+            remember(modifiedContent) {
+                CommonmarkAstNodeParser(MarkdownParseOptions.MarkdownWithLinks).parse(modifiedContent)
             }
 
         val renderer =
-            remember(content) {
+            remember(modifiedContent) {
                 MarkdownMediaRenderer(
                     startOfText = content.take(100),
                     imetaByUrl = tags?.lists?.imetasByUrl() ?: emptyMap(),
@@ -111,6 +112,15 @@ fun RenderContentAsMarkdown(
         ) {
             BasicMarkdown(astNode)
         }
+    }
+}
+
+private fun prependEmojiToLinks(markdownText: String): String {
+    val linkRegex = Regex("""\[(.*?)]\((.*?)\)""")
+    return markdownText.replace(linkRegex) { matchResult ->
+        val label = matchResult.groupValues[1]
+        val url = matchResult.groupValues[2]
+        "[\uD83D\uDD17 $label]($url)"
     }
 }
 


### PR DESCRIPTION
bugfix: fix typo preventing opening of hashtags from markdown notes
prepend clickable user with @ sign
prepend clickable link with link emoji

Before:
![links-emoji-before](https://github.com/user-attachments/assets/54552da0-98e6-4b0b-b22f-dde271818837)

After:
![links-emoji](https://github.com/user-attachments/assets/de0fcef7-d430-4324-8111-7d4538dc7613)
