### PR TITLE
defensive backup rules

### DIFF
--- a/amethyst/src/main/res/xml/backup_rules.xml
+++ b/amethyst/src/main/res/xml/backup_rules.xml
@@ -1,13 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample backup rules file; uncomment and customize as necessary.
-   See https://developer.android.com/guide/topics/data/autobackup
-   for details.
-   Note: This file is ignored for devices older that API 31
-   See https://developer.android.com/about/versions/12/backup-restore
--->
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Defense-in-depth: allowBackup="false" is set in AndroidManifest.xml.
+     These rules provide additional protection if backup is ever enabled. -->
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <!-- Exclude encrypted secrets (device-bound, can't decrypt on other devices) -->
+    <exclude domain="sharedpref" path="secret_keeper.xml" />
+    <exclude domain="sharedpref" path="." requireFlags="clientSideEncryption" />
+
+    <!-- Exclude all DataStore files (contains encrypted keys and account prefs) -->
+    <exclude domain="file" path="datastore" />
+
+    <!-- Exclude external storage (large, ephemeral) -->
+    <exclude domain="external" path="." />
 </full-backup-content>

--- a/amethyst/src/main/res/xml/data_extraction_rules.xml
+++ b/amethyst/src/main/res/xml/data_extraction_rules.xml
@@ -1,19 +1,28 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample data extraction rules file; uncomment and customize as necessary.
-   See https://developer.android.com/about/versions/12/backup-restore#xml-changes
-   for details.
--->
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Defense-in-depth: allowBackup="false" is set in AndroidManifest.xml.
+     These rules provide additional protection if backup is ever enabled. -->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <!-- Exclude encrypted secrets (device-bound KeyStore encryption) -->
+        <exclude domain="sharedpref" path="secret_keeper.xml" />
+        <exclude domain="sharedpref" path="." requireFlags="clientSideEncryption" />
+
+        <!-- Exclude all DataStore files (encrypted keys and account preferences) -->
+        <exclude domain="file" path="datastore" />
+
+        <!-- Exclude external storage -->
+        <exclude domain="external" path="." />
     </cloud-backup>
-    <!--
+
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <!-- Exclude encrypted secrets (device-bound, unusable on target device) -->
+        <exclude domain="sharedpref" path="secret_keeper.xml" />
+        <exclude domain="sharedpref" path="." requireFlags="clientSideEncryption" />
+
+        <!-- Exclude all DataStore files (encrypted keys and account preferences) -->
+        <exclude domain="file" path="datastore" />
+
+        <!-- Exclude external storage -->
+        <exclude domain="external" path="." />
     </device-transfer>
-    -->
 </data-extraction-rules>


### PR DESCRIPTION
allowBackup="false" is set in AndroidManifest.xml.

These rules provide additional protection if backup is ever enabled.

Replaces the existing copy paste defaults...