### PR TITLE
Fix URL parsing bounds checking in Url.kt

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/utils/urldetector/Url.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/utils/urldetector/Url.kt
@@ -228,11 +228,17 @@ class Url(
             return null
         }
 
+        val startIndex = urlMarker.indexOf(part)
+        if (startIndex < 0 || startIndex >= originalUrl.length) {
+            return null
+        }
+
         val nextPart = nextExistingPart(part)
         return if (nextPart == null) {
-            originalUrl.substring(urlMarker.indexOf(part))
+            originalUrl.substring(startIndex)
         } else {
-            originalUrl.substring(urlMarker.indexOf(part), urlMarker.indexOf(nextPart))
+            val endIndex = urlMarker.indexOf(nextPart)
+            originalUrl.substring(startIndex, minOf(endIndex, originalUrl.length))
         }
     }
 


### PR DESCRIPTION
## Summary
This change improves the robustness of URL part extraction by adding proper bounds validation and preventing potential index out of bounds exceptions.

## Key Changes
- Added early validation of `startIndex` to ensure it's within valid bounds before attempting substring operations
- Cached the `startIndex` value to avoid redundant `indexOf()` calls
- Added bounds checking for `endIndex` using `minOf()` to prevent substring operations that exceed the original URL length
- Improved code efficiency by computing indices once and reusing them

## Implementation Details
The changes address potential edge cases where:
- The URL part marker might not be found in the original URL (negative index)
- The start index could exceed the original URL length
- The end index calculation could result in an invalid range for substring extraction

These safeguards ensure the method returns `null` gracefully when encountering malformed or unexpected URL structures, rather than throwing exceptions.

https://claude.ai/code/session_014Q2SvTE5vKgUm1w8dPVjYo