### PR TITLE
feat: separate favorite relay feeds into own category in nav popup

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/FeedFilterSpinner.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/FeedFilterSpinner.kt
@@ -328,6 +328,7 @@ private enum class FeedGroup(
     HASHTAGS(R.string.feed_group_hashtags),
     COMMUNITIES(R.string.feed_group_communities),
     LISTS(R.string.feed_group_lists),
+    RELAYS(R.string.feed_group_relays),
 }
 
 private fun groupFeedDefinitions(options: ImmutableList<FeedDefinition>): Map<FeedGroup, List<IndexedFeedDefinition>> {
@@ -337,6 +338,7 @@ private fun groupFeedDefinitions(options: ImmutableList<FeedDefinition>): Map<Fe
             is HashtagName -> FeedGroup.HASHTAGS
             is CommunityName -> FeedGroup.COMMUNITIES
             is PeopleListName -> FeedGroup.LISTS
+            is RelayName -> FeedGroup.RELAYS
             else -> FeedGroup.FEEDS
         }
     }

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -1567,6 +1567,7 @@
     <string name="feed_group_hashtags">Hashtags</string>
     <string name="feed_group_communities">Communities</string>
     <string name="feed_group_lists">Lists</string>
+    <string name="feed_group_relays">Relays</string>
 
     <string name="temporary_account">Log off on device lock</string>
     <string name="private_message">Private Message</string>


### PR DESCRIPTION
## Summary

- Adds a dedicated **Relays** group in the top nav bar feed filter dialog, so favorite relay feeds are no longer mixed into the generic "Feeds" category
- Adds `RELAYS` enum entry to `FeedGroup` with a new `feed_group_relays` string resource
- Routes `RelayName` items to the new group in `groupFeedDefinitions()`

## Test plan

- [ ] Open the app and tap the feed filter spinner in the top nav bar
- [ ] Verify relay feeds appear under a separate "RELAYS" section
- [ ] Verify the "FEEDS" section no longer contains relay entries
- [ ] Verify all other groups (Hashtags, Communities, Lists) are unaffected

https://claude.ai/code/session_016gjbPgYRXrQCoY1zKPz5PX