### PR TITLE
Removed COMBINE_UNICODE_SURROGATES_IN_UTF8 for compatibility with standard Nostr implementations

### DIFF
--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/crypto/EventHasherSerializer.jvmAndroid.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/crypto/EventHasherSerializer.jvmAndroid.kt
@@ -21,7 +21,6 @@
 package com.vitorpamplona.quartz.nip01Core.crypto
 
 import com.fasterxml.jackson.core.JsonEncoding
-import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.core.util.BufferRecycler
 import com.fasterxml.jackson.core.util.ByteArrayBuilder
@@ -78,7 +77,7 @@ actual object EventHasherSerializer {
         try {
             ByteArrayBuilder(br).use { bb ->
                 val generator = JacksonMapper.mapper.createGenerator(bb, JsonEncoding.UTF8)
-                generator.enable(JsonGenerator.Feature.COMBINE_UNICODE_SURROGATES_IN_UTF8)
+
                 generator.use {
                     it.writeStartArray()
                     it.writeNumber(0)


### PR DESCRIPTION
@greenart7c3 

We've had user report of crash when posting a note that has an emoji.

I wild guess is that the recent `JsonGenerator.Feature.COMBINE_UNICODE_SURROGATES_IN_UTF8` in combination with Amber causes this issue.

I will suggest this dev build to the user to see if it fixes the issue.

Crash report:

IllegalStateException: 1.04.2-PLAY

| Prop | Value |
|------|-------|
| Manuf |samsung |
| Model |SM-N975U1 |
| Prod |d2que |
| Android |12 |
| SDK Int |31 |
| Brand |samsung |
| Hardware |qcom |
| Device | d2q |
| Host | 21DKG914 |
| User | dpi |

```
java.lang.IllegalStateException: Could not sign: Failed to verify event: {"id":"8611dc5bf90d689937cfe7b95f393f38ccc05fa53bdce474c5dcdef71943ae56","pubkey":"0c45d7d45edb0fadda4215d36ca0d9aba0c771b85d3717764b8a128d5e443e4d","created_at":1763871352,"kind":1,"tags":[["alt","A short note: Don't get too comfortable, he's coming back soon ?..."]],"content":"Don't get too comfortable, he's coming back soon 🐻.","sig":"dc8bbec750e536318e670714eeb7ada3b4e915b9f0370ed3982198b617555a7ffcb2b0944a5fa7200d4baf9d1264e37ca11803b4b18df811573444b5b7dae90b"}.
    com.vitorpamplona.quartz.nip55AndroidSigner.client.NostrSignerExternal.convertExceptions(r8-map-id-c10adbbb0b27043aeec2ce1b5e20aa66bd1e1b48a775e7c74f62f97e679f8657:95)
    com.vitorpamplona.quartz.nip55AndroidSigner.client.NostrSignerExternal.sign(r8-map-id-c10adbbb0b27043aeec2ce1b5e20aa66bd1e1b48a775e7c74f62f97e679f8657:167)
    com.vitorpamplona.quartz.nip01Core.signers.NostrSigner.sign(r8-map-id-c10adbbb0b27043aeec2ce1b5e20aa66bd1e1b48a775e7c74f62f97e679f8657:1)
    com.vitorpamplona.amethyst.model.Account.signAndComputeBroadcast(r8-map-id-c10adbbb0b27043aeec2ce1b5e20aa66bd1e1b48a775e7c74f62f97e679f8657:74)
    [com.vitorpamplona.amethyst.ui](http://com.vitorpamplona.amethyst.ui/).screen.loggedIn.home.ShortNotePostViewModel.sendPostSync(r8-map-id-c10adbbb0b27043aeec2ce1b5e20aa66bd1e1b48a775e7c74f62f97e679f8657:201)
    [com.vitorpamplona.amethyst.ui](http://com.vitorpamplona.amethyst.ui/).screen.loggedIn.home.ShortNotePostScreenKt$NewPostScreenInner$lambda$1$2$0$$inlined$launchSigner$1.invokeSuspend(r8-map-id-c10adbbb0b27043aeec2ce1b5e20aa66bd1e1b48a775e7c74f62f97e679f8657:58)
    kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(r8-map-id-c10adbbb0b27043aeec2ce1b5e20aa66bd1e1b48a775e7c74f62f97e679f8657:12)
    kotlinx.coroutines.DispatchedTask.run(r8-map-id-c10adbbb0b27043aeec2ce1b5e20aa66bd1e1b48a775e7c74f62f97e679f8657:129)
    kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(r8-map-id-c10adbbb0b27043aeec2ce1b5e20aa66bd1e1b48a775e7c74f62f97e679f8657:4)
    kotlinx.coroutines.scheduling.TaskImpl.run(r8-map-id-c10adbbb0b27043aeec2ce1b5e20aa66bd1e1b48a775e7c74f62f97e679f8657:3)
    kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(r8-map-id-c10adbbb0b27043aeec2ce1b5e20aa66bd1e1b48a775e7c74f62f97e679f8657:1)
    kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(r8-map-id-c10adbbb0b27043aeec2ce1b5e20aa66bd1e1b48a775e7c74f62f97e679f8657:34)
    kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(r8-map-id-c10adbbb0b27043aeec2ce1b5e20aa66bd1e1b48a775e7c74f62f97e679f8657:29)
    kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(r8-map-id-c10adbbb0b27043aeec2ce1b5e20aa66bd1e1b48a775e7c74f62f97e679f8657:1)
```