### PR TITLE
fix: render audio MIME types in imeta tags as playable media

### DIFF
--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
@@ -64,10 +64,10 @@ class RichTextParser {
 
         if (contentType != null) {
             isImage = contentType.startsWith("image/")
-            isVideo = contentType.startsWith("video/")
+            isVideo = contentType.startsWith("video/") || contentType.startsWith("audio/")
         } else if (fullUrl.startsWith("data:")) {
             isImage = fullUrl.startsWith("data:image/")
-            isVideo = fullUrl.startsWith("data:video/")
+            isVideo = fullUrl.startsWith("data:video/") || fullUrl.startsWith("data:audio/")
         } else {
             val removedParamsFromUrl = removeQueryParamsForExtensionComparison(fullUrl)
             isImage = imageExtensions.any { removedParamsFromUrl.endsWith(it) }
@@ -355,7 +355,7 @@ class RichTextParser {
                 .toRegex(RegexOption.IGNORE_CASE)
 
         val imageExt = listOf("png", "jpg", "gif", "bmp", "jpeg", "webp", "svg", "avif")
-        val videoExt = listOf("mp4", "avi", "wmv", "mpg", "amv", "webm", "mov", "mp3", "m3u8")
+        val videoExt = listOf("mp4", "avi", "wmv", "mpg", "amv", "webm", "mov", "mp3", "m3u8", "ogg", "wav", "flac", "aac", "opus", "m4a")
 
         val imageExtensions = imageExt + imageExt.map { it.uppercase() }
         val videoExtensions = videoExt + videoExt.map { it.uppercase() }


### PR DESCRIPTION
Audio URLs with `audio/*` MIME types in NIP-92 imeta tags were silently
dropped (createMediaContent returned null) because only `image/` and
`video/` prefixes were checked. They now map to MediaUrlVideo, which
Media3/ExoPlayer already handles correctly for audio playback.

Also adds common audio extensions (ogg, wav, flac, aac, opus, m4a) to
the extension-based fallback so audio files without imeta tags are also
detected.

Fixes https://github.com/vitorpamplona/amethyst/issues/1701

https://claude.ai/code/session_01YSi64eXRokSy2GzYHoNFES