### PR TITLE
Setting JvmTarget to 21 for quartz

### DIFF
--- a/quartz/build.gradle.kts
+++ b/quartz/build.gradle.kts
@@ -152,8 +152,8 @@ kotlin {
                 api(libs.secp256k1.kmp.jni.android)
 
                 // LibSodium for ChaCha encryption (NIP-44)
-                implementation (libs.lazysodium.android)
-                implementation (libs.jna)
+                implementation ("com.goterl:lazysodium-android:5.2.0@aar")
+                implementation ("net.java.dev.jna:jna:5.17.0@aar")
 
                 // Performant Parser of JSONs into Events
                 api(libs.jackson.module.kotlin)


### PR DESCRIPTION
to fix build/push issue due to mixed Java versions when using Java 23 locally

Similar issue to before. I'm using Java 23 locally and since Quartz didn't have JVM target specified it compiles with 23 and fails to inline with the other 21 code.