### PR TITLE
Use explicit field annotation target for constructor params

### DIFF
--- a/quartz/src/androidTest/java/com/vitorpamplona/quartz/nip44Encryption/TestPackageClasses.kt
+++ b/quartz/src/androidTest/java/com/vitorpamplona/quartz/nip44Encryption/TestPackageClasses.kt
@@ -32,61 +32,59 @@ data class V2(
 )
 
 data class Valid(
-    @JsonProperty("get_conversation_key")
-    val getConversationKey: ArrayList<GetConversationKey> = arrayListOf(),
-    @JsonProperty("get_message_keys") val getMessageKeys: GetMessageKeys? = GetMessageKeys(),
-    @JsonProperty("calc_padded_len") val calcPaddedLen: ArrayList<ArrayList<Int>> = arrayListOf(),
-    @JsonProperty("encrypt_decrypt") val encryptDecrypt: ArrayList<EncryptDecrypt> = arrayListOf(),
-    @JsonProperty("encrypt_decrypt_long_msg")
+    @field:JsonProperty("get_conversation_key") val getConversationKey: ArrayList<GetConversationKey> = arrayListOf(),
+    @field:JsonProperty("get_message_keys") val getMessageKeys: GetMessageKeys? = GetMessageKeys(),
+    @field:JsonProperty("calc_padded_len") val calcPaddedLen: ArrayList<ArrayList<Int>> = arrayListOf(),
+    @field:JsonProperty("encrypt_decrypt") val encryptDecrypt: ArrayList<EncryptDecrypt> = arrayListOf(),
+    @field:JsonProperty("encrypt_decrypt_long_msg")
     val encryptDecryptLongMsg: ArrayList<EncryptDecryptLongMsg> = arrayListOf(),
 )
 
 data class Invalid(
-    @JsonProperty("encrypt_msg_lengths") val encryptMsgLengths: ArrayList<Int> = arrayListOf(),
-    @JsonProperty("get_conversation_key")
-    val getConversationKey: ArrayList<GetConversationKey> = arrayListOf(),
-    @JsonProperty("decrypt") val decrypt: ArrayList<Decrypt> = arrayListOf(),
+    @field:JsonProperty("encrypt_msg_lengths") val encryptMsgLengths: ArrayList<Int> = arrayListOf(),
+    @field:JsonProperty("get_conversation_key") val getConversationKey: ArrayList<GetConversationKey> = arrayListOf(),
+    @field:JsonProperty("decrypt") val decrypt: ArrayList<Decrypt> = arrayListOf(),
 )
 
 data class GetConversationKey(
     val sec1: String? = null,
     val pub2: String? = null,
     val note: String? = null,
-    @JsonProperty("conversation_key") val conversationKey: String? = null,
+    @field:JsonProperty("conversation_key") val conversationKey: String? = null,
 )
 
 data class GetMessageKeys(
-    @JsonProperty("conversation_key") val conversationKey: String? = null,
+    @field:JsonProperty("conversation_key") val conversationKey: String? = null,
     val keys: ArrayList<Keys> = arrayListOf(),
 )
 
 data class Keys(
-    @JsonProperty("nonce") val nonce: String? = null,
-    @JsonProperty("chacha_key") val chachaKey: String? = null,
-    @JsonProperty("chacha_nonce") val chachaNonce: String? = null,
-    @JsonProperty("hmac_key") val hmacKey: String? = null,
+    @field:JsonProperty("nonce") val nonce: String? = null,
+    @field:JsonProperty("chacha_key") val chachaKey: String? = null,
+    @field:JsonProperty("chacha_nonce") val chachaNonce: String? = null,
+    @field:JsonProperty("hmac_key") val hmacKey: String? = null,
 )
 
 data class EncryptDecrypt(
     val sec1: String? = null,
     val sec2: String? = null,
-    @JsonProperty("conversation_key") val conversationKey: String? = null,
+    @field:JsonProperty("conversation_key") val conversationKey: String? = null,
     val nonce: String? = null,
     val plaintext: String? = null,
     val payload: String? = null,
 )
 
 data class EncryptDecryptLongMsg(
-    @JsonProperty("conversation_key") val conversationKey: String? = null,
+    @field:JsonProperty("conversation_key") val conversationKey: String? = null,
     val nonce: String? = null,
     val pattern: String? = null,
     val repeat: Int? = null,
-    @JsonProperty("plaintext_sha256") val plaintextSha256: String? = null,
-    @JsonProperty("payload_sha256") val payloadSha256: String? = null,
+    @field:JsonProperty("plaintext_sha256") val plaintextSha256: String? = null,
+    @field:JsonProperty("payload_sha256") val payloadSha256: String? = null,
 )
 
 data class Decrypt(
-    @JsonProperty("conversation_key") val conversationKey: String? = null,
+    @field:JsonProperty("conversation_key") val conversationKey: String? = null,
     val nonce: String? = null,
     val plaintext: String? = null,
     val payload: String? = null,

--- a/quartz/src/main/java/com/vitorpamplona/quartz/experimental/limits/Limits.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/experimental/limits/Limits.kt
@@ -23,36 +23,20 @@ package com.vitorpamplona.quartz.experimental.limits
 import com.fasterxml.jackson.annotation.JsonProperty
 
 class Limits(
-    @JsonProperty("can_write")
-    val canWrite: Boolean?,
-    @JsonProperty("can_read")
-    val canRead: Boolean?,
-    @JsonProperty("accepted_event_kinds")
-    val acceptedEventKinds: Set<Int>?,
-    @JsonProperty("blocked_event_kinds")
-    val blockedEventKinds: Set<Int>?,
-    @JsonProperty("min_pow_difficulty")
-    val minPoW: Int?,
-    @JsonProperty("max_message_length")
-    val maxMessageLength: Int?,
-    @JsonProperty("max_subscriptions")
-    val maxSubscriptions: Int?,
-    @JsonProperty("max_filters")
-    val maxFilters: Int?,
-    @JsonProperty("max_limit")
-    val maxLimit: Int?,
-    @JsonProperty("max_event_tags")
-    val maxEventTags: Int?,
-    @JsonProperty("max_content_length")
-    val maxContentLength: Int?,
-    @JsonProperty("created_at_msecs_ago")
-    val createdAtMillisecsAgo: Long?,
-    @JsonProperty("created_at_msecs_ahead")
-    val createdAtMillisecsAhead: Long?,
-    @JsonProperty("filter_rate_limit")
-    val filterRateLimit: Long?,
-    @JsonProperty("publishing_rate_limit")
-    val publishingRateLimit: Long?,
-    @JsonProperty("required_tags")
-    val requiredTags: Array<Array<String>>?,
+    @field:JsonProperty("can_write") val canWrite: Boolean?,
+    @field:JsonProperty("can_read") val canRead: Boolean?,
+    @field:JsonProperty("accepted_event_kinds") val acceptedEventKinds: Set<Int>?,
+    @field:JsonProperty("blocked_event_kinds") val blockedEventKinds: Set<Int>?,
+    @field:JsonProperty("min_pow_difficulty") val minPoW: Int?,
+    @field:JsonProperty("max_message_length") val maxMessageLength: Int?,
+    @field:JsonProperty("max_subscriptions") val maxSubscriptions: Int?,
+    @field:JsonProperty("max_filters") val maxFilters: Int?,
+    @field:JsonProperty("max_limit") val maxLimit: Int?,
+    @field:JsonProperty("max_event_tags") val maxEventTags: Int?,
+    @field:JsonProperty("max_content_length") val maxContentLength: Int?,
+    @field:JsonProperty("created_at_msecs_ago") val createdAtMillisecsAgo: Long?,
+    @field:JsonProperty("created_at_msecs_ahead") val createdAtMillisecsAhead: Long?,
+    @field:JsonProperty("filter_rate_limit") val filterRateLimit: Long?,
+    @field:JsonProperty("publishing_rate_limit") val publishingRateLimit: Long?,
+    @field:JsonProperty("required_tags") val requiredTags: Array<Array<String>>?,
 )

--- a/quartz/src/main/java/com/vitorpamplona/quartz/nip01Core/signers/EventTemplate.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/nip01Core/signers/EventTemplate.kt
@@ -30,7 +30,7 @@ import com.vitorpamplona.quartz.nip01Core.jackson.JsonMapper
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 class EventTemplate<T : Event>(
-    @JsonProperty("created_at")
+    @field:JsonProperty("created_at")
     val createdAt: Long,
     val kind: Int,
     val tags: TagArray,

--- a/quartz/src/main/java/com/vitorpamplona/quartz/nip47WalletConnect/Response.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/nip47WalletConnect/Response.kt
@@ -26,7 +26,7 @@ import com.vitorpamplona.quartz.utils.pointerSizeInBytes
 
 // RESPONSE OBJECTS
 abstract class Response(
-    @JsonProperty("result_type") val resultType: String,
+    @field:JsonProperty("result_type") val resultType: String,
 ) {
     abstract fun countMemory(): Long
 }

--- a/quartz/src/main/java/com/vitorpamplona/quartz/nip59Giftwrap/rumors/Rumor.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/nip59Giftwrap/rumors/Rumor.kt
@@ -30,8 +30,8 @@ import com.vitorpamplona.quartz.nip59Giftwrap.seals.SealedRumorEvent
 
 class Rumor(
     val id: HexKey?,
-    @JsonProperty("pubkey") val pubKey: HexKey?,
-    @JsonProperty("created_at") val createdAt: Long?,
+    @field:JsonProperty("pubkey") val pubKey: HexKey?,
+    @field:JsonProperty("created_at") val createdAt: Long?,
     val kind: Int?,
     val tags: Array<Array<String>>?,
     val content: String?,

--- a/quartz/src/main/java/com/vitorpamplona/quartz/nip96FileStorage/actions/UploadResult.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/nip96FileStorage/actions/UploadResult.kt
@@ -27,11 +27,9 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 data class UploadResult(
     val status: String? = null,
     val message: String? = null,
-    @JsonProperty("processing_url")
-    val processingUrl: String? = null,
+    @field:JsonProperty("processing_url") val processingUrl: String? = null,
     val percentage: Int? = null,
-    @JsonProperty("nip94_event")
-    val nip94Event: PartialEvent? = null,
+    @field:JsonProperty("nip94_event") val nip94Event: PartialEvent? = null,
 ) {
     companion object {
         fun parse(body: String): UploadResult {

--- a/quartz/src/main/java/com/vitorpamplona/quartz/nip96FileStorage/info/ServerInfo.kt
+++ b/quartz/src/main/java/com/vitorpamplona/quartz/nip96FileStorage/info/ServerInfo.kt
@@ -27,33 +27,20 @@ typealias PlanName = String
 typealias MimeType = String
 
 data class ServerInfo(
-    @JsonProperty("api_url")
-    val apiUrl: String,
-    @JsonProperty("download_url")
-    val downloadUrl: String? = null,
-    @JsonProperty("delegated_to_url")
-    val delegatedToUrl: String? = null,
-    @JsonProperty("supported_nips")
-    val supportedNips: ArrayList<Int> = arrayListOf(),
-    @JsonProperty("tos_url") val
-    tosUrl: String? = null,
-    @JsonProperty("content_types") val
-    contentTypes: ArrayList<MimeType> = arrayListOf(),
-    @JsonProperty("plans") val
-    plans: Map<PlanName, Plan> = mapOf(),
+    @field:JsonProperty("api_url") val apiUrl: String,
+    @field:JsonProperty("download_url") val downloadUrl: String? = null,
+    @field:JsonProperty("delegated_to_url") val delegatedToUrl: String? = null,
+    @field:JsonProperty("supported_nips") val supportedNips: ArrayList<Int> = arrayListOf(),
+    @field:JsonProperty("tos_url") val tosUrl: String? = null,
+    @field:JsonProperty("content_types") val contentTypes: ArrayList<MimeType> = arrayListOf(),
+    @field:JsonProperty("plans") val plans: Map<PlanName, Plan> = mapOf(),
 )
 
 data class Plan(
-    @JsonProperty("name") val
-    name: String? = null,
-    @JsonProperty("is_nip98_required") val
-    isNip98Required: Boolean? = null,
-    @JsonProperty("url") val
-    url: String? = null,
-    @JsonProperty("max_byte_size") val
-    maxByteSize: Long? = null,
-    @JsonProperty("file_expiration") val
-    fileExpiration: ArrayList<Int> = arrayListOf(),
-    @JsonProperty("media_transformations")
-    val mediaTransformations: Map<MimeType, Array<String>> = emptyMap(),
+    @field:JsonProperty("name") val name: String? = null,
+    @field:JsonProperty("is_nip98_required") val isNip98Required: Boolean? = null,
+    @field:JsonProperty("url") val url: String? = null,
+    @field:JsonProperty("max_byte_size") val maxByteSize: Long? = null,
+    @field:JsonProperty("file_expiration") val fileExpiration: ArrayList<Int> = arrayListOf(),
+    @field:JsonProperty("media_transformations") val mediaTransformations: Map<MimeType, Array<String>> = emptyMap(),
 )


### PR DESCRIPTION
Kotlin's behaviour for annotation targets is changing. This change adds @field as explicit annotation target.

Only constructor params have been changed. Regular properties are not affected by the behaviour change.

`See https://youtrack.jetbrains.com/issue/KT-73255 for more details.`
`w: file:///Users/david/StudioProjects/amethyst/quartz/src/main/java/com/vitorpamplona/quartz/nip96FileStorage/info/ServerInfo.kt:57:5 This annotation is currently applied to the value parameter only, but in the future it will also be applied to field.`
`- To opt in to applying to both value parameter and field, add '-Xannotation-default-target=param-property' to your compiler arguments.`
`- To keep applying to the value parameter only, use the '@param:' annotation target.`