### PR TITLE
Investigating intermittent build issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
           path: amethyst/build/outputs/apk/fdroid/debug/amethyst-fdroid-universal-debug.apk
 
       - name: Build APK (gradle)
-        run: ./gradlew assembleBenchmark --no-daemon --max-workers=2 -Dorg.gradle.jvmargs="-Xmx3g"
+        run: ./gradlew assembleBenchmark
 
       - name: Upload Play APK Benchmark
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
           path: amethyst/build/outputs/apk/fdroid/debug/amethyst-fdroid-universal-debug.apk
 
       - name: Build APK (gradle)
-        run: ./gradlew assembleBenchmark
+        run: ./gradlew assembleBenchmark --no-daemon --max-workers=2 -Dorg.gradle.jvmargs="-Xmx3g"
 
       - name: Upload Play APK Benchmark
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,8 @@ jobs:
 
 
 
+
+
       - name: Upload Play APK
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,13 +61,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Play Benchmark APK
-          path: amethyst/build/outputs/apk/play/debug/amethyst-play-universal-benchmark.apk
+          path: amethyst/build/outputs/apk/play/benchmark/amethyst-play-universal-benchmark.apk
 
       - name: Upload FDroid APK Benchmark
         uses: actions/upload-artifact@v4
         with:
           name: FDroid Benchmark APK
-          path: amethyst/build/outputs/apk/fdroid/debug/amethyst-fdroid-universal-benchmark.apk
+          path: amethyst/build/outputs/apk/fdroid/benchmark/amethyst-fdroid-universal-benchmark.apk
 
       - name: Upload Compose Reports
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Build APK (gradle)
         run: ./gradlew assembleDebug
 
+
       - name: Upload Play APK
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
         run: ./gradlew assembleDebug
 
 
+
       - name: Upload Play APK
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,10 +42,6 @@ jobs:
       - name: Build APK (gradle)
         run: ./gradlew assembleDebug
 
-
-
-
-
       - name: Upload Play APK
         uses: actions/upload-artifact@v4
         with:
@@ -59,7 +55,7 @@ jobs:
           path: amethyst/build/outputs/apk/fdroid/debug/amethyst-fdroid-universal-debug.apk
 
       - name: Build APK (gradle)
-        run: ./gradlew assembleBenchmark --no-daemon --max-workers=2 -Dorg.gradle.jvmargs="-Xmx3g"
+        run: ./gradlew assembleBenchmark
 
       - name: Upload Play APK Benchmark
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
add memory limits and worker constraints to the benchmark build step
