### PR TITLE
Convert AccountBackupDialog to full-screen navigation route

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -105,6 +105,7 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.relay.RelayFeedScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.AllRelayListScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.RelayInformationScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.search.SearchScreen
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.keyBackup.AccountBackupScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.AllSettingsScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.NIP47SetupScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.SecurityFiltersScreen
@@ -165,6 +166,7 @@ fun AppNavigation(
             composable<Route.Search> { SearchScreen(accountViewModel, nav) }
 
             composableFromEnd<Route.AllSettings> { AllSettingsScreen(accountViewModel, nav) }
+            composableFromBottom<Route.AccountBackup> { AccountBackupScreen(accountViewModel, nav) }
             composableFromEnd<Route.SecurityFilters> { SecurityFiltersScreen(accountViewModel, nav) }
             composableFromEnd<Route.PrivacyOptions> { PrivacyOptionsScreen(Amethyst.instance.torPrefs.value, nav) }
             composableFromEnd<Route.Bookmarks> { BookmarkListScreen(accountViewModel, nav) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
@@ -81,6 +81,8 @@ sealed class Route {
 
     @Serializable object AllSettings : Route()
 
+    @Serializable object AccountBackup : Route()
+
     @Serializable object Settings : Route()
 
     @Serializable object UserSettings : Route()
@@ -332,6 +334,7 @@ fun getRouteWithArguments(navController: NavHostController): Route? {
         dest.hasRoute<Route.ContentDiscovery>() -> entry.toRoute<Route.ContentDiscovery>()
         dest.hasRoute<Route.Drafts>() -> entry.toRoute<Route.Drafts>()
         dest.hasRoute<Route.AllSettings>() -> entry.toRoute<Route.AllSettings>()
+        dest.hasRoute<Route.AccountBackup>() -> entry.toRoute<Route.AccountBackup>()
         dest.hasRoute<Route.Settings>() -> entry.toRoute<Route.Settings>()
         dest.hasRoute<Route.EditProfile>() -> entry.toRoute<Route.EditProfile>()
         dest.hasRoute<Route.Profile>() -> entry.toRoute<Route.Profile>()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/keyBackup/AccountBackupDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/keyBackup/AccountBackupDialog.kt
@@ -80,8 +80,6 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import androidx.fragment.app.FragmentActivity
 import com.halilibo.richtext.commonmark.CommonMarkdownParseOptions
 import com.halilibo.richtext.commonmark.CommonmarkAstNodeParser
@@ -91,6 +89,7 @@ import com.halilibo.richtext.ui.material3.RichText
 import com.halilibo.richtext.ui.resolveDefaults
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.Account
+import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.ArrowBackIcon
 import com.vitorpamplona.amethyst.ui.note.authenticate
 import com.vitorpamplona.amethyst.ui.painterRes
@@ -112,23 +111,18 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
-fun AccountBackupDialog(
+fun AccountBackupScreen(
     accountViewModel: AccountViewModel,
-    onClose: () -> Unit,
+    nav: INav,
 ) {
-    Dialog(
-        onDismissRequest = onClose,
-        properties = DialogProperties(usePlatformDefaultWidth = false),
-    ) {
-        DialogContents(accountViewModel, onClose)
-    }
+    AccountBackupScreenContent(accountViewModel, nav::popBack)
 }
 
 @Preview(device = "spec:width=2160px,height=2340px,dpi=440")
 @Composable
-fun DialogContentsPreview() {
+fun AccountBackupScreenPreview() {
     ThemeComparisonRow {
-        DialogContents(
+        AccountBackupScreenContent(
             mockAccountViewModel(),
         ) {}
     }
@@ -136,7 +130,7 @@ fun DialogContentsPreview() {
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
-private fun DialogContents(
+private fun AccountBackupScreenContent(
     accountViewModel: AccountViewModel,
     onClose: () -> Unit,
 ) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AllSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AllSettingsScreen.kt
@@ -61,7 +61,6 @@ import com.vitorpamplona.amethyst.ui.note.UpdateReactionTypeDialog
 import com.vitorpamplona.amethyst.ui.note.UpdateZapAmountDialog
 import com.vitorpamplona.amethyst.ui.painterRes
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.keyBackup.AccountBackupDialog
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.mockAccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.ThemeComparisonColumn
@@ -152,22 +151,13 @@ fun AllSettingsScreen(
                 onClick = { nav.nav(Route.UserSettings) },
             )
             accountViewModel.account.settings.keyPair.privKey?.let {
-                var backupDialogOpen by remember { mutableStateOf(false) }
-
                 HorizontalDivider()
                 SettingsNavigationRow(
                     title = R.string.backup_keys,
                     icon = Icons.Outlined.Key,
                     tint = tint,
-                    onClick = {
-                        nav.closeDrawer()
-                        backupDialogOpen = true
-                    },
+                    onClick = { nav.nav(Route.AccountBackup) },
                 )
-
-                if (backupDialogOpen) {
-                    AccountBackupDialog(accountViewModel, onClose = { backupDialogOpen = false })
-                }
             }
             HorizontalDivider(thickness = 4.dp)
             SettingsSectionHeader(R.string.app_settings)


### PR DESCRIPTION
## Summary
Refactored the account backup feature from a modal dialog to a full-screen navigable route, improving the navigation architecture and user experience.

## Key Changes
- **Renamed and restructured**: `AccountBackupDialog` → `AccountBackupScreen` with updated function signatures
  - Changed from `onClose: () -> Unit` callback to `nav: INav` parameter for navigation integration
  - Removed `Dialog` and `DialogProperties` imports as the component is no longer a modal overlay
  
- **Navigation integration**: 
  - Added new `Route.AccountBackup` serializable route object
  - Registered the route in `getRouteWithArguments()` function
  - Added navigation composition in `AppNavigation` using `composableFromBottom<Route.AccountBackup>`
  
- **Updated AllSettingsScreen**:
  - Removed local state management (`backupDialogOpen`) for the dialog
  - Changed backup button to navigate via `nav.nav(Route.AccountBackup)` instead of opening a dialog
  - Removed the conditional dialog rendering logic
  - Removed the import of `AccountBackupDialog`

- **Preview updates**: Renamed preview function from `DialogContentsPreview` to `AccountBackupScreenPreview`

## Implementation Details
The refactoring maintains the same UI content through the renamed `AccountBackupScreenContent` composable while moving the navigation responsibility to the routing system. This follows the app's navigation patterns and allows the backup screen to be accessed as a full-screen destination rather than an overlay dialog.

https://claude.ai/code/session_01KRRANB1b7wV7mpxEvpfjc7