### PR TITLE
perf: move cache lookups from NavHost route lambdas into screen composables

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -130,10 +130,7 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.wallet.WalletSendScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.wallet.WalletTransactionsScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedOff.AddAccountDialog
 import com.vitorpamplona.amethyst.ui.uriToRoute
-import com.vitorpamplona.quartz.experimental.ephemChat.chat.RoomId
 import com.vitorpamplona.quartz.nip01Core.core.Address
-import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
-import com.vitorpamplona.quartz.nip02FollowList.ContactListEvent
 import com.vitorpamplona.quartz.nip19Bech32.Nip19Parser
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -209,11 +206,7 @@ fun AppNavigation(
             composableFromEnd<Route.ReactionsSettings> { ReactionsSettingsScreen(accountViewModel, nav) }
             composableFromEnd<Route.ImportFollowsSelectUser> { ImportFollowListSelectUserScreen(accountViewModel, nav) }
             composableFromEndArgs<Route.ImportFollowsPickFollows> {
-                ImportFollowListPickFollowsScreen(
-                    accountViewModel.getOrCreateAddressableNote(ContactListEvent.createAddress(it.userHex)),
-                    accountViewModel,
-                    nav,
-                )
+                ImportFollowListPickFollowsScreen(it.userHex, accountViewModel, nav)
             }
 
             composableFromEndArgs<Route.Nip47NWCSetup> { NIP47SetupScreen(accountViewModel, nav, it.nip47) }
@@ -238,35 +231,28 @@ fun AppNavigation(
             composableFromEndArgs<Route.RoomByAuthor> { ChatroomByAuthorScreen(it.id, null, accountViewModel, nav) }
 
             composableFromEndArgs<Route.PublicChatChannel> {
-                PublicChatChannelScreen(
-                    it.id,
-                    it.draftId?.let { hex -> accountViewModel.getNoteIfExists(hex) },
-                    it.replyTo?.let { hex -> accountViewModel.checkGetOrCreateNote(hex) },
-                    accountViewModel,
-                    nav,
-                )
+                PublicChatChannelScreen(it.id, it.draftId, it.replyTo, accountViewModel, nav)
             }
 
             composableFromEndArgs<Route.LiveActivityChannel> {
                 LiveActivityChannelScreen(
                     Address(it.kind, it.pubKeyHex, it.dTag),
-                    draft = it.draftId?.let { hex -> accountViewModel.getNoteIfExists(hex) },
-                    replyTo = it.replyTo?.let { hex -> accountViewModel.checkGetOrCreateNote(hex) },
+                    draftId = it.draftId,
+                    replyToId = it.replyTo,
                     accountViewModel,
                     nav,
                 )
             }
 
             composableFromEndArgs<Route.EphemeralChat> {
-                RelayUrlNormalizer.normalizeOrNull(it.relayUrl)?.let { relay ->
-                    EphemeralChatScreen(
-                        channelId = RoomId(it.id, relay),
-                        draft = it.draftId?.let { hex -> accountViewModel.getNoteIfExists(hex) },
-                        replyTo = it.replyTo?.let { hex -> accountViewModel.checkGetOrCreateNote(hex) },
-                        accountViewModel = accountViewModel,
-                        nav = nav,
-                    )
-                }
+                EphemeralChatScreen(
+                    id = it.id,
+                    relayUrl = it.relayUrl,
+                    draftId = it.draftId,
+                    replyToId = it.replyTo,
+                    accountViewModel = accountViewModel,
+                    nav = nav,
+                )
             }
 
             composableFromBottomArgs<Route.ChannelMetadataEdit> { ChannelMetadataScreen(it.id, accountViewModel, nav) }
@@ -280,9 +266,9 @@ fun AppNavigation(
                     geohash = it.geohash,
                     message = it.message,
                     attachment = it.attachment?.ifBlank { null }?.toUri(),
-                    reply = it.replyTo?.let { hex -> accountViewModel.getNoteIfExists(hex) },
-                    quote = it.quote?.let { hex -> accountViewModel.getNoteIfExists(hex) },
-                    draft = it.draft?.let { hex -> accountViewModel.getNoteIfExists(hex) },
+                    replyId = it.replyTo,
+                    quoteId = it.quote,
+                    draftId = it.draft,
                     accountViewModel,
                     nav,
                 )
@@ -291,8 +277,8 @@ fun AppNavigation(
             composableFromBottomArgs<Route.NewPublicMessage> {
                 NewPublicMessageScreen(
                     to = it.toKey(),
-                    reply = it.replyId?.let { hex -> accountViewModel.getNoteIfExists(hex) },
-                    draft = it.draftId?.let { hex -> accountViewModel.getNoteIfExists(hex) },
+                    replyId = it.replyId,
+                    draftId = it.draftId,
                     accountViewModel = accountViewModel,
                     nav = nav,
                 )
@@ -303,9 +289,9 @@ fun AppNavigation(
                     hashtag = it.hashtag,
                     message = it.message,
                     attachment = it.attachment?.ifBlank { null }?.toUri(),
-                    reply = it.replyTo?.let { hex -> accountViewModel.getNoteIfExists(hex) },
-                    quote = it.quote?.let { hex -> accountViewModel.getNoteIfExists(hex) },
-                    draft = it.draft?.let { hex -> accountViewModel.getNoteIfExists(hex) },
+                    replyId = it.replyTo,
+                    quoteId = it.quote,
+                    draftId = it.draft,
                     accountViewModel,
                     nav,
                 )
@@ -313,11 +299,11 @@ fun AppNavigation(
 
             composableFromBottomArgs<Route.GenericCommentPost> {
                 ReplyCommentPostScreen(
-                    reply = it.replyTo?.let { hex -> accountViewModel.getNoteIfExists(hex) },
+                    replyId = it.replyTo,
                     message = it.message,
                     attachment = it.attachment?.ifBlank { null }?.toUri(),
-                    quote = it.quote?.let { hex -> accountViewModel.getNoteIfExists(hex) },
-                    draft = it.draft?.let { hex -> accountViewModel.getNoteIfExists(hex) },
+                    quoteId = it.quote,
+                    draftId = it.draft,
                     accountViewModel,
                     nav,
                 )
@@ -327,8 +313,8 @@ fun AppNavigation(
                 NewProductScreen(
                     message = it.message,
                     attachment = it.attachment?.ifBlank { null }?.toUri(),
-                    quote = it.quote?.let { hex -> accountViewModel.getNoteIfExists(hex) },
-                    draft = it.draft?.let { hex -> accountViewModel.getNoteIfExists(hex) },
+                    quoteId = it.quote,
+                    draftId = it.draft,
                     accountViewModel,
                     nav,
                 )
@@ -336,8 +322,8 @@ fun AppNavigation(
 
             composableFromBottomArgs<Route.NewLongFormPost> {
                 LongFormPostScreen(
-                    draft = it.draft?.let { hex -> accountViewModel.getNoteIfExists(hex) },
-                    version = it.version?.let { hex -> accountViewModel.getNoteIfExists(hex) },
+                    draftId = it.draft,
+                    versionId = it.version,
                     accountViewModel = accountViewModel,
                     nav = nav,
                 )
@@ -347,11 +333,11 @@ fun AppNavigation(
                 ShortNotePostScreen(
                     message = it.message,
                     attachment = it.attachment?.ifBlank { null }?.toUri(),
-                    baseReplyTo = it.baseReplyTo?.let { hex -> accountViewModel.getNoteIfExists(hex) },
-                    quote = it.quote?.let { hex -> accountViewModel.getNoteIfExists(hex) },
-                    fork = it.fork?.let { hex -> accountViewModel.getNoteIfExists(hex) },
-                    version = it.version?.let { hex -> accountViewModel.getNoteIfExists(hex) },
-                    draft = it.draft?.let { hex -> accountViewModel.getNoteIfExists(hex) },
+                    baseReplyToId = it.baseReplyTo,
+                    quoteId = it.quote,
+                    forkId = it.fork,
+                    versionId = it.version,
+                    draftId = it.draft,
                     accountViewModel = accountViewModel,
                     nav = nav,
                 )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/GenericCommentPostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/GenericCommentPostScreen.kt
@@ -47,7 +47,6 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.actions.StrippingFailureDialog
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromFiles
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromGallery
@@ -87,6 +86,7 @@ import com.vitorpamplona.amethyst.ui.theme.Size35dp
 import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
 import com.vitorpamplona.amethyst.ui.theme.SuggestionListDefaultHeightPage
 import com.vitorpamplona.amethyst.ui.theme.replyModifier
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
@@ -94,11 +94,11 @@ import kotlinx.coroutines.withContext
 
 @Composable
 fun ReplyCommentPostScreen(
-    reply: Note? = null,
+    replyId: HexKey? = null,
     message: String? = null,
     attachment: Uri? = null,
-    quote: Note? = null,
-    draft: Note? = null,
+    quoteId: HexKey? = null,
+    draftId: HexKey? = null,
     accountViewModel: AccountViewModel,
     nav: Nav,
 ) {
@@ -108,13 +108,13 @@ fun ReplyCommentPostScreen(
     val context = LocalContext.current
 
     LaunchedEffect(postViewModel, accountViewModel) {
-        reply?.let {
+        replyId?.let { accountViewModel.getNoteIfExists(it) }?.let {
             postViewModel.reply(it)
         }
-        draft?.let {
+        draftId?.let { accountViewModel.getNoteIfExists(it) }?.let {
             postViewModel.editFromDraft(it)
         }
-        quote?.let {
+        quoteId?.let { accountViewModel.getNoteIfExists(it) }?.let {
             postViewModel.quote(it)
         }
         message?.ifBlank { null }?.let {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/ephemChat/EphemeralChatScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/ephemChat/EphemeralChatScreen.kt
@@ -23,22 +23,30 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.ephem
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.layouts.DisappearingScaffold
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.ephemChat.header.EphemeralChatTopBar
 import com.vitorpamplona.quartz.experimental.ephemChat.chat.RoomId
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
 
 @Composable
 fun EphemeralChatScreen(
-    channelId: RoomId,
-    draft: Note? = null,
-    replyTo: Note? = null,
+    id: HexKey,
+    relayUrl: String,
+    draftId: HexKey? = null,
+    replyToId: HexKey? = null,
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
+    val relay = remember(relayUrl) { RelayUrlNormalizer.normalizeOrNull(relayUrl) } ?: return
+    val channelId = remember(id, relay) { RoomId(id, relay) }
+    val draft = remember(draftId) { draftId?.let { accountViewModel.getNoteIfExists(it) } }
+    val replyTo = remember(replyToId) { replyToId?.let { accountViewModel.checkGetOrCreateNote(it) } }
+
     DisappearingScaffold(
         isInvertedLayout = true,
         topBar = {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/nip28PublicChat/PublicChatChannelScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/nip28PublicChat/PublicChatChannelScreen.kt
@@ -23,8 +23,8 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.nip28
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.layouts.DisappearingScaffold
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.LoadPublicChatChannel
@@ -35,12 +35,15 @@ import com.vitorpamplona.quartz.nip01Core.core.HexKey
 @Composable
 fun PublicChatChannelScreen(
     channelId: HexKey?,
-    draft: Note?,
-    replyTo: Note? = null,
+    draftId: HexKey? = null,
+    replyToId: HexKey? = null,
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
     if (channelId == null) return
+
+    val draft = remember(draftId) { draftId?.let { accountViewModel.getNoteIfExists(it) } }
+    val replyTo = remember(replyToId) { replyToId?.let { accountViewModel.checkGetOrCreateNote(it) } }
 
     DisappearingScaffold(
         isInvertedLayout = true,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/nip53LiveActivities/LiveActivityChannelScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/nip53LiveActivities/LiveActivityChannelScreen.kt
@@ -24,8 +24,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.service.OnlineChecker
 import com.vitorpamplona.amethyst.ui.layouts.DisappearingScaffold
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -33,16 +33,20 @@ import com.vitorpamplona.amethyst.ui.note.LoadLiveActivityChannel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.nip53LiveActivities.header.LiveActivityTopBar
 import com.vitorpamplona.quartz.nip01Core.core.Address
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
 
 @Composable
 fun LiveActivityChannelScreen(
     channelId: Address?,
-    draft: Note? = null,
-    replyTo: Note? = null,
+    draftId: HexKey? = null,
+    replyToId: HexKey? = null,
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
     if (channelId == null) return
+
+    val draft = remember(draftId) { draftId?.let { accountViewModel.getNoteIfExists(it) } }
+    val replyTo = remember(replyToId) { replyToId?.let { accountViewModel.checkGetOrCreateNote(it) } }
 
     DisappearingScaffold(
         isInvertedLayout = true,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip23LongForm/LongFormPostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip23LongForm/LongFormPostScreen.kt
@@ -61,7 +61,6 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.model.EmptyTagList
-import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.actions.StrippingFailureDialog
 import com.vitorpamplona.amethyst.ui.actions.UrlUserTagTransformation
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromFiles
@@ -98,12 +97,13 @@ import com.vitorpamplona.amethyst.ui.theme.Size10dp
 import com.vitorpamplona.amethyst.ui.theme.Size5dp
 import com.vitorpamplona.amethyst.ui.theme.SuggestionListDefaultHeightPage
 import com.vitorpamplona.amethyst.ui.theme.placeholderText
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LongFormPostScreen(
-    draft: Note? = null,
-    version: Note? = null,
+    draftId: HexKey? = null,
+    versionId: HexKey? = null,
     accountViewModel: AccountViewModel,
     nav: Nav,
 ) {
@@ -111,6 +111,8 @@ fun LongFormPostScreen(
     postViewModel.init(accountViewModel)
 
     LaunchedEffect(postViewModel, accountViewModel) {
+        val draft = draftId?.let { accountViewModel.getNoteIfExists(it) }
+        val version = versionId?.let { accountViewModel.getNoteIfExists(it) }
         postViewModel.load(draft, version)
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/NewProductScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/NewProductScreen.kt
@@ -46,7 +46,6 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.actions.StrippingFailureDialog
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromFiles
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromGallery
@@ -83,6 +82,7 @@ import com.vitorpamplona.amethyst.ui.theme.Size10dp
 import com.vitorpamplona.amethyst.ui.theme.Size35dp
 import com.vitorpamplona.amethyst.ui.theme.Size5dp
 import com.vitorpamplona.amethyst.ui.theme.SuggestionListDefaultHeightPage
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
@@ -93,8 +93,8 @@ import kotlinx.coroutines.withContext
 fun NewProductScreen(
     message: String? = null,
     attachment: Uri? = null,
-    quote: Note? = null,
-    draft: Note? = null,
+    quoteId: HexKey? = null,
+    draftId: HexKey? = null,
     accountViewModel: AccountViewModel,
     nav: Nav,
 ) {
@@ -105,10 +105,10 @@ fun NewProductScreen(
 
     LaunchedEffect(postViewModel, accountViewModel) {
         postViewModel.reloadRelaySet()
-        draft?.let {
+        draftId?.let { accountViewModel.getNoteIfExists(it) }?.let {
             postViewModel.editFromDraft(it)
         }
-        quote?.let {
+        quoteId?.let { accountViewModel.getNoteIfExists(it) }?.let {
             postViewModel.quote(it)
         }
         message?.ifBlank { null }?.let {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/geohash/GeoHashPostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/geohash/GeoHashPostScreen.kt
@@ -26,12 +26,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.note.nip22Comments.CommentPostViewModel
 import com.vitorpamplona.amethyst.ui.note.nip22Comments.GenericCommentPostScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip73ExternalIds.location.GeohashId
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.Dispatchers
@@ -42,9 +42,9 @@ fun GeoHashPostScreen(
     geohash: String? = null,
     message: String? = null,
     attachment: Uri? = null,
-    reply: Note? = null,
-    quote: Note? = null,
-    draft: Note? = null,
+    replyId: HexKey? = null,
+    quoteId: HexKey? = null,
+    draftId: HexKey? = null,
     accountViewModel: AccountViewModel,
     nav: Nav,
 ) {
@@ -57,13 +57,13 @@ fun GeoHashPostScreen(
         geohash?.let {
             postViewModel.newPostFor(GeohashId(it))
         }
-        reply?.let {
+        replyId?.let { accountViewModel.getNoteIfExists(it) }?.let {
             postViewModel.reply(it)
         }
-        draft?.let {
+        draftId?.let { accountViewModel.getNoteIfExists(it) }?.let {
             postViewModel.editFromDraft(it)
         }
-        quote?.let {
+        quoteId?.let { accountViewModel.getNoteIfExists(it) }?.let {
             postViewModel.quote(it)
         }
         message?.ifBlank { null }?.let {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/HashtagPostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/HashtagPostScreen.kt
@@ -26,12 +26,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.note.nip22Comments.CommentPostViewModel
 import com.vitorpamplona.amethyst.ui.note.nip22Comments.GenericCommentPostScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip73ExternalIds.topics.HashtagId
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.Dispatchers
@@ -42,9 +42,9 @@ fun HashtagPostScreen(
     hashtag: String? = null,
     message: String? = null,
     attachment: Uri? = null,
-    reply: Note? = null,
-    quote: Note? = null,
-    draft: Note? = null,
+    replyId: HexKey? = null,
+    quoteId: HexKey? = null,
+    draftId: HexKey? = null,
     accountViewModel: AccountViewModel,
     nav: Nav,
 ) {
@@ -57,13 +57,13 @@ fun HashtagPostScreen(
         hashtag?.let {
             postViewModel.newPostFor(HashtagId(it))
         }
-        reply?.let {
+        replyId?.let { accountViewModel.getNoteIfExists(it) }?.let {
             postViewModel.reply(it)
         }
-        draft?.let {
+        draftId?.let { accountViewModel.getNoteIfExists(it) }?.let {
             postViewModel.editFromDraft(it)
         }
-        quote?.let {
+        quoteId?.let { accountViewModel.getNoteIfExists(it) }?.let {
             postViewModel.quote(it)
         }
         message?.ifBlank { null }?.let {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostScreen.kt
@@ -59,7 +59,6 @@ import androidx.compose.ui.unit.dp
 import androidx.core.util.Consumer
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.actions.StrippingFailureDialog
 import com.vitorpamplona.amethyst.ui.actions.mediaServers.FileServerSelectionRow
 import com.vitorpamplona.amethyst.ui.actions.uploads.MAX_VOICE_RECORD_SECONDS
@@ -112,6 +111,7 @@ import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
 import com.vitorpamplona.amethyst.ui.theme.SuggestionListDefaultHeightPage
 import com.vitorpamplona.amethyst.ui.theme.ThemeComparisonColumn
 import com.vitorpamplona.amethyst.ui.theme.replyModifier
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
@@ -123,11 +123,11 @@ import kotlinx.coroutines.withContext
 fun ShortNotePostScreen(
     message: String? = null,
     attachment: Uri? = null,
-    baseReplyTo: Note? = null,
-    quote: Note? = null,
-    fork: Note? = null,
-    version: Note? = null,
-    draft: Note? = null,
+    baseReplyToId: HexKey? = null,
+    quoteId: HexKey? = null,
+    forkId: HexKey? = null,
+    versionId: HexKey? = null,
+    draftId: HexKey? = null,
     accountViewModel: AccountViewModel,
     nav: Nav,
 ) {
@@ -138,6 +138,11 @@ fun ShortNotePostScreen(
     val activity = context.getActivity()
 
     LaunchedEffect(postViewModel, accountViewModel) {
+        val baseReplyTo = baseReplyToId?.let { accountViewModel.getNoteIfExists(it) }
+        val quote = quoteId?.let { accountViewModel.getNoteIfExists(it) }
+        val fork = forkId?.let { accountViewModel.getNoteIfExists(it) }
+        val version = versionId?.let { accountViewModel.getNoteIfExists(it) }
+        val draft = draftId?.let { accountViewModel.getNoteIfExists(it) }
         postViewModel.load(baseReplyTo, quote, fork, version, draft)
         message?.ifBlank { null }?.let {
             postViewModel.updateMessage(TextFieldValue(it))

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/newUser/ImportFollowListPickFollowsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/newUser/ImportFollowListPickFollowsScreen.kt
@@ -68,16 +68,22 @@ import com.vitorpamplona.amethyst.ui.note.creators.userSuggestions.UserLine
 import com.vitorpamplona.amethyst.ui.note.types.DisplayFollowList
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip02FollowList.ContactListEvent
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toPersistentList
 
 @Composable
 fun ImportFollowListPickFollowsScreen(
-    contactListNote: AddressableNote,
+    userHex: HexKey,
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
+    val contactListNote =
+        remember(userHex) {
+            accountViewModel.getOrCreateAddressableNote(ContactListEvent.createAddress(userHex))
+        }
+
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         topBar = {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/publicMessages/NewPublicMessageScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/publicMessages/NewPublicMessageScreen.kt
@@ -55,7 +55,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.actions.StrippingFailureDialog
 import com.vitorpamplona.amethyst.ui.actions.UrlUserTagTransformation
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromFiles
@@ -108,8 +107,8 @@ import kotlinx.coroutines.withContext
 @Composable
 fun NewPublicMessageScreen(
     to: Set<HexKey>? = null,
-    reply: Note? = null,
-    draft: Note? = null,
+    replyId: HexKey? = null,
+    draftId: HexKey? = null,
     accountViewModel: AccountViewModel,
     nav: Nav,
 ) {
@@ -121,10 +120,10 @@ fun NewPublicMessageScreen(
             to?.let {
                 postViewModel.load(it)
             }
-            reply?.let {
+            replyId?.let { accountViewModel.getNoteIfExists(it) }?.let {
                 postViewModel.reply(it)
             }
-            draft?.let {
+            draftId?.let { accountViewModel.getNoteIfExists(it) }?.let {
                 postViewModel.editFromDraft(it)
             }
         }


### PR DESCRIPTION
## Summary

- **Defer cache lookups out of NavHost route lambdas** — Route lambdas in `NavHost` run during navigation composition and should be kept lightweight. Calls like `getNoteIfExists`, `checkGetOrCreateNote`, `getOrCreateAddressableNote`, and object construction (`RoomId`, `RelayUrlNormalizer`) are now performed inside the screen composables themselves via `remember {}` or `LaunchedEffect` blocks.
- **Reduces recomposition overhead** — By moving these lookups into the destination composables, the NavHost graph setup stays fast and avoids triggering unnecessary work during navigation transitions.
- **No behavioral changes** — All screens receive the same data as before; only the timing of when lookups occur has changed.

## Affected Screens

- `PublicChatChannelScreen`
- `LiveActivityChannelScreen`
- `EphemeralChatScreen`
- `GeoHashPostScreen`
- `HashtagPostScreen`
- `GenericCommentPostScreen`
- `NewProductScreen`
- `LongFormPostScreen`
- `ShortNotePostScreen`
- `NewPublicMessageScreen`
- `ImportFollowListPickFollowsScreen`

## Test plan

- [ ] Verify navigation to each affected screen works correctly
- [ ] Confirm no regressions in note/channel loading
- [ ] Check that navigation transitions remain smooth
- [ ] Verify deep links still resolve properly

https://claude.ai/code/session_01NrVHL4zdCghQvqE8xmi4Gf