### PR TITLE
Fix hyphen applied in all languages in TranslatableRichTextViewer.kt

### DIFF
--- a/amethyst/src/play/java/com/vitorpamplona/amethyst/ui/components/TranslatableRichTextViewer.kt
+++ b/amethyst/src/play/java/com/vitorpamplona/amethyst/ui/components/TranslatableRichTextViewer.kt
@@ -173,7 +173,7 @@ private fun TranslationMessage(
             text =
                 buildAnnotatedString {
                     appendLink(stringRes(R.string.translations_auto), textColor) { langSettingsPopupExpanded = !langSettingsPopupExpanded }
-                    append("-${stringRes(R.string.translations_translated_from)} ")
+                    append(" ${stringRes(R.string.translations_translated_from)} ")
                     appendLink(Locale(source).displayName, textColor) { onChangeWhatToShow(true) }
                     append(" ${stringRes(R.string.translations_to)} ")
                     appendLink(Locale(target).displayName, textColor) { onChangeWhatToShow(false) }


### PR DESCRIPTION
Changed the hyphen to a space to move the word "auto-translated" (and its translations) to "translations_auto" string and "from" (and its translations) to "translated_from" string, as this hyphen only exists in some languages.

[this change will likely require adjustments to be made in most languages]