### PR TITLE
fix: stricter URL detection to prevent false positive link previews

### DIFF
--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
@@ -116,8 +116,13 @@ class RichTextParser {
             } else if (it.originalUrl.contains("。")) {
                 null // avoids Japanese characters as fake urls
             } else {
-                if (HTTPRegex.matches(it.originalUrl)) {
-                    it.originalUrl
+                // Only include URLs with explicit http/https scheme to avoid false positives.
+                // Scheme-less domains (e.g. noscha.io) will be handled by SchemelessUrlSegment
+                // in wordIdentifier, which renders them as simple clickable text without a preview card.
+                val url = it.originalUrl
+                if (HTTPRegex.matches(url) &&
+                    (url.startsWith("http://", ignoreCase = true) || url.startsWith("https://", ignoreCase = true))) {
+                    url
                 } else {
                     null
                 }
@@ -275,7 +280,11 @@ class RichTextParser {
             if (schemelessMatcher != null) {
                 val url = schemelessMatcher.groups[1]?.value // url
                 val additionalChars = schemelessMatcher.groups[4]?.value?.ifEmpty { null } // additional chars
-                if (additionalUrlSchema.find(word) != null && url != null) {
+                // Do not treat as URL if the domain is embedded in a larger word
+                // (e.g., "noscha.ioが面白い" should not become a link because Japanese chars follow).
+                // Only treat as SchemelessUrl when additional chars are non-word characters (punctuation only).
+                val additionalCharsAreSafe = additionalChars == null || !additionalChars[0].isLetterOrDigit()
+                if (additionalUrlSchema.find(word) != null && url != null && additionalCharsAreSafe) {
                     return SchemelessUrlSegment(word, url, additionalChars)
                 }
             }


### PR DESCRIPTION
## Problem

When a domain like `noscha.io` appears as text in a Nostr post, Amethyst's LinkedIn URL Detector picks it up as a URL. This causes the word to be treated as a `LinkSegment`, which triggers `LoadUrlPreview` to render a **full-width preview card**.

This preview card visually breaks the surrounding text — words before and after the domain appear to be on separate lines, collapsed around the card. In Japanese text, this is especially noticeable because domains can appear without spaces (e.g. `noscha.ioが面白い`).

## Root Cause

### Issue 1: Scheme-less URLs in `parseValidUrls`
`UrlDetector` with `UrlDetectorOptions.Default` detects `noscha.io` (no scheme) from the post content. The `HTTPRegex` filter accepts it (scheme is optional), so it enters the URL set and becomes a `LinkSegment` → `LoadUrlPreview` (full-width card).

### Issue 2: Embedded domains in `wordIdentifier`
For Japanese text like `noscha.ioが面白い` (single space-separated word), `noProtocolUrlValidator` finds `noscha.io` within the word and creates a `SchemelessUrlSegment`, incorrectly splitting the word into a link + extra text.

## Fix

**Fix 1** (`parseValidUrls`): Only add URLs with an explicit `http://` or `https://` scheme to the URL set. Scheme-less domains fall through to the `SchemelessUrlSegment` path in `wordIdentifier`, which renders them as simple inline clickable text — no preview card, no layout disruption.

**Fix 2** (`wordIdentifier`): When detecting a scheme-less URL, skip words where the characters immediately following the URL are letters or digits. If `additionalChars` starts with a letter/digit, the domain is embedded inside a larger word and should be treated as regular text.

## Behavior Change

| Input | Before | After |
|-------|--------|-------|
| `https://noscha.io` | LinkSegment → preview card ✅ | LinkSegment → preview card ✅ |
| `noscha.io` (standalone) | LinkSegment → preview card ❌ | SchemelessUrlSegment → inline link ✅ |
| `noscha.ioが面白い` | SchemelessUrlSegment (split) ❌ | RegularTextSegment ✅ |

## Testing

Build verified: `./gradlew compileDebugKotlin` passes with no errors.