### PR TITLE
Add always-on notification service for real-time Nostr relay connections

### DIFF
--- a/PULL_NOTIFICATION.md
+++ b/PULL_NOTIFICATION.md
@@ -1,0 +1,276 @@
+# Always-On Notification Service
+
+Amethyst's always-on notification service maintains persistent WebSocket connections to the
+user's inbox relays, ensuring real-time delivery of DMs, zaps, mentions, and other
+notifications without depending on an external push server.
+
+## Why
+
+The existing push notification system (`push.amethyst.social`) can only monitor relays it
+knows about. Private, paid, or obscure inbox relays get missed entirely. The only way to
+guarantee 100% notification coverage is for the device itself to maintain connections to
+the user's NIP-65 inbox relays.
+
+## Architecture
+
+```
+User's inbox relays <──WebSocket──> [NotificationRelayService]
+                                          |
+                                          v
+                                   EventNotificationConsumer
+                                          |
+                                          v
+                                   Android Notification
+```
+
+The service shares the **same `NostrClient` instance** as the UI. This is the key design
+decision. When the app is in the foreground, both the UI and the service are collecting
+the `relayServices` flow. When the app backgrounds, UI subscriptions drop but the service
+keeps collecting, so inbox relay connections stay alive. When the app returns to the
+foreground, the UI piggybacks on the already-open connections. **Zero reconnection, zero
+dropped messages.**
+
+```
+BACKGROUND MODE:
+  inbox-relay-1 ──WebSocket──> [Service keeps collecting relayServices flow]
+  inbox-relay-2 ──WebSocket──> [Service keeps collecting relayServices flow]
+
+APP OPENS:
+  inbox-relay-1 ──WebSocket──> [Same connection] <── UI adds feed subscriptions
+  inbox-relay-2 ──WebSocket──> [Same connection] <── UI adds feed subscriptions
+  outbox-relay-3 ──WebSocket──> [New connection]  <── feed-only relay
+```
+
+## Foreground Service
+
+`NotificationRelayService` is a foreground service with `specialUse` type:
+
+- **No time limit**: Unlike `dataSync` (6-hour limit on Android 15), `specialUse` has no
+  timeout restriction.
+- **BOOT_COMPLETED safe**: Can be started from boot receivers on Android 15+, unlike
+  `dataSync` which is restricted.
+- **START_STICKY**: Android will restart the service if it's killed by the system.
+- **Persistent notification**: Shows "Connected to N inbox relays" with a Pause action.
+  Uses `IMPORTANCE_LOW` so it's silent and unobtrusive.
+
+### ForegroundServiceStartNotAllowedException
+
+On Android 12+, starting a foreground service from the background can throw
+`ForegroundServiceStartNotAllowedException`. The service catches this gracefully and stops
+itself rather than crashing the app.
+
+### Redundant startForeground()
+
+`startForeground()` is called from both `onCreate()` and `onStartCommand()` as a safety
+net. In rare edge cases, `onStartCommand()` can fire before `onCreate()` completes
+(observed in ntfy issue #1520). The `foregroundStarted` flag prevents double invocation.
+
+## 8-Layer Auto-Restart Defense
+
+Android (and OEM battery optimizers) will aggressively try to kill background services.
+The notification service uses 8 independent mechanisms to stay alive:
+
+### Layer 1: START_STICKY
+
+```kotlin
+override fun onStartCommand(...): Int {
+    ...
+    return START_STICKY
+}
+```
+
+When Android kills the service due to memory pressure, `START_STICKY` tells the system
+to recreate it. The service will receive a new `onStartCommand()` call with a null intent.
+
+### Layer 2: onTaskRemoved() Alarm
+
+```kotlin
+override fun onTaskRemoved(rootIntent: Intent?) {
+    val alarmManager = getSystemService(ALARM_SERVICE) as AlarmManager
+    alarmManager.set(
+        AlarmManager.ELAPSED_REALTIME,
+        SystemClock.elapsedRealtime() + 1000,
+        pendingIntent,
+    )
+}
+```
+
+When the user swipes the app from recents, some OEMs (Xiaomi, Huawei, Samsung) kill the
+foreground service. This schedules a 1-second alarm to restart the service immediately.
+Without this, the service would stay dead until the next watchdog or WorkManager cycle.
+
+### Layer 3: onDestroy() Broadcast
+
+```kotlin
+override fun onDestroy() {
+    sendBroadcast(Intent(this, AutoRestartReceiver::class.java))
+}
+```
+
+When the service is destroyed for any reason, it broadcasts to `AutoRestartReceiver`,
+which enqueues a one-time WorkManager task with a network connectivity constraint. This
+catches kills that `START_STICKY` might miss (e.g., OEM battery optimizers that prevent
+service restart).
+
+### Layer 4: AlarmManager Watchdog (5 minutes)
+
+```kotlin
+alarmManager.setInexactRepeating(
+    AlarmManager.ELAPSED_REALTIME_WAKEUP,
+    SystemClock.elapsedRealtime() + WATCHDOG_INTERVAL_MS,
+    WATCHDOG_INTERVAL_MS,  // 5 minutes
+    pendingIntent,
+)
+```
+
+`ServiceWatchdogManager` fires an alarm every 5 minutes. The `WatchdogReceiver` checks
+if the service should be running and restarts it if needed. Uses
+`ELAPSED_REALTIME_WAKEUP` to wake the device from sleep.
+
+### Layer 5: WorkManager Periodic Catch-Up (15 minutes)
+
+```kotlin
+PeriodicWorkRequestBuilder<NotificationCatchUpWorker>(
+    15, TimeUnit.MINUTES,
+).setConstraints(networkConstraint).build()
+```
+
+`NotificationCatchUpWorker` runs every 15 minutes (WorkManager's minimum interval) with
+a network connectivity constraint. It collects `relayServices` to ensure connections are
+active, waits briefly for events to flow, and also restarts the foreground service if
+it's supposed to be running but isn't.
+
+### Layer 6: Network-Available One-Time Worker
+
+```kotlin
+OneTimeWorkRequestBuilder<NotificationCatchUpWorker>()
+    .setConstraints(networkConnectedConstraint)
+    .build()
+```
+
+When the `AutoRestartReceiver` fires, it enqueues a one-time WorkManager task that runs
+as soon as network connectivity is available. This means the service restarts immediately
+when the device comes back online, rather than waiting up to 15 minutes for the periodic
+worker.
+
+### Layer 7: Boot and Package Receivers
+
+```kotlin
+when (intent.action) {
+    Intent.ACTION_BOOT_COMPLETED,
+    "android.intent.action.QUICKBOOT_POWERON",
+    Intent.ACTION_MY_PACKAGE_REPLACED,
+    -> NotificationRelayService.start(context)
+}
+```
+
+`BootCompletedReceiver` restarts the service after:
+- **Device reboot** (`BOOT_COMPLETED`, `QUICKBOOT_POWERON`)
+- **App update** (`MY_PACKAGE_REPLACED`) — without this, the service stays dead after
+  Play Store updates until the user manually opens the app
+
+### Layer 8: FCM / UnifiedPush (existing)
+
+The existing push notification system (`PushNotificationReceiverService` for Play,
+`PushMessageReceiver` for F-Droid) continues to work as a complementary wakeup mechanism.
+Push notifications from the server can wake the app process even if all other layers fail.
+
+## WakeLock During Notification Processing
+
+```kotlin
+private inline fun <T> withWakeLock(block: () -> T): T {
+    val wakeLock = powerManager.newWakeLock(
+        PowerManager.PARTIAL_WAKE_LOCK,
+        "amethyst:notification_processing",
+    )
+    wakeLock.acquire(10 * 60 * 1000L)  // 10-minute timeout
+    try {
+        return block()
+    } finally {
+        if (wakeLock.isHeld) wakeLock.release()
+    }
+}
+```
+
+`EventNotificationConsumer` acquires a `PARTIAL_WAKE_LOCK` with a 10-minute timeout when
+processing incoming notifications. This ensures the CPU stays awake long enough to
+decrypt NIP-59 gift wraps, verify signatures, resolve accounts, and dispatch the Android
+notification — even if the device is in Doze mode.
+
+## Battery Optimization Exemption
+
+The service works best when the app is exempted from Android's battery optimizations
+(Doze). Without the exemption, Android may restrict network access and defer alarms even
+for foreground services.
+
+`BatteryOptimizationHelper` checks the exemption status and provides a method to launch
+the system settings dialog:
+
+```kotlin
+BatteryOptimizationHelper.isIgnoringBatteryOptimizations(context)
+BatteryOptimizationHelper.requestBatteryOptimizationExemption(context)
+```
+
+When the always-on service is enabled but the app isn't whitelisted, the settings screen
+shows a warning banner with a "Fix now" button that opens the system battery optimization
+settings directly.
+
+Messaging apps are explicitly listed as a valid use case for this exemption in Google Play
+policy.
+
+## Coordinator
+
+`AlwaysOnNotificationServiceManager` watches the account's `alwaysOnNotificationService`
+setting (a `MutableStateFlow<Boolean>`) and activates or deactivates all layers in
+response:
+
+```
+Setting ON  → Start foreground service + Schedule WorkManager + Schedule watchdog alarm
+Setting OFF → Stop foreground service + Cancel WorkManager + Cancel watchdog alarm
+```
+
+The manager is initialized in `AppModules` and watches the account state. When a user
+logs in, it starts watching their setting. When they log out, it stops.
+
+## Settings
+
+The always-on notification service is **opt-in** (off by default). Users enable it from
+**App Settings** with a toggle switch. The setting is persisted per-account in
+`AccountSettings.alwaysOnNotificationService` and saved to `EncryptedSharedPreferences`.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `NotificationRelayService.kt` | Foreground service, connection lifecycle, auto-restart |
+| `BootCompletedReceiver.kt` | Restart on boot and app update |
+| `AutoRestartReceiver.kt` | Restart via WorkManager when service is destroyed |
+| `NotificationCatchUpWorker.kt` | Periodic and on-demand catch-up worker |
+| `ServiceWatchdogManager.kt` | AlarmManager-based health monitor |
+| `AlwaysOnNotificationServiceManager.kt` | Coordinates all layers based on setting |
+| `BatteryOptimizationHelper.kt` | Battery optimization check and exemption request |
+| `EventNotificationConsumer.kt` | WakeLock wrapper for notification processing |
+| `AccountSettings.kt` | `alwaysOnNotificationService` setting |
+| `LocalPreferences.kt` | Setting persistence |
+| `AppSettingsScreen.kt` | Toggle UI and battery optimization banner |
+| `AndroidManifest.xml` | Permissions, service, and receiver declarations |
+
+## Permissions
+
+| Permission | Purpose |
+|------------|---------|
+| `FOREGROUND_SERVICE` | Run the foreground service |
+| `FOREGROUND_SERVICE_SPECIAL_USE` | Declare `specialUse` service type |
+| `RECEIVE_BOOT_COMPLETED` | Restart on boot |
+| `WAKE_LOCK` | Keep CPU awake during notification processing |
+| `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` | Request Doze exemption |
+
+## Inspiration
+
+This implementation draws from battle-tested patterns in:
+
+- **ntfy** — `onTaskRemoved()` alarm, `onDestroy()` broadcast restart,
+  `ForegroundServiceStartNotAllowedException` handling, redundant `startForeground()`,
+  battery optimization guidance, WakeLock during processing
+- **Pokey** — `specialUse` foreground service type, `MY_PACKAGE_REPLACED` restart
+- **Signal** — Hybrid FCM + persistent WebSocket architecture

--- a/PULL_NOTIFICATION.md
+++ b/PULL_NOTIFICATION.md
@@ -26,82 +26,61 @@ NIP-17 DM inbox relays ───────────WebSocket──┘      
 
 The service shares the **same `NostrClient` instance** as the UI. This is the key design
 decision. When the app is in the foreground, both the UI and the service are collecting
-the `relayServices` flow and have active subscriptions. When the app backgrounds, UI
-subscriptions drop but the service's subscriptions remain, keeping inbox and DM relay
-connections alive. When the app returns to the foreground, the UI piggybacks on the
-already-open connections. **Zero reconnection, zero dropped messages.**
+the `relayServices` flow. The `AccountFilterAssembler` subscription from the Compose UI
+tree stays active as long as the Activity exists (even when stopped/backgrounded),
+keeping notification and DM relay connections alive. When the app returns to the
+foreground, the UI piggybacks on the already-open connections. **Zero reconnection, zero
+dropped messages.**
 
 ```
-BACKGROUND MODE:
-  inbox-relay-1 ──WebSocket──> [Service: svc:notif subscription]
-  inbox-relay-2 ──WebSocket──> [Service: svc:notif subscription]
-  dm-relay-1 ────WebSocket──> [Service: svc:giftwrap subscription]
+BACKGROUND MODE (service running):
+  inbox-relay-1 ──WebSocket──> [AccountFilterAssembler: notifications, metadata, follows]
+  inbox-relay-2 ──WebSocket──> [AccountFilterAssembler: notifications, metadata, follows]
+  dm-relay-1 ────WebSocket──> [AccountFilterAssembler: gift wraps]
+  (outbox relays disconnected — no Home/Video/Discovery subscriptions)
 
-APP OPENS:
-  inbox-relay-1 ──WebSocket──> [Same connection] <── UI adds feed subscriptions
-  inbox-relay-2 ──WebSocket──> [Same connection] <── UI adds feed subscriptions
-  dm-relay-1 ────WebSocket──> [Same connection]  <── UI adds chat subscriptions
-  outbox-relay-3 ──WebSocket──> [New connection]  <── feed-only relay
+APP FOREGROUNDS:
+  inbox-relay-1 ──WebSocket──> [Same connection] <── Home/Discovery subs resume
+  inbox-relay-2 ──WebSocket──> [Same connection] <── Home/Discovery subs resume
+  dm-relay-1 ────WebSocket──> [Same connection]  <── ChatroomList subs resume
+  outbox-relay-3 ──WebSocket──> [New connection]  <── Home/Video feed relay
 ```
 
-## Relay Subscriptions
+## Subscription Architecture
 
-The service maintains two independent subscriptions on the shared `NostrClient`:
+### What the service does
 
-### `svc:notif` — Notification Inbox Relays
+The service does NOT create its own relay subscriptions. It only keeps the
+`RelayProxyClientConnector` alive by collecting `relayServices`. The actual subscriptions
+come from the `AccountFilterAssembler` in the Compose tree (`LoggedInPage`), which
+stays active as long as the Activity exists and covers:
 
-Subscribes to the user's NIP-65 inbox relays (from `Account.notificationRelays.flow`)
-for notification-relevant event kinds:
+- **Metadata** — user profile, relay lists, mute lists, follows (via `AccountMetadataEoseManager`)
+- **Follows** — follow list changes that affect notification filtering (via `AccountFollowsLoaderSubAssembler`)
+- **Notifications** — mentions, zaps, reactions on NIP-65 inbox relays (via `AccountNotificationsEoseFromInboxRelaysManager`)
+- **Gift wraps** — NIP-59 encrypted DMs on NIP-17 DM relays (via `AccountGiftWrapsEoseManager`)
+- **Drafts** — draft events (via `AccountDraftsEoseManager`)
 
-- **Summary kinds**: TextNote, Reaction, Repost, LnZap (limit 2000)
-- **Per-key kinds**: Reports, Zaps, Channel Messages, Polls, Badges, etc. (limit 500)
-- **Per-key kinds 2**: Git events, Highlights, Comments, Calendar events (limit 200)
-- **Per-key kinds 3**: Attestation events (limit 10)
+This is critical because notification filtering depends on follow lists, mute lists,
+and relay configurations. If the service maintained its own isolated subscriptions,
+it would miss follow list changes and display notifications from muted users.
 
-All filtered by `p` tag matching the user's pubkey.
+### What pauses on background
 
-**Why separate from the UI's subscriptions?** The UI's `AccountNotificationsEoseFromInboxRelaysManager`
-is part of `AccountFilterAssembler`, which is driven by the Compose lifecycle. When the
-app backgrounds and composables leave composition, these subscriptions are dropped. The
-relay pool then disconnects relays that no longer have any active subscriptions. The
-service's `svc:notif` subscription ensures notification inbox relays stay connected.
+Heavy feed subscriptions use `LifecycleAwareKeyDataSourceSubscription` which subscribes
+on `ON_START` and unsubscribes on `ON_STOP`. When the app backgrounds:
 
-### `svc:giftwrap` — DM Inbox Relays
+| Subscription | Behavior | Why |
+|-------------|----------|-----|
+| `AccountFilterAssembler` | **Stays active** | Needed for notifications, DMs, follow/mute list changes |
+| `HomeFilterAssembler` | **Pauses** | Home feed data with nobody viewing wastes bandwidth |
+| `VideoFilterAssembler` | **Pauses** | Video feed data with nobody viewing wastes bandwidth |
+| `DiscoveryFilterAssembler` | **Pauses** | Discovery feed data with nobody viewing wastes bandwidth |
+| `ChatroomListFilterAssembler` | **Pauses** | Chatroom list updates with nobody viewing waste bandwidth |
 
-Subscribes to the user's DM inbox relays (from `Account.dmRelays.flow`) for NIP-59
-gift-wrapped messages:
-
-- **Kinds**: GiftWrapEvent (1059), EphemeralGiftWrapEvent
-- **Tag filter**: `p` tag matching the user's pubkey
-- **Lookback**: 2 days from `since` timestamp
-
-The DM relay set is broader than the notification relay set — it combines NIP-17 DM relays
-(ChatMessageRelayListEvent, kind 10050), NIP-65 inbox relays, private outbox relays, and
-local relays.
-
-**Why?** DM relays may be completely different from notification inbox relays. Without
-this subscription, DM relays that aren't also notification inbox relays would disconnect
-when the app backgrounds, and incoming encrypted DMs would be missed.
-
-### Reactive Updates
-
-Both subscriptions reactively update when relay lists change:
-
-```kotlin
-combine(
-    account.notificationRelays.flow,
-    account.dmRelays.flow,
-) { notifRelays, dmRelays ->
-    Pair(notifRelays, dmRelays)
-}.collectLatest { (notifRelays, dmRelays) ->
-    updateNotificationSubscription(account, notifRelays)
-    updateGiftWrapSubscription(account, dmRelays)
-}
-```
-
-If the user adds or removes relays from their NIP-65 or NIP-17 lists, the service's
-subscriptions are updated immediately. The shared relay pool handles connecting to new
-relays and disconnecting from removed ones.
+When the feed subscriptions pause, the relay pool automatically disconnects outbox relays
+that no longer have any active subscriptions. Only inbox and DM relays stay connected
+(because `AccountFilterAssembler` still has active subscriptions on them).
 
 ## Foreground Service
 
@@ -284,7 +263,8 @@ The always-on notification service is **opt-in** (off by default). Users enable 
 
 | File | Purpose |
 |------|---------|
-| `NotificationRelayService.kt` | Foreground service, relay subscriptions, auto-restart |
+| `NotificationRelayService.kt` | Foreground service, keeps relay connections alive, auto-restart |
+| `LifecycleAwareKeyDataSourceSubscription.kt` | Pauses heavy feed subs when app backgrounds |
 | `BootCompletedReceiver.kt` | Restart on boot and app update |
 | `AutoRestartReceiver.kt` | Restart via WorkManager when service is destroyed |
 | `NotificationCatchUpWorker.kt` | Periodic and on-demand catch-up worker |

--- a/PULL_NOTIFICATION.md
+++ b/PULL_NOTIFICATION.md
@@ -1,54 +1,119 @@
 # Always-On Notification Service
 
 Amethyst's always-on notification service maintains persistent WebSocket connections to the
-user's inbox relays, ensuring real-time delivery of DMs, zaps, mentions, and other
-notifications without depending on an external push server.
+user's inbox relays and DM relays, ensuring real-time delivery of DMs, zaps, mentions, and
+other notifications without depending on an external push server.
 
 ## Why
 
 The existing push notification system (`push.amethyst.social`) can only monitor relays it
 knows about. Private, paid, or obscure inbox relays get missed entirely. The only way to
 guarantee 100% notification coverage is for the device itself to maintain connections to
-the user's NIP-65 inbox relays.
+the user's NIP-65 inbox relays and NIP-17 DM relays.
 
 ## Architecture
 
 ```
-User's inbox relays <──WebSocket──> [NotificationRelayService]
-                                          |
-                                          v
-                                   EventNotificationConsumer
-                                          |
-                                          v
-                                   Android Notification
+NIP-65 notification inbox relays ──WebSocket──┐
+                                              ├──> [NotificationRelayService]
+NIP-17 DM inbox relays ───────────WebSocket──┘           |
+                                                         v
+                                                  EventNotificationConsumer
+                                                         |
+                                                         v
+                                                  Android Notification
 ```
 
 The service shares the **same `NostrClient` instance** as the UI. This is the key design
 decision. When the app is in the foreground, both the UI and the service are collecting
-the `relayServices` flow. When the app backgrounds, UI subscriptions drop but the service
-keeps collecting, so inbox relay connections stay alive. When the app returns to the
-foreground, the UI piggybacks on the already-open connections. **Zero reconnection, zero
-dropped messages.**
+the `relayServices` flow and have active subscriptions. When the app backgrounds, UI
+subscriptions drop but the service's subscriptions remain, keeping inbox and DM relay
+connections alive. When the app returns to the foreground, the UI piggybacks on the
+already-open connections. **Zero reconnection, zero dropped messages.**
 
 ```
 BACKGROUND MODE:
-  inbox-relay-1 ──WebSocket──> [Service keeps collecting relayServices flow]
-  inbox-relay-2 ──WebSocket──> [Service keeps collecting relayServices flow]
+  inbox-relay-1 ──WebSocket──> [Service: svc:notif subscription]
+  inbox-relay-2 ──WebSocket──> [Service: svc:notif subscription]
+  dm-relay-1 ────WebSocket──> [Service: svc:giftwrap subscription]
 
 APP OPENS:
   inbox-relay-1 ──WebSocket──> [Same connection] <── UI adds feed subscriptions
   inbox-relay-2 ──WebSocket──> [Same connection] <── UI adds feed subscriptions
+  dm-relay-1 ────WebSocket──> [Same connection]  <── UI adds chat subscriptions
   outbox-relay-3 ──WebSocket──> [New connection]  <── feed-only relay
 ```
+
+## Relay Subscriptions
+
+The service maintains two independent subscriptions on the shared `NostrClient`:
+
+### `svc:notif` — Notification Inbox Relays
+
+Subscribes to the user's NIP-65 inbox relays (from `Account.notificationRelays.flow`)
+for notification-relevant event kinds:
+
+- **Summary kinds**: TextNote, Reaction, Repost, LnZap (limit 2000)
+- **Per-key kinds**: Reports, Zaps, Channel Messages, Polls, Badges, etc. (limit 500)
+- **Per-key kinds 2**: Git events, Highlights, Comments, Calendar events (limit 200)
+- **Per-key kinds 3**: Attestation events (limit 10)
+
+All filtered by `p` tag matching the user's pubkey.
+
+**Why separate from the UI's subscriptions?** The UI's `AccountNotificationsEoseFromInboxRelaysManager`
+is part of `AccountFilterAssembler`, which is driven by the Compose lifecycle. When the
+app backgrounds and composables leave composition, these subscriptions are dropped. The
+relay pool then disconnects relays that no longer have any active subscriptions. The
+service's `svc:notif` subscription ensures notification inbox relays stay connected.
+
+### `svc:giftwrap` — DM Inbox Relays
+
+Subscribes to the user's DM inbox relays (from `Account.dmRelays.flow`) for NIP-59
+gift-wrapped messages:
+
+- **Kinds**: GiftWrapEvent (1059), EphemeralGiftWrapEvent
+- **Tag filter**: `p` tag matching the user's pubkey
+- **Lookback**: 2 days from `since` timestamp
+
+The DM relay set is broader than the notification relay set — it combines NIP-17 DM relays
+(ChatMessageRelayListEvent, kind 10050), NIP-65 inbox relays, private outbox relays, and
+local relays.
+
+**Why?** DM relays may be completely different from notification inbox relays. Without
+this subscription, DM relays that aren't also notification inbox relays would disconnect
+when the app backgrounds, and incoming encrypted DMs would be missed.
+
+### Reactive Updates
+
+Both subscriptions reactively update when relay lists change:
+
+```kotlin
+combine(
+    account.notificationRelays.flow,
+    account.dmRelays.flow,
+) { notifRelays, dmRelays ->
+    Pair(notifRelays, dmRelays)
+}.collectLatest { (notifRelays, dmRelays) ->
+    updateNotificationSubscription(account, notifRelays)
+    updateGiftWrapSubscription(account, dmRelays)
+}
+```
+
+If the user adds or removes relays from their NIP-65 or NIP-17 lists, the service's
+subscriptions are updated immediately. The shared relay pool handles connecting to new
+relays and disconnecting from removed ones.
 
 ## Foreground Service
 
 `NotificationRelayService` is a foreground service with `specialUse` type:
 
 - **No time limit**: Unlike `dataSync` (6-hour limit on Android 15), `specialUse` has no
-  timeout restriction.
+  timeout restriction. **Why it matters:** A notification service must run indefinitely.
+  The `dataSync` type would force the service to stop after 6 cumulative hours per 24-hour
+  period, making it useless for always-on notifications.
 - **BOOT_COMPLETED safe**: Can be started from boot receivers on Android 15+, unlike
-  `dataSync` which is restricted.
+  `dataSync` which is restricted. **Why it matters:** Without this, the service couldn't
+  auto-restart after a reboot on modern Android.
 - **START_STICKY**: Android will restart the service if it's killed by the system.
 - **Persistent notification**: Shows "Connected to N inbox relays" with a Pause action.
   Uses `IMPORTANCE_LOW` so it's silent and unobtrusive.
@@ -59,161 +124,138 @@ On Android 12+, starting a foreground service from the background can throw
 `ForegroundServiceStartNotAllowedException`. The service catches this gracefully and stops
 itself rather than crashing the app.
 
+**Why it matters:** Without this catch, if the watchdog alarm or WorkManager tries to
+restart the service while the app lacks the background-start exemption (e.g., battery
+optimization is active), the app would crash with an unhandled exception.
+
 ### Redundant startForeground()
 
 `startForeground()` is called from both `onCreate()` and `onStartCommand()` as a safety
 net. In rare edge cases, `onStartCommand()` can fire before `onCreate()` completes
 (observed in ntfy issue #1520). The `foregroundStarted` flag prevents double invocation.
 
+**Why it matters:** If `startForeground()` isn't called within 5 seconds of
+`startForegroundService()`, the app crashes with an ANR. The redundant call ensures the
+foreground notification is posted regardless of which lifecycle method runs first.
+
 ## 8-Layer Auto-Restart Defense
 
 Android (and OEM battery optimizers) will aggressively try to kill background services.
-The notification service uses 8 independent mechanisms to stay alive:
+The notification service uses 8 independent mechanisms to stay alive. Each addresses a
+specific kill vector that the others don't cover:
 
 ### Layer 1: START_STICKY
 
-```kotlin
-override fun onStartCommand(...): Int {
-    ...
-    return START_STICKY
-}
-```
+**What:** When Android kills the service due to memory pressure, `START_STICKY` tells the
+system to recreate it with a null intent.
 
-When Android kills the service due to memory pressure, `START_STICKY` tells the system
-to recreate it. The service will receive a new `onStartCommand()` call with a null intent.
+**Why needed:** This is the baseline restart mechanism provided by Android. However, it's
+unreliable in practice — many OEMs (Xiaomi MIUI, Huawei EMUI, Samsung One UI, Oppo
+ColorOS) override this behavior and prevent sticky service restarts. That's why we need
+the remaining 7 layers.
 
 ### Layer 2: onTaskRemoved() Alarm
 
-```kotlin
-override fun onTaskRemoved(rootIntent: Intent?) {
-    val alarmManager = getSystemService(ALARM_SERVICE) as AlarmManager
-    alarmManager.set(
-        AlarmManager.ELAPSED_REALTIME,
-        SystemClock.elapsedRealtime() + 1000,
-        pendingIntent,
-    )
-}
-```
+**What:** When the user swipes the app from recents, schedules a 1-second alarm to restart
+the service.
 
-When the user swipes the app from recents, some OEMs (Xiaomi, Huawei, Samsung) kill the
-foreground service. This schedules a 1-second alarm to restart the service immediately.
-Without this, the service would stay dead until the next watchdog or WorkManager cycle.
+**Why needed:** On stock Android, swiping from recents only removes the task but leaves
+the foreground service running. However, many OEMs treat swipe-from-recents as a force
+stop, killing the foreground service. `START_STICKY` won't help because some OEMs block
+sticky restarts after a task removal. The alarm bypasses this by scheduling the restart
+through `AlarmManager`, which is a separate system that OEM modifications rarely touch.
 
 ### Layer 3: onDestroy() Broadcast
 
-```kotlin
-override fun onDestroy() {
-    sendBroadcast(Intent(this, AutoRestartReceiver::class.java))
-}
-```
+**What:** When the service is destroyed for any reason, it broadcasts to
+`AutoRestartReceiver`, which enqueues a one-time WorkManager task with a network
+connectivity constraint.
 
-When the service is destroyed for any reason, it broadcasts to `AutoRestartReceiver`,
-which enqueues a one-time WorkManager task with a network connectivity constraint. This
-catches kills that `START_STICKY` might miss (e.g., OEM battery optimizers that prevent
-service restart).
+**Why needed:** This catches the gap between `START_STICKY` and `onTaskRemoved()`.
+If the system kills the service during normal operation (not from recents), `START_STICKY`
+should restart it — but if the OEM blocks that restart, the broadcast fires a WorkManager
+task as a backup. WorkManager is harder for OEMs to suppress because it's part of
+Google Play Services infrastructure.
 
 ### Layer 4: AlarmManager Watchdog (5 minutes)
 
-```kotlin
-alarmManager.setInexactRepeating(
-    AlarmManager.ELAPSED_REALTIME_WAKEUP,
-    SystemClock.elapsedRealtime() + WATCHDOG_INTERVAL_MS,
-    WATCHDOG_INTERVAL_MS,  // 5 minutes
-    pendingIntent,
-)
-```
+**What:** `ServiceWatchdogManager` fires an `ELAPSED_REALTIME_WAKEUP` alarm every 5
+minutes. The receiver checks if the service should be running and restarts it.
 
-`ServiceWatchdogManager` fires an alarm every 5 minutes. The `WatchdogReceiver` checks
-if the service should be running and restarts it if needed. Uses
-`ELAPSED_REALTIME_WAKEUP` to wake the device from sleep.
+**Why needed:** This is the "belt and suspenders" layer. If all of the above layers fail
+(sticky restart blocked, alarm from `onTaskRemoved` didn't fire, broadcast wasn't
+delivered), the watchdog will catch it within 5 minutes. Uses `ELAPSED_REALTIME_WAKEUP` to
+wake the device from sleep, ensuring the check happens even in Doze.
 
 ### Layer 5: WorkManager Periodic Catch-Up (15 minutes)
 
-```kotlin
-PeriodicWorkRequestBuilder<NotificationCatchUpWorker>(
-    15, TimeUnit.MINUTES,
-).setConstraints(networkConstraint).build()
-```
+**What:** Runs every 15 minutes with a network connectivity constraint. Ensures relay
+connections are active and restarts the foreground service if needed.
 
-`NotificationCatchUpWorker` runs every 15 minutes (WorkManager's minimum interval) with
-a network connectivity constraint. It collects `relayServices` to ensure connections are
-active, waits briefly for events to flow, and also restarts the foreground service if
-it's supposed to be running but isn't.
+**Why needed:** WorkManager survives process death and device reboots — it's the most
+persistent scheduling mechanism on Android. Even if the app process is completely dead,
+WorkManager (backed by JobScheduler) will eventually wake it. The 15-minute interval is
+WorkManager's minimum, ensuring regular catch-up even if the foreground service has been
+dead for a while.
 
 ### Layer 6: Network-Available One-Time Worker
 
-```kotlin
-OneTimeWorkRequestBuilder<NotificationCatchUpWorker>()
-    .setConstraints(networkConnectedConstraint)
-    .build()
-```
+**What:** When `AutoRestartReceiver` fires, it enqueues a one-time WorkManager task that
+runs as soon as network connectivity is available.
 
-When the `AutoRestartReceiver` fires, it enqueues a one-time WorkManager task that runs
-as soon as network connectivity is available. This means the service restarts immediately
-when the device comes back online, rather than waiting up to 15 minutes for the periodic
-worker.
+**Why needed:** If the service dies during a network outage, there's no point restarting it
+immediately (the relays won't connect). This worker waits for connectivity and restarts
+then, rather than waiting up to 15 minutes for the next periodic worker. This is especially
+important after airplane mode, tunnel/elevator scenarios, or switching between WiFi and
+cellular.
 
 ### Layer 7: Boot and Package Receivers
 
-```kotlin
-when (intent.action) {
-    Intent.ACTION_BOOT_COMPLETED,
-    "android.intent.action.QUICKBOOT_POWERON",
-    Intent.ACTION_MY_PACKAGE_REPLACED,
-    -> NotificationRelayService.start(context)
-}
-```
+**What:** `BootCompletedReceiver` restarts the service after device reboot
+(`BOOT_COMPLETED`, `QUICKBOOT_POWERON`) and app update (`MY_PACKAGE_REPLACED`).
 
-`BootCompletedReceiver` restarts the service after:
-- **Device reboot** (`BOOT_COMPLETED`, `QUICKBOOT_POWERON`)
-- **App update** (`MY_PACKAGE_REPLACED`) — without this, the service stays dead after
-  Play Store updates until the user manually opens the app
+**Why needed:** After a reboot, no services are running — `START_STICKY` doesn't apply
+across reboots. The boot receiver is the only way to restart. After an app update, the
+old process is killed and the new version's services don't auto-start. Without
+`MY_PACKAGE_REPLACED`, users would need to manually open the app after every Play Store
+update to restore notifications.
 
 ### Layer 8: FCM / UnifiedPush (existing)
 
-The existing push notification system (`PushNotificationReceiverService` for Play,
-`PushMessageReceiver` for F-Droid) continues to work as a complementary wakeup mechanism.
-Push notifications from the server can wake the app process even if all other layers fail.
+**What:** The existing push notification system continues to work alongside the always-on
+service.
+
+**Why needed:** FCM is the only mechanism that survives a force stop (because Google Play
+Services handles delivery outside the app's process). If the user explicitly force-stops
+Amethyst from Settings, all 7 layers above are disabled. Only FCM can still deliver
+notifications until the user opens the app again.
 
 ## WakeLock During Notification Processing
 
-```kotlin
-private inline fun <T> withWakeLock(block: () -> T): T {
-    val wakeLock = powerManager.newWakeLock(
-        PowerManager.PARTIAL_WAKE_LOCK,
-        "amethyst:notification_processing",
-    )
-    wakeLock.acquire(10 * 60 * 1000L)  // 10-minute timeout
-    try {
-        return block()
-    } finally {
-        if (wakeLock.isHeld) wakeLock.release()
-    }
-}
-```
-
 `EventNotificationConsumer` acquires a `PARTIAL_WAKE_LOCK` with a 10-minute timeout when
-processing incoming notifications. This ensures the CPU stays awake long enough to
-decrypt NIP-59 gift wraps, verify signatures, resolve accounts, and dispatch the Android
-notification — even if the device is in Doze mode.
+processing incoming notifications.
+
+**Why needed:** When a notification event arrives from a relay, the app needs to decrypt
+NIP-59 gift wraps, verify signatures, look up accounts, resolve display names, load
+profile pictures, and construct the Android notification. In Doze mode, the CPU can sleep
+between alarm windows. Without a WakeLock, the CPU could sleep mid-processing, causing the
+notification to be delayed or lost. The 10-minute timeout is generous to handle slow
+decryption (especially with external signers) while preventing indefinite wake locks from
+battery drain.
 
 ## Battery Optimization Exemption
 
-The service works best when the app is exempted from Android's battery optimizations
-(Doze). Without the exemption, Android may restrict network access and defer alarms even
-for foreground services.
+The service works best when the app is exempted from Android's battery optimizations (Doze).
+
+**Why needed:** Even with a foreground service, Android can restrict network access during
+Doze maintenance windows. The battery optimization exemption tells Android that this app's
+network activity is user-expected and should not be deferred. Without it, relay connections
+may be broken during Doze, causing missed notifications that only arrive when the device
+exits Doze (which can be hours for a stationary, charging device).
 
 `BatteryOptimizationHelper` checks the exemption status and provides a method to launch
-the system settings dialog:
-
-```kotlin
-BatteryOptimizationHelper.isIgnoringBatteryOptimizations(context)
-BatteryOptimizationHelper.requestBatteryOptimizationExemption(context)
-```
-
-When the always-on service is enabled but the app isn't whitelisted, the settings screen
-shows a warning banner with a "Fix now" button that opens the system battery optimization
-settings directly.
+the system settings dialog. When the always-on service is enabled but the app isn't
+whitelisted, the settings screen shows a warning banner with a "Fix now" button.
 
 Messaging apps are explicitly listed as a valid use case for this exemption in Google Play
 policy.
@@ -242,7 +284,7 @@ The always-on notification service is **opt-in** (off by default). Users enable 
 
 | File | Purpose |
 |------|---------|
-| `NotificationRelayService.kt` | Foreground service, connection lifecycle, auto-restart |
+| `NotificationRelayService.kt` | Foreground service, relay subscriptions, auto-restart |
 | `BootCompletedReceiver.kt` | Restart on boot and app update |
 | `AutoRestartReceiver.kt` | Restart via WorkManager when service is destroyed |
 | `NotificationCatchUpWorker.kt` | Periodic and on-demand catch-up worker |
@@ -269,8 +311,9 @@ The always-on notification service is **opt-in** (off by default). Users enable 
 
 This implementation draws from battle-tested patterns in:
 
-- **ntfy** — `onTaskRemoved()` alarm, `onDestroy()` broadcast restart,
+- **ntfy** (millions of users) — `onTaskRemoved()` alarm, `onDestroy()` broadcast restart,
   `ForegroundServiceStartNotAllowedException` handling, redundant `startForeground()`,
   battery optimization guidance, WakeLock during processing
-- **Pokey** — `specialUse` foreground service type, `MY_PACKAGE_REPLACED` restart
+- **Pokey** (Nostr notification app) — `specialUse` foreground service type,
+  `MY_PACKAGE_REPLACED` restart
 - **Signal** — Hybrid FCM + persistent WebSocket architecture

--- a/amethyst/build.gradle
+++ b/amethyst/build.gradle
@@ -279,6 +279,9 @@ dependencies {
     // Biometrics
     implementation libs.androidx.biometric.ktx
 
+    // Background Work
+    implementation libs.androidx.work.runtime.ktx
+
     // Websockets API
     implementation libs.okhttp
     implementation libs.okhttpCoroutines

--- a/amethyst/src/main/AndroidManifest.xml
+++ b/amethyst/src/main/AndroidManifest.xml
@@ -282,6 +282,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
         </receiver>
 

--- a/amethyst/src/main/AndroidManifest.xml
+++ b/amethyst/src/main/AndroidManifest.xml
@@ -43,6 +43,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_PHONE_CALL" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
 
     <!-- Phone calls -->
@@ -51,6 +52,9 @@
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+
+    <!-- Always-on notification service: restart after reboot -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <!-- Keeps screen on while playing videos -->
     <uses-permission android:name="android.permission.WAKE_LOCK" />
@@ -262,6 +266,28 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
+
+        <service
+            android:name=".service.notifications.NotificationRelayService"
+            android:foregroundServiceType="specialUse"
+            android:exported="false">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Persistent real-time messaging relay connection for Nostr protocol. Maintains WebSocket connections to user-configured inbox relays for immediate notification delivery of direct messages, zaps, and mentions." />
+        </service>
+
+        <receiver
+            android:name=".service.notifications.BootCompletedReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+            </intent-filter>
+        </receiver>
+
+        <receiver
+            android:name=".service.notifications.ServiceWatchdogManager$WatchdogReceiver"
+            android:exported="false" />
 
         <receiver
             android:name=".service.notifications.PokeyReceiver"

--- a/amethyst/src/main/AndroidManifest.xml
+++ b/amethyst/src/main/AndroidManifest.xml
@@ -56,6 +56,9 @@
     <!-- Always-on notification service: restart after reboot -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
+    <!-- Always-on notification service: battery optimization exemption -->
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+
     <!-- Keeps screen on while playing videos -->
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
@@ -288,6 +291,10 @@
 
         <receiver
             android:name=".service.notifications.ServiceWatchdogManager$WatchdogReceiver"
+            android:exported="false" />
+
+        <receiver
+            android:name=".service.notifications.AutoRestartReceiver"
             android:exported="false" />
 
         <receiver

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/AppModules.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/AppModules.kt
@@ -49,6 +49,7 @@ import com.vitorpamplona.amethyst.service.images.ImageCacheFactory
 import com.vitorpamplona.amethyst.service.images.ImageLoaderSetup
 import com.vitorpamplona.amethyst.service.images.ThumbnailDiskCache
 import com.vitorpamplona.amethyst.service.location.LocationState
+import com.vitorpamplona.amethyst.service.notifications.AlwaysOnNotificationServiceManager
 import com.vitorpamplona.amethyst.service.notifications.PokeyReceiver
 import com.vitorpamplona.amethyst.service.okhttp.DualHttpClientManager
 import com.vitorpamplona.amethyst.service.okhttp.DualHttpClientManagerForRelays
@@ -71,6 +72,7 @@ import com.vitorpamplona.amethyst.service.uploads.blossom.bud10.BlossomServerRes
 import com.vitorpamplona.amethyst.service.uploads.nip95.Nip95CacheFactory
 import com.vitorpamplona.amethyst.ui.resourceCacheInit
 import com.vitorpamplona.amethyst.ui.screen.AccountSessionManager
+import com.vitorpamplona.amethyst.ui.screen.AccountState
 import com.vitorpamplona.amethyst.ui.screen.UiSettingsState
 import com.vitorpamplona.amethyst.ui.tor.TorManager
 import com.vitorpamplona.quartz.nip01Core.core.Address
@@ -98,6 +100,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.transform
@@ -391,6 +394,9 @@ class AppModules(
         )
     }
 
+    // Manages always-on notification service lifecycle
+    val alwaysOnNotificationServiceManager = AlwaysOnNotificationServiceManager(appContext, applicationIOScope)
+
     // Organizes cache clearing
     val trimmingService by
         lazy {
@@ -488,6 +494,17 @@ class AppModules(
         // registers to receive events
         pokeyReceiver.register(appContext)
 
+        // Watch for account login and start/stop always-on notification service
+        applicationIOScope.launch {
+            sessionManager.accountContent.collectLatest { state ->
+                if (state is AccountState.LoggedIn) {
+                    alwaysOnNotificationServiceManager.watchAccount(state.account)
+                } else {
+                    alwaysOnNotificationServiceManager.stop()
+                }
+            }
+        }
+
         // initializes diskcache on an IO thread.
         applicationIOScope.launch {
             // Prepares video cache later
@@ -500,6 +517,7 @@ class AppModules(
         pokeyReceiver.unregister(appContext)
         BackgroundMedia.removeBackgroundControllerAndReleaseIt()
         PlaybackServiceClient.shutdown()
+        alwaysOnNotificationServiceManager.stop()
         applicationIOScope.cancel("Application onTerminate $appContext")
         accountsCache.clear()
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
@@ -136,6 +136,7 @@ private object PrefKeys {
     const val HIDE_DELETE_REQUEST_DIALOG = "hide_delete_request_dialog"
     const val HIDE_BLOCK_ALERT_DIALOG = "hide_block_alert_dialog"
     const val HIDE_NIP_17_WARNING_DIALOG = "hide_nip24_warning_dialog" // delete later
+    const val ALWAYS_ON_NOTIFICATION_SERVICE = "always_on_notification_service"
     const val TOR_SETTINGS = "tor_settings"
     const val USE_PROXY = "use_proxy"
     const val PROXY_PORT = "proxy_port"
@@ -409,6 +410,7 @@ object LocalPreferences {
                     putBoolean(PrefKeys.HIDE_NIP_17_WARNING_DIALOG, settings.hideNIP17WarningDialog)
                     putBoolean(PrefKeys.HIDE_BLOCK_ALERT_DIALOG, settings.hideBlockAlertDialog)
                     putBoolean(PrefKeys.CALLS_ENABLED, settings.callsEnabled.value)
+                    putBoolean(PrefKeys.ALWAYS_ON_NOTIFICATION_SERVICE, settings.alwaysOnNotificationService.value)
 
                     // migrating from previous design
                     remove(PrefKeys.USE_PROXY)
@@ -513,6 +515,7 @@ object LocalPreferences {
                     val hideBlockAlertDialog = getBoolean(PrefKeys.HIDE_BLOCK_ALERT_DIALOG, false)
                     val hideNIP17WarningDialog = getBoolean(PrefKeys.HIDE_NIP_17_WARNING_DIALOG, false)
                     val callsEnabled = getBoolean(PrefKeys.CALLS_ENABLED, true)
+                    val alwaysOnNotificationService = getBoolean(PrefKeys.ALWAYS_ON_NOTIFICATION_SERVICE, false)
                     val hasDonatedInVersion = getStringSet(PrefKeys.HAS_DONATED_IN_VERSION, null) ?: setOf()
                     val dismissedPollNoteIds = getStringSet(PrefKeys.DISMISSED_POLL_NOTE_IDS, null) ?: setOf()
                     val viewedPollResultNoteIdsStr = getString(PrefKeys.VIEWED_POLL_RESULT_NOTE_IDS, null)
@@ -636,6 +639,7 @@ object LocalPreferences {
                         hideDeleteRequestDialog = hideDeleteRequestDialog,
                         hideBlockAlertDialog = hideBlockAlertDialog,
                         hideNIP17WarningDialog = hideNIP17WarningDialog,
+                        alwaysOnNotificationService = MutableStateFlow(alwaysOnNotificationService),
                         backupUserMetadata = latestUserMetadata.await(),
                         backupContactList = latestContactList.await(),
                         backupNIP65RelayList = latestNip65RelayList.await(),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -170,6 +170,7 @@ class AccountSettings(
     var hideDeleteRequestDialog: Boolean = false,
     var hideBlockAlertDialog: Boolean = false,
     var hideNIP17WarningDialog: Boolean = false,
+    val alwaysOnNotificationService: MutableStateFlow<Boolean> = MutableStateFlow(false),
     var backupUserMetadata: MetadataEvent? = null,
     var backupContactList: ContactListEvent? = null,
     var backupDMRelayList: ChatMessageRelayListEvent? = null,
@@ -214,6 +215,17 @@ class AccountSettings(
     }
 
     fun isWriteable(): Boolean = keyPair.privKey != null || externalSignerPackageName != null
+
+    // ---
+    // Always-on Notification Service
+    // ---
+
+    fun toggleAlwaysOnNotificationService(): Boolean {
+        val newValue = !alwaysOnNotificationService.value
+        alwaysOnNotificationService.tryEmit(newValue)
+        saveAccountSettings()
+        return newValue
+    }
 
     // ---
     // Zaps and Reactions

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/AlwaysOnNotificationServiceManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/AlwaysOnNotificationServiceManager.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.notifications
+
+import android.content.Context
+import com.vitorpamplona.amethyst.model.Account
+import com.vitorpamplona.quartz.utils.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+/**
+ * Coordinates all 5 layers of the always-on notification system:
+ *
+ * L1 - NotificationRelayService (foreground service with persistent WebSocket)
+ * L2 - FCM/UnifiedPush (existing push system, wakeup trigger)
+ * L3 - NotificationCatchUpWorker (WorkManager, 15-min periodic catch-up)
+ * L4 - BootCompletedReceiver (restart on boot)
+ * L5 - ServiceWatchdogManager (AlarmManager, 5-min health check)
+ *
+ * When enabled, all layers activate. When disabled, all layers deactivate.
+ * The manager watches the account's alwaysOnNotificationService setting
+ * and reacts to changes in real time.
+ */
+class AlwaysOnNotificationServiceManager(
+    private val context: Context,
+    private val scope: CoroutineScope,
+) {
+    companion object {
+        private const val TAG = "AlwaysOnNotifManager"
+    }
+
+    private var watchJob: Job? = null
+
+    /**
+     * Starts watching the given account's always-on setting.
+     * When the setting changes, all layers are started or stopped accordingly.
+     */
+    fun watchAccount(account: Account) {
+        watchJob?.cancel()
+        watchJob =
+            scope.launch {
+                account.settings.alwaysOnNotificationService.collectLatest { enabled ->
+                    if (enabled) {
+                        enableAllLayers()
+                    } else {
+                        disableAllLayers()
+                    }
+                }
+            }
+    }
+
+    fun stop() {
+        watchJob?.cancel()
+        watchJob = null
+    }
+
+    private fun enableAllLayers() {
+        Log.d(TAG, "Enabling all notification service layers")
+
+        // L1: Start foreground service
+        NotificationRelayService.start(context)
+
+        // L3: Schedule periodic catch-up worker
+        NotificationCatchUpWorker.schedule(context)
+
+        // L5: Start watchdog alarm
+        ServiceWatchdogManager.schedule(context)
+
+        // L2 (FCM) and L4 (BOOT_COMPLETED) are always active via manifest
+    }
+
+    private fun disableAllLayers() {
+        Log.d(TAG, "Disabling all notification service layers")
+
+        // L1: Stop foreground service
+        NotificationRelayService.stop(context)
+
+        // L3: Cancel periodic catch-up worker
+        NotificationCatchUpWorker.cancel(context)
+
+        // L5: Cancel watchdog alarm
+        ServiceWatchdogManager.cancel(context)
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/AlwaysOnNotificationServiceManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/AlwaysOnNotificationServiceManager.kt
@@ -50,19 +50,23 @@ class AlwaysOnNotificationServiceManager(
     }
 
     private var watchJob: Job? = null
+    private var wasEnabled = false
 
     /**
      * Starts watching the given account's always-on setting.
      * When the setting changes, all layers are started or stopped accordingly.
+     * On initial load with false, nothing happens (no-op for users who never enabled it).
      */
     fun watchAccount(account: Account) {
         watchJob?.cancel()
+        wasEnabled = false
         watchJob =
             scope.launch {
                 account.settings.alwaysOnNotificationService.collectLatest { enabled ->
                     if (enabled) {
+                        wasEnabled = true
                         enableAllLayers()
-                    } else {
+                    } else if (wasEnabled) {
                         disableAllLayers()
                     }
                 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/AutoRestartReceiver.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/AutoRestartReceiver.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.notifications
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import com.vitorpamplona.quartz.utils.Log
+
+/**
+ * Receives a broadcast from NotificationRelayService.onDestroy() and
+ * enqueues a one-time WorkManager task to restart the service.
+ *
+ * This catches kills that START_STICKY might miss (e.g., OEM battery
+ * optimizers, aggressive memory reclaim). The WorkManager task requires
+ * network connectivity, so the service won't restart until the device
+ * has an active connection.
+ *
+ * Pattern inspired by ntfy's AutoRestartReceiver.
+ */
+class AutoRestartReceiver : BroadcastReceiver() {
+    companion object {
+        private const val TAG = "AutoRestartReceiver"
+        private const val WORK_NAME = "notification_service_restart"
+    }
+
+    override fun onReceive(
+        context: Context,
+        intent: Intent?,
+    ) {
+        if (intent?.action != NotificationRelayService.ACTION_AUTO_RESTART) return
+
+        Log.d(TAG, "Received auto-restart broadcast, enqueuing restart work")
+
+        val constraints =
+            Constraints
+                .Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build()
+
+        val request =
+            OneTimeWorkRequestBuilder<NotificationCatchUpWorker>()
+                .setConstraints(constraints)
+                .build()
+
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            WORK_NAME,
+            ExistingWorkPolicy.KEEP,
+            request,
+        )
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/BatteryOptimizationHelper.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/BatteryOptimizationHelper.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.notifications
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.PowerManager
+import android.provider.Settings
+import com.vitorpamplona.quartz.utils.Log
+
+/**
+ * Helper for checking and requesting battery optimization exemption.
+ *
+ * When the always-on notification service is enabled, the app needs to be
+ * exempted from battery optimizations (Doze) to maintain reliable relay
+ * connections. Without the exemption, Android may restrict network access
+ * and defer alarms even for foreground services.
+ *
+ * Messaging apps are explicitly listed as a valid use case for this exemption
+ * in Google Play policy.
+ */
+object BatteryOptimizationHelper {
+    private const val TAG = "BatteryOptimization"
+
+    fun isIgnoringBatteryOptimizations(context: Context): Boolean {
+        val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        return powerManager.isIgnoringBatteryOptimizations(context.packageName)
+    }
+
+    /**
+     * Launches the system dialog to request battery optimization exemption.
+     * Falls back to the general battery settings page if the direct intent fails.
+     */
+    fun requestBatteryOptimizationExemption(context: Context) {
+        try {
+            val intent =
+                Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+                    data = Uri.parse("package:${context.packageName}")
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+            context.startActivity(intent)
+        } catch (e: Exception) {
+            Log.w(TAG, "Direct battery exemption request failed, opening settings", e)
+            try {
+                val fallback =
+                    Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS).apply {
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                context.startActivity(fallback)
+            } catch (e2: Exception) {
+                Log.e(TAG, "Failed to open battery settings", e2)
+            }
+        }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/BootCompletedReceiver.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/BootCompletedReceiver.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.notifications
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.vitorpamplona.quartz.utils.Log
+
+/**
+ * Restarts the NotificationRelayService after device reboot.
+ *
+ * The specialUse foreground service type is allowed to start from BOOT_COMPLETED
+ * on Android 15+, unlike dataSync which is restricted.
+ */
+class BootCompletedReceiver : BroadcastReceiver() {
+    companion object {
+        private const val TAG = "BootCompletedReceiver"
+    }
+
+    override fun onReceive(
+        context: Context,
+        intent: Intent,
+    ) {
+        if (intent.action == Intent.ACTION_BOOT_COMPLETED ||
+            intent.action == "android.intent.action.QUICKBOOT_POWERON"
+        ) {
+            Log.d(TAG, "Boot completed, checking if notification service should start")
+            if (NotificationRelayService.isEnabled(context)) {
+                Log.d(TAG, "Starting notification relay service after boot")
+                NotificationRelayService.start(context)
+            }
+        }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/BootCompletedReceiver.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/BootCompletedReceiver.kt
@@ -26,7 +26,12 @@ import android.content.Intent
 import com.vitorpamplona.quartz.utils.Log
 
 /**
- * Restarts the NotificationRelayService after device reboot.
+ * Restarts the NotificationRelayService after device reboot or app update.
+ *
+ * Handles:
+ * - BOOT_COMPLETED / QUICKBOOT_POWERON: restart after device reboot
+ * - MY_PACKAGE_REPLACED: restart after app update (without this, the service
+ *   stays dead until the user manually opens the app or reboots)
  *
  * The specialUse foreground service type is allowed to start from BOOT_COMPLETED
  * on Android 15+, unlike dataSync which is restricted.
@@ -40,13 +45,16 @@ class BootCompletedReceiver : BroadcastReceiver() {
         context: Context,
         intent: Intent,
     ) {
-        if (intent.action == Intent.ACTION_BOOT_COMPLETED ||
-            intent.action == "android.intent.action.QUICKBOOT_POWERON"
-        ) {
-            Log.d(TAG, "Boot completed, checking if notification service should start")
-            if (NotificationRelayService.isEnabled(context)) {
-                Log.d(TAG, "Starting notification relay service after boot")
-                NotificationRelayService.start(context)
+        when (intent.action) {
+            Intent.ACTION_BOOT_COMPLETED,
+            "android.intent.action.QUICKBOOT_POWERON",
+            Intent.ACTION_MY_PACKAGE_REPLACED,
+            -> {
+                Log.d(TAG) { "Received ${intent.action}, checking if notification service should start" }
+                if (NotificationRelayService.isEnabled(context)) {
+                    Log.d(TAG, "Starting notification relay service")
+                    NotificationRelayService.start(context)
+                }
             }
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
@@ -23,6 +23,7 @@ package com.vitorpamplona.amethyst.service.notifications
 import android.app.NotificationManager
 import android.content.Context
 import android.graphics.drawable.BitmapDrawable
+import android.os.PowerManager
 import androidx.compose.runtime.getValue
 import androidx.core.content.ContextCompat
 import coil3.ImageLoader
@@ -88,28 +89,55 @@ private const val SCROLL_TO_QUERY_PARAM = "&scrollTo="
 class EventNotificationConsumer(
     private val applicationContext: Context,
 ) {
-    suspend fun consume(event: GiftWrapEvent) {
-        Log.d(TAG, "New Notification Arrived")
+    companion object {
+        private const val WAKELOCK_TIMEOUT_MS = 10 * 60 * 1000L // 10 minutes
+    }
 
-        // PushNotification Wraps don't include a receiver.
-        // Test with all logged in accounts
-        var matchAccount = false
-        LocalPreferences.allSavedAccounts().forEach {
-            if (!matchAccount && (it.hasPrivKey || it.loggedInWithExternalSigner)) {
-                LocalPreferences.loadAccountConfigFromEncryptedStorage(it.npub)?.let { acc ->
-                    Log.d(TAG) { "New Notification Testing if for ${it.npub}" }
-                    try {
-                        val account = Amethyst.instance.accountsCache.loadAccount(acc)
-                        consumeIfMatchesAccount(event, account)
-                        matchAccount = true
-                    } catch (e: Exception) {
-                        if (e is CancellationException) throw e
-                        Log.d(TAG) { "Message was not for user ${it.npub}: ${e.message}" }
+    /**
+     * Acquires a partial WakeLock during notification processing to ensure
+     * the CPU stays awake long enough to decrypt, process, and dispatch
+     * the notification, even in Doze mode.
+     */
+    private inline fun <T> withWakeLock(block: () -> T): T {
+        val powerManager = applicationContext.getSystemService(Context.POWER_SERVICE) as PowerManager
+        val wakeLock =
+            powerManager.newWakeLock(
+                PowerManager.PARTIAL_WAKE_LOCK,
+                "amethyst:notification_processing",
+            )
+        wakeLock.acquire(WAKELOCK_TIMEOUT_MS)
+        try {
+            return block()
+        } finally {
+            if (wakeLock.isHeld) {
+                wakeLock.release()
+            }
+        }
+    }
+
+    suspend fun consume(event: GiftWrapEvent) =
+        withWakeLock {
+            Log.d(TAG, "New Notification Arrived")
+
+            // PushNotification Wraps don't include a receiver.
+            // Test with all logged in accounts
+            var matchAccount = false
+            LocalPreferences.allSavedAccounts().forEach {
+                if (!matchAccount && (it.hasPrivKey || it.loggedInWithExternalSigner)) {
+                    LocalPreferences.loadAccountConfigFromEncryptedStorage(it.npub)?.let { acc ->
+                        Log.d(TAG) { "New Notification Testing if for ${it.npub}" }
+                        try {
+                            val account = Amethyst.instance.accountsCache.loadAccount(acc)
+                            consumeIfMatchesAccount(event, account)
+                            matchAccount = true
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
+                            Log.d(TAG) { "Message was not for user ${it.npub}: ${e.message}" }
+                        }
                     }
                 }
             }
         }
-    }
 
     private suspend fun consumeIfMatchesAccount(
         pushWrappedEvent: GiftWrapEvent,
@@ -221,30 +249,31 @@ class EventNotificationConsumer(
         }
     }
 
-    suspend fun findAccountAndConsume(event: Event) {
-        Log.d(TAG, "New Notification Arrived")
-        val users = event.taggedUserIds().map { LocalCache.getOrCreateUser(it) }
-        val npubs = users.map { it.pubkeyNpub() }.toSet()
+    suspend fun findAccountAndConsume(event: Event) =
+        withWakeLock {
+            Log.d(TAG, "New Notification Arrived")
+            val users = event.taggedUserIds().map { LocalCache.getOrCreateUser(it) }
+            val npubs = users.map { it.pubkeyNpub() }.toSet()
 
-        // PushNotification Wraps don't include a receiver.
-        // Test with all logged in accounts
-        var matchAccount = false
-        LocalPreferences.allSavedAccounts().forEach {
-            if (!matchAccount && (it.hasPrivKey || it.loggedInWithExternalSigner) && it.npub in npubs) {
-                LocalPreferences.loadAccountConfigFromEncryptedStorage(it.npub)?.let { accountSettings ->
-                    Log.d(TAG) { "New Notification Testing if for ${it.npub}" }
-                    try {
-                        val account = Amethyst.instance.accountsCache.loadAccount(accountSettings)
-                        consumeNotificationEvent(event, account)
-                        matchAccount = true
-                    } catch (e: Exception) {
-                        if (e is CancellationException) throw e
-                        Log.d(TAG) { "Message was not for user ${it.npub}: ${e.message}" }
+            // PushNotification Wraps don't include a receiver.
+            // Test with all logged in accounts
+            var matchAccount = false
+            LocalPreferences.allSavedAccounts().forEach {
+                if (!matchAccount && (it.hasPrivKey || it.loggedInWithExternalSigner) && it.npub in npubs) {
+                    LocalPreferences.loadAccountConfigFromEncryptedStorage(it.npub)?.let { accountSettings ->
+                        Log.d(TAG) { "New Notification Testing if for ${it.npub}" }
+                        try {
+                            val account = Amethyst.instance.accountsCache.loadAccount(accountSettings)
+                            consumeNotificationEvent(event, account)
+                            matchAccount = true
+                        } catch (e: Exception) {
+                            if (e is CancellationException) throw e
+                            Log.d(TAG) { "Message was not for user ${it.npub}: ${e.message}" }
+                        }
                     }
                 }
             }
         }
-    }
 
     private suspend fun unwrapAndConsume(
         event: Event,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationCatchUpWorker.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationCatchUpWorker.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.notifications
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.vitorpamplona.amethyst.Amethyst
+import com.vitorpamplona.quartz.utils.Log
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.TimeUnit
+
+/**
+ * WorkManager periodic worker that catches up on missed notifications.
+ *
+ * This runs every 15 minutes (WorkManager's minimum interval) and ensures
+ * relay connections are active. It acts as a safety net:
+ *
+ * - If the foreground service was killed by an OEM battery optimizer, this
+ *   worker will briefly restore connections and pull missed events.
+ * - If the foreground service is running fine, this worker is essentially a no-op
+ *   since the connections are already live and filters are active.
+ *
+ * The worker collects relayServices to ensure connections are active,
+ * waits briefly for data to flow, then exits. The foreground service
+ * (if alive) handles the persistent connection.
+ */
+class NotificationCatchUpWorker(
+    appContext: Context,
+    workerParams: WorkerParameters,
+) : CoroutineWorker(appContext, workerParams) {
+    companion object {
+        private const val TAG = "NotificationCatchUpWorker"
+        private const val WORK_NAME = "notification_catch_up"
+        private const val CATCH_UP_DURATION_MS = 30_000L
+
+        fun schedule(context: Context) {
+            val constraints =
+                Constraints
+                    .Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .build()
+
+            val request =
+                PeriodicWorkRequestBuilder<NotificationCatchUpWorker>(
+                    15,
+                    TimeUnit.MINUTES,
+                ).setConstraints(constraints)
+                    .build()
+
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                request,
+            )
+            Log.d(TAG, "Scheduled periodic catch-up work")
+        }
+
+        fun cancel(context: Context) {
+            WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
+            Log.d(TAG, "Cancelled periodic catch-up work")
+        }
+    }
+
+    override suspend fun doWork(): Result {
+        Log.d(TAG, "Starting notification catch-up")
+
+        return try {
+            val appModules = Amethyst.instance
+
+            // Collecting relayServices ensures connections are active.
+            // If the foreground service is alive, connections are already up
+            // and this is essentially free. If it was killed, this briefly
+            // restores them.
+            withTimeoutOrNull(CATCH_UP_DURATION_MS) {
+                // Trigger connection by collecting the first emission
+                appModules.relayProxyClientConnector.relayServices.first()
+
+                // Give the relay subscriptions time to receive pending events
+                delay(CATCH_UP_DURATION_MS - 5_000)
+            }
+
+            Log.d(TAG, "Notification catch-up completed")
+            Result.success()
+        } catch (e: Exception) {
+            Log.e(TAG, "Notification catch-up failed", e)
+            Result.retry()
+        }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationCatchUpWorker.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationCatchUpWorker.kt
@@ -24,7 +24,9 @@ import android.content.Context
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
@@ -83,7 +85,36 @@ class NotificationCatchUpWorker(
 
         fun cancel(context: Context) {
             WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME)
+            WorkManager.getInstance(context).cancelUniqueWork(WORK_NAME_ON_NETWORK)
             Log.d(TAG, "Cancelled periodic catch-up work")
+        }
+
+        private const val WORK_NAME_ON_NETWORK = "notification_catch_up_on_network"
+
+        /**
+         * Enqueues a one-time catch-up task that runs as soon as network
+         * connectivity is available. Call this when the service detects
+         * network loss to ensure it restarts immediately when network returns,
+         * rather than waiting for the next periodic worker.
+         */
+        fun scheduleOnNetworkAvailable(context: Context) {
+            val constraints =
+                Constraints
+                    .Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .build()
+
+            val request =
+                OneTimeWorkRequestBuilder<NotificationCatchUpWorker>()
+                    .setConstraints(constraints)
+                    .build()
+
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                WORK_NAME_ON_NETWORK,
+                ExistingWorkPolicy.KEEP,
+                request,
+            )
+            Log.d(TAG, "Scheduled one-time catch-up on network available")
         }
     }
 
@@ -91,6 +122,11 @@ class NotificationCatchUpWorker(
         Log.d(TAG, "Starting notification catch-up")
 
         return try {
+            // If the foreground service should be running but isn't, restart it
+            if (NotificationRelayService.isEnabled(applicationContext)) {
+                NotificationRelayService.start(applicationContext)
+            }
+
             val appModules = Amethyst.instance
 
             // Collecting relayServices ensures connections are active.

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationRelayService.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationRelayService.kt
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.notifications
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import androidx.core.content.ContextCompat
+import com.vitorpamplona.amethyst.Amethyst
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.ui.MainActivity
+import com.vitorpamplona.quartz.utils.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+/**
+ * A foreground service that maintains persistent WebSocket connections to the user's
+ * inbox relays for real-time notification delivery.
+ *
+ * This service:
+ * - Keeps the shared NostrClient alive by collecting the relayServices flow
+ * - Adds notification-specific subscriptions on inbox relays
+ * - Routes incoming events through EventNotificationConsumer
+ * - Survives app backgrounding (connections stay open)
+ * - Uses specialUse foreground service type (no Android 15 time limit)
+ *
+ * The key insight is that this service shares the same NostrClient as the UI.
+ * When the app is in the foreground, both the UI and this service are subscribers.
+ * When the app backgrounds, UI subscriptions drop but this service's subscriptions
+ * remain, keeping inbox relay connections alive. No reconnection needed.
+ */
+class NotificationRelayService : Service() {
+    companion object {
+        private const val TAG = "NotificationRelayService"
+        private const val CHANNEL_ID = "notification_relay_service"
+        private const val NOTIFICATION_ID = 9832
+
+        private const val ACTION_START = "com.vitorpamplona.amethyst.START_NOTIFICATION_SERVICE"
+        private const val ACTION_STOP = "com.vitorpamplona.amethyst.STOP_NOTIFICATION_SERVICE"
+
+        fun start(context: Context) {
+            val intent =
+                Intent(context, NotificationRelayService::class.java).apply {
+                    action = ACTION_START
+                }
+            ContextCompat.startForegroundService(context, intent)
+        }
+
+        fun stop(context: Context) {
+            val intent =
+                Intent(context, NotificationRelayService::class.java).apply {
+                    action = ACTION_STOP
+                }
+            context.startService(intent)
+        }
+
+        fun isEnabled(context: Context): Boolean {
+            // Check if service should be enabled based on account settings
+            return try {
+                Amethyst.instance.sessionManager
+                    .loggedInAccount()
+                    ?.settings
+                    ?.alwaysOnNotificationService
+                    ?.value == true
+            } catch (e: Exception) {
+                false
+            }
+        }
+    }
+
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private var relayServiceCollectorJob: Job? = null
+    private var connectedRelayCount = 0
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        Log.d(TAG, "Service created")
+        createNotificationChannel()
+    }
+
+    override fun onStartCommand(
+        intent: Intent?,
+        flags: Int,
+        startId: Int,
+    ): Int {
+        when (intent?.action) {
+            ACTION_STOP -> {
+                Log.d(TAG, "Stopping service")
+                stopSelf()
+                return START_NOT_STICKY
+            }
+
+            else -> {
+                Log.d(TAG, "Starting service")
+                startForegroundWithNotification()
+                startRelayConnection()
+            }
+        }
+        return START_STICKY
+    }
+
+    private fun startForegroundWithNotification() {
+        val notification = buildNotification(0)
+        ServiceCompat.startForeground(
+            this,
+            NOTIFICATION_ID,
+            notification,
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+            } else {
+                0
+            },
+        )
+    }
+
+    private fun startRelayConnection() {
+        relayServiceCollectorJob?.cancel()
+        relayServiceCollectorJob =
+            scope.launch {
+                // Collecting the relayServices flow keeps the RelayProxyClientConnector alive.
+                // This is the same flow that ManageRelayServices() composable collects in the UI.
+                // By collecting it here, relay connections survive app backgrounding.
+                launch {
+                    Amethyst.instance.relayProxyClientConnector.relayServices.collectLatest {
+                        Log.d(TAG, "Relay services state updated: $it")
+                    }
+                }
+
+                // Monitor connected relay count to update the notification
+                launch {
+                    Amethyst.instance.client.connectedRelaysFlow().collectLatest { relays ->
+                        val count = relays.size
+                        if (count != connectedRelayCount) {
+                            connectedRelayCount = count
+                            updateNotification(count)
+                        }
+                    }
+                }
+            }
+    }
+
+    private fun updateNotification(connectedRelays: Int) {
+        val notification = buildNotification(connectedRelays)
+        val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.notify(NOTIFICATION_ID, notification)
+    }
+
+    private fun buildNotification(connectedRelays: Int): Notification {
+        val contentText =
+            if (connectedRelays > 0) {
+                getString(R.string.always_on_notif_connected, connectedRelays)
+            } else {
+                getString(R.string.always_on_notif_connecting)
+            }
+
+        val openAppIntent =
+            Intent(this, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+            }
+        val pendingIntent =
+            PendingIntent.getActivity(
+                this,
+                0,
+                openAppIntent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+
+        val stopIntent =
+            Intent(this, NotificationRelayService::class.java).apply {
+                action = ACTION_STOP
+            }
+        val stopPendingIntent =
+            PendingIntent.getService(
+                this,
+                1,
+                stopIntent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+
+        return NotificationCompat
+            .Builder(this, CHANNEL_ID)
+            .setContentTitle(getString(R.string.always_on_notif_title))
+            .setContentText(contentText)
+            .setSmallIcon(R.drawable.amethyst)
+            .setContentIntent(pendingIntent)
+            .addAction(0, getString(R.string.always_on_notif_stop), stopPendingIntent)
+            .setOngoing(true)
+            .setSilent(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .build()
+    }
+
+    private fun createNotificationChannel() {
+        val channel =
+            NotificationChannel(
+                CHANNEL_ID,
+                getString(R.string.always_on_notif_channel_name),
+                NotificationManager.IMPORTANCE_LOW,
+            ).apply {
+                description = getString(R.string.always_on_notif_channel_description)
+                setShowBadge(false)
+            }
+        val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.createNotificationChannel(channel)
+    }
+
+    override fun onDestroy() {
+        Log.d(TAG, "Service destroyed")
+        relayServiceCollectorJob?.cancel()
+        scope.cancel()
+        super.onDestroy()
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationRelayService.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationRelayService.kt
@@ -95,11 +95,7 @@ class NotificationRelayService : Service() {
         }
 
         fun stop(context: Context) {
-            val intent =
-                Intent(context, NotificationRelayService::class.java).apply {
-                    action = ACTION_STOP
-                }
-            context.startService(intent)
+            context.stopService(Intent(context, NotificationRelayService::class.java))
         }
 
         fun isEnabled(context: Context): Boolean =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationRelayService.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationRelayService.kt
@@ -38,38 +38,30 @@ import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.model.Account
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.nip01Notifications.filterNotificationsToPubkey
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.nip01Notifications.filterSummaryNotificationsToPubkey
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.nip59GiftWraps.filterGiftWrapsToPubkey
 import com.vitorpamplona.amethyst.ui.MainActivity
-import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
-import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.utils.Log
-import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
 /**
  * A foreground service that maintains persistent WebSocket connections to the user's
  * inbox relays for real-time notification delivery.
  *
- * This service:
- * - Keeps the shared NostrClient alive by collecting the relayServices flow
- * - Routes incoming events through EventNotificationConsumer
- * - Survives app backgrounding (connections stay open)
- * - Uses specialUse foreground service type (no Android 15 time limit)
+ * This service keeps the shared NostrClient alive by collecting the relayServices flow.
+ * It does NOT create its own relay subscriptions — instead, it relies on the
+ * AccountFilterAssembler subscription from the Compose UI tree, which stays active
+ * as long as the Activity is alive (even when stopped/backgrounded). That subscription
+ * covers notifications, gift wraps, metadata, follows, relay lists, and drafts.
  *
- * The key insight is that this service shares the same NostrClient as the UI.
- * When the app is in the foreground, both the UI and this service are subscribers.
- * When the app backgrounds, UI subscriptions drop but this service's subscriptions
- * remain, keeping inbox relay connections alive. No reconnection needed.
+ * Heavy feed subscriptions (Home, Video, Discovery, ChatroomList) are managed
+ * separately with lifecycle awareness — they pause when the app backgrounds
+ * and resume when it foregrounds. This prevents bandwidth waste on feeds
+ * nobody is viewing.
  *
  * Auto-restart mechanisms (inspired by ntfy):
  * - START_STICKY: Android restarts killed services
@@ -126,9 +118,6 @@ class NotificationRelayService : Service() {
     private var relayServiceCollectorJob: Job? = null
     private var connectedRelayCount = 0
     private var foregroundStarted = false
-
-    private val subIdNotifications = "svc:notif"
-    private val subIdGiftWraps = "svc:giftwrap"
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -198,16 +187,6 @@ class NotificationRelayService : Service() {
     override fun onDestroy() {
         Log.d(TAG, "Service destroyed")
         relayServiceCollectorJob?.cancel()
-
-        // Clean up our subscriptions so the relay pool can disconnect
-        // relays that are no longer needed by anyone
-        try {
-            Amethyst.instance.client.unsubscribe(subIdNotifications)
-            Amethyst.instance.client.unsubscribe(subIdGiftWraps)
-        } catch (e: Exception) {
-            // App might already be torn down
-        }
-
         scope.cancel()
 
         if (isEnabled(this)) {
@@ -249,28 +228,32 @@ class NotificationRelayService : Service() {
         }
     }
 
+    /**
+     * Keeps the relay infrastructure alive. The service collects two flows:
+     *
+     * 1. relayServices: Keeps the RelayProxyClientConnector active (connectivity,
+     *    Tor, network changes). Without this, the client disconnects 30s after
+     *    the UI stops collecting.
+     *
+     * 2. connectedRelaysFlow: Updates the persistent notification with relay count.
+     *
+     * The service does NOT create its own relay subscriptions. Instead, it relies on
+     * the AccountFilterAssembler subscription that lives in the Compose tree (LoggedInPage).
+     * That subscription stays active as long as the Activity exists (even when stopped)
+     * and covers: metadata, follows, notifications (inbox relays), gift wraps (DM relays),
+     * drafts, and relay list changes. Since the service keeps the client connected,
+     * those subscriptions remain active on the relays.
+     */
     private fun startRelayConnection() {
         relayServiceCollectorJob?.cancel()
         relayServiceCollectorJob =
             scope.launch {
-                // Collecting the relayServices flow keeps the RelayProxyClientConnector alive.
-                // This is the same flow that ManageRelayServices() composable collects in the UI.
-                // By collecting it here, relay connections survive app backgrounding.
                 launch {
                     Amethyst.instance.relayProxyClientConnector.relayServices.collectLatest {
                         Log.d(TAG) { "Relay services state updated: $it" }
                     }
                 }
 
-                // Maintain notification + DM subscriptions on inbox relays.
-                // When the UI backgrounds, its subscriptions drop and relays that are
-                // only needed for those subscriptions disconnect. By opening our own
-                // subscriptions here, we ensure inbox + DM relay connections persist.
-                launch {
-                    maintainInboxSubscriptions()
-                }
-
-                // Monitor connected relay count to update the notification
                 launch {
                     Amethyst.instance.client.connectedRelaysFlow().collectLatest { relays ->
                         val count = relays.size
@@ -281,99 +264,6 @@ class NotificationRelayService : Service() {
                     }
                 }
             }
-    }
-
-    /**
-     * Watches the logged-in account's notification inbox relays and DM inbox relays,
-     * maintaining lightweight subscriptions on them. This ensures these relay connections
-     * persist even when the UI's subscriptions drop.
-     *
-     * Notification relays: NIP-65 inbox + local relays → subscribe to mentions, zaps, etc.
-     * DM relays: NIP-17 DM relays + NIP-65 inbox + private outbox + local relays → gift wraps
-     */
-    private suspend fun maintainInboxSubscriptions() {
-        // Wait for account to be available
-        Amethyst.instance.sessionManager.accountContent.collectLatest { state ->
-            val account =
-                (state as? com.vitorpamplona.amethyst.ui.screen.AccountState.LoggedIn)?.account
-
-            if (account == null || !account.isWriteable()) {
-                // No account or read-only — close any existing subscriptions
-                Amethyst.instance.client.unsubscribe(subIdNotifications)
-                Amethyst.instance.client.unsubscribe(subIdGiftWraps)
-                return@collectLatest
-            }
-
-            // Reactively update subscriptions when relay lists change
-            combine(
-                account.notificationRelays.flow,
-                account.dmRelays.flow,
-            ) { notifRelays, dmRelays ->
-                Pair(notifRelays, dmRelays)
-            }.collectLatest { (notifRelays, dmRelays) ->
-                updateNotificationSubscription(account, notifRelays)
-                updateGiftWrapSubscription(account, dmRelays)
-            }
-        }
-    }
-
-    private fun updateNotificationSubscription(
-        account: Account,
-        relays: Set<NormalizedRelayUrl>,
-    ) {
-        if (relays.isEmpty()) {
-            Amethyst.instance.client.unsubscribe(subIdNotifications)
-            return
-        }
-
-        val pubkey = account.signer.pubKey
-        val since = TimeUtils.oneWeekAgo()
-        val filters = mutableMapOf<NormalizedRelayUrl, List<Filter>>()
-
-        relays.forEach { relay ->
-            val relayFilters =
-                (
-                    filterSummaryNotificationsToPubkey(relay, pubkey, since) +
-                        filterNotificationsToPubkey(relay, pubkey, since)
-                ).map { it.filter }
-
-            if (relayFilters.isNotEmpty()) {
-                filters[relay] = relayFilters
-            }
-        }
-
-        if (filters.isNotEmpty()) {
-            Amethyst.instance.client.subscribe(subIdNotifications, filters)
-            Log.d(TAG) { "Subscribed to notifications on ${filters.size} relays" }
-        }
-    }
-
-    private fun updateGiftWrapSubscription(
-        account: Account,
-        relays: Set<NormalizedRelayUrl>,
-    ) {
-        if (relays.isEmpty()) {
-            Amethyst.instance.client.unsubscribe(subIdGiftWraps)
-            return
-        }
-
-        val pubkey = account.signer.pubKey
-        val since = TimeUtils.oneWeekAgo()
-        val filters = mutableMapOf<NormalizedRelayUrl, List<Filter>>()
-
-        relays.forEach { relay ->
-            val relayFilters =
-                filterGiftWrapsToPubkey(relay, pubkey, since).map { it.filter }
-
-            if (relayFilters.isNotEmpty()) {
-                filters[relay] = relayFilters
-            }
-        }
-
-        if (filters.isNotEmpty()) {
-            Amethyst.instance.client.subscribe(subIdGiftWraps, filters)
-            Log.d(TAG) { "Subscribed to gift wraps on ${filters.size} DM relays" }
-        }
     }
 
     private fun updateNotification(connectedRelays: Int) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationRelayService.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationRelayService.kt
@@ -38,14 +38,22 @@ import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.model.Account
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.nip01Notifications.filterNotificationsToPubkey
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.nip01Notifications.filterSummaryNotificationsToPubkey
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.nip59GiftWraps.filterGiftWrapsToPubkey
 import com.vitorpamplona.amethyst.ui.MainActivity
+import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.utils.Log
+import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
 /**
@@ -119,6 +127,9 @@ class NotificationRelayService : Service() {
     private var connectedRelayCount = 0
     private var foregroundStarted = false
 
+    private val subIdNotifications = "svc:notif"
+    private val subIdGiftWraps = "svc:giftwrap"
+
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onCreate() {
@@ -187,6 +198,16 @@ class NotificationRelayService : Service() {
     override fun onDestroy() {
         Log.d(TAG, "Service destroyed")
         relayServiceCollectorJob?.cancel()
+
+        // Clean up our subscriptions so the relay pool can disconnect
+        // relays that are no longer needed by anyone
+        try {
+            Amethyst.instance.client.unsubscribe(subIdNotifications)
+            Amethyst.instance.client.unsubscribe(subIdGiftWraps)
+        } catch (e: Exception) {
+            // App might already be torn down
+        }
+
         scope.cancel()
 
         if (isEnabled(this)) {
@@ -241,6 +262,14 @@ class NotificationRelayService : Service() {
                     }
                 }
 
+                // Maintain notification + DM subscriptions on inbox relays.
+                // When the UI backgrounds, its subscriptions drop and relays that are
+                // only needed for those subscriptions disconnect. By opening our own
+                // subscriptions here, we ensure inbox + DM relay connections persist.
+                launch {
+                    maintainInboxSubscriptions()
+                }
+
                 // Monitor connected relay count to update the notification
                 launch {
                     Amethyst.instance.client.connectedRelaysFlow().collectLatest { relays ->
@@ -252,6 +281,99 @@ class NotificationRelayService : Service() {
                     }
                 }
             }
+    }
+
+    /**
+     * Watches the logged-in account's notification inbox relays and DM inbox relays,
+     * maintaining lightweight subscriptions on them. This ensures these relay connections
+     * persist even when the UI's subscriptions drop.
+     *
+     * Notification relays: NIP-65 inbox + local relays → subscribe to mentions, zaps, etc.
+     * DM relays: NIP-17 DM relays + NIP-65 inbox + private outbox + local relays → gift wraps
+     */
+    private suspend fun maintainInboxSubscriptions() {
+        // Wait for account to be available
+        Amethyst.instance.sessionManager.accountContent.collectLatest { state ->
+            val account =
+                (state as? com.vitorpamplona.amethyst.ui.screen.AccountState.LoggedIn)?.account
+
+            if (account == null || !account.isWriteable()) {
+                // No account or read-only — close any existing subscriptions
+                Amethyst.instance.client.unsubscribe(subIdNotifications)
+                Amethyst.instance.client.unsubscribe(subIdGiftWraps)
+                return@collectLatest
+            }
+
+            // Reactively update subscriptions when relay lists change
+            combine(
+                account.notificationRelays.flow,
+                account.dmRelays.flow,
+            ) { notifRelays, dmRelays ->
+                Pair(notifRelays, dmRelays)
+            }.collectLatest { (notifRelays, dmRelays) ->
+                updateNotificationSubscription(account, notifRelays)
+                updateGiftWrapSubscription(account, dmRelays)
+            }
+        }
+    }
+
+    private fun updateNotificationSubscription(
+        account: Account,
+        relays: Set<NormalizedRelayUrl>,
+    ) {
+        if (relays.isEmpty()) {
+            Amethyst.instance.client.unsubscribe(subIdNotifications)
+            return
+        }
+
+        val pubkey = account.signer.pubKey
+        val since = TimeUtils.oneWeekAgo()
+        val filters = mutableMapOf<NormalizedRelayUrl, List<Filter>>()
+
+        relays.forEach { relay ->
+            val relayFilters =
+                (
+                    filterSummaryNotificationsToPubkey(relay, pubkey, since) +
+                        filterNotificationsToPubkey(relay, pubkey, since)
+                ).map { it.filter }
+
+            if (relayFilters.isNotEmpty()) {
+                filters[relay] = relayFilters
+            }
+        }
+
+        if (filters.isNotEmpty()) {
+            Amethyst.instance.client.subscribe(subIdNotifications, filters)
+            Log.d(TAG) { "Subscribed to notifications on ${filters.size} relays" }
+        }
+    }
+
+    private fun updateGiftWrapSubscription(
+        account: Account,
+        relays: Set<NormalizedRelayUrl>,
+    ) {
+        if (relays.isEmpty()) {
+            Amethyst.instance.client.unsubscribe(subIdGiftWraps)
+            return
+        }
+
+        val pubkey = account.signer.pubKey
+        val since = TimeUtils.oneWeekAgo()
+        val filters = mutableMapOf<NormalizedRelayUrl, List<Filter>>()
+
+        relays.forEach { relay ->
+            val relayFilters =
+                filterGiftWrapsToPubkey(relay, pubkey, since).map { it.filter }
+
+            if (relayFilters.isNotEmpty()) {
+                filters[relay] = relayFilters
+            }
+        }
+
+        if (filters.isNotEmpty()) {
+            Amethyst.instance.client.subscribe(subIdGiftWraps, filters)
+            Log.d(TAG) { "Subscribed to gift wraps on ${filters.size} DM relays" }
+        }
     }
 
     private fun updateNotification(connectedRelays: Int) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationRelayService.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationRelayService.kt
@@ -20,6 +20,8 @@
  */
 package com.vitorpamplona.amethyst.service.notifications
 
+import android.app.AlarmManager
+import android.app.ForegroundServiceStartNotAllowedException
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -30,6 +32,7 @@ import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
+import android.os.SystemClock
 import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
@@ -51,7 +54,6 @@ import kotlinx.coroutines.launch
  *
  * This service:
  * - Keeps the shared NostrClient alive by collecting the relayServices flow
- * - Adds notification-specific subscriptions on inbox relays
  * - Routes incoming events through EventNotificationConsumer
  * - Survives app backgrounding (connections stay open)
  * - Uses specialUse foreground service type (no Android 15 time limit)
@@ -60,6 +62,14 @@ import kotlinx.coroutines.launch
  * When the app is in the foreground, both the UI and this service are subscribers.
  * When the app backgrounds, UI subscriptions drop but this service's subscriptions
  * remain, keeping inbox relay connections alive. No reconnection needed.
+ *
+ * Auto-restart mechanisms (inspired by ntfy):
+ * - START_STICKY: Android restarts killed services
+ * - onTaskRemoved(): 1-second alarm restart when swiped from recents
+ * - onDestroy(): broadcast to AutoRestartReceiver for WorkManager restart
+ * - AlarmManager watchdog (external, ServiceWatchdogManager)
+ * - WorkManager catch-up (external, NotificationCatchUpWorker)
+ * - BOOT_COMPLETED + MY_PACKAGE_REPLACED receivers (external, BootCompletedReceiver)
  */
 class NotificationRelayService : Service() {
     companion object {
@@ -70,12 +80,18 @@ class NotificationRelayService : Service() {
         private const val ACTION_START = "com.vitorpamplona.amethyst.START_NOTIFICATION_SERVICE"
         private const val ACTION_STOP = "com.vitorpamplona.amethyst.STOP_NOTIFICATION_SERVICE"
 
+        const val ACTION_AUTO_RESTART = "com.vitorpamplona.amethyst.AUTO_RESTART_NOTIFICATION_SERVICE"
+
         fun start(context: Context) {
             val intent =
                 Intent(context, NotificationRelayService::class.java).apply {
                     action = ACTION_START
                 }
-            ContextCompat.startForegroundService(context, intent)
+            try {
+                ContextCompat.startForegroundService(context, intent)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to start foreground service", e)
+            }
         }
 
         fun stop(context: Context) {
@@ -86,9 +102,8 @@ class NotificationRelayService : Service() {
             context.startService(intent)
         }
 
-        fun isEnabled(context: Context): Boolean {
-            // Check if service should be enabled based on account settings
-            return try {
+        fun isEnabled(context: Context): Boolean =
+            try {
                 Amethyst.instance.sessionManager
                     .loggedInAccount()
                     ?.settings
@@ -97,12 +112,12 @@ class NotificationRelayService : Service() {
             } catch (e: Exception) {
                 false
             }
-        }
     }
 
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private var relayServiceCollectorJob: Job? = null
     private var connectedRelayCount = 0
+    private var foregroundStarted = false
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -110,6 +125,7 @@ class NotificationRelayService : Service() {
         super.onCreate()
         Log.d(TAG, "Service created")
         createNotificationChannel()
+        initializeForeground()
     }
 
     override fun onStartCommand(
@@ -126,25 +142,90 @@ class NotificationRelayService : Service() {
 
             else -> {
                 Log.d(TAG, "Starting service")
-                startForegroundWithNotification()
+                // Safety: also call startForeground from onStartCommand in case
+                // onCreate didn't complete before onStartCommand fired (ntfy #1520)
+                initializeForeground()
                 startRelayConnection()
             }
         }
         return START_STICKY
     }
 
-    private fun startForegroundWithNotification() {
-        val notification = buildNotification(0)
-        ServiceCompat.startForeground(
-            this,
-            NOTIFICATION_ID,
-            notification,
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
-            } else {
-                0
-            },
+    /**
+     * Called when the user swipes the app from recents. Some OEMs kill the
+     * foreground service at this point. Schedule an alarm to restart in 1 second.
+     */
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+        if (!isEnabled(this)) return
+
+        Log.d(TAG, "Task removed, scheduling restart alarm")
+        val restartIntent =
+            Intent(this, NotificationRelayService::class.java).apply {
+                action = ACTION_START
+            }
+        val pendingIntent =
+            PendingIntent.getService(
+                this,
+                2,
+                restartIntent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_ONE_SHOT,
+            )
+        val alarmManager = getSystemService(ALARM_SERVICE) as AlarmManager
+        alarmManager.set(
+            AlarmManager.ELAPSED_REALTIME,
+            SystemClock.elapsedRealtime() + 1000,
+            pendingIntent,
         )
+    }
+
+    /**
+     * Called when the service is being destroyed. Send a broadcast to
+     * AutoRestartReceiver which will enqueue a WorkManager task to restart.
+     * This catches kills that START_STICKY might miss.
+     */
+    override fun onDestroy() {
+        Log.d(TAG, "Service destroyed")
+        relayServiceCollectorJob?.cancel()
+        scope.cancel()
+
+        if (isEnabled(this)) {
+            Log.d(TAG, "Broadcasting auto-restart request")
+            val intent =
+                Intent(this, AutoRestartReceiver::class.java).apply {
+                    action = ACTION_AUTO_RESTART
+                }
+            sendBroadcast(intent)
+        }
+
+        super.onDestroy()
+    }
+
+    private fun initializeForeground() {
+        if (foregroundStarted) return
+        try {
+            val notification = buildNotification(0)
+            ServiceCompat.startForeground(
+                this,
+                NOTIFICATION_ID,
+                notification,
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+                } else {
+                    0
+                },
+            )
+            foregroundStarted = true
+        } catch (e: Exception) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+                e is ForegroundServiceStartNotAllowedException
+            ) {
+                Log.w(TAG, "Foreground service start not allowed, stopping self")
+                stopSelf()
+            } else {
+                Log.e(TAG, "Failed to start foreground", e)
+            }
+        }
     }
 
     private fun startRelayConnection() {
@@ -156,7 +237,7 @@ class NotificationRelayService : Service() {
                 // By collecting it here, relay connections survive app backgrounding.
                 launch {
                     Amethyst.instance.relayProxyClientConnector.relayServices.collectLatest {
-                        Log.d(TAG, "Relay services state updated: $it")
+                        Log.d(TAG) { "Relay services state updated: $it" }
                     }
                 }
 
@@ -237,12 +318,5 @@ class NotificationRelayService : Service() {
             }
         val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.createNotificationChannel(channel)
-    }
-
-    override fun onDestroy() {
-        Log.d(TAG, "Service destroyed")
-        relayServiceCollectorJob?.cancel()
-        scope.cancel()
-        super.onDestroy()
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/ServiceWatchdogManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/ServiceWatchdogManager.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.notifications
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.SystemClock
+import com.vitorpamplona.quartz.utils.Log
+
+/**
+ * Uses AlarmManager to periodically check if the NotificationRelayService is still alive
+ * and restart it if needed.
+ *
+ * This serves as a watchdog: OEM battery optimizations (Xiaomi MIUI, Huawei EMUI,
+ * Samsung One UI) may kill the foreground service despite it being "foreground".
+ * The alarm fires every 5 minutes and checks if the service should be running.
+ */
+class ServiceWatchdogManager {
+    companion object {
+        private const val TAG = "ServiceWatchdogManager"
+        private const val WATCHDOG_INTERVAL_MS = 5 * 60 * 1000L // 5 minutes
+
+        fun schedule(context: Context) {
+            val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+            val intent = Intent(context, WatchdogReceiver::class.java)
+            val pendingIntent =
+                PendingIntent.getBroadcast(
+                    context,
+                    0,
+                    intent,
+                    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+                )
+
+            alarmManager.setInexactRepeating(
+                AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                SystemClock.elapsedRealtime() + WATCHDOG_INTERVAL_MS,
+                WATCHDOG_INTERVAL_MS,
+                pendingIntent,
+            )
+            Log.d(TAG, "Watchdog alarm scheduled")
+        }
+
+        fun cancel(context: Context) {
+            val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+            val intent = Intent(context, WatchdogReceiver::class.java)
+            val pendingIntent =
+                PendingIntent.getBroadcast(
+                    context,
+                    0,
+                    intent,
+                    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_NO_CREATE,
+                )
+            if (pendingIntent != null) {
+                alarmManager.cancel(pendingIntent)
+                Log.d(TAG, "Watchdog alarm cancelled")
+            }
+        }
+    }
+
+    class WatchdogReceiver : BroadcastReceiver() {
+        override fun onReceive(
+            context: Context,
+            intent: Intent?,
+        ) {
+            Log.d(TAG, "Watchdog fired, checking service state")
+            if (NotificationRelayService.isEnabled(context)) {
+                NotificationRelayService.start(context)
+            }
+        }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/datasource/ChatroomListFilterAssemblerSubscription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/datasource/ChatroomListFilterAssemblerSubscription.kt
@@ -22,7 +22,7 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.datasource
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.KeyDataSourceSubscription
+import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.LifecycleAwareKeyDataSourceSubscription
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
 @Composable
@@ -45,5 +45,5 @@ fun ChatroomListFilterAssemblerSubscription(
             ChatroomListState(accountViewModel.account)
         }
 
-    KeyDataSourceSubscription(state, dataSource)
+    LifecycleAwareKeyDataSourceSubscription(state, dataSource)
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/datasource/DiscoveryFilterAssemblerSubscription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/datasource/DiscoveryFilterAssemblerSubscription.kt
@@ -23,7 +23,7 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.discover.datasource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.lifecycle.viewModelScope
-import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.KeyDataSourceSubscription
+import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.LifecycleAwareKeyDataSourceSubscription
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
 @Composable
@@ -46,5 +46,5 @@ fun DiscoveryFilterAssemblerSubscription(
             DiscoveryQueryState(accountViewModel.account, accountViewModel.feedStates, accountViewModel.viewModelScope)
         }
 
-    KeyDataSourceSubscription(state, dataSource)
+    LifecycleAwareKeyDataSourceSubscription(state, dataSource)
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/datasource/HomeFilterAssemblerSubscription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/datasource/HomeFilterAssemblerSubscription.kt
@@ -23,7 +23,7 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.lifecycle.viewModelScope
-import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.KeyDataSourceSubscription
+import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.LifecycleAwareKeyDataSourceSubscription
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
 @Composable
@@ -50,5 +50,5 @@ fun HomeFilterAssemblerSubscription(
             )
         }
 
-    KeyDataSourceSubscription(state, dataSource)
+    LifecycleAwareKeyDataSourceSubscription(state, dataSource)
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
@@ -31,6 +31,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
@@ -43,6 +46,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -60,6 +64,7 @@ import com.vitorpamplona.amethyst.model.parseConnectivityType
 import com.vitorpamplona.amethyst.model.parseFeatureSetType
 import com.vitorpamplona.amethyst.model.parseGalleryType
 import com.vitorpamplona.amethyst.model.parseThemeType
+import com.vitorpamplona.amethyst.service.notifications.BatteryOptimizationHelper
 import com.vitorpamplona.amethyst.ui.components.PushNotificationSettingsRow
 import com.vitorpamplona.amethyst.ui.components.TextSpinner
 import com.vitorpamplona.amethyst.ui.components.TitleExplainer
@@ -519,5 +524,52 @@ fun AlwaysOnNotificationServiceChoice(accountViewModel: AccountViewModel) {
                 accountViewModel.account.settings.toggleAlwaysOnNotificationService()
             },
         )
+    }
+
+    if (enabled) {
+        BatteryOptimizationBanner()
+    }
+}
+
+@Composable
+fun BatteryOptimizationBanner() {
+    val context = LocalContext.current
+    val isExempt =
+        remember {
+            BatteryOptimizationHelper.isIgnoringBatteryOptimizations(context)
+        }
+
+    if (!isExempt) {
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors =
+                CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                ),
+        ) {
+            Column(
+                modifier = Modifier.padding(12.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(
+                    text = stringRes(R.string.battery_optimization_title),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                )
+                Text(
+                    text = stringRes(R.string.battery_optimization_description),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                )
+                Button(
+                    onClick = {
+                        BatteryOptimizationHelper.requestBatteryOptimizationExemption(context)
+                    },
+                ) {
+                    Text(stringRes(R.string.battery_optimization_fix_now))
+                }
+            }
+        }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -47,6 +48,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.os.LocaleListCompat
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.ConnectivityType
 import com.vitorpamplona.amethyst.model.FeatureSetType
@@ -89,7 +91,7 @@ fun SettingsScreen(
         },
     ) {
         Column(Modifier.padding(it)) {
-            SettingsScreen(accountViewModel.settings.uiSettingsFlow)
+            SettingsScreen(accountViewModel.settings.uiSettingsFlow, accountViewModel)
         }
     }
 }
@@ -103,7 +105,10 @@ fun SettingsScreenPreview() {
 }
 
 @Composable
-fun SettingsScreen(sharedPrefs: UiSettingsFlow) {
+fun SettingsScreen(
+    sharedPrefs: UiSettingsFlow,
+    accountViewModel: AccountViewModel? = null,
+) {
     Column(
         Modifier
             .fillMaxSize()
@@ -124,6 +129,9 @@ fun SettingsScreen(sharedPrefs: UiSettingsFlow) {
         GalleryChoice(sharedPrefs)
         AiWritingHelpChoice(sharedPrefs)
         PushNotificationSettingsRow(sharedPrefs)
+        if (accountViewModel != null) {
+            AlwaysOnNotificationServiceChoice(accountViewModel)
+        }
     }
 }
 
@@ -493,5 +501,23 @@ fun SettingsRow(
                 overflow = TextOverflow.Ellipsis,
             )
         }
+    }
+}
+
+@Composable
+fun AlwaysOnNotificationServiceChoice(accountViewModel: AccountViewModel) {
+    val enabled by accountViewModel.account.settings.alwaysOnNotificationService
+        .collectAsStateWithLifecycle()
+
+    SettingsRow(
+        R.string.always_on_notif_setting_title,
+        R.string.always_on_notif_setting_description,
+    ) {
+        Switch(
+            checked = enabled,
+            onCheckedChange = {
+                accountViewModel.account.settings.toggleAlwaysOnNotificationService()
+            },
+        )
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/datasource/VideoFilterAssemblerSubscription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/datasource/VideoFilterAssemblerSubscription.kt
@@ -23,7 +23,7 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.video.datasource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.lifecycle.viewModelScope
-import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.KeyDataSourceSubscription
+import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.LifecycleAwareKeyDataSourceSubscription
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
 @Composable
@@ -46,5 +46,5 @@ fun VideoFilterAssemblerSubscription(
             VideoQueryState(accountViewModel.account, accountViewModel.feedStates, accountViewModel.viewModelScope)
         }
 
-    KeyDataSourceSubscription(state, filterAssembler)
+    LifecycleAwareKeyDataSourceSubscription(state, filterAssembler)
 }

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -920,6 +920,15 @@
     <string name="call_settings_turn_username">Username</string>
     <string name="call_settings_turn_credential">Credential</string>
 
+    <string name="always_on_notif_channel_name" translatable="false">Relay Connection Service</string>
+    <string name="always_on_notif_channel_description">Keeps connections to your inbox relays active for real-time notifications</string>
+    <string name="always_on_notif_title">Amethyst Notifications Active</string>
+    <string name="always_on_notif_connected">Connected to %1$d inbox relays</string>
+    <string name="always_on_notif_connecting">Connecting to inbox relays\u2026</string>
+    <string name="always_on_notif_stop">Pause</string>
+    <string name="always_on_notif_setting_title">Always-on notification service</string>
+    <string name="always_on_notif_setting_description">Keeps a persistent connection to your inbox relays for instant notification delivery. Shows an ongoing notification. Uses more battery but ensures you never miss a message.</string>
+
     <string name="reply_notify">Notify: </string>
 
     <string name="channel_list_join_conversation">Join Conversation</string>

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -929,6 +929,10 @@
     <string name="always_on_notif_setting_title">Always-on notification service</string>
     <string name="always_on_notif_setting_description">Keeps a persistent connection to your inbox relays for instant notification delivery. Shows an ongoing notification. Uses more battery but ensures you never miss a message.</string>
 
+    <string name="battery_optimization_title">Battery optimization active</string>
+    <string name="battery_optimization_description">Android may restrict relay connections in the background. Disable battery optimization for Amethyst to ensure reliable notifications.</string>
+    <string name="battery_optimization_fix_now">Fix now</string>
+
     <string name="reply_notify">Notify: </string>
 
     <string name="channel_list_join_conversation">Join Conversation</string>

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/subscriptions/LifecycleAwareKeyDataSourceSubscription.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/subscriptions/LifecycleAwareKeyDataSourceSubscription.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.relayClient.subscriptions
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.vitorpamplona.amethyst.commons.relayClient.composeSubscriptionManagers.ComposeSubscriptionManager
+
+/**
+ * A lifecycle-aware version of [KeyDataSourceSubscription] that subscribes
+ * when the lifecycle reaches STARTED and unsubscribes when it reaches STOPPED.
+ *
+ * Use this for heavy feed subscriptions (home, video, discovery, chatroom list)
+ * that should NOT run when the app is in the background. When an always-on
+ * notification service keeps the relay client connected, these subscriptions
+ * would otherwise leak bandwidth on feeds nobody is viewing.
+ *
+ * Lightweight subscriptions that should always run (account metadata, notifications,
+ * gift wraps) should continue using the regular [KeyDataSourceSubscription].
+ */
+@Composable
+fun <T> LifecycleAwareKeyDataSourceSubscription(
+    state: T,
+    dataSource: ComposeSubscriptionManager<T>,
+) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    var isStarted by remember { mutableStateOf(false) }
+
+    DisposableEffect(state, lifecycleOwner) {
+        val observer =
+            LifecycleEventObserver { _, event ->
+                when (event) {
+                    Lifecycle.Event.ON_START -> {
+                        if (!isStarted) {
+                            dataSource.subscribe(state)
+                            isStarted = true
+                        }
+                    }
+
+                    Lifecycle.Event.ON_STOP -> {
+                        if (isStarted) {
+                            dataSource.unsubscribe(state)
+                            isStarted = false
+                        }
+                    }
+
+                    else -> {}
+                }
+            }
+
+        lifecycleOwner.lifecycle.addObserver(observer)
+
+        // If already started (e.g., recomposition while visible), subscribe immediately
+        if (lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+            dataSource.subscribe(state)
+            isStarted = true
+        }
+
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+            if (isStarted) {
+                dataSource.unsubscribe(state)
+                isStarted = false
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -71,6 +71,7 @@ commonsImaging = "1.0.0-alpha6"
 zxing = "3.5.4"
 zxingAndroidEmbedded = "4.3.0"
 windowCoreAndroid = "1.5.1"
+workRuntime = "2.10.1"
 androidxCamera = "1.6.0"
 androidxCollection = "1.6.0"
 androidxExifinterface = "1.4.2"
@@ -190,6 +191,7 @@ androidx-core = { group = "androidx.test", name = "core", version.ref = "core" }
 androidx-sqlite = { group = "androidx.sqlite", name = "sqlite", version.ref = "sqlite" }
 androidx-sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version.ref = "sqlite" }
 androidx-sqlite-bundled-jvm = { module = "androidx.sqlite:sqlite-bundled-jvm", version.ref = "sqlite" }
+androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workRuntime" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
Implements a comprehensive always-on notification system that maintains persistent WebSocket connections to the user's inbox relays, enabling real-time delivery of direct messages, zaps, and mentions even when the app is backgrounded.

## Key Changes

### New Services & Components
- **NotificationRelayService**: Foreground service that keeps inbox relay connections alive by collecting the shared NostrClient's relayServices flow. Uses Android 15's `specialUse` foreground service type to avoid time limits.
- **NotificationCatchUpWorker**: WorkManager periodic task (15-minute intervals) that acts as a safety net to restore connections if the foreground service is killed by OEM battery optimizers.
- **ServiceWatchdogManager**: AlarmManager-based watchdog that checks every 5 minutes if the service should be running and restarts it if needed.
- **BootCompletedReceiver**: Restarts the notification service after device reboot.
- **AlwaysOnNotificationServiceManager**: Orchestrates all five layers of the notification system, watching the account's `alwaysOnNotificationService` setting and enabling/disabling all components accordingly.

### UI Updates
- Added toggle switch in AppSettingsScreen to enable/disable the always-on notification service
- New setting stored in AccountSettings with persistent state management

### Manifest & Permissions
- Added `FOREGROUND_SERVICE_SPECIAL_USE` permission
- Added `RECEIVE_BOOT_COMPLETED` permission
- Registered NotificationRelayService with `specialUse` foreground service type
- Registered BootCompletedReceiver and WatchdogReceiver broadcast receivers
- Added special use property describing the service's purpose

### Configuration
- Added WorkManager dependency (`androidx.work.runtime.ktx`)
- New notification channel for the relay service with low importance

## Implementation Details
- The service shares the same NostrClient instance as the UI, so when the app backgrounds, UI subscriptions drop but the service's subscriptions remain, keeping connections alive without reconnection overhead.
- Uses coroutine flows to monitor relay connection state and update the foreground notification with connected relay count.
- Notification includes action button to stop the service and tap-to-open action to return to the app.
- All components respect the user's setting and can be toggled on/off in real-time.

https://claude.ai/code/session_01LEPfmgGnwjB9a5SDFw5U8t