### PR TITLE
Docs: Undocumented identity-based comparison in `equalImmutableLists`

### DIFF
--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/utils/ListUtils.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/utils/ListUtils.kt
@@ -22,6 +22,14 @@ package com.vitorpamplona.amethyst.commons.utils
 
 import kotlinx.collections.immutable.ImmutableList
 
+/**
+ * Compares two [ImmutableList] instances by element identity (`===`), not value equality (`==`).
+ *
+ * Returns `true` only when both lists have the same size and each element at the same index
+ * is the exact same object reference.
+ *
+ * Useful for cheap change detection in UI/state pipelines where object identity is meaningful.
+ */
 fun <T> equalImmutableLists(
     list1: ImmutableList<T>,
     list2: ImmutableList<T>,


### PR DESCRIPTION
Hi there! 👋

While going through the codebase, I noticed a minor opportunity for improvement regarding `commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/utils/ListUtils.kt`.

**Context:**
`equalImmutableLists` is public and uses referential equality (`===`) per element rather than structural equality (`==`). Without documentation, callers may assume normal list equality and get false negatives for value-equal but distinct instances. This is a non-obvious contract and should be documented explicitly to prevent subtle logic bugs.


**Proposed fix:**
Add KDoc that clearly states identity semantics and intended use case:

/**
 * Compares two [ImmutableList] instances by element identity (`===`), not value equality (`==`).
 *
 * Returns `true` only when both lists have the same size and each element at the same index
 * is the exact same object reference.
 *
 * Useful for cheap change detection in UI/state pipelines where object identity is meaningful.
 */
fun <T> equalImmutableLists(
    list1: ImmutableList<T>,
    list2: ImmutableList<T>,
): Boolean { ... }


**Files touched:**
- `commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/utils/ListUtils.kt` (modified)

*(Note: Tested the changes locally to ensure everything works as expected. Let me know if you need any adjustments, happy to help!)*

—
**NamNV**
📍 Hanoi, Vietnam
📧 nam.nv205106@gmail.com
