### PR TITLE
Reduce compilation warnings

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -2016,6 +2016,7 @@ class Account(
         }
 
         scope.launch(Dispatchers.IO) {
+            @OptIn(kotlinx.coroutines.FlowPreview::class)
             settings.saveable.debounce(1000).collect {
                 if (it.accountSettings != null) {
                     LocalPreferences.saveToEncryptedStorage(it.accountSettings)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -358,19 +358,19 @@ object LocalCache : ILocalCache, ICacheProvider {
 
     fun load(keys: Set<String>): Set<User> = keys.mapNotNullTo(mutableSetOf(), ::checkGetOrCreateUser)
 
-    override fun getOrCreateUser(key: HexKey): User {
-        require(isValidHex(key = key)) { "$key is not a valid hex" }
+    override fun getOrCreateUser(pubkey: HexKey): User {
+        require(isValidHex(key = pubkey)) { "$pubkey is not a valid hex" }
 
-        return users.getOrCreate(key) {
-            val nip65RelayListNote = getOrCreateAddressableNoteInternal(AdvertisedRelayListEvent.createAddress(key))
-            val dmRelayListNote = getOrCreateAddressableNoteInternal(ChatMessageRelayListEvent.createAddress(key))
+        return users.getOrCreate(pubkey) {
+            val nip65RelayListNote = getOrCreateAddressableNoteInternal(AdvertisedRelayListEvent.createAddress(pubkey))
+            val dmRelayListNote = getOrCreateAddressableNoteInternal(ChatMessageRelayListEvent.createAddress(pubkey))
             User(it, nip65RelayListNote, dmRelayListNote)
         }
     }
 
-    override fun getUserIfExists(key: String): User? {
-        if (key.isEmpty()) return null
-        return users.get(key)
+    override fun getUserIfExists(pubkey: String): User? {
+        if (pubkey.isEmpty()) return null
+        return users.get(pubkey)
     }
 
     override fun countUsers(predicate: (String, User) -> Boolean): Int {
@@ -394,7 +394,7 @@ object LocalCache : ILocalCache, ICacheProvider {
 
     fun getAddressableNoteIfExists(address: Address): AddressableNote? = addressables.get(address)
 
-    override fun getNoteIfExists(key: String): Note? = if (key.length == 64) notes.get(key) else Address.parse(key)?.let { addressables.get(it) }
+    override fun getNoteIfExists(hexKey: String): Note? = if (hexKey.length == 64) notes.get(hexKey) else Address.parse(hexKey)?.let { addressables.get(it) }
 
     fun getNoteIfExists(key: ETag): Note? = notes.get(key.eventId)
 
@@ -2250,6 +2250,7 @@ object LocalCache : ILocalCache, ICacheProvider {
 
             requestNote?.let { request -> zappedNote?.addZapPayment(request, note) }
 
+            @OptIn(kotlinx.coroutines.DelicateCoroutinesApi::class)
             GlobalScope.launch(Dispatchers.IO) {
                 responseCallback(event)
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcSignerState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcSignerState.kt
@@ -114,7 +114,7 @@ class NwcSignerState(
 
     fun hasWalletConnectSetup(): Boolean = nip47Setup.value != null
 
-    override fun isNIP47Author(pubkey: HexKey?): Boolean = nip47Signer.value.pubKey == pubkey
+    override fun isNIP47Author(pubKey: HexKey?): Boolean = nip47Signer.value.pubKey == pubKey
 
     /**
      * Decrypts a NIP-47 payment request using the current signer.

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/labeledBookmarkLists/LabeledBookmarkListsState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/labeledBookmarkLists/LabeledBookmarkListsState.kt
@@ -36,7 +36,7 @@ import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.BookmarkIdTag
 import com.vitorpamplona.quartz.nip51Lists.labeledBookmarkList.LabeledBookmarkListEvent
 import com.vitorpamplona.quartz.nip51Lists.labeledBookmarkList.description
 import com.vitorpamplona.quartz.nip51Lists.labeledBookmarkList.image
-import com.vitorpamplona.quartz.nip51Lists.labeledBookmarkList.name
+import com.vitorpamplona.quartz.nip51Lists.labeledBookmarkList.title
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -181,7 +181,7 @@ class LabeledBookmarkListsState(
 
         val template =
             listEvent.update {
-                if (listName != null) name(listName)
+                if (listName != null) title(listName)
                 if (listDescription != null) description(listDescription)
                 if (listImage != null) image(listImage)
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/peopleList/PeopleListsState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/peopleList/PeopleListsState.kt
@@ -38,7 +38,7 @@ import com.vitorpamplona.quartz.nip51Lists.muteList.tags.UserTag
 import com.vitorpamplona.quartz.nip51Lists.peopleList.PeopleListEvent
 import com.vitorpamplona.quartz.nip51Lists.peopleList.description
 import com.vitorpamplona.quartz.nip51Lists.peopleList.image
-import com.vitorpamplona.quartz.nip51Lists.peopleList.name
+import com.vitorpamplona.quartz.nip51Lists.peopleList.title
 import com.vitorpamplona.quartz.utils.flattenToSet
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -226,7 +226,7 @@ class PeopleListsState(
 
         val template =
             listEvent.update {
-                if (listName != null) name(listName)
+                if (listName != null) title(listName)
                 if (listDescription != null) description(listDescription)
                 if (listImage != null) image(listImage)
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/serverList/MergedFollowListsState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/serverList/MergedFollowListsState.kt
@@ -79,6 +79,7 @@ class MergedFollowListsState(
             communities = community.mapTo(mutableSetOf()) { it.address.toValue() },
         )
 
+    @OptIn(kotlinx.coroutines.FlowPreview::class)
     val flow: StateFlow<AllFollows> =
         combine(
             listOf(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/cashu/v4/V4Models.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/cashu/v4/V4Models.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.service.cashu.v4
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.cbor.ByteString
 
@@ -34,6 +35,7 @@ class V4Token(
     val t: Array<V4T>?,
 )
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 class V4T(
     // identifier
@@ -42,6 +44,7 @@ class V4T(
     val p: Array<V4Proof>,
 )
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 class V4Proof(
     // amount
@@ -57,6 +60,7 @@ class V4Proof(
     val w: String? = null,
 )
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 class V4DleqProof(
     @ByteString

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/watchers/EventWatcherSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/watchers/EventWatcherSubAssembler.kt
@@ -51,14 +51,14 @@ class EventWatcherSubAssembler(
     }
 
     override fun updateFilter(
-        key: List<EventFinderQueryState>,
+        keys: List<EventFinderQueryState>,
         since: SincePerRelayMap?,
     ): List<RelayBasedFilter>? {
-        if (key.isEmpty()) {
+        if (keys.isEmpty()) {
             return null
         }
 
-        lastNotesOnFilter = key.map { it.note }
+        lastNotesOnFilter = keys.map { it.note }
 
         return groupByRelayPresence(lastNotesOnFilter, latestEOSEs)
             .map { group ->

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/mediaServers/BlossomServersViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/mediaServers/BlossomServersViewModel.kt
@@ -53,7 +53,7 @@ class BlossomServersViewModel : ViewModel() {
     fun refresh() {
         isModified = false
         _fileServers.update {
-            val obtainedFileServers = obtainFileServers() ?: emptyList()
+            val obtainedFileServers = obtainFileServers()
             obtainedFileServers.mapNotNull { serverUrl ->
                 try {
                     ServerName(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/BadgeCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/BadgeCompose.kt
@@ -62,7 +62,7 @@ fun BadgeCompose(
     nav: INav,
 ) {
     val noteState by observeNote(likeSetCard.note, accountViewModel)
-    val note = noteState?.note
+    val note = noteState.note
 
     val context = LocalContext.current.applicationContext
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/UsernameDisplay.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/UsernameDisplay.kt
@@ -30,10 +30,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.vitorpamplona.amethyst.commons.model.ImmutableListOfLists
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapFormatterNoDecimals.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapFormatterNoDecimals.kt
@@ -49,10 +49,10 @@ fun showAmountInteger(amount: BigDecimal?): String {
     if (amount.abs() < BigDecimal(0.01)) return ""
 
     return when {
-        amount >= OneGiga -> dfG.get().format(amount.div(OneGiga).setScale(0, RoundingMode.HALF_UP))
-        amount >= OneMega -> dfM.get().format(amount.div(OneMega).setScale(0, RoundingMode.HALF_UP))
-        amount >= TenKilo -> dfK.get().format(amount.div(OneKilo).setScale(0, RoundingMode.HALF_UP))
-        else -> dfN.get().format(amount)
+        amount >= OneGiga -> dfG.get()?.format(amount.div(OneGiga).setScale(0, RoundingMode.HALF_UP)) ?: ""
+        amount >= OneMega -> dfM.get()?.format(amount.div(OneMega).setScale(0, RoundingMode.HALF_UP)) ?: ""
+        amount >= TenKilo -> dfK.get()?.format(amount.div(OneKilo).setScale(0, RoundingMode.HALF_UP)) ?: ""
+        else -> dfN.get()?.format(amount) ?: ""
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapPollNoteViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapPollNoteViewModel.kt
@@ -118,13 +118,13 @@ class PollNoteViewModel : ViewModel() {
                 it.zappedValue.value = zappedValue
                 it.tally.value = tallyValue.toFloat()
                 it.consensusThreadhold.value = consensusThreshold != null && tallyValue >= consensusThreshold!!
-                it.zappedByLoggedIn.value = account?.userProfile()?.let { it1 -> cachedIsPollOptionZappedBy(it.option, it1) } ?: false
+                it.zappedByLoggedIn.value = account.userProfile().let { it1 -> cachedIsPollOptionZappedBy(it.option, it1) }
             }
         }
     }
 
     fun checkIfCanZap(): Boolean {
-        val account = account ?: return false
+        val account = account
         val note = pollNote ?: return false
         return account.userProfile() != note.author && !wasZappedByLoggedInAccount
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Chess.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Chess.kt
@@ -96,7 +96,7 @@ fun RenderLiveChessChallenge(
     nav: INav,
 ) {
     val event = (note.event as? LiveChessGameChallengeEvent) ?: return
-    val gameId = event.gameId() ?: return
+    val gameId = event.gameId()
 
     val chessViewModel: ChessViewModelNew =
         viewModel(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/FileStorage.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/FileStorage.kt
@@ -72,9 +72,9 @@ private fun ObserverAndRenderNIP95(
     val content by
         remember(noteState) {
             // Creates a new object when the event arrives to force an update of the image.
-            val note = noteState?.note
+            val note = noteState.note
             val uri = header.toNostrUri()
-            val localDir = note?.idHex?.let { File(Amethyst.instance.nip95cache, it) }
+            val localDir = note.idHex.let { File(Amethyst.instance.nip95cache, it) }
             val blurHash = eventHeader.blurhash()
             val dimensions = eventHeader.dimensions()
             val description = eventHeader.alt() ?: eventHeader.content

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/TextModification.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/TextModification.kt
@@ -163,7 +163,7 @@ fun RenderTextModificationEvent(
                             }
 
                         LaunchedEffect(key1 = noteState) {
-                            val newAuthor = accountViewModel.isLoggedUser(noteState?.note?.author)
+                            val newAuthor = accountViewModel.isLoggedUser(noteState.note.author)
 
                             if (isAuthorTheLoggedUser.value != newAuthor) {
                                 isAuthorTheLoggedUser.value = newAuthor

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/nip28PublicChat/metadata/ChannelMetadataViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/nip28PublicChat/metadata/ChannelMetadataViewModel.kt
@@ -104,7 +104,7 @@ class ChannelMetadataViewModel : ViewModel() {
 
     fun createOrUpdate(onDone: (PublicChatChannel) -> Unit) {
         viewModelScope.launch(Dispatchers.IO) {
-            account?.let { account ->
+            account.let { account ->
                 val channel = originalChannel
                 if (channel == null) {
                     val template =
@@ -204,7 +204,7 @@ class ChannelMetadataViewModel : ViewModel() {
         onUploaded: (String) -> Unit,
         onError: (String, String) -> Unit,
     ) {
-        val account = account ?: return
+        val account = account
         onUploading(true)
 
         val compResult = MediaCompressor().compress(galleryUri.uri, galleryUri.mimeType, CompressorQuality.MEDIUM, context.applicationContext)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/NewProductViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/NewProductViewModel.kt
@@ -220,7 +220,7 @@ open class NewProductViewModel :
     }
 
     open fun quote(quote: Note) {
-        val accountViewModel = accountViewModel ?: return
+        val accountViewModel = accountViewModel
 
         message = TextFieldValue(message.text + "\nnostr:${quote.toNEvent()}")
 
@@ -307,7 +307,6 @@ open class NewProductViewModel :
     }
 
     suspend fun sendPostSync() {
-        val accountViewModel = accountViewModel ?: return
         val template = createTemplate() ?: return
 
         val version = draftTag.current
@@ -320,8 +319,6 @@ open class NewProductViewModel :
     }
 
     suspend fun sendDraftSync() {
-        val accountViewModel = accountViewModel ?: return
-
         if (message.text.isBlank()) {
             accountViewModel.account.deleteDraftIgnoreErrors(draftTag.current)
         } else {
@@ -331,7 +328,7 @@ open class NewProductViewModel :
     }
 
     private suspend fun createTemplate(): EventTemplate<out Event>? {
-        val accountViewModel = accountViewModel ?: return null
+        val accountViewModel = accountViewModel
 
         val tagger =
             NewMessageTagger(
@@ -340,7 +337,7 @@ open class NewProductViewModel :
             )
         tagger.run()
 
-        val emojis = findEmoji(tagger.message, account?.emoji?.myEmojis?.value)
+        val emojis = findEmoji(tagger.message, account.emoji.myEmojis.value)
         val urls = findURLs(tagger.message)
         val usedAttachments = iMetaDescription.filterIsIn(urls.toSet()) + productImages.map { it.toIMeta() }
 
@@ -399,7 +396,7 @@ open class NewProductViewModel :
         context: Context,
     ) {
         viewModelScope.launch(Dispatchers.IO) {
-            val myAccount = account ?: return@launch
+            val myAccount = account
             val myMultiOrchestrator = multiOrchestrator ?: return@launch
 
             mediaUploadTracker.startUpload(myMultiOrchestrator.hasNonMedia())
@@ -501,8 +498,8 @@ open class NewProductViewModel :
         this.multiOrchestrator?.remove(selected)
     }
 
-    override fun updateMessage(it: TextFieldValue) {
-        message = it
+    override fun updateMessage(newMessage: TextFieldValue) {
+        message = newMessage
         urlPreviews.update(message)
 
         if (message.selection.collapsed) {
@@ -616,7 +613,7 @@ open class NewProductViewModel :
 
     override fun updateZapFromText() {
         viewModelScope.launch(Dispatchers.IO) {
-            val tagger = NewMessageTagger(message.text, emptyList(), emptyList(), accountViewModel!!)
+            val tagger = NewMessageTagger(message.text, emptyList(), emptyList(), accountViewModel)
             tagger.run()
             tagger.pTags?.forEach { taggedUser ->
                 if (!forwardZapTo.value.items.any { it.key == taggedUser }) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/publicMessages/NewPublicMessageViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/publicMessages/NewPublicMessageViewModel.kt
@@ -322,7 +322,7 @@ class NewPublicMessageViewModel :
     }
 
     suspend fun sendPostSync() {
-        val template = createTemplate() ?: return
+        val template = createTemplate()
         val extraNotesToBroadcast = mutableListOf<Event>()
 
         if (nip95attachments.isNotEmpty()) {
@@ -354,7 +354,7 @@ class NewPublicMessageViewModel :
                 broadcast.add(it.second)
             }
 
-            val template = createTemplate() ?: return
+            val template = createTemplate()
             accountViewModel.account.createAndSendDraftIgnoreErrors(draftTag.current, template, broadcast)
         }
     }
@@ -459,7 +459,7 @@ class NewPublicMessageViewModel :
                     if (state.result is UploadOrchestrator.OrchestratorResult.NIP95Result) {
                         val nip95 = account.createNip95(state.result.bytes, headerInfo = state.result.fileHeader, alt, contentWarningReason)
                         nip95attachments = nip95attachments + nip95
-                        val note = nip95.let { it1 -> account?.consumeNip95(it1.first, it1.second) }
+                        val note = nip95.let { it1 -> account.consumeNip95(it1.first, it1.second) }
 
                         note?.let {
                             message = message.insertUrlAtCursor("nostr:" + it.toNEvent())

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/followers/dal/UserProfileFollowersUserFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/followers/dal/UserProfileFollowersUserFeedViewModel.kt
@@ -63,6 +63,7 @@ class UserProfileFollowersUserFeedViewModel(
             }
         }
 
+    @OptIn(kotlinx.coroutines.FlowPreview::class)
     val followersFlow: StateFlow<List<User>> =
         account.cache
             .observeEvents(followerFilter)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/follows/dal/UserProfileFollowsUserFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/follows/dal/UserProfileFollowsUserFeedViewModel.kt
@@ -55,6 +55,7 @@ class UserProfileFollowsUserFeedViewModel(
         return LocalCache.load(nonHiddenFollows).sortedWith(sortingModel)
     }
 
+    @OptIn(kotlinx.coroutines.FlowPreview::class)
     val followsFlow: StateFlow<List<User>> =
         contactList
             .flow()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/apps/WatchApp.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/apps/WatchApp.kt
@@ -56,7 +56,7 @@ fun WatchApp(
 
     LaunchedEffect(key1 = appState) {
         withContext(Dispatchers.IO) {
-            (appState?.note?.event as? AppDefinitionEvent)?.appMetaData()?.let { metaData ->
+            (appState.note.event as? AppDefinitionEvent)?.appMetaData()?.let { metaData ->
                 metaData.picture?.ifBlank { null }?.let { newLogo ->
                     if (newLogo != appLogo) appLogo = newLogo
                 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/zaps/dal/UserProfileZapsViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/zaps/dal/UserProfileZapsViewModel.kt
@@ -112,6 +112,7 @@ class UserProfileZapsViewModel(
         return results.map { (user, amount) -> ZapAmount(user, amount) }.sortedWith(sortingModel)
     }
 
+    @OptIn(kotlinx.coroutines.FlowPreview::class)
     val receivedZapAmountsByUser: StateFlow<List<ZapAmount>> =
         account.cache
             .observeEvents(zapsToUser)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/RelayInformationScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/RelayInformationScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.material.icons.automirrored.filled.Feed
 import androidx.compose.material.icons.automirrored.filled.Label
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.automirrored.filled.Message
+import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.AttachMoney
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.Code
@@ -61,7 +62,6 @@ import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Payment
 import androidx.compose.material.icons.filled.PrivacyTip
-import androidx.compose.material.icons.filled.Send
 import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.filled.Tag
 import androidx.compose.material.icons.filled.Topic
@@ -931,7 +931,7 @@ private fun OutboxEventsCard(eventIds: Set<HexKey>) {
                         horizontalArrangement = Arrangement.spacedBy(4.dp),
                     ) {
                         Icon(
-                            imageVector = Icons.Default.Send,
+                            imageVector = Icons.AutoMirrored.Filled.Send,
                             contentDescription = null,
                             modifier = Modifier.size(12.dp),
                             tint = MaterialTheme.colorScheme.onTertiaryContainer,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/search/SearchBarViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/search/SearchBarViewModel.kt
@@ -90,6 +90,7 @@ class SearchBarViewModel(
 
     val listState: LazyListState = LazyListState(0, 0)
 
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
     val directNip05Resolver: Flow<User?> =
         searchTerm
             .debounce(400)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/SecurityFiltersScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/SecurityFiltersScreen.kt
@@ -55,7 +55,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -63,6 +62,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletViewModel.kt
@@ -99,7 +99,7 @@ class WalletViewModel : ViewModel() {
 
     fun init(account: Account) {
         this.account = account
-        _hasWalletSetup.value = account.nip47SignerState?.hasWalletConnectSetup() == true
+        _hasWalletSetup.value = account.nip47SignerState.hasWalletConnectSetup()
     }
 
     fun refreshWalletSetup() {

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/LiveChessGame.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/LiveChessGame.kt
@@ -237,7 +237,7 @@ fun LiveChessGameScreen(
             ) {
                 // Game info - use currentPosition.activeColor for turn display
                 GameInfoHeader(
-                    gameId = gameState.gameId,
+                    gameId = gameState.startEventId,
                     opponentName = opponentName,
                     playerColor = gameState.playerColor,
                     currentTurn = currentPosition.activeColor,
@@ -463,7 +463,7 @@ private fun GameInfoHeader(
                 // Show turn or game result
                 when (gameStatus) {
                     is GameStatus.Finished -> {
-                        val result = (gameStatus as GameStatus.Finished).result
+                        val result = gameStatus.result
                         val resultText =
                             when {
                                 result == GameResult.DRAW -> "Draw"

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/MoveNavigator.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/MoveNavigator.kt
@@ -25,8 +25,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.KeyboardArrowLeft
-import androidx.compose.material.icons.filled.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material3.Icon
@@ -82,7 +82,7 @@ fun MoveNavigator(
             enabled = currentMove > 0,
         ) {
             Icon(
-                Icons.Default.KeyboardArrowLeft,
+                Icons.AutoMirrored.Filled.KeyboardArrowLeft,
                 contentDescription = "Previous move",
                 tint =
                     if (currentMove > 0) {
@@ -106,7 +106,7 @@ fun MoveNavigator(
             enabled = currentMove < totalMoves,
         ) {
             Icon(
-                Icons.Default.KeyboardArrowRight,
+                Icons.AutoMirrored.Filled.KeyboardArrowRight,
                 contentDescription = "Next move",
                 tint =
                     if (currentMove < totalMoves) {

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Note.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Note.kt
@@ -1027,7 +1027,7 @@ public inline fun <T> Iterable<Note>.filterEvents(predicate: (T) -> Boolean): Li
     return dest
 }
 
-public inline fun <T> Iterable<Note>.filterAuthoredEvents(pubkey: HexKey): List<T> {
+public fun <T> Iterable<Note>.filterAuthoredEvents(pubkey: HexKey): List<T> {
     if (this is Collection && isEmpty()) return emptyList()
 
     val dest = ArrayList<T>()


### PR DESCRIPTION
Just low risk mechanical changes. Compilation warnings from 250 -> 199

- Unnecessary ?. / ?: / !! on non-null
- Missing @OptIn annotations
- Parameter name mismatches
- Icons.Filled.*  / Icons.AutoMirrored.*
- No cast needed / remove inline
- LocalLifecycleOwner import fix
- NIP-51 name() → title()
- Chess gameId → startEventId
- Nullable DecimalFormat safe calls
- DelicateCoroutinesApi opt-in