### PR TITLE
feat: add multiple choice poll type selector

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/polls/PollOptionsField.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/polls/PollOptionsField.kt
@@ -22,7 +22,9 @@ package com.vitorpamplona.amethyst.ui.note.creators.polls
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -32,6 +34,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -47,6 +50,7 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.home.ShortNotePostViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.placeholderText
 import com.vitorpamplona.quartz.nip88Polls.poll.tags.OptionTag
+import com.vitorpamplona.quartz.nip88Polls.poll.tags.PollType
 import com.vitorpamplona.quartz.utils.RandomInstance
 
 @Composable
@@ -55,6 +59,13 @@ fun PollOptionsField(postViewModel: ShortNotePostViewModel) {
     Column(
         modifier = Modifier.fillMaxWidth(),
     ) {
+        PollTypeSelector(
+            selectedType = postViewModel.pollType,
+            onTypeSelected = { postViewModel.pollType = it },
+        )
+
+        Spacer(Modifier.height(4.dp))
+
         optionsList.forEach { option ->
             OutlinedTextField(
                 modifier = Modifier.fillMaxWidth(),
@@ -115,6 +126,27 @@ fun PollOptionsField(postViewModel: ShortNotePostViewModel) {
         ) {
             Icon(Icons.Default.Add, contentDescription = stringRes(R.string.add_poll_option_button))
         }
+    }
+}
+
+@Composable
+fun PollTypeSelector(
+    selectedType: PollType,
+    onTypeSelected: (PollType) -> Unit,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        FilterChip(
+            selected = selectedType == PollType.SINGLE_CHOICE,
+            onClick = { onTypeSelected(PollType.SINGLE_CHOICE) },
+            label = { Text(stringRes(R.string.poll_single_choice)) },
+        )
+        FilterChip(
+            selected = selectedType == PollType.MULTI_CHOICE,
+            onClick = { onTypeSelected(PollType.MULTI_CHOICE) },
+            label = { Text(stringRes(R.string.poll_multiple_choice)) },
+        )
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostViewModel.kt
@@ -117,6 +117,7 @@ import com.vitorpamplona.quartz.nip57Zaps.zapraiser.zapraiserAmount
 import com.vitorpamplona.quartz.nip72ModCommunities.definition.CommunityDefinitionEvent
 import com.vitorpamplona.quartz.nip88Polls.poll.PollEvent
 import com.vitorpamplona.quartz.nip88Polls.poll.tags.OptionTag
+import com.vitorpamplona.quartz.nip88Polls.poll.tags.PollType
 import com.vitorpamplona.quartz.nip92IMeta.IMetaTagBuilder
 import com.vitorpamplona.quartz.nip92IMeta.imetas
 import com.vitorpamplona.quartz.nip94FileMetadata.alt
@@ -238,6 +239,7 @@ open class ShortNotePostViewModel :
     var canUsePoll by mutableStateOf(false)
     var wantsPoll by mutableStateOf(false)
     var pollOptions: SnapshotStateMap<Int, OptionTag> = newStateMapPollOptions()
+    var pollType by mutableStateOf(PollType.SINGLE_CHOICE)
     var closedAt by mutableLongStateOf(TimeUtils.oneDayAhead())
 
     // ZapPolls
@@ -596,6 +598,7 @@ open class ShortNotePostViewModel :
             pollOptions[index] = tag
         }
 
+        pollType = draftEvent.pollType() ?: PollType.SINGLE_CHOICE
         closedAt = draftEvent.endsAt() ?: TimeUtils.oneDayAhead()
 
         message = TextFieldValue(draftEvent.content)
@@ -828,7 +831,7 @@ open class ShortNotePostViewModel :
                 accountViewModel.account.nip65RelayList.outboxFlow.value
                     .toList()
 
-            PollEvent.build(tagger.message, options, closedAt, relays) {
+            PollEvent.build(tagger.message, options, closedAt, relays, pollType) {
                 pTags(tagger.directMentionsUsers.map { it.toPTag() })
                 quotes(quotes)
                 hashtags(findHashtags(tagger.message))
@@ -1054,6 +1057,7 @@ open class ShortNotePostViewModel :
 
         wantsPoll = false
         pollOptions = newStateMapPollOptions()
+        pollType = PollType.SINGLE_CHOICE
         closedAt = TimeUtils.oneDayAhead()
 
         wantsZapPoll = false

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -483,6 +483,8 @@
     <string name="poll_zap_value_max">Zap maximum</string>
     <string name="poll_consensus_threshold">Consensus</string>
     <string name="poll_consensus_threshold_percent">(0–100)%</string>
+    <string name="poll_single_choice">Single choice</string>
+    <string name="poll_multiple_choice">Multiple choice</string>
     <string name="poll_closing_date_time">Poll Closing Date &amp; Time</string>
     <string name="poll_closing_in">Poll closes in %1$s</string>
     <string name="poll_closing_time">Close after</string>


### PR DESCRIPTION
## Summary
- Adds a poll type selector (FilterChip UI) to the poll creation screen, allowing users to choose between **Single choice** and **Multiple choice** polls
- Previously, poll creation was hardcoded to single choice only, even though the protocol (`PollType.MULTI_CHOICE`) and rendering (`RenderMultiChoiceOptions`) already supported it
- The selected poll type is passed to `PollEvent.build()`, persisted in drafts, and reset on clear

## Changes
- **ShortNotePostViewModel**: Added `pollType` state variable, passed to `PollEvent.build()`, restored from drafts, reset in `clear()`
- **PollOptionsField**: Added `PollTypeSelector` composable with two `FilterChip`s above the poll options
- **strings.xml**: Added `poll_single_choice` and `poll_multiple_choice` string resources

## Test plan
- [ ] Create a poll with "Single choice" selected — verify the event has `["polltype", "singlechoice"]`
- [ ] Create a poll with "Multiple choice" selected — verify the event has `["polltype", "multiplechoice"]`
- [ ] Vote on a multiple choice poll — verify checkboxes appear and multiple selections work
- [ ] Save a multiple choice poll as draft, reopen — verify poll type is restored
- [ ] Verify the selector defaults to "Single choice"

https://claude.ai/code/session_01PEsEyGiNvNcNPSjREN4WzW