### PR TITLE
Add optional description field for sensitive content warnings

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/contentWarning/ContentSensitivityExplainer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/contentWarning/ContentSensitivityExplainer.kt
@@ -34,6 +34,7 @@ import androidx.compose.material.icons.rounded.Warning
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -48,7 +49,10 @@ import com.vitorpamplona.amethyst.ui.theme.DividerThickness
 import com.vitorpamplona.amethyst.ui.theme.placeholderText
 
 @Composable
-fun ContentSensitivityExplainer() {
+fun ContentSensitivityExplainer(
+    description: String,
+    onDescriptionChange: (String) -> Unit,
+) {
     Column(Modifier.fillMaxWidth()) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -96,6 +100,19 @@ fun ContentSensitivityExplainer() {
             text = stringRes(R.string.add_sensitive_content_explainer),
             color = MaterialTheme.colorScheme.placeholderText,
             modifier = Modifier.padding(vertical = 10.dp),
+        )
+
+        OutlinedTextField(
+            value = description,
+            onValueChange = onDescriptionChange,
+            modifier = Modifier.fillMaxWidth(),
+            placeholder = {
+                Text(
+                    text = stringRes(R.string.add_sensitive_content_description_placeholder),
+                    color = MaterialTheme.colorScheme.placeholderText,
+                )
+            },
+            singleLine = true,
         )
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostScreen.kt
@@ -304,7 +304,10 @@ private fun NewPostScreenBody(
                         verticalAlignment = CenterVertically,
                         modifier = Modifier.padding(vertical = Size5dp, horizontal = Size10dp),
                     ) {
-                        ContentSensitivityExplainer()
+                        ContentSensitivityExplainer(
+                            description = postViewModel.contentWarningDescription,
+                            onDescriptionChange = { postViewModel.contentWarningDescription = it },
+                        )
                     }
                 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostViewModel.kt
@@ -94,6 +94,7 @@ import com.vitorpamplona.quartz.nip30CustomEmoji.CustomEmoji
 import com.vitorpamplona.quartz.nip30CustomEmoji.EmojiUrlTag
 import com.vitorpamplona.quartz.nip30CustomEmoji.emojis
 import com.vitorpamplona.quartz.nip36SensitiveContent.contentWarning
+import com.vitorpamplona.quartz.nip36SensitiveContent.contentWarningReason
 import com.vitorpamplona.quartz.nip36SensitiveContent.isSensitive
 import com.vitorpamplona.quartz.nip36SensitiveContent.isSensitiveOrNSFW
 import com.vitorpamplona.quartz.nip37Drafts.DraftWrapEvent
@@ -236,6 +237,7 @@ open class ShortNotePostViewModel :
 
     // NSFW, Sensitive
     var wantsToMarkAsSensitive by mutableStateOf(false)
+    var contentWarningDescription by mutableStateOf("")
 
     // GeoHash
     var wantsToAddGeoHash by mutableStateOf(false)
@@ -423,6 +425,7 @@ open class ShortNotePostViewModel :
         wantsForwardZapTo = localForwardZapTo.isNotEmpty()
 
         wantsToMarkAsSensitive = draftEvent.isSensitive()
+        contentWarningDescription = draftEvent.contentWarningReason() ?: ""
 
         val geohash = draftEvent.getGeoHash()
         wantsToAddGeoHash = geohash != null
@@ -502,6 +505,7 @@ open class ShortNotePostViewModel :
         wantsForwardZapTo = localForwardZapTo.isNotEmpty()
 
         wantsToMarkAsSensitive = draftEvent.isSensitive()
+        contentWarningDescription = draftEvent.contentWarningReason() ?: ""
 
         val geohash = draftEvent.getGeoHash()
         wantsToAddGeoHash = geohash != null
@@ -685,7 +689,7 @@ open class ShortNotePostViewModel :
         val urls = findURLs(tagger.message)
         val usedAttachments = iMetaAttachments.filterIsIn(urls.toSet())
 
-        val contentWarningReason = if (wantsToMarkAsSensitive) "" else null
+        val contentWarningReason = if (wantsToMarkAsSensitive) contentWarningDescription else null
 
         return if (wantsPoll) {
             val options = pollOptions.map { it.value }
@@ -896,6 +900,7 @@ open class ShortNotePostViewModel :
 
         wantsForwardZapTo = false
         wantsToMarkAsSensitive = false
+        contentWarningDescription = ""
         wantsToAddGeoHash = false
         wantsExclusiveGeoPost = false
         wantsSecretEmoji = false

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -962,6 +962,7 @@
     <string name="lack_location_permissions">No Location Permissions</string>
 
     <string name="add_sensitive_content_explainer">Adds sensitive content warning before showing your content. This is ideal for any NSFW content or content some people may find offensive or disturbing</string>
+    <string name="add_sensitive_content_description_placeholder">Reason (optional)</string>
 
     <string name="new_feature_nip17_might_not_be_available_title">New Feature</string>
     <string name="new_feature_nip17_might_not_be_available_description">Activating this mode requires Amethyst to send a NIP-17 message (GiftWrapped, Sealed Direct and Group Messages). NIP-17 is new and most clients have not implemented it yet. Make sure the receiver is using a compatible client.</string>

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip36SensitiveContent/EventExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip36SensitiveContent/EventExt.kt
@@ -25,3 +25,5 @@ import com.vitorpamplona.quartz.nip01Core.core.Event
 fun Event.isSensitive() = tags.isSensitive()
 
 fun Event.isSensitiveOrNSFW() = tags.isSensitiveOrNSFW()
+
+fun Event.contentWarningReason() = tags.contentWarningReason()

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip36SensitiveContent/TagArrayExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip36SensitiveContent/TagArrayExt.kt
@@ -28,3 +28,5 @@ val nsfwTags = setOf("nsfw", "nude", "NSFW", "NUDE", "Nsfw", "Nude")
 fun TagArray.isSensitive() = this.any(ContentWarningTag::isTag)
 
 fun TagArray.isSensitiveOrNSFW() = this.any { ContentWarningTag.isTag(it) || HashtagTag.isAnyTagged(it, nsfwTags) }
+
+fun TagArray.contentWarningReason() = this.firstOrNull(ContentWarningTag::isTag)?.getOrNull(1)


### PR DESCRIPTION
## Summary
This PR adds support for optional descriptions/reasons when marking content as sensitive, implementing NIP-36 content warning reason tags. Users can now provide context for why content is marked sensitive.

## Key Changes
- **ContentSensitivityExplainer**: Added `description` parameter and `onDescriptionChange` callback, plus an `OutlinedTextField` to allow users to input an optional reason for the content warning
- **ShortNotePostViewModel**: 
  - Added `contentWarningDescription` state variable to track the warning reason
  - Updated draft loading logic to restore the content warning description from saved drafts
  - Modified event creation to use the description when marking content as sensitive (instead of empty string)
  - Clear description on post reset
- **ShortNotePostScreen**: Updated `ContentSensitivityExplainer` call to pass the description state and callback
- **Quartz library extensions**: 
  - Added `contentWarningReason()` extension functions to extract the reason from content warning tags
- **Strings**: Added placeholder text for the description field

## Implementation Details
- The description field is optional and only included in the event when the user marks content as sensitive
- When loading drafts, the existing content warning reason is extracted and restored to the UI
- The implementation follows NIP-36 specification for sensitive content with optional reason tags

https://claude.ai/code/session_01P2nkYdNiWXiAcfMPTRTVEW