### PR TITLE
Added ./gradlew --stop (with if: always()) after the Gradle steps in both test and build-desktop jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,10 @@ jobs:
       - name: Test (gradle)
         run: ./gradlew test --no-daemon
 
+      - name: Stop Gradle Daemon
+        if: always()
+        run: ./gradlew --stop
+
       - name: Android Test Report
         uses: asadmansr/android-test-report-action@v1.2.0
         if: ${{ always() && matrix.os == 'ubuntu-latest' }}
@@ -190,6 +194,10 @@ jobs:
 
       - name: Build Desktop Distribution
         run: ./gradlew :desktopApp:${{ matrix.task }}
+
+      - name: Stop Gradle Daemon
+        if: always()
+        run: ./gradlew --stop
 
       - name: Upload Desktop Distribution
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
Attempt to fix the below **5 minute "hang"** due to: Gradle daemon is still running when the cache action tries to archive .gradle/caches, and the .lock files are held open. The fix is to stop the Gradle daemon before the cache save step. 

fix: Added ./gradlew --stop (with if: always()) after the Gradle steps in both test and build-desktop jobs

(Windows-latest): Post job cleanup
                                                                                                                         
```
"C:\Program Files\Git\usr\bin\tar.exe" --posix -cf cache.tzst --exclude cache.tzst -P -C D:/a/amethyst/amethyst --files-from manifest.txt --force-local --use-compress-program "zstd -T0"                        
/usr/bin/tar: C\:/Users/runneradmin/.gradle/caches/9.3.1/fileHashes/fileHashes.lock: Read error at byte 0, while reading 39 bytes: Device or resource busy                                                       
/usr/bin/tar: C\:/Users/runneradmin/.gradle/caches/9.3.1/javaCompile/javaCompile.lock: Read error at byte 0, while reading 39 bytes: Device or resource busy                                                     
/usr/bin/tar: C\:/Users/runneradmin/.gradle/caches/9.3.1/kotlin-dsl/accessors/749ea6392a8bea47c2f081a370e4232c-PS/749ea6392a8bea47c2f081a370e4232c-PS.lock: Read error at byte 0, while reading 39 bytes: Device 
 or resource busy                                                                                                                                                                                                
/usr/bin/tar: C\:/Users/runneradmin/.gradle/caches/9.3.1/kotlin-dsl/accessors/749ea6392a8bea47c2f081a370e4232c-VC/749ea6392a8bea47c2f081a370e4232c-VC.lock: Read error at byte 0, while reading 39 bytes: Device 
 or resource busy                                                                                                                                                                                                
/usr/bin/tar: C\:/Users/runneradmin/.gradle/caches/9.3.1/kotlin-dsl/accessors/a0fc5dd95f6bcd9f33743083f8d78973/a0fc5dd95f6bcd9f33743083f8d78973.lock: Read error at byte 0, while reading 39 bytes: Device or    
resource busy                                                                                                                                                                                                    
/usr/bin/tar: C\:/Users/runneradmin/.gradle/caches/9.3.1/kotlin-dsl/accessors/b69ee105ba686a916a5d5621d91a1b91/b69ee105ba686a916a5d5621d91a1b91.lock: Read error at byte 0, while reading 39 bytes: Device or    
resource busy                                                                                                                                                                                                    
/usr/bin/tar: C\:/Users/runneradmin/.gradle/caches/9.3.1/kotlin-dsl/accessors/fb6d23103ad077269201772c67cf2d2d/fb6d23103ad077269201772c67cf2d2d.lock: Read error at byte 0, while reading 39 bytes: Device or    
resource busy                                                                                                                                                                                                    
/usr/bin/tar: C\:/Users/runneradmin/.gradle/caches/9.3.1/kotlin-dsl/scripts/34a98d6c6ce0e94cc97a093c77561db5/34a98d6c6ce0e94cc97a093c77561db5.lock: Read error at byte 0, while reading 39 bytes: Device or      
resource busy
```