### PR TITLE
only check follow sets when user1 is the logged-in user

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/user/UserObservers.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/user/UserObservers.kt
@@ -413,7 +413,12 @@ fun observeUserIsFollowing(
     UserFinderFilterAssemblerSubscription(user1, accountViewModel)
     val isUserInFollowSets =
         remember(accountViewModel.account.followSetsState) {
-            accountViewModel.account.followSetsState.isUserInFollowSets(user2)
+            // Only check follow sets if user1 is the logged-in user
+            if (user1 == accountViewModel.account.userProfile()) {
+                accountViewModel.account.followSetsState.isUserInFollowSets(user2)
+            } else {
+                false
+            }
         }
 
     // Subscribe in the LocalCache for changes that arrive in the device


### PR DESCRIPTION
If you add yourself to one of your follows lists then all user profiles will show "follow back".

This fix is to check follow sets only if user1 is logged in user (in effect `isUserFollowingLoggedIn` is being called).

Maybe it's time to split up the `observeUserIsFollowing` for those two different cases?

fix for: #1535 