### PR TITLE
fix: reduce NoteCompose recomposition and scroll jitter

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/feeds/FeedLoaded.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/feeds/FeedLoaded.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
@@ -48,6 +49,7 @@ fun FeedLoaded(
     nav: INav,
 ) {
     val items by loaded.feed.collectAsStateWithLifecycle()
+    val fillMaxWidthModifier = remember { Modifier.fillMaxWidth() }
 
     LazyColumn(
         contentPadding = FeedPadding,
@@ -58,10 +60,10 @@ fun FeedLoaded(
             key = { _, item -> item.idHex },
             contentType = { _, item -> item.event?.kind ?: -1 },
         ) { _, item ->
-            Row(Modifier.fillMaxWidth().animateItem()) {
+            Row(fillMaxWidthModifier.animateItem()) {
                 NoteCompose(
                     item,
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = fillMaxWidthModifier,
                     routeForLastRead = routeForLastRead,
                     isBoostedNote = false,
                     isHiddenFeed = items.showHidden,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteCompose.kt
@@ -48,6 +48,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
@@ -455,30 +456,31 @@ fun calculateBackgroundColor(
 ): MutableState<Color> {
     val defaultBackgroundColor = MaterialTheme.colorScheme.background
     val newItemColor = MaterialTheme.colorScheme.newItemBackgroundColor
+    val defaultColor = parentBackgroundColor?.value ?: defaultBackgroundColor.copy(alpha = 0f)
+    val isNew =
+        remember(createdAt) {
+            routeForLastRead != null && accountViewModel.loadAndMarkAsRead(routeForLastRead, createdAt)
+        }
     val bgColor =
         remember(createdAt) {
             mutableStateOf(
-                if (routeForLastRead != null) {
-                    val isNew = accountViewModel.loadAndMarkAsRead(routeForLastRead, createdAt)
-
-                    if (isNew) {
-                        if (parentBackgroundColor != null) {
-                            newItemColor.compositeOver(parentBackgroundColor.value)
-                        } else {
-                            newItemColor.compositeOver(defaultBackgroundColor)
-                        }
+                if (isNew) {
+                    if (parentBackgroundColor != null) {
+                        newItemColor.compositeOver(parentBackgroundColor.value)
                     } else {
-                        parentBackgroundColor?.value ?: defaultBackgroundColor.copy(alpha = 0f)
+                        newItemColor.compositeOver(defaultBackgroundColor)
                     }
                 } else {
-                    parentBackgroundColor?.value ?: defaultBackgroundColor.copy(alpha = 0f)
+                    defaultColor
                 },
             )
         }
 
-    LaunchedEffect(createdAt) {
-        delay(5000)
-        bgColor.value = parentBackgroundColor?.value ?: defaultBackgroundColor.copy(alpha = 0f)
+    if (isNew) {
+        LaunchedEffect(createdAt) {
+            delay(5000)
+            bgColor.value = defaultColor
+        }
     }
 
     return bgColor
@@ -570,7 +572,12 @@ fun ClickableNote(
                 )
         }
 
-    Column(modifier = updatedModifier.background(backgroundColor.value)) { content() }
+    Column(
+        modifier =
+            updatedModifier.drawBehind {
+                drawRect(backgroundColor.value)
+            },
+    ) { content() }
 }
 
 @Composable
@@ -588,7 +595,9 @@ fun InnerNoteWithReactions(
     moreOptions: (@Composable () -> Unit)? = null,
 ) {
     val notBoostedNorQuote = !isBoostedNote && !isQuotedNote
+    val noteEvent = baseNote.event
     val editState = observeEdits(baseNote = baseNote, accountViewModel = accountViewModel)
+    val isRepost = noteEvent is RepostEvent || noteEvent is GenericRepostEvent
 
     Row(
         modifier =
@@ -612,8 +621,7 @@ fun InnerNoteWithReactions(
 
         Column(Modifier.fillMaxWidth()) {
             val showSecondRow =
-                baseNote.event !is RepostEvent &&
-                    baseNote.event !is GenericRepostEvent &&
+                !isRepost &&
                     !isBoostedNote &&
                     !isQuotedNote &&
                     accountViewModel.settings.isCompleteUIMode()
@@ -636,7 +644,7 @@ fun InnerNoteWithReactions(
         }
     }
 
-    val isNotRepost = baseNote.event !is RepostEvent && baseNote.event !is GenericRepostEvent && baseNote.event !is DraftWrapEvent
+    val isNotRepost = !isRepost && noteEvent !is DraftWrapEvent
 
     if (isNotRepost) {
         if (makeItShort) {
@@ -652,7 +660,7 @@ fun InnerNoteWithReactions(
             )
         }
     } else {
-        if (baseNote.event is DraftWrapEvent) {
+        if (noteEvent is DraftWrapEvent) {
             Spacer(modifier = DoubleVertSpacer)
         }
     }
@@ -732,7 +740,8 @@ fun NoteBody(
         )
     }
 
-    if (baseNote.event !is RepostEvent && baseNote.event !is GenericRepostEvent) {
+    val noteEvent = baseNote.event
+    if (noteEvent !is RepostEvent && noteEvent !is GenericRepostEvent) {
         Spacer(modifier = Height4dpModifier)
     }
 
@@ -749,7 +758,6 @@ fun NoteBody(
     )
 
     if (!makeItShort) {
-        val noteEvent = baseNote.event
         val zapSplits = remember(noteEvent) { noteEvent?.hasZapSplitSetup() ?: false }
         if (zapSplits && noteEvent != null) {
             Spacer(modifier = HalfDoubleVertSpacer)
@@ -1444,7 +1452,8 @@ fun FirstUserInfoRow(
     moreOptions: (@Composable () -> Unit)? = null,
 ) {
     Row(verticalAlignment = CenterVertically, modifier = UserNameRowHeight) {
-        val isRepost = baseNote.event is RepostEvent || baseNote.event is GenericRepostEvent
+        val noteEvent = baseNote.event
+        val isRepost = noteEvent is RepostEvent || noteEvent is GenericRepostEvent
         val isDraft = baseNote.isDraft()
         val textColor = if (isRepost) MaterialTheme.colorScheme.grayText else Color.Unspecified
 


### PR DESCRIPTION
## Summary

- **Use `drawBehind` for backgroundColor in `ClickableNote`** — the biggest win. Previously `backgroundColor.value` was read during composition, causing the entire note subtree to recompose when the "new item" highlight fades after 5 seconds. Now the color is only read during the draw phase.
- **Only launch fade-out `LaunchedEffect` for actually-new notes** — previously every note spawned a coroutine with `delay(5000)` even when `routeForLastRead` was null or the note wasn't new. During fast scrolling this created many unnecessary coroutines.
- **Cache `baseNote.event` in local vals** — `InnerNoteWithReactions`, `NoteBody`, and `FirstUserInfoRow` each accessed `baseNote.event` multiple times via property reads. Caching in a local val avoids repeated reads and redundant `is` checks.
- **Hoist `Modifier.fillMaxWidth()` in `FeedLoaded`** — avoids creating a new modifier instance per LazyColumn item on each recomposition.

## Test plan

- [ ] Scroll through home feed — should feel smoother with less jitter when new items appear
- [ ] Verify "new note" highlight still appears and fades after ~5 seconds
- [ ] Verify note click/long-press actions still work correctly
- [ ] Verify boosted/quoted notes render correctly
- [ ] Check that reactions row still displays properly

https://claude.ai/code/session_01XUiYFd7aiZ4Gd1pyCLXpdE