### PR TITLE
NIP-59: Remove expiration tags from kind-13 seals

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip59Giftwrap/seals/SealedRumorEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip59Giftwrap/seals/SealedRumorEvent.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.Immutable
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
-import com.vitorpamplona.quartz.nip40Expiration.ExpirationTag
 import com.vitorpamplona.quartz.nip59Giftwrap.HostStub
 import com.vitorpamplona.quartz.nip59Giftwrap.WrappedEvent
 import com.vitorpamplona.quartz.nip59Giftwrap.rumors.Rumor
@@ -118,12 +117,9 @@ class SealedRumorEvent(
         ): SealedRumorEvent {
             val msg = Rumor.toJson(rumor)
 
-            val tags =
-                expirationDelta?.let {
-                    // minimum expiration is two days in the future due to the random created at
-                    // this will make sure the even arrives and is not deleted because of the 2 days.
-                    arrayOf(ExpirationTag.assemble(createdAt + it + TimeUtils.twoDays()))
-                } ?: emptyArray()
+            // NIP-59: "Tags MUST always be empty in a kind:13"
+            // Expiration belongs on the gift wrap (kind 1059), not the seal.
+            val tags = emptyArray<Array<String>>()
 
             return signer.sign(
                 createdAt = createdAt,


### PR DESCRIPTION
## Summary

NIP-59 explicitly requires **"Tags MUST always be empty in a kind:13"**. Previously, seals were being created with expiration tags, violating this specification.

## Changes

- Modified `SealedRumorEvent.kt:121-126` to ensure seal tags are always empty
- Removed conditional expiration tag logic from seal creation
- Expiration data remains on the gift wrap (kind 1059) where it belongs per spec

## Impact

Non-compliant seals can be rejected by stricter relays/clients and leak metadata meant to live only in the gift wrap. This fix ensures compliance with NIP-59.

## Testing

- ✅ Unit tests passing
- ✅ Spotless formatting checks
- ✅ Successfully built and installed to Android device

🤖 Generated with [Claude Code](https://claude.com/claude-code)