### PR TITLE
Upgrade agp and add JvmTarget.JVM_21 to Quartz

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 accompanistAdaptive = "0.37.3"
 activityCompose = "1.10.1"
-agp = "8.12.1"
+agp = "8.12.2"
 android-compileSdk = "36"
 android-minSdk = "26"
 android-targetSdk = "36"

--- a/quartz/build.gradle.kts
+++ b/quartz/build.gradle.kts
@@ -4,7 +4,11 @@ plugins {
 }
 
 kotlin {
-    jvm()
+    jvm {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
+        }
+    }
 
     // Target declarations - add or remove as needed below. These define
     // which platforms this KMP module supports.
@@ -35,6 +39,7 @@ kotlin {
         }
 
         compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
             freeCompilerArgs.add("-Xstring-concat=inline")
         }
     }

--- a/quartz/build.gradle.kts
+++ b/quartz/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 kotlin {
     jvm {
         compilerOptions {
-            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
         }
     }
 
@@ -39,7 +39,7 @@ kotlin {
         }
 
         compilerOptions {
-            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
             freeCompilerArgs.add("-Xstring-concat=inline")
         }
     }


### PR DESCRIPTION
- Upgraded AGP to 8.12.2
- Added JvmTarget.JVM_21 to Quartz because I was getting several errors when trying to push:

`/amethyst/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/pip/IntentExtras.kt:48:13 Cannot inline bytecode built with JVM target 23 into bytecode that is being built with JVM target 21. Specify proper '-jvm-target' option.`

I'm using JDK 23... maybe if JDK 21 is used then this issue wasn't noticed.
