### PR TITLE
Rename build step for Benchmark APK in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
           name: FDroid Debug APK
           path: amethyst/build/outputs/apk/fdroid/debug/amethyst-fdroid-universal-debug.apk
 
-      - name: Build APK (gradle)
+      - name: Build Benchmark APK (gradle)
         run: ./gradlew assembleBenchmark
 
       - name: Upload Play APK Benchmark


### PR DESCRIPTION
Can we do this minor change or will it cause issue with some historical data?