### PR TITLE
Fix PiP video playback: keep screen on and improve lifecycle

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/pip/PipVideoActivity.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/pip/PipVideoActivity.kt
@@ -60,14 +60,22 @@ class PipVideoActivity : ComponentActivity() {
         }
     }
 
-    override fun onStop() {
-        super.onStop()
-        finishAndRemoveTask()
+    override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean) {
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode)
+        if (!isInPictureInPictureMode) {
+            // User dismissed PiP (swiped away or expanded).
+            finishAndRemoveTask()
+        }
     }
 
-    override fun finish() {
-        finishAndRemoveTask()
-        super.finish()
+    override fun onStop() {
+        super.onStop()
+        if (!isInPictureInPictureMode) {
+            // Only finish if we're not in PiP mode.
+            // When the screen locks while in PiP, we stay alive
+            // so the PlaybackService can continue audio playback.
+            finishAndRemoveTask()
+        }
     }
 
     companion object {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/pip/PipVideoView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/pip/PipVideoView.kt
@@ -32,7 +32,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.core.content.ContextCompat
+import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.ui.compose.ContentFrame
 import androidx.media3.ui.compose.state.rememberMuteButtonState
@@ -51,6 +53,8 @@ fun RenderPipVideo(
     controller: MediaControllerState,
     waveformData: WaveformData?,
 ) {
+    KeepScreenOnWhilePlaying(controller)
+
     val modifier =
         remember {
             val ratio =
@@ -74,6 +78,31 @@ fun RenderPipVideo(
 
         Row(VoiceHeightModifier, verticalAlignment = Alignment.CenterVertically) {
             waveformData?.let { Waveform(it, controller, Modifier) }
+        }
+    }
+}
+
+@Composable
+fun KeepScreenOnWhilePlaying(controller: MediaControllerState) {
+    val view = LocalView.current
+
+    DisposableEffect(controller.controller, view) {
+        val listener =
+            object : Player.Listener {
+                override fun onIsPlayingChanged(isPlaying: Boolean) {
+                    if (view.keepScreenOn != isPlaying) {
+                        view.keepScreenOn = isPlaying
+                    }
+                }
+            }
+
+        // Set initial state
+        view.keepScreenOn = controller.controller.isPlaying
+
+        controller.controller.addListener(listener)
+        onDispose {
+            controller.controller.removeListener(listener)
+            view.keepScreenOn = false
         }
     }
 }


### PR DESCRIPTION
## Summary
Improves the Picture-in-Picture (PiP) video playback experience by keeping the screen on during playback and fixing the activity lifecycle management to properly handle PiP mode transitions.

## Key Changes

- **Screen on during playback**: Added `KeepScreenOnWhilePlaying()` composable that listens to player state changes and keeps the screen on while video is actively playing, preventing the screen from locking during playback.

- **Improved PiP lifecycle handling**: 
  - Replaced `onStop()` + `finish()` logic with `onPictureInPictureModeChanged()` callback to properly detect when user dismisses PiP
  - Modified `onStop()` to only finish the activity when NOT in PiP mode, allowing audio playback to continue via PlaybackService when screen locks
  - Removed the override of `finish()` method which was causing premature activity termination

## Implementation Details

- The `KeepScreenOnWhilePlaying()` composable uses `DisposableEffect` to manage a `Player.Listener` that responds to `onIsPlayingChanged()` events
- Initial screen state is set based on the current player playing status
- Listener is properly cleaned up on disposal and screen is reset to off
- Activity now correctly distinguishes between user-initiated PiP dismissal and system-initiated stops (like screen lock)

https://claude.ai/code/session_01QJzmFaabSA9YQ3oCQwEHTJ