### PR TITLE
Fix for crash when attempting to share an image that is still loading

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
@@ -22,6 +22,8 @@ package com.vitorpamplona.amethyst.ui.components
 
 import android.content.Context
 import android.content.Intent
+import android.util.Log
+import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.fadeIn
@@ -786,21 +788,26 @@ private suspend fun shareImageFile(
     videoUri: String,
     mimeType: String?,
 ) {
-    // Get sharable URI and file extension
-    val (uri, fileExtension) = ShareHelper.getSharableUriFromUrl(context, videoUri)
+    try {
+        // Get sharable URI and file extension
+        val (uri, fileExtension) = ShareHelper.getSharableUriFromUrl(context, videoUri)
 
-    // Determine mime type, use provided or derive from extension
-    val determinedMimeType = mimeType ?: "image/$fileExtension"
+        // Determine mime type, use provided or derive from extension
+        val determinedMimeType = mimeType ?: "image/$fileExtension"
 
-    // Create share intent
-    val shareIntent =
-        Intent(Intent.ACTION_SEND).apply {
-            type = determinedMimeType
-            putExtra(Intent.EXTRA_STREAM, uri)
-            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-        }
+        // Create share intent
+        val shareIntent =
+            Intent(Intent.ACTION_SEND).apply {
+                type = determinedMimeType
+                putExtra(Intent.EXTRA_STREAM, uri)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
 
-    context.startActivity(Intent.createChooser(shareIntent, null))
+        context.startActivity(Intent.createChooser(shareIntent, null))
+    } catch (e: Exception) {
+        Log.w("ZoomableContentView", "Failed to share image: $videoUri", e)
+        Toast.makeText(context, context.getString(R.string.unable_to_share_image), Toast.LENGTH_SHORT).show()
+    }
 }
 
 private fun verifyHash(content: MediaUrlContent): Boolean? {

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -1238,6 +1238,7 @@
     <string name="group_relay">Chat Relay</string>
     <string name="group_relay_explanation">The relay that all users of this chat connect to</string>
     <string name="share_image">Share image…</string>
+    <string name="unable_to_share_image">Unable to share image, please try again later…</string>
 
     <string name="search_by_hashtag">Search hashtag: #%1$s</string>
 


### PR DESCRIPTION
This happens because the image isn't in cache yet

catch exception when sharing image
Show toast