### PR TITLE
Add RelayUrlSegment for WebSocket relay URL parsing

### DIFF
--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
@@ -245,6 +245,8 @@ class RichTextParser {
 
         if (videos.contains(word)) return VideoSegment(word)
 
+        if (word.startsWith("ws://", ignoreCase = true) || word.startsWith("wss://", ignoreCase = true)) return RelayUrlSegment(word)
+
         if (urls.contains(word)) return LinkSegment(word)
 
         if (CustomEmoji.fastMightContainEmoji(word, emojis) && emojis.any { word.contains(it.key) }) return EmojiSegment(word)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParserSegments.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParserSegments.kt
@@ -147,6 +147,11 @@ class SchemelessUrlSegment(
 ) : Segment(segment)
 
 @Immutable
+class RelayUrlSegment(
+    segment: String,
+) : Segment(segment)
+
+@Immutable
 class RegularTextSegment(
     segment: String,
 ) : Segment(segment)


### PR DESCRIPTION
## Summary
Added support for parsing WebSocket relay URLs (ws:// and wss://) as a distinct segment type in the rich text parser.

## Key Changes
- Created new `RelayUrlSegment` class to represent WebSocket relay URLs as an immutable segment type
- Updated `RichTextParser` to detect and parse WebSocket URLs (ws:// and wss://) before generic link parsing
- WebSocket URL detection is case-insensitive and occurs in the parsing pipeline before standard URL handling

## Implementation Details
The new `RelayUrlSegment` is checked during word parsing after video detection but before generic link detection. This ensures WebSocket relay URLs are properly categorized separately from standard HTTP(S) links, allowing for specialized handling in the UI layer if needed.

https://claude.ai/code/session_01U21sGdEEMLo4hY8dwxNzPr