### PR TITLE
Suppress deprecation warnings and improve code quality

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ allprojects {
                 target 'src/**/*.kt'
 
                 ktlint()
-                licenseHeaderFile rootProject.file('.spotless/copyright.kt'), "package|import|class|object|sealed|open|interface|abstract "
+                licenseHeaderFile rootProject.file('.spotless/copyright.kt'), "@file:|package|import|class|object|sealed|open|interface|abstract "
             }
 
             groovyGradle {

--- a/quartz/src/androidMain/kotlin/com/vitorpamplona/quartz/nip55AndroidSigner/client/NostrSignerExternal.kt
+++ b/quartz/src/androidMain/kotlin/com/vitorpamplona/quartz/nip55AndroidSigner/client/NostrSignerExternal.kt
@@ -83,6 +83,7 @@ class NostrSignerExternal(
         val result = backgroundQuery.sign(unsignedEvent) ?: foregroundQuery.sign(unsignedEvent)
 
         if (result is SignerResult.RequestAddressed.Successful<SignResult>) {
+            @Suppress("UNCHECKED_CAST")
             (result.result.event as? T)?.let {
                 return it
             }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/profileGallery/GalleryListEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/profileGallery/GalleryListEvent.kt
@@ -38,6 +38,7 @@ class GalleryListEvent(
     content: String,
     sig: HexKey,
 ) : PrivateTagArrayEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+    @Suppress("DEPRECATION")
     companion object {
         const val KIND = 10011
         const val ALT = "Profile Gallery"

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip19Bech32/entities/NNote.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip19Bech32/entities/NNote.kt
@@ -36,6 +36,7 @@ data class NNote(
             return NNote(bytes.toHexKey())
         }
 
+        @Suppress("DEPRECATION")
         fun create(eventId: HexKey): String = eventId.hexToByteArray().toNote()
     }
 }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip34Git/reply/GitReplyEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip34Git/reply/GitReplyEvent.kt
@@ -115,6 +115,7 @@ class GitReplyEvent(
 
     fun rootIssueOrPatch() = tags.lastNotNullOfOrNull(MarkedETag::parseRootId)
 
+    @Suppress("DEPRECATION")
     companion object {
         const val KIND = 1622
         const val ALT_DESCRIPTION = "A Git Reply"

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip34Git/reply/TagArrayBuilderExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip34Git/reply/TagArrayBuilderExt.kt
@@ -32,12 +32,17 @@ import com.vitorpamplona.quartz.nip34Git.issue.GitIssueEvent
 import com.vitorpamplona.quartz.nip34Git.patch.GitPatchEvent
 import com.vitorpamplona.quartz.nip34Git.repository.GitRepositoryEvent
 
+@Suppress("DEPRECATION")
 fun TagArrayBuilder<GitReplyEvent>.repository(rep: ATag) = addUnique(rep.toATagArray())
 
+@Suppress("DEPRECATION")
 fun TagArrayBuilder<GitReplyEvent>.repository(rep: EventHintBundle<GitRepositoryEvent>) = addUnique(rep.toATag().toATagArray())
 
+@Suppress("DEPRECATION")
 fun TagArrayBuilder<GitReplyEvent>.patch(rep: EventHintBundle<GitPatchEvent>) = addUnique(rep.toMarkedETag(MarkedETag.MARKER.ROOT).toTagArray())
 
+@Suppress("DEPRECATION")
 fun TagArrayBuilder<GitReplyEvent>.issue(rep: EventHintBundle<GitIssueEvent>) = addUnique(rep.toMarkedETag(MarkedETag.MARKER.ROOT).toTagArray())
 
+@Suppress("DEPRECATION")
 fun TagArrayBuilder<GitReplyEvent>.notify(list: List<PTag>) = pTags(list)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip35Torrents/TorrentCommentEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip35Torrents/TorrentCommentEvent.kt
@@ -111,6 +111,7 @@ class TorrentCommentEvent(
 
     fun torrentIds() = tags.firstNotNullOfOrNull(MarkedETag::parseRootId) ?: tags.firstNotNullOfOrNull(ETag::parseId)
 
+    @Suppress("DEPRECATION")
     companion object {
         const val KIND = 2004
         const val ALT_DESCRIPTION = "Comment for a Torrent file"

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip44Encryption/crypto/ChaCha20Core.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip44Encryption/crypto/ChaCha20Core.kt
@@ -32,10 +32,10 @@ package com.vitorpamplona.quartz.nip44Encryption.crypto
  */
 object ChaCha20Core {
     // "expand 32-byte k" as little-endian integers
-    private const val SIGMA0 = 0x61707865.toInt()
-    private const val SIGMA1 = 0x3320646e.toInt()
-    private const val SIGMA2 = 0x79622d32.toInt()
-    private const val SIGMA3 = 0x6b206574.toInt()
+    private const val SIGMA0 = 0x61707865
+    private const val SIGMA1 = 0x3320646e
+    private const val SIGMA2 = 0x79622d32
+    private const val SIGMA3 = 0x6b206574
 
     /**
      * ChaCha20 quarter round (RFC 8439 §2.1).

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip46RemoteSigner/signer/NostrSignerRemote.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip46RemoteSigner/signer/NostrSignerRemote.kt
@@ -118,6 +118,7 @@ class NostrSignerRemote(
             )
 
         if (result is SignerResult.RequestAddressed.Successful<SignResult>) {
+            @Suppress("UNCHECKED_CAST")
             (result.result.event as? T)?.let {
                 return it
             }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/labeledBookmarkList/LabeledBookmarkListEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/labeledBookmarkList/LabeledBookmarkListEvent.kt
@@ -73,6 +73,7 @@ class LabeledBookmarkListEvent(
 
     fun title() = tags.firstNotNullOfOrNull(TitleTag::parse)
 
+    @Suppress("DEPRECATION")
     fun titleOrName() = title() ?: name()
 
     fun description() = tags.firstNotNullOfOrNull(DescriptionTag::parse)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/peopleList/PeopleListEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/peopleList/PeopleListEvent.kt
@@ -64,6 +64,7 @@ class PeopleListEvent(
     @Deprecated("NIP-51 has deprecated name. Use title instead", ReplaceWith("title()"))
     fun name() = tags.firstNotNullOfOrNull(NameTag::parse)
 
+    @Suppress("DEPRECATION")
     fun titleOrName() = title() ?: name()
 
     fun title() = tags.firstNotNullOfOrNull(TitleTag::parse)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip56Reports/ReportEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip56Reports/ReportEvent.kt
@@ -18,6 +18,8 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+@file:Suppress("DEPRECATION")
+
 package com.vitorpamplona.quartz.nip56Reports
 
 import androidx.compose.runtime.Immutable

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/utils/EventFactory.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/utils/EventFactory.kt
@@ -18,6 +18,8 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+@file:Suppress("DEPRECATION", "UNCHECKED_CAST")
+
 package com.vitorpamplona.quartz.utils
 
 import com.vitorpamplona.quartz.experimental.attestations.attestation.AttestationEvent

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip96FileStorage/info/ServerInfoParser.jvmAndroid.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip96FileStorage/info/ServerInfoParser.jvmAndroid.kt
@@ -21,7 +21,6 @@
 package com.vitorpamplona.quartz.nip96FileStorage.info
 
 import java.net.URI
-import java.net.URL
 
 actual fun makeAbsoluteIfRelativeUrl(
     baseUrl: String,
@@ -32,7 +31,7 @@ actual fun makeAbsoluteIfRelativeUrl(
         if (apiUrl.isAbsolute) {
             potentiallyRelativeUrl
         } else {
-            URL(URL(baseUrl), potentiallyRelativeUrl).toString()
+            URI(baseUrl).resolve(potentiallyRelativeUrl).toString()
         }
     } catch (e: Exception) {
         potentiallyRelativeUrl


### PR DESCRIPTION
## Summary
This PR addresses deprecation warnings throughout the codebase by adding appropriate `@Suppress` annotations and makes several code quality improvements including simplifying numeric literals and replacing deprecated APIs.

## Key Changes

- **Deprecation Suppression**: Added `@Suppress("DEPRECATION")` annotations to multiple files that use deprecated APIs:
  - `TagArrayBuilderExt.kt`: Suppressed for all extension functions using deprecated tag builders
  - `ReportEvent.kt`: File-level suppression for deprecated event types
  - `EventFactory.kt`: File-level suppression for deprecated APIs and unchecked casts
  - `GalleryListEvent.kt`, `NNote.kt`, `GitReplyEvent.kt`, `TorrentCommentEvent.kt`, `PeopleListEvent.kt`, `LabeledBookmarkListEvent.kt`: Companion object and function-level suppressions
  - `NostrSignerExternal.kt` and `NostrSignerRemote.kt`: Inline suppressions for unchecked casts

- **Numeric Literal Simplification**: Removed unnecessary `.toInt()` calls from hexadecimal constants in `ChaCha20Core.kt` (SIGMA0-3), as Kotlin infers the correct type automatically

- **API Modernization**: Replaced deprecated `java.net.URL` constructor with `java.net.URI.resolve()` in `ServerInfoParser.jvmAndroid.kt` for better URL resolution

- **Build Configuration**: Updated Spotless license header pattern in `build.gradle` to recognize `@file:` annotations, ensuring proper license header placement in files with file-level annotations

## Implementation Details
The changes maintain backward compatibility while cleaning up compiler warnings. The deprecation suppressions are scoped appropriately—either at the file level for widespread usage or at the function/expression level for isolated cases. This allows the codebase to continue using these APIs while acknowledging their deprecated status.

https://claude.ai/code/session_01EwS56YAGGnnac5EuwhaUSs