### PR TITLE
Reduce compiler warnings: amethyst module

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/DebugUtils.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/DebugUtils.kt
@@ -164,7 +164,7 @@ inline fun <T> logTime(
         block()
     }
 
-inline fun debug(
+fun debug(
     tag: String,
     debugMessage: String,
 ) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -181,6 +181,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -1086,6 +1087,7 @@ class Account(
             )
     }
 
+    @OptIn(FlowPreview::class)
     val decryptBookmarks: Flow<BookmarkListEvent?> by lazy {
         userProfile()
             .flow()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Note.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Note.kt
@@ -926,7 +926,14 @@ open class Note(
         }
     }
 
-    fun <T : Event> toEventHint() = (event as? T)?.let { EventHintBundle(it, relayHintUrl(), author?.bestRelayHint()) }
+    inline fun <reified T : Event> toEventHint(): EventHintBundle<T>? {
+        val safeEvent = event
+        return if (safeEvent is T) {
+            EventHintBundle(safeEvent, relayHintUrl(), author?.bestRelayHint())
+        } else {
+            null
+        }
+    }
 
     fun toMarkedETag(marker: MarkedETag.MARKER): MarkedETag {
         val noteEvent = event

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/images/ImageLoaderSetup.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/images/ImageLoaderSetup.kt
@@ -24,6 +24,7 @@ import android.app.Application
 import android.os.Build
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
+import coil3.annotation.DelicateCoilApi
 import coil3.disk.DiskCache
 import coil3.gif.AnimatedImageDecoder
 import coil3.gif.GifDecoder
@@ -37,6 +38,7 @@ import okhttp3.Call
 
 class ImageLoaderSetup {
     companion object {
+        @OptIn(DelicateCoilApi::class)
         fun setup(
             app: Application,
             diskCache: DiskCache,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/EventObservers.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/EventObservers.kt
@@ -50,7 +50,7 @@ fun observeNote(note: Note): State<NoteState> {
 }
 
 @Suppress("UNCHECKED_CAST")
-@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 @Composable
 fun <T : Event> observeNoteEvent(note: Note): State<T?> {
     // Subscribe in the relay for changes in this note.
@@ -68,7 +68,7 @@ fun <T : Event> observeNoteEvent(note: Note): State<T?> {
     return flow.collectAsStateWithLifecycle(note.event as? T?)
 }
 
-@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 @Composable
 fun <T> observeNoteAndMap(
     note: Note,
@@ -91,8 +91,8 @@ fun <T> observeNoteAndMap(
     return flow.collectAsStateWithLifecycle(map(note))
 }
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @Suppress("UNCHECKED_CAST")
-@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
 @Composable
 fun <T, U> observeNoteEventAndMap(
     note: Note,
@@ -116,7 +116,7 @@ fun <T, U> observeNoteEventAndMap(
     return flow.collectAsStateWithLifecycle((note.event as? T)?.let { map(it) })
 }
 
-@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 @Composable
 fun observeNoteHasEvent(note: Note): State<Boolean> {
     // Subscribe in the relay for changes in this note.
@@ -225,7 +225,7 @@ fun observeNoteReposts(note: Note): State<NoteState?> {
         .collectAsStateWithLifecycle()
 }
 
-@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 @Composable
 fun observeNoteRepostsBy(
     note: Note,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/user/UserObservers.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/user/UserObservers.kt
@@ -565,7 +565,7 @@ data class RelayUsage(
     val userRelayList: List<String> = emptyList(),
 )
 
-@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
+@OptIn(FlowPreview::class)
 @Composable
 fun observeUserRelaysUsing(user: User): State<RelayUsage> {
     // Subscribe in the relay for changes in the metadata of this user.

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AccountSwitchBottomSheet.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AccountSwitchBottomSheet.kt
@@ -32,7 +32,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Logout
+import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.RadioButtonChecked
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -285,7 +285,7 @@ private fun LogoutButton(
         onClick = { logoutDialog = true },
     ) {
         Icon(
-            imageVector = Icons.Default.Logout,
+            imageVector = Icons.AutoMirrored.Filled.Logout,
             contentDescription = stringRes(R.string.log_out),
             tint = MaterialTheme.colorScheme.onSurface,
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/DrawerContent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/DrawerContent.kt
@@ -46,9 +46,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.outlined.AccountCircle
 import androidx.compose.material.icons.outlined.BookmarkBorder
-import androidx.compose.material.icons.outlined.Bookmarks
 import androidx.compose.material.icons.outlined.CloudUpload
 import androidx.compose.material.icons.outlined.Drafts
 import androidx.compose.material.icons.outlined.GroupAdd
@@ -283,7 +281,7 @@ private fun EditStatusBoxes(
             statuses.forEach {
                 val noteStatus by observeNote(it)
 
-                StatusEditBar(noteStatus?.note?.event?.content, it.address, accountViewModel, nav)
+                StatusEditBar(noteStatus.note.event?.content, it.address, accountViewModel, nav)
             }
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/Icons.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/Icons.kt
@@ -52,7 +52,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
-import coil3.compose.AsyncImagePainter.State.Empty.painter
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.hashtags.Amethyst
 import com.vitorpamplona.amethyst.commons.hashtags.Cashu

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NIP05VerificationDisplay.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NIP05VerificationDisplay.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
-import androidx.compose.material.icons.filled.OpenInNew
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalTextStyle

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/previews/PreviewState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/previews/PreviewState.kt
@@ -23,6 +23,7 @@ package com.vitorpamplona.amethyst.ui.note.creators.previews
 import androidx.compose.ui.text.input.TextFieldValue
 import com.vitorpamplona.amethyst.commons.richtext.RichTextParser
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -32,6 +33,7 @@ import kotlinx.coroutines.flow.map
 class PreviewState {
     var source = MutableStateFlow(TextFieldValue(""))
 
+    @OptIn(FlowPreview::class)
     val results =
         source
             .debounce(200)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/userSuggestions/UserSuggestionState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/userSuggestions/UserSuggestionState.kt
@@ -52,6 +52,7 @@ class UserSuggestionState(
             .map(::userSearchTermOrNull)
             .onEach(::updateDataSource)
 
+    @OptIn(FlowPreview::class)
     val results =
         combine(searchTerm, invalidations.debounce(100)) { prefix, version ->
             if (prefix != null) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/CommunityHeader.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/CommunityHeader.kt
@@ -226,7 +226,10 @@ fun LongCommunityHeader(
         ) {
             it.first.role?.let { it1 ->
                 Text(
-                    text = it1.capitalize(Locale.ROOT),
+                    text =
+                        it1.replaceFirstChar {
+                            if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString()
+                        },
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.width(75.dp),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/CommunityHeader.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/CommunityHeader.kt
@@ -228,7 +228,7 @@ fun LongCommunityHeader(
                 Text(
                     text =
                         it1.replaceFirstChar {
-                            if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString()
+                            if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
                         },
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/LiveActivity.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/LiveActivity.kt
@@ -262,7 +262,10 @@ fun RenderLiveActivityEventInner(
             Spacer(StdHorzSpacer)
             it.first.role?.let {
                 Text(
-                    text = it.capitalize(Locale.ROOT),
+                    text =
+                        it.replaceFirstChar {
+                            if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString()
+                        },
                     color = MaterialTheme.colorScheme.placeholderText,
                     maxLines = 1,
                 )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/LiveActivity.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/LiveActivity.kt
@@ -264,7 +264,7 @@ fun RenderLiveActivityEventInner(
                 Text(
                     text =
                         it.replaceFirstChar {
-                            if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString()
+                            if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
                         },
                     color = MaterialTheme.colorScheme.placeholderText,
                     maxLines = 1,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/MedicalData.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/MedicalData.kt
@@ -258,7 +258,9 @@ fun RenderEyeGlassesPrescription(
         }
         visionPrescription.status?.let {
             Text(
-                text = "Status: ${it.capitalize(Locale.getDefault())}",
+                text = "Status: ${it.replaceFirstChar {
+                    if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString()
+                }}",
                 modifier = Modifier.padding(4.dp).fillMaxWidth(),
             )
         }
@@ -359,7 +361,10 @@ fun RenderEyeGlassesPrescriptionRow(data: LensSpecification) {
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
-            text = data.eye?.capitalize(Locale.getDefault()) ?: "Unknown",
+            text =
+                data.eye?.replaceFirstChar {
+                    if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString()
+                } ?: "Unknown",
             modifier = Modifier.padding(4.dp).weight(1f),
         )
         VerticalDivider(thickness = DividerThickness)
@@ -515,7 +520,10 @@ fun RenderEyeContactsPrescriptionRow(data: LensSpecification) {
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
-            text = data.eye?.capitalize(Locale.getDefault()) ?: "Unknown",
+            text =
+                data.eye?.replaceFirstChar {
+                    if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString()
+                } ?: "Unknown",
             modifier = Modifier.padding(4.dp).weight(1f),
         )
         VerticalDivider(thickness = DividerThickness)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/nip53LiveActivities/LongLiveActivityChannelHeader.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/nip53LiveActivities/LongLiveActivityChannelHeader.kt
@@ -181,7 +181,10 @@ fun LongLiveActivityChannelHeader(
         ) {
             it.first.role?.let { it1 ->
                 Text(
-                    text = it1.capitalize(Locale.ROOT),
+                    text =
+                        it1.replaceFirstChar {
+                            if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString()
+                        },
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.width(55.dp),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/nip53LiveActivities/LongLiveActivityChannelHeader.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/nip53LiveActivities/LongLiveActivityChannelHeader.kt
@@ -183,7 +183,7 @@ fun LongLiveActivityChannelHeader(
                 Text(
                     text =
                         it1.replaceFirstChar {
-                            if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString()
+                            if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
                         },
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/utils/ThinSendButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/utils/ThinSendButton.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.utils
 
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Send
+import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
@@ -42,7 +42,7 @@ fun ThinSendButton(
         onClick = onClick,
     ) {
         Icon(
-            imageVector = Icons.Default.Send,
+            imageVector = Icons.AutoMirrored.Filled.Send,
             contentDescription = stringRes(id = R.string.accessibility_send),
             modifier = Size20Modifier,
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/datasource/DiscoveryFilterAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/datasource/DiscoveryFilterAssembler.kt
@@ -114,7 +114,9 @@ class DiscoveryFilterAssembler(
                                                     it,
                                                     it.lowercase(),
                                                     it.uppercase(),
-                                                    it.capitalize(Locale.getDefault()),
+                                                    it.replaceFirstChar {
+                                                        if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString()
+                                                    },
                                                 )
                                             }.flatten(),
                                 ),
@@ -277,7 +279,9 @@ class DiscoveryFilterAssembler(
                                             it,
                                             it.lowercase(),
                                             it.uppercase(),
-                                            it.capitalize(Locale.getDefault()),
+                                            it.replaceFirstChar {
+                                                if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString()
+                                            },
                                         )
                                     }.flatten(),
                         ),
@@ -338,7 +342,9 @@ class DiscoveryFilterAssembler(
                                             it,
                                             it.lowercase(),
                                             it.uppercase(),
-                                            it.capitalize(Locale.getDefault()),
+                                            it.replaceFirstChar {
+                                                if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString()
+                                            },
                                         )
                                     }.flatten(),
                         ),
@@ -400,7 +406,9 @@ class DiscoveryFilterAssembler(
                                             it,
                                             it.lowercase(),
                                             it.uppercase(),
-                                            it.capitalize(Locale.getDefault()),
+                                            it.replaceFirstChar {
+                                                if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString()
+                                            },
                                         )
                                     }.flatten(),
                         ),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/datasource/HashtagFilterAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/datasource/HashtagFilterAssembler.kt
@@ -80,7 +80,9 @@ class HashtagFilterAssembler(
                         it.hashtag,
                         it.hashtag.lowercase(),
                         it.hashtag.uppercase(),
-                        it.hashtag.capitalize(Locale.getDefault()),
+                        it.hashtag.replaceFirstChar {
+                            if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString()
+                        },
                     )
                 }.flatten()
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/datasource/HomeFilterAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/datasource/HomeFilterAssembler.kt
@@ -177,7 +177,9 @@ class HomeFilterAssembler(
                                             it,
                                             it.lowercase(),
                                             it.uppercase(),
-                                            it.capitalize(Locale.getDefault()),
+                                            it.replaceFirstChar {
+                                                if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString()
+                                            },
                                         )
                                     }.flatten(),
                         ),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/relays/RelayFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/relays/RelayFeedViewModel.kt
@@ -33,6 +33,7 @@ import com.vitorpamplona.ammolite.relays.BundledUpdate
 import com.vitorpamplona.quartz.nip02FollowList.ReadWrite
 import com.vitorpamplona.quartz.nip65RelayList.RelayUrlFormatter
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -96,6 +97,7 @@ class RelayFeedViewModel :
         return (userRelaysBeingUsed + currentUserRelays).sortedWith(order)
     }
 
+    @OptIn(FlowPreview::class)
     fun subscribeTo(user: User) {
         if (currentUser != user) {
             currentUser = user

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/AllRelayListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/AllRelayListScreen.kt
@@ -20,7 +20,6 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.relays
 
-import android.R.attr.action
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/dal/HiddenAccountsFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/dal/HiddenAccountsFeedViewModel.kt
@@ -31,7 +31,12 @@ class HiddenAccountsFeedViewModel(
     class Factory(
         val account: Account,
     ) : ViewModelProvider.Factory {
-        @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(modelClass: Class<T>): T = HiddenAccountsFeedViewModel(account) as T
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(HiddenAccountsFeedViewModel::class.java)) {
+                @Suppress("UNCHECKED_CAST")
+                return HiddenAccountsFeedViewModel(account) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+        }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/datasource/VideoFilterAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/datasource/VideoFilterAssembler.kt
@@ -103,8 +103,16 @@ class VideoFilterAssembler(
 
         val hashtags =
             hashToLoad
-                .map { listOf(it, it.lowercase(), it.uppercase(), it.capitalize(Locale.getDefault())) }
-                .flatten()
+                .map {
+                    listOf(
+                        it,
+                        it.lowercase(),
+                        it.uppercase(),
+                        it.replaceFirstChar {
+                            if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString()
+                        },
+                    )
+                }.flatten()
 
         return listOf(
             TypedFilter(


### PR DESCRIPTION
- Add @optins
- Change to auto mirrored icons
- Remove unnecessary inline
- Replace deprecated String.capitalize with replaceFirstChar(it.titlecase
- Safe checked casting (where straight forward)

Compiler warnings went down from 143 to 113 (including some of your fixes)

@vitorpamplona Turns out we were both looking at some of the fixes at the same time so it made for some fun merge conflicts 😆 