### PR TITLE
fix: disable snap animation on DisappearingScaffold scroll

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/DisappearingScaffold.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/DisappearingScaffold.kt
@@ -49,6 +49,7 @@ fun DisappearingScaffold(
             canScroll = {
                 topBar != null && isActive() && accountViewModel.settings.isImmersiveScrollingActive()
             },
+            snapAnimationSpec = null,
             reverseLayout = isInvertedLayout,
         )
     val bottomBehavior =
@@ -56,6 +57,7 @@ fun DisappearingScaffold(
             canScroll = {
                 (bottomBar != null || floatingButton != null) && isActive() && accountViewModel.settings.isImmersiveScrollingActive()
             },
+            snapAnimationSpec = null,
         )
 
     Scaffold(


### PR DESCRIPTION
Pass snapAnimationSpec = null to both top and bottom scroll behaviors
so bars stay at their current position when the user releases the drag
instead of snapping to fully visible or fully hidden.

https://claude.ai/code/session_013pVpWCotXGHcUq7u4ZNqbZ