### PR TITLE
Replace ContextCompat.startActivity with Context.startActivity

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/CashuRedeem.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/CashuRedeem.kt
@@ -51,7 +51,6 @@ import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.content.ContextCompat.startActivity
 import androidx.core.net.toUri
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.hashtags.Cashu
@@ -217,7 +216,7 @@ fun CashuPreviewNew(
                             val intent = Intent(Intent.ACTION_VIEW, "cashu://${token.token}".toUri())
                             intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
 
-                            startActivity(context, intent, null)
+                            context.startActivity(intent)
                         } catch (e: Exception) {
                             if (e is CancellationException) throw e
                             toast(stringRes(context, R.string.cashu), stringRes(context, R.string.cashu_no_wallet_found))

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DropDownMenu.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DropDownMenu.kt
@@ -49,7 +49,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.AddressableNote
@@ -223,7 +222,7 @@ fun NoteDropDownMenu(
                         putExtra(Intent.EXTRA_TITLE, stringRes(actContext, R.string.quick_action_share_browser_link))
                     }
                 val shareIntent = Intent.createChooser(sendIntent, stringRes(actContext, R.string.quick_action_share))
-                ContextCompat.startActivity(actContext, shareIntent, null)
+                actContext.startActivity(shareIntent)
                 onDismiss()
             }
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/CommunityHeader.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/CommunityHeader.kt
@@ -57,7 +57,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.model.EmptyTagList
@@ -519,7 +518,7 @@ fun ShareCommunityButton(
 
             val shareIntent =
                 Intent.createChooser(sendIntent, stringRes(actContext, R.string.quick_action_share))
-            ContextCompat.startActivity(actContext, shareIntent, null)
+            actContext.startActivity(shareIntent)
         },
     ) {
         Icon(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/display/BookmarkGroupItemOptions.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/display/BookmarkGroupItemOptions.kt
@@ -44,7 +44,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.Note
@@ -237,7 +236,7 @@ fun BookmarkGroupItemOptionsMenu(
 
                 val shareIntent =
                     Intent.createChooser(sendIntent, stringRes(actContext, R.string.quick_action_share))
-                ContextCompat.startActivity(actContext, shareIntent, null)
+                actContext.startActivity(shareIntent)
                 onDismiss()
             }
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/lists/PeopleListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/lists/PeopleListScreen.kt
@@ -70,7 +70,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
@@ -448,7 +447,7 @@ private fun ListActionsMenuButton(
 
                     val shareIntent =
                         Intent.createChooser(sendIntent, stringRes(context, R.string.quick_action_share))
-                    ContextCompat.startActivity(context, shareIntent, null)
+                    context.startActivity(shareIntent)
                     isActionListOpen.value = false
                 }
                 M3ActionRow(icon = Icons.Outlined.Edit, text = stringRes(R.string.follow_set_edit_list_metadata)) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/packs/FollowPackScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/packs/FollowPackScreen.kt
@@ -63,7 +63,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
@@ -303,7 +302,7 @@ private fun ListActionsMenuButton(
 
                     val shareIntent =
                         Intent.createChooser(sendIntent, stringRes(context, R.string.quick_action_share))
-                    ContextCompat.startActivity(context, shareIntent, null)
+                    context.startActivity(shareIntent)
                     isActionListOpen.value = false
                 }
                 M3ActionRow(icon = Icons.Outlined.Edit, text = stringRes(R.string.follow_pack_edit_list_metadata)) {


### PR DESCRIPTION
## Summary
This PR modernizes the codebase by replacing deprecated `ContextCompat.startActivity()` calls with the direct `Context.startActivity()` method, which is now available on all supported API levels.

## Key Changes
- Removed unused imports of `androidx.core.content.ContextCompat` from 6 files
- Removed unused import of `androidx.core.content.ContextCompat.startActivity` from CashuRedeem.kt
- Replaced all `ContextCompat.startActivity(context, intent, null)` calls with `context.startActivity(intent)` across:
  - CashuRedeem.kt
  - DropDownMenu.kt
  - CommunityHeader.kt
  - BookmarkGroupItemOptions.kt
  - PeopleListScreen.kt
  - FollowPackScreen.kt

## Implementation Details
The changes simplify the code by using the native `Context.startActivity()` method instead of the compatibility wrapper. This is safe as the minimum API level supported by the project is high enough to include this method natively. The functionality remains identical while reducing unnecessary abstraction layers.

https://claude.ai/code/session_01CVyJYm4GzfE1r1baxizSST