### PR TITLE
BUGFIX: Fix nwc string deleted on restart

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
@@ -325,7 +325,13 @@ object LocalPreferences {
                         PrefKeys.DEFAULT_DISCOVERY_FOLLOW_LIST,
                         settings.defaultDiscoveryFollowList.value,
                     )
-                    putOrRemove(PrefKeys.ZAP_PAYMENT_REQUEST_SERVER, settings.zapPaymentRequest.value?.denormalize())
+
+                    val nwcToBeSaved = settings.zapPaymentRequest.value?.denormalize()
+                    if (nwcToBeSaved != null) {
+                        putString(PrefKeys.ZAP_PAYMENT_REQUEST_SERVER, JsonMapper.toJson(nwcToBeSaved))
+                    } else {
+                        remove(PrefKeys.ZAP_PAYMENT_REQUEST_SERVER)
+                    }
 
                     putOrRemove(PrefKeys.LATEST_CONTACT_LIST, settings.backupContactList)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
@@ -389,7 +389,7 @@ object LocalPreferences {
 
     suspend fun loadAccountConfigFromEncryptedStorage(): AccountSettings? = currentAccount()?.let { loadAccountConfigFromEncryptedStorage(it) }
 
-    suspend fun saveSharedSettings(
+    fun saveSharedSettings(
         sharedSettings: UiSettings,
         prefs: SharedPreferences = encryptedPreferences(),
     ) {
@@ -399,7 +399,7 @@ object LocalPreferences {
         }
     }
 
-    suspend fun loadSharedSettings(prefs: SharedPreferences = encryptedPreferences()): UiSettings? {
+    fun loadSharedSettings(prefs: SharedPreferences = encryptedPreferences()): UiSettings? {
         Log.d("LocalPreferences", "Load shared settings")
         with(prefs) {
             return try {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
@@ -326,12 +326,7 @@ object LocalPreferences {
                         settings.defaultDiscoveryFollowList.value,
                     )
 
-                    val nwcToBeSaved = settings.zapPaymentRequest.value?.denormalize()
-                    if (nwcToBeSaved != null) {
-                        putString(PrefKeys.ZAP_PAYMENT_REQUEST_SERVER, JsonMapper.toJson(nwcToBeSaved))
-                    } else {
-                        remove(PrefKeys.ZAP_PAYMENT_REQUEST_SERVER)
-                    }
+                    putOrRemove(PrefKeys.ZAP_PAYMENT_REQUEST_SERVER, settings.zapPaymentRequest.value?.denormalize())
 
                     putOrRemove(PrefKeys.LATEST_CONTACT_LIST, settings.backupContactList)
 
@@ -585,6 +580,17 @@ object LocalPreferences {
     ) {
         if (event != null) {
             putString(key, OptimizedJsonMapper.toJson(event))
+        } else {
+            remove(key)
+        }
+    }
+
+    fun SharedPreferences.Editor.putOrRemove(
+        key: String,
+        nwc: Nip47WalletConnect.Nip47URI?,
+    ) {
+        if (nwc != null) {
+            putString(key, JsonMapper.toJson(nwc))
         } else {
             remove(key)
         }


### PR DESCRIPTION
The putOrRemove(key: String, event: Any?) signature loses type information. When JsonMapper.toJson() tries to serialise, it sees Any? and can't find the serialiser for Nip47URI, causing:

  `SerializationException: Serializer for class 'Any' is not found`

I've added an overloaded putOrRemove method for Nip47URI.

This fixes the issue for me.

@vitorpamplona, should JsonMapper or OptimizedJsonMapper be used?