### PR TITLE
Add birthday field support to UserMetadata

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/metadata/UserMetadata.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/metadata/UserMetadata.kt
@@ -28,6 +28,13 @@ import com.vitorpamplona.quartz.utils.startsWithAny
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+@Serializable
+class Birthday {
+    var year: Int? = null
+    var month: Int? = null
+    var day: Int? = null
+}
+
 @Stable
 @Serializable
 class UserMetadata {
@@ -41,6 +48,7 @@ class UserMetadata {
     var about: String? = null
     var bot: Boolean? = null
     var pronouns: String? = null
+    var birthday: Birthday? = null
     var nip05: String? = null
     var domain: String? = null
     var lud06: String? = null

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/metadata/UpdateMetadataTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/metadata/UpdateMetadataTest.kt
@@ -20,10 +20,13 @@
  */
 package com.vitorpamplona.quartz.nip01Core.metadata
 
+import com.vitorpamplona.quartz.nip01Core.core.JsonMapper
 import com.vitorpamplona.quartz.utils.nsecToSigner
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class UpdateMetadataTest {
     val signer = "nsec10g0wheggqn9dawlc0yuv6adnat6n09anr7eyykevw2dm8xa5fffs0wsdsr".nsecToSigner()
@@ -192,5 +195,44 @@ class UpdateMetadataTest {
             )
 
         assertEquals(expected3, test3)
+    }
+
+    @Test
+    fun parseBirthdayFull() {
+        val json = """{"name":"Test","birthday":{"year":1990,"month":6,"day":15}}"""
+        val metadata = JsonMapper.fromJson<UserMetadata>(json)
+        assertNotNull(metadata.birthday)
+        assertEquals(1990, metadata.birthday!!.year)
+        assertEquals(6, metadata.birthday!!.month)
+        assertEquals(15, metadata.birthday!!.day)
+    }
+
+    @Test
+    fun parseBirthdayPartial() {
+        val json = """{"name":"Test","birthday":{"month":6,"day":15}}"""
+        val metadata = JsonMapper.fromJson<UserMetadata>(json)
+        assertNotNull(metadata.birthday)
+        assertNull(metadata.birthday!!.year)
+        assertEquals(6, metadata.birthday!!.month)
+        assertEquals(15, metadata.birthday!!.day)
+    }
+
+    @Test
+    fun parseBirthdayAbsent() {
+        val json = """{"name":"Test"}"""
+        val metadata = JsonMapper.fromJson<UserMetadata>(json)
+        assertNull(metadata.birthday)
+    }
+
+    @Test
+    fun birthdayRoundTrip() {
+        val json = """{"name":"Test","birthday":{"year":1990,"month":6,"day":15}}"""
+        val metadata = JsonMapper.fromJson<UserMetadata>(json)
+        val serialized = JsonMapper.toJson(metadata)
+        val reparsed = JsonMapper.fromJson<UserMetadata>(serialized)
+        assertNotNull(reparsed.birthday)
+        assertEquals(1990, reparsed.birthday!!.year)
+        assertEquals(6, reparsed.birthday!!.month)
+        assertEquals(15, reparsed.birthday!!.day)
     }
 }


### PR DESCRIPTION
## Summary
This PR adds support for storing and serializing birthday information in user metadata, including a new `Birthday` data class to represent partial or complete date information.

## Key Changes
- **New `Birthday` class**: Created a serializable data class with optional `year`, `month`, and `day` fields to support partial birthday information
- **UserMetadata enhancement**: Added `birthday: Birthday?` field to the `UserMetadata` class
- **Comprehensive test coverage**: Added four new test cases covering:
  - Full birthday parsing (year, month, day)
  - Partial birthday parsing (month and day without year)
  - Absent birthday handling (when not provided in JSON)
  - Round-trip serialization/deserialization validation

## Implementation Details
- The `Birthday` class uses nullable `Int?` fields to allow partial date information (e.g., only month and day without year)
- All fields are optional to maintain backward compatibility with existing metadata
- Tests verify both parsing from JSON and serialization back to JSON work correctly

https://claude.ai/code/session_01Sbj2DF5XDtEuDCeJ7yR6oS