### PR TITLE
Fix disappearing stats on relay screen

### DIFF
--- a/quartz/src/androidMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/stats/RelayStats.kt
+++ b/quartz/src/androidMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/stats/RelayStats.kt
@@ -25,7 +25,7 @@ import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 
 object RelayStats {
     private val innerCache =
-        object : LruCache<NormalizedRelayUrl, RelayStat>(100) {
+        object : LruCache<NormalizedRelayUrl, RelayStat>(1000) {
             override fun create(key: NormalizedRelayUrl?) = RelayStat()
         }
 


### PR DESCRIPTION
Increase LruCache max size from 100 to 1,000 since we have so many more relays active with outbox

I saw this was changed in 0886af43. Was it intentional or accidental?

Before:
<img  height="400" alt="Screenshot_20250917_205602" src="https://github.com/user-attachments/assets/2faa1a8f-8d03-47ec-8a3c-9dcb3c96fbf4" />

After fix:
<img  height="400" alt="Screenshot_20250917_205339" src="https://github.com/user-attachments/assets/74120206-7b0d-47c2-ad1c-823e80aab90d" />
