### PR TITLE
Update pt_rbr strings.xml

### DIFF
--- a/amethyst/src/main/res/values-pt-rBR/strings.xml
+++ b/amethyst/src/main/res/values-pt-rBR/strings.xml
@@ -247,8 +247,8 @@
     <string name="tor_relay">Forçar uso do Tor ao conectar</string>
     <string name="posts_received">postagens recebidas</string>
     <string name="remove">Remover</string>
-    <string name="translations_auto">Automaticamente </string>
-    <string name="translations_translated_from">traduzido de </string>
+    <string name="translations_auto">Autotraduzido </string>
+    <string name="translations_translated_from"> de </string>
     <string name="translations_to">para</string>
     <string name="translations_show_in_lang_first">Mostrar em %1$s primeiro</string>
     <string name="chat_about_topic">Chat público sobre %1$s</string>


### PR DESCRIPTION
More compact translation, with corrected spelling (there is no "automaticamente-traduzido" with dash in Portuguese, so I changed it to 'autotraduzido' and moved the dash away to use as a ':' ) and visually more pleasing.