### PR TITLE
Bugfix: use correct overload that accepts argument

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/UpdateZapAmountDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/UpdateZapAmountDialog.kt
@@ -353,7 +353,7 @@ fun UpdateZapAmountContent(
                             postViewModel.copyFromClipboard(it)
                         }
                     } catch (e: IllegalArgumentException) {
-                        accountViewModel.toastManager.toast(R.string.invalid_nip47_uri_title, R.string.invalid_nip47_uri_description)
+                        accountViewModel.toastManager.toast(R.string.invalid_nip47_uri_title, R.string.invalid_nip47_uri_description, uri ?: "")
                     }
                 },
             ) {


### PR DESCRIPTION
zap config, when pasting from clipboard, use correct overload that accepts argument for error message