### PR TITLE
Capture and post video

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/MediaCompressor.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/MediaCompressor.kt
@@ -84,14 +84,15 @@ class MediaCompressor {
         val videoQuality =
             when (mediaQuality) {
                 CompressorQuality.VERY_LOW -> VideoQuality.VERY_LOW
-                CompressorQuality.LOW -> VideoQuality.LOW
+                // Override user selection LOW to use VERY_LOW for better video streaming experience
+                CompressorQuality.LOW -> VideoQuality.VERY_LOW
                 CompressorQuality.MEDIUM -> VideoQuality.MEDIUM
                 CompressorQuality.HIGH -> VideoQuality.HIGH
                 CompressorQuality.VERY_HIGH -> VideoQuality.VERY_HIGH
                 else -> VideoQuality.MEDIUM
             }
 
-        Log.d("MediaCompressor", "Using video compression $mediaQuality")
+        Log.d("MediaCompressor", "Using video compression $videoQuality")
 
         val result =
             withTimeoutOrNull(30000) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/uploads/TakePicture.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/uploads/TakePicture.kt
@@ -137,22 +137,13 @@ fun PictureButton(onClick: () -> Unit) {
     }
 }
 
-fun getPhotoUri(context: Context): Uri {
-    val timeStamp: String = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
-    val storageDir: File? = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES)
-    return File
-        .createTempFile(
-            "JPEG_${timeStamp}_",
-            ".jpg",
-            storageDir,
-        ).let {
-            FileProvider.getUriForFile(
-                context,
-                "${context.packageName}.provider",
-                it,
-            )
-        }
-}
+fun getPhotoUri(context: Context): Uri =
+    getMediaUri(
+        context = context,
+        filePrefix = "JPEG",
+        fileExtension = ".jpg",
+        storageDir = Environment.DIRECTORY_PICTURES,
+    )
 
 @Composable
 fun TakeVideoButton(onVideoTaken: (ImmutableList<SelectedMedia>) -> Unit) {
@@ -233,14 +224,27 @@ fun VideoButton(onClick: () -> Unit) {
     }
 }
 
-fun getVideoUri(context: Context): Uri {
+fun getVideoUri(context: Context): Uri =
+    getMediaUri(
+        context = context,
+        filePrefix = "MP4",
+        fileExtension = ".mp4",
+        storageDir = Environment.DIRECTORY_MOVIES,
+    )
+
+private fun getMediaUri(
+    context: Context,
+    filePrefix: String,
+    fileExtension: String,
+    storageDir: String,
+): Uri {
     val timeStamp: String = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
-    val storageDir: File? = context.getExternalFilesDir(Environment.DIRECTORY_MOVIES)
+    val storageDirectory: File? = context.getExternalFilesDir(storageDir)
     return File
         .createTempFile(
-            "MP4_${timeStamp}_",
-            ".mp4",
-            storageDir,
+            "${filePrefix}_${timeStamp}_",
+            fileExtension,
+            storageDirectory,
         ).let {
             FileProvider.getUriForFile(
                 context,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/uploads/TakePicture.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/uploads/TakePicture.kt
@@ -29,6 +29,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.height
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.Videocam
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -143,6 +144,102 @@ fun getPhotoUri(context: Context): Uri {
         .createTempFile(
             "JPEG_${timeStamp}_",
             ".jpg",
+            storageDir,
+        ).let {
+            FileProvider.getUriForFile(
+                context,
+                "${context.packageName}.provider",
+                it,
+            )
+        }
+}
+
+@Composable
+fun TakeVideoButton(onVideoTaken: (ImmutableList<SelectedMedia>) -> Unit) {
+    var showCamera by remember { mutableStateOf(false) }
+    if (showCamera) {
+        TakeVideo(
+            onVideoTaken = { uri ->
+                showCamera = false
+                if (uri.isNotEmpty()) {
+                    onVideoTaken(uri)
+                }
+            },
+        )
+    }
+
+    VideoButton { showCamera = true }
+}
+
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+fun TakeVideo(onVideoTaken: (ImmutableList<SelectedMedia>) -> Unit) {
+    val context = LocalContext.current
+    var videoUri by remember { mutableStateOf<Uri?>(null) }
+    val scope = rememberCoroutineScope()
+
+    val launcher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.CaptureVideo(),
+        ) { success ->
+            if (success) {
+                videoUri?.let {
+                    onVideoTaken(persistentListOf(SelectedMedia(it, "video/mp4")))
+                }
+            } else {
+                onVideoTaken(persistentListOf())
+            }
+            videoUri = null
+        }
+
+    val cameraPermissionState =
+        rememberPermissionState(
+            Manifest.permission.CAMERA,
+            onPermissionResult = {
+                if (it) {
+                    scope.launch(Dispatchers.IO) {
+                        videoUri = getVideoUri(context)
+                        videoUri?.let { launcher.launch(it) }
+                    }
+                }
+            },
+        )
+
+    if (cameraPermissionState.status.isGranted) {
+        LaunchedEffect(key1 = Unit) {
+            launch(Dispatchers.IO) {
+                videoUri = getVideoUri(context)
+                videoUri?.let { launcher.launch(it) }
+            }
+        }
+    } else {
+        LaunchedEffect(key1 = Unit) {
+            cameraPermissionState.launchPermissionRequest()
+        }
+    }
+}
+
+@Composable
+fun VideoButton(onClick: () -> Unit) {
+    IconButton(
+        onClick = onClick,
+    ) {
+        Icon(
+            imageVector = Icons.Default.Videocam,
+            contentDescription = stringRes(id = R.string.record_a_video),
+            modifier = Modifier.height(22.dp),
+            tint = MaterialTheme.colorScheme.onBackground,
+        )
+    }
+}
+
+fun getVideoUri(context: Context): Uri {
+    val timeStamp: String = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
+    val storageDir: File? = context.getExternalFilesDir(Environment.DIRECTORY_MOVIES)
+    return File
+        .createTempFile(
+            "MP4_${timeStamp}_",
+            ".mp4",
             storageDir,
         ).let {
             FileProvider.getUriForFile(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/GenericCommentPostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/GenericCommentPostScreen.kt
@@ -53,6 +53,7 @@ import com.vitorpamplona.amethyst.ui.actions.mediaServers.ServerType
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromGallery
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.actions.uploads.TakePictureButton
+import com.vitorpamplona.amethyst.ui.actions.uploads.TakeVideoButton
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.PostingTopBar
 import com.vitorpamplona.amethyst.ui.note.BaseUserPicture
@@ -386,6 +387,12 @@ private fun BottomRowActions(postViewModel: CommentPostViewModel) {
 
         TakePictureButton(
             onPictureTaken = {
+                postViewModel.selectImage(it)
+            },
+        )
+
+        TakeVideoButton(
+            onVideoTaken = {
                 postViewModel.selectImage(it)
             },
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/NewGroupDMScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/NewGroupDMScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AddPhotoAlternate
+import androidx.compose.material.icons.filled.Videocam
 import androidx.compose.material.icons.outlined.CameraAlt
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -85,6 +86,7 @@ import com.vitorpamplona.amethyst.ui.actions.mediaServers.ServerType
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromGallery
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.actions.uploads.TakePictureButton
+import com.vitorpamplona.amethyst.ui.actions.uploads.TakeVideoButton
 import com.vitorpamplona.amethyst.ui.components.ThinPaddingTextField
 import com.vitorpamplona.amethyst.ui.components.ZoomableContentView
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -408,7 +410,26 @@ private fun BottomRowActions(
             ) {
                 Icon(
                     imageVector = Icons.Outlined.CameraAlt,
-                    contentDescription = stringRes(id = R.string.upload_image),
+                    contentDescription = stringRes(id = R.string.take_a_picture),
+                    modifier = Modifier.height(22.dp),
+                    tint = MaterialTheme.colorScheme.placeholderText,
+                )
+            }
+        }
+
+        if (postViewModel.room != null) {
+            TakeVideoButton(
+                onVideoTaken = { postViewModel.pickedMedia(it) },
+            )
+        } else {
+            IconButton(
+                onClick = {
+                    accountViewModel.toastManager.toast(R.string.messages_cant_upload_title, R.string.messages_cant_upload_explainer)
+                },
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Videocam,
+                    contentDescription = stringRes(id = R.string.record_a_video),
                     modifier = Modifier.height(22.dp),
                     tint = MaterialTheme.colorScheme.placeholderText,
                 )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/NewProductScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/NewProductScreen.kt
@@ -53,6 +53,7 @@ import com.vitorpamplona.amethyst.ui.actions.mediaServers.ServerType
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromGallery
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.actions.uploads.TakePictureButton
+import com.vitorpamplona.amethyst.ui.actions.uploads.TakeVideoButton
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.PostingTopBar
@@ -366,6 +367,12 @@ private fun BottomRowActions(postViewModel: NewProductViewModel) {
 
         TakePictureButton(
             onPictureTaken = {
+                postViewModel.selectImage(it)
+            },
+        )
+
+        TakeVideoButton(
+            onVideoTaken = {
                 postViewModel.selectImage(it)
             },
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostScreen.kt
@@ -60,6 +60,7 @@ import com.vitorpamplona.amethyst.ui.actions.mediaServers.ServerType
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromGallery
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.actions.uploads.TakePictureButton
+import com.vitorpamplona.amethyst.ui.actions.uploads.TakeVideoButton
 import com.vitorpamplona.amethyst.ui.components.getActivity
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.PostingTopBar
@@ -427,6 +428,12 @@ private fun BottomRowActions(postViewModel: ShortNotePostViewModel) {
 
         TakePictureButton(
             onPictureTaken = {
+                postViewModel.selectImage(it)
+            },
+        )
+
+        TakeVideoButton(
+            onVideoTaken = {
                 postViewModel.selectImage(it)
             },
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/publicMessages/NewPublicMessageScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/publicMessages/NewPublicMessageScreen.kt
@@ -43,7 +43,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
@@ -62,6 +61,7 @@ import com.vitorpamplona.amethyst.ui.actions.UrlUserTagTransformation
 import com.vitorpamplona.amethyst.ui.actions.mediaServers.ServerType
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromGallery
 import com.vitorpamplona.amethyst.ui.actions.uploads.TakePictureButton
+import com.vitorpamplona.amethyst.ui.actions.uploads.TakeVideoButton
 import com.vitorpamplona.amethyst.ui.components.ThinPaddingTextField
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
@@ -86,7 +86,6 @@ import com.vitorpamplona.amethyst.ui.note.creators.zapsplits.ForwardZapTo
 import com.vitorpamplona.amethyst.ui.note.creators.zapsplits.ForwardZapToButton
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.privateDM.send.MessageFieldRow
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.privateDM.send.SendDirectMessageTo
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.DividerThickness
 import com.vitorpamplona.amethyst.ui.theme.Font14SP
@@ -318,6 +317,12 @@ private fun BottomRowActions(
 
         TakePictureButton(
             onPictureTaken = {
+                postViewModel.selectImage(it)
+            },
+        )
+
+        TakeVideoButton(
+            onVideoTaken = {
                 postViewModel.selectImage(it)
             },
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/NewImageButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/NewImageButton.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AddPhotoAlternate
 import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.Videocam
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -53,6 +54,7 @@ import com.vitorpamplona.amethyst.ui.actions.NewMediaView
 import com.vitorpamplona.amethyst.ui.actions.uploads.GallerySelect
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.actions.uploads.TakePicture
+import com.vitorpamplona.amethyst.ui.actions.uploads.TakeVideo
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.painterRes
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -78,6 +80,8 @@ fun NewImageButton(
 
     var wantsToPostFromCamera by remember { mutableStateOf(false) }
 
+    var wantsToPostFromVideo by remember { mutableStateOf(false) }
+
     var pickedURIs by remember { mutableStateOf<ImmutableList<SelectedMedia>>(persistentListOf()) }
 
     val scope = rememberCoroutineScope()
@@ -93,6 +97,13 @@ fun NewImageButton(
     if (wantsToPostFromCamera) {
         TakePicture { uri ->
             wantsToPostFromCamera = false
+            pickedURIs = uri
+        }
+    }
+
+    if (wantsToPostFromVideo) {
+        TakeVideo { uri ->
+            wantsToPostFromVideo = false
             pickedURIs = uri
         }
     }
@@ -134,7 +145,26 @@ fun NewImageButton(
                 ) {
                     Icon(
                         imageVector = Icons.Default.CameraAlt,
-                        contentDescription = stringRes(id = R.string.upload_image),
+                        contentDescription = stringRes(id = R.string.take_a_picture),
+                        modifier = Modifier.size(26.dp),
+                        tint = Color.White,
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                FloatingActionButton(
+                    onClick = {
+                        wantsToPostFromVideo = true
+                        isOpen = false
+                    },
+                    modifier = Size55Modifier,
+                    shape = CircleShape,
+                    containerColor = MaterialTheme.colorScheme.primary,
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Videocam,
+                        contentDescription = stringRes(id = R.string.record_a_video),
                         modifier = Modifier.size(26.dp),
                         tint = Color.White,
                     )

--- a/amethyst/src/main/res/values-cs-rCZ/strings.xml
+++ b/amethyst/src/main/res/values-cs-rCZ/strings.xml
@@ -148,6 +148,7 @@
     <string name="failed_to_save_the_video">Nepodařilo se uložit video</string>
     <string name="upload_image">Nahrát obrázek</string>
     <string name="take_a_picture">Pořiďte fotografii</string>
+    <string name="record_a_video">Nahrát video</string>
     <string name="record_a_message">Nahrajte zprávu</string>
     <string name="record_a_message_title">Nahrajte zprávu</string>
     <string name="record_a_message_description">Stiskněte a podržte pro nahrání zprávy</string>

--- a/amethyst/src/main/res/values-de/strings.xml
+++ b/amethyst/src/main/res/values-de/strings.xml
@@ -947,6 +947,7 @@ anz der Bedingungen ist erforderlich</string>
     <string name="signer_not_found_exception_description">Wurde die Signierer-App deinstalliert? Überprüfe, ob sie installiert ist und dieses Konto enthält. Melde dich ab und wieder an, falls sich die App geändert hat.</string>
     <string name="no_description">Keine Beschreibung gefunden</string>
     <string name="take_a_picture">Ein Foto aufnehmen</string>
+    <string name="record_a_video">Video aufnehmen</string>
     <string name="record_a_message">Eine Nachricht aufnehmen</string>
     <string name="record_a_message_title">Eine Nachricht aufnehmen</string>
     <string name="record_a_message_description">Zum Aufnehmen einer Nachricht gedrückt halten</string>

--- a/amethyst/src/main/res/values-pt-rBR/strings.xml
+++ b/amethyst/src/main/res/values-pt-rBR/strings.xml
@@ -148,6 +148,7 @@
     <string name="failed_to_save_the_video">Falha ao salvar o vídeo</string>
     <string name="upload_image">Enviar Imagem</string>
     <string name="take_a_picture">Tirar uma foto</string>
+    <string name="record_a_video">Gravar um vídeo</string>
     <string name="record_a_message">Gravar uma mensagem</string>
     <string name="record_a_message_title">Gravar uma mensagem</string>
     <string name="record_a_message_description">Clique e segure para gravar uma mensagem</string>

--- a/amethyst/src/main/res/values-sv-rSE/strings.xml
+++ b/amethyst/src/main/res/values-sv-rSE/strings.xml
@@ -148,6 +148,7 @@
     <string name="failed_to_save_the_video">Det gick inte att spara videon</string>
     <string name="upload_image">Ladda upp bilden</string>
     <string name="take_a_picture">Ta en bild</string>
+    <string name="record_a_video">Spela in video</string>
     <string name="record_a_message">Spela in ett meddelande</string>
     <string name="record_a_message_title">Spela in ett meddelande</string>
     <string name="record_a_message_description">Tryck och håll in för att spela in ett meddelande</string>

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -160,6 +160,7 @@
     <string name="failed_to_save_the_video">Failed to save the video</string>
     <string name="upload_image">Upload Image</string>
     <string name="take_a_picture">Take a picture</string>
+    <string name="record_a_video">Record a video</string>
     <string name="record_a_message">Record a message</string>
     <string name="record_a_message_title">Record a message</string>
     <string name="record_a_message_description">Click and hold to record a message</string>


### PR DESCRIPTION
I really like the instant post photo feature but always felt it missed an option to post a video instantly.

This PR adds a video camera icon next to the photo camera icon in the bottom row actions. It has been added to the following "new post" screens:

- Short note post screen (aka new post)
- New media post
- New Group DM
- New public message (don't think this is active)
- New product
- GeoHashTag post and HashTag post via GenericCommentPostScreen

I have changed the video compression level "low" (20% of original) to "very low" (10% of original) to allow for faster media streaming. Video compression is a complex topic and it would be fun to make it even better at some point!

Code review? @KotlinGeekDev

