### PR TITLE
Hide video controls on playback start

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/VideoViewInner.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/VideoViewInner.kt
@@ -47,7 +47,7 @@ fun VideoViewInner(
     authorName: String? = null,
     nostrUriCallback: String? = null,
     automaticallyStartPlayback: Boolean,
-    controllerVisible: MutableState<Boolean> = mutableStateOf(true),
+    controllerVisible: MutableState<Boolean> = mutableStateOf(false),
     onZoom: (() -> Unit)? = null,
     accountViewModel: AccountViewModel,
 ) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
@@ -124,7 +124,6 @@ import okhttp3.coroutines.executeAsync
 import okio.sink
 import java.io.File
 import java.io.IOException
-import kotlin.time.Duration.Companion.seconds
 
 // Delay before cleaning up shared video temp files.
 // Allows time for receiving app to copy the file after user confirms share.
@@ -224,12 +223,7 @@ fun TwoSecondController(
     content: BaseMediaContent,
     inner: @Composable (controllerVisible: MutableState<Boolean>) -> Unit,
 ) {
-    val controllerVisible = remember(content) { mutableStateOf(true) }
-
-    LaunchedEffect(content) {
-        delay(2.seconds)
-        controllerVisible.value = false
-    }
+    val controllerVisible = remember(content) { mutableStateOf(false) }
 
     inner(controllerVisible)
 }


### PR DESCRIPTION
## Summary
- Video controls are now hidden by default when playback begins, providing a cleaner viewing experience
- Removed the `TwoSecondController` auto-hide delay — controls start hidden instead of showing for 2 seconds then fading out
- Changed `VideoViewInner` default `controllerVisible` from `true` to `false`
- Users can still tap to reveal controls at any time

## Test plan
- [ ] Play a video in a note feed and verify controls are not shown initially
- [ ] Tap the video to verify controls appear on tap
- [ ] Tap again to verify controls hide
- [ ] Open a video in the fullscreen/zoomed dialog and verify controls behavior
- [ ] Test with voice tracks to ensure they are unaffected (they already use `false`)

https://claude.ai/code/session_01WpAqbodB5w8oDJpN6MLBs6