### PR TITLE
feat: scroll to replied message when clicking reply preview in chat

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/feed/ChatFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/feed/ChatFeedView.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedContentState
@@ -43,6 +44,7 @@ import com.vitorpamplona.amethyst.ui.screen.SaveableFeedState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.theme.FeedPadding
 import com.vitorpamplona.quartz.nip37Drafts.DraftWrapEvent
+import kotlinx.coroutines.launch
 
 @Composable
 fun RefreshingChatroomFeedView(
@@ -131,6 +133,16 @@ fun ChatFeedLoaded(
         }
     }
 
+    val scope = rememberCoroutineScope()
+    val onScrollToNote: (Note) -> Unit = { note ->
+        val index = items.list.indexOfFirst { it.idHex == note.idHex }
+        if (index >= 0) {
+            scope.launch {
+                listState.animateScrollToItem(index)
+            }
+        }
+    }
+
     LazyColumn(
         contentPadding = FeedPadding,
         modifier = Modifier.fillMaxSize(),
@@ -147,6 +159,7 @@ fun ChatFeedLoaded(
                     nav = nav,
                     onWantsToReply = onWantsToReply,
                     onWantsToEditDraft = onWantsToEditDraft,
+                    onScrollToNote = onScrollToNote,
                 )
 
                 NewDateOrSubjectDivisor(items.list.getOrNull(index + 1), item)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/feed/ChatMessageCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/feed/ChatMessageCompose.kt
@@ -95,6 +95,7 @@ fun ChatroomMessageCompose(
     nav: INav,
     onWantsToReply: (Note) -> Unit,
     onWantsToEditDraft: (Note) -> Unit,
+    onScrollToNote: ((Note) -> Unit)? = null,
 ) {
     WatchNoteEvent(baseNote = baseNote, accountViewModel = accountViewModel, nav) {
         WatchBlockAndReport(
@@ -114,6 +115,7 @@ fun ChatroomMessageCompose(
                 nav,
                 onWantsToReply,
                 onWantsToEditDraft,
+                onScrollToNote,
             )
         }
     }
@@ -130,6 +132,7 @@ fun NormalChatNote(
     nav: INav,
     onWantsToReply: (Note) -> Unit,
     onWantsToEditDraft: (Note) -> Unit,
+    onScrollToNote: ((Note) -> Unit)? = null,
 ) {
     val isLoggedInUser =
         remember(note.author) {
@@ -170,6 +173,9 @@ fun NormalChatNote(
         onClick = {
             if (note.event is ChannelCreateEvent) {
                 nav.nav(Route.PublicChatChannel(note.idHex))
+                true
+            } else if (innerQuote && onScrollToNote != null) {
+                onScrollToNote(note)
                 true
             } else {
                 false
@@ -253,6 +259,7 @@ fun NormalChatNote(
             canPreview,
             accountViewModel,
             nav,
+            onScrollToNote,
         )
     }
 }
@@ -288,6 +295,7 @@ private fun MessageBubbleLines(
     canPreview: Boolean,
     accountViewModel: AccountViewModel,
     nav: INav,
+    onScrollToNote: ((Note) -> Unit)? = null,
 ) {
     if (baseNote.event !is DraftWrapEvent) {
         RenderReplyRow(
@@ -298,6 +306,7 @@ private fun MessageBubbleLines(
             nav = nav,
             onWantsToReply = onWantsToReply,
             onWantsToEditDraft = onWantsToEditDraft,
+            onScrollToNote = onScrollToNote,
         )
     }
 
@@ -334,9 +343,10 @@ fun RenderReplyRow(
     nav: INav,
     onWantsToReply: (Note) -> Unit,
     onWantsToEditDraft: (Note) -> Unit,
+    onScrollToNote: ((Note) -> Unit)? = null,
 ) {
     if (!innerQuote && note.replyTo?.lastOrNull() != null) {
-        RenderReply(note, bgColor, accountViewModel, nav, onWantsToReply, onWantsToEditDraft)
+        RenderReply(note, bgColor, accountViewModel, nav, onWantsToReply, onWantsToEditDraft, onScrollToNote)
     }
 }
 
@@ -348,6 +358,7 @@ private fun RenderReply(
     nav: INav,
     onWantsToReply: (Note) -> Unit,
     onWantsToEditDraft: (Note) -> Unit,
+    onScrollToNote: ((Note) -> Unit)? = null,
 ) {
     Row(verticalAlignment = Alignment.CenterVertically) {
         @Suppress("ProduceStateDoesNotAssignValue")
@@ -368,6 +379,7 @@ private fun RenderReply(
                 nav = nav,
                 onWantsToReply = onWantsToReply,
                 onWantsToEditDraft = onWantsToEditDraft,
+                onScrollToNote = onScrollToNote,
             )
         }
     }


### PR DESCRIPTION
## Summary

- When clicking on a reply preview (inner quote bubble) in a chat message, the chat feed now smoothly scrolls to the original replied-to message within the same screen
- Previously, clicking on the reply preview did nothing (only toggled the detail row in non-complete UI mode)
- Threads an `onScrollToNote` callback from the `ChatFeedLoaded` LazyColumn (which has access to the list state and items) down through `ChatroomMessageCompose` → `RenderReply`, so the inner quote's click handler can trigger `animateScrollToItem`

## Test plan

- [ ] Open a private DM chat with reply messages
- [ ] Tap on a reply preview (the smaller inner quote bubble) — verify the chat scrolls to the original message
- [ ] Open a public channel (NIP-28) chat with replies — verify same scroll behavior
- [ ] Verify that tapping on a non-reply message bubble still works as before (toggles details in compact mode)
- [ ] Verify long-press on reply preview still opens the action menu
- [ ] Verify that if the replied-to message is not in the current feed (e.g., very old), nothing breaks (no crash, just no scroll)

https://claude.ai/code/session_01UF4VxoWGvvvwtLYBLBYw9w