### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,6 +5,9 @@ on:
     tags:
     - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
+permissions:
+  contents: write
+
 jobs:
   create-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -5,6 +5,10 @@ on:
     # paths: ["app/src/main/res/**/strings.xml"] // removes filter to allow downloads at any moment.
     branches: [ main ]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   synchronize-with-crowdin:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
This PR adds explicit permission declarations to all GitHub Actions workflows to follow the principle of least privilege and improve security posture.

## Key Changes
- **crowdin.yml**: Added `contents: write` and `pull-requests: write` permissions to support creating pull requests with translated content
- **build.yml**: Added `contents: read` permission for read-only access needed during the build process
- **create-release.yml**: Added `contents: write` permission to allow creating release artifacts

## Implementation Details
These permission declarations follow GitHub's security best practice of explicitly specifying the minimum required permissions for each workflow, rather than relying on default permissions. This reduces the potential impact of compromised workflow tokens by limiting their scope to only what is necessary for each workflow's operations.

https://claude.ai/code/session_01J83RSnhi3WBRUXxyj9DdaC