### PR TITLE
Render Namecoin identifiers as clickable Nostr profile links

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/NamecoinIdentifierLink.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/NamecoinIdentifierLink.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.components
+
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
+import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.routes.Route
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.quartz.nip05DnsIdentifiers.Nip05Client
+
+@Composable
+fun NamecoinIdentifierLink(
+    identifier: String,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    var resolvedPubkey by remember(identifier) { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(identifier) {
+        try {
+            val trimmed = identifier.trimEnd('.', ',', '!', '?', ')', ']')
+            val client = accountViewModel.nip05Client
+            if (client is Nip05Client) {
+                val resolver = client.namecoinResolver
+                if (resolver != null) {
+                    val result = resolver.resolve(trimmed)
+                    resolvedPubkey = result?.pubkey
+                }
+            }
+        } catch (_: Exception) {
+            resolvedPubkey = null
+        }
+    }
+
+    val pubkey = resolvedPubkey
+    if (pubkey != null) {
+        CreateClickableText(
+            clickablePart = identifier,
+            suffix = null,
+            route = Route.Profile(pubkey),
+            nav = nav,
+        )
+    } else {
+        Text(
+            text = identifier,
+            color = Color(0xFF4A90D9),
+            style = LocalTextStyle.current,
+        )
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/RichTextViewer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/RichTextViewer.kt
@@ -80,6 +80,7 @@ import com.vitorpamplona.amethyst.commons.richtext.ImageGalleryParagraph
 import com.vitorpamplona.amethyst.commons.richtext.ImageSegment
 import com.vitorpamplona.amethyst.commons.richtext.InvoiceSegment
 import com.vitorpamplona.amethyst.commons.richtext.LinkSegment
+import com.vitorpamplona.amethyst.commons.richtext.NamecoinSegment
 import com.vitorpamplona.amethyst.commons.richtext.ParagraphState
 import com.vitorpamplona.amethyst.commons.richtext.PhoneSegment
 import com.vitorpamplona.amethyst.commons.richtext.RegularTextSegment
@@ -506,6 +507,8 @@ private fun RenderWordWithoutPreview(
 
         is HashIndexEventSegment -> TagLink(word, false, 0, backgroundColor, accountViewModel, nav)
 
+        is NamecoinSegment -> NamecoinIdentifierLink(word.segmentText, accountViewModel, nav)
+
         is RegularTextSegment -> Text(word.segmentText)
 
         is RelayUrlSegment -> ClickableRelayUrl(word.segmentText, nav)
@@ -541,6 +544,7 @@ private fun RenderWordWithPreview(
         is HashTagSegment -> HashTag(word, nav)
         is HashIndexUserSegment -> TagLink(word, accountViewModel, nav)
         is HashIndexEventSegment -> TagLink(word, true, quotesLeft, backgroundColor, accountViewModel, nav)
+        is NamecoinSegment -> NamecoinIdentifierLink(word.segmentText, accountViewModel, nav)
         is RegularTextSegment -> Text(word.segmentText)
         is Base64Segment -> ZoomableContentView(word.segmentText, state, accountViewModel)
         is RelayUrlSegment -> ClickableRelayUrl(word.segmentText, nav)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
@@ -24,6 +24,7 @@ import com.vitorpamplona.amethyst.commons.emojicoder.EmojiCoder
 import com.vitorpamplona.amethyst.commons.model.ImmutableListOfLists
 import com.vitorpamplona.amethyst.commons.richtext.mimeTypeMap
 import com.vitorpamplona.quartz.experimental.inlineMetadata.Nip54InlineMetadata
+import com.vitorpamplona.quartz.nip05DnsIdentifiers.namecoin.NamecoinNameResolver
 import com.vitorpamplona.quartz.nip30CustomEmoji.CustomEmoji
 import com.vitorpamplona.quartz.nip31Alts.AltTag
 import com.vitorpamplona.quartz.nip36SensitiveContent.ContentWarningTag
@@ -288,6 +289,21 @@ class RichTextParser {
                 VideoSegment(word)
             }
         }
+
+        // Namecoin identifiers (d/name, id/name, bare .bit domains) must be
+        // checked BEFORE schemeless URLs, because .bit domains look like URLs
+        // to the URL parser but should resolve via the Namecoin blockchain.
+        //
+        // However, explicit URLs with a scheme (https://example.bit,
+        // http://www.example.bit) SHOULD open the browser — .bit domains
+        // are real DNS names resolvable via ncdns/Namecoin DNS bridges,
+        // and browsers with Namecoin support (Chromium+ncdns, Tor Browser,
+        // Fingertip) can access them as websites.
+        val trimmedWord = word.trimEnd('.', ',', '!', '?', ')', ']')
+        val hasScheme =
+            trimmedWord.startsWith("https://", ignoreCase = true) ||
+                trimmedWord.startsWith("http://", ignoreCase = true)
+        if (!hasScheme && NamecoinNameResolver.isNamecoinIdentifier(trimmedWord)) return NamecoinSegment(word)
 
         if (urls.withoutScheme.contains(word)) return SchemelessUrlSegment(word)
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParserSegments.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParserSegments.kt
@@ -154,6 +154,11 @@ class SchemelessUrlSegment(
 ) : Segment(segment)
 
 @Immutable
+class NamecoinSegment(
+    segment: String,
+) : Segment(segment)
+
+@Immutable
 class RegularTextSegment(
     segment: String,
 ) : Segment(segment)


### PR DESCRIPTION
Make Namecoin identifiers (`d/name`, `id/name`, `name@domain.bit`, `@domain.bit`, `domain.bit`) clickable in note content, resolving to Nostr profiles via ElectrumX blockchain lookups.

## Behavior

| Format | Example | Rendered as |
|--------|---------|-------------|
| Bare .bit domain | `testls.bit` | Clickable → resolves to Nostr profile |
| NIP-05 style | `m@testls.bit` | Clickable → resolves to Nostr profile |
| d/ namespace | `d/testls` | Clickable → resolves to Nostr profile |
| id/ namespace | `id/alice` | Clickable → resolves to Nostr profile |
| URL with scheme | `https://example.bit` | Opens browser (normal URL behavior) |
| URL with scheme | `http://www.example.bit` | Opens browser (normal URL behavior) |

## Why `https://example.bit` should open the browser

.bit domains are real DNS names on the Namecoin blockchain. They can host actual websites, resolvable via:

- **[ncdns](https://www.namecoin.org/docs/ncdns/)** — Namecoin-to-DNS bridge that works with most applications. The ncdns Windows installer configures the Windows certificate verifier, so Chromium and Edge work with .bit HTTPS out of the box.
- **Tor Browser** — ncdns installer also configures .bit resolution in Tor Browser.
- **Namecoin TLS** — .bit domains support [full TLS certificate chains](https://www.namecoin.org/docs/name-owners/tls/) stored on-chain, providing censorship-resistant HTTPS.

When a user explicitly writes `https://example.bit`, they intend to visit a website. The browser handles resolution (or shows an error if no Namecoin DNS bridge is configured). This is consistent with how other alternative TLDs work.

Only **bare identifiers without a URL scheme** are treated as Nostr identity lookups.

## Changes

### Rich text parser (`commons`)
- New `NamecoinSegment` type in `RichTextParserSegments.kt`
- Namecoin identifier detection runs BEFORE schemeless URL classification in `RichTextParser.kt`
- Words starting with `https://` or `http://` are excluded from Namecoin detection — these are browser URLs
- Uses `NamecoinNameResolver.isNamecoinIdentifier()` from quartz with trailing punctuation stripping

### Note content rendering (`amethyst`)
- New `NamecoinIdentifierLink.kt` composable:
  - Resolves identifiers via `Nip05Client.namecoinResolver` (ElectrumX blockchain)
  - On success → navigates to `Route.Profile(pubkey)` (in-app Nostr profile)
  - While resolving / on failure → Namecoin-blue (#4A90D9) styled text
- Wired into both `RenderWordWithPreview` and `RenderWordWithoutPreview`

## Testing
- ✅ Tested on Android emulator (API 35)
- ✅ All unit tests pass
- ✅ spotless clean
