### PR TITLE
feat: add full-width note layout option

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/UiSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/UiSettings.kt
@@ -38,6 +38,7 @@ data class UiSettings(
     val dontAskForNotificationPermissions: Boolean = false,
     val featureSet: FeatureSetType = FeatureSetType.SIMPLIFIED,
     val gallerySet: ProfileGalleryType = ProfileGalleryType.CLASSIC,
+    val noteLayout: NoteLayoutType = NoteLayoutType.CLASSIC,
 )
 
 enum class ThemeType(
@@ -106,6 +107,21 @@ fun parseFeatureSetType(screenCode: Int): FeatureSetType =
         FeatureSetType.SIMPLIFIED.screenCode -> FeatureSetType.SIMPLIFIED
         FeatureSetType.PERFORMANCE.screenCode -> FeatureSetType.PERFORMANCE
         else -> FeatureSetType.COMPLETE
+    }
+
+enum class NoteLayoutType(
+    val screenCode: Int,
+    val resourceId: Int,
+) {
+    CLASSIC(0, R.string.note_layout_type_classic),
+    FULL_WIDTH(1, R.string.note_layout_type_full_width),
+}
+
+fun parseNoteLayoutType(screenCode: Int): NoteLayoutType =
+    when (screenCode) {
+        NoteLayoutType.CLASSIC.screenCode -> NoteLayoutType.CLASSIC
+        NoteLayoutType.FULL_WIDTH.screenCode -> NoteLayoutType.FULL_WIDTH
+        else -> NoteLayoutType.CLASSIC
     }
 
 fun parseGalleryType(screenCode: Int): ProfileGalleryType =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/UiSettingsFlow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/UiSettingsFlow.kt
@@ -38,6 +38,7 @@ class UiSettingsFlow(
     val dontAskForNotificationPermissions: MutableStateFlow<Boolean> = MutableStateFlow(false),
     val featureSet: MutableStateFlow<FeatureSetType> = MutableStateFlow(FeatureSetType.SIMPLIFIED),
     val gallerySet: MutableStateFlow<ProfileGalleryType> = MutableStateFlow(ProfileGalleryType.CLASSIC),
+    val noteLayout: MutableStateFlow<NoteLayoutType> = MutableStateFlow(NoteLayoutType.CLASSIC),
 ) {
     val listOfFlows: List<Flow<Any?>> =
         listOf<Flow<Any?>>(
@@ -52,6 +53,7 @@ class UiSettingsFlow(
             dontAskForNotificationPermissions,
             featureSet,
             gallerySet,
+            noteLayout,
         )
 
     // emits at every change in any of the propertyes.
@@ -69,6 +71,7 @@ class UiSettingsFlow(
                 flows[8] as Boolean,
                 flows[9] as FeatureSetType,
                 flows[10] as ProfileGalleryType,
+                flows[11] as NoteLayoutType,
             )
         }
 
@@ -85,6 +88,7 @@ class UiSettingsFlow(
             dontAskForNotificationPermissions.value,
             featureSet.value,
             gallerySet.value,
+            noteLayout.value,
         )
 
     fun update(torSettings: UiSettings): Boolean {
@@ -134,6 +138,10 @@ class UiSettingsFlow(
             gallerySet.tryEmit(torSettings.gallerySet)
             any = true
         }
+        if (noteLayout.value != torSettings.noteLayout) {
+            noteLayout.tryEmit(torSettings.noteLayout)
+            any = true
+        }
 
         return any
     }
@@ -164,6 +172,7 @@ class UiSettingsFlow(
                 MutableStateFlow(torSettings.dontAskForNotificationPermissions),
                 MutableStateFlow(torSettings.featureSet),
                 MutableStateFlow(torSettings.gallerySet),
+                MutableStateFlow(torSettings.noteLayout),
             )
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/preferences/UISharedPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/preferences/UISharedPreferences.kt
@@ -34,6 +34,7 @@ import com.vitorpamplona.amethyst.LocalPreferences
 import com.vitorpamplona.amethyst.model.BooleanType
 import com.vitorpamplona.amethyst.model.ConnectivityType
 import com.vitorpamplona.amethyst.model.FeatureSetType
+import com.vitorpamplona.amethyst.model.NoteLayoutType
 import com.vitorpamplona.amethyst.model.ProfileGalleryType
 import com.vitorpamplona.amethyst.model.ThemeType
 import com.vitorpamplona.amethyst.model.UiSettings
@@ -72,6 +73,7 @@ class UiSharedPreferences(
         val UI_DONT_ASK_FOR_NOTIFICATION_PERMISSIONS = booleanPreferencesKey("ui.dont_ask_for_notification_permissions")
         val UI_FEATURE_SET = stringPreferencesKey("ui.feature_set")
         val UI_GALLERY_SET = stringPreferencesKey("ui.gallery_set")
+        val UI_NOTE_LAYOUT = stringPreferencesKey("ui.note_layout")
     }
 
     // UI Preferences. Makes sure to wait for it to avoid blinking themes and language preferences
@@ -123,6 +125,7 @@ class UiSharedPreferences(
                 dontAskForNotificationPermissions = preferences[UI_DONT_ASK_FOR_NOTIFICATION_PERMISSIONS] ?: false,
                 featureSet = preferences[UI_FEATURE_SET]?.let { FeatureSetType.valueOf(it) } ?: FeatureSetType.SIMPLIFIED,
                 gallerySet = preferences[UI_GALLERY_SET]?.let { ProfileGalleryType.valueOf(it) } ?: ProfileGalleryType.CLASSIC,
+                noteLayout = preferences[UI_NOTE_LAYOUT]?.let { NoteLayoutType.valueOf(it) } ?: NoteLayoutType.CLASSIC,
             )
         } catch (e: Exception) {
             if (e is CancellationException) throw e
@@ -155,6 +158,7 @@ class UiSharedPreferences(
                 preferences[UI_DONT_ASK_FOR_NOTIFICATION_PERMISSIONS] = sharedSettings.dontAskForNotificationPermissions
                 preferences[UI_FEATURE_SET] = sharedSettings.featureSet.name
                 preferences[UI_GALLERY_SET] = sharedSettings.gallerySet.name
+                preferences[UI_NOTE_LAYOUT] = sharedSettings.noteLayout.name
             }
         } catch (e: Exception) {
             if (e is CancellationException) throw e

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteCompose.kt
@@ -589,6 +589,7 @@ fun InnerNoteWithReactions(
 ) {
     val notBoostedNorQuote = !isBoostedNote && !isQuotedNote
     val editState = observeEdits(baseNote = baseNote, accountViewModel = accountViewModel)
+    val isFullWidth = notBoostedNorQuote && accountViewModel.settings.isFullWidthNoteLayout()
 
     Row(
         modifier =
@@ -599,7 +600,7 @@ fun InnerNoteWithReactions(
             },
         horizontalArrangement = RowColSpacing10dp,
     ) {
-        if (notBoostedNorQuote) {
+        if (notBoostedNorQuote && !isFullWidth) {
             Column(WidthAuthorPictureModifier, verticalArrangement = RowColSpacing5dp) {
                 // Draws the boosted picture outside the boosted card.
                 Box(modifier = Size55Modifier, contentAlignment = Alignment.BottomEnd) {
@@ -619,7 +620,7 @@ fun InnerNoteWithReactions(
                     accountViewModel.settings.isCompleteUIMode()
             NoteBody(
                 baseNote = baseNote,
-                showAuthorPicture = isQuotedNote,
+                showAuthorPicture = isQuotedNote || isFullWidth,
                 unPackReply = unPackReply,
                 makeItShort = makeItShort,
                 canPreview = canPreview,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/UiSettingsState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/UiSettingsState.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Stable
 import com.vitorpamplona.amethyst.model.BooleanType
 import com.vitorpamplona.amethyst.model.ConnectivityType
 import com.vitorpamplona.amethyst.model.FeatureSetType
+import com.vitorpamplona.amethyst.model.NoteLayoutType
 import com.vitorpamplona.amethyst.model.ProfileGalleryType
 import com.vitorpamplona.amethyst.model.UiSettingsFlow
 import kotlinx.coroutines.CoroutineScope
@@ -139,4 +140,6 @@ class UiSettingsState(
     fun startVideoPlayback() = startVideoPlayback.value
 
     fun showImages() = showImages.value
+
+    fun isFullWidthNoteLayout() = uiSettingsFlow.noteLayout.value == NoteLayoutType.FULL_WIDTH
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
@@ -50,6 +50,7 @@ import androidx.core.os.LocaleListCompat
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.ConnectivityType
 import com.vitorpamplona.amethyst.model.FeatureSetType
+import com.vitorpamplona.amethyst.model.NoteLayoutType
 import com.vitorpamplona.amethyst.model.ProfileGalleryType
 import com.vitorpamplona.amethyst.model.ThemeType
 import com.vitorpamplona.amethyst.model.UiSettingsFlow
@@ -57,6 +58,7 @@ import com.vitorpamplona.amethyst.model.parseBooleanType
 import com.vitorpamplona.amethyst.model.parseConnectivityType
 import com.vitorpamplona.amethyst.model.parseFeatureSetType
 import com.vitorpamplona.amethyst.model.parseGalleryType
+import com.vitorpamplona.amethyst.model.parseNoteLayoutType
 import com.vitorpamplona.amethyst.model.parseThemeType
 import com.vitorpamplona.amethyst.ui.components.PushNotificationSettingsRow
 import com.vitorpamplona.amethyst.ui.components.TextSpinner
@@ -120,6 +122,7 @@ fun SettingsScreen(sharedPrefs: UiSettingsFlow) {
         ShowProfilePictureChoice(sharedPrefs)
         ImmersiveScrollingChoice(sharedPrefs)
         FeatureSetChoice(sharedPrefs)
+        NoteLayoutChoice(sharedPrefs)
         GalleryChoice(sharedPrefs)
         PushNotificationSettingsRow(sharedPrefs)
     }
@@ -343,6 +346,26 @@ fun FeatureSetChoice(sharedPrefs: UiSettingsFlow) {
         featureSetIndex.screenCode,
     ) {
         sharedPrefs.featureSet.tryEmit(parseFeatureSetType(it))
+    }
+}
+
+@Composable
+fun NoteLayoutChoice(sharedPrefs: UiSettingsFlow) {
+    val noteLayoutItems =
+        persistentListOf(
+            TitleExplainer(stringRes(NoteLayoutType.CLASSIC.resourceId)),
+            TitleExplainer(stringRes(NoteLayoutType.FULL_WIDTH.resourceId)),
+        )
+
+    val noteLayoutIndex by sharedPrefs.noteLayout.collectAsState()
+
+    SettingsRow(
+        R.string.note_layout_style,
+        R.string.note_layout_style_description,
+        noteLayoutItems,
+        noteLayoutIndex.screenCode,
+    ) {
+        sharedPrefs.noteLayout.tryEmit(parseNoteLayoutType(it))
     }
 }
 

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -916,6 +916,11 @@
     <string name="gallery_type_classic">Classic</string>
     <string name="gallery_type_modern">Modern</string>
 
+    <string name="note_layout_type_classic">Classic</string>
+    <string name="note_layout_type_full_width">Full Width</string>
+    <string name="note_layout_style">Note Layout</string>
+    <string name="note_layout_style_description">Choose the note layout style</string>
+
     <string name="system">System</string>
     <string name="light">Light</string>
     <string name="dark">Dark</string>


### PR DESCRIPTION
## Summary

- Adds a new **Note Layout** setting in Application Preferences with two options: **Classic** (default) and **Full Width**
- In Full Width mode, the left column containing the profile picture (55dp) and relay badges is removed, giving note content the full display width
- The author's profile picture is shown inline in the note header row instead (25dp, same as quoted notes)
- Relay badges are hidden in full-width mode since there's no left column to host them

## Changes

| File | Change |
|------|--------|
| `UiSettings.kt` | Added `NoteLayoutType` enum (CLASSIC/FULL_WIDTH) and `noteLayout` field |
| `UiSettingsFlow.kt` | Added `noteLayout` MutableStateFlow and wired into combine/update/build |
| `UISharedPreferences.kt` | Added `UI_NOTE_LAYOUT` DataStore key for persistence |
| `UiSettingsState.kt` | Added `isFullWidthNoteLayout()` helper method |
| `AppSettingsScreen.kt` | Added `NoteLayoutChoice` settings UI composable |
| `NoteCompose.kt` | Modified `InnerNoteWithReactions` to skip left column and show inline author pic in full-width mode |
| `strings.xml` | Added 4 new string resources for the setting |

## Test plan

- [ ] Open Application Preferences and verify "Note Layout" setting appears between "UI Mode" and "Profile Gallery Style"
- [ ] Select "Full Width" and verify notes use the full display width without the left profile picture column
- [ ] Verify the author's profile picture appears inline in the note header row in full-width mode
- [ ] Verify relay badges are hidden in full-width mode
- [ ] Switch back to "Classic" and verify the original layout is restored
- [ ] Verify boosted/quoted notes are unaffected by the setting
- [ ] Verify the setting persists across app restarts

https://claude.ai/code/session_01JSiy1vBpxBrnpJFb19ydhb