### PR TITLE
Handle git worktree where .git is a file, not a directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,9 +62,18 @@ subprojects {
 }
 
 tasks.register('installGitHook', Copy) {
+    def dotGit = new File(rootProject.rootDir, '.git')
+    def hooksDir
+    if (dotGit.isFile()) {
+        // Git worktree: .git is a file with "gitdir: <path>"
+        def gitDir = new File(dotGit.text.trim().replace('gitdir: ', ''))
+        hooksDir = new File(gitDir, 'hooks')
+    } else {
+        hooksDir = new File(dotGit, 'hooks')
+    }
     from new File(rootProject.rootDir, '.git-hooks/pre-commit')
     from new File(rootProject.rootDir, '.git-hooks/pre-push')
-    into { new File(rootProject.rootDir, '.git/hooks') }
+    into { hooksDir }
     filePermissions { unix(0777) }
 }
 tasks.getByPath(':amethyst:preBuild').dependsOn installGitHook


### PR DESCRIPTION
When using a git work tree locally to work in parallel I got githook installation issues because .git is a file, not a directory

fix: resolves the .git file in worktrees by reading the gitdir: pointer and using the actual git directory for hooks installation

