### PR TITLE
feat: swipe on user picture to switch accounts in post screens

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -284,6 +284,7 @@ fun AppNavigation(
                     quote = it.quote?.let { hex -> accountViewModel.getNoteIfExists(hex) },
                     draft = it.draft?.let { hex -> accountViewModel.getNoteIfExists(hex) },
                     accountViewModel,
+                    accountSessionManager,
                     nav,
                 )
             }
@@ -307,6 +308,7 @@ fun AppNavigation(
                     quote = it.quote?.let { hex -> accountViewModel.getNoteIfExists(hex) },
                     draft = it.draft?.let { hex -> accountViewModel.getNoteIfExists(hex) },
                     accountViewModel,
+                    accountSessionManager,
                     nav,
                 )
             }
@@ -319,6 +321,7 @@ fun AppNavigation(
                     quote = it.quote?.let { hex -> accountViewModel.getNoteIfExists(hex) },
                     draft = it.draft?.let { hex -> accountViewModel.getNoteIfExists(hex) },
                     accountViewModel,
+                    accountSessionManager,
                     nav,
                 )
             }
@@ -353,6 +356,7 @@ fun AppNavigation(
                     version = it.version?.let { hex -> accountViewModel.getNoteIfExists(hex) },
                     draft = it.draft?.let { hex -> accountViewModel.getNoteIfExists(hex) },
                     accountViewModel = accountViewModel,
+                    accountSessionManager = accountSessionManager,
                     nav = nav,
                 )
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/SwipeToSwitchAccountPicture.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/SwipeToSwitchAccountPicture.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.note
+
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.Dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.LocalPreferences
+import com.vitorpamplona.amethyst.ui.screen.AccountSessionManager
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+
+private const val SWIPE_THRESHOLD = 50f
+
+@Composable
+fun SwipeToSwitchAccountPicture(
+    size: Dp,
+    accountViewModel: AccountViewModel,
+    accountSessionManager: AccountSessionManager,
+) {
+    val accounts by LocalPreferences.accountsFlow().collectAsStateWithLifecycle()
+    var dragAccumulator by remember { mutableFloatStateOf(0f) }
+
+    val swipeModifier =
+        Modifier.pointerInput(accounts) {
+            detectVerticalDragGestures(
+                onDragStart = { dragAccumulator = 0f },
+                onVerticalDrag = { change, dragAmount ->
+                    dragAccumulator += dragAmount
+                    val accountList = accounts ?: return@detectVerticalDragGestures
+
+                    if (accountList.size <= 1) return@detectVerticalDragGestures
+
+                    if (kotlin.math.abs(dragAccumulator) > SWIPE_THRESHOLD) {
+                        val currentNpub = accountViewModel.account.userProfile().pubkeyNpub()
+                        val currentIndex = accountList.indexOfFirst { it.npub == currentNpub }
+                        if (currentIndex < 0) return@detectVerticalDragGestures
+
+                        val nextIndex =
+                            if (dragAccumulator > 0) {
+                                (currentIndex + 1) % accountList.size
+                            } else {
+                                (currentIndex - 1 + accountList.size) % accountList.size
+                            }
+
+                        change.consume()
+                        dragAccumulator = 0f
+                        accountSessionManager.switchUser(accountList[nextIndex])
+                    }
+                },
+            )
+        }
+
+    Box(modifier = swipeModifier) {
+        BaseUserPicture(
+            accountViewModel.userProfile(),
+            size,
+            accountViewModel = accountViewModel,
+        )
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/GenericCommentPostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/GenericCommentPostScreen.kt
@@ -56,8 +56,8 @@ import com.vitorpamplona.amethyst.ui.actions.uploads.TakePictureButton
 import com.vitorpamplona.amethyst.ui.actions.uploads.TakeVideoButton
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.PostingTopBar
-import com.vitorpamplona.amethyst.ui.note.BaseUserPicture
 import com.vitorpamplona.amethyst.ui.note.NoteCompose
+import com.vitorpamplona.amethyst.ui.note.SwipeToSwitchAccountPicture
 import com.vitorpamplona.amethyst.ui.note.creators.contentWarning.ContentSensitivityExplainer
 import com.vitorpamplona.amethyst.ui.note.creators.contentWarning.MarkAsSensitiveButton
 import com.vitorpamplona.amethyst.ui.note.creators.emojiSuggestions.ShowEmojiSuggestionList
@@ -80,6 +80,7 @@ import com.vitorpamplona.amethyst.ui.note.creators.zapraiser.ZapRaiserRequest
 import com.vitorpamplona.amethyst.ui.note.creators.zapsplits.ForwardZapTo
 import com.vitorpamplona.amethyst.ui.note.creators.zapsplits.ForwardZapToButton
 import com.vitorpamplona.amethyst.ui.note.types.ReplyRenderType
+import com.vitorpamplona.amethyst.ui.screen.AccountSessionManager
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.Size10dp
@@ -100,6 +101,7 @@ fun ReplyCommentPostScreen(
     quote: Note? = null,
     draft: Note? = null,
     accountViewModel: AccountViewModel,
+    accountSessionManager: AccountSessionManager,
     nav: Nav,
 ) {
     val postViewModel: CommentPostViewModel = viewModel()
@@ -128,7 +130,7 @@ fun ReplyCommentPostScreen(
         }
     }
 
-    GenericCommentPostScreen(postViewModel, accountViewModel, nav)
+    GenericCommentPostScreen(postViewModel, accountViewModel, accountSessionManager, nav)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -136,6 +138,7 @@ fun ReplyCommentPostScreen(
 fun GenericCommentPostScreen(
     postViewModel: CommentPostViewModel,
     accountViewModel: AccountViewModel,
+    accountSessionManager: AccountSessionManager,
     nav: Nav,
 ) {
     WatchAndLoadMyEmojiList(accountViewModel)
@@ -184,6 +187,7 @@ fun GenericCommentPostScreen(
             GenericCommentPostBody(
                 postViewModel,
                 accountViewModel,
+                accountSessionManager,
                 nav,
             )
         }
@@ -194,6 +198,7 @@ fun GenericCommentPostScreen(
 private fun GenericCommentPostBody(
     postViewModel: CommentPostViewModel,
     accountViewModel: AccountViewModel,
+    accountSessionManager: AccountSessionManager,
     nav: Nav,
 ) {
     val scrollState = rememberScrollState()
@@ -241,10 +246,10 @@ private fun GenericCommentPostBody(
                 Row(
                     modifier = Modifier.padding(vertical = Size10dp),
                 ) {
-                    BaseUserPicture(
-                        accountViewModel.userProfile(),
+                    SwipeToSwitchAccountPicture(
                         Size35dp,
                         accountViewModel = accountViewModel,
+                        accountSessionManager = accountSessionManager,
                     )
                     MessageField(
                         R.string.what_s_on_your_mind,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/geohash/GeoHashPostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/geohash/GeoHashPostScreen.kt
@@ -31,6 +31,7 @@ import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.note.nip22Comments.CommentPostViewModel
 import com.vitorpamplona.amethyst.ui.note.nip22Comments.GenericCommentPostScreen
+import com.vitorpamplona.amethyst.ui.screen.AccountSessionManager
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.quartz.nip73ExternalIds.location.GeohashId
 import kotlinx.collections.immutable.persistentListOf
@@ -46,6 +47,7 @@ fun GeoHashPostScreen(
     quote: Note? = null,
     draft: Note? = null,
     accountViewModel: AccountViewModel,
+    accountSessionManager: AccountSessionManager,
     nav: Nav,
 ) {
     val postViewModel: CommentPostViewModel = viewModel()
@@ -77,5 +79,5 @@ fun GeoHashPostScreen(
         }
     }
 
-    GenericCommentPostScreen(postViewModel, accountViewModel, nav)
+    GenericCommentPostScreen(postViewModel, accountViewModel, accountSessionManager, nav)
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/HashtagPostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/HashtagPostScreen.kt
@@ -31,6 +31,7 @@ import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.note.nip22Comments.CommentPostViewModel
 import com.vitorpamplona.amethyst.ui.note.nip22Comments.GenericCommentPostScreen
+import com.vitorpamplona.amethyst.ui.screen.AccountSessionManager
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.quartz.nip73ExternalIds.topics.HashtagId
 import kotlinx.collections.immutable.persistentListOf
@@ -46,6 +47,7 @@ fun HashtagPostScreen(
     quote: Note? = null,
     draft: Note? = null,
     accountViewModel: AccountViewModel,
+    accountSessionManager: AccountSessionManager,
     nav: Nav,
 ) {
     val postViewModel: CommentPostViewModel = viewModel()
@@ -77,5 +79,5 @@ fun HashtagPostScreen(
         }
     }
 
-    GenericCommentPostScreen(postViewModel, accountViewModel, nav)
+    GenericCommentPostScreen(postViewModel, accountViewModel, accountSessionManager, nav)
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostScreen.kt
@@ -75,8 +75,8 @@ import com.vitorpamplona.amethyst.ui.actions.uploads.VoiceMessagePreview
 import com.vitorpamplona.amethyst.ui.components.getActivity
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.PostingTopBar
-import com.vitorpamplona.amethyst.ui.note.BaseUserPicture
 import com.vitorpamplona.amethyst.ui.note.NoteCompose
+import com.vitorpamplona.amethyst.ui.note.SwipeToSwitchAccountPicture
 import com.vitorpamplona.amethyst.ui.note.creators.contentWarning.ContentSensitivityExplainer
 import com.vitorpamplona.amethyst.ui.note.creators.contentWarning.MarkAsSensitiveButton
 import com.vitorpamplona.amethyst.ui.note.creators.emojiSuggestions.ShowEmojiSuggestionList
@@ -102,6 +102,7 @@ import com.vitorpamplona.amethyst.ui.note.creators.zapsplits.ForwardZapTo
 import com.vitorpamplona.amethyst.ui.note.creators.zapsplits.ForwardZapToButton
 import com.vitorpamplona.amethyst.ui.note.types.ReplyRenderType
 import com.vitorpamplona.amethyst.ui.painterRes
+import com.vitorpamplona.amethyst.ui.screen.AccountSessionManager
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.SettingsRow
 import com.vitorpamplona.amethyst.ui.stringRes
@@ -129,6 +130,7 @@ fun ShortNotePostScreen(
     version: Note? = null,
     draft: Note? = null,
     accountViewModel: AccountViewModel,
+    accountSessionManager: AccountSessionManager,
     nav: Nav,
 ) {
     val postViewModel: ShortNotePostViewModel = viewModel()
@@ -170,7 +172,7 @@ fun ShortNotePostScreen(
         onDispose { activity.removeOnNewIntentListener(consumer) }
     }
 
-    NewPostScreenInner(postViewModel, accountViewModel, nav)
+    NewPostScreenInner(postViewModel, accountViewModel, accountSessionManager, nav)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -178,6 +180,7 @@ fun ShortNotePostScreen(
 private fun NewPostScreenInner(
     postViewModel: ShortNotePostViewModel,
     accountViewModel: AccountViewModel,
+    accountSessionManager: AccountSessionManager,
     nav: Nav,
 ) {
     WatchAndLoadMyEmojiList(accountViewModel)
@@ -223,7 +226,7 @@ private fun NewPostScreenInner(
                     .consumeWindowInsets(pad)
                     .imePadding(),
         ) {
-            NewPostScreenBody(postViewModel, accountViewModel, nav)
+            NewPostScreenBody(postViewModel, accountViewModel, accountSessionManager, nav)
         }
     }
 }
@@ -232,6 +235,7 @@ private fun NewPostScreenInner(
 private fun NewPostScreenBody(
     postViewModel: ShortNotePostViewModel,
     accountViewModel: AccountViewModel,
+    accountSessionManager: AccountSessionManager,
     nav: Nav,
 ) {
     val scrollState = rememberScrollState()
@@ -283,10 +287,10 @@ private fun NewPostScreenBody(
                     Row(
                         modifier = Modifier.padding(vertical = Size10dp),
                     ) {
-                        BaseUserPicture(
-                            accountViewModel.userProfile(),
+                        SwipeToSwitchAccountPicture(
                             Size35dp,
                             accountViewModel = accountViewModel,
+                            accountSessionManager = accountSessionManager,
                         )
                         MessageField(
                             R.string.what_s_on_your_mind,


### PR DESCRIPTION
## Summary

- Adds a vertical swipe gesture on the user's profile picture in new post screens that cycles through available accounts
- Swiping up switches to the previous account, swiping down switches to the next account
- Applied to ShortNotePostScreen, GenericCommentPostScreen, GeoHashPostScreen, and HashtagPostScreen
- Created a reusable `SwipeToSwitchAccountPicture` composable that wraps `PostSendingPictureRow` with swipe detection

## Test plan

- [ ] Open a new post screen (short note, comment, geohash, or hashtag)
- [ ] Swipe up on the user profile picture — should switch to the previous account
- [ ] Swipe down on the user profile picture — should switch to the next account
- [ ] Verify the post content and UI updates to reflect the newly selected account
- [ ] Verify with a single account that swiping does nothing harmful

https://claude.ai/code/session_015JRte25vpsNisbArQuSh4h