### PR TITLE
feat: make profile relay rows open relay info dialog

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/RelayCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/RelayCompose.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.note
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -59,11 +60,12 @@ fun RelayCompose(
     accountViewModel: AccountViewModel,
     onAddRelay: () -> Unit,
     onRemoveRelay: () -> Unit,
+    onClick: (() -> Unit)? = null,
 ) {
     val context = LocalContext.current
 
     Row(
-        modifier = StdPadding,
+        modifier = StdPadding.then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/relays/RelayFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/relays/RelayFeedView.kt
@@ -105,6 +105,9 @@ private fun RenderRelayRow(
         onRemoveRelay = {
             nav.nav(Route.EditRelays)
         },
+        onClick = {
+            nav.nav(Route.RelayInfo(relay.url.url))
+        },
     )
     HorizontalDivider(
         thickness = DividerThickness,


### PR DESCRIPTION
## Summary
- Adds an `onClick` parameter to `RelayCompose` that makes relay rows clickable
- In the profile relay tab, clicking a relay row now navigates to the `RelayInformationScreen` for that relay

## Test plan
- [ ] Open a user's profile page
- [ ] Navigate to the Relays tab
- [ ] Tap on any relay row — should open the relay information screen
- [ ] Verify the Add/Remove buttons still work independently

https://claude.ai/code/session_01PBFQz53xzXoFsEHD5Ghyqr