### PR TITLE
bugfix: strip anything after ";" in media-type before passing to ContentResolver

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
@@ -201,10 +201,11 @@ object MediaSaverToDisk {
         contentSource: BufferedSource,
         contentResolver: ContentResolver,
     ) {
+        val cleanMimeType = contentType.substringBefore(";").trim()
         val contentValues =
             ContentValues().apply {
                 put(MediaStore.MediaColumns.DISPLAY_NAME, displayName)
-                put(MediaStore.MediaColumns.MIME_TYPE, contentType)
+                put(MediaStore.MediaColumns.MIME_TYPE, cleanMimeType)
                 put(
                     MediaStore.MediaColumns.RELATIVE_PATH,
                     Environment.DIRECTORY_PICTURES + File.separatorChar + PICTURES_SUBDIRECTORY,


### PR DESCRIPTION
the _"; codec"_ is part of rfc6381 but android ContentResolver doesn't seem to like it.

This fix simply grabs the media-type before any ";"

See note:
`nostr:nevent1qqsvdm3mgv348v7schxmcnd5wv0z434346chp795qff6zzea2es88tspz4mhxue69uhkummnw3ezummcw3ezuer9wchsyg8hw67vzgn3heulcudk2heuhl4n4zsknue7uye4lnqvy2pfjqw6fgpsgqqqqqqs7s4480`

Exception before fix:
`
java.lang.IllegalArgumentException: Unsupported MIME type video/mp4; codecs=avc1
	at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:172)
	at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:142)
	at android.content.ContentProviderProxy.insert(ContentProviderNative.java:589)
	at android.content.ContentResolver.insert(ContentResolver.java:2209)
	at android.content.ContentResolver.insert(ContentResolver.java:2171)
	at com.vitorpamplona.amethyst.ui.actions.MediaSaverToDisk.saveContentQ(MediaSaverToDisk.kt:220)
	at com.vitorpamplona.amethyst.ui.actions.MediaSaverToDisk.access$saveContentQ(MediaSaverToDisk.kt:50)
	at com.vitorpamplona.amethyst.ui.actions.MediaSaverToDisk$downloadAndSave$1.onResponse(MediaSaverToDisk.kt:134)
	at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:529)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
	at java.lang.Thread.run(Thread.java:1012)
`