### PR TITLE
Open Njump, Yakihonne and Primal links in Amethyst

### DIFF
--- a/amethyst/src/main/AndroidManifest.xml
+++ b/amethyst/src/main/AndroidManifest.xml
@@ -115,6 +115,37 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="image/*" />
             </intent-filter>
+
+            <intent-filter android:label="njump.me">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" />
+                <data android:host="njump.me" />
+            </intent-filter>
+
+            <intent-filter android:label="Primal">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" />
+                <data android:host="primal.net" />
+                <data android:pathPrefix="/e/" />
+                <data android:pathPrefix="/p/" />
+                <data android:pathPrefix="/a/" />
+            </intent-filter>
+
+            <intent-filter android:label="Yakihonne">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" />
+                <data android:host="yakihonne.com" />
+                <data android:pathPrefix="/notes/" />
+                <data android:pathPrefix="/users/" />
+                <data android:pathPrefix="/videos/" />
+                <data android:pathPrefix="/article/" />
+            </intent-filter>
         </activity>
 
         <activity


### PR DESCRIPTION
fixes: #1217

This allows the  user to enable Amethyst to open Njump, Ykihonne and Primal links for the link types I could find via their various share buttons.

njump 
- All (I don't believe njump has any prefixes)
Yakihonne
- /e/ - Note
- /users/ - Profile
- /videos/ - Video
- /article/ - Long-form article
Primal
- /e/ - Note
- /a/ - Long-form article
- /p/ - Profile

Tested:
- Pixel 8 (LineageOS 22.2) Android 15
- Samsung Galaxy  Tab S9 Android 14

To enable for Yakihonne and Primal, one must first ensure no other apps have Open by default enabled. If they're the official apps they'll be verified and take a higher priority.
1. Long-press the app icon for [Yakihonne|Primal] and select App info 
2. Tap [Set as default|Open by default] and either uncheck "Open supported links" or select "In your browser".
3. Back to home, long-press the Amethyst app icon and select App info.
4. Tap [Set as default|Open by default] and either check "Open supported links" or select "In the app".
5. Check the boxes next to the app links you'd like Amethyst to open.