### PR TITLE
fix: resolve scroll jitter at top bar collapse boundary in DisappearingScaffold

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/DisappearingTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/DisappearingTopBar.kt
@@ -248,7 +248,9 @@ class CustomEnterAlwaysScrollBehavior(
                 // Note that when the content was set with a revered layout, we always return a
                 // zero offset.
                 return if (!reverseLayout && prevHeightOffset != state.heightOffset) {
-                    available.copy(x = 0f)
+                    // Only report the actually consumed scroll (after clamping),
+                    // so the remaining delta flows through to the bottom bar.
+                    Offset(x = 0f, y = state.heightOffset - prevHeightOffset)
                 } else {
                     Offset.Zero
                 }


### PR DESCRIPTION
The top bar's onPreScroll was consuming the entire available scroll delta
even when the heightOffset was clamped at its limit. This caused a visible
pause at the exact point the top bar became fully collapsed, because scroll
was being "eaten" without any visual effect before finally flowing through
to the bottom bar. Now only the actually consumed delta is reported, allowing
leftover scroll to immediately reach the bottom bar for smooth continuous motion.

https://claude.ai/code/session_01QD9ch2SqMsS9uC8ZUthCs6