### PR TITLE
remove unused string ids from translations

### DIFF
--- a/amethyst/src/main/res/values-cs/strings.xml
+++ b/amethyst/src/main/res/values-cs/strings.xml
@@ -286,7 +286,6 @@
     <string name="quick_action_unfollow">Přestat sledovat</string>
     <string name="quick_action_follow">Sledovat</string>
     <string name="quick_action_request_deletion_gallery_title">Odstranit z galerie</string>
-    <string name="quick_action_request_deletion_gallery_alert_body">Odstraňte tato média z vaší galerie, můžete je přidat později</string>
     <string name="quick_action_request_deletion_alert_title">Požadavek na smazání</string>
     <string name="quick_action_request_deletion_alert_body">Amethyst požádá o smazání vaší poznámky ze spojek, ke kterým jste v současnosti připojeni. Není zaručeno, že vaše poznámka bude trvale smazána z těchto spojek nebo z dalších spojek, kde může být uložena.</string>
     <string name="quick_action_block_dialog_btn">Blokovat</string>
@@ -535,10 +534,7 @@
     <string name="are_you_sure_you_want_to_log_out">Odhlášení vymaže všechny vaše místní informace. Ujistěte se, že máte zálohované své privátní klíče, abyste se vyhnuli ztrátě účtu. Chcete pokračovat?</string>
     <string name="followed_tags">Sledované značky</string>
     <string name="relay_setup">Rele</string>
-    <string name="discover_content">Objevování poznámek</string>
     <string name="discover_marketplace">Trh</string>
-    <string name="discover_live">Živě</string>
-    <string name="discover_community">Komunita</string>
     <string name="discover_chat">Chaty</string>
     <string name="community_approved_posts">Schválené příspěvky</string>
     <string name="groups_no_descriptor">Tato skupina nemá popis ani pravidla. Promluvte si s majitelem, aby je přidal/a.</string>

--- a/amethyst/src/main/res/values-de/strings.xml
+++ b/amethyst/src/main/res/values-de/strings.xml
@@ -290,7 +290,6 @@ anz der Bedingungen ist erforderlich</string>
     <string name="quick_action_unfollow">Entfolgen</string>
     <string name="quick_action_follow">Folgen</string>
     <string name="quick_action_request_deletion_gallery_title">Aus Galerie löschen</string>
-    <string name="quick_action_request_deletion_gallery_alert_body">Entferne diese Medien von deiner Galerie, du kannst sie später hinzufügen</string>
     <string name="quick_action_request_deletion_alert_title">Löschung anfordern</string>
     <string name="quick_action_request_deletion_alert_body">Amethyst wird beantragen, dass Ihre Notiz von den Relays gelöscht wird, mit denen Sie derzeit verbunden sind. Es gibt keine Garantie dafür, dass Ihre Notiz dauerhaft von diesen Relays oder anderen Relays, in denen sie gespeichert sein kann, gelöscht wird.</string>
     <string name="quick_action_block_dialog_btn">Blockieren</string>
@@ -540,10 +539,7 @@ anz der Bedingungen ist erforderlich</string>
     <string name="are_you_sure_you_want_to_log_out">Das Abmelden löscht alle Ihre lokalen Informationen. Stellen Sie sicher, dass Sie Ihre privaten Schlüssel gesichert haben, um einen Kontoverlust zu vermeiden. Möchten Sie fortfahren?</string>
     <string name="followed_tags">Gefolgte Tags</string>
     <string name="relay_setup">Relais</string>
-    <string name="discover_content">Notizen Entdeckung</string>
     <string name="discover_marketplace">Marktplatz</string>
-    <string name="discover_live">Live</string>
-    <string name="discover_community">Gemeinschaft</string>
     <string name="discover_chat">Plaudern</string>
     <string name="community_approved_posts">Genehmigte Beiträge</string>
     <string name="groups_no_descriptor">Diese Gruppe hat keine Beschreibung oder Regeln. Sprechen Sie mit dem Eigentümer, um eine hinzuzufügen.</string>

--- a/amethyst/src/main/res/values-eo/strings.xml
+++ b/amethyst/src/main/res/values-eo/strings.xml
@@ -379,8 +379,6 @@
     <string name="are_you_sure_you_want_to_log_out">Elsaluti forigas ĉiujn viajn lokajn datumojn. Certigi ke vi sekurkopis vian privatan ŝlosilon por eviti perdi vian konton. Ĉu vi volas daŭrigi?</string>
     <string name="followed_tags">Sekvitaj Etikedoj</string>
     <string name="relay_setup">Plusendiloj</string>
-    <string name="discover_live">Vive</string>
-    <string name="discover_community">Komunumo</string>
     <string name="discover_chat">Babilejoj</string>
     <string name="community_approved_posts">Aprobitaj Afiŝoj</string>
     <string name="groups_no_descriptor">Ĉi tiu grupo ne havas priskribon aŭ regulojn. Parolu kun la posedanto por aldoni</string>

--- a/amethyst/src/main/res/values-fa/strings.xml
+++ b/amethyst/src/main/res/values-fa/strings.xml
@@ -270,7 +270,6 @@
     <string name="quick_action_unfollow">دنبال نکردن</string>
     <string name="quick_action_follow">دنبال کردن</string>
     <string name="quick_action_request_deletion_gallery_title">حذف از گالری</string>
-    <string name="quick_action_request_deletion_gallery_alert_body">حذف این رسانه از گالری، بعدا می توانید آن را بخوانید</string>
     <string name="quick_action_request_deletion_alert_title">درخواست حذف</string>
     <string name="quick_action_request_deletion_alert_body">آماتیست درخواست می کند که یادداشت شما از رله هایی که درحال حاضر به آن متصل هستید حذف شود. هیچ تضمینی نیست که یادداشت شما برای همیشه از آن رله ها یا از رله های دیگری که ممکن است در آنها ذخیره شده باشد حذف خواهد شد.. </string>
     <string name="quick_action_block_dialog_btn">بلاک</string>
@@ -519,10 +518,7 @@
     <string name="are_you_sure_you_want_to_log_out">خروج همه اطلاعات محلی شما را پاک می کند. مطمئن شوید که کلید خصوصی خود را بکاپ گرفته و ذخیره کرده اید تا حساب کاربری تان را از دست ندهید. می خواهید ادامه دهید؟</string>
     <string name="followed_tags">برچسب های دنبال شده</string>
     <string name="relay_setup">رله ها</string>
-    <string name="discover_content">اکتشاف یادداشت</string>
     <string name="discover_marketplace">بازار</string>
-    <string name="discover_live">زنده</string>
-    <string name="discover_community">انجمن</string>
     <string name="discover_chat">گپ</string>
     <string name="community_approved_posts">یادداشت های تایید شده</string>
     <string name="groups_no_descriptor">این گروه هیچ توصیف و قوانینی ندارد. با مالک گروه برای افزودن آن صحبت کنید.</string>

--- a/amethyst/src/main/res/values-fr/strings.xml
+++ b/amethyst/src/main/res/values-fr/strings.xml
@@ -282,7 +282,6 @@
     <string name="quick_action_unfollow">Ne plus suivre</string>
     <string name="quick_action_follow">Suivre</string>
     <string name="quick_action_request_deletion_gallery_title">Supprimer de la galerie</string>
-    <string name="quick_action_request_deletion_gallery_alert_body">Retirer ce média de votre galerie, vous pourrez le réajouter plus tard</string>
     <string name="quick_action_request_deletion_alert_title">Demande de Suppression</string>
     <string name="quick_action_request_deletion_alert_body">Amethyst demandera que votre note soit supprimée des relais auxquels vous êtes actuellement connecté. Il n\'y a aucune garantie que votre note sera définitivement supprimée de ces relais, ou d\'autres relais où elle peut être stockée.</string>
     <string name="quick_action_block_dialog_btn">Bloquer</string>
@@ -531,10 +530,7 @@
     <string name="are_you_sure_you_want_to_log_out">Se déconnecter supprime toutes vos informations locales. Assurez-vous d\'avoir vos clés privées sauvegardées pour éviter de perdre votre compte. Voulez-vous continuer ?</string>
     <string name="followed_tags">Tags suivis</string>
     <string name="relay_setup">Relais</string>
-    <string name="discover_content">Découverte de notes</string>
     <string name="discover_marketplace">Place de Marché</string>
-    <string name="discover_live">Direct</string>
-    <string name="discover_community">Communauté</string>
     <string name="discover_chat">Salons</string>
     <string name="community_approved_posts">Messages approuvés</string>
     <string name="groups_no_descriptor">Ce groupe n\'a pas de description ou de règles. Parlez au propriétaire pour en ajouter une</string>

--- a/amethyst/src/main/res/values-hu/strings.xml
+++ b/amethyst/src/main/res/values-hu/strings.xml
@@ -288,7 +288,6 @@
     <string name="quick_action_unfollow">Követés megszüntetése</string>
     <string name="quick_action_follow">Követés</string>
     <string name="quick_action_request_deletion_gallery_title">Törlés a galériából</string>
-    <string name="quick_action_request_deletion_gallery_alert_body">Távolítsa el ezt a médiát a galériából, később újra hozzáadhatja</string>
     <string name="quick_action_request_deletion_alert_title">Törlés kérése</string>
     <string name="quick_action_request_deletion_alert_body">Az Amethyst kérni fogja, hogy a bejegyzését töröljék azokról az átjátszókról, amelyekhez jelenleg csatlakozik. Nem garantálható, hogy a bejegyzése véglegesen törlődik ezekről az átjátszókról, vagy más átjátszókról, ahol esetleg tárolva van.</string>
     <string name="quick_action_block_dialog_btn">Letiltás</string>
@@ -537,10 +536,7 @@
     <string name="are_you_sure_you_want_to_log_out">A kijelentkezéssel törlődik az összes helyben tárolt adat. Győződjön meg arról, hogy a privát kulcsokról biztonsági mentést készített, hogy elkerülje fiókja elvesztését. Szeretné folytatni?</string>
     <string name="followed_tags">Követett címke</string>
     <string name="relay_setup">Átjátszók</string>
-    <string name="discover_content">Bejegyzések felfedezése</string>
     <string name="discover_marketplace">Piac</string>
-    <string name="discover_live">Élő</string>
-    <string name="discover_community">Közösség</string>
     <string name="discover_chat">Csevegések</string>
     <string name="community_approved_posts">Elfogadott bejegyzések</string>
     <string name="groups_no_descriptor">Ennek a csoportnak nincs leírása vagy szabályai. Kérje meg a tulajdonosát, hogy adjon hozzá egyet</string>

--- a/amethyst/src/main/res/values-in/strings.xml
+++ b/amethyst/src/main/res/values-in/strings.xml
@@ -375,8 +375,6 @@
     <string name="are_you_sure_you_want_to_log_out">Keluar akan menghapus semua informasi lokal Anda. Pastikan kunci pribadi Anda dicadangkan untuk menghindari kehilangan akun Anda. Apakah Anda ingin melanjutkan?</string>
     <string name="followed_tags">Tags yg diikuti</string>
     <string name="relay_setup">Relai</string>
-    <string name="discover_live">Siaran Langsung</string>
-    <string name="discover_community">Komunitas</string>
     <string name="discover_chat">Percakapan</string>
     <string name="community_approved_posts">Kiriman yg disetujui</string>
     <string name="groups_no_descriptor">Grup ini tidak memiliki deskripsi atau aturan. Bicaralah dengan pemiliknya untuk menambahkannya</string>

--- a/amethyst/src/main/res/values-ja/strings.xml
+++ b/amethyst/src/main/res/values-ja/strings.xml
@@ -370,8 +370,6 @@
     <string name="are_you_sure_you_want_to_log_out">ログアウトするとローカル情報はすべて削除されます。アカウントを紛失しないよう、秘密鍵のバックアップがあることを確認してください。続行しますか？</string>
     <string name="followed_tags">フォロー済みタグ</string>
     <string name="relay_setup">リレー</string>
-    <string name="discover_live">ライブ</string>
-    <string name="discover_community">コミュニティ</string>
     <string name="discover_chat">チャット</string>
     <string name="community_approved_posts">承認済みの投稿</string>
     <string name="groups_no_descriptor">このグループには説明またはルールがありません。追加するには管理者に相談してください</string>

--- a/amethyst/src/main/res/values-nl/strings.xml
+++ b/amethyst/src/main/res/values-nl/strings.xml
@@ -281,7 +281,6 @@
     <string name="quick_action_unfollow">Ontvolgen</string>
     <string name="quick_action_follow">Volgen</string>
     <string name="quick_action_request_deletion_gallery_title">Verwijderen uit galerij</string>
-    <string name="quick_action_request_deletion_gallery_alert_body">Verwijder deze media uit je galerij, je kunt het terug zien in je feed.</string>
     <string name="quick_action_request_deletion_alert_title">Verzoek om te verwijderen</string>
     <string name="quick_action_request_deletion_alert_body">Amethyst zal vragen om uw note te verwijderen van de relays waarmee u momenteel verbonden bent. Er is geen garantie dat uw note permanent wordt verwijderd van deze relays, of van andere relays waar het kan worden opgeslagen.</string>
     <string name="quick_action_block_dialog_btn">Blokkeren</string>
@@ -530,10 +529,7 @@
     <string name="are_you_sure_you_want_to_log_out">Uitloggen verwijdert al je lokale informatie. Zorg ervoor dat je een back-up hebt van je geheime sleutels om te voorkomen dat je je account kwijtraakt. Wilt u doorgaan?</string>
     <string name="followed_tags">Gevolgde tags</string>
     <string name="relay_setup">Relays</string>
-    <string name="discover_content">Note ontdekking</string>
     <string name="discover_marketplace">Marktplaats</string>
-    <string name="discover_live">Live</string>
-    <string name="discover_community">Community</string>
     <string name="discover_chat">Chats</string>
     <string name="community_approved_posts">Goedgekeurde berichten</string>
     <string name="groups_no_descriptor">Deze groep heeft geen beschrijving of regels. Praat met de eigenaar om er een toe te voegen</string>

--- a/amethyst/src/main/res/values-ru/strings.xml
+++ b/amethyst/src/main/res/values-ru/strings.xml
@@ -353,8 +353,6 @@
     <string name="live_stream_is_offline">Трансляция выключена</string>
     <string name="live_stream_has_ended">Трансляция закончена</string>
     <string name="discover_marketplace">Рынок</string>
-    <string name="discover_live">Стримы</string>
-    <string name="discover_community">Сообщества</string>
     <string name="discover_chat">Чаты</string>
     <string name="groups_no_descriptor">У этой группы нет описания или правил. Поговорите с владельцем, чтобы добавить их</string>
     <string name="community_no_descriptor">У этого сообщества нет описания. Поговорите с владельцем, чтобы добавить</string>

--- a/amethyst/src/main/res/values-ta/strings.xml
+++ b/amethyst/src/main/res/values-ta/strings.xml
@@ -365,8 +365,6 @@
     <string name="are_you_sure_you_want_to_log_out">வெளியேறுவதல் உங்கள் அனைத்து விவரங்களையும் நீக்கிவிடும். வெளியேறும் முன் உங்கள் கணக்கைத் தொலையாமல் இருக்க ரகசியசாவியை பத்திரமாக பிரதி செய்து சேமிக்கப்பட்டுள்ளதா என்று சரிபார்க்கவும். வெளியேற வேண்டுமா?</string>
     <string name="followed_tags">பின்பற்றப்படும் சிட்டைகள்</string>
     <string name="relay_setup">ரிலேகள்</string>
-    <string name="discover_live">நேரலை</string>
-    <string name="discover_community">சமூகம்</string>
     <string name="discover_chat">அரட்டை</string>
     <string name="community_approved_posts">அங்கீகரிக்கப்பட்ட குறிப்பு</string>
     <string name="groups_no_descriptor">இந்த அரட்டைக் குழுவின் விளக்கமும் விதிகளும் இன்னும் சேர்க்கபடவில்லை. உரிமையாளரை அணுகி அவற்றை சேர்க்க கோரவும் </string>

--- a/amethyst/src/main/res/values-th/strings.xml
+++ b/amethyst/src/main/res/values-th/strings.xml
@@ -258,7 +258,6 @@
     <string name="quick_action_unfollow">เลิกติดตาม</string>
     <string name="quick_action_follow">ติดตาม</string>
     <string name="quick_action_request_deletion_gallery_title">ลบออกจากคลังภาพ</string>
-    <string name="quick_action_request_deletion_gallery_alert_body">เอาออกจากคลังภาพ คุณสามารถเพิ่มใหม่ได้ภายหลัง</string>
     <string name="quick_action_request_deletion_alert_title">ส่งคำขอให้ลบ</string>
     <string name="quick_action_request_deletion_alert_body">Amethyst จะขอให้ลบโน้ตของคุณออกจากรีเลย์ที่คุณเชื่อมต่ออยู่ ไม่มีการรับประกันว่าโน้ตของคุณจะถูกลบออกอย่างถาวรจากรีเลย์เหล่านั้น หรือ จากรีเลย์อื่น ๆ ที่อาจเก็บไว้</string>
     <string name="quick_action_block_dialog_btn">บล๊อก</string>
@@ -455,10 +454,7 @@
     <string name="are_you_sure_you_want_to_log_out">การออกจากระบบจะลบข้อมูลทั้งหมดของคุณ ตรวจสอบให้แน่ใจว่าได้สํารองข้อมูล private key ไว้เพื่อหลีกเลี่ยงการสูญเสียบัญชีของคุณ คุณต้องการดําเนินการต่อหรือไม่?</string>
     <string name="followed_tags">ติดตามแท็ก</string>
     <string name="relay_setup">รีเลย์</string>
-    <string name="discover_content">ค้นหาโน๊ตใหม่ ๆ</string>
     <string name="discover_marketplace">ตลาด</string>
-    <string name="discover_live">ถ่ายทอดสด</string>
-    <string name="discover_community">ชุมชน</string>
     <string name="discover_chat">ช่องสนทนา</string>
     <string name="community_approved_posts">อนุมัติโพสต์</string>
     <string name="groups_no_descriptor">ชุมชนนี้ไม่มีคำอธิบายหรือกฏ พูดคุยกับเจ้าของเพื่อเพิ่มเติมสิ่งนี้</string>

--- a/amethyst/src/main/res/values-uk/strings.xml
+++ b/amethyst/src/main/res/values-uk/strings.xml
@@ -381,8 +381,6 @@
     <string name="are_you_sure_you_want_to_log_out">Вихід з облікового запису видаляє всю вашу локальну інформацію. Переконайтеся, що ваші особисті ключі були збережені, щоб уникнути втрати вашого облікового запису. Ви хочете продовжити?</string>
     <string name="followed_tags">Відстежувані теги</string>
     <string name="discover_marketplace">Торгівельний майданчик</string>
-    <string name="discover_live">Наживо</string>
-    <string name="discover_community">Спільнота</string>
     <string name="discover_chat">Чати</string>
     <string name="community_approved_posts">Затверджені публікації</string>
     <string name="groups_no_descriptor">Ця група не має опису або правил. Зверніться до автора, щоб додати один</string>


### PR DESCRIPTION
Not sure why github build didnt fail but a local full clean and bundle fails on lint due to the removed translations string in main strings.xml (See #1360)

I have removed the unused string ids from translation files and it resolves the lint / build error.

