### PR TITLE
Reduce duplications: hint providers

### DIFF
--- a/quartz/src/main/java/com/vitorpamplona/quartz/experimental/zapPolls/PollNoteEvent.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/experimental/zapPolls/PollNoteEvent.kt
@@ -28,24 +28,9 @@ import com.vitorpamplona.quartz.experimental.zapPolls.tags.MinimumTag
 import com.vitorpamplona.quartz.experimental.zapPolls.tags.PollOptionTag
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
-import com.vitorpamplona.quartz.nip01Core.hints.AddressHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.EventHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.PubKeyHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.types.AddressHint
-import com.vitorpamplona.quartz.nip01Core.hints.types.EventIdHint
-import com.vitorpamplona.quartz.nip01Core.hints.types.PubKeyHint
+import com.vitorpamplona.quartz.nip01Core.hints.ExtendedHintProvider
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
-import com.vitorpamplona.quartz.nip01Core.tags.addressables.ATag
-import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip10Notes.BaseThreadedEvent
-import com.vitorpamplona.quartz.nip10Notes.tags.MarkedETag
-import com.vitorpamplona.quartz.nip18Reposts.quotes.QTag
-import com.vitorpamplona.quartz.nip19Bech32.addressHints
-import com.vitorpamplona.quartz.nip19Bech32.addressIds
-import com.vitorpamplona.quartz.nip19Bech32.eventHints
-import com.vitorpamplona.quartz.nip19Bech32.eventIds
-import com.vitorpamplona.quartz.nip19Bech32.pubKeyHints
-import com.vitorpamplona.quartz.nip19Bech32.pubKeys
 import com.vitorpamplona.quartz.nip31Alts.alt
 import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
@@ -59,57 +44,9 @@ class PollNoteEvent(
     content: String,
     sig: HexKey,
 ) : BaseThreadedEvent(id, pubKey, createdAt, KIND, tags, content, sig),
-    EventHintProvider,
-    AddressHintProvider,
-    PubKeyHintProvider,
+    ExtendedHintProvider,
     SearchableEvent {
     override fun indexableContent() = content + pollOptionsArray().map { "\nOption: " + it.descriptor }
-
-    override fun eventHints(): List<EventIdHint> {
-        val eHints = tags.mapNotNull(MarkedETag::parseAsHint)
-        val qHints = tags.mapNotNull(QTag::parseEventAsHint)
-        val nip19Hints = citedNIP19().eventHints()
-
-        return eHints + qHints + nip19Hints
-    }
-
-    override fun linkedEventIds(): List<HexKey> {
-        val eHints = tags.mapNotNull(MarkedETag::parseId)
-        val qHints = tags.mapNotNull(QTag::parseEventId)
-        val nip19Hints = citedNIP19().eventIds()
-
-        return eHints + qHints + nip19Hints
-    }
-
-    override fun addressHints(): List<AddressHint> {
-        val aHints = tags.mapNotNull(ATag::parseAsHint)
-        val qHints = tags.mapNotNull(QTag::parseAddressAsHint)
-        val nip19Hints = citedNIP19().addressHints()
-
-        return aHints + qHints + nip19Hints
-    }
-
-    override fun linkedAddressIds(): List<String> {
-        val aHints = tags.mapNotNull(ATag::parseAddressId)
-        val qHints = tags.mapNotNull(QTag::parseAddressId)
-        val nip19Hints = citedNIP19().addressIds()
-
-        return aHints + qHints + nip19Hints
-    }
-
-    override fun pubKeyHints(): List<PubKeyHint> {
-        val pHints = tags.mapNotNull(PTag::parseAsHint)
-        val nip19Hints = citedNIP19().pubKeyHints()
-
-        return pHints + nip19Hints
-    }
-
-    override fun linkedPubKeys(): List<HexKey> {
-        val pHints = tags.mapNotNull(PTag::parseKey)
-        val nip19Hints = citedNIP19().pubKeys()
-
-        return pHints + nip19Hints
-    }
 
     fun pollOptionsArray() = tags.mapNotNull(PollOptionTag::parse)
 

--- a/quartz/src/main/java/com/vitorpamplona/quartz/nip01Core/hints/HintProviders.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/nip01Core/hints/HintProviders.kt
@@ -26,6 +26,7 @@ import com.vitorpamplona.quartz.nip01Core.hints.types.AddressHint
 import com.vitorpamplona.quartz.nip01Core.hints.types.EventIdHint
 import com.vitorpamplona.quartz.nip01Core.hints.types.PubKeyHint
 import com.vitorpamplona.quartz.nip01Core.tags.addressables.ATag
+import com.vitorpamplona.quartz.nip01Core.tags.events.ETag
 import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip10Notes.BaseNoteEvent
 import com.vitorpamplona.quartz.nip10Notes.tags.MarkedETag
@@ -110,6 +111,61 @@ interface StandardHintProvider :
     fun getAdditionalAddressHints(): List<AddressHint> = emptyList()
 
     fun getAdditionalAddressIds(): List<String> = emptyList()
+}
+
+interface ETagHintProvider :
+    EventHintProvider,
+    AddressHintProvider,
+    PubKeyHintProvider {
+    private val event: Event get() = this as Event
+
+    private val baseNoteEvent: BaseNoteEvent get() = this as BaseNoteEvent
+
+    override fun eventHints(): List<EventIdHint> {
+        val eHints = event.tags.mapNotNull(ETag::parseAsHint)
+        val qHints = event.tags.mapNotNull(QTag::parseEventAsHint)
+        val nip19Hints = baseNoteEvent.citedNIP19().eventHints()
+
+        return eHints + qHints + nip19Hints
+    }
+
+    override fun linkedEventIds(): List<HexKey> {
+        val eHints = event.tags.mapNotNull(ETag::parseId)
+        val qHints = event.tags.mapNotNull(QTag::parseEventId)
+        val nip19Hints = baseNoteEvent.citedNIP19().eventIds()
+
+        return eHints + qHints + nip19Hints
+    }
+
+    override fun addressHints(): List<AddressHint> {
+        val aHints = event.tags.mapNotNull(ATag::parseAsHint)
+        val qHints = event.tags.mapNotNull(QTag::parseAddressAsHint)
+        val nip19Hints = baseNoteEvent.citedNIP19().addressHints()
+
+        return aHints + qHints + nip19Hints
+    }
+
+    override fun linkedAddressIds(): List<String> {
+        val aHints = event.tags.mapNotNull(ATag::parseAddressId)
+        val qHints = event.tags.mapNotNull(QTag::parseAddressId)
+        val nip19Hints = baseNoteEvent.citedNIP19().addressIds()
+
+        return aHints + qHints + nip19Hints
+    }
+
+    override fun pubKeyHints(): List<PubKeyHint> {
+        val pHints = event.tags.mapNotNull(PTag::parseAsHint)
+        val nip19Hints = baseNoteEvent.citedNIP19().pubKeyHints()
+
+        return pHints + nip19Hints
+    }
+
+    override fun linkedPubKeys(): List<HexKey> {
+        val pHints = event.tags.mapNotNull(PTag::parseKey)
+        val nip19Hints = baseNoteEvent.citedNIP19().pubKeys()
+
+        return pHints + nip19Hints
+    }
 }
 
 interface ExtendedHintProvider : StandardHintProvider {

--- a/quartz/src/main/java/com/vitorpamplona/quartz/nip01Core/hints/HintProviders.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/nip01Core/hints/HintProviders.kt
@@ -60,49 +60,47 @@ interface StandardHintProvider :
     EventHintProvider,
     AddressHintProvider,
     PubKeyHintProvider {
-    private val event: Event get() = this as Event
-
     private val baseNoteEvent: BaseNoteEvent get() = this as BaseNoteEvent
 
     override fun eventHints(): List<EventIdHint> {
-        val eHints = event.tags.mapNotNull(MarkedETag::parseAsHint)
-        val qHints = event.tags.mapNotNull(QTag::parseEventAsHint)
+        val eHints = baseNoteEvent.tags.mapNotNull(MarkedETag::parseAsHint)
+        val qHints = baseNoteEvent.tags.mapNotNull(QTag::parseEventAsHint)
         val nip19Hints = baseNoteEvent.citedNIP19().eventHints()
 
         return eHints + qHints + nip19Hints
     }
 
     override fun linkedEventIds(): List<HexKey> {
-        val eHints = event.tags.mapNotNull(MarkedETag::parseId)
-        val qHints = event.tags.mapNotNull(QTag::parseEventId)
+        val eHints = baseNoteEvent.tags.mapNotNull(MarkedETag::parseId)
+        val qHints = baseNoteEvent.tags.mapNotNull(QTag::parseEventId)
         val nip19Hints = baseNoteEvent.citedNIP19().eventIds()
 
         return eHints + qHints + nip19Hints
     }
 
     override fun addressHints(): List<AddressHint> {
-        val qHints = event.tags.mapNotNull(QTag::parseAddressAsHint)
+        val qHints = baseNoteEvent.tags.mapNotNull(QTag::parseAddressAsHint)
         val nip19Hints = baseNoteEvent.citedNIP19().addressHints()
 
         return qHints + nip19Hints + getAdditionalAddressHints()
     }
 
     override fun linkedAddressIds(): List<String> {
-        val qHints = event.tags.mapNotNull(QTag::parseAddressId)
+        val qHints = baseNoteEvent.tags.mapNotNull(QTag::parseAddressId)
         val nip19Hints = baseNoteEvent.citedNIP19().addressIds()
 
         return qHints + nip19Hints + getAdditionalAddressIds()
     }
 
     override fun pubKeyHints(): List<PubKeyHint> {
-        val pHints = event.tags.mapNotNull(PTag::parseAsHint)
+        val pHints = baseNoteEvent.tags.mapNotNull(PTag::parseAsHint)
         val nip19Hints = baseNoteEvent.citedNIP19().pubKeyHints()
 
         return pHints + nip19Hints
     }
 
     override fun linkedPubKeys(): List<HexKey> {
-        val pHints = event.tags.mapNotNull(PTag::parseKey)
+        val pHints = baseNoteEvent.tags.mapNotNull(PTag::parseKey)
         val nip19Hints = baseNoteEvent.citedNIP19().pubKeys()
 
         return pHints + nip19Hints
@@ -117,51 +115,49 @@ interface ETagHintProvider :
     EventHintProvider,
     AddressHintProvider,
     PubKeyHintProvider {
-    private val event: Event get() = this as Event
-
     private val baseNoteEvent: BaseNoteEvent get() = this as BaseNoteEvent
 
     override fun eventHints(): List<EventIdHint> {
-        val eHints = event.tags.mapNotNull(ETag::parseAsHint)
-        val qHints = event.tags.mapNotNull(QTag::parseEventAsHint)
+        val eHints = baseNoteEvent.tags.mapNotNull(ETag::parseAsHint)
+        val qHints = baseNoteEvent.tags.mapNotNull(QTag::parseEventAsHint)
         val nip19Hints = baseNoteEvent.citedNIP19().eventHints()
 
         return eHints + qHints + nip19Hints
     }
 
     override fun linkedEventIds(): List<HexKey> {
-        val eHints = event.tags.mapNotNull(ETag::parseId)
-        val qHints = event.tags.mapNotNull(QTag::parseEventId)
+        val eHints = baseNoteEvent.tags.mapNotNull(ETag::parseId)
+        val qHints = baseNoteEvent.tags.mapNotNull(QTag::parseEventId)
         val nip19Hints = baseNoteEvent.citedNIP19().eventIds()
 
         return eHints + qHints + nip19Hints
     }
 
     override fun addressHints(): List<AddressHint> {
-        val aHints = event.tags.mapNotNull(ATag::parseAsHint)
-        val qHints = event.tags.mapNotNull(QTag::parseAddressAsHint)
+        val aHints = baseNoteEvent.tags.mapNotNull(ATag::parseAsHint)
+        val qHints = baseNoteEvent.tags.mapNotNull(QTag::parseAddressAsHint)
         val nip19Hints = baseNoteEvent.citedNIP19().addressHints()
 
         return aHints + qHints + nip19Hints
     }
 
     override fun linkedAddressIds(): List<String> {
-        val aHints = event.tags.mapNotNull(ATag::parseAddressId)
-        val qHints = event.tags.mapNotNull(QTag::parseAddressId)
+        val aHints = baseNoteEvent.tags.mapNotNull(ATag::parseAddressId)
+        val qHints = baseNoteEvent.tags.mapNotNull(QTag::parseAddressId)
         val nip19Hints = baseNoteEvent.citedNIP19().addressIds()
 
         return aHints + qHints + nip19Hints
     }
 
     override fun pubKeyHints(): List<PubKeyHint> {
-        val pHints = event.tags.mapNotNull(PTag::parseAsHint)
+        val pHints = baseNoteEvent.tags.mapNotNull(PTag::parseAsHint)
         val nip19Hints = baseNoteEvent.citedNIP19().pubKeyHints()
 
         return pHints + nip19Hints
     }
 
     override fun linkedPubKeys(): List<HexKey> {
-        val pHints = event.tags.mapNotNull(PTag::parseKey)
+        val pHints = baseNoteEvent.tags.mapNotNull(PTag::parseKey)
         val nip19Hints = baseNoteEvent.citedNIP19().pubKeys()
 
         return pHints + nip19Hints
@@ -169,15 +165,11 @@ interface ETagHintProvider :
 }
 
 interface ExtendedHintProvider : StandardHintProvider {
-    override fun getAdditionalAddressHints(): List<AddressHint> {
-        val event = this as Event
-        return event.tags.mapNotNull(ATag::parseAsHint)
-    }
+    private val event: Event get() = this as Event
 
-    override fun getAdditionalAddressIds(): List<String> {
-        val event = this as Event
-        return event.tags.mapNotNull(ATag::parseAddressId)
-    }
+    override fun getAdditionalAddressHints(): List<AddressHint> = event.tags.mapNotNull(ATag::parseAsHint)
+
+    override fun getAdditionalAddressIds(): List<String> = event.tags.mapNotNull(ATag::parseAddressId)
 }
 
 interface BasicHintProvider :

--- a/quartz/src/main/java/com/vitorpamplona/quartz/nip01Core/hints/HintProviders.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/nip01Core/hints/HintProviders.kt
@@ -179,3 +179,22 @@ interface ExtendedHintProvider : StandardHintProvider {
         return event.tags.mapNotNull(ATag::parseAddressId)
     }
 }
+
+interface BasicHintProvider :
+    EventHintProvider,
+    AddressHintProvider,
+    PubKeyHintProvider {
+    private val event: Event get() = this as Event
+
+    override fun eventHints(): List<EventIdHint> = event.tags.mapNotNull(ETag::parseAsHint)
+
+    override fun linkedEventIds(): List<HexKey> = event.tags.mapNotNull(ETag::parseId)
+
+    override fun addressHints(): List<AddressHint> = event.tags.mapNotNull(ATag::parseAsHint)
+
+    override fun linkedAddressIds(): List<String> = event.tags.mapNotNull(ATag::parseAddressId)
+
+    override fun pubKeyHints(): List<PubKeyHint> = event.tags.mapNotNull(PTag::parseAsHint)
+
+    override fun linkedPubKeys(): List<HexKey> = event.tags.mapNotNull(PTag::parseKey)
+}

--- a/quartz/src/main/java/com/vitorpamplona/quartz/nip10Notes/TextNoteEvent.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/nip10Notes/TextNoteEvent.kt
@@ -23,27 +23,12 @@ package com.vitorpamplona.quartz.nip10Notes
 import androidx.compose.runtime.Immutable
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
-import com.vitorpamplona.quartz.nip01Core.hints.AddressHintProvider
 import com.vitorpamplona.quartz.nip01Core.hints.EventHintBundle
-import com.vitorpamplona.quartz.nip01Core.hints.EventHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.PubKeyHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.types.AddressHint
-import com.vitorpamplona.quartz.nip01Core.hints.types.EventIdHint
-import com.vitorpamplona.quartz.nip01Core.hints.types.PubKeyHint
+import com.vitorpamplona.quartz.nip01Core.hints.ExtendedHintProvider
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
-import com.vitorpamplona.quartz.nip01Core.tags.addressables.ATag
-import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
-import com.vitorpamplona.quartz.nip10Notes.tags.MarkedETag
 import com.vitorpamplona.quartz.nip10Notes.tags.markedETags
 import com.vitorpamplona.quartz.nip10Notes.tags.prepareETagsAsReplyTo
 import com.vitorpamplona.quartz.nip14Subject.subject
-import com.vitorpamplona.quartz.nip18Reposts.quotes.QTag
-import com.vitorpamplona.quartz.nip19Bech32.addressHints
-import com.vitorpamplona.quartz.nip19Bech32.addressIds
-import com.vitorpamplona.quartz.nip19Bech32.eventHints
-import com.vitorpamplona.quartz.nip19Bech32.eventIds
-import com.vitorpamplona.quartz.nip19Bech32.pubKeyHints
-import com.vitorpamplona.quartz.nip19Bech32.pubKeys
 import com.vitorpamplona.quartz.nip31Alts.alt
 import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
@@ -57,57 +42,9 @@ class TextNoteEvent(
     content: String,
     sig: HexKey,
 ) : BaseThreadedEvent(id, pubKey, createdAt, KIND, tags, content, sig),
-    EventHintProvider,
-    AddressHintProvider,
-    PubKeyHintProvider,
+    ExtendedHintProvider,
     SearchableEvent {
     override fun indexableContent() = "Subject: " + subject() + "\n" + content
-
-    override fun eventHints(): List<EventIdHint> {
-        val eHints = tags.mapNotNull(MarkedETag::parseAsHint)
-        val qHints = tags.mapNotNull(QTag::parseEventAsHint)
-        val nip19Hints = citedNIP19().eventHints()
-
-        return eHints + qHints + nip19Hints
-    }
-
-    override fun linkedEventIds(): List<HexKey> {
-        val eHints = tags.mapNotNull(MarkedETag::parseId)
-        val qHints = tags.mapNotNull(QTag::parseEventId)
-        val nip19Hints = citedNIP19().eventIds()
-
-        return eHints + qHints + nip19Hints
-    }
-
-    override fun addressHints(): List<AddressHint> {
-        val aHints = tags.mapNotNull(ATag::parseAsHint)
-        val qHints = tags.mapNotNull(QTag::parseAddressAsHint)
-        val nip19Hints = citedNIP19().addressHints()
-
-        return aHints + qHints + nip19Hints
-    }
-
-    override fun linkedAddressIds(): List<String> {
-        val aHints = tags.mapNotNull(ATag::parseAddressId)
-        val qHints = tags.mapNotNull(QTag::parseAddressId)
-        val nip19Hints = citedNIP19().addressIds()
-
-        return aHints + qHints + nip19Hints
-    }
-
-    override fun pubKeyHints(): List<PubKeyHint> {
-        val pHints = tags.mapNotNull(PTag::parseAsHint)
-        val nip19Hints = citedNIP19().pubKeyHints()
-
-        return pHints + nip19Hints
-    }
-
-    override fun linkedPubKeys(): List<HexKey> {
-        val pHints = tags.mapNotNull(PTag::parseKey)
-        val nip19Hints = citedNIP19().pubKeys()
-
-        return pHints + nip19Hints
-    }
 
     companion object {
         const val KIND = 1

--- a/quartz/src/main/java/com/vitorpamplona/quartz/nip18Reposts/RepostEvent.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/nip18Reposts/RepostEvent.kt
@@ -25,9 +25,7 @@ import com.vitorpamplona.quartz.nip01Core.core.AddressableEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
-import com.vitorpamplona.quartz.nip01Core.hints.AddressHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.EventHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.PubKeyHintProvider
+import com.vitorpamplona.quartz.nip01Core.hints.BasicHintProvider
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.addressables.ATag
@@ -50,21 +48,7 @@ class RepostEvent(
     content: String,
     sig: HexKey,
 ) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
-    EventHintProvider,
-    PubKeyHintProvider,
-    AddressHintProvider {
-    override fun pubKeyHints() = tags.mapNotNull(PTag::parseAsHint)
-
-    override fun linkedPubKeys() = tags.mapNotNull(PTag::parseKey)
-
-    override fun eventHints() = tags.mapNotNull(ETag::parseAsHint)
-
-    override fun linkedEventIds() = tags.mapNotNull(ETag::parseId)
-
-    override fun addressHints() = tags.mapNotNull(ATag::parseAsHint)
-
-    override fun linkedAddressIds() = tags.mapNotNull(ATag::parseAddressId)
-
+    BasicHintProvider {
     fun boostedEvent() = tags.lastNotNullOfOrNull(ETag::parse)
 
     fun boostedATag() = tags.lastNotNullOfOrNull(ATag::parse)

--- a/quartz/src/main/java/com/vitorpamplona/quartz/nip23LongContent/LongTextNoteEvent.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/nip23LongContent/LongTextNoteEvent.kt
@@ -24,28 +24,15 @@ import androidx.compose.runtime.Immutable
 import com.vitorpamplona.quartz.nip01Core.core.AddressableEvent
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
-import com.vitorpamplona.quartz.nip01Core.hints.AddressHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.EventHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.PubKeyHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.types.AddressHint
-import com.vitorpamplona.quartz.nip01Core.hints.types.EventIdHint
-import com.vitorpamplona.quartz.nip01Core.hints.types.PubKeyHint
+import com.vitorpamplona.quartz.nip01Core.hints.ExtendedHintProvider
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.addressables.ATag
 import com.vitorpamplona.quartz.nip01Core.tags.addressables.Address
 import com.vitorpamplona.quartz.nip01Core.tags.dTags.dTag
 import com.vitorpamplona.quartz.nip01Core.tags.hashtags.hashtags
-import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip01Core.tags.publishedAt.PublishedAtProvider
 import com.vitorpamplona.quartz.nip10Notes.BaseThreadedEvent
-import com.vitorpamplona.quartz.nip18Reposts.quotes.QTag
-import com.vitorpamplona.quartz.nip19Bech32.addressHints
-import com.vitorpamplona.quartz.nip19Bech32.addressIds
-import com.vitorpamplona.quartz.nip19Bech32.eventHints
-import com.vitorpamplona.quartz.nip19Bech32.eventIds
-import com.vitorpamplona.quartz.nip19Bech32.pubKeyHints
-import com.vitorpamplona.quartz.nip19Bech32.pubKeys
 import com.vitorpamplona.quartz.nip22Comments.RootScope
 import com.vitorpamplona.quartz.nip23LongContent.tags.ImageTag
 import com.vitorpamplona.quartz.nip23LongContent.tags.PublishedAtTag
@@ -66,55 +53,11 @@ class LongTextNoteEvent(
     sig: HexKey,
 ) : BaseThreadedEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     AddressableEvent,
-    EventHintProvider,
-    PubKeyHintProvider,
-    AddressHintProvider,
+    ExtendedHintProvider,
     PublishedAtProvider,
     RootScope,
     SearchableEvent {
     override fun indexableContent() = "title: " + title() + "\nsummary: " + summary() + "\n" + content
-
-    override fun eventHints(): List<EventIdHint> {
-        val qHints = tags.mapNotNull(QTag::parseEventAsHint)
-        val nip19Hints = citedNIP19().eventHints()
-
-        return qHints + nip19Hints
-    }
-
-    override fun linkedEventIds(): List<HexKey> {
-        val qHints = tags.mapNotNull(QTag::parseEventId)
-        val nip19Hints = citedNIP19().eventIds()
-
-        return qHints + nip19Hints
-    }
-
-    override fun addressHints(): List<AddressHint> {
-        val qHints = tags.mapNotNull(QTag::parseAddressAsHint)
-        val nip19Hints = citedNIP19().addressHints()
-
-        return qHints + nip19Hints
-    }
-
-    override fun linkedAddressIds(): List<String> {
-        val qHints = tags.mapNotNull(QTag::parseAddressId)
-        val nip19Hints = citedNIP19().addressIds()
-
-        return qHints + nip19Hints
-    }
-
-    override fun pubKeyHints(): List<PubKeyHint> {
-        val pHints = tags.mapNotNull(PTag::parseAsHint)
-        val nip19Hints = citedNIP19().pubKeyHints()
-
-        return pHints + nip19Hints
-    }
-
-    override fun linkedPubKeys(): List<HexKey> {
-        val pHints = tags.mapNotNull(PTag::parseKey)
-        val nip19Hints = citedNIP19().pubKeys()
-
-        return pHints + nip19Hints
-    }
 
     override fun dTag() = tags.dTag()
 

--- a/quartz/src/main/java/com/vitorpamplona/quartz/nip28PublicChat/message/ChannelMessageEvent.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/nip28PublicChat/message/ChannelMessageEvent.kt
@@ -24,27 +24,12 @@ import androidx.compose.runtime.Immutable
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.core.tagArray
-import com.vitorpamplona.quartz.nip01Core.hints.AddressHintProvider
 import com.vitorpamplona.quartz.nip01Core.hints.EventHintBundle
-import com.vitorpamplona.quartz.nip01Core.hints.EventHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.PubKeyHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.types.AddressHint
-import com.vitorpamplona.quartz.nip01Core.hints.types.EventIdHint
-import com.vitorpamplona.quartz.nip01Core.hints.types.PubKeyHint
+import com.vitorpamplona.quartz.nip01Core.hints.ExtendedHintProvider
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
-import com.vitorpamplona.quartz.nip01Core.tags.addressables.ATag
 import com.vitorpamplona.quartz.nip01Core.tags.events.ETag
-import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip10Notes.BaseThreadedEvent
-import com.vitorpamplona.quartz.nip10Notes.tags.MarkedETag
 import com.vitorpamplona.quartz.nip10Notes.tags.markedETag
-import com.vitorpamplona.quartz.nip18Reposts.quotes.QTag
-import com.vitorpamplona.quartz.nip19Bech32.addressHints
-import com.vitorpamplona.quartz.nip19Bech32.addressIds
-import com.vitorpamplona.quartz.nip19Bech32.eventHints
-import com.vitorpamplona.quartz.nip19Bech32.eventIds
-import com.vitorpamplona.quartz.nip19Bech32.pubKeyHints
-import com.vitorpamplona.quartz.nip19Bech32.pubKeys
 import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelCreateEvent
 import com.vitorpamplona.quartz.nip28PublicChat.base.IsInPublicChatChannel
 import com.vitorpamplona.quartz.nip28PublicChat.base.channel
@@ -64,57 +49,9 @@ class ChannelMessageEvent(
 ) : BaseThreadedEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     IsInPublicChatChannel,
     ExposeInDraft,
-    EventHintProvider,
-    AddressHintProvider,
-    PubKeyHintProvider,
+    ExtendedHintProvider,
     SearchableEvent {
     override fun indexableContent() = content
-
-    override fun eventHints(): List<EventIdHint> {
-        val eHints = tags.mapNotNull(MarkedETag::parseAsHint)
-        val qHints = tags.mapNotNull(QTag::parseEventAsHint)
-        val nip19Hints = citedNIP19().eventHints()
-
-        return eHints + qHints + nip19Hints
-    }
-
-    override fun linkedEventIds(): List<HexKey> {
-        val eHints = tags.mapNotNull(MarkedETag::parseId)
-        val qHints = tags.mapNotNull(QTag::parseEventId)
-        val nip19Hints = citedNIP19().eventIds()
-
-        return eHints + qHints + nip19Hints
-    }
-
-    override fun addressHints(): List<AddressHint> {
-        val aHints = tags.mapNotNull(ATag::parseAsHint)
-        val qHints = tags.mapNotNull(QTag::parseAddressAsHint)
-        val nip19Hints = citedNIP19().addressHints()
-
-        return aHints + qHints + nip19Hints
-    }
-
-    override fun linkedAddressIds(): List<String> {
-        val aHints = tags.mapNotNull(ATag::parseAddressId)
-        val qHints = tags.mapNotNull(QTag::parseAddressId)
-        val nip19Hints = citedNIP19().addressIds()
-
-        return aHints + qHints + nip19Hints
-    }
-
-    override fun pubKeyHints(): List<PubKeyHint> {
-        val pHints = tags.mapNotNull(PTag::parseAsHint)
-        val nip19Hints = citedNIP19().pubKeyHints()
-
-        return pHints + nip19Hints
-    }
-
-    override fun linkedPubKeys(): List<HexKey> {
-        val pHints = tags.mapNotNull(PTag::parseKey)
-        val nip19Hints = citedNIP19().pubKeys()
-
-        return pHints + nip19Hints
-    }
 
     override fun channel() = markedRoot() ?: unmarkedRoot()
 

--- a/quartz/src/main/java/com/vitorpamplona/quartz/nip34Git/reply/GitReplyEvent.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/nip34Git/reply/GitReplyEvent.kt
@@ -23,28 +23,14 @@ package com.vitorpamplona.quartz.nip34Git.reply
 import androidx.compose.runtime.Immutable
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
-import com.vitorpamplona.quartz.nip01Core.hints.AddressHintProvider
+import com.vitorpamplona.quartz.nip01Core.hints.ETagHintProvider
 import com.vitorpamplona.quartz.nip01Core.hints.EventHintBundle
-import com.vitorpamplona.quartz.nip01Core.hints.EventHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.PubKeyHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.types.AddressHint
-import com.vitorpamplona.quartz.nip01Core.hints.types.EventIdHint
-import com.vitorpamplona.quartz.nip01Core.hints.types.PubKeyHint
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.addressables.ATag
-import com.vitorpamplona.quartz.nip01Core.tags.events.ETag
-import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip10Notes.BaseThreadedEvent
 import com.vitorpamplona.quartz.nip10Notes.tags.MarkedETag
 import com.vitorpamplona.quartz.nip10Notes.tags.markedETags
 import com.vitorpamplona.quartz.nip10Notes.tags.prepareMarkedETagsAsReplyTo
-import com.vitorpamplona.quartz.nip18Reposts.quotes.QTag
-import com.vitorpamplona.quartz.nip19Bech32.addressHints
-import com.vitorpamplona.quartz.nip19Bech32.addressIds
-import com.vitorpamplona.quartz.nip19Bech32.eventHints
-import com.vitorpamplona.quartz.nip19Bech32.eventIds
-import com.vitorpamplona.quartz.nip19Bech32.pubKeyHints
-import com.vitorpamplona.quartz.nip19Bech32.pubKeys
 import com.vitorpamplona.quartz.nip34Git.issue.GitIssueEvent
 import com.vitorpamplona.quartz.nip34Git.patch.GitPatchEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
@@ -60,55 +46,7 @@ class GitReplyEvent(
     content: String,
     sig: HexKey,
 ) : BaseThreadedEvent(id, pubKey, createdAt, KIND, tags, content, sig),
-    PubKeyHintProvider,
-    EventHintProvider,
-    AddressHintProvider {
-    override fun eventHints(): List<EventIdHint> {
-        val eHints = tags.mapNotNull(ETag::parseAsHint)
-        val qHints = tags.mapNotNull(QTag::parseEventAsHint)
-        val nip19Hints = citedNIP19().eventHints()
-
-        return eHints + qHints + nip19Hints
-    }
-
-    override fun linkedEventIds(): List<HexKey> {
-        val eHints = tags.mapNotNull(ETag::parseId)
-        val qHints = tags.mapNotNull(QTag::parseEventId)
-        val nip19Hints = citedNIP19().eventIds()
-
-        return eHints + qHints + nip19Hints
-    }
-
-    override fun addressHints(): List<AddressHint> {
-        val aHints = tags.mapNotNull(ATag::parseAsHint)
-        val qHints = tags.mapNotNull(QTag::parseAddressAsHint)
-        val nip19Hints = citedNIP19().addressHints()
-
-        return aHints + qHints + nip19Hints
-    }
-
-    override fun linkedAddressIds(): List<String> {
-        val aHints = tags.mapNotNull(ATag::parseAddressId)
-        val qHints = tags.mapNotNull(QTag::parseAddressId)
-        val nip19Hints = citedNIP19().addressIds()
-
-        return aHints + qHints + nip19Hints
-    }
-
-    override fun pubKeyHints(): List<PubKeyHint> {
-        val pHints = tags.mapNotNull(PTag::parseAsHint)
-        val nip19Hints = citedNIP19().pubKeyHints()
-
-        return pHints + nip19Hints
-    }
-
-    override fun linkedPubKeys(): List<HexKey> {
-        val pHints = tags.mapNotNull(PTag::parseKey)
-        val nip19Hints = citedNIP19().pubKeys()
-
-        return pHints + nip19Hints
-    }
-
+    ETagHintProvider {
     fun repositoryHex() = tags.firstNotNullOfOrNull(ATag::parseAddressId)
 
     fun repository() = tags.firstNotNullOfOrNull(ATag::parse)

--- a/quartz/src/main/java/com/vitorpamplona/quartz/nip35Torrents/TorrentCommentEvent.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/nip35Torrents/TorrentCommentEvent.kt
@@ -23,29 +23,16 @@ package com.vitorpamplona.quartz.nip35Torrents
 import androidx.compose.runtime.Immutable
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
-import com.vitorpamplona.quartz.nip01Core.hints.AddressHintProvider
 import com.vitorpamplona.quartz.nip01Core.hints.EventHintBundle
-import com.vitorpamplona.quartz.nip01Core.hints.EventHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.PubKeyHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.types.AddressHint
-import com.vitorpamplona.quartz.nip01Core.hints.types.EventIdHint
-import com.vitorpamplona.quartz.nip01Core.hints.types.PubKeyHint
+import com.vitorpamplona.quartz.nip01Core.hints.StandardHintProvider
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.events.ETag
 import com.vitorpamplona.quartz.nip01Core.tags.events.eTags
 import com.vitorpamplona.quartz.nip01Core.tags.events.taggedEvents
-import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip10Notes.BaseThreadedEvent
 import com.vitorpamplona.quartz.nip10Notes.tags.MarkedETag
 import com.vitorpamplona.quartz.nip10Notes.tags.positionalMarkedTags
-import com.vitorpamplona.quartz.nip18Reposts.quotes.QTag
-import com.vitorpamplona.quartz.nip19Bech32.addressHints
-import com.vitorpamplona.quartz.nip19Bech32.addressIds
-import com.vitorpamplona.quartz.nip19Bech32.eventHints
-import com.vitorpamplona.quartz.nip19Bech32.eventIds
-import com.vitorpamplona.quartz.nip19Bech32.pubKeyHints
-import com.vitorpamplona.quartz.nip19Bech32.pubKeys
 import com.vitorpamplona.quartz.nip31Alts.alt
 import com.vitorpamplona.quartz.utils.TimeUtils
 
@@ -59,53 +46,7 @@ class TorrentCommentEvent(
     content: String,
     sig: HexKey,
 ) : BaseThreadedEvent(id, pubKey, createdAt, KIND, tags, content, sig),
-    EventHintProvider,
-    PubKeyHintProvider,
-    AddressHintProvider {
-    override fun eventHints(): List<EventIdHint> {
-        val eHints = tags.mapNotNull(MarkedETag::parseAsHint)
-        val qHints = tags.mapNotNull(QTag::parseEventAsHint)
-        val nip19Hints = citedNIP19().eventHints()
-
-        return eHints + qHints + nip19Hints
-    }
-
-    override fun linkedEventIds(): List<HexKey> {
-        val eHints = tags.mapNotNull(MarkedETag::parseId)
-        val qHints = tags.mapNotNull(QTag::parseEventId)
-        val nip19Hints = citedNIP19().eventIds()
-
-        return eHints + qHints + nip19Hints
-    }
-
-    override fun addressHints(): List<AddressHint> {
-        val qHints = tags.mapNotNull(QTag::parseAddressAsHint)
-        val nip19Hints = citedNIP19().addressHints()
-
-        return qHints + nip19Hints
-    }
-
-    override fun linkedAddressIds(): List<String> {
-        val qHints = tags.mapNotNull(QTag::parseAddressId)
-        val nip19Hints = citedNIP19().addressIds()
-
-        return qHints + nip19Hints
-    }
-
-    override fun pubKeyHints(): List<PubKeyHint> {
-        val pHints = tags.mapNotNull(PTag::parseAsHint)
-        val nip19Hints = citedNIP19().pubKeyHints()
-
-        return pHints + nip19Hints
-    }
-
-    override fun linkedPubKeys(): List<HexKey> {
-        val pHints = tags.mapNotNull(PTag::parseKey)
-        val nip19Hints = citedNIP19().pubKeys()
-
-        return pHints + nip19Hints
-    }
-
+    StandardHintProvider {
     fun torrent() = tags.firstNotNullOfOrNull(MarkedETag::parseRoot) ?: tags.firstNotNullOfOrNull(ETag::parse)
 
     fun torrentIds() = tags.firstNotNullOfOrNull(MarkedETag::parseRootId) ?: tags.firstNotNullOfOrNull(ETag::parseId)

--- a/quartz/src/main/java/com/vitorpamplona/quartz/nip53LiveActivities/chat/LiveActivitiesChatMessageEvent.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/nip53LiveActivities/chat/LiveActivitiesChatMessageEvent.kt
@@ -24,27 +24,13 @@ import androidx.compose.runtime.Immutable
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.core.tagArray
-import com.vitorpamplona.quartz.nip01Core.hints.AddressHintProvider
+import com.vitorpamplona.quartz.nip01Core.hints.ETagHintProvider
 import com.vitorpamplona.quartz.nip01Core.hints.EventHintBundle
-import com.vitorpamplona.quartz.nip01Core.hints.EventHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.PubKeyHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.types.AddressHint
-import com.vitorpamplona.quartz.nip01Core.hints.types.EventIdHint
-import com.vitorpamplona.quartz.nip01Core.hints.types.PubKeyHint
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.addressables.ATag
 import com.vitorpamplona.quartz.nip01Core.tags.addressables.aTag
-import com.vitorpamplona.quartz.nip01Core.tags.events.ETag
-import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip10Notes.BaseThreadedEvent
 import com.vitorpamplona.quartz.nip10Notes.tags.markedETag
-import com.vitorpamplona.quartz.nip18Reposts.quotes.QTag
-import com.vitorpamplona.quartz.nip19Bech32.addressHints
-import com.vitorpamplona.quartz.nip19Bech32.addressIds
-import com.vitorpamplona.quartz.nip19Bech32.eventHints
-import com.vitorpamplona.quartz.nip19Bech32.eventIds
-import com.vitorpamplona.quartz.nip19Bech32.pubKeyHints
-import com.vitorpamplona.quartz.nip19Bech32.pubKeys
 import com.vitorpamplona.quartz.nip37Drafts.ExposeInDraft
 import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip53LiveActivities.streaming.LiveActivitiesEvent
@@ -59,58 +45,10 @@ class LiveActivitiesChatMessageEvent(
     content: String,
     sig: HexKey,
 ) : BaseThreadedEvent(id, pubKey, createdAt, KIND, tags, content, sig),
-    EventHintProvider,
-    PubKeyHintProvider,
-    AddressHintProvider,
+    ETagHintProvider,
     ExposeInDraft,
     SearchableEvent {
     override fun indexableContent() = content
-
-    override fun eventHints(): List<EventIdHint> {
-        val eHints = tags.mapNotNull(ETag::parseAsHint)
-        val qHints = tags.mapNotNull(QTag::parseEventAsHint)
-        val nip19Hints = citedNIP19().eventHints()
-
-        return eHints + qHints + nip19Hints
-    }
-
-    override fun linkedEventIds(): List<HexKey> {
-        val eHints = tags.mapNotNull(ETag::parseId)
-        val qHints = tags.mapNotNull(QTag::parseEventId)
-        val nip19Hints = citedNIP19().eventIds()
-
-        return eHints + qHints + nip19Hints
-    }
-
-    override fun addressHints(): List<AddressHint> {
-        val aHints = tags.mapNotNull(ATag::parseAsHint)
-        val qHints = tags.mapNotNull(QTag::parseAddressAsHint)
-        val nip19Hints = citedNIP19().addressHints()
-
-        return aHints + qHints + nip19Hints
-    }
-
-    override fun linkedAddressIds(): List<String> {
-        val aHints = tags.mapNotNull(ATag::parseAddressId)
-        val qHints = tags.mapNotNull(QTag::parseAddressId)
-        val nip19Hints = citedNIP19().addressIds()
-
-        return aHints + qHints + nip19Hints
-    }
-
-    override fun pubKeyHints(): List<PubKeyHint> {
-        val pHints = tags.mapNotNull(PTag::parseAsHint)
-        val nip19Hints = citedNIP19().pubKeyHints()
-
-        return pHints + nip19Hints
-    }
-
-    override fun linkedPubKeys(): List<HexKey> {
-        val pHints = tags.mapNotNull(PTag::parseKey)
-        val nip19Hints = citedNIP19().pubKeys()
-
-        return pHints + nip19Hints
-    }
 
     private fun activityHex() = tags.firstNotNullOfOrNull(ATag::parseAddressId)
 

--- a/quartz/src/main/java/com/vitorpamplona/quartz/nip54Wiki/WikiNoteEvent.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/nip54Wiki/WikiNoteEvent.kt
@@ -23,29 +23,15 @@ package com.vitorpamplona.quartz.nip54Wiki
 import androidx.compose.runtime.Immutable
 import com.vitorpamplona.quartz.nip01Core.core.AddressableEvent
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
-import com.vitorpamplona.quartz.nip01Core.hints.AddressHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.EventHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.PubKeyHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.types.AddressHint
-import com.vitorpamplona.quartz.nip01Core.hints.types.EventIdHint
-import com.vitorpamplona.quartz.nip01Core.hints.types.PubKeyHint
+import com.vitorpamplona.quartz.nip01Core.hints.ExtendedHintProvider
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import com.vitorpamplona.quartz.nip01Core.tags.addressables.ATag
 import com.vitorpamplona.quartz.nip01Core.tags.addressables.Address
 import com.vitorpamplona.quartz.nip01Core.tags.dTags.dTag
 import com.vitorpamplona.quartz.nip01Core.tags.hashtags.hashtags
-import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip01Core.tags.publishedAt.PublishedAtProvider
 import com.vitorpamplona.quartz.nip10Notes.BaseThreadedEvent
-import com.vitorpamplona.quartz.nip10Notes.tags.MarkedETag
-import com.vitorpamplona.quartz.nip18Reposts.quotes.QTag
-import com.vitorpamplona.quartz.nip19Bech32.addressHints
-import com.vitorpamplona.quartz.nip19Bech32.addressIds
-import com.vitorpamplona.quartz.nip19Bech32.eventHints
-import com.vitorpamplona.quartz.nip19Bech32.eventIds
-import com.vitorpamplona.quartz.nip19Bech32.pubKeyHints
-import com.vitorpamplona.quartz.nip19Bech32.pubKeys
 import com.vitorpamplona.quartz.nip31Alts.AltTag
 import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
@@ -60,58 +46,10 @@ class WikiNoteEvent(
     sig: HexKey,
 ) : BaseThreadedEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     AddressableEvent,
-    EventHintProvider,
-    AddressHintProvider,
-    PubKeyHintProvider,
+    ExtendedHintProvider,
     PublishedAtProvider,
     SearchableEvent {
     override fun indexableContent() = "title: " + title() + "\nsummary: " + summary() + "\n" + content
-
-    override fun eventHints(): List<EventIdHint> {
-        val eHints = tags.mapNotNull(MarkedETag::parseAsHint)
-        val qHints = tags.mapNotNull(QTag::parseEventAsHint)
-        val nip19Hints = citedNIP19().eventHints()
-
-        return eHints + qHints + nip19Hints
-    }
-
-    override fun linkedEventIds(): List<HexKey> {
-        val eHints = tags.mapNotNull(MarkedETag::parseId)
-        val qHints = tags.mapNotNull(QTag::parseEventId)
-        val nip19Hints = citedNIP19().eventIds()
-
-        return eHints + qHints + nip19Hints
-    }
-
-    override fun addressHints(): List<AddressHint> {
-        val aHints = tags.mapNotNull(ATag::parseAsHint)
-        val qHints = tags.mapNotNull(QTag::parseAddressAsHint)
-        val nip19Hints = citedNIP19().addressHints()
-
-        return aHints + qHints + nip19Hints
-    }
-
-    override fun linkedAddressIds(): List<String> {
-        val aHints = tags.mapNotNull(ATag::parseAddressId)
-        val qHints = tags.mapNotNull(QTag::parseAddressId)
-        val nip19Hints = citedNIP19().addressIds()
-
-        return aHints + qHints + nip19Hints
-    }
-
-    override fun pubKeyHints(): List<PubKeyHint> {
-        val pHints = tags.mapNotNull(PTag::parseAsHint)
-        val nip19Hints = citedNIP19().pubKeyHints()
-
-        return pHints + nip19Hints
-    }
-
-    override fun linkedPubKeys(): List<HexKey> {
-        val pHints = tags.mapNotNull(PTag::parseKey)
-        val nip19Hints = citedNIP19().pubKeys()
-
-        return pHints + nip19Hints
-    }
 
     override fun dTag() = tags.dTag()
 

--- a/quartz/src/main/java/com/vitorpamplona/quartz/nip57Zaps/LnZapEvent.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/nip57Zaps/LnZapEvent.kt
@@ -26,10 +26,7 @@ import com.vitorpamplona.quartz.experimental.zapPolls.tags.PollOptionTag
 import com.vitorpamplona.quartz.lightning.LnInvoiceUtil
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
-import com.vitorpamplona.quartz.nip01Core.hints.AddressHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.EventHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.PubKeyHintProvider
-import com.vitorpamplona.quartz.nip01Core.tags.addressables.ATag
+import com.vitorpamplona.quartz.nip01Core.hints.BasicHintProvider
 import com.vitorpamplona.quartz.nip01Core.tags.events.ETag
 import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.utils.pointerSizeInBytes
@@ -44,21 +41,7 @@ class LnZapEvent(
     sig: HexKey,
 ) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
     LnZapEventInterface,
-    EventHintProvider,
-    AddressHintProvider,
-    PubKeyHintProvider {
-    override fun pubKeyHints() = tags.mapNotNull(PTag::parseAsHint)
-
-    override fun linkedPubKeys() = tags.mapNotNull(PTag::parseKey)
-
-    override fun eventHints() = tags.mapNotNull(ETag::parseAsHint)
-
-    override fun linkedEventIds() = tags.mapNotNull(ETag::parseId)
-
-    override fun addressHints() = tags.mapNotNull(ATag::parseAsHint)
-
-    override fun linkedAddressIds() = tags.mapNotNull(ATag::parseAddressId)
-
+    BasicHintProvider {
     // This event is also kept in LocalCache (same object)
     @Transient val zapRequest: LnZapRequestEvent?
 

--- a/quartz/src/main/java/com/vitorpamplona/quartz/nip57Zaps/LnZapPrivateEvent.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/nip57Zaps/LnZapPrivateEvent.kt
@@ -23,14 +23,9 @@ package com.vitorpamplona.quartz.nip57Zaps
 import androidx.compose.runtime.Immutable
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
-import com.vitorpamplona.quartz.nip01Core.hints.AddressHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.EventHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.PubKeyHintProvider
+import com.vitorpamplona.quartz.nip01Core.hints.BasicHintProvider
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerSync
-import com.vitorpamplona.quartz.nip01Core.tags.addressables.ATag
-import com.vitorpamplona.quartz.nip01Core.tags.events.ETag
-import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 @Immutable
@@ -42,21 +37,7 @@ class LnZapPrivateEvent(
     content: String,
     sig: HexKey,
 ) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
-    EventHintProvider,
-    AddressHintProvider,
-    PubKeyHintProvider {
-    override fun pubKeyHints() = tags.mapNotNull(PTag::parseAsHint)
-
-    override fun linkedPubKeys() = tags.mapNotNull(PTag::parseKey)
-
-    override fun eventHints() = tags.mapNotNull(ETag::parseAsHint)
-
-    override fun linkedEventIds() = tags.mapNotNull(ETag::parseId)
-
-    override fun addressHints() = tags.mapNotNull(ATag::parseAsHint)
-
-    override fun linkedAddressIds() = tags.mapNotNull(ATag::parseAddressId)
-
+    BasicHintProvider {
     companion object {
         const val KIND = 9733
         const val ALT = "Private zap"

--- a/quartz/src/main/java/com/vitorpamplona/quartz/nip58Badges/BadgeAwardEvent.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/nip58Badges/BadgeAwardEvent.kt
@@ -23,13 +23,8 @@ package com.vitorpamplona.quartz.nip58Badges
 import androidx.compose.runtime.Immutable
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
-import com.vitorpamplona.quartz.nip01Core.hints.AddressHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.EventHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.PubKeyHintProvider
-import com.vitorpamplona.quartz.nip01Core.tags.addressables.ATag
+import com.vitorpamplona.quartz.nip01Core.hints.BasicHintProvider
 import com.vitorpamplona.quartz.nip01Core.tags.addressables.taggedAddresses
-import com.vitorpamplona.quartz.nip01Core.tags.events.ETag
-import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip01Core.tags.people.taggedUserIds
 import com.vitorpamplona.quartz.nip01Core.tags.people.taggedUsers
 
@@ -42,21 +37,7 @@ class BadgeAwardEvent(
     content: String,
     sig: HexKey,
 ) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
-    EventHintProvider,
-    AddressHintProvider,
-    PubKeyHintProvider {
-    override fun pubKeyHints() = tags.mapNotNull(PTag::parseAsHint)
-
-    override fun linkedPubKeys() = tags.mapNotNull(PTag::parseKey)
-
-    override fun eventHints() = tags.mapNotNull(ETag::parseAsHint)
-
-    override fun linkedEventIds() = tags.mapNotNull(ETag::parseId)
-
-    override fun addressHints() = tags.mapNotNull(ATag::parseAsHint)
-
-    override fun linkedAddressIds() = tags.mapNotNull(ATag::parseAddressId)
-
+    BasicHintProvider {
     fun awardees() = taggedUsers()
 
     fun awardeeIds() = taggedUserIds()

--- a/quartz/src/main/java/com/vitorpamplona/quartz/nip58Badges/BadgeProfilesEvent.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/nip58Badges/BadgeProfilesEvent.kt
@@ -23,15 +23,11 @@ package com.vitorpamplona.quartz.nip58Badges
 import androidx.compose.runtime.Immutable
 import com.vitorpamplona.quartz.nip01Core.core.BaseAddressableEvent
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
-import com.vitorpamplona.quartz.nip01Core.hints.AddressHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.EventHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.PubKeyHintProvider
+import com.vitorpamplona.quartz.nip01Core.hints.BasicHintProvider
 import com.vitorpamplona.quartz.nip01Core.tags.addressables.ATag
 import com.vitorpamplona.quartz.nip01Core.tags.addressables.Address
 import com.vitorpamplona.quartz.nip01Core.tags.addressables.taggedAddresses
-import com.vitorpamplona.quartz.nip01Core.tags.events.ETag
 import com.vitorpamplona.quartz.nip01Core.tags.events.taggedEvents
-import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 
 @Immutable
 class BadgeProfilesEvent(
@@ -42,21 +38,7 @@ class BadgeProfilesEvent(
     content: String,
     sig: HexKey,
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
-    EventHintProvider,
-    AddressHintProvider,
-    PubKeyHintProvider {
-    override fun pubKeyHints() = tags.mapNotNull(PTag::parseAsHint)
-
-    override fun linkedPubKeys() = tags.mapNotNull(PTag::parseKey)
-
-    override fun eventHints() = tags.mapNotNull(ETag::parseAsHint)
-
-    override fun linkedEventIds() = tags.mapNotNull(ETag::parseId)
-
-    override fun addressHints() = tags.mapNotNull(ATag::parseAsHint)
-
-    override fun linkedAddressIds() = tags.mapNotNull(ATag::parseAddressId)
-
+    BasicHintProvider {
     fun badgeAwardEvents() = taggedEvents()
 
     fun badgeAwardDefinitions() = taggedAddresses()

--- a/quartz/src/main/java/com/vitorpamplona/quartz/nip75ZapGoals/GoalEvent.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/nip75ZapGoals/GoalEvent.kt
@@ -26,15 +26,10 @@ import com.vitorpamplona.quartz.nip01Core.core.BaseAddressableEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
-import com.vitorpamplona.quartz.nip01Core.hints.AddressHintProvider
+import com.vitorpamplona.quartz.nip01Core.hints.BasicHintProvider
 import com.vitorpamplona.quartz.nip01Core.hints.EventHintBundle
-import com.vitorpamplona.quartz.nip01Core.hints.EventHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.PubKeyHintProvider
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
-import com.vitorpamplona.quartz.nip01Core.tags.addressables.ATag
-import com.vitorpamplona.quartz.nip01Core.tags.events.ETag
 import com.vitorpamplona.quartz.nip01Core.tags.hashtags.hashtags
-import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip01Core.tags.references.reference
 import com.vitorpamplona.quartz.nip23LongContent.tags.ImageTag
 import com.vitorpamplona.quartz.nip23LongContent.tags.SummaryTag
@@ -53,21 +48,7 @@ class GoalEvent(
     content: String,
     sig: HexKey,
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
-    EventHintProvider,
-    AddressHintProvider,
-    PubKeyHintProvider {
-    override fun pubKeyHints() = tags.mapNotNull(PTag::parseAsHint)
-
-    override fun linkedPubKeys() = tags.mapNotNull(PTag::parseKey)
-
-    override fun eventHints() = tags.mapNotNull(ETag::parseAsHint)
-
-    override fun linkedEventIds() = tags.mapNotNull(ETag::parseId)
-
-    override fun addressHints() = tags.mapNotNull(ATag::parseAsHint)
-
-    override fun linkedAddressIds() = tags.mapNotNull(ATag::parseAddressId)
-
+    BasicHintProvider {
     fun topics() = hashtags()
 
     fun image() = tags.firstNotNullOfOrNull(ImageTag::parse)

--- a/quartz/src/main/java/com/vitorpamplona/quartz/nip84Highlights/HighlightEvent.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/nip84Highlights/HighlightEvent.kt
@@ -22,29 +22,14 @@ package com.vitorpamplona.quartz.nip84Highlights
 
 import androidx.compose.runtime.Immutable
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
-import com.vitorpamplona.quartz.nip01Core.hints.AddressHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.EventHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.PubKeyHintProvider
-import com.vitorpamplona.quartz.nip01Core.hints.types.AddressHint
-import com.vitorpamplona.quartz.nip01Core.hints.types.EventIdHint
-import com.vitorpamplona.quartz.nip01Core.hints.types.PubKeyHint
+import com.vitorpamplona.quartz.nip01Core.hints.ETagHintProvider
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
-import com.vitorpamplona.quartz.nip01Core.tags.addressables.ATag
 import com.vitorpamplona.quartz.nip01Core.tags.addressables.firstTaggedATag
 import com.vitorpamplona.quartz.nip01Core.tags.addressables.firstTaggedAddress
-import com.vitorpamplona.quartz.nip01Core.tags.events.ETag
 import com.vitorpamplona.quartz.nip01Core.tags.events.firstTaggedEvent
-import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip01Core.tags.people.firstTaggedUser
 import com.vitorpamplona.quartz.nip01Core.tags.references.ReferenceTag
 import com.vitorpamplona.quartz.nip10Notes.BaseThreadedEvent
-import com.vitorpamplona.quartz.nip18Reposts.quotes.QTag
-import com.vitorpamplona.quartz.nip19Bech32.addressHints
-import com.vitorpamplona.quartz.nip19Bech32.addressIds
-import com.vitorpamplona.quartz.nip19Bech32.eventHints
-import com.vitorpamplona.quartz.nip19Bech32.eventIds
-import com.vitorpamplona.quartz.nip19Bech32.pubKeyHints
-import com.vitorpamplona.quartz.nip19Bech32.pubKeys
 import com.vitorpamplona.quartz.nip22Comments.RootScope
 import com.vitorpamplona.quartz.nip31Alts.AltTag
 import com.vitorpamplona.quartz.nip50Search.SearchableEvent
@@ -62,57 +47,9 @@ class HighlightEvent(
     sig: HexKey,
 ) : BaseThreadedEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     RootScope,
-    EventHintProvider,
-    AddressHintProvider,
-    PubKeyHintProvider,
+    ETagHintProvider,
     SearchableEvent {
     override fun indexableContent() = "comment: " + comment() + "\ncontext: " + context() + "\n" + content
-
-    override fun eventHints(): List<EventIdHint> {
-        val eHints = tags.mapNotNull(ETag::parseAsHint)
-        val qHints = tags.mapNotNull(QTag::parseEventAsHint)
-        val nip19Hints = citedNIP19().eventHints()
-
-        return eHints + qHints + nip19Hints
-    }
-
-    override fun linkedEventIds(): List<HexKey> {
-        val eHints = tags.mapNotNull(ETag::parseId)
-        val qHints = tags.mapNotNull(QTag::parseEventId)
-        val nip19Hints = citedNIP19().eventIds()
-
-        return eHints + qHints + nip19Hints
-    }
-
-    override fun addressHints(): List<AddressHint> {
-        val aHints = tags.mapNotNull(ATag::parseAsHint)
-        val qHints = tags.mapNotNull(QTag::parseAddressAsHint)
-        val nip19Hints = citedNIP19().addressHints()
-
-        return aHints + qHints + nip19Hints
-    }
-
-    override fun linkedAddressIds(): List<String> {
-        val aHints = tags.mapNotNull(ATag::parseAddressId)
-        val qHints = tags.mapNotNull(QTag::parseAddressId)
-        val nip19Hints = citedNIP19().addressIds()
-
-        return aHints + qHints + nip19Hints
-    }
-
-    override fun pubKeyHints(): List<PubKeyHint> {
-        val pHints = tags.mapNotNull(PTag::parseAsHint)
-        val nip19Hints = citedNIP19().pubKeyHints()
-
-        return pHints + nip19Hints
-    }
-
-    override fun linkedPubKeys(): List<HexKey> {
-        val pHints = tags.mapNotNull(PTag::parseKey)
-        val nip19Hints = citedNIP19().pubKeys()
-
-        return pHints + nip19Hints
-    }
 
     fun inUrl() = tags.firstNotNullOfOrNull(ReferenceTag::parse)
 


### PR DESCRIPTION
There is duplicated code in the various hint providers. I was able to identify four patterns that allowed me to extract the most common code into the existing HintProviders interface that the various hint providers can now implement.

514 lines of duplicate code removed. Smaller byte code and also now a single point of change should it be needed.

New hint providers (interfaces) with common logic:
- BasicHintProvider: For simple events extending Event directly
- StandardHintProvider: For threaded events using MarkedETag 
- ExtendedHintProvider: Adds ATag support to StandardHintProvider
- ETagHintProvider: For events using ETag 

Performance: should be identical performance since no logic was changed (expect additional casting to make the logic general). Smaller byte code due to less duplicate code (514 loc removed).

Testing: testing on device for a few days. Please let me know if you'd like to see tests added and run before and after changes.

No profiling done but the logic is identical.