### PR TITLE
Fix swipe-back triggering unwanted draft deletion signing

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/PrivateMessageEditFieldRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/PrivateMessageEditFieldRow.kt
@@ -88,10 +88,12 @@ fun PrivateMessageEditFieldRow(
     nav: INav,
 ) {
     BackHandler {
-        accountViewModel.launchSigner {
-            channelScreenModel.sendDraftSync()
-            channelScreenModel.cancel()
+        if (channelScreenModel.message.text.isNotBlank()) {
+            accountViewModel.launchSigner {
+                channelScreenModel.sendDraftSync()
+            }
         }
+        channelScreenModel.cancel()
         nav.popBack()
     }
 


### PR DESCRIPTION
When swiping back on a DM conversation screen with an empty reply, the BackHandler was calling sendDraftSync() which checks if the message is blank and then calls deleteDraftIgnoreErrors(). This creates and signs a NIP-09 DeletionEvent, prompting the external signer to sign a deletion event.

The fix adds a check to only call sendDraftSync() when there's actual content in the message, avoiding the unnecessary signing prompt.

This behavior was not happening when pressing the back button, suggesting different behavior from the same intent. Combining those behaviors is out-of-scope for this PR.