### PR TITLE
Capture and post video

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/MediaCompressor.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/MediaCompressor.kt
@@ -84,14 +84,14 @@ class MediaCompressor {
         val videoQuality =
             when (mediaQuality) {
                 CompressorQuality.VERY_LOW -> VideoQuality.VERY_LOW
-                CompressorQuality.LOW -> VideoQuality.LOW
+                CompressorQuality.LOW -> VideoQuality.VERY_LOW
                 CompressorQuality.MEDIUM -> VideoQuality.MEDIUM
                 CompressorQuality.HIGH -> VideoQuality.HIGH
                 CompressorQuality.VERY_HIGH -> VideoQuality.VERY_HIGH
                 else -> VideoQuality.MEDIUM
             }
 
-        Log.d("MediaCompressor", "Using video compression $mediaQuality")
+        Log.d("MediaCompressor", "Using video compression $videoQuality")
 
         val result =
             withTimeoutOrNull(30000) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/uploads/TakePicture.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/uploads/TakePicture.kt
@@ -26,12 +26,23 @@ import android.net.Uri
 import android.os.Environment
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.Videocam
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -39,9 +50,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 import androidx.core.content.FileProvider
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
@@ -59,19 +72,111 @@ import java.util.Locale
 
 @Composable
 fun TakePictureButton(onPictureTaken: (ImmutableList<SelectedMedia>) -> Unit) {
-    var showCamera by remember { mutableStateOf(false) }
-    if (showCamera) {
-        TakePicture(
-            onPictureTaken = { uri ->
-                showCamera = false
-                if (uri.isNotEmpty()) {
-                    onPictureTaken(uri)
-                }
+    var showSelection by remember { mutableStateOf(false) }
+
+    if (showSelection) {
+        CameraSelectionDialog(
+            onDismiss = { showSelection = false },
+            onMediaTaken = { media ->
+                showSelection = false
+                onPictureTaken(media)
             },
         )
     }
 
-    PictureButton { showCamera = true }
+    PictureButton { showSelection = true }
+}
+
+@Composable
+fun CameraSelectionDialog(
+    onDismiss: () -> Unit,
+    onMediaTaken: (ImmutableList<SelectedMedia>) -> Unit,
+) {
+    var showPicture by remember { mutableStateOf(false) }
+    var showVideo by remember { mutableStateOf(false) }
+
+    if (showPicture) {
+        TakePicture(
+            onPictureTaken = { media ->
+                showPicture = false
+                onDismiss()
+                onMediaTaken(media)
+            },
+        )
+    }
+
+    if (showVideo) {
+        TakeVideo(
+            onVideoTaken = { media ->
+                showVideo = false
+                onDismiss()
+                onMediaTaken(media)
+            },
+        )
+    }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Card(
+            shape = RoundedCornerShape(16.dp),
+            modifier = Modifier.padding(16.dp),
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Text(
+                    text = stringRes(R.string.select_media_type),
+                    style = MaterialTheme.typography.headlineSmall,
+                )
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Button(
+                        onClick = { showPicture = true },
+                        modifier = Modifier.weight(1f),
+                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
+                    ) {
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.CameraAlt,
+                                contentDescription = null,
+                            )
+                            Text(
+                                text = stringRes(R.string.photo),
+                                maxLines = 1,
+                            )
+                        }
+                    }
+
+                    Button(
+                        onClick = { showVideo = true },
+                        modifier = Modifier.weight(1f),
+                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
+                    ) {
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Videocam,
+                                contentDescription = null,
+                            )
+                            Text(
+                                text = stringRes(R.string.video),
+                                maxLines = 1,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 @OptIn(ExperimentalPermissionsApi::class)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/uploads/TakePicture.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/uploads/TakePicture.kt
@@ -136,13 +136,18 @@ fun PictureButton(onClick: () -> Unit) {
     }
 }
 
-fun getPhotoUri(context: Context): Uri {
+private fun getMediaUri(
+    context: Context,
+    directory: String,
+    filePrefix: String,
+    fileExtension: String,
+): Uri {
     val timeStamp: String = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
-    val storageDir: File? = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES)
+    val storageDir: File? = context.getExternalFilesDir(directory)
     return File
         .createTempFile(
-            "JPEG_${timeStamp}_",
-            ".jpg",
+            "${filePrefix}_${timeStamp}_",
+            fileExtension,
             storageDir,
         ).let {
             FileProvider.getUriForFile(
@@ -152,3 +157,19 @@ fun getPhotoUri(context: Context): Uri {
             )
         }
 }
+
+fun getPhotoUri(context: Context): Uri =
+    getMediaUri(
+        context,
+        Environment.DIRECTORY_PICTURES,
+        "JPEG",
+        ".jpg",
+    )
+
+fun getVideoUri(context: Context): Uri =
+    getMediaUri(
+        context,
+        Environment.DIRECTORY_MOVIES,
+        "VIDEO",
+        ".mp4",
+    )

--- a/amethyst/src/main/res/values-cs-rCZ/strings.xml
+++ b/amethyst/src/main/res/values-cs-rCZ/strings.xml
@@ -148,6 +148,9 @@
     <string name="failed_to_save_the_video">Nepodařilo se uložit video</string>
     <string name="upload_image">Nahrát obrázek</string>
     <string name="take_a_picture">Pořiďte fotografii</string>
+    <string name="select_media_type">Vybrat typ média</string>
+    <string name="photo">Foto</string>
+    <string name="video">Video</string>
     <string name="record_a_message">Nahrajte zprávu</string>
     <string name="record_a_message_title">Nahrajte zprávu</string>
     <string name="record_a_message_description">Stiskněte a podržte pro nahrání zprávy</string>

--- a/amethyst/src/main/res/values-de-rDE/strings.xml
+++ b/amethyst/src/main/res/values-de-rDE/strings.xml
@@ -150,6 +150,9 @@ erie gespeichert</string>
     <string name="failed_to_save_the_video">Video konnte nicht gespeichert werden</string>
     <string name="upload_image">Bild hochladen</string>
     <string name="take_a_picture">Ein Foto aufnehmen</string>
+    <string name="select_media_type">Medientyp auswählen</string>
+    <string name="photo">Foto</string>
+    <string name="video">Video</string>
     <string name="record_a_message">Eine Nachricht aufnehmen</string>
     <string name="record_a_message_title">Eine Nachricht aufnehmen</string>
     <string name="record_a_message_description">Zum Aufnehmen einer Nachricht gedrückt halten</string>

--- a/amethyst/src/main/res/values-pt-rBR/strings.xml
+++ b/amethyst/src/main/res/values-pt-rBR/strings.xml
@@ -148,6 +148,9 @@
     <string name="failed_to_save_the_video">Falha ao salvar o vídeo</string>
     <string name="upload_image">Enviar Imagem</string>
     <string name="take_a_picture">Tirar uma foto</string>
+    <string name="select_media_type">Selecionar Tipo de Mídia</string>
+    <string name="photo">Foto</string>
+    <string name="video">Vídeo</string>
     <string name="record_a_message">Gravar uma mensagem</string>
     <string name="record_a_message_title">Gravar uma mensagem</string>
     <string name="record_a_message_description">Clique e segure para gravar uma mensagem</string>

--- a/amethyst/src/main/res/values-sv-rSE/strings.xml
+++ b/amethyst/src/main/res/values-sv-rSE/strings.xml
@@ -148,6 +148,9 @@
     <string name="failed_to_save_the_video">Det gick inte att spara videon</string>
     <string name="upload_image">Ladda upp bilden</string>
     <string name="take_a_picture">Ta en bild</string>
+    <string name="select_media_type">Välj Mediatyp</string>
+    <string name="photo">Foto</string>
+    <string name="video">Video</string>
     <string name="record_a_message">Spela in ett meddelande</string>
     <string name="record_a_message_title">Spela in ett meddelande</string>
     <string name="record_a_message_description">Tryck och håll in för att spela in ett meddelande</string>

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -160,6 +160,9 @@
     <string name="failed_to_save_the_video">Failed to save the video</string>
     <string name="upload_image">Upload Image</string>
     <string name="take_a_picture">Take a picture</string>
+    <string name="select_media_type">Select Media Type</string>
+    <string name="photo">Photo</string>
+    <string name="video">Video</string>
     <string name="record_a_message">Record a message</string>
     <string name="record_a_message_title">Record a message</string>
     <string name="record_a_message_description">Click and hold to record a message</string>


### PR DESCRIPTION
I really like the instant post photo feature but always felt it missed an option to post a video instantly.

- This adds a dialog to select photo (as before) or video (new).
- The UI isn't as slick as I would want to but maybe somebody with better UI skills can improve on it
- I changed the video compression LOW setting to VERY_LOW. LOW results in 8mbit, VERY_LOW results in 4mbit which streams better
- Doesn't work in emulator due to emulator limitations around recording video

Code review? @KotlinGeekDev 

Screen recording:

https://github.com/user-attachments/assets/f7239718-cdfe-4305-b4dc-b01321d6cac5

Screen grab:

<img width="125" height="250" alt="Screenshot 2025-08-26 at 12 36 40" src="https://github.com/user-attachments/assets/6598be34-2e04-4857-ba36-e9c56f4a3060" />
