### PR TITLE
Persist search screen scroll position across navigation

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/feeds/RememberForeverStates.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/feeds/RememberForeverStates.kt
@@ -54,6 +54,8 @@ object ScrollStateKeys {
     const val DISCOVER_LIVE = "DiscoverLiveFeed"
     const val DISCOVER_COMMUNITY = "DiscoverCommunitiesFeed"
     const val DISCOVER_CHATS = "DiscoverChatsFeed"
+
+    const val SEARCH_SCREEN = "SearchFeed"
 }
 
 object PagerStateKeys {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/search/SearchScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/search/SearchScreen.kt
@@ -33,7 +33,8 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.lazy.rememberLazyListState
+import com.vitorpamplona.amethyst.ui.feeds.ScrollStateKeys
+import com.vitorpamplona.amethyst.ui.feeds.rememberForeverLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.HorizontalDivider
@@ -107,7 +108,7 @@ fun SearchScreen(
 ) {
     WatchLifecycleAndUpdateModel(searchBarViewModel)
 
-    val listState = rememberLazyListState()
+    val listState = rememberForeverLazyListState(ScrollStateKeys.SEARCH_SCREEN)
 
     LaunchedEffect(searchBarViewModel.focusRequester) {
         searchBarViewModel.focusRequester.requestFocus()


### PR DESCRIPTION
## Summary
This change implements scroll position persistence for the Search Screen by replacing the standard lazy list state with a persistent state management solution.

## Key Changes
- **SearchScreen.kt**: Updated the LazyColumn state initialization to use `rememberForeverLazyListState()` instead of `rememberLazyListState()`, enabling scroll position to be preserved when navigating away and returning to the search screen
- **RememberForeverStates.kt**: Added `SEARCH_SCREEN` constant to the `ScrollStateKeys` object to identify and manage the search screen's scroll state

## Implementation Details
The change leverages the existing `rememberForeverLazyListState()` infrastructure that was already in use for other feed screens (Discover Live, Discover Communities, Discover Chats). This ensures consistent scroll position persistence behavior across the application's feed-based screens.

https://claude.ai/code/session_01PmSFQqSMzP51mtqPLwFEtp