### PR TITLE
Add NIP-69 P2P Order Events support

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/P2POrderEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/P2POrderEvent.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip69P2pOrderEvents
+
+import androidx.compose.runtime.Immutable
+import com.vitorpamplona.quartz.nip01Core.core.BaseAddressableEvent
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
+import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
+import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
+import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip40Expiration.expiration
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.FiatAmountTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.OrderStatus
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.OrderType
+import com.vitorpamplona.quartz.utils.TimeUtils
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@Immutable
+class P2POrderEvent(
+    id: HexKey,
+    pubKey: HexKey,
+    createdAt: Long,
+    tags: Array<Array<String>>,
+    content: String,
+    sig: HexKey,
+) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+    fun orderType() = tags.orderType()
+
+    fun currency() = tags.currency()
+
+    fun status() = tags.orderStatus()
+
+    fun amount() = tags.amount()
+
+    fun fiatAmount() = tags.fiatAmount()
+
+    fun paymentMethods() = tags.paymentMethods()
+
+    fun premium() = tags.premium()
+
+    fun expiresAt() = tags.expiresAt()
+
+    fun platform() = tags.platform()
+
+    fun documentType() = tags.documentType()
+
+    fun source() = tags.source()
+
+    fun rating() = tags.rating()
+
+    fun network() = tags.network()
+
+    fun layer() = tags.layer()
+
+    fun makerName() = tags.makerName()
+
+    fun bond() = tags.bond()
+
+    companion object {
+        const val KIND = 38383
+        const val ALT_DESCRIPTION = "P2P Order"
+
+        @OptIn(ExperimentalUuidApi::class)
+        fun build(
+            orderType: OrderType,
+            currency: String,
+            status: OrderStatus,
+            amount: Long,
+            fiatAmount: FiatAmountTag,
+            paymentMethods: List<String>,
+            premium: String,
+            platform: String,
+            expiresAt: Long,
+            expiration: Long? = null,
+            source: String? = null,
+            ratingJson: String? = null,
+            network: String? = null,
+            layer: String? = null,
+            makerName: String? = null,
+            geohash: String? = null,
+            bond: Long? = null,
+            dTag: String = Uuid.random().toString(),
+            createdAt: Long = TimeUtils.now(),
+            initializer: TagArrayBuilder<P2POrderEvent>.() -> Unit = {},
+        ) = eventTemplate(KIND, "", createdAt) {
+            dTag(dTag)
+            orderType(orderType)
+            currency(currency)
+            orderStatus(status)
+            amount(amount)
+            fiatAmount(fiatAmount)
+            paymentMethods(paymentMethods)
+            premium(premium)
+            expiresAt(expiresAt)
+            expiration?.let { expiration(it) }
+            platform(platform)
+            documentType()
+            source?.let { source(it) }
+            ratingJson?.let { rating(it) }
+            network?.let { network(it) }
+            layer?.let { layer(it) }
+            makerName?.let { makerName(it) }
+            geohash?.let { geohash(it) }
+            bond?.let { bond(it) }
+            alt(ALT_DESCRIPTION)
+            initializer()
+        }
+    }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/TagArrayBuilderExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/TagArrayBuilderExt.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip69P2pOrderEvents
+
+import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
+import com.vitorpamplona.quartz.nip01Core.tags.geohash.GeoHashTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.AmountTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.BondTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.CurrencyTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.DocumentTypeTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.ExpiresAtTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.FiatAmountTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.LayerTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.MakerNameTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.NetworkTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.OrderStatus
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.OrderStatusTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.OrderType
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.OrderTypeTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.PaymentMethodTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.PlatformTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.PremiumTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.RatingTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.SourceTag
+
+fun TagArrayBuilder<P2POrderEvent>.orderType(type: OrderType) = addUnique(OrderTypeTag.assemble(type))
+
+fun TagArrayBuilder<P2POrderEvent>.orderStatus(status: OrderStatus) = addUnique(OrderStatusTag.assemble(status))
+
+fun TagArrayBuilder<P2POrderEvent>.currency(currency: String) = addUnique(CurrencyTag.assemble(currency))
+
+fun TagArrayBuilder<P2POrderEvent>.amount(amountSats: Long) = addUnique(AmountTag.assemble(amountSats))
+
+fun TagArrayBuilder<P2POrderEvent>.fiatAmount(fiatAmount: FiatAmountTag) = addUnique(FiatAmountTag.assemble(fiatAmount))
+
+fun TagArrayBuilder<P2POrderEvent>.paymentMethods(methods: List<String>) = addUnique(PaymentMethodTag.assemble(methods))
+
+fun TagArrayBuilder<P2POrderEvent>.premium(premium: String) = addUnique(PremiumTag.assemble(premium))
+
+fun TagArrayBuilder<P2POrderEvent>.expiresAt(timestamp: Long) = addUnique(ExpiresAtTag.assemble(timestamp))
+
+fun TagArrayBuilder<P2POrderEvent>.platform(platform: String) = addUnique(PlatformTag.assemble(platform))
+
+fun TagArrayBuilder<P2POrderEvent>.documentType(type: String = DocumentTypeTag.ORDER) = addUnique(DocumentTypeTag.assemble(type))
+
+fun TagArrayBuilder<P2POrderEvent>.source(url: String) = addUnique(SourceTag.assemble(url))
+
+fun TagArrayBuilder<P2POrderEvent>.rating(ratingJson: String) = addUnique(RatingTag.assemble(ratingJson))
+
+fun TagArrayBuilder<P2POrderEvent>.network(network: String) = addUnique(NetworkTag.assemble(network))
+
+fun TagArrayBuilder<P2POrderEvent>.layer(layer: String) = addUnique(LayerTag.assemble(layer))
+
+fun TagArrayBuilder<P2POrderEvent>.makerName(name: String) = addUnique(MakerNameTag.assemble(name))
+
+fun TagArrayBuilder<P2POrderEvent>.geohash(geohash: String) = addAll(GeoHashTag.assemble(geohash).toList())
+
+fun TagArrayBuilder<P2POrderEvent>.bond(bond: Long) = addUnique(BondTag.assemble(bond))

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/TagArrayExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/TagArrayExt.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip69P2pOrderEvents
+
+import com.vitorpamplona.quartz.nip01Core.core.TagArray
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.AmountTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.BondTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.CurrencyTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.DocumentTypeTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.ExpiresAtTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.FiatAmountTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.LayerTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.MakerNameTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.NetworkTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.OrderStatusTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.OrderTypeTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.PaymentMethodTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.PlatformTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.PremiumTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.RatingTag
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.SourceTag
+
+fun TagArray.orderType() = firstNotNullOfOrNull(OrderTypeTag::parse)
+
+fun TagArray.orderStatus() = firstNotNullOfOrNull(OrderStatusTag::parse)
+
+fun TagArray.currency() = firstNotNullOfOrNull(CurrencyTag::parse)
+
+fun TagArray.amount() = firstNotNullOfOrNull(AmountTag::parse)
+
+fun TagArray.fiatAmount() = firstNotNullOfOrNull(FiatAmountTag::parse)
+
+fun TagArray.paymentMethods() = firstNotNullOfOrNull(PaymentMethodTag::parse)
+
+fun TagArray.premium() = firstNotNullOfOrNull(PremiumTag::parse)
+
+fun TagArray.expiresAt() = firstNotNullOfOrNull(ExpiresAtTag::parse)
+
+fun TagArray.platform() = firstNotNullOfOrNull(PlatformTag::parse)
+
+fun TagArray.documentType() = firstNotNullOfOrNull(DocumentTypeTag::parse)
+
+fun TagArray.source() = firstNotNullOfOrNull(SourceTag::parse)
+
+fun TagArray.rating() = firstNotNullOfOrNull(RatingTag::parse)
+
+fun TagArray.network() = firstNotNullOfOrNull(NetworkTag::parse)
+
+fun TagArray.layer() = firstNotNullOfOrNull(LayerTag::parse)
+
+fun TagArray.makerName() = firstNotNullOfOrNull(MakerNameTag::parse)
+
+fun TagArray.bond() = firstNotNullOfOrNull(BondTag::parse)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/AmountTag.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/AmountTag.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip69P2pOrderEvents.tags
+
+import com.vitorpamplona.quartz.nip01Core.core.has
+import com.vitorpamplona.quartz.utils.ensure
+
+class AmountTag {
+    companion object {
+        const val TAG_NAME = "amt"
+
+        fun parse(tag: Array<String>): Long? {
+            ensure(tag.has(1)) { return null }
+            ensure(tag[0] == TAG_NAME) { return null }
+            ensure(tag[1].isNotEmpty()) { return null }
+            return tag[1].toLongOrNull()
+        }
+
+        fun assemble(amountSats: Long) = arrayOf(TAG_NAME, amountSats.toString())
+    }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/BondTag.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/BondTag.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip69P2pOrderEvents.tags
+
+import com.vitorpamplona.quartz.nip01Core.core.has
+import com.vitorpamplona.quartz.utils.ensure
+
+class BondTag {
+    companion object {
+        const val TAG_NAME = "bond"
+
+        fun parse(tag: Array<String>): Long? {
+            ensure(tag.has(1)) { return null }
+            ensure(tag[0] == TAG_NAME) { return null }
+            ensure(tag[1].isNotEmpty()) { return null }
+            return tag[1].toLongOrNull()
+        }
+
+        fun assemble(bond: Long) = arrayOf(TAG_NAME, bond.toString())
+    }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/CurrencyTag.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/CurrencyTag.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip69P2pOrderEvents.tags
+
+import com.vitorpamplona.quartz.nip01Core.core.has
+import com.vitorpamplona.quartz.utils.ensure
+
+class CurrencyTag {
+    companion object {
+        const val TAG_NAME = "f"
+
+        fun parse(tag: Array<String>): String? {
+            ensure(tag.has(1)) { return null }
+            ensure(tag[0] == TAG_NAME) { return null }
+            ensure(tag[1].isNotEmpty()) { return null }
+            return tag[1]
+        }
+
+        fun assemble(currency: String) = arrayOf(TAG_NAME, currency)
+    }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/DocumentTypeTag.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/DocumentTypeTag.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip69P2pOrderEvents.tags
+
+import com.vitorpamplona.quartz.nip01Core.core.has
+import com.vitorpamplona.quartz.utils.ensure
+
+class DocumentTypeTag {
+    companion object {
+        const val TAG_NAME = "z"
+        const val ORDER = "order"
+
+        fun parse(tag: Array<String>): String? {
+            ensure(tag.has(1)) { return null }
+            ensure(tag[0] == TAG_NAME) { return null }
+            ensure(tag[1].isNotEmpty()) { return null }
+            return tag[1]
+        }
+
+        fun assemble(type: String = ORDER) = arrayOf(TAG_NAME, type)
+    }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/ExpiresAtTag.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/ExpiresAtTag.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip69P2pOrderEvents.tags
+
+import com.vitorpamplona.quartz.nip01Core.core.has
+import com.vitorpamplona.quartz.utils.ensure
+
+class ExpiresAtTag {
+    companion object {
+        const val TAG_NAME = "expires_at"
+
+        fun parse(tag: Array<String>): Long? {
+            ensure(tag.has(1)) { return null }
+            ensure(tag[0] == TAG_NAME) { return null }
+            ensure(tag[1].isNotEmpty()) { return null }
+            return tag[1].toLongOrNull()
+        }
+
+        fun assemble(timestamp: Long) = arrayOf(TAG_NAME, timestamp.toString())
+    }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/FiatAmountTag.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/FiatAmountTag.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip69P2pOrderEvents.tags
+
+import androidx.compose.runtime.Stable
+import com.vitorpamplona.quartz.nip01Core.core.has
+import com.vitorpamplona.quartz.utils.ensure
+
+@Stable
+class FiatAmountTag(
+    val min: String,
+    val max: String?,
+) {
+    companion object {
+        const val TAG_NAME = "fa"
+
+        fun parse(tag: Array<String>): FiatAmountTag? {
+            ensure(tag.has(1)) { return null }
+            ensure(tag[0] == TAG_NAME) { return null }
+            ensure(tag[1].isNotEmpty()) { return null }
+            return FiatAmountTag(tag[1], tag.getOrNull(2))
+        }
+
+        fun assemble(amount: String) = arrayOf(TAG_NAME, amount)
+
+        fun assemble(
+            min: String,
+            max: String,
+        ) = arrayOf(TAG_NAME, min, max)
+
+        fun assemble(fiatAmount: FiatAmountTag) =
+            if (fiatAmount.max != null) {
+                assemble(fiatAmount.min, fiatAmount.max)
+            } else {
+                assemble(fiatAmount.min)
+            }
+    }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/LayerTag.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/LayerTag.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip69P2pOrderEvents.tags
+
+import com.vitorpamplona.quartz.nip01Core.core.has
+import com.vitorpamplona.quartz.utils.ensure
+
+class LayerTag {
+    companion object {
+        const val TAG_NAME = "layer"
+
+        fun parse(tag: Array<String>): String? {
+            ensure(tag.has(1)) { return null }
+            ensure(tag[0] == TAG_NAME) { return null }
+            ensure(tag[1].isNotEmpty()) { return null }
+            return tag[1]
+        }
+
+        fun assemble(layer: String) = arrayOf(TAG_NAME, layer)
+    }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/MakerNameTag.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/MakerNameTag.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip69P2pOrderEvents.tags
+
+import com.vitorpamplona.quartz.nip01Core.core.has
+import com.vitorpamplona.quartz.utils.ensure
+
+class MakerNameTag {
+    companion object {
+        const val TAG_NAME = "name"
+
+        fun parse(tag: Array<String>): String? {
+            ensure(tag.has(1)) { return null }
+            ensure(tag[0] == TAG_NAME) { return null }
+            ensure(tag[1].isNotEmpty()) { return null }
+            return tag[1]
+        }
+
+        fun assemble(name: String) = arrayOf(TAG_NAME, name)
+    }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/NetworkTag.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/NetworkTag.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip69P2pOrderEvents.tags
+
+import com.vitorpamplona.quartz.nip01Core.core.has
+import com.vitorpamplona.quartz.utils.ensure
+
+class NetworkTag {
+    companion object {
+        const val TAG_NAME = "network"
+
+        fun parse(tag: Array<String>): String? {
+            ensure(tag.has(1)) { return null }
+            ensure(tag[0] == TAG_NAME) { return null }
+            ensure(tag[1].isNotEmpty()) { return null }
+            return tag[1]
+        }
+
+        fun assemble(network: String) = arrayOf(TAG_NAME, network)
+    }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/OrderStatusTag.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/OrderStatusTag.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip69P2pOrderEvents.tags
+
+import com.vitorpamplona.quartz.nip01Core.core.has
+import com.vitorpamplona.quartz.utils.ensure
+
+enum class OrderStatus(
+    val code: String,
+) {
+    PENDING("pending"),
+    CANCELED("canceled"),
+    IN_PROGRESS("in-progress"),
+    SUCCESS("success"),
+    EXPIRED("expired"),
+}
+
+class OrderStatusTag {
+    companion object {
+        const val TAG_NAME = "s"
+
+        fun parse(tag: Array<String>): OrderStatus? {
+            ensure(tag.has(1)) { return null }
+            ensure(tag[0] == TAG_NAME) { return null }
+            ensure(tag[1].isNotEmpty()) { return null }
+
+            return when (tag[1]) {
+                OrderStatus.PENDING.code -> OrderStatus.PENDING
+                OrderStatus.CANCELED.code -> OrderStatus.CANCELED
+                OrderStatus.IN_PROGRESS.code -> OrderStatus.IN_PROGRESS
+                OrderStatus.SUCCESS.code -> OrderStatus.SUCCESS
+                OrderStatus.EXPIRED.code -> OrderStatus.EXPIRED
+                else -> null
+            }
+        }
+
+        fun assemble(status: OrderStatus) = arrayOf(TAG_NAME, status.code)
+    }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/OrderTypeTag.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/OrderTypeTag.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip69P2pOrderEvents.tags
+
+import com.vitorpamplona.quartz.nip01Core.core.has
+import com.vitorpamplona.quartz.utils.ensure
+
+enum class OrderType(
+    val code: String,
+) {
+    BUY("buy"),
+    SELL("sell"),
+}
+
+class OrderTypeTag {
+    companion object {
+        const val TAG_NAME = "k"
+
+        fun parse(tag: Array<String>): OrderType? {
+            ensure(tag.has(1)) { return null }
+            ensure(tag[0] == TAG_NAME) { return null }
+            ensure(tag[1].isNotEmpty()) { return null }
+
+            return when (tag[1]) {
+                OrderType.BUY.code -> OrderType.BUY
+                OrderType.SELL.code -> OrderType.SELL
+                else -> null
+            }
+        }
+
+        fun assemble(type: OrderType) = arrayOf(TAG_NAME, type.code)
+    }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/PaymentMethodTag.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/PaymentMethodTag.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip69P2pOrderEvents.tags
+
+import com.vitorpamplona.quartz.nip01Core.core.has
+import com.vitorpamplona.quartz.utils.ensure
+
+class PaymentMethodTag {
+    companion object {
+        const val TAG_NAME = "pm"
+
+        fun parse(tag: Array<String>): List<String>? {
+            ensure(tag.has(1)) { return null }
+            ensure(tag[0] == TAG_NAME) { return null }
+            ensure(tag[1].isNotEmpty()) { return null }
+            return tag.drop(1)
+        }
+
+        fun assemble(methods: List<String>) = arrayOf(TAG_NAME, *methods.toTypedArray())
+    }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/PlatformTag.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/PlatformTag.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip69P2pOrderEvents.tags
+
+import com.vitorpamplona.quartz.nip01Core.core.has
+import com.vitorpamplona.quartz.utils.ensure
+
+class PlatformTag {
+    companion object {
+        const val TAG_NAME = "y"
+
+        fun parse(tag: Array<String>): String? {
+            ensure(tag.has(1)) { return null }
+            ensure(tag[0] == TAG_NAME) { return null }
+            ensure(tag[1].isNotEmpty()) { return null }
+            return tag[1]
+        }
+
+        fun assemble(platform: String) = arrayOf(TAG_NAME, platform)
+    }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/PremiumTag.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/PremiumTag.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip69P2pOrderEvents.tags
+
+import com.vitorpamplona.quartz.nip01Core.core.has
+import com.vitorpamplona.quartz.utils.ensure
+
+class PremiumTag {
+    companion object {
+        const val TAG_NAME = "premium"
+
+        fun parse(tag: Array<String>): String? {
+            ensure(tag.has(1)) { return null }
+            ensure(tag[0] == TAG_NAME) { return null }
+            ensure(tag[1].isNotEmpty()) { return null }
+            return tag[1]
+        }
+
+        fun assemble(premium: String) = arrayOf(TAG_NAME, premium)
+    }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/RatingTag.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/RatingTag.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip69P2pOrderEvents.tags
+
+import com.vitorpamplona.quartz.nip01Core.core.has
+import com.vitorpamplona.quartz.utils.ensure
+
+class RatingTag {
+    companion object {
+        const val TAG_NAME = "rating"
+
+        fun parse(tag: Array<String>): String? {
+            ensure(tag.has(1)) { return null }
+            ensure(tag[0] == TAG_NAME) { return null }
+            ensure(tag[1].isNotEmpty()) { return null }
+            return tag[1]
+        }
+
+        fun assemble(ratingJson: String) = arrayOf(TAG_NAME, ratingJson)
+    }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/SourceTag.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/tags/SourceTag.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip69P2pOrderEvents.tags
+
+import com.vitorpamplona.quartz.nip01Core.core.has
+import com.vitorpamplona.quartz.utils.ensure
+
+class SourceTag {
+    companion object {
+        const val TAG_NAME = "source"
+
+        fun parse(tag: Array<String>): String? {
+            ensure(tag.has(1)) { return null }
+            ensure(tag[0] == TAG_NAME) { return null }
+            ensure(tag[1].isNotEmpty()) { return null }
+            return tag[1]
+        }
+
+        fun assemble(url: String) = arrayOf(TAG_NAME, url)
+    }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/utils/EventFactory.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/utils/EventFactory.kt
@@ -147,6 +147,7 @@ import com.vitorpamplona.quartz.nip65RelayList.AdvertisedRelayListEvent
 import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.RelayDiscoveryEvent
 import com.vitorpamplona.quartz.nip66RelayMonitor.monitor.RelayMonitorEvent
 import com.vitorpamplona.quartz.nip68Picture.PictureEvent
+import com.vitorpamplona.quartz.nip69P2pOrderEvents.P2POrderEvent
 import com.vitorpamplona.quartz.nip71Video.VideoHorizontalEvent
 import com.vitorpamplona.quartz.nip71Video.VideoNormalEvent
 import com.vitorpamplona.quartz.nip71Video.VideoShortEvent
@@ -329,6 +330,7 @@ class EventFactory {
                 OtsEvent.KIND -> OtsEvent(id, pubKey, createdAt, tags, content, sig)
                 PaymentTargetsEvent.KIND -> PaymentTargetsEvent(id, pubKey, createdAt, tags, content, sig)
                 PeopleListEvent.KIND -> PeopleListEvent(id, pubKey, createdAt, tags, content, sig)
+                P2POrderEvent.KIND -> P2POrderEvent(id, pubKey, createdAt, tags, content, sig)
                 PictureEvent.KIND -> PictureEvent(id, pubKey, createdAt, tags, content, sig)
                 PinListEvent.KIND -> PinListEvent(id, pubKey, createdAt, tags, content, sig)
                 ZapPollEvent.KIND -> ZapPollEvent(id, pubKey, createdAt, tags, content, sig)


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for NIP-69 P2P Order Events, enabling the creation and parsing of peer-to-peer order events on the Nostr protocol.

## Key Changes
- **New P2POrderEvent class**: Implements a `BaseAddressableEvent` (kind 38383) for representing P2P orders with comprehensive order metadata
- **Tag implementations**: Added 16 specialized tag classes for parsing and assembling order-related data:
  - Order metadata: `OrderTypeTag` (buy/sell), `OrderStatusTag` (pending/canceled/in-progress/success/expired)
  - Financial data: `AmountTag`, `FiatAmountTag`, `CurrencyTag`, `PremiumTag`, `BondTag`
  - Order details: `PaymentMethodTag`, `PlatformTag`, `ExpiresAtTag`, `DocumentTypeTag`
  - Additional info: `SourceTag`, `RatingTag`, `NetworkTag`, `LayerTag`, `MakerNameTag`
- **Extension functions**: 
  - `TagArrayBuilderExt.kt`: Builder functions for constructing P2P order events with fluent API
  - `TagArrayExt.kt`: Parser functions for extracting order data from event tags
- **Event factory integration**: Updated `EventFactory.kt` to register the new P2POrderEvent type for deserialization

## Implementation Details
- All tag classes follow a consistent pattern with `parse()` and `assemble()` companion functions
- The `P2POrderEvent.build()` factory method provides a convenient DSL-style constructor with optional parameters
- Uses UUID for default d-tag generation and current timestamp for event creation
- Supports both single and range-based fiat amounts via `FiatAmountTag`
- Integrates with existing NIP standards (NIP-1, NIP-31, NIP-40) for core event functionality

https://claude.ai/code/session_01VpvrrRMLdjpB5C9Pq4VupK