### PR TITLE
Update english strings.xml

### DIFF
--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -268,8 +268,8 @@
     <string name="posts_received">posts received</string>
     <string name="remove">Remove</string>
     <string name="sats" translatable="false">sats</string>
-    <string name="translations_auto">Auto</string>
-    <string name="translations_translated_from">translated from</string>
+    <string name="translations_auto">Auto-translated</string>
+    <string name="translations_translated_from">from</string>
     <string name="translations_to">to</string>
     <string name="translations_show_in_lang_first">Show in %1$s first</string>
     <string name="chat_about_topic">Public chat about %1$s</string>


### PR DESCRIPTION
According to PR #1444, commit 64df323, which changed the hyphen that was being applied to all languages ​​to a space, this is the adjustment made in English and will be followed for other languages.

[pt_rbr already adjusted]