### PR TITLE
Fix for properly switch between single and two-pane layouts on rotation

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/MessagesScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/MessagesScreen.kt
@@ -43,7 +43,7 @@ fun MessagesScreen(
     val act = LocalContext.current.getActivity()
     val windowSizeClass = calculateWindowSizeClass(act)
 
-    val twoPane by remember {
+    val twoPane by remember(windowSizeClass.widthSizeClass) {
         derivedStateOf {
             when (windowSizeClass.widthSizeClass) {
                 WindowWidthSizeClass.Compact -> false


### PR DESCRIPTION
 Commit 404d0ab40 moved windowSizeClass calculation from global state to local activity scope
 
But the remember block in MessagesScreen.kt:46 wasn't updated to properly react to the changing windowSizeClass
