### PR TITLE
Add date range filtering to relay event sync

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
@@ -500,7 +500,6 @@ object LocalPreferences {
 
                     val keyPair = KeyPair(privKey = privKey?.hexToByteArray(), pubKey = pubKey.hexToByteArray())
                     val hasDonatedInVersion = getStringSet(PrefKeys.HAS_DONATED_IN_VERSION, null) ?: setOf()
-
                     return@with AccountSettings(
                         keyPair = keyPair,
                         transientAccount = false,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -190,6 +190,7 @@ class AccountSettings(
     val lastReadPerRoute: MutableStateFlow<Map<String, MutableStateFlow<Long>>> = MutableStateFlow(mapOf()),
     val hasDonatedInVersion: MutableStateFlow<Set<String>> = MutableStateFlow(setOf()),
     val pendingAttestations: MutableStateFlow<Map<HexKey, String>> = MutableStateFlow(mapOf()),
+    val lastRelaySyncTimestamp: MutableStateFlow<Long?> = MutableStateFlow(null),
     var backupNipA3PaymentTargets: PaymentTargetsEvent? = null,
 ) : EphemeralChatRepository,
     PublicChatListRepository {
@@ -677,6 +678,15 @@ class AccountSettings(
                 saveAccountSettings()
             }
         }
+    }
+
+    // ---
+    // relay sync
+    // ---
+
+    fun updateLastRelaySyncTimestamp(timestamp: Long) {
+        lastRelaySyncTimestamp.tryEmit(timestamp)
+        saveAccountSettings()
     }
 
     // ---

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -207,6 +207,7 @@ class AccountViewModel(
             outboxTargets = { account.nip65RelayList.outboxFlow.value },
             inboxTargets = { account.nip65RelayList.inboxFlow.value },
             dmTargets = { account.dmRelayList.flow.value },
+            onSyncComplete = { timestamp -> account.settings.updateLastRelaySyncTimestamp(timestamp) },
             clientBuilder = {
                 // creates a new client to make sure these events don't end up polluting the local cache.
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/eventsync/EventSync.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/eventsync/EventSync.kt
@@ -80,6 +80,7 @@ class EventSync(
     private val inboxTargets: () -> Set<NormalizedRelayUrl>,
     private val dmTargets: () -> Set<NormalizedRelayUrl>,
     private val clientBuilder: () -> INostrClient,
+    private val onSyncComplete: (Long) -> Unit,
     private val scope: CoroutineScope,
 ) {
     companion object {
@@ -284,12 +285,18 @@ class EventSync(
 
     private var syncJob: Job? = null
 
+    /** User-selected date range for the sync filter (epoch seconds). */
+    val sinceSecs = MutableStateFlow<Long?>(null)
+    val untilSecs = MutableStateFlow<Long?>(null)
+
     fun start() {
         if (_syncState.value is SyncState.Running) return
         _liveActivity.value = LiveSyncActivity()
+        val capturedSince = sinceSecs.value
+        val capturedUntil = untilSecs.value
         syncJob =
             scope.launch(Dispatchers.IO) {
-                runSync()
+                runSync(capturedSince, capturedUntil)
             }
     }
 
@@ -300,7 +307,10 @@ class EventSync(
     // -------------------------------------------------------------------------
     // Sync logic
     // -------------------------------------------------------------------------
-    suspend fun runSync() {
+    suspend fun runSync(
+        filterSince: Long? = null,
+        filterUntil: Long? = null,
+    ) {
         val startTime = System.currentTimeMillis()
 
         _liveActivity.value = LiveSyncActivity()
@@ -323,9 +333,9 @@ class EventSync(
 
         val defaultFilters =
             buildList {
-                if (outboxTargets.isNotEmpty()) add(Filter(authors = listOf(myPubKey)))
+                if (outboxTargets.isNotEmpty()) add(Filter(authors = listOf(myPubKey), since = filterSince, until = filterUntil))
                 if (inboxTargets.isNotEmpty() || dmTargets.isNotEmpty()) {
-                    add(Filter(tags = mapOf("p" to listOf(myPubKey))))
+                    add(Filter(tags = mapOf("p" to listOf(myPubKey)), since = filterSince, until = filterUntil))
                 }
             }
 
@@ -342,9 +352,9 @@ class EventSync(
                     defaultFilters
                 } else {
                     buildList {
-                        if (it !in outboxTargets) add(Filter(authors = listOf(myPubKey)))
+                        if (it !in outboxTargets) add(Filter(authors = listOf(myPubKey), since = filterSince, until = filterUntil))
                         if (it !in inboxTargets && it !in dmTargets) {
-                            add(Filter(tags = mapOf("p" to listOf(myPubKey))))
+                            add(Filter(tags = mapOf("p" to listOf(myPubKey)), since = filterSince, until = filterUntil))
                         }
                     }
                 }
@@ -556,6 +566,9 @@ class EventSync(
                         runningState.relaysCompleted.update { it + 1 }
                     },
                 )
+
+                val completionTimestamp = System.currentTimeMillis() / 1000
+                onSyncComplete(completionTimestamp)
 
                 _syncState.value =
                     SyncState.Done(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/eventsync/EventSyncScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/eventsync/EventSyncScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.RangeSlider
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -70,6 +71,9 @@ import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.ThemeComparisonColumn
 import com.vitorpamplona.amethyst.ui.theme.ThemeComparisonRow
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 @Composable
 fun EventSyncScreen(
@@ -80,6 +84,8 @@ fun EventSyncScreen(
     val isMobileOrMetered by accountViewModel.settings.isMobileOrMeteredConnection.collectAsStateWithLifecycle()
     val syncState by syncViewModel.syncState.collectAsStateWithLifecycle()
     val liveActivity by syncViewModel.liveActivity.collectAsStateWithLifecycle()
+    val lastSyncTimestamp by accountViewModel.account.settings.lastRelaySyncTimestamp
+        .collectAsStateWithLifecycle()
 
     Scaffold(
         topBar = {
@@ -94,6 +100,9 @@ fun EventSyncScreen(
                 syncState = syncState,
                 liveActivity = liveActivity,
                 isMobileOrMetered = isMobileOrMetered,
+                lastSyncTimestamp = lastSyncTimestamp,
+                onSinceChanged = { syncViewModel.sinceSecs.value = it },
+                onUntilChanged = { syncViewModel.untilSecs.value = it },
                 onStart = syncViewModel::start,
                 onCancel = syncViewModel::cancel,
             )
@@ -106,6 +115,9 @@ fun EventScreenBody(
     syncState: EventSync.SyncState,
     liveActivity: EventSync.LiveSyncActivity,
     isMobileOrMetered: Boolean = false,
+    lastSyncTimestamp: Long? = null,
+    onSinceChanged: (Long?) -> Unit = {},
+    onUntilChanged: (Long?) -> Unit = {},
     onStart: () -> Unit = {},
     onCancel: () -> Unit = {},
 ) {
@@ -119,10 +131,41 @@ fun EventScreenBody(
         item {
             // ---- Progress / Status area ----
             when (syncState) {
-                is EventSync.SyncState.Idle -> ExplanationCard(isMobileOrMetered, onStart)
-                is EventSync.SyncState.Running -> SyncProgressCard(state = syncState, onCancel)
-                is EventSync.SyncState.Done -> DoneCard(state = syncState, isMobileOrMetered, onStart)
-                is EventSync.SyncState.Error -> ErrorCard(syncState.message, isMobileOrMetered, onStart)
+                is EventSync.SyncState.Idle -> {
+                    ExplanationCard(
+                        isMobileOrMetered = isMobileOrMetered,
+                        lastSyncTimestamp = lastSyncTimestamp,
+                        onSinceChanged = onSinceChanged,
+                        onUntilChanged = onUntilChanged,
+                        onStart = onStart,
+                    )
+                }
+
+                is EventSync.SyncState.Running -> {
+                    SyncProgressCard(state = syncState, onCancel)
+                }
+
+                is EventSync.SyncState.Done -> {
+                    DoneCard(
+                        state = syncState,
+                        isMobileOrMetered = isMobileOrMetered,
+                        lastSyncTimestamp = lastSyncTimestamp,
+                        onSinceChanged = onSinceChanged,
+                        onUntilChanged = onUntilChanged,
+                        onStart = onStart,
+                    )
+                }
+
+                is EventSync.SyncState.Error -> {
+                    ErrorCard(
+                        message = syncState.message,
+                        isMobileOrMetered = isMobileOrMetered,
+                        lastSyncTimestamp = lastSyncTimestamp,
+                        onSinceChanged = onSinceChanged,
+                        onUntilChanged = onUntilChanged,
+                        onStart = onStart,
+                    )
+                }
             }
         }
 
@@ -231,6 +274,9 @@ private fun StartSyncButton(
 @Composable
 private fun ExplanationCard(
     isMobileOrMetered: Boolean,
+    lastSyncTimestamp: Long? = null,
+    onSinceChanged: (Long?) -> Unit = {},
+    onUntilChanged: (Long?) -> Unit = {},
     onStart: () -> Unit,
 ) {
     // ---- Explanation card ----
@@ -255,6 +301,14 @@ private fun ExplanationCard(
             StepRow(number = "2", text = stringRes(R.string.event_sync_step2))
             Spacer(Modifier.height(4.dp))
             StepRow(number = "3", text = stringRes(R.string.event_sync_step3))
+            Spacer(Modifier.height(14.dp))
+
+            DateRangeFilterCard(
+                lastSyncTimestamp = lastSyncTimestamp,
+                onSinceChanged = onSinceChanged,
+                onUntilChanged = onUntilChanged,
+            )
+
             Spacer(Modifier.height(10.dp))
             // ---- WiFi warning ----
             if (isMobileOrMetered) {
@@ -352,6 +406,9 @@ private fun RelayStatement(state: EventSync.SyncState.Running) {
 private fun DoneCard(
     state: EventSync.SyncState.Done,
     isMobileOrMetered: Boolean = false,
+    lastSyncTimestamp: Long? = null,
+    onSinceChanged: (Long?) -> Unit = {},
+    onUntilChanged: (Long?) -> Unit = {},
     onStart: () -> Unit = { },
 ) {
     Card(
@@ -387,6 +444,14 @@ private fun DoneCard(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
             )
+            Spacer(Modifier.height(14.dp))
+
+            DateRangeFilterCard(
+                lastSyncTimestamp = lastSyncTimestamp,
+                onSinceChanged = onSinceChanged,
+                onUntilChanged = onUntilChanged,
+            )
+
             Spacer(Modifier.height(10.dp))
             StartSyncButton(isMobileOrMetered, onStart)
         }
@@ -397,6 +462,9 @@ private fun DoneCard(
 private fun ErrorCard(
     message: String,
     isMobileOrMetered: Boolean = false,
+    lastSyncTimestamp: Long? = null,
+    onSinceChanged: (Long?) -> Unit = {},
+    onUntilChanged: (Long?) -> Unit = {},
     onStart: () -> Unit = {},
 ) {
     Card(
@@ -419,6 +487,14 @@ private fun ErrorCard(
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onErrorContainer,
             )
+            Spacer(Modifier.height(14.dp))
+
+            DateRangeFilterCard(
+                lastSyncTimestamp = lastSyncTimestamp,
+                onSinceChanged = onSinceChanged,
+                onUntilChanged = onUntilChanged,
+            )
+
             Spacer(Modifier.height(10.dp))
             StartSyncButton(isMobileOrMetered, onStart)
         }
@@ -661,6 +737,123 @@ private fun ActivityLogRow(info: EventSync.LiveSyncActivity.SourceRelayInfo) {
 }
 
 // -------------------------------------------------------------------------
+// Date range filter
+// -------------------------------------------------------------------------
+
+/** Oldest possible "since" — roughly 2020-01-01 in epoch seconds. */
+private const val EPOCH_2020 = 1_577_836_800L
+
+@Composable
+private fun DateRangeFilterCard(
+    lastSyncTimestamp: Long? = null,
+    onSinceChanged: (Long?) -> Unit = {},
+    onUntilChanged: (Long?) -> Unit = {},
+) {
+    val now = remember { System.currentTimeMillis() / 1000 }
+
+    // Slider range: 0f = EPOCH_2020, 1f = now
+    val range = (now - EPOCH_2020).toFloat()
+
+    // Initialise from lastSyncTimestamp when available, otherwise full range
+    var sliderValues by remember(lastSyncTimestamp) {
+        val initialSince =
+            if (lastSyncTimestamp != null) {
+                ((lastSyncTimestamp - EPOCH_2020) / range).coerceIn(0f, 1f)
+            } else {
+                0f
+            }
+        mutableStateOf(initialSince..1f)
+    }
+
+    // Derive actual timestamps
+    val sinceEpoch = (EPOCH_2020 + (sliderValues.start * range).toLong())
+    val untilEpoch = (EPOCH_2020 + (sliderValues.endInclusive * range).toLong())
+
+    // Fire callbacks
+    val effectiveSince = if (sliderValues.start <= 0.001f) null else sinceEpoch
+    val effectiveUntil = if (sliderValues.endInclusive >= 0.999f) null else untilEpoch
+
+    // Notify parent on each change
+    androidx.compose.runtime.LaunchedEffect(effectiveSince) { onSinceChanged(effectiveSince) }
+    androidx.compose.runtime.LaunchedEffect(effectiveUntil) { onUntilChanged(effectiveUntil) }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringRes(R.string.event_sync_date_filter_title),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+            )
+
+            if (lastSyncTimestamp != null) {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = stringRes(R.string.event_sync_date_filter_last_sync, formatEpochDate(lastSyncTimestamp)),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            Spacer(Modifier.height(12.dp))
+
+            // Labels for current selection
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text =
+                        if (effectiveSince == null) {
+                            stringRes(R.string.event_sync_date_filter_all_time)
+                        } else {
+                            stringRes(R.string.event_sync_date_filter_since) + " " + formatEpochDate(sinceEpoch)
+                        },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Text(
+                    text =
+                        if (effectiveUntil == null) {
+                            stringRes(R.string.event_sync_date_filter_now)
+                        } else {
+                            stringRes(R.string.event_sync_date_filter_until) + " " + formatEpochDate(untilEpoch)
+                        },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+
+            RangeSlider(
+                value = sliderValues,
+                onValueChange = { sliderValues = it },
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            if (lastSyncTimestamp != null) {
+                OutlinedButton(
+                    onClick = {
+                        val syncNorm = ((lastSyncTimestamp - EPOCH_2020) / range).coerceIn(0f, 1f)
+                        sliderValues = syncNorm..1f
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(stringRes(R.string.event_sync_date_filter_since_last_sync))
+                }
+            }
+        }
+    }
+}
+
+private fun formatEpochDate(epochSecs: Long): String {
+    val sdf = SimpleDateFormat("MMM d, yyyy", Locale.getDefault())
+    return sdf.format(Date(epochSecs * 1000))
+}
+
+// -------------------------------------------------------------------------
 // Helpers
 // -------------------------------------------------------------------------
 
@@ -747,7 +940,7 @@ private val previewActivity =
 @Preview
 fun IdleCardWifiPreview() {
     ThemeComparisonColumn {
-        ExplanationCard(false, {})
+        ExplanationCard(isMobileOrMetered = false, onStart = {})
     }
 }
 
@@ -755,7 +948,7 @@ fun IdleCardWifiPreview() {
 @Preview
 fun IdleCardMobilePreview() {
     ThemeComparisonColumn {
-        ExplanationCard(true, {})
+        ExplanationCard(isMobileOrMetered = true, onStart = {})
     }
 }
 

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -1873,4 +1873,12 @@
     <string name="event_sync_status_downloading">Downloading</string>
     <string name="event_sync_status_error">Error</string>
     <string name="event_sync_status_completed">Completed</string>
+
+    <string name="event_sync_date_filter_title">Date Range</string>
+    <string name="event_sync_date_filter_since">Since</string>
+    <string name="event_sync_date_filter_until">Until</string>
+    <string name="event_sync_date_filter_now">Now</string>
+    <string name="event_sync_date_filter_all_time">All time</string>
+    <string name="event_sync_date_filter_last_sync">Last sync: %1$s</string>
+    <string name="event_sync_date_filter_since_last_sync">Since Last Sync</string>
 </resources>


### PR DESCRIPTION
## Summary
This PR adds the ability to filter relay event syncs by a custom date range. Users can now select "since" and "until" timestamps using an interactive range slider, with the option to quickly sync from the last sync timestamp.

## Key Changes
- **Date Range Filter UI**: Added a new `DateRangeFilterCard` composable with a `RangeSlider` allowing users to select custom date ranges (from 2020-01-01 to present)
- **Sync State Integration**: Updated `ExplanationCard`, `DoneCard`, and `ErrorCard` to display the date range filter, enabling users to adjust filters before or after sync attempts
- **Filter Application**: Modified `EventSync.runSync()` to accept optional `filterSince` and `filterUntil` parameters and apply them to all relay filters
- **Last Sync Tracking**: Added `lastRelaySyncTimestamp` to `AccountSettings` to persist and display when the last sync occurred
- **Quick Sync Button**: Added "Since Last Sync" button to quickly reset the range to sync only new events since the previous sync
- **Callback Integration**: Added `onSyncComplete` callback to `EventSync` to update the last sync timestamp when sync completes successfully
- **String Resources**: Added UI strings for the date filter component (title, labels, button text)

## Implementation Details
- The date range slider uses normalized values (0f to 1f) mapped to epoch seconds, with EPOCH_2020 (1,577,836,800) as the minimum reference point
- Date formatting uses `SimpleDateFormat` with locale-aware "MMM d, yyyy" pattern
- The filter intelligently treats edge values (≤0.001f for start, ≥0.999f for end) as null to represent "all time" ranges
- `LaunchedEffect` hooks ensure parent components are notified of filter changes for real-time updates

https://claude.ai/code/session_01D3ZgdWAgr1DPrvRmqaar3n