### PR TITLE
Convert UpdateReactionTypeDialog to screen-based navigation

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -55,6 +55,7 @@ import com.vitorpamplona.amethyst.ui.navigation.routes.getRouteWithArguments
 import com.vitorpamplona.amethyst.ui.navigation.routes.isBaseRoute
 import com.vitorpamplona.amethyst.ui.navigation.routes.isSameRoute
 import com.vitorpamplona.amethyst.ui.note.PayViaIntentScreen
+import com.vitorpamplona.amethyst.ui.note.UpdateReactionTypeScreen
 import com.vitorpamplona.amethyst.ui.note.nip22Comments.ReplyCommentPostScreen
 import com.vitorpamplona.amethyst.ui.screen.AccountStateViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountSwitcherAndLeftDrawerLayout
@@ -174,6 +175,7 @@ fun AppNavigation(
             composableFromBottomArgs<Route.Nip47NWCSetup> { NIP47SetupScreen(accountViewModel, nav, it.nip47) }
             composableFromEndArgs<Route.EditRelays> { AllRelayListScreen(accountViewModel, nav) }
             composableFromEndArgs<Route.EditMediaServers> { AllMediaServersScreen(accountViewModel, nav) }
+            composableFromBottom<Route.UpdateReactionType> { UpdateReactionTypeScreen(accountViewModel, nav) }
 
             composableFromEndArgs<Route.ContentDiscovery> { DvmContentDiscoveryScreen(it.id, accountViewModel, nav) }
             composableFromEndArgs<Route.Profile> { ProfileScreen(it.id, accountViewModel, nav) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
@@ -113,6 +113,8 @@ sealed class Route {
 
     @Serializable object EditMediaServers : Route()
 
+    @Serializable object UpdateReactionType : Route()
+
     @Serializable data class Nip47NWCSetup(
         val nip47: String? = null,
     ) : Route()
@@ -351,6 +353,7 @@ fun getRouteWithArguments(navController: NavHostController): Route? {
         dest.hasRoute<Route.EventRedirect>() -> entry.toRoute<Route.EventRedirect>()
         dest.hasRoute<Route.EditRelays>() -> entry.toRoute<Route.EditRelays>()
         dest.hasRoute<Route.EditMediaServers>() -> entry.toRoute<Route.EditMediaServers>()
+        dest.hasRoute<Route.UpdateReactionType>() -> entry.toRoute<Route.UpdateReactionType>()
         dest.hasRoute<Route.Nip47NWCSetup>() -> entry.toRoute<Route.Nip47NWCSetup>()
         dest.hasRoute<Route.Room>() -> entry.toRoute<Route.Room>()
         dest.hasRoute<Route.NewShortNote>() -> entry.toRoute<Route.NewShortNote>()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
@@ -871,7 +871,6 @@ fun LikeReaction(
     heartSizeModifier: Modifier = Size18Modifier,
     iconFontSize: TextUnit = Font14SP,
 ) {
-    var wantsToChangeReactionSymbol by remember { mutableStateOf(false) }
     var wantsToReact by remember { mutableStateOf(false) }
 
     ClickableBox(
@@ -883,7 +882,7 @@ fun LikeReaction(
                 onWantsToSignReaction = { accountViewModel.reactToOrDelete(baseNote) },
             )
         },
-        onLongClick = { wantsToChangeReactionSymbol = true },
+        onLongClick = { nav.nav(Route.UpdateReactionType) },
     ) {
         ObserveLikeIcon(baseNote, accountViewModel) { reactionType ->
             CrossfadeIfEnabled(targetState = reactionType, contentAlignment = Center, label = "LikeIcon", accountViewModel = accountViewModel) {
@@ -895,14 +894,6 @@ fun LikeReaction(
             }
         }
 
-        if (wantsToChangeReactionSymbol) {
-            UpdateReactionTypeDialog(
-                { wantsToChangeReactionSymbol = false },
-                accountViewModel = accountViewModel,
-                nav,
-            )
-        }
-
         if (wantsToReact) {
             ReactionChoicePopup(
                 baseNote,
@@ -911,7 +902,7 @@ fun LikeReaction(
                 onDismiss = { wantsToReact = false },
                 onChangeAmount = {
                     wantsToReact = false
-                    wantsToChangeReactionSymbol = true
+                    nav.nav(Route.UpdateReactionType)
                 },
             )
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/UpdateReactionTypeDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/UpdateReactionTypeDialog.kt
@@ -69,8 +69,6 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
@@ -81,7 +79,6 @@ import com.vitorpamplona.amethyst.service.firstFullChar
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.observeNoteEventAndMapNotNull
 import com.vitorpamplona.amethyst.ui.components.AnimatedBorderTextCornerRadius
 import com.vitorpamplona.amethyst.ui.components.InLineIconRenderer
-import com.vitorpamplona.amethyst.ui.components.SetDialogToEdgeToEdge
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.routeFor
 import com.vitorpamplona.amethyst.ui.navigation.topbars.SavingTopBar
@@ -153,8 +150,7 @@ class UpdateReactionTypeViewModel : ViewModel() {
 }
 
 @Composable
-fun UpdateReactionTypeDialog(
-    onClose: () -> Unit,
+fun UpdateReactionTypeScreen(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
@@ -165,119 +161,106 @@ fun UpdateReactionTypeDialog(
         postViewModel.load()
     }
 
-    UpdateReactionTypeDialog(postViewModel, onClose, accountViewModel, nav)
+    UpdateReactionTypeScreen(postViewModel, accountViewModel, nav)
 }
 
 @OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
 @Composable
-fun UpdateReactionTypeDialog(
+fun UpdateReactionTypeScreen(
     postViewModel: UpdateReactionTypeViewModel,
-    onClose: () -> Unit,
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    Dialog(
-        onDismissRequest = { onClose() },
-        properties =
-            DialogProperties(
-                usePlatformDefaultWidth = false,
-                dismissOnClickOutside = false,
-                decorFitsSystemWindows = false,
-            ),
-    ) {
-        SetDialogToEdgeToEdge()
-
-        Scaffold(
-            topBar = {
-                SavingTopBar(
-                    isActive = postViewModel::hasChanged,
-                    onCancel = {
-                        postViewModel.cancel()
-                        onClose()
-                    },
-                    onPost = {
-                        postViewModel.sendPost()
-                        onClose()
-                    },
-                )
-            },
-        ) { pad ->
-            Surface(
-                modifier =
-                    Modifier
-                        .padding(pad)
-                        .consumeWindowInsets(pad)
-                        .imePadding(),
+    Scaffold(
+        topBar = {
+            SavingTopBar(
+                isActive = postViewModel::hasChanged,
+                onCancel = {
+                    postViewModel.cancel()
+                    nav.popBack()
+                },
+                onPost = {
+                    postViewModel.sendPost()
+                    nav.popBack()
+                },
+            )
+        },
+    ) { pad ->
+        Surface(
+            modifier =
+                Modifier
+                    .padding(pad)
+                    .consumeWindowInsets(pad)
+                    .imePadding(),
+        ) {
+            Column(
+                modifier = Modifier.padding(10.dp),
             ) {
-                Column(
-                    modifier = Modifier.padding(10.dp),
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
                 ) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
+                    Column(
+                        modifier = Modifier.verticalScroll(rememberScrollState()),
                     ) {
-                        Column(
-                            modifier = Modifier.verticalScroll(rememberScrollState()),
-                        ) {
-                            Row(modifier = Modifier.fillMaxWidth()) {
-                                Column(modifier = Modifier.animateContentSize()) {
-                                    FlowRow(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        horizontalArrangement = Arrangement.Center,
-                                    ) {
-                                        postViewModel.reactionSet.forEach { reactionType ->
-                                            RenderReactionOption(reactionType, postViewModel)
-                                        }
+                        Row(modifier = Modifier.fillMaxWidth()) {
+                            Column(modifier = Modifier.animateContentSize()) {
+                                FlowRow(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.Center,
+                                ) {
+                                    postViewModel.reactionSet.forEach { reactionType ->
+                                        RenderReactionOption(reactionType, postViewModel)
                                     }
                                 }
                             }
+                        }
 
-                            Spacer(modifier = Modifier.height(10.dp))
+                        Spacer(modifier = Modifier.height(10.dp))
 
-                            Row(
-                                modifier = Modifier.fillMaxWidth().padding(vertical = 5.dp),
-                                verticalAlignment = Alignment.CenterVertically,
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(vertical = 5.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            OutlinedTextField(
+                                label = { Text(text = stringRes(R.string.new_reaction_symbol)) },
+                                value = postViewModel.nextChoice,
+                                onValueChange = { postViewModel.nextChoice = it },
+                                keyboardOptions =
+                                    KeyboardOptions.Default.copy(
+                                        capitalization = KeyboardCapitalization.None,
+                                        keyboardType = KeyboardType.Text,
+                                    ),
+                                placeholder = {
+                                    Text(
+                                        text = "\uD83D\uDCAF, \uD83C\uDF89, \uD83D\uDC4E",
+                                        color = MaterialTheme.colorScheme.placeholderText,
+                                    )
+                                },
+                                singleLine = true,
+                                modifier = Modifier.padding(end = 10.dp).weight(1f),
+                            )
+
+                            Button(
+                                onClick = { postViewModel.addChoice() },
+                                shape = ButtonBorder,
+                                colors =
+                                    ButtonDefaults.buttonColors(
+                                        containerColor = MaterialTheme.colorScheme.primary,
+                                    ),
                             ) {
-                                OutlinedTextField(
-                                    label = { Text(text = stringRes(R.string.new_reaction_symbol)) },
-                                    value = postViewModel.nextChoice,
-                                    onValueChange = { postViewModel.nextChoice = it },
-                                    keyboardOptions =
-                                        KeyboardOptions.Default.copy(
-                                            capitalization = KeyboardCapitalization.None,
-                                            keyboardType = KeyboardType.Text,
-                                        ),
-                                    placeholder = {
-                                        Text(
-                                            text = "\uD83D\uDCAF, \uD83C\uDF89, \uD83D\uDC4E",
-                                            color = MaterialTheme.colorScheme.placeholderText,
-                                        )
-                                    },
-                                    singleLine = true,
-                                    modifier = Modifier.padding(end = 10.dp).weight(1f),
-                                )
-
-                                Button(
-                                    onClick = { postViewModel.addChoice() },
-                                    shape = ButtonBorder,
-                                    colors =
-                                        ButtonDefaults.buttonColors(
-                                            containerColor = MaterialTheme.colorScheme.primary,
-                                        ),
-                                ) {
-                                    Text(text = stringRes(R.string.add), color = Color.White)
-                                }
+                                Text(text = stringRes(R.string.add), color = Color.White)
                             }
                         }
                     }
+                }
 
-                    Spacer(StdVertSpacer)
+                Spacer(StdVertSpacer)
 
-                    EmojiSelector(
-                        accountViewModel = accountViewModel,
-                        nav = nav,
-                    ) {
-                        postViewModel.addChoice(it)
-                    }
+                EmojiSelector(
+                    accountViewModel = accountViewModel,
+                    nav = nav,
+                ) {
+                    postViewModel.addChoice(it)
                 }
             }
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AllSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AllSettingsScreen.kt
@@ -57,7 +57,6 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.navigation.topbars.TopBarWithBackButton
-import com.vitorpamplona.amethyst.ui.note.UpdateReactionTypeDialog
 import com.vitorpamplona.amethyst.ui.note.UpdateZapAmountDialog
 import com.vitorpamplona.amethyst.ui.painterRes
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -84,16 +83,7 @@ fun AllSettingsScreen(
 ) {
     val tint = MaterialTheme.colorScheme.onBackground
 
-    var showReactionDialog by remember { mutableStateOf(false) }
     var wantsToChangeZapAmount by remember { mutableStateOf(false) }
-
-    if (showReactionDialog) {
-        UpdateReactionTypeDialog(
-            onClose = { showReactionDialog = false },
-            accountViewModel = accountViewModel,
-            nav = nav,
-        )
-    }
 
     if (wantsToChangeZapAmount) {
         UpdateZapAmountDialog(
@@ -128,7 +118,7 @@ fun AllSettingsScreen(
                 title = R.string.reactions,
                 icon = Icons.Outlined.FavoriteBorder,
                 tint = tint,
-                onClick = { showReactionDialog = true },
+                onClick = { nav.nav(Route.UpdateReactionType) },
             )
             HorizontalDivider()
             SettingsNavigationRow(


### PR DESCRIPTION
## Summary
Refactored the reaction type update feature from a dialog-based implementation to a screen-based navigation approach, integrating it into the app's navigation system.

## Key Changes
- **Renamed and restructured**: `UpdateReactionTypeDialog` → `UpdateReactionTypeScreen`
  - Removed `Dialog` wrapper and `DialogProperties` 
  - Removed `SetDialogToEdgeToEdge()` call
  - Removed `onClose` callback parameter in favor of `nav.popBack()`
  
- **Navigation integration**:
  - Added `Route.UpdateReactionType` to the sealed Route class
  - Updated route handling in `getRouteWithArguments()` to recognize the new route
  - Imported and registered `UpdateReactionTypeScreen` in `AppNavigation.kt`

- **Updated call sites**:
  - `ReactionsRow.kt`: Changed long-click handler in `LikeReaction()` to use `nav.nav(Route.UpdateReactionType)` instead of local state management
  - `AllSettingsScreen.kt`: Replaced dialog state and callback with direct navigation call
  - Removed local `mutableStateOf` state management for showing/hiding the dialog

## Implementation Details
- The screen now uses the standard Scaffold layout directly instead of being wrapped in a Dialog
- Navigation back is handled through `nav.popBack()` instead of callback functions
- This aligns with the app's navigation architecture and improves state management by using the navigation stack instead of local composable state

https://claude.ai/code/session_01TSjuYdBADTRXwT4w8Yx1vU