### PR TITLE
Add reaction type settings to AllSettingsScreen

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -163,7 +163,7 @@ fun AppNavigation(
             composableFromBottomArgs<Route.EditProfile> { NewUserMetadataScreen(nav, accountViewModel) }
             composable<Route.Search> { SearchScreen(accountViewModel, nav) }
 
-            composableFromEnd<Route.AllSettings> { AllSettingsScreen(nav) }
+            composableFromEnd<Route.AllSettings> { AllSettingsScreen(accountViewModel, nav) }
             composableFromEnd<Route.SecurityFilters> { SecurityFiltersScreen(accountViewModel, nav) }
             composableFromEnd<Route.PrivacyOptions> { PrivacyOptionsScreen(Amethyst.instance.torPrefs.value, nav) }
             composableFromEnd<Route.Bookmarks> { BookmarkListScreen(accountViewModel, nav) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AllSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AllSettingsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.CloudUpload
+import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.outlined.Security
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.Translate
@@ -37,6 +38,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -47,12 +52,26 @@ import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.navigation.topbars.TopBarWithBackButton
+import com.vitorpamplona.amethyst.ui.note.UpdateReactionTypeDialog
 import com.vitorpamplona.amethyst.ui.painterRes
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
 
 @Composable
-fun AllSettingsScreen(nav: INav) {
+fun AllSettingsScreen(
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
     val tint = MaterialTheme.colorScheme.onBackground
+    var showReactionDialog by remember { mutableStateOf(false) }
+
+    if (showReactionDialog) {
+        UpdateReactionTypeDialog(
+            onClose = { showReactionDialog = false },
+            accountViewModel = accountViewModel,
+            nav = nav,
+        )
+    }
 
     Scaffold(
         topBar = {
@@ -88,6 +107,13 @@ fun AllSettingsScreen(nav: INav) {
                 iconPainterRef = 1,
                 tint = tint,
                 onClick = { nav.nav(Route.PrivacyOptions) },
+            )
+            HorizontalDivider()
+            SettingsNavigationRow(
+                title = R.string.reactions,
+                icon = Icons.Outlined.FavoriteBorder,
+                tint = tint,
+                onClick = { showReactionDialog = true },
             )
             HorizontalDivider()
             SettingsNavigationRow(

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -1518,6 +1518,7 @@
     <string name="bradcasting_result_success">All events succeeded</string>
     <string name="bradcasting_result_failure">All events failed</string>
 
+    <string name="reactions">Reactions</string>
     <string name="reaction">Reaction</string>
     <string name="voice_post">Voice Post</string>
     <string name="voice_reply">Voice Reply</string>


### PR DESCRIPTION
## Summary
Added a new "Reactions" settings option to the AllSettingsScreen that allows users to configure their reaction type preferences through a dialog.

## Key Changes
- Updated `AllSettingsScreen` to accept `accountViewModel` parameter, enabling access to account-related functionality
- Added state management for the reaction type dialog using `remember` and `mutableStateOf`
- Integrated `UpdateReactionTypeDialog` component that displays when users tap the Reactions settings option
- Added a new "Reactions" settings row with a heart icon (`FavoriteBorder`) in the settings menu
- Updated the navigation call in `AppNavigation.kt` to pass the `accountViewModel` to `AllSettingsScreen`
- Added the "Reactions" string resource to `strings.xml`

## Implementation Details
- The reaction dialog is conditionally rendered based on `showReactionDialog` state
- The dialog is dismissed via the `onClose` callback which sets the state back to false
- The new settings row is positioned between Privacy Options and Preferences sections
- All necessary Compose runtime imports were added to support state management

https://claude.ai/code/session_01XZWHLsU2NcqPTEtKNFSCYN