### PR TITLE
Add GitHub Actions workflow for building benchmark APK

### DIFF
--- a/.github/workflows/build-benchmark-apk.yml
+++ b/.github/workflows/build-benchmark-apk.yml
@@ -37,7 +37,20 @@ jobs:
         run: ./gradlew assemblePlayBenchmark
 
       - name: Upload Play Benchmark APK
+        id: upload
         uses: actions/upload-artifact@v6
         with:
           name: Play Benchmark APK
           path: amethyst/build/outputs/apk/play/benchmark/amethyst-play-universal-benchmark.apk
+
+      - name: Comment on commit with APK link
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.repos.createCommitComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+              body: `📦 **Benchmark APK ready!**\n\nDownload it from the [workflow run artifacts](${runUrl}#artifacts).`
+            });


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow that automatically builds a benchmark APK for branches matching the `claude/**` pattern and provides easy access to the artifact.

## Key Changes
- **New workflow file**: `.github/workflows/build-benchmark-apk.yml`
  - Triggers on push events to `claude/**` branches
  - Sets up JDK 21 environment
  - Implements Gradle caching for faster builds
  - Builds the Play Benchmark variant using `./gradlew assemblePlayBenchmark`
  - Uploads the resulting APK as a workflow artifact
  - Automatically comments on the commit with a link to download the APK

## Notable Implementation Details
- Uses concurrency controls to cancel previous runs on the same branch
- Caches both Gradle caches and wrapper to optimize build times
- Leverages GitHub Script action to post a user-friendly commit comment with artifact download link
- 30-minute timeout to prevent hanging builds
- Targets the universal APK output from the Play benchmark build variant

https://claude.ai/code/session_013hcKzBgJgfsrArSgTTGNEk