### PR TITLE
Migrate clipboard API from deprecated LocalClipboardManager to Clipboard

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/InformationDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/InformationDialog.kt
@@ -38,17 +38,19 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.ui.components.toasts.ThrowableToastMsg
 import com.vitorpamplona.amethyst.ui.components.toasts.ThrowableToastMsg2
+import com.vitorpamplona.amethyst.ui.components.util.setPlainText
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.Size16dp
 import com.vitorpamplona.amethyst.ui.theme.StdHorzSpacer
+import kotlinx.coroutines.launch
 import java.io.PrintWriter
 import java.io.StringWriter
 
@@ -119,9 +121,10 @@ fun InformationDialog(
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 moreInfo?.let {
-                    val clipboardManager = LocalClipboardManager.current
+                    val clipboardManager = LocalClipboard.current
+                    val scope = rememberCoroutineScope()
                     TextButton(onClick = {
-                        clipboardManager.setText(AnnotatedString(it))
+                        scope.launch { clipboardManager.setPlainText(it) }
                     }) {
                         Text(stringRes(R.string.copy_stack_to_clipboard))
                     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/CashuRedeem.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/CashuRedeem.kt
@@ -40,13 +40,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -59,6 +59,7 @@ import com.vitorpamplona.amethyst.commons.hashtags.CustomHashTagIcons
 import com.vitorpamplona.amethyst.service.cashu.CachedCashuParser
 import com.vitorpamplona.amethyst.service.cashu.CashuToken
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
+import com.vitorpamplona.amethyst.ui.components.util.setPlainText
 import com.vitorpamplona.amethyst.ui.note.CopyIcon
 import com.vitorpamplona.amethyst.ui.note.OpenInNewIcon
 import com.vitorpamplona.amethyst.ui.note.ZapIcon
@@ -73,6 +74,7 @@ import com.vitorpamplona.amethyst.ui.theme.ThemeComparisonColumn
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 @Composable
@@ -142,7 +144,8 @@ fun CashuPreviewNew(
     toast: (String, String) -> Unit,
 ) {
     val context = LocalContext.current
-    val clipboardManager = LocalClipboardManager.current
+    val clipboardManager = LocalClipboard.current
+    val scope = rememberCoroutineScope()
 
     Card(
         modifier = CashuCardBorders,
@@ -234,7 +237,7 @@ fun CashuPreviewNew(
                 FilledTonalButton(
                     onClick = {
                         // Copying the token to clipboard
-                        clipboardManager.setText(AnnotatedString(token.token))
+                        scope.launch { clipboardManager.setPlainText(token.token) }
                     },
                     shape = SmallishBorder,
                     contentPadding = PaddingValues(0.dp),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ClickableRelayUrl.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ClickableRelayUrl.kt
@@ -25,24 +25,27 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.style.TextOverflow
+import com.vitorpamplona.amethyst.ui.components.util.setPlainText
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
+import kotlinx.coroutines.launch
 
 @Composable
 fun ClickableRelayUrl(
     relayUrl: String,
     nav: INav,
 ) {
-    val clipboardManager = LocalClipboardManager.current
+    val clipboardManager = LocalClipboard.current
+    val scope = rememberCoroutineScope()
     val clickableModifier =
         remember(relayUrl) {
             Modifier
                 .combinedClickable(
-                    onLongClick = { clipboardManager.setText(AnnotatedString(relayUrl)) },
+                    onLongClick = { scope.launch { clipboardManager.setPlainText(relayUrl) } },
                     onClick = { nav.nav(Route.RelayInfo(relayUrl)) },
                 )
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/UrlPreviewCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/UrlPreviewCard.kt
@@ -31,20 +31,22 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import coil3.compose.AsyncImage
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.preview.UrlInfoItem
+import com.vitorpamplona.amethyst.ui.components.util.setPlainText
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.DoubleVertSpacer
 import com.vitorpamplona.amethyst.ui.theme.MaxWidthWithHorzPadding
 import com.vitorpamplona.amethyst.ui.theme.innerPostModifier
 import com.vitorpamplona.amethyst.ui.theme.previewCardImageModifier
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -59,7 +61,8 @@ fun UrlPreviewCard(
         }
 
     if (popupExpanded.value) {
-        val clipboardManager = LocalClipboardManager.current
+        val clipboardManager = LocalClipboard.current
+        val scope = rememberCoroutineScope()
         M3ActionDialog(
             title = stringRes(R.string.link_actions_dialog_title),
             onDismiss = { popupExpanded.value = false },
@@ -69,7 +72,7 @@ fun UrlPreviewCard(
                     icon = Icons.Outlined.ContentCopy,
                     text = stringRes(R.string.copy_url_to_clipboard),
                 ) {
-                    clipboardManager.setText(AnnotatedString(url))
+                    scope.launch { clipboardManager.setPlainText(url) }
                     popupExpanded.value = false
                 }
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
@@ -59,10 +59,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
@@ -90,6 +89,7 @@ import com.vitorpamplona.amethyst.service.playback.composable.VideoView
 import com.vitorpamplona.amethyst.service.uploads.blossom.bud10.openBlossomUriAsIntent
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.actions.InformationDialog
+import com.vitorpamplona.amethyst.ui.components.util.setPlainText
 import com.vitorpamplona.amethyst.ui.note.BlankNote
 import com.vitorpamplona.amethyst.ui.note.DownloadForOfflineIcon
 import com.vitorpamplona.amethyst.ui.painterRes
@@ -771,20 +771,20 @@ fun ShareMediaAction(
             title = stringRes(R.string.media_actions_dialog_title),
             onDismiss = { if (!isDownloadingVideo.value) onDismiss() },
         ) {
-            val clipboardManager = LocalClipboardManager.current
+            val clipboardManager = LocalClipboard.current
 
             // Copy & Gallery section
             if ((videoUri != null && !videoUri.startsWith("file")) || postNostrUri != null) {
                 M3ActionSection {
                     if (videoUri != null && !videoUri.startsWith("file")) {
                         M3ActionRow(icon = Icons.Outlined.Link, text = stringRes(R.string.copy_url_to_clipboard)) {
-                            clipboardManager.setText(AnnotatedString(videoUri))
+                            scope.launch { clipboardManager.setPlainText(videoUri) }
                             onDismiss()
                         }
                     }
                     postNostrUri?.let {
                         M3ActionRow(icon = Icons.Outlined.ContentCopy, text = stringRes(R.string.copy_the_note_id_to_the_clipboard)) {
-                            clipboardManager.setText(AnnotatedString(it))
+                            scope.launch { clipboardManager.setPlainText(it) }
                             onDismiss()
                         }
                         M3ActionRow(icon = Icons.Outlined.Collections, text = stringRes(R.string.add_media_to_gallery)) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/util/ClipboardExt.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/util/ClipboardExt.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.components.util
+
+import android.content.ClipData
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.Clipboard
+
+suspend fun Clipboard.setPlainText(text: String) {
+    setClipEntry(ClipEntry(ClipData.newPlainText("", text)))
+}
+
+suspend fun Clipboard.getPlainText(): String? =
+    getClipEntry()
+        ?.clipData
+        ?.getItemAt(0)
+        ?.text
+        ?.toString()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteQuickActionMenu.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteQuickActionMenu.kt
@@ -67,10 +67,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -80,6 +79,7 @@ import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.AddressableNote
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
+import com.vitorpamplona.amethyst.ui.components.util.setPlainText
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.routeEditDraftTo
 import com.vitorpamplona.amethyst.ui.painterRes
@@ -265,7 +265,7 @@ fun CardBody(
 ) {
     val context = LocalContext.current
     val primaryLight = lightenColor(MaterialTheme.colorScheme.primary, 0.1f)
-    val clipboardManager = LocalClipboardManager.current
+    val clipboardManager = LocalClipboard.current
     val scope = rememberCoroutineScope()
 
     val showToast = { stringRes: Int ->
@@ -289,7 +289,7 @@ fun CardBody(
                 label = stringRes(R.string.quick_action_copy_text),
             ) {
                 accountViewModel.decrypt(note) {
-                    clipboardManager.setText(AnnotatedString(it))
+                    scope.launch { clipboardManager.setPlainText(it) }
                     showToast(R.string.copied_note_text_to_clipboard)
                 }
 
@@ -302,7 +302,7 @@ fun CardBody(
             ) {
                 note.author?.let {
                     scope.launch {
-                        clipboardManager.setText(AnnotatedString(it.toNostrUri()))
+                        clipboardManager.setPlainText(it.toNostrUri())
                         showToast(R.string.copied_user_id_to_clipboard)
                         onDismiss()
                     }
@@ -314,7 +314,7 @@ fun CardBody(
                 stringRes(R.string.quick_action_copy_note_id),
             ) {
                 scope.launch {
-                    clipboardManager.setText(AnnotatedString(note.toNostrUri()))
+                    clipboardManager.setPlainText(note.toNostrUri())
                     showToast(R.string.copied_note_id_to_clipboard)
                     onDismiss()
                 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/RelayListRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/RelayListRow.kt
@@ -39,11 +39,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -54,6 +54,7 @@ import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.nip11RelayInfo.loadRelayInfo
 import com.vitorpamplona.amethyst.ui.components.ClickableBox
 import com.vitorpamplona.amethyst.ui.components.RobohashFallbackAsyncImage
+import com.vitorpamplona.amethyst.ui.components.util.setPlainText
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -71,6 +72,7 @@ import com.vitorpamplona.amethyst.ui.theme.relayIconModifier
 import com.vitorpamplona.amethyst.ui.theme.ripple24dp
 import com.vitorpamplona.amethyst.ui.theme.warningColorOnSecondSurface
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import kotlinx.coroutines.launch
 
 private const val DAMUS_RELAY_URL = "wss://relay.damus.io"
 
@@ -129,7 +131,8 @@ fun RenderRelay(
 ) {
     val relayInfo by loadRelayInfo(relay)
 
-    val clipboardManager = LocalClipboardManager.current
+    val clipboardManager = LocalClipboard.current
+    val scope = rememberCoroutineScope()
     val clickableModifier =
         remember(relay) {
             Modifier
@@ -138,7 +141,7 @@ fun RenderRelay(
                     indication = ripple24dp,
                     interactionSource = MutableInteractionSource(),
                     onLongClick = {
-                        clipboardManager.setText(AnnotatedString(relay.url))
+                        scope.launch { clipboardManager.setPlainText(relay.url) }
                     },
                     onClick = { nav.nav(Route.RelayInfo(relay.url)) },
                 )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/UpdateZapAmountDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/UpdateZapAmountDialog.kt
@@ -84,11 +84,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.input.ImeAction
@@ -102,6 +103,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.ui.components.TextSpinner
 import com.vitorpamplona.amethyst.ui.components.TitleExplainer
+import com.vitorpamplona.amethyst.ui.components.util.getPlainText
 import com.vitorpamplona.amethyst.ui.painterRes
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.keyBackup.getFragmentActivity
@@ -120,6 +122,7 @@ import com.vitorpamplona.amethyst.ui.theme.ThemeComparisonRow
 import com.vitorpamplona.amethyst.ui.theme.placeholderText
 import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -147,7 +150,8 @@ fun UpdateZapAmountContent(
     accountViewModel: AccountViewModel,
 ) {
     val context = LocalContext.current
-    val clipboardManager = LocalClipboardManager.current
+    val clipboardManager = LocalClipboard.current
+    val scope = rememberCoroutineScope()
     val uri = LocalUriHandler.current
 
     val zapTypes =
@@ -443,15 +447,17 @@ fun UpdateZapAmountContent(
             // Paste from clipboard
             IconButton(
                 onClick = {
-                    val clipText = clipboardManager.getText()?.text
-                    try {
-                        clipText?.let { postViewModel.copyFromClipboard(it) }
-                    } catch (e: IllegalArgumentException) {
-                        accountViewModel.toastManager.toast(
-                            R.string.invalid_nip47_uri_title,
-                            R.string.invalid_nip47_uri_description,
-                            clipText ?: "",
-                        )
+                    scope.launch {
+                        val clipText = clipboardManager.getPlainText()
+                        try {
+                            clipText?.let { postViewModel.copyFromClipboard(it) }
+                        } catch (e: IllegalArgumentException) {
+                            accountViewModel.toastManager.toast(
+                                R.string.invalid_nip47_uri_title,
+                                R.string.invalid_nip47_uri_description,
+                                clipText ?: "",
+                            )
+                        }
                     }
                 },
             ) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DropDownMenu.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DropDownMenu.kt
@@ -46,9 +46,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.AnnotatedString
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
@@ -60,6 +59,7 @@ import com.vitorpamplona.amethyst.ui.components.GenericLoadable
 import com.vitorpamplona.amethyst.ui.components.M3ActionDialog
 import com.vitorpamplona.amethyst.ui.components.M3ActionRow
 import com.vitorpamplona.amethyst.ui.components.M3ActionSection
+import com.vitorpamplona.amethyst.ui.components.util.setPlainText
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.navigation.routes.routeEditDraftTo
@@ -167,7 +167,7 @@ fun NoteDropDownMenu(
         title = stringRes(R.string.note_actions_dialog_title),
         onDismiss = onDismiss,
     ) {
-        val clipboardManager = LocalClipboardManager.current
+        val clipboardManager = LocalClipboard.current
         val actContext = LocalContext.current
         val scope = rememberCoroutineScope()
 
@@ -197,20 +197,20 @@ fun NoteDropDownMenu(
         M3ActionSection {
             M3ActionRow(icon = Icons.Outlined.ContentCopy, text = stringRes(R.string.copy_text)) {
                 val lastNoteVersion = (editState?.value as? GenericLoadable.Loaded)?.loaded?.modificationToShow?.value ?: note
-                accountViewModel.decrypt(lastNoteVersion) { clipboardManager.setText(AnnotatedString(it)) }
+                accountViewModel.decrypt(lastNoteVersion) { scope.launch { clipboardManager.setPlainText(it) } }
                 onDismiss()
             }
             M3ActionRow(icon = Icons.Outlined.ContentCopy, text = stringRes(R.string.copy_user_pubkey)) {
                 note.author?.let {
                     scope.launch(Dispatchers.IO) {
-                        clipboardManager.setText(AnnotatedString("nostr:${it.pubkeyNpub()}"))
+                        clipboardManager.setPlainText("nostr:${it.pubkeyNpub()}")
                         onDismiss()
                     }
                 }
             }
             M3ActionRow(icon = Icons.Outlined.ContentCopy, text = stringRes(R.string.copy_note_id)) {
                 scope.launch(Dispatchers.IO) {
-                    clipboardManager.setText(AnnotatedString(note.toNostrUri()))
+                    clipboardManager.setPlainText(note.toNostrUri())
                     onDismiss()
                 }
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/AppDefinition.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/AppDefinition.kt
@@ -42,14 +42,14 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -63,6 +63,7 @@ import com.vitorpamplona.amethyst.ui.components.ClickableTextPrimary
 import com.vitorpamplona.amethyst.ui.components.CreateTextWithEmoji
 import com.vitorpamplona.amethyst.ui.components.TranslatableRichTextViewer
 import com.vitorpamplona.amethyst.ui.components.ZoomableImageDialog
+import com.vitorpamplona.amethyst.ui.components.util.setPlainText
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.LinkIcon
 import com.vitorpamplona.amethyst.ui.painterRes
@@ -74,6 +75,7 @@ import com.vitorpamplona.amethyst.ui.theme.placeholderText
 import com.vitorpamplona.quartz.nip89AppHandlers.definition.AppDefinitionEvent
 import com.vitorpamplona.quartz.nip89AppHandlers.definition.AppMetadata
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -93,7 +95,8 @@ fun RenderAppDefinition(
 
     metadata?.let { theAppMetadata ->
         Box {
-            val clipboardManager = LocalClipboardManager.current
+            val clipboardManager = LocalClipboard.current
+            val scope = rememberCoroutineScope()
             val uri = LocalUriHandler.current
 
             if (!theAppMetadata.banner.isNullOrBlank()) {
@@ -109,7 +112,7 @@ fun RenderAppDefinition(
                             .height(125.dp)
                             .combinedClickable(
                                 onClick = {},
-                                onLongClick = { clipboardManager.setText(AnnotatedString(theAppMetadata.banner!!)) },
+                                onLongClick = { scope.launch { clipboardManager.setPlainText(theAppMetadata.banner!!) } },
                             ),
                 )
 
@@ -161,7 +164,7 @@ fun RenderAppDefinition(
                                         .background(MaterialTheme.colorScheme.background)
                                         .combinedClickable(
                                             onClick = { zoomImageDialogOpen = true },
-                                            onLongClick = { clipboardManager.setText(AnnotatedString(picture)) },
+                                            onLongClick = { scope.launch { clipboardManager.setPlainText(picture) } },
                                         ),
                             )
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/RelayList.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/RelayList.kt
@@ -33,12 +33,12 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -49,6 +49,7 @@ import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.nip51Lists.relayLists.RelayListCard
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserRelayIntoList
 import com.vitorpamplona.amethyst.ui.components.ShowMoreButton
+import com.vitorpamplona.amethyst.ui.components.util.setPlainText
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.note.AddRelayButton
@@ -63,6 +64,7 @@ import com.vitorpamplona.quartz.nip17Dm.settings.ChatMessageRelayListEvent
 import com.vitorpamplona.quartz.nip51Lists.relaySets.RelaySetEvent
 import com.vitorpamplona.quartz.nip65RelayList.AdvertisedRelayListEvent
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.launch
 
 @Composable
 fun DisplayRelaySet(
@@ -410,11 +412,12 @@ private fun RelayOptionsAction(
     nav: INav,
 ) {
     val isCurrentlyOnTheUsersList by observeUserRelayIntoList(relay, accountViewModel)
-    val clipboardManager = LocalClipboardManager.current
+    val clipboardManager = LocalClipboard.current
+    val scope = rememberCoroutineScope()
 
     if (isCurrentlyOnTheUsersList) {
         AddRelayButton {
-            clipboardManager.setText(AnnotatedString(relay.url))
+            scope.launch { clipboardManager.setPlainText(relay.url) }
             nav.nav(Route.EditRelays)
         }
     } else {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/display/BookmarkGroupItemOptions.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/display/BookmarkGroupItemOptions.kt
@@ -41,9 +41,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.AnnotatedString
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
@@ -54,6 +53,7 @@ import com.vitorpamplona.amethyst.ui.components.GenericLoadable
 import com.vitorpamplona.amethyst.ui.components.M3ActionDialog
 import com.vitorpamplona.amethyst.ui.components.M3ActionRow
 import com.vitorpamplona.amethyst.ui.components.M3ActionSection
+import com.vitorpamplona.amethyst.ui.components.util.setPlainText
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.navigation.routes.routeEditDraftTo
@@ -160,7 +160,7 @@ fun BookmarkGroupItemOptionsMenu(
         title = stringRes(R.string.bookmark_item_actions_dialog_title),
         onDismiss = onDismiss,
     ) {
-        val clipboardManager = LocalClipboardManager.current
+        val clipboardManager = LocalClipboard.current
         val actContext = LocalContext.current
         val scope = rememberCoroutineScope()
 
@@ -203,20 +203,20 @@ fun BookmarkGroupItemOptionsMenu(
         M3ActionSection {
             M3ActionRow(icon = Icons.Outlined.ContentCopy, text = stringRes(R.string.copy_text)) {
                 val lastNoteVersion = (editState?.value as? GenericLoadable.Loaded)?.loaded?.modificationToShow?.value ?: note
-                accountViewModel.decrypt(lastNoteVersion) { clipboardManager.setText(AnnotatedString(it)) }
+                accountViewModel.decrypt(lastNoteVersion) { scope.launch { clipboardManager.setPlainText(it) } }
                 onDismiss()
             }
             M3ActionRow(icon = Icons.Outlined.ContentCopy, text = stringRes(R.string.copy_user_pubkey)) {
                 note.author?.let {
                     scope.launch(Dispatchers.IO) {
-                        clipboardManager.setText(AnnotatedString("nostr:${it.pubkeyNpub()}"))
+                        clipboardManager.setPlainText("nostr:${it.pubkeyNpub()}")
                         onDismiss()
                     }
                 }
             }
             M3ActionRow(icon = Icons.Outlined.ContentCopy, text = stringRes(R.string.copy_note_id)) {
                 scope.launch(Dispatchers.IO) {
-                    clipboardManager.setText(AnnotatedString(note.toNostrUri()))
+                    clipboardManager.setPlainText(note.toNostrUri())
                     onDismiss()
                 }
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/feed/types/RenderCreateChannelNote.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/feed/types/RenderCreateChannelNote.kt
@@ -37,12 +37,12 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -57,6 +57,7 @@ import com.vitorpamplona.amethyst.model.nip11RelayInfo.loadRelayInfo
 import com.vitorpamplona.amethyst.ui.components.CreateTextWithEmoji
 import com.vitorpamplona.amethyst.ui.components.RobohashFallbackAsyncImage
 import com.vitorpamplona.amethyst.ui.components.TranslatableRichTextViewer
+import com.vitorpamplona.amethyst.ui.components.util.setPlainText
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
@@ -74,6 +75,7 @@ import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.displayUrl
 import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelCreateEvent
 import com.vitorpamplona.quartz.nip28PublicChat.base.ChannelDataNorm
+import kotlinx.coroutines.launch
 
 @Composable
 fun RenderCreateChannelNote(
@@ -238,12 +240,13 @@ fun RenderRelayLinePublicChat(
     @Suppress("ProduceStateDoesNotAssignValue")
     val relayInfo by loadRelayInfo(relay)
 
-    val clipboardManager = LocalClipboardManager.current
+    val clipboardManager = LocalClipboard.current
+    val scope = rememberCoroutineScope()
     val clickableModifier =
         remember(relay) {
             Modifier.combinedClickable(
                 onLongClick = {
-                    clipboardManager.setText(AnnotatedString(relay.url))
+                    scope.launch { clipboardManager.setPlainText(relay.url) }
                 },
                 onClick = { nav.nav(Route.RelayInfo(relay.url)) },
             )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/keyBackup/AccountBackupScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/keyBackup/AccountBackupScreen.kt
@@ -68,12 +68,11 @@ import androidx.compose.ui.autofill.AutofillType
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.ClipboardManager
+import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.platform.LocalAutofill
 import androidx.compose.ui.platform.LocalAutofillTree
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -92,6 +91,7 @@ import com.halilibo.richtext.ui.material3.RichText
 import com.halilibo.richtext.ui.resolveDefaults
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.Account
+import com.vitorpamplona.amethyst.ui.components.util.setPlainText
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.TopBarWithBackButton
 import com.vitorpamplona.amethyst.ui.note.authenticate
@@ -281,7 +281,7 @@ private fun AccountBackupScreenContent(
 
 @Composable
 private fun NSecCopyButton(accountViewModel: AccountViewModel) {
-    val clipboardManager = LocalClipboardManager.current
+    val clipboardManager = LocalClipboard.current
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
@@ -329,7 +329,7 @@ private fun EncryptNSecCopyButton(
     accountViewModel: AccountViewModel,
     password: MutableState<TextFieldValue>,
 ) {
-    val clipboardManager = LocalClipboardManager.current
+    val clipboardManager = LocalClipboard.current
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
@@ -390,10 +390,12 @@ private fun copyNSec(
     context: Context,
     scope: CoroutineScope,
     account: Account,
-    clipboardManager: ClipboardManager,
+    clipboardManager: Clipboard,
 ) {
     account.settings.keyPair.privKey?.let {
-        clipboardManager.setText(AnnotatedString(it.toNsec()))
+        scope.launch {
+            clipboardManager.setPlainText(it.toNsec())
+        }
         scope.launch {
             Toast
                 .makeText(
@@ -410,7 +412,7 @@ private fun encryptCopyNSec(
     context: Context,
     scope: CoroutineScope,
     accountViewModel: AccountViewModel,
-    clipboardManager: ClipboardManager,
+    clipboardManager: Clipboard,
 ) {
     if (password.value.text.isBlank()) {
         scope.launch {
@@ -425,7 +427,9 @@ private fun encryptCopyNSec(
         accountViewModel.account.settings.keyPair.privKey?.let {
             val key = runCatching { Nip49().encrypt(it.toHexKey(), password.value.text) }.getOrNull()
             if (key != null) {
-                clipboardManager.setText(AnnotatedString(key))
+                scope.launch {
+                    clipboardManager.setPlainText(key)
+                }
                 scope.launch {
                     Toast
                         .makeText(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/DrawBanner.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/DrawBanner.kt
@@ -29,11 +29,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.vitorpamplona.amethyst.R
@@ -41,9 +41,11 @@ import com.vitorpamplona.amethyst.commons.richtext.RichTextParser
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserBanner
 import com.vitorpamplona.amethyst.ui.components.ZoomableImageDialog
+import com.vitorpamplona.amethyst.ui.components.util.setPlainText
 import com.vitorpamplona.amethyst.ui.painterRes
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -63,7 +65,8 @@ fun DrawBanner(
     accountViewModel: AccountViewModel,
 ) {
     if (!banner.isNullOrBlank()) {
-        val clipboardManager = LocalClipboardManager.current
+        val clipboardManager = LocalClipboard.current
+        val scope = rememberCoroutineScope()
         var zoomImageDialogOpen by remember { mutableStateOf(false) }
 
         AsyncImage(
@@ -78,7 +81,7 @@ fun DrawBanner(
                     .height(150.dp)
                     .combinedClickable(
                         onClick = { zoomImageDialogOpen = true },
-                        onLongClick = { clipboardManager.setText(AnnotatedString(banner)) },
+                        onLongClick = { scope.launch { clipboardManager.setPlainText(banner) } },
                     ),
         )
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/UserProfileDropDownMenu.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/UserProfileDropDownMenu.kt
@@ -28,18 +28,20 @@ import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Report
 import androidx.compose.material.icons.outlined.Share
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.AnnotatedString
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.ui.components.M3ActionDialog
 import com.vitorpamplona.amethyst.ui.components.M3ActionRow
 import com.vitorpamplona.amethyst.ui.components.M3ActionSection
+import com.vitorpamplona.amethyst.ui.components.util.setPlainText
 import com.vitorpamplona.amethyst.ui.note.externalLinkForUser
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.quartz.nip56Reports.ReportType
+import kotlinx.coroutines.launch
 
 @Composable
 fun UserProfileDropDownMenu(
@@ -54,7 +56,8 @@ fun UserProfileDropDownMenu(
         title = stringRes(R.string.profile_actions_dialog_title),
         onDismiss = onDismiss,
     ) {
-        val clipboardManager = LocalClipboardManager.current
+        val clipboardManager = LocalClipboard.current
+        val scope = rememberCoroutineScope()
         val context = LocalContext.current
 
         // Share section
@@ -63,7 +66,7 @@ fun UserProfileDropDownMenu(
                 icon = Icons.Outlined.ContentCopy,
                 text = stringRes(R.string.copy_user_id),
             ) {
-                clipboardManager.setText(AnnotatedString(user.pubkeyNpub()))
+                scope.launch { clipboardManager.setPlainText(user.pubkeyNpub()) }
                 onDismiss()
             }
             M3ActionRow(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/relays/RelayFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/relays/RelayFeedView.kt
@@ -28,18 +28,20 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.ui.components.util.setPlainText
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.note.RelayCompose
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.SettingsCategory
 import com.vitorpamplona.amethyst.ui.theme.DividerThickness
+import kotlinx.coroutines.launch
 
 @Composable
 fun RelayFeedView(
@@ -94,12 +96,13 @@ private fun RenderRelayRow(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    val clipboardManager = LocalClipboardManager.current
+    val clipboardManager = LocalClipboard.current
+    val scope = rememberCoroutineScope()
     RelayCompose(
         relay,
         accountViewModel = accountViewModel,
         onAddRelay = {
-            clipboardManager.setText(AnnotatedString(relay.url.url))
+            scope.launch { clipboardManager.setPlainText(relay.url.url) }
             nav.nav(Route.EditRelays)
         },
         onRemoveRelay = {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoClickableRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoClickableRow.kt
@@ -32,13 +32,14 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.platform.LocalClipboard
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.nip11RelayInfo.Nip11CachedRetriever
 import com.vitorpamplona.amethyst.model.nip11RelayInfo.loadRelayInfo
+import com.vitorpamplona.amethyst.ui.components.util.setPlainText
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.RenderRelayIcon
 import com.vitorpamplona.amethyst.ui.note.UserPicture
@@ -52,6 +53,7 @@ import com.vitorpamplona.amethyst.ui.theme.LargeRelayIconModifier
 import com.vitorpamplona.amethyst.ui.theme.ReactionRowHeightChatMaxWidth
 import com.vitorpamplona.amethyst.ui.theme.Size25dp
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.displayUrl
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -67,14 +69,15 @@ fun BasicRelaySetupInfoClickableRow(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    val clipboardManager = LocalClipboardManager.current
+    val clipboardManager = LocalClipboard.current
+    val scope = rememberCoroutineScope()
     Column(
         Modifier
             .fillMaxWidth()
             .combinedClickable(
                 onClick = onClick,
                 onLongClick = {
-                    clipboardManager.setText(AnnotatedString(item.relay.url))
+                    scope.launch { clipboardManager.setPlainText(item.relay.url) }
                 },
             ),
     ) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/RelayNameAndRemoveButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/RelayNameAndRemoveButton.kt
@@ -33,18 +33,20 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.ui.components.util.setPlainText
 import com.vitorpamplona.amethyst.ui.painterRes
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.LightRedColor
 import com.vitorpamplona.amethyst.ui.theme.allGoodColor
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.displayUrl
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -54,7 +56,8 @@ fun RelayNameAndRemoveButton(
     onDelete: ((BasicRelaySetupInfo) -> Unit)?,
     modifier: Modifier,
 ) {
-    val clipboardManager = LocalClipboardManager.current
+    val clipboardManager = LocalClipboard.current
+    val scope = rememberCoroutineScope()
     Row(verticalAlignment = Alignment.CenterVertically, modifier = modifier) {
         Row(Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {
             Text(
@@ -63,7 +66,7 @@ fun RelayNameAndRemoveButton(
                     Modifier.combinedClickable(
                         onClick = onClick,
                         onLongClick = {
-                            clipboardManager.setText(AnnotatedString(item.relay.url))
+                            scope.launch { clipboardManager.setPlainText(item.relay.url) }
                         },
                     ),
                 maxLines = 1,

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ClipboardExt.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ClipboardExt.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.desktop
+
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.Clipboard
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.StringSelection
+import java.awt.datatransfer.Transferable
+
+@OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+suspend fun Clipboard.setPlainText(text: String) {
+    setClipEntry(ClipEntry(StringSelection(text)))
+}
+
+@OptIn(androidx.compose.ui.ExperimentalComposeUiApi::class)
+suspend fun Clipboard.getPlainText(): String? {
+    val entry = getClipEntry() ?: return null
+    val transferable = entry.nativeClipEntry as? Transferable ?: return null
+    return try {
+        transferable.getTransferData(DataFlavor.stringFlavor) as? String
+    } catch (_: Exception) {
+        null
+    }
+}

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/ArticleReaderScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/ArticleReaderScreen.kt
@@ -69,7 +69,7 @@ import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.commons.compose.article.ArticleHeader
 import com.vitorpamplona.amethyst.commons.compose.article.TableOfContents
@@ -80,6 +80,7 @@ import com.vitorpamplona.amethyst.commons.ui.components.EmptyState
 import com.vitorpamplona.amethyst.commons.ui.components.LoadingState
 import com.vitorpamplona.amethyst.desktop.account.AccountState
 import com.vitorpamplona.amethyst.desktop.cache.DesktopLocalCache
+import com.vitorpamplona.amethyst.desktop.getPlainText
 import com.vitorpamplona.amethyst.desktop.network.DesktopRelayConnectionManager
 import com.vitorpamplona.amethyst.desktop.service.highlights.DesktopHighlightStore
 import com.vitorpamplona.amethyst.desktop.subscriptions.DesktopRelaySubscriptionsCoordinator
@@ -366,7 +367,7 @@ fun ArticleReaderScreen(
     val authorName = authorUser?.toBestDisplayName()
     val authorPicture = authorUser?.profilePicture()
 
-    val clipboardManager = LocalClipboardManager.current
+    val clipboardManager = LocalClipboard.current
 
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
@@ -574,6 +575,7 @@ fun ArticleReaderScreen(
                                         HighlightContextMenuRepresentation(
                                             delegate = defaultRepresentation,
                                             clipboardManager = clipboardManager,
+                                            scope = scope,
                                             onHighlight = { text ->
                                                 scope.launch {
                                                     highlightStore?.addHighlight(
@@ -695,7 +697,8 @@ fun ArticleReaderScreen(
  */
 private class HighlightContextMenuRepresentation(
     private val delegate: ContextMenuRepresentation,
-    private val clipboardManager: androidx.compose.ui.platform.ClipboardManager,
+    private val clipboardManager: androidx.compose.ui.platform.Clipboard,
+    private val scope: kotlinx.coroutines.CoroutineScope,
     private val onHighlight: (String) -> Unit,
     private val onHighlightWithNote: (String) -> Unit,
 ) : ContextMenuRepresentation {
@@ -713,16 +716,20 @@ private class HighlightContextMenuRepresentation(
                     listOf(
                         ContextMenuItem("Highlight") {
                             copyItem.onClick()
-                            val text = clipboardManager.getText()?.text
-                            if (!text.isNullOrBlank()) {
-                                onHighlight(text)
+                            scope.launch {
+                                val text = clipboardManager.getPlainText()
+                                if (!text.isNullOrBlank()) {
+                                    onHighlight(text)
+                                }
                             }
                         },
                         ContextMenuItem("Highlight with Note") {
                             copyItem.onClick()
-                            val text = clipboardManager.getText()?.text
-                            if (!text.isNullOrBlank()) {
-                                onHighlightWithNote(text)
+                            scope.launch {
+                                val text = clipboardManager.getPlainText()
+                                if (!text.isNullOrBlank()) {
+                                    onHighlightWithNote(text)
+                                }
                             }
                         },
                     )

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/auth/LoginCard.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/auth/LoginCard.kt
@@ -49,8 +49,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -63,6 +62,7 @@ import com.vitorpamplona.amethyst.commons.resources.login_card_title
 import com.vitorpamplona.amethyst.commons.resources.login_generate_button
 import com.vitorpamplona.amethyst.desktop.account.LoginProgress
 import com.vitorpamplona.amethyst.desktop.account.validateBunkerUri
+import com.vitorpamplona.amethyst.desktop.setPlainText
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -250,8 +250,7 @@ private fun NostrConnectContent(
     var errorMessage by remember { mutableStateOf<String?>(null) }
     val scope = rememberCoroutineScope()
 
-    @Suppress("DEPRECATION")
-    val clipboardManager = LocalClipboardManager.current
+    val clipboardManager = LocalClipboard.current
 
     if (errorMessage != null) {
         Text(
@@ -318,7 +317,7 @@ private fun NostrConnectContent(
             Spacer(Modifier.height(8.dp))
 
             OutlinedButton(
-                onClick = { clipboardManager.setText(AnnotatedString(uri)) },
+                onClick = { scope.launch { clipboardManager.setPlainText(uri) } },
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text("Copy URI")


### PR DESCRIPTION
## Summary
This PR migrates the codebase from the deprecated `LocalClipboardManager` API to the newer `Clipboard` API across both Android and Desktop platforms. The changes include creating platform-specific extension functions for clipboard operations and updating all call sites to use the new async-based API.

## Key Changes

- **New Extension Functions**: Created two new files with platform-specific clipboard extensions:
  - `amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/util/ClipboardExt.kt` (Android) - Uses `ClipData` for clipboard operations
  - `desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ClipboardExt.kt` (Desktop) - Uses AWT `Transferable` for clipboard operations

- **Extension Functions Implemented**:
  - `suspend fun Clipboard.setPlainText(text: String)` - Sets plain text to clipboard
  - `suspend fun Clipboard.getPlainText(): String?` - Retrieves plain text from clipboard

- **API Migration**: Updated all call sites throughout the codebase to:
  - Replace `LocalClipboardManager.current` with `LocalClipboard.current`
  - Replace synchronous `setText(AnnotatedString(...))` with `scope.launch { setPlainText(...) }`
  - Replace synchronous `getText()?.text` with `scope.launch { getPlainText() }`
  - Remove `AnnotatedString` imports where no longer needed

- **Files Updated** (20+ files):
  - Android UI components: `UpdateZapAmountDialog.kt`, `AccountBackupScreen.kt`, `AppDefinition.kt`, `NoteQuickActionMenu.kt`, `DropDownMenu.kt`, `BookmarkGroupItemOptions.kt`, `InformationDialog.kt`, `CashuRedeem.kt`, `ClickableRelayUrl.kt`, `UrlPreviewCard.kt`, `RelayListRow.kt`, `RelayList.kt`, `RenderCreateChannelNote.kt`, `DrawBanner.kt`, `UserProfileDropDownMenu.kt`, `RelayFeedView.kt`, `BasicRelaySetupInfoClickableRow.kt`, `RelayNameAndRemoveButton.kt`, `ZoomableContentView.kt`
  - Desktop UI components: `ArticleReaderScreen.kt`, `LoginCard.kt`

## Implementation Details

- All clipboard operations are now properly async using coroutine scopes
- Platform-specific implementations handle the differences between Android's `ClipData` and Desktop's AWT `Transferable`
- Error handling is preserved with try-catch blocks for clipboard access failures
- The new API is more robust and follows Compose best practices for async operations

https://claude.ai/code/session_01NtCrrpWNyMySXix98kZvdz