### PR TITLE
resolve intermittent CI build failures - fix benchmark apk location

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,13 +61,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Play Benchmark APK
-          path: amethyst/build/outputs/apk/play/debug/amethyst-play-universal-benchmark.apk
+          path: amethyst/build/outputs/apk/play/benchmark/amethyst-play-universal-benchmark.apk
 
       - name: Upload FDroid APK Benchmark
         uses: actions/upload-artifact@v4
         with:
           name: FDroid Benchmark APK
-          path: amethyst/build/outputs/apk/fdroid/debug/amethyst-fdroid-universal-benchmark.apk
+          path: amethyst/build/outputs/apk/fdroid/benchmark/amethyst-fdroid-universal-benchmark.apk
 
       - name: Upload Compose Reports
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
@vitorpamplona  is there a reason why benchmark apk was copied to debug folder?

I ran a few builds using this change and none failed...