### PR TITLE
Enabled the reactions expand control for zapraisers even when there are no zaps

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
@@ -415,7 +415,9 @@ private fun WatchReactionsZapsBoostsAndDisplayIfExists(
 ) {
     val hasReactions by observeNoteReferences(baseNote, accountViewModel)
 
-    if (hasReactions) {
+    val hasZapraiser = (baseNote.event?.zapraiserAmount() ?: 0) > 0
+
+    if (hasReactions || hasZapraiser) {
         content()
     }
 }


### PR DESCRIPTION
fix for #1680 

<img width="350" alt="Screenshot_20260122-183023" src="https://github.com/user-attachments/assets/588e9f12-f647-41a7-8a81-dc5cefc37dd2" />
