### PR TITLE
ui: center QR dialog content and reduce excessive top spacing

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/qrcode/ShowQRDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/qrcode/ShowQRDialog.kt
@@ -150,8 +150,9 @@ fun ShowQRDialog(
             ) {
                 Column {
                     Column(
-                        modifier = Modifier.fillMaxSize().padding(horizontal = 10.dp),
-                        verticalArrangement = Arrangement.SpaceAround,
+                        modifier = Modifier.padding(horizontal = 10.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
                     ) {
                         if (presenting) {
                             Column {


### PR DESCRIPTION
_Tested and styled with Pixel 4a_


**Previous UI**
------------------

<img width="531" height="1151" alt="Screenshot_20251117-174240" src="https://github.com/user-attachments/assets/9905d77e-7635-4a78-94be-d0de6fa0395e" />

**Corrected UI**
------------------

<img width="531" height="1151" alt="Screenshot_20251118-142442" src="https://github.com/user-attachments/assets/0a4e3dcd-2f6c-4491-94f9-5a8ff70f641f" />
