### PR TITLE
Reduce duplications: large cache

### DIFF
--- a/quartz/src/main/java/com/vitorpamplona/quartz/utils/CacheCollectors.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/utils/CacheCollectors.kt
@@ -33,7 +33,7 @@ object CacheCollectors {
     class BiFilterCollector<K, V>(
         val filter: BiFilter<K, V>,
     ) : BiConsumer<K, V> {
-        var results: ArrayList<V> = ArrayList()
+        val results: ArrayList<V> = ArrayList()
 
         override fun accept(
             k: K,
@@ -48,7 +48,7 @@ object CacheCollectors {
     class BiFilterUniqueCollector<K, V>(
         val filter: BiFilter<K, V>,
     ) : BiConsumer<K, V> {
-        var results: HashSet<V> = HashSet()
+        val results: HashSet<V> = HashSet()
 
         override fun accept(
             k: K,
@@ -77,7 +77,7 @@ object CacheCollectors {
     class BiMapCollector<K, V, R>(
         val mapper: BiMapper<K, V, R?>,
     ) : BiConsumer<K, V> {
-        var results: ArrayList<R> = ArrayList()
+        val results: ArrayList<R> = ArrayList()
 
         override fun accept(
             k: K,
@@ -94,7 +94,7 @@ object CacheCollectors {
         val size: Int,
         val mapper: BiMapperNotNull<K, V, Pair<T, U>>,
     ) : BiConsumer<K, V> {
-        var results: LinkedHashMap<T, U> = LinkedHashMap(size)
+        val results: LinkedHashMap<T, U> = LinkedHashMap(size)
 
         override fun accept(
             k: K,
@@ -109,7 +109,7 @@ object CacheCollectors {
         val size: Int,
         val mapper: BiMapper<K, V, Pair<T, U>?>,
     ) : BiConsumer<K, V> {
-        var results: LinkedHashMap<T, U> = LinkedHashMap(size)
+        val results: LinkedHashMap<T, U> = LinkedHashMap(size)
 
         override fun accept(
             k: K,
@@ -126,7 +126,7 @@ object CacheCollectors {
         val size: Int,
         val mapper: BiMapper<K, V, U?>,
     ) : BiConsumer<K, V> {
-        var results: LinkedHashMap<K, U?> = LinkedHashMap(size)
+        val results: LinkedHashMap<K, U?> = LinkedHashMap(size)
 
         override fun accept(
             k: K,
@@ -140,7 +140,7 @@ object CacheCollectors {
         val size: Int,
         val mapper: BiMapper<K, V, U>,
     ) : BiConsumer<K, V> {
-        var results: LinkedHashMap<K, U> = LinkedHashMap(size)
+        val results: LinkedHashMap<K, U> = LinkedHashMap(size)
 
         override fun accept(
             k: K,
@@ -156,7 +156,7 @@ object CacheCollectors {
     class BiMapUniqueCollector<K, V, R>(
         val mapper: BiMapper<K, V, R?>,
     ) : BiConsumer<K, V> {
-        var results: HashSet<R> = HashSet()
+        val results: HashSet<R> = HashSet()
 
         override fun accept(
             k: K,
@@ -172,7 +172,7 @@ object CacheCollectors {
     class BiMapFlattenCollector<K, V, R>(
         val mapper: BiMapper<K, V, Collection<R>?>,
     ) : BiConsumer<K, V> {
-        var results: ArrayList<R> = ArrayList()
+        val results: ArrayList<R> = ArrayList()
 
         override fun accept(
             k: K,
@@ -188,7 +188,7 @@ object CacheCollectors {
     class BiMapFlattenUniqueCollector<K, V, R>(
         val mapper: BiMapper<K, V, Collection<R>?>,
     ) : BiConsumer<K, V> {
-        var results: HashSet<R> = HashSet()
+        val results: HashSet<R> = HashSet()
 
         override fun accept(
             k: K,
@@ -211,7 +211,7 @@ object CacheCollectors {
     class BiNotNullMapCollector<K, V, R>(
         val mapper: BiNotNullMapper<K, V, R>,
     ) : BiConsumer<K, V> {
-        var results: ArrayList<R> = ArrayList()
+        val results: ArrayList<R> = ArrayList()
 
         override fun accept(
             k: K,
@@ -284,7 +284,7 @@ object CacheCollectors {
     class BiGroupByCollector<K, V, R>(
         val mapper: BiNotNullMapper<K, V, R>,
     ) : BiConsumer<K, V> {
-        var results = HashMap<R, ArrayList<V>>()
+        val results = HashMap<R, ArrayList<V>>()
 
         override fun accept(
             k: K,
@@ -306,7 +306,7 @@ object CacheCollectors {
     class BiCountByGroupCollector<K, V, R>(
         val mapper: BiNotNullMapper<K, V, R>,
     ) : BiConsumer<K, V> {
-        var results = HashMap<R, Int>()
+        val results = HashMap<R, Int>()
 
         override fun accept(
             k: K,
@@ -327,7 +327,7 @@ object CacheCollectors {
         val mapper: BiNotNullMapper<K, V, R>,
         val sumOf: BiNotNullMapper<K, V, Long>,
     ) : BiConsumer<K, V> {
-        var results = HashMap<R, Long>()
+        val results = HashMap<R, Long>()
 
         override fun accept(
             k: K,

--- a/quartz/src/main/java/com/vitorpamplona/quartz/utils/CacheCollectors.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/utils/CacheCollectors.kt
@@ -1,0 +1,359 @@
+/**
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.utils
+
+import java.util.function.BiConsumer
+
+object CacheCollectors {
+    fun interface BiFilter<K, V> {
+        fun filter(
+            k: K,
+            v: V,
+        ): Boolean
+    }
+
+    class BiFilterCollector<K, V>(
+        val filter: BiFilter<K, V>,
+    ) : BiConsumer<K, V> {
+        var results: ArrayList<V> = ArrayList()
+
+        override fun accept(
+            k: K,
+            v: V,
+        ) {
+            if (filter.filter(k, v)) {
+                results.add(v)
+            }
+        }
+    }
+
+    class BiFilterUniqueCollector<K, V>(
+        val filter: BiFilter<K, V>,
+    ) : BiConsumer<K, V> {
+        var results: HashSet<V> = HashSet()
+
+        override fun accept(
+            k: K,
+            v: V,
+        ) {
+            if (filter.filter(k, v)) {
+                results.add(v)
+            }
+        }
+    }
+
+    fun interface BiMapper<K, V, R> {
+        fun map(
+            k: K,
+            v: V,
+        ): R?
+    }
+
+    fun interface BiMapperNotNull<K, V, R> {
+        fun map(
+            k: K,
+            v: V,
+        ): R
+    }
+
+    class BiMapCollector<K, V, R>(
+        val mapper: BiMapper<K, V, R?>,
+    ) : BiConsumer<K, V> {
+        var results: ArrayList<R> = ArrayList()
+
+        override fun accept(
+            k: K,
+            v: V,
+        ) {
+            val result = mapper.map(k, v)
+            if (result != null) {
+                results.add(result)
+            }
+        }
+    }
+
+    class BiAssociateCollector<K, V, T, U>(
+        val size: Int,
+        val mapper: BiMapperNotNull<K, V, Pair<T, U>>,
+    ) : BiConsumer<K, V> {
+        var results: LinkedHashMap<T, U> = LinkedHashMap(size)
+
+        override fun accept(
+            k: K,
+            v: V,
+        ) {
+            val pair = mapper.map(k, v)
+            results.put(pair.first, pair.second)
+        }
+    }
+
+    class BiAssociateNotNullCollector<K, V, T, U>(
+        val size: Int,
+        val mapper: BiMapper<K, V, Pair<T, U>?>,
+    ) : BiConsumer<K, V> {
+        var results: LinkedHashMap<T, U> = LinkedHashMap(size)
+
+        override fun accept(
+            k: K,
+            v: V,
+        ) {
+            val pair = mapper.map(k, v)
+            if (pair != null) {
+                results.put(pair.first, pair.second)
+            }
+        }
+    }
+
+    class BiAssociateWithCollector<K, V, U>(
+        val size: Int,
+        val mapper: BiMapper<K, V, U?>,
+    ) : BiConsumer<K, V> {
+        var results: LinkedHashMap<K, U?> = LinkedHashMap(size)
+
+        override fun accept(
+            k: K,
+            v: V,
+        ) {
+            results.put(k, mapper.map(k, v))
+        }
+    }
+
+    class BiAssociateNotNullWithCollector<K, V, U>(
+        val size: Int,
+        val mapper: BiMapper<K, V, U>,
+    ) : BiConsumer<K, V> {
+        var results: LinkedHashMap<K, U> = LinkedHashMap(size)
+
+        override fun accept(
+            k: K,
+            v: V,
+        ) {
+            val newValue = mapper.map(k, v)
+            if (newValue != null) {
+                results.put(k, newValue)
+            }
+        }
+    }
+
+    class BiMapUniqueCollector<K, V, R>(
+        val mapper: BiMapper<K, V, R?>,
+    ) : BiConsumer<K, V> {
+        var results: HashSet<R> = HashSet()
+
+        override fun accept(
+            k: K,
+            v: V,
+        ) {
+            val result = mapper.map(k, v)
+            if (result != null) {
+                results.add(result)
+            }
+        }
+    }
+
+    class BiMapFlattenCollector<K, V, R>(
+        val mapper: BiMapper<K, V, Collection<R>?>,
+    ) : BiConsumer<K, V> {
+        var results: ArrayList<R> = ArrayList()
+
+        override fun accept(
+            k: K,
+            v: V,
+        ) {
+            val result = mapper.map(k, v)
+            if (result != null) {
+                results.addAll(result)
+            }
+        }
+    }
+
+    class BiMapFlattenUniqueCollector<K, V, R>(
+        val mapper: BiMapper<K, V, Collection<R>?>,
+    ) : BiConsumer<K, V> {
+        var results: HashSet<R> = HashSet()
+
+        override fun accept(
+            k: K,
+            v: V,
+        ) {
+            val result = mapper.map(k, v)
+            if (result != null) {
+                results.addAll(result)
+            }
+        }
+    }
+
+    fun interface BiNotNullMapper<K, V, R> {
+        fun map(
+            k: K,
+            v: V,
+        ): R
+    }
+
+    class BiNotNullMapCollector<K, V, R>(
+        val mapper: BiNotNullMapper<K, V, R>,
+    ) : BiConsumer<K, V> {
+        var results: ArrayList<R> = ArrayList()
+
+        override fun accept(
+            k: K,
+            v: V,
+        ) {
+            results.add(mapper.map(k, v))
+        }
+    }
+
+    fun interface BiSumOf<K, V> {
+        fun map(
+            k: K,
+            v: V,
+        ): Int
+    }
+
+    class BiMaxOfCollector<K, V>(
+        val filter: BiFilter<K, V>,
+        val comparator: Comparator<V>,
+    ) : BiConsumer<K, V> {
+        var maxK: K? = null
+        var maxV: V? = null
+
+        override fun accept(
+            k: K,
+            v: V,
+        ) {
+            if (filter.filter(k, v)) {
+                if (maxK == null || comparator.compare(v, maxV) > 0) {
+                    maxK = k
+                    maxV = v
+                }
+            }
+        }
+    }
+
+    class BiSumOfCollector<K, V>(
+        val mapper: BiSumOf<K, V>,
+    ) : BiConsumer<K, V> {
+        var sum = 0
+
+        override fun accept(
+            k: K,
+            v: V,
+        ) {
+            sum += mapper.map(k, v)
+        }
+    }
+
+    fun interface BiSumOfLong<K, V> {
+        fun map(
+            k: K,
+            v: V,
+        ): Long
+    }
+
+    class BiSumOfLongCollector<K, V>(
+        val mapper: BiSumOfLong<K, V>,
+    ) : BiConsumer<K, V> {
+        var sum = 0L
+
+        override fun accept(
+            k: K,
+            v: V,
+        ) {
+            sum += mapper.map(k, v)
+        }
+    }
+
+    class BiGroupByCollector<K, V, R>(
+        val mapper: BiNotNullMapper<K, V, R>,
+    ) : BiConsumer<K, V> {
+        var results = HashMap<R, ArrayList<V>>()
+
+        override fun accept(
+            k: K,
+            v: V,
+        ) {
+            val group = mapper.map(k, v)
+
+            val list = results[group]
+            if (list == null) {
+                val answer = ArrayList<V>()
+                answer.add(v)
+                results[group] = answer
+            } else {
+                list.add(v)
+            }
+        }
+    }
+
+    class BiCountByGroupCollector<K, V, R>(
+        val mapper: BiNotNullMapper<K, V, R>,
+    ) : BiConsumer<K, V> {
+        var results = HashMap<R, Int>()
+
+        override fun accept(
+            k: K,
+            v: V,
+        ) {
+            val group = mapper.map(k, v)
+
+            val count = results[group]
+            if (count == null) {
+                results[group] = 1
+            } else {
+                results[group] = count + 1
+            }
+        }
+    }
+
+    class BiSumByGroupCollector<K, V, R>(
+        val mapper: BiNotNullMapper<K, V, R>,
+        val sumOf: BiNotNullMapper<K, V, Long>,
+    ) : BiConsumer<K, V> {
+        var results = HashMap<R, Long>()
+
+        override fun accept(
+            k: K,
+            v: V,
+        ) {
+            val group = mapper.map(k, v)
+
+            val sum = results[group]
+            if (sum == null) {
+                results[group] = sumOf.map(k, v)
+            } else {
+                results[group] = sum + sumOf.map(k, v)
+            }
+        }
+    }
+
+    class BiCountIfCollector<K, V>(
+        val filter: BiFilter<K, V>,
+    ) : BiConsumer<K, V> {
+        var count = 0
+
+        override fun accept(
+            k: K,
+            v: V,
+        ) {
+            if (filter.filter(k, v)) count++
+        }
+    }
+}

--- a/quartz/src/main/java/com/vitorpamplona/quartz/utils/CacheOperations.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/utils/CacheOperations.kt
@@ -28,43 +28,43 @@ interface CacheOperations<K, V> {
     fun size(): Int
 
     fun filter(consumer: CacheCollectors.BiFilter<K, V>): List<V> {
-        val runner = CacheCollectors.BiFilterCollector(consumer)
+        val runner = BiFilterCollector(consumer)
         forEach(runner)
         return runner.results
     }
 
     fun filterIntoSet(consumer: CacheCollectors.BiFilter<K, V>): Set<V> {
-        val runner = CacheCollectors.BiFilterUniqueCollector(consumer)
+        val runner = BiFilterUniqueCollector(consumer)
         forEach(runner)
         return runner.results
     }
 
     fun <R> map(consumer: CacheCollectors.BiNotNullMapper<K, V, R>): List<R> {
-        val runner = CacheCollectors.BiNotNullMapCollector(consumer)
+        val runner = BiNotNullMapCollector(consumer)
         forEach(runner)
         return runner.results
     }
 
     fun <R> mapNotNull(consumer: CacheCollectors.BiMapper<K, V, R?>): List<R> {
-        val runner = CacheCollectors.BiMapCollector(consumer)
+        val runner = BiMapCollector(consumer)
         forEach(runner)
         return runner.results
     }
 
     fun <R> mapNotNullIntoSet(consumer: CacheCollectors.BiMapper<K, V, R?>): Set<R> {
-        val runner = CacheCollectors.BiMapUniqueCollector(consumer)
+        val runner = BiMapUniqueCollector(consumer)
         forEach(runner)
         return runner.results
     }
 
     fun <R> mapFlatten(consumer: CacheCollectors.BiMapper<K, V, Collection<R>?>): List<R> {
-        val runner = CacheCollectors.BiMapFlattenCollector(consumer)
+        val runner = BiMapFlattenCollector(consumer)
         forEach(runner)
         return runner.results
     }
 
     fun <R> mapFlattenIntoSet(consumer: CacheCollectors.BiMapper<K, V, Collection<R>?>): Set<R> {
-        val runner = CacheCollectors.BiMapFlattenUniqueCollector(consumer)
+        val runner = BiMapFlattenUniqueCollector(consumer)
         forEach(runner)
         return runner.results
     }
@@ -73,31 +73,31 @@ interface CacheOperations<K, V> {
         filter: CacheCollectors.BiFilter<K, V>,
         comparator: Comparator<V>,
     ): V? {
-        val runner = CacheCollectors.BiMaxOfCollector(filter, comparator)
+        val runner = BiMaxOfCollector(filter, comparator)
         forEach(runner)
         return runner.maxV
     }
 
     fun sumOf(consumer: CacheCollectors.BiSumOf<K, V>): Int {
-        val runner = CacheCollectors.BiSumOfCollector(consumer)
+        val runner = BiSumOfCollector(consumer)
         forEach(runner)
         return runner.sum
     }
 
     fun sumOfLong(consumer: CacheCollectors.BiSumOfLong<K, V>): Long {
-        val runner = CacheCollectors.BiSumOfLongCollector(consumer)
+        val runner = BiSumOfLongCollector(consumer)
         forEach(runner)
         return runner.sum
     }
 
     fun <R> groupBy(consumer: CacheCollectors.BiNotNullMapper<K, V, R>): Map<R, List<V>> {
-        val runner = CacheCollectors.BiGroupByCollector(consumer)
+        val runner = BiGroupByCollector(consumer)
         forEach(runner)
         return runner.results
     }
 
     fun <R> countByGroup(consumer: CacheCollectors.BiNotNullMapper<K, V, R>): Map<R, Int> {
-        val runner = CacheCollectors.BiCountByGroupCollector(consumer)
+        val runner = BiCountByGroupCollector(consumer)
         forEach(runner)
         return runner.results
     }
@@ -106,25 +106,25 @@ interface CacheOperations<K, V> {
         groupMap: CacheCollectors.BiNotNullMapper<K, V, R>,
         sumOf: CacheCollectors.BiNotNullMapper<K, V, Long>,
     ): Map<R, Long> {
-        val runner = CacheCollectors.BiSumByGroupCollector(groupMap, sumOf)
+        val runner = BiSumByGroupCollector(groupMap, sumOf)
         forEach(runner)
         return runner.results
     }
 
     fun count(consumer: CacheCollectors.BiFilter<K, V>): Int {
-        val runner = CacheCollectors.BiCountIfCollector(consumer)
+        val runner = BiCountIfCollector(consumer)
         forEach(runner)
         return runner.count
     }
 
     fun <T, U> associate(transform: (K, V) -> Pair<T, U>): Map<T, U> {
-        val runner = CacheCollectors.BiAssociateCollector(size(), transform)
+        val runner = BiAssociateCollector(size(), transform)
         forEach(runner)
         return runner.results
     }
 
     fun <U> associateWith(transform: (K, V) -> U?): Map<K, U?> {
-        val runner = CacheCollectors.BiAssociateWithCollector(size(), transform)
+        val runner = BiAssociateWithCollector(size(), transform)
         forEach(runner)
         return runner.results
     }

--- a/quartz/src/main/java/com/vitorpamplona/quartz/utils/CacheOperations.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/utils/CacheOperations.kt
@@ -123,20 +123,8 @@ interface CacheOperations<K, V> {
         return runner.results
     }
 
-    fun <T, U> associateNotNull(transform: (K, V) -> Pair<T, U>?): Map<T, U> {
-        val runner = CacheCollectors.BiAssociateNotNullCollector(size(), transform)
-        forEach(runner)
-        return runner.results
-    }
-
     fun <U> associateWith(transform: (K, V) -> U?): Map<K, U?> {
         val runner = CacheCollectors.BiAssociateWithCollector(size(), transform)
-        forEach(runner)
-        return runner.results
-    }
-
-    fun <U> associateNotNullWith(transform: (K, V) -> U): Map<K, U> {
-        val runner = CacheCollectors.BiAssociateNotNullWithCollector(size(), transform)
         forEach(runner)
         return runner.results
     }

--- a/quartz/src/main/java/com/vitorpamplona/quartz/utils/CacheOperations.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/utils/CacheOperations.kt
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.utils
+
+import java.util.function.BiConsumer
+
+interface CacheOperations<K, V> {
+    fun forEach(consumer: BiConsumer<K, V>)
+
+    fun size(): Int
+
+    fun filter(consumer: CacheCollectors.BiFilter<K, V>): List<V> {
+        val runner = CacheCollectors.BiFilterCollector(consumer)
+        forEach(runner)
+        return runner.results
+    }
+
+    fun filterIntoSet(consumer: CacheCollectors.BiFilter<K, V>): Set<V> {
+        val runner = CacheCollectors.BiFilterUniqueCollector(consumer)
+        forEach(runner)
+        return runner.results
+    }
+
+    fun <R> map(consumer: CacheCollectors.BiNotNullMapper<K, V, R>): List<R> {
+        val runner = CacheCollectors.BiNotNullMapCollector(consumer)
+        forEach(runner)
+        return runner.results
+    }
+
+    fun <R> mapNotNull(consumer: CacheCollectors.BiMapper<K, V, R?>): List<R> {
+        val runner = CacheCollectors.BiMapCollector(consumer)
+        forEach(runner)
+        return runner.results
+    }
+
+    fun <R> mapNotNullIntoSet(consumer: CacheCollectors.BiMapper<K, V, R?>): Set<R> {
+        val runner = CacheCollectors.BiMapUniqueCollector(consumer)
+        forEach(runner)
+        return runner.results
+    }
+
+    fun <R> mapFlatten(consumer: CacheCollectors.BiMapper<K, V, Collection<R>?>): List<R> {
+        val runner = CacheCollectors.BiMapFlattenCollector(consumer)
+        forEach(runner)
+        return runner.results
+    }
+
+    fun <R> mapFlattenIntoSet(consumer: CacheCollectors.BiMapper<K, V, Collection<R>?>): Set<R> {
+        val runner = CacheCollectors.BiMapFlattenUniqueCollector(consumer)
+        forEach(runner)
+        return runner.results
+    }
+
+    fun maxOrNullOf(
+        filter: CacheCollectors.BiFilter<K, V>,
+        comparator: Comparator<V>,
+    ): V? {
+        val runner = CacheCollectors.BiMaxOfCollector(filter, comparator)
+        forEach(runner)
+        return runner.maxV
+    }
+
+    fun sumOf(consumer: CacheCollectors.BiSumOf<K, V>): Int {
+        val runner = CacheCollectors.BiSumOfCollector(consumer)
+        forEach(runner)
+        return runner.sum
+    }
+
+    fun sumOfLong(consumer: CacheCollectors.BiSumOfLong<K, V>): Long {
+        val runner = CacheCollectors.BiSumOfLongCollector(consumer)
+        forEach(runner)
+        return runner.sum
+    }
+
+    fun <R> groupBy(consumer: CacheCollectors.BiNotNullMapper<K, V, R>): Map<R, List<V>> {
+        val runner = CacheCollectors.BiGroupByCollector(consumer)
+        forEach(runner)
+        return runner.results
+    }
+
+    fun <R> countByGroup(consumer: CacheCollectors.BiNotNullMapper<K, V, R>): Map<R, Int> {
+        val runner = CacheCollectors.BiCountByGroupCollector(consumer)
+        forEach(runner)
+        return runner.results
+    }
+
+    fun <R> sumByGroup(
+        groupMap: CacheCollectors.BiNotNullMapper<K, V, R>,
+        sumOf: CacheCollectors.BiNotNullMapper<K, V, Long>,
+    ): Map<R, Long> {
+        val runner = CacheCollectors.BiSumByGroupCollector(groupMap, sumOf)
+        forEach(runner)
+        return runner.results
+    }
+
+    fun count(consumer: CacheCollectors.BiFilter<K, V>): Int {
+        val runner = CacheCollectors.BiCountIfCollector(consumer)
+        forEach(runner)
+        return runner.count
+    }
+
+    fun <T, U> associate(transform: (K, V) -> Pair<T, U>): Map<T, U> {
+        val runner = CacheCollectors.BiAssociateCollector(size(), transform)
+        forEach(runner)
+        return runner.results
+    }
+
+    fun <T, U> associateNotNull(transform: (K, V) -> Pair<T, U>?): Map<T, U> {
+        val runner = CacheCollectors.BiAssociateNotNullCollector(size(), transform)
+        forEach(runner)
+        return runner.results
+    }
+
+    fun <U> associateWith(transform: (K, V) -> U?): Map<K, U?> {
+        val runner = CacheCollectors.BiAssociateWithCollector(size(), transform)
+        forEach(runner)
+        return runner.results
+    }
+
+    fun <U> associateNotNullWith(transform: (K, V) -> U): Map<K, U> {
+        val runner = CacheCollectors.BiAssociateNotNullWithCollector(size(), transform)
+        forEach(runner)
+        return runner.results
+    }
+
+    fun joinToString(
+        separator: CharSequence = ", ",
+        prefix: CharSequence = "",
+        postfix: CharSequence = "",
+        limit: Int = -1,
+        truncated: CharSequence = "...",
+        transform: ((K, V) -> CharSequence)? = null,
+    ): String {
+        val buffer = StringBuilder()
+        buffer.append(prefix)
+        var count = 0
+        forEach { key, value ->
+            val str = if (transform != null) transform(key, value) else ""
+            if (str.isNotEmpty()) {
+                if (++count > 1) buffer.append(separator)
+                if (limit < 0 || count <= limit) {
+                    when {
+                        transform != null -> buffer.append(str)
+                        else -> buffer.append("$key $value")
+                    }
+                } else {
+                    return@forEach
+                }
+            }
+        }
+        if (limit >= 0 && count > limit) buffer.append(truncated)
+        buffer.append(postfix)
+        return buffer.toString()
+    }
+}

--- a/quartz/src/main/java/com/vitorpamplona/quartz/utils/LargeCache.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/utils/LargeCache.kt
@@ -67,7 +67,7 @@ class LargeCache<K, V> : CacheOperations<K, V> {
         key: K,
         builder: (key: K) -> V,
     ): Boolean {
-        val value = cache[key]
+        val value = cache.get(key)
         return if (value != null) {
             false
         } else {

--- a/quartz/src/main/java/com/vitorpamplona/quartz/utils/LargeCache.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/utils/LargeCache.kt
@@ -23,7 +23,7 @@ package com.vitorpamplona.quartz.utils
 import java.util.concurrent.ConcurrentSkipListMap
 import java.util.function.BiConsumer
 
-class LargeCache<K, V> {
+class LargeCache<K, V> : CacheOperations<K, V> {
     private val cache = ConcurrentSkipListMap<K, V>()
 
     fun keys() = cache.keys
@@ -34,7 +34,7 @@ class LargeCache<K, V> {
 
     fun remove(key: K) = cache.remove(key)
 
-    fun size() = cache.size
+    override fun size() = cache.size
 
     fun isEmpty() = cache.isEmpty()
 
@@ -76,155 +76,7 @@ class LargeCache<K, V> {
         }
     }
 
-    fun forEach(consumer: BiConsumer<K, V>) {
-        innerForEach(consumer)
-    }
-
-    fun filter(consumer: CacheCollectors.BiFilter<K, V>): List<V> {
-        val runner = CacheCollectors.BiFilterCollector(consumer)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun filterIntoSet(consumer: CacheCollectors.BiFilter<K, V>): Set<V> {
-        val runner = CacheCollectors.BiFilterUniqueCollector(consumer)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun <R> map(consumer: CacheCollectors.BiNotNullMapper<K, V, R>): List<R> {
-        val runner = CacheCollectors.BiNotNullMapCollector(consumer)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun <R> mapNotNull(consumer: CacheCollectors.BiMapper<K, V, R?>): List<R> {
-        val runner = CacheCollectors.BiMapCollector(consumer)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun <R> mapNotNullIntoSet(consumer: CacheCollectors.BiMapper<K, V, R?>): Set<R> {
-        val runner = CacheCollectors.BiMapUniqueCollector(consumer)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun <R> mapFlatten(consumer: CacheCollectors.BiMapper<K, V, Collection<R>?>): List<R> {
-        val runner = CacheCollectors.BiMapFlattenCollector(consumer)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun <R> mapFlattenIntoSet(consumer: CacheCollectors.BiMapper<K, V, Collection<R>?>): Set<R> {
-        val runner = CacheCollectors.BiMapFlattenUniqueCollector(consumer)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun maxOrNullOf(
-        filter: CacheCollectors.BiFilter<K, V>,
-        comparator: Comparator<V>,
-    ): V? {
-        val runner = CacheCollectors.BiMaxOfCollector(filter, comparator)
-        innerForEach(runner)
-        return runner.maxV
-    }
-
-    fun sumOf(consumer: CacheCollectors.BiSumOf<K, V>): Int {
-        val runner = CacheCollectors.BiSumOfCollector(consumer)
-        innerForEach(runner)
-        return runner.sum
-    }
-
-    fun sumOfLong(consumer: CacheCollectors.BiSumOfLong<K, V>): Long {
-        val runner = CacheCollectors.BiSumOfLongCollector(consumer)
-        innerForEach(runner)
-        return runner.sum
-    }
-
-    fun <R> groupBy(consumer: CacheCollectors.BiNotNullMapper<K, V, R>): Map<R, List<V>> {
-        val runner = CacheCollectors.BiGroupByCollector(consumer)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun <R> countByGroup(consumer: CacheCollectors.BiNotNullMapper<K, V, R>): Map<R, Int> {
-        val runner = CacheCollectors.BiCountByGroupCollector(consumer)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun <R> sumByGroup(
-        groupMap: CacheCollectors.BiNotNullMapper<K, V, R>,
-        sumOf: CacheCollectors.BiNotNullMapper<K, V, Long>,
-    ): Map<R, Long> {
-        val runner = CacheCollectors.BiSumByGroupCollector(groupMap, sumOf)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun count(consumer: CacheCollectors.BiFilter<K, V>): Int {
-        val runner = CacheCollectors.BiCountIfCollector(consumer)
-        innerForEach(runner)
-        return runner.count
-    }
-
-    fun <T, U> associate(transform: (K, V) -> Pair<T, U>): Map<T, U> {
-        val runner = CacheCollectors.BiAssociateCollector(size(), transform)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun <T, U> associateNotNull(transform: (K, V) -> Pair<T, U>?): Map<T, U> {
-        val runner = CacheCollectors.BiAssociateNotNullCollector(size(), transform)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun <U> associateWith(transform: (K, V) -> U?): Map<K, U?> {
-        val runner = CacheCollectors.BiAssociateWithCollector(size(), transform)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun <U> associateNotNullWith(transform: (K, V) -> U): Map<K, U> {
-        val runner = CacheCollectors.BiAssociateNotNullWithCollector(size(), transform)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    private fun innerForEach(runner: BiConsumer<K, V>) {
-        cache.forEach(runner)
-    }
-
-    fun joinToString(
-        separator: CharSequence = ", ",
-        prefix: CharSequence = "",
-        postfix: CharSequence = "",
-        limit: Int = -1,
-        truncated: CharSequence = "...",
-        transform: ((K, V) -> CharSequence)? = null,
-    ): String {
-        val buffer = StringBuilder()
-        buffer.append(prefix)
-        var count = 0
-        forEach { key, value ->
-            val str = if (transform != null) transform(key, value) else ""
-            if (str.isNotEmpty()) {
-                if (++count > 1) buffer.append(separator)
-                if (limit < 0 || count <= limit) {
-                    when {
-                        transform != null -> buffer.append(str)
-                        else -> buffer.append("$key $value")
-                    }
-                } else {
-                    return@forEach
-                }
-            }
-        }
-        if (limit >= 0 && count > limit) buffer.append(truncated)
-        buffer.append(postfix)
-        return buffer.toString()
+    override fun forEach(consumer: BiConsumer<K, V>) {
+        cache.forEach(consumer)
     }
 }

--- a/quartz/src/main/java/com/vitorpamplona/quartz/utils/LargeCache.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/utils/LargeCache.kt
@@ -80,116 +80,116 @@ class LargeCache<K, V> {
         innerForEach(consumer)
     }
 
-    fun filter(consumer: BiFilter<K, V>): List<V> {
-        val runner = BiFilterCollector(consumer)
+    fun filter(consumer: CacheCollectors.BiFilter<K, V>): List<V> {
+        val runner = CacheCollectors.BiFilterCollector(consumer)
         innerForEach(runner)
         return runner.results
     }
 
-    fun filterIntoSet(consumer: BiFilter<K, V>): Set<V> {
-        val runner = BiFilterUniqueCollector(consumer)
+    fun filterIntoSet(consumer: CacheCollectors.BiFilter<K, V>): Set<V> {
+        val runner = CacheCollectors.BiFilterUniqueCollector(consumer)
         innerForEach(runner)
         return runner.results
     }
 
-    fun <R> map(consumer: BiNotNullMapper<K, V, R>): List<R> {
-        val runner = BiNotNullMapCollector(consumer)
+    fun <R> map(consumer: CacheCollectors.BiNotNullMapper<K, V, R>): List<R> {
+        val runner = CacheCollectors.BiNotNullMapCollector(consumer)
         innerForEach(runner)
         return runner.results
     }
 
-    fun <R> mapNotNull(consumer: BiMapper<K, V, R?>): List<R> {
-        val runner = BiMapCollector(consumer)
+    fun <R> mapNotNull(consumer: CacheCollectors.BiMapper<K, V, R?>): List<R> {
+        val runner = CacheCollectors.BiMapCollector(consumer)
         innerForEach(runner)
         return runner.results
     }
 
-    fun <R> mapNotNullIntoSet(consumer: BiMapper<K, V, R?>): Set<R> {
-        val runner = BiMapUniqueCollector(consumer)
+    fun <R> mapNotNullIntoSet(consumer: CacheCollectors.BiMapper<K, V, R?>): Set<R> {
+        val runner = CacheCollectors.BiMapUniqueCollector(consumer)
         innerForEach(runner)
         return runner.results
     }
 
-    fun <R> mapFlatten(consumer: BiMapper<K, V, Collection<R>?>): List<R> {
-        val runner = BiMapFlattenCollector(consumer)
+    fun <R> mapFlatten(consumer: CacheCollectors.BiMapper<K, V, Collection<R>?>): List<R> {
+        val runner = CacheCollectors.BiMapFlattenCollector(consumer)
         innerForEach(runner)
         return runner.results
     }
 
-    fun <R> mapFlattenIntoSet(consumer: BiMapper<K, V, Collection<R>?>): Set<R> {
-        val runner = BiMapFlattenUniqueCollector(consumer)
+    fun <R> mapFlattenIntoSet(consumer: CacheCollectors.BiMapper<K, V, Collection<R>?>): Set<R> {
+        val runner = CacheCollectors.BiMapFlattenUniqueCollector(consumer)
         innerForEach(runner)
         return runner.results
     }
 
     fun maxOrNullOf(
-        filter: BiFilter<K, V>,
+        filter: CacheCollectors.BiFilter<K, V>,
         comparator: Comparator<V>,
     ): V? {
-        val runner = BiMaxOfCollector(filter, comparator)
+        val runner = CacheCollectors.BiMaxOfCollector(filter, comparator)
         innerForEach(runner)
         return runner.maxV
     }
 
-    fun sumOf(consumer: BiSumOf<K, V>): Int {
-        val runner = BiSumOfCollector(consumer)
+    fun sumOf(consumer: CacheCollectors.BiSumOf<K, V>): Int {
+        val runner = CacheCollectors.BiSumOfCollector(consumer)
         innerForEach(runner)
         return runner.sum
     }
 
-    fun sumOfLong(consumer: BiSumOfLong<K, V>): Long {
-        val runner = BiSumOfLongCollector(consumer)
+    fun sumOfLong(consumer: CacheCollectors.BiSumOfLong<K, V>): Long {
+        val runner = CacheCollectors.BiSumOfLongCollector(consumer)
         innerForEach(runner)
         return runner.sum
     }
 
-    fun <R> groupBy(consumer: BiNotNullMapper<K, V, R>): Map<R, List<V>> {
-        val runner = BiGroupByCollector(consumer)
+    fun <R> groupBy(consumer: CacheCollectors.BiNotNullMapper<K, V, R>): Map<R, List<V>> {
+        val runner = CacheCollectors.BiGroupByCollector(consumer)
         innerForEach(runner)
         return runner.results
     }
 
-    fun <R> countByGroup(consumer: BiNotNullMapper<K, V, R>): Map<R, Int> {
-        val runner = BiCountByGroupCollector(consumer)
+    fun <R> countByGroup(consumer: CacheCollectors.BiNotNullMapper<K, V, R>): Map<R, Int> {
+        val runner = CacheCollectors.BiCountByGroupCollector(consumer)
         innerForEach(runner)
         return runner.results
     }
 
     fun <R> sumByGroup(
-        groupMap: BiNotNullMapper<K, V, R>,
-        sumOf: BiNotNullMapper<K, V, Long>,
+        groupMap: CacheCollectors.BiNotNullMapper<K, V, R>,
+        sumOf: CacheCollectors.BiNotNullMapper<K, V, Long>,
     ): Map<R, Long> {
-        val runner = BiSumByGroupCollector(groupMap, sumOf)
+        val runner = CacheCollectors.BiSumByGroupCollector(groupMap, sumOf)
         innerForEach(runner)
         return runner.results
     }
 
-    fun count(consumer: BiFilter<K, V>): Int {
-        val runner = BiCountIfCollector(consumer)
+    fun count(consumer: CacheCollectors.BiFilter<K, V>): Int {
+        val runner = CacheCollectors.BiCountIfCollector(consumer)
         innerForEach(runner)
         return runner.count
     }
 
     fun <T, U> associate(transform: (K, V) -> Pair<T, U>): Map<T, U> {
-        val runner = BiAssociateCollector(size(), transform)
+        val runner = CacheCollectors.BiAssociateCollector(size(), transform)
         innerForEach(runner)
         return runner.results
     }
 
     fun <T, U> associateNotNull(transform: (K, V) -> Pair<T, U>?): Map<T, U> {
-        val runner = BiAssociateNotNullCollector(size(), transform)
+        val runner = CacheCollectors.BiAssociateNotNullCollector(size(), transform)
         innerForEach(runner)
         return runner.results
     }
 
     fun <U> associateWith(transform: (K, V) -> U?): Map<K, U?> {
-        val runner = BiAssociateWithCollector(size(), transform)
+        val runner = CacheCollectors.BiAssociateWithCollector(size(), transform)
         innerForEach(runner)
         return runner.results
     }
 
     fun <U> associateNotNullWith(transform: (K, V) -> U): Map<K, U> {
-        val runner = BiAssociateNotNullWithCollector(size(), transform)
+        val runner = CacheCollectors.BiAssociateNotNullWithCollector(size(), transform)
         innerForEach(runner)
         return runner.results
     }
@@ -226,339 +226,5 @@ class LargeCache<K, V> {
         if (limit >= 0 && count > limit) buffer.append(truncated)
         buffer.append(postfix)
         return buffer.toString()
-    }
-
-    fun interface BiFilter<K, V> {
-        fun filter(
-            k: K,
-            v: V,
-        ): Boolean
-    }
-
-    class BiFilterCollector<K, V>(
-        val filter: BiFilter<K, V>,
-    ) : BiConsumer<K, V> {
-        var results: ArrayList<V> = ArrayList()
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            if (filter.filter(k, v)) {
-                results.add(v)
-            }
-        }
-    }
-
-    class BiFilterUniqueCollector<K, V>(
-        val filter: BiFilter<K, V>,
-    ) : BiConsumer<K, V> {
-        var results: HashSet<V> = HashSet()
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            if (filter.filter(k, v)) {
-                results.add(v)
-            }
-        }
-    }
-
-    fun interface BiMapper<K, V, R> {
-        fun map(
-            k: K,
-            v: V,
-        ): R?
-    }
-
-    fun interface BiMapperNotNull<K, V, R> {
-        fun map(
-            k: K,
-            v: V,
-        ): R
-    }
-
-    class BiMapCollector<K, V, R>(
-        val mapper: BiMapper<K, V, R?>,
-    ) : BiConsumer<K, V> {
-        var results: ArrayList<R> = ArrayList()
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            val result = mapper.map(k, v)
-            if (result != null) {
-                results.add(result)
-            }
-        }
-    }
-
-    class BiAssociateCollector<K, V, T, U>(
-        val size: Int,
-        val mapper: BiMapperNotNull<K, V, Pair<T, U>>,
-    ) : BiConsumer<K, V> {
-        var results: LinkedHashMap<T, U> = LinkedHashMap(size)
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            val pair = mapper.map(k, v)
-            results.put(pair.first, pair.second)
-        }
-    }
-
-    class BiAssociateNotNullCollector<K, V, T, U>(
-        val size: Int,
-        val mapper: BiMapper<K, V, Pair<T, U>?>,
-    ) : BiConsumer<K, V> {
-        var results: LinkedHashMap<T, U> = LinkedHashMap(size)
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            val pair = mapper.map(k, v)
-            if (pair != null) {
-                results.put(pair.first, pair.second)
-            }
-        }
-    }
-
-    class BiAssociateWithCollector<K, V, U>(
-        val size: Int,
-        val mapper: BiMapper<K, V, U?>,
-    ) : BiConsumer<K, V> {
-        var results: LinkedHashMap<K, U?> = LinkedHashMap(size)
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            results.put(k, mapper.map(k, v))
-        }
-    }
-
-    class BiAssociateNotNullWithCollector<K, V, U>(
-        val size: Int,
-        val mapper: BiMapper<K, V, U>,
-    ) : BiConsumer<K, V> {
-        var results: LinkedHashMap<K, U> = LinkedHashMap(size)
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            val newValue = mapper.map(k, v)
-            if (newValue != null) {
-                results.put(k, newValue)
-            }
-        }
-    }
-
-    class BiMapUniqueCollector<K, V, R>(
-        val mapper: BiMapper<K, V, R?>,
-    ) : BiConsumer<K, V> {
-        var results: HashSet<R> = HashSet()
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            val result = mapper.map(k, v)
-            if (result != null) {
-                results.add(result)
-            }
-        }
-    }
-
-    class BiMapFlattenCollector<K, V, R>(
-        val mapper: BiMapper<K, V, Collection<R>?>,
-    ) : BiConsumer<K, V> {
-        var results: ArrayList<R> = ArrayList()
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            val result = mapper.map(k, v)
-            if (result != null) {
-                results.addAll(result)
-            }
-        }
-    }
-
-    class BiMapFlattenUniqueCollector<K, V, R>(
-        val mapper: BiMapper<K, V, Collection<R>?>,
-    ) : BiConsumer<K, V> {
-        var results: HashSet<R> = HashSet()
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            val result = mapper.map(k, v)
-            if (result != null) {
-                results.addAll(result)
-            }
-        }
-    }
-
-    fun interface BiNotNullMapper<K, V, R> {
-        fun map(
-            k: K,
-            v: V,
-        ): R
-    }
-
-    class BiNotNullMapCollector<K, V, R>(
-        val mapper: BiNotNullMapper<K, V, R>,
-    ) : BiConsumer<K, V> {
-        var results: ArrayList<R> = ArrayList()
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            results.add(mapper.map(k, v))
-        }
-    }
-
-    fun interface BiSumOf<K, V> {
-        fun map(
-            k: K,
-            v: V,
-        ): Int
-    }
-
-    class BiMaxOfCollector<K, V>(
-        val filter: BiFilter<K, V>,
-        val comparator: Comparator<V>,
-    ) : BiConsumer<K, V> {
-        var maxK: K? = null
-        var maxV: V? = null
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            if (filter.filter(k, v)) {
-                if (maxK == null || comparator.compare(v, maxV) > 0) {
-                    maxK = k
-                    maxV = v
-                }
-            }
-        }
-    }
-
-    class BiSumOfCollector<K, V>(
-        val mapper: BiSumOf<K, V>,
-    ) : BiConsumer<K, V> {
-        var sum = 0
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            sum += mapper.map(k, v)
-        }
-    }
-
-    fun interface BiSumOfLong<K, V> {
-        fun map(
-            k: K,
-            v: V,
-        ): Long
-    }
-
-    class BiSumOfLongCollector<K, V>(
-        val mapper: BiSumOfLong<K, V>,
-    ) : BiConsumer<K, V> {
-        var sum = 0L
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            sum += mapper.map(k, v)
-        }
-    }
-
-    class BiGroupByCollector<K, V, R>(
-        val mapper: BiNotNullMapper<K, V, R>,
-    ) : BiConsumer<K, V> {
-        var results = HashMap<R, ArrayList<V>>()
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            val group = mapper.map(k, v)
-
-            val list = results[group]
-            if (list == null) {
-                val answer = ArrayList<V>()
-                answer.add(v)
-                results[group] = answer
-            } else {
-                list.add(v)
-            }
-        }
-    }
-
-    class BiCountByGroupCollector<K, V, R>(
-        val mapper: BiNotNullMapper<K, V, R>,
-    ) : BiConsumer<K, V> {
-        var results = HashMap<R, Int>()
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            val group = mapper.map(k, v)
-
-            val count = results[group]
-            if (count == null) {
-                results[group] = 1
-            } else {
-                results[group] = count + 1
-            }
-        }
-    }
-
-    class BiSumByGroupCollector<K, V, R>(
-        val mapper: BiNotNullMapper<K, V, R>,
-        val sumOf: BiNotNullMapper<K, V, Long>,
-    ) : BiConsumer<K, V> {
-        var results = HashMap<R, Long>()
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            val group = mapper.map(k, v)
-
-            val sum = results[group]
-            if (sum == null) {
-                results[group] = sumOf.map(k, v)
-            } else {
-                results[group] = sum + sumOf.map(k, v)
-            }
-        }
-    }
-
-    class BiCountIfCollector<K, V>(
-        val filter: BiFilter<K, V>,
-    ) : BiConsumer<K, V> {
-        var count = 0
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            if (filter.filter(k, v)) count++
-        }
     }
 }

--- a/quartz/src/main/java/com/vitorpamplona/quartz/utils/LargeCache.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/utils/LargeCache.kt
@@ -67,7 +67,7 @@ class LargeCache<K, V> : CacheOperations<K, V> {
         key: K,
         builder: (key: K) -> V,
     ): Boolean {
-        val value = cache.get(key)
+        val value = cache[key]
         return if (value != null) {
             false
         } else {

--- a/quartz/src/main/java/com/vitorpamplona/quartz/utils/LargeSoftCache.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/utils/LargeSoftCache.kt
@@ -24,7 +24,7 @@ import java.lang.ref.WeakReference
 import java.util.concurrent.ConcurrentSkipListMap
 import java.util.function.BiConsumer
 
-class LargeSoftCache<K, V> {
+class LargeSoftCache<K, V> : CacheOperations<K, V> {
     private val cache = ConcurrentSkipListMap<K, WeakReference<V>>()
 
     fun keys() = cache.keys
@@ -43,7 +43,7 @@ class LargeSoftCache<K, V> {
 
     fun remove(key: K) = cache.remove(key)
 
-    fun size() = cache.size
+    override fun size() = cache.size
 
     fun isEmpty() = cache.isEmpty()
 
@@ -122,156 +122,8 @@ class LargeSoftCache<K, V> {
         println("Cache cleanup completed. Remaining size: ${cache.size}")
     }
 
-    fun forEach(consumer: BiConsumer<K, V>) {
-        innerForEach(consumer)
-    }
-
-    fun filter(consumer: CacheCollectors.BiFilter<K, V>): List<V> {
-        val runner = CacheCollectors.BiFilterCollector(consumer)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun filterIntoSet(consumer: CacheCollectors.BiFilter<K, V>): Set<V> {
-        val runner = CacheCollectors.BiFilterUniqueCollector(consumer)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun <R> map(consumer: CacheCollectors.BiNotNullMapper<K, V, R>): List<R> {
-        val runner = CacheCollectors.BiNotNullMapCollector(consumer)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun <R> mapNotNull(consumer: CacheCollectors.BiMapper<K, V, R?>): List<R> {
-        val runner = CacheCollectors.BiMapCollector(consumer)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun <R> mapNotNullIntoSet(consumer: CacheCollectors.BiMapper<K, V, R?>): Set<R> {
-        val runner = CacheCollectors.BiMapUniqueCollector(consumer)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun <R> mapFlatten(consumer: CacheCollectors.BiMapper<K, V, Collection<R>?>): List<R> {
-        val runner = CacheCollectors.BiMapFlattenCollector(consumer)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun <R> mapFlattenIntoSet(consumer: CacheCollectors.BiMapper<K, V, Collection<R>?>): Set<R> {
-        val runner = CacheCollectors.BiMapFlattenUniqueCollector(consumer)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun maxOrNullOf(
-        filter: CacheCollectors.BiFilter<K, V>,
-        comparator: Comparator<V>,
-    ): V? {
-        val runner = CacheCollectors.BiMaxOfCollector(filter, comparator)
-        innerForEach(runner)
-        return runner.maxV
-    }
-
-    fun sumOf(consumer: CacheCollectors.BiSumOf<K, V>): Int {
-        val runner = CacheCollectors.BiSumOfCollector(consumer)
-        innerForEach(runner)
-        return runner.sum
-    }
-
-    fun sumOfLong(consumer: CacheCollectors.BiSumOfLong<K, V>): Long {
-        val runner = CacheCollectors.BiSumOfLongCollector(consumer)
-        innerForEach(runner)
-        return runner.sum
-    }
-
-    fun <R> groupBy(consumer: CacheCollectors.BiNotNullMapper<K, V, R>): Map<R, List<V>> {
-        val runner = CacheCollectors.BiGroupByCollector(consumer)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun <R> countByGroup(consumer: CacheCollectors.BiNotNullMapper<K, V, R>): Map<R, Int> {
-        val runner = CacheCollectors.BiCountByGroupCollector(consumer)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun <R> sumByGroup(
-        groupMap: CacheCollectors.BiNotNullMapper<K, V, R>,
-        sumOf: CacheCollectors.BiNotNullMapper<K, V, Long>,
-    ): Map<R, Long> {
-        val runner = CacheCollectors.BiSumByGroupCollector(groupMap, sumOf)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun count(consumer: CacheCollectors.BiFilter<K, V>): Int {
-        val runner = CacheCollectors.BiCountIfCollector(consumer)
-        innerForEach(runner)
-        return runner.count
-    }
-
-    fun <T, U> associate(transform: (K, V) -> Pair<T, U>): Map<T, U> {
-        val runner = CacheCollectors.BiAssociateCollector(size(), transform)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun <T, U> associateNotNull(transform: (K, V) -> Pair<T, U>?): Map<T, U> {
-        val runner = CacheCollectors.BiAssociateNotNullCollector(size(), transform)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun <U> associateWith(transform: (K, V) -> U?): Map<K, U?> {
-        val runner = CacheCollectors.BiAssociateWithCollector(size(), transform)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    fun <U> associateNotNullWith(transform: (K, V) -> U): Map<K, U> {
-        val runner = CacheCollectors.BiAssociateNotNullWithCollector(size(), transform)
-        innerForEach(runner)
-        return runner.results
-    }
-
-    private fun innerForEach(runner: BiConsumer<K, V>) {
-        cache.forEach(BiConsumerWrapper(this, runner))
-    }
-
-    fun joinToString(
-        separator: CharSequence = ", ",
-        prefix: CharSequence = "",
-        postfix: CharSequence = "",
-        limit: Int = -1,
-        truncated: CharSequence = "...",
-        transform: ((K, V) -> CharSequence)? = null,
-    ): String {
-        val buffer = StringBuilder()
-        buffer.append(prefix)
-        var count = 0
-        forEach { key, value ->
-            val str = if (transform != null) transform(key, value) else ""
-            if (str.isNotEmpty()) {
-                if (++count > 1) buffer.append(separator)
-                if (limit < 0 || count <= limit) {
-                    when {
-                        transform != null -> buffer.append(str)
-                        else -> buffer.append("$key $value")
-                    }
-                } else {
-                    return@forEach
-                }
-            }
-        }
-        if (limit >= 0 && count > limit) buffer.append(truncated)
-        buffer.append(postfix)
-        return buffer.toString()
+    override fun forEach(consumer: BiConsumer<K, V>) {
+        cache.forEach(BiConsumerWrapper(this, consumer))
     }
 
     class BiConsumerWrapper<K, V>(

--- a/quartz/src/main/java/com/vitorpamplona/quartz/utils/LargeSoftCache.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/utils/LargeSoftCache.kt
@@ -126,116 +126,116 @@ class LargeSoftCache<K, V> {
         innerForEach(consumer)
     }
 
-    fun filter(consumer: BiFilter<K, V>): List<V> {
-        val runner = BiFilterCollector(consumer)
+    fun filter(consumer: CacheCollectors.BiFilter<K, V>): List<V> {
+        val runner = CacheCollectors.BiFilterCollector(consumer)
         innerForEach(runner)
         return runner.results
     }
 
-    fun filterIntoSet(consumer: BiFilter<K, V>): Set<V> {
-        val runner = BiFilterUniqueCollector(consumer)
+    fun filterIntoSet(consumer: CacheCollectors.BiFilter<K, V>): Set<V> {
+        val runner = CacheCollectors.BiFilterUniqueCollector(consumer)
         innerForEach(runner)
         return runner.results
     }
 
-    fun <R> map(consumer: BiNotNullMapper<K, V, R>): List<R> {
-        val runner = BiNotNullMapCollector(consumer)
+    fun <R> map(consumer: CacheCollectors.BiNotNullMapper<K, V, R>): List<R> {
+        val runner = CacheCollectors.BiNotNullMapCollector(consumer)
         innerForEach(runner)
         return runner.results
     }
 
-    fun <R> mapNotNull(consumer: BiMapper<K, V, R?>): List<R> {
-        val runner = BiMapCollector(consumer)
+    fun <R> mapNotNull(consumer: CacheCollectors.BiMapper<K, V, R?>): List<R> {
+        val runner = CacheCollectors.BiMapCollector(consumer)
         innerForEach(runner)
         return runner.results
     }
 
-    fun <R> mapNotNullIntoSet(consumer: BiMapper<K, V, R?>): Set<R> {
-        val runner = BiMapUniqueCollector(consumer)
+    fun <R> mapNotNullIntoSet(consumer: CacheCollectors.BiMapper<K, V, R?>): Set<R> {
+        val runner = CacheCollectors.BiMapUniqueCollector(consumer)
         innerForEach(runner)
         return runner.results
     }
 
-    fun <R> mapFlatten(consumer: BiMapper<K, V, Collection<R>?>): List<R> {
-        val runner = BiMapFlattenCollector(consumer)
+    fun <R> mapFlatten(consumer: CacheCollectors.BiMapper<K, V, Collection<R>?>): List<R> {
+        val runner = CacheCollectors.BiMapFlattenCollector(consumer)
         innerForEach(runner)
         return runner.results
     }
 
-    fun <R> mapFlattenIntoSet(consumer: BiMapper<K, V, Collection<R>?>): Set<R> {
-        val runner = BiMapFlattenUniqueCollector(consumer)
+    fun <R> mapFlattenIntoSet(consumer: CacheCollectors.BiMapper<K, V, Collection<R>?>): Set<R> {
+        val runner = CacheCollectors.BiMapFlattenUniqueCollector(consumer)
         innerForEach(runner)
         return runner.results
     }
 
     fun maxOrNullOf(
-        filter: BiFilter<K, V>,
+        filter: CacheCollectors.BiFilter<K, V>,
         comparator: Comparator<V>,
     ): V? {
-        val runner = BiMaxOfCollector(filter, comparator)
+        val runner = CacheCollectors.BiMaxOfCollector(filter, comparator)
         innerForEach(runner)
         return runner.maxV
     }
 
-    fun sumOf(consumer: BiSumOf<K, V>): Int {
-        val runner = BiSumOfCollector(consumer)
+    fun sumOf(consumer: CacheCollectors.BiSumOf<K, V>): Int {
+        val runner = CacheCollectors.BiSumOfCollector(consumer)
         innerForEach(runner)
         return runner.sum
     }
 
-    fun sumOfLong(consumer: BiSumOfLong<K, V>): Long {
-        val runner = BiSumOfLongCollector(consumer)
+    fun sumOfLong(consumer: CacheCollectors.BiSumOfLong<K, V>): Long {
+        val runner = CacheCollectors.BiSumOfLongCollector(consumer)
         innerForEach(runner)
         return runner.sum
     }
 
-    fun <R> groupBy(consumer: BiNotNullMapper<K, V, R>): Map<R, List<V>> {
-        val runner = BiGroupByCollector(consumer)
+    fun <R> groupBy(consumer: CacheCollectors.BiNotNullMapper<K, V, R>): Map<R, List<V>> {
+        val runner = CacheCollectors.BiGroupByCollector(consumer)
         innerForEach(runner)
         return runner.results
     }
 
-    fun <R> countByGroup(consumer: BiNotNullMapper<K, V, R>): Map<R, Int> {
-        val runner = BiCountByGroupCollector(consumer)
+    fun <R> countByGroup(consumer: CacheCollectors.BiNotNullMapper<K, V, R>): Map<R, Int> {
+        val runner = CacheCollectors.BiCountByGroupCollector(consumer)
         innerForEach(runner)
         return runner.results
     }
 
     fun <R> sumByGroup(
-        groupMap: BiNotNullMapper<K, V, R>,
-        sumOf: BiNotNullMapper<K, V, Long>,
+        groupMap: CacheCollectors.BiNotNullMapper<K, V, R>,
+        sumOf: CacheCollectors.BiNotNullMapper<K, V, Long>,
     ): Map<R, Long> {
-        val runner = BiSumByGroupCollector(groupMap, sumOf)
+        val runner = CacheCollectors.BiSumByGroupCollector(groupMap, sumOf)
         innerForEach(runner)
         return runner.results
     }
 
-    fun count(consumer: BiFilter<K, V>): Int {
-        val runner = BiCountIfCollector(consumer)
+    fun count(consumer: CacheCollectors.BiFilter<K, V>): Int {
+        val runner = CacheCollectors.BiCountIfCollector(consumer)
         innerForEach(runner)
         return runner.count
     }
 
     fun <T, U> associate(transform: (K, V) -> Pair<T, U>): Map<T, U> {
-        val runner = BiAssociateCollector(size(), transform)
+        val runner = CacheCollectors.BiAssociateCollector(size(), transform)
         innerForEach(runner)
         return runner.results
     }
 
     fun <T, U> associateNotNull(transform: (K, V) -> Pair<T, U>?): Map<T, U> {
-        val runner = BiAssociateNotNullCollector(size(), transform)
+        val runner = CacheCollectors.BiAssociateNotNullCollector(size(), transform)
         innerForEach(runner)
         return runner.results
     }
 
     fun <U> associateWith(transform: (K, V) -> U?): Map<K, U?> {
-        val runner = BiAssociateWithCollector(size(), transform)
+        val runner = CacheCollectors.BiAssociateWithCollector(size(), transform)
         innerForEach(runner)
         return runner.results
     }
 
     fun <U> associateNotNullWith(transform: (K, V) -> U): Map<K, U> {
-        val runner = BiAssociateNotNullWithCollector(size(), transform)
+        val runner = CacheCollectors.BiAssociateNotNullWithCollector(size(), transform)
         innerForEach(runner)
         return runner.results
     }
@@ -288,340 +288,6 @@ class LargeSoftCache<K, V> {
             } else {
                 inner.accept(k, value)
             }
-        }
-    }
-
-    fun interface BiFilter<K, V> {
-        fun filter(
-            k: K,
-            v: V,
-        ): Boolean
-    }
-
-    class BiFilterCollector<K, V>(
-        val filter: BiFilter<K, V>,
-    ) : BiConsumer<K, V> {
-        var results: ArrayList<V> = ArrayList()
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            if (filter.filter(k, v)) {
-                results.add(v)
-            }
-        }
-    }
-
-    class BiFilterUniqueCollector<K, V>(
-        val filter: BiFilter<K, V>,
-    ) : BiConsumer<K, V> {
-        var results: HashSet<V> = HashSet()
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            if (filter.filter(k, v)) {
-                results.add(v)
-            }
-        }
-    }
-
-    fun interface BiMapper<K, V, R> {
-        fun map(
-            k: K,
-            v: V,
-        ): R?
-    }
-
-    fun interface BiMapperNotNull<K, V, R> {
-        fun map(
-            k: K,
-            v: V,
-        ): R
-    }
-
-    class BiMapCollector<K, V, R>(
-        val mapper: BiMapper<K, V, R?>,
-    ) : BiConsumer<K, V> {
-        var results: ArrayList<R> = ArrayList()
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            val result = mapper.map(k, v)
-            if (result != null) {
-                results.add(result)
-            }
-        }
-    }
-
-    class BiAssociateCollector<K, V, T, U>(
-        val size: Int,
-        val mapper: BiMapperNotNull<K, V, Pair<T, U>>,
-    ) : BiConsumer<K, V> {
-        var results: LinkedHashMap<T, U> = LinkedHashMap(size)
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            val pair = mapper.map(k, v)
-            results.put(pair.first, pair.second)
-        }
-    }
-
-    class BiAssociateNotNullCollector<K, V, T, U>(
-        val size: Int,
-        val mapper: BiMapper<K, V, Pair<T, U>?>,
-    ) : BiConsumer<K, V> {
-        var results: LinkedHashMap<T, U> = LinkedHashMap(size)
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            val pair = mapper.map(k, v)
-            if (pair != null) {
-                results.put(pair.first, pair.second)
-            }
-        }
-    }
-
-    class BiAssociateWithCollector<K, V, U>(
-        val size: Int,
-        val mapper: BiMapper<K, V, U?>,
-    ) : BiConsumer<K, V> {
-        var results: LinkedHashMap<K, U?> = LinkedHashMap(size)
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            results.put(k, mapper.map(k, v))
-        }
-    }
-
-    class BiAssociateNotNullWithCollector<K, V, U>(
-        val size: Int,
-        val mapper: BiMapper<K, V, U>,
-    ) : BiConsumer<K, V> {
-        var results: LinkedHashMap<K, U> = LinkedHashMap(size)
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            val newValue = mapper.map(k, v)
-            if (newValue != null) {
-                results.put(k, newValue)
-            }
-        }
-    }
-
-    class BiMapUniqueCollector<K, V, R>(
-        val mapper: BiMapper<K, V, R?>,
-    ) : BiConsumer<K, V> {
-        var results: HashSet<R> = HashSet()
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            val result = mapper.map(k, v)
-            if (result != null) {
-                results.add(result)
-            }
-        }
-    }
-
-    class BiMapFlattenCollector<K, V, R>(
-        val mapper: BiMapper<K, V, Collection<R>?>,
-    ) : BiConsumer<K, V> {
-        var results: ArrayList<R> = ArrayList()
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            val result = mapper.map(k, v)
-            if (result != null) {
-                results.addAll(result)
-            }
-        }
-    }
-
-    class BiMapFlattenUniqueCollector<K, V, R>(
-        val mapper: BiMapper<K, V, Collection<R>?>,
-    ) : BiConsumer<K, V> {
-        var results: HashSet<R> = HashSet()
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            val result = mapper.map(k, v)
-            if (result != null) {
-                results.addAll(result)
-            }
-        }
-    }
-
-    fun interface BiNotNullMapper<K, V, R> {
-        fun map(
-            k: K,
-            v: V,
-        ): R
-    }
-
-    class BiNotNullMapCollector<K, V, R>(
-        val mapper: BiNotNullMapper<K, V, R>,
-    ) : BiConsumer<K, V> {
-        var results: ArrayList<R> = ArrayList()
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            results.add(mapper.map(k, v))
-        }
-    }
-
-    fun interface BiSumOf<K, V> {
-        fun map(
-            k: K,
-            v: V,
-        ): Int
-    }
-
-    class BiMaxOfCollector<K, V>(
-        val filter: BiFilter<K, V>,
-        val comparator: Comparator<V>,
-    ) : BiConsumer<K, V> {
-        var maxK: K? = null
-        var maxV: V? = null
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            if (filter.filter(k, v)) {
-                if (maxK == null || comparator.compare(v, maxV) > 0) {
-                    maxK = k
-                    maxV = v
-                }
-            }
-        }
-    }
-
-    class BiSumOfCollector<K, V>(
-        val mapper: BiSumOf<K, V>,
-    ) : BiConsumer<K, V> {
-        var sum = 0
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            sum += mapper.map(k, v)
-        }
-    }
-
-    fun interface BiSumOfLong<K, V> {
-        fun map(
-            k: K,
-            v: V,
-        ): Long
-    }
-
-    class BiSumOfLongCollector<K, V>(
-        val mapper: BiSumOfLong<K, V>,
-    ) : BiConsumer<K, V> {
-        var sum = 0L
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            sum += mapper.map(k, v)
-        }
-    }
-
-    class BiGroupByCollector<K, V, R>(
-        val mapper: BiNotNullMapper<K, V, R>,
-    ) : BiConsumer<K, V> {
-        var results = HashMap<R, ArrayList<V>>()
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            val group = mapper.map(k, v)
-
-            val list = results[group]
-            if (list == null) {
-                val answer = ArrayList<V>()
-                answer.add(v)
-                results[group] = answer
-            } else {
-                list.add(v)
-            }
-        }
-    }
-
-    class BiCountByGroupCollector<K, V, R>(
-        val mapper: BiNotNullMapper<K, V, R>,
-    ) : BiConsumer<K, V> {
-        var results = HashMap<R, Int>()
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            val group = mapper.map(k, v)
-
-            val count = results[group]
-            if (count == null) {
-                results[group] = 1
-            } else {
-                results[group] = count + 1
-            }
-        }
-    }
-
-    class BiSumByGroupCollector<K, V, R>(
-        val mapper: BiNotNullMapper<K, V, R>,
-        val sumOf: BiNotNullMapper<K, V, Long>,
-    ) : BiConsumer<K, V> {
-        var results = HashMap<R, Long>()
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            val group = mapper.map(k, v)
-
-            val sum = results[group]
-            if (sum == null) {
-                results[group] = sumOf.map(k, v)
-            } else {
-                results[group] = sum + sumOf.map(k, v)
-            }
-        }
-    }
-
-    class BiCountIfCollector<K, V>(
-        val filter: BiFilter<K, V>,
-    ) : BiConsumer<K, V> {
-        var count = 0
-
-        override fun accept(
-            k: K,
-            v: V,
-        ) {
-            if (filter.filter(k, v)) count++
         }
     }
 }

--- a/quartz/src/main/java/com/vitorpamplona/quartz/utils/LargeSoftCache.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/utils/LargeSoftCache.kt
@@ -78,7 +78,7 @@ class LargeSoftCache<K, V> : CacheOperations<K, V> {
         key: K,
         builder: (key: K) -> V,
     ): V {
-        val softRef = cache.get(key)
+        val softRef = cache[key]
         val value = softRef?.get()
 
         return if (value != null) {
@@ -86,20 +86,6 @@ class LargeSoftCache<K, V> : CacheOperations<K, V> {
         } else {
             val newObject = builder(key)
             cache.putIfAbsent(key, WeakReference(newObject))?.get() ?: newObject
-        }
-    }
-
-    fun createIfAbsent(
-        key: K,
-        builder: (key: K) -> V,
-    ): Boolean {
-        val softRef = cache.get(key)
-        val value = softRef?.get()
-        return if (value != null) {
-            false
-        } else {
-            val newObject = builder(key)
-            cache.putIfAbsent(key, WeakReference(newObject)) == null
         }
     }
 


### PR DESCRIPTION
- Only identical code was extracted to common utility classes. Some more de-duplication could be done but would require rewriting logic.
- Extracted common collectors to an utility class
- Extracted common logic to an interface
- Each cache class keeps reference to its internal data
- Use override for two functions that are used inside common caching logic
- Updated LargeCache and LargeSoftCache to use common collectors and common caching logic

Performance: identical performance since no caching logic was changed. Smaller byte code due to less duplicate code (458 loc removed). 

Testing: testing on device. Please let me know if you'd like to see tests added and run before and after changes.

No profiling done but the caching logic is identical.