### PR TITLE
Assign `rejected` based on the presence of the "rejected" key in intent extras rather than retrieving its specific boolean value

### DIFF
--- a/quartz/src/androidMain/kotlin/com/vitorpamplona/quartz/nip55AndroidSigner/api/foreground/intents/results/IntentResult.kt
+++ b/quartz/src/androidMain/kotlin/com/vitorpamplona/quartz/nip55AndroidSigner/api/foreground/intents/results/IntentResult.kt
@@ -52,12 +52,7 @@ data class IntentResult(
                 result = data.getStringExtra("result"),
                 event = data.getStringExtra("event"),
                 `package` = data.getStringExtra("package"),
-                rejected =
-                    if (data.extras?.containsKey("rejected") == true) {
-                        data.getBooleanExtra("rejected", false)
-                    } else {
-                        null
-                    },
+                rejected = data.extras?.containsKey("rejected"),
             )
 
         fun fromJson(json: String): IntentResult = JsonMapperNip55.fromJsonTo<IntentResult>(json)


### PR DESCRIPTION
Old versions of amber below 5.0.2 would return just a empty string and not a boolean so the rejected check would never be true.
You can to reject this if you want, updating amber will make the rejection work
Only happens with intent no content provider