### PR TITLE
feat: add strfry Nostr relay deployment to VPS from Amethyst

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/vps/StrfryDeployScript.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/vps/StrfryDeployScript.kt
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.vps
+
+object StrfryDeployScript {
+    private const val D = "$"
+
+    fun generate(
+        relayName: String,
+        relayDescription: String,
+        adminPubkey: String,
+        domain: String?,
+    ): String {
+        val serverName = domain ?: "$D(curl -s http://169.254.169.254/v1/meta-data/public-ipv4 2>/dev/null || hostname -I | awk '{print ${D}1}')"
+
+        return buildString {
+            appendLine("#!/bin/bash")
+            appendLine("set -euo pipefail")
+            appendLine()
+            appendLine("export DEBIAN_FRONTEND=noninteractive")
+            appendLine()
+            appendLine("# Log everything for debugging")
+            appendLine("exec > >(tee /var/log/strfry-deploy.log) 2>&1")
+            appendLine("echo \"Starting strfry deployment at $D(date)\"")
+            appendLine()
+            appendLine("# Update system")
+            appendLine("apt-get update -y")
+            appendLine("apt-get upgrade -y")
+            appendLine()
+            appendLine("# Install dependencies")
+            appendLine("apt-get install -y git build-essential libyaml-cpp-dev \\")
+            appendLine("  libsecp256k1-dev libzstd-dev liblmdb-dev libflatbuffers-dev \\")
+            appendLine("  libssl-dev zlib1g-dev cmake pkg-config nginx certbot \\")
+            appendLine("  python3-certbot-nginx ufw")
+            appendLine()
+            appendLine("# Configure firewall")
+            appendLine("ufw default deny incoming")
+            appendLine("ufw default allow outgoing")
+            appendLine("ufw allow ssh")
+            appendLine("ufw allow 80/tcp")
+            appendLine("ufw allow 443/tcp")
+            appendLine("ufw --force enable")
+            appendLine()
+            appendLine("# Build strfry from source")
+            appendLine("cd /opt")
+            appendLine("git clone https://github.com/hoytech/strfry.git")
+            appendLine("cd strfry")
+            appendLine("git submodule update --init")
+            appendLine("make setup-golpe")
+            appendLine("make -j$D(nproc)")
+            appendLine("cp strfry /usr/local/bin/")
+            appendLine()
+            appendLine("# Create strfry user and directories")
+            appendLine("useradd -r -s /bin/false strfry || true")
+            appendLine("mkdir -p /var/lib/strfry /etc/strfry")
+            appendLine("chown strfry:strfry /var/lib/strfry")
+            appendLine()
+            appendLine("# Generate strfry config")
+            appendLine("cat > /etc/strfry/strfry.conf << 'STRFRY_CONF'")
+            appendLine("db = \"/var/lib/strfry/\"")
+            appendLine()
+            appendLine("dbParams {")
+            appendLine("    maxreaders = 256")
+            appendLine("    mapsize = 10995116277760")
+            appendLine("}")
+            appendLine()
+            appendLine("events {")
+            appendLine("    maxEventSize = 65536")
+            appendLine("    rejectEventsNewerThanSeconds = 900")
+            appendLine("    rejectEventsOlderThanSeconds = 94608000")
+            appendLine("    rejectEphemeralEventsOlderThanSeconds = 60")
+            appendLine("    ephemeralEventsLifetimeSeconds = 300")
+            appendLine("    maxNumTags = 2000")
+            appendLine("    maxTagValSize = 1024")
+            appendLine("}")
+            appendLine()
+            appendLine("relay {")
+            appendLine("    bind = \"127.0.0.1\"")
+            appendLine("    port = 7777")
+            appendLine()
+            appendLine("    info {")
+            append("        name = \"")
+            append(relayName.replace("\"", "\\\""))
+            appendLine("\"")
+            append("        description = \"")
+            append(relayDescription.replace("\"", "\\\""))
+            appendLine("\"")
+            append("        pubkey = \"")
+            append(adminPubkey)
+            appendLine("\"")
+            appendLine("        contact = \"\"")
+            appendLine("    }")
+            appendLine()
+            appendLine("    maxWebsocketPayloadSize = 131072")
+            appendLine("    autoPingSeconds = 55")
+            appendLine("    enableTcpKeepalive = false")
+            appendLine("    queryTimesliceBudgetMicroseconds = 10000")
+            appendLine("    maxFilterLimit = 500")
+            appendLine("    maxSubsPerConnection = 20")
+            appendLine("}")
+            appendLine("STRFRY_CONF")
+            appendLine()
+            appendLine("chown -R strfry:strfry /etc/strfry")
+            appendLine()
+            appendLine("# Create systemd service")
+            appendLine("cat > /etc/systemd/system/strfry.service << 'SYSTEMD_CONF'")
+            appendLine("[Unit]")
+            appendLine("Description=strfry Nostr relay")
+            appendLine("After=network.target")
+            appendLine()
+            appendLine("[Service]")
+            appendLine("Type=simple")
+            appendLine("User=strfry")
+            appendLine("ExecStart=/usr/local/bin/strfry --config /etc/strfry/strfry.conf relay")
+            appendLine("Restart=on-failure")
+            appendLine("RestartSec=5")
+            appendLine("LimitNOFILE=65536")
+            appendLine()
+            appendLine("[Install]")
+            appendLine("WantedBy=multi-user.target")
+            appendLine("SYSTEMD_CONF")
+            appendLine()
+            appendLine("systemctl daemon-reload")
+            appendLine("systemctl enable strfry")
+            appendLine("systemctl start strfry")
+            appendLine()
+            appendLine("# Configure nginx as reverse proxy")
+            appendLine("SERVER_IP=\"${serverName}\"")
+            appendLine()
+            appendLine("cat > /etc/nginx/sites-available/strfry << NGINX_CONF")
+            appendLine("server {")
+            appendLine("    listen 80;")
+            appendLine("    server_name ${D}SERVER_IP;")
+            appendLine()
+            appendLine("    location / {")
+            appendLine("        proxy_pass http://127.0.0.1:7777;")
+            appendLine("        proxy_http_version 1.1;")
+            appendLine("        proxy_set_header Upgrade ${D}http_upgrade;")
+            appendLine("        proxy_set_header Connection \"upgrade\";")
+            appendLine("        proxy_set_header Host ${D}host;")
+            appendLine("        proxy_set_header X-Real-IP ${D}remote_addr;")
+            appendLine("        proxy_set_header X-Forwarded-For ${D}proxy_add_x_forwarded_for;")
+            appendLine("        proxy_set_header X-Forwarded-Proto ${D}scheme;")
+            appendLine("        proxy_read_timeout 86400s;")
+            appendLine("        proxy_send_timeout 86400s;")
+            appendLine("    }")
+            appendLine("}")
+            appendLine("NGINX_CONF")
+            appendLine()
+            appendLine("rm -f /etc/nginx/sites-enabled/default")
+            appendLine("ln -sf /etc/nginx/sites-available/strfry /etc/nginx/sites-enabled/")
+            appendLine("nginx -t && systemctl reload nginx")
+            appendLine()
+            if (domain != null) {
+                appendLine("# Set up SSL with Let's Encrypt")
+                appendLine("certbot --nginx -d $domain --non-interactive --agree-tos --register-unsafely-without-email")
+                appendLine()
+            }
+            appendLine("echo \"strfry deployment completed at $D(date)\"")
+            appendLine("echo \"Relay is running on port 7777, proxied through nginx on port 80\"")
+            if (domain != null) {
+                appendLine("echo \"Relay URL: wss://$domain\"")
+            } else {
+                appendLine("echo \"Relay URL: ws://${D}SERVER_IP\"")
+            }
+        }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/vps/VpsProvider.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/vps/VpsProvider.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.vps
+
+data class VpsRegion(
+    val id: String,
+    val city: String,
+    val country: String,
+    val continent: String,
+)
+
+data class VpsPlan(
+    val id: String,
+    val name: String,
+    val vcpuCount: Int,
+    val ramMb: Int,
+    val diskGb: Int,
+    val bandwidthTb: Double,
+    val monthlyPriceCents: Int,
+    val regions: List<String>,
+) {
+    val monthlyPriceDisplay: String
+        get() = "$${monthlyPriceCents / 100}.${"%02d".format(monthlyPriceCents % 100)}/mo"
+
+    val specsDisplay: String
+        get() = "${vcpuCount}vCPU, ${if (ramMb >= 1024) "${ramMb / 1024}GB" else "${ramMb}MB"} RAM, ${diskGb}GB SSD"
+}
+
+enum class VpsServerStatus {
+    PENDING,
+    ACTIVE,
+    SUSPENDED,
+    RESIZING,
+    UNKNOWN,
+}
+
+data class VpsServer(
+    val id: String,
+    val label: String,
+    val status: VpsServerStatus,
+    val ipv4: String,
+    val ipv6: String,
+    val region: String,
+    val plan: String,
+    val os: String,
+    val relayUrl: String?,
+)
+
+data class VpsProviderInfo(
+    val id: String,
+    val name: String,
+    val description: String,
+    val website: String,
+    val acceptsCrypto: Boolean,
+)
+
+interface VpsProvider {
+    val info: VpsProviderInfo
+
+    suspend fun validateApiKey(apiKey: String): Boolean
+
+    suspend fun listRegions(apiKey: String): Result<List<VpsRegion>>
+
+    suspend fun listPlans(apiKey: String): Result<List<VpsPlan>>
+
+    suspend fun createServer(
+        apiKey: String,
+        region: String,
+        plan: String,
+        label: String,
+        userData: String,
+    ): Result<VpsServer>
+
+    suspend fun getServer(
+        apiKey: String,
+        serverId: String,
+    ): Result<VpsServer>
+
+    suspend fun listServers(apiKey: String): Result<List<VpsServer>>
+
+    suspend fun deleteServer(
+        apiKey: String,
+        serverId: String,
+    ): Result<Unit>
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/vps/VultrProvider.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/vps/VultrProvider.kt
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.vps
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.coroutines.executeAsync
+import java.util.concurrent.TimeUnit
+
+class VultrProvider(
+    private val httpClientProvider: () -> OkHttpClient =
+        {
+            OkHttpClient
+                .Builder()
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(60, TimeUnit.SECONDS)
+                .build()
+        },
+) : VpsProvider {
+    companion object {
+        private const val BASE_URL = "https://api.vultr.com/v2"
+        private val JSON_TYPE = "application/json".toMediaType()
+        private val mapper = jacksonObjectMapper()
+
+        // Ubuntu 24.04 LTS
+        private const val UBUNTU_OS_ID = 2284
+    }
+
+    override val info =
+        VpsProviderInfo(
+            id = "vultr",
+            name = "Vultr",
+            description = "Cloud hosting with global data centers. Accepts cryptocurrency payments.",
+            website = "https://www.vultr.com",
+            acceptsCrypto = true,
+        )
+
+    private fun authRequest(
+        apiKey: String,
+        url: String,
+    ): Request.Builder =
+        Request
+            .Builder()
+            .url(url)
+            .header("Authorization", "Bearer $apiKey")
+
+    override suspend fun validateApiKey(apiKey: String): Boolean =
+        withContext(Dispatchers.IO) {
+            try {
+                val request = authRequest(apiKey, "$BASE_URL/account").get().build()
+                httpClientProvider().newCall(request).executeAsync().use { response ->
+                    response.isSuccessful
+                }
+            } catch (e: Exception) {
+                false
+            }
+        }
+
+    override suspend fun listRegions(apiKey: String): Result<List<VpsRegion>> =
+        withContext(Dispatchers.IO) {
+            try {
+                val request = authRequest(apiKey, "$BASE_URL/regions").get().build()
+                httpClientProvider().newCall(request).executeAsync().use { response ->
+                    if (!response.isSuccessful) {
+                        return@withContext Result.failure(Exception("HTTP ${response.code}"))
+                    }
+                    val body = response.body.string()
+                    val tree = mapper.readTree(body)
+                    val regions =
+                        tree["regions"]?.map { node ->
+                            VpsRegion(
+                                id = node["id"].asText(),
+                                city = node["city"].asText(),
+                                country = node["country"].asText(),
+                                continent = node["continent"].asText(),
+                            )
+                        } ?: emptyList()
+                    Result.success(regions)
+                }
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+
+    override suspend fun listPlans(apiKey: String): Result<List<VpsPlan>> =
+        withContext(Dispatchers.IO) {
+            try {
+                val request =
+                    authRequest(apiKey, "$BASE_URL/plans?type=vc2&per_page=100")
+                        .get()
+                        .build()
+                httpClientProvider().newCall(request).executeAsync().use { response ->
+                    if (!response.isSuccessful) {
+                        return@withContext Result.failure(Exception("HTTP ${response.code}"))
+                    }
+                    val body = response.body.string()
+                    val tree = mapper.readTree(body)
+                    val plans =
+                        tree["plans"]
+                            ?.filter { node ->
+                                // Only plans with at least 1GB RAM suitable for strfry
+                                node["ram"].asInt() >= 1024
+                            }?.map { node ->
+                                VpsPlan(
+                                    id = node["id"].asText(),
+                                    name =
+                                        node["id"].asText().replace("vc2-", "").uppercase(),
+                                    vcpuCount = node["vcpu_count"].asInt(),
+                                    ramMb = node["ram"].asInt(),
+                                    diskGb = node["disk"].asInt(),
+                                    bandwidthTb = node["bandwidth"].asDouble() / 1024.0,
+                                    monthlyPriceCents = (node["monthly_cost"].asDouble() * 100).toInt(),
+                                    regions = node["locations"]?.map { it.asText() } ?: emptyList(),
+                                )
+                            }?.sortedBy { it.monthlyPriceCents } ?: emptyList()
+                    Result.success(plans)
+                }
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+
+    override suspend fun createServer(
+        apiKey: String,
+        region: String,
+        plan: String,
+        label: String,
+        userData: String,
+    ): Result<VpsServer> =
+        withContext(Dispatchers.IO) {
+            try {
+                val payload =
+                    mapper.writeValueAsString(
+                        mapOf(
+                            "region" to region,
+                            "plan" to plan,
+                            "os_id" to UBUNTU_OS_ID,
+                            "label" to label,
+                            "hostname" to label.replace(Regex("[^a-zA-Z0-9-]"), "-").take(63),
+                            "user_data" to android.util.Base64.encodeToString(userData.toByteArray(), android.util.Base64.NO_WRAP),
+                            "backups" to "disabled",
+                            "enable_ipv6" to true,
+                        ),
+                    )
+                val request =
+                    authRequest(apiKey, "$BASE_URL/instances")
+                        .post(payload.toRequestBody(JSON_TYPE))
+                        .build()
+                httpClientProvider().newCall(request).executeAsync().use { response ->
+                    if (!response.isSuccessful) {
+                        val errorBody = response.body.string()
+                        return@withContext Result.failure(Exception("HTTP ${response.code}: $errorBody"))
+                    }
+                    val body = response.body.string()
+                    val node = mapper.readTree(body)["instance"]
+                    Result.success(parseServer(node))
+                }
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+
+    override suspend fun getServer(
+        apiKey: String,
+        serverId: String,
+    ): Result<VpsServer> =
+        withContext(Dispatchers.IO) {
+            try {
+                val request =
+                    authRequest(apiKey, "$BASE_URL/instances/$serverId")
+                        .get()
+                        .build()
+                httpClientProvider().newCall(request).executeAsync().use { response ->
+                    if (!response.isSuccessful) {
+                        return@withContext Result.failure(Exception("HTTP ${response.code}"))
+                    }
+                    val body = response.body.string()
+                    val node = mapper.readTree(body)["instance"]
+                    Result.success(parseServer(node))
+                }
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+
+    override suspend fun listServers(apiKey: String): Result<List<VpsServer>> =
+        withContext(Dispatchers.IO) {
+            try {
+                val request =
+                    authRequest(apiKey, "$BASE_URL/instances?label=strfry-relay&per_page=100")
+                        .get()
+                        .build()
+                httpClientProvider().newCall(request).executeAsync().use { response ->
+                    if (!response.isSuccessful) {
+                        return@withContext Result.failure(Exception("HTTP ${response.code}"))
+                    }
+                    val body = response.body.string()
+                    val tree = mapper.readTree(body)
+                    val servers =
+                        tree["instances"]?.map { node ->
+                            parseServer(node)
+                        } ?: emptyList()
+                    Result.success(servers)
+                }
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+
+    override suspend fun deleteServer(
+        apiKey: String,
+        serverId: String,
+    ): Result<Unit> =
+        withContext(Dispatchers.IO) {
+            try {
+                val request =
+                    authRequest(apiKey, "$BASE_URL/instances/$serverId")
+                        .delete()
+                        .build()
+                httpClientProvider().newCall(request).executeAsync().use { response ->
+                    if (!response.isSuccessful) {
+                        return@withContext Result.failure(Exception("HTTP ${response.code}"))
+                    }
+                    Result.success(Unit)
+                }
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+
+    private fun parseServer(node: com.fasterxml.jackson.databind.JsonNode): VpsServer {
+        val mainIp = node["main_ip"]?.asText() ?: ""
+        return VpsServer(
+            id = node["id"].asText(),
+            label = node["label"]?.asText() ?: "",
+            status = parseStatus(node["status"]?.asText(), node["power_status"]?.asText()),
+            ipv4 = mainIp,
+            ipv6 = node["v6_main_ip"]?.asText() ?: "",
+            region = node["region"]?.asText() ?: "",
+            plan = node["plan"]?.asText() ?: "",
+            os = node["os"]?.asText() ?: "",
+            relayUrl = if (mainIp.isNotEmpty() && mainIp != "0.0.0.0") "wss://$mainIp" else null,
+        )
+    }
+
+    private fun parseStatus(
+        status: String?,
+        powerStatus: String?,
+    ): VpsServerStatus =
+        when {
+            status == "active" && powerStatus == "running" -> VpsServerStatus.ACTIVE
+            status == "pending" -> VpsServerStatus.PENDING
+            status == "suspended" -> VpsServerStatus.SUSPENDED
+            status == "resizing" -> VpsServerStatus.RESIZING
+            else -> VpsServerStatus.UNKNOWN
+        }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -109,6 +109,7 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.redirect.LoadRedirectScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relay.RelayFeedScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.AllRelayListScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.RelayInformationScreen
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.deployment.RelayDeploymentScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.eventsync.EventSyncScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.nip43.RelayMembersScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.nip86.RelayManagementScreen
@@ -227,6 +228,7 @@ fun BuildNavigation(
         composableFromEnd<Route.RequestToVanish> { RequestToVanishScreen(accountViewModel, nav) }
         composableFromEnd<Route.VanishEvents> { VanishEventsScreen(accountViewModel, nav) }
         composableFromEndArgs<Route.EditMediaServers> { AllMediaServersScreen(accountViewModel, nav) }
+        composableFromEnd<Route.DeployRelay> { RelayDeploymentScreen(accountViewModel, nav) }
         composableFromEndArgs<Route.UpdateReactionType> { UpdateReactionTypeScreen(accountViewModel, nav) }
 
         composableFromEndArgs<Route.ContentDiscovery> { DvmContentDiscoveryScreen(it.id, accountViewModel, nav) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
@@ -146,6 +146,8 @@ sealed class Route {
 
     @Serializable object EditMediaServers : Route()
 
+    @Serializable object DeployRelay : Route()
+
     @Serializable object UpdateReactionType : Route()
 
     @Serializable data class Nip47NWCSetup(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/deployment/RelayDeploymentScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/deployment/RelayDeploymentScreen.kt
@@ -1,0 +1,943 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.deployment
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Cloud
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Dns
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.icons.outlined.AttachMoney
+import androidx.compose.material.icons.outlined.Cloud
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import com.vitorpamplona.amethyst.service.vps.VpsPlan
+import com.vitorpamplona.amethyst.service.vps.VpsProviderInfo
+import com.vitorpamplona.amethyst.service.vps.VpsRegion
+import com.vitorpamplona.amethyst.service.vps.VpsServer
+import com.vitorpamplona.amethyst.service.vps.VpsServerStatus
+import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.topbars.TopBarWithBackButton
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.stringRes
+
+@Composable
+fun RelayDeploymentScreen(
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    val viewModel =
+        remember {
+            RelayDeploymentViewModel(
+                userPubkeyHex = accountViewModel.account.signer.pubKey,
+            )
+        }
+
+    val currentStep by viewModel.currentStep.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopBarWithBackButton(
+                caption = stringRes(com.vitorpamplona.amethyst.R.string.deploy_relay),
+                popBack = {
+                    if (currentStep == DeploymentStep.PROVIDER_SELECTION) {
+                        nav.popBack()
+                    } else {
+                        viewModel.goBack()
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Box(Modifier.padding(padding).fillMaxSize()) {
+            when (currentStep) {
+                DeploymentStep.PROVIDER_SELECTION -> ProviderSelectionStep(viewModel)
+                DeploymentStep.API_KEY_INPUT -> ApiKeyInputStep(viewModel)
+                DeploymentStep.PLAN_SELECTION -> PlanSelectionStep(viewModel)
+                DeploymentStep.CONFIGURE_RELAY -> ConfigureRelayStep(viewModel)
+                DeploymentStep.DEPLOYING -> DeployingStep(viewModel)
+                DeploymentStep.MANAGEMENT -> ManagementStep(viewModel)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProviderSelectionStep(viewModel: RelayDeploymentViewModel) {
+    val providers by viewModel.availableProviders.collectAsState()
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+    ) {
+        Text(
+            text = stringRes(com.vitorpamplona.amethyst.R.string.deploy_relay_subtitle),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(Modifier.height(24.dp))
+
+        Text(
+            text = stringRes(com.vitorpamplona.amethyst.R.string.choose_provider),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+        )
+
+        Spacer(Modifier.height(12.dp))
+
+        providers.forEach { provider ->
+            ProviderCard(provider) { viewModel.selectProvider(provider.id) }
+            Spacer(Modifier.height(8.dp))
+        }
+
+        Spacer(Modifier.height(24.dp))
+
+        Card(
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        ) {
+            Column(Modifier.padding(16.dp)) {
+                Text(
+                    text = stringRes(com.vitorpamplona.amethyst.R.string.what_is_strfry),
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = stringRes(com.vitorpamplona.amethyst.R.string.strfry_description),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProviderCard(
+    provider: VpsProviderInfo,
+    onClick: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                Icons.Outlined.Cloud,
+                contentDescription = null,
+                modifier = Modifier.size(40.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(Modifier.width(16.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = provider.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                )
+                Text(
+                    text = provider.description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (provider.acceptsCrypto) {
+                    Spacer(Modifier.height(4.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            Icons.Outlined.AttachMoney,
+                            contentDescription = null,
+                            modifier = Modifier.size(14.dp),
+                            tint = MaterialTheme.colorScheme.tertiary,
+                        )
+                        Text(
+                            text = stringRes(com.vitorpamplona.amethyst.R.string.accepts_crypto),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.tertiary,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ApiKeyInputStep(viewModel: RelayDeploymentViewModel) {
+    val apiKey by viewModel.apiKey.collectAsState()
+    val isValidating by viewModel.isValidatingKey.collectAsState()
+    val error by viewModel.error.collectAsState()
+    val provider by viewModel.selectedProvider.collectAsState()
+    var showKey by remember { mutableStateOf(false) }
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+    ) {
+        Text(
+            text = stringRes(com.vitorpamplona.amethyst.R.string.enter_api_key_title, provider?.info?.name ?: ""),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        Text(
+            text = stringRes(com.vitorpamplona.amethyst.R.string.enter_api_key_description, provider?.info?.website ?: ""),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = apiKey,
+            onValueChange = { viewModel.updateApiKey(it) },
+            label = { Text(stringRes(com.vitorpamplona.amethyst.R.string.api_key)) },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            visualTransformation = if (showKey) VisualTransformation.None else PasswordVisualTransformation(),
+            trailingIcon = {
+                IconButton(onClick = { showKey = !showKey }) {
+                    Icon(
+                        if (showKey) Icons.Filled.VisibilityOff else Icons.Filled.Visibility,
+                        contentDescription = null,
+                    )
+                }
+            },
+        )
+
+        error?.let {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = it,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+
+        Spacer(Modifier.height(24.dp))
+
+        Button(
+            onClick = { viewModel.validateAndProceed() },
+            modifier = Modifier.fillMaxWidth(),
+            enabled = apiKey.isNotBlank() && !isValidating,
+        ) {
+            if (isValidating) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                )
+                Spacer(Modifier.width(8.dp))
+            }
+            Text(stringRes(com.vitorpamplona.amethyst.R.string.validate_and_continue))
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        Card(
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        ) {
+            Column(Modifier.padding(16.dp)) {
+                Text(
+                    text = stringRes(com.vitorpamplona.amethyst.R.string.api_key_security_note),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlanSelectionStep(viewModel: RelayDeploymentViewModel) {
+    val regions by viewModel.regions.collectAsState()
+    val plans by viewModel.plans.collectAsState()
+    val selectedRegion by viewModel.selectedRegion.collectAsState()
+    val selectedPlan by viewModel.selectedPlan.collectAsState()
+    val existingServers by viewModel.existingServers.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+    val error by viewModel.error.collectAsState()
+
+    if (isLoading && plans.isEmpty()) {
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator()
+        }
+        return
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        if (existingServers.isNotEmpty()) {
+            item {
+                Text(
+                    text = stringRes(com.vitorpamplona.amethyst.R.string.existing_servers),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+
+            items(existingServers) { server ->
+                ExistingServerCard(server) { viewModel.manageExistingServer(server) }
+            }
+
+            item {
+                HorizontalDivider(Modifier.padding(vertical = 8.dp))
+                Text(
+                    text = stringRes(com.vitorpamplona.amethyst.R.string.deploy_new_relay),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                )
+                Spacer(Modifier.height(8.dp))
+            }
+        }
+
+        item {
+            Text(
+                text = stringRes(com.vitorpamplona.amethyst.R.string.select_region),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+
+        item {
+            RegionSelector(regions, selectedRegion) { viewModel.selectRegion(it) }
+        }
+
+        item {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = stringRes(com.vitorpamplona.amethyst.R.string.select_plan),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+
+        val filteredPlans =
+            if (selectedRegion != null) {
+                plans.filter { it.regions.contains(selectedRegion!!.id) }
+            } else {
+                plans
+            }
+
+        items(filteredPlans) { plan ->
+            PlanCard(plan, plan == selectedPlan) { viewModel.selectPlan(plan) }
+        }
+
+        item {
+            error?.let {
+                Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            Button(
+                onClick = { viewModel.proceedToConfigure() },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = selectedRegion != null && selectedPlan != null,
+            ) {
+                Text(stringRes(com.vitorpamplona.amethyst.R.string.continue_button))
+            }
+        }
+    }
+}
+
+@Composable
+private fun RegionSelector(
+    regions: List<VpsRegion>,
+    selectedRegion: VpsRegion?,
+    onSelect: (VpsRegion) -> Unit,
+) {
+    val grouped = regions.groupBy { it.continent }.toSortedMap()
+
+    Column {
+        grouped.forEach { (continent, regionList) ->
+            Text(
+                text = continent,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(vertical = 4.dp),
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                regionList.sortedBy { it.city }.take(6).forEach { region ->
+                    val isSelected = region == selectedRegion
+                    OutlinedButton(
+                        onClick = { onSelect(region) },
+                        colors =
+                            if (isSelected) {
+                                ButtonDefaults.outlinedButtonColors(
+                                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                                )
+                            } else {
+                                ButtonDefaults.outlinedButtonColors()
+                            },
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        Text(
+                            region.city,
+                            style = MaterialTheme.typography.labelSmall,
+                            maxLines = 1,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlanCard(
+    plan: VpsPlan,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+        border =
+            if (isSelected) {
+                BorderStroke(2.dp, MaterialTheme.colorScheme.primary)
+            } else {
+                BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
+            },
+        colors =
+            if (isSelected) {
+                CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.3f))
+            } else {
+                CardDefaults.cardColors()
+            },
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp).fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Column(Modifier.weight(1f)) {
+                Text(
+                    text = plan.specsDisplay,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                )
+                Text(
+                    text = "${plan.bandwidthTb}TB bandwidth",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Text(
+                text = plan.monthlyPriceDisplay,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ExistingServerCard(
+    server: VpsServer,
+    onClick: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp).fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                Icons.Filled.Dns,
+                contentDescription = null,
+                tint =
+                    when (server.status) {
+                        VpsServerStatus.ACTIVE -> MaterialTheme.colorScheme.primary
+                        VpsServerStatus.PENDING -> MaterialTheme.colorScheme.tertiary
+                        else -> MaterialTheme.colorScheme.error
+                    },
+            )
+            Spacer(Modifier.width(12.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    text = server.label.ifEmpty { server.id },
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                )
+                Text(
+                    text = "${server.ipv4} (${server.status.name.lowercase()})",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConfigureRelayStep(viewModel: RelayDeploymentViewModel) {
+    val relayName by viewModel.relayName.collectAsState()
+    val relayDescription by viewModel.relayDescription.collectAsState()
+    val domain by viewModel.domain.collectAsState()
+    val selectedPlan by viewModel.selectedPlan.collectAsState()
+    val selectedRegion by viewModel.selectedRegion.collectAsState()
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+    ) {
+        Text(
+            text = stringRes(com.vitorpamplona.amethyst.R.string.configure_relay),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+        )
+
+        Spacer(Modifier.height(16.dp))
+
+        Card(
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        ) {
+            Column(Modifier.padding(12.dp)) {
+                Text(
+                    stringRes(com.vitorpamplona.amethyst.R.string.deployment_summary),
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.Bold,
+                )
+                selectedRegion?.let {
+                    Text("${it.city}, ${it.country}", style = MaterialTheme.typography.bodySmall)
+                }
+                selectedPlan?.let {
+                    Text("${it.specsDisplay} - ${it.monthlyPriceDisplay}", style = MaterialTheme.typography.bodySmall)
+                }
+            }
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = relayName,
+            onValueChange = { viewModel.updateRelayName(it) },
+            label = { Text(stringRes(com.vitorpamplona.amethyst.R.string.relay_name)) },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        OutlinedTextField(
+            value = relayDescription,
+            onValueChange = { viewModel.updateRelayDescription(it) },
+            label = { Text(stringRes(com.vitorpamplona.amethyst.R.string.relay_description_label)) },
+            modifier = Modifier.fillMaxWidth(),
+            minLines = 2,
+            maxLines = 4,
+        )
+
+        Spacer(Modifier.height(8.dp))
+
+        OutlinedTextField(
+            value = domain,
+            onValueChange = { viewModel.updateDomain(it) },
+            label = { Text(stringRes(com.vitorpamplona.amethyst.R.string.domain_optional)) },
+            placeholder = { Text("relay.example.com") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+        )
+
+        Spacer(Modifier.height(4.dp))
+
+        Text(
+            text = stringRes(com.vitorpamplona.amethyst.R.string.domain_hint),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Spacer(Modifier.height(24.dp))
+
+        Button(
+            onClick = { viewModel.deploy() },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Icon(Icons.Outlined.Add, contentDescription = null)
+            Spacer(Modifier.width(8.dp))
+            Text(stringRes(com.vitorpamplona.amethyst.R.string.deploy_now))
+        }
+    }
+}
+
+@Composable
+private fun DeployingStep(viewModel: RelayDeploymentViewModel) {
+    val logs by viewModel.deploymentLog.collectAsState()
+    val error by viewModel.error.collectAsState()
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+    ) {
+        Text(
+            text = stringRes(com.vitorpamplona.amethyst.R.string.deploying_relay),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+        )
+
+        Spacer(Modifier.height(16.dp))
+
+        if (error == null) {
+            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        Card(
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+            modifier = Modifier.fillMaxWidth().weight(1f),
+        ) {
+            LazyColumn(Modifier.padding(12.dp)) {
+                items(logs) { log ->
+                    Text(
+                        text = log,
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace,
+                        modifier = Modifier.padding(vertical = 2.dp),
+                    )
+                }
+            }
+        }
+
+        error?.let {
+            Spacer(Modifier.height(8.dp))
+            Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+            Spacer(Modifier.height(8.dp))
+            OutlinedButton(
+                onClick = { viewModel.goBack() },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringRes(com.vitorpamplona.amethyst.R.string.go_back))
+            }
+        }
+    }
+}
+
+@Composable
+private fun ManagementStep(viewModel: RelayDeploymentViewModel) {
+    val server by viewModel.deployedServer.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+    val error by viewModel.error.collectAsState()
+    val clipboardManager = LocalClipboardManager.current
+    var showDeleteConfirm by remember { mutableStateOf(false) }
+
+    val currentServer = server ?: return
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+    ) {
+        Text(
+            text = stringRes(com.vitorpamplona.amethyst.R.string.server_management),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+        )
+
+        Spacer(Modifier.height(16.dp))
+
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(Modifier.padding(16.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        Icons.Filled.Cloud,
+                        contentDescription = null,
+                        tint =
+                            when (currentServer.status) {
+                                VpsServerStatus.ACTIVE -> MaterialTheme.colorScheme.primary
+                                VpsServerStatus.PENDING -> MaterialTheme.colorScheme.tertiary
+                                else -> MaterialTheme.colorScheme.error
+                            },
+                        modifier = Modifier.size(32.dp),
+                    )
+                    Spacer(Modifier.width(12.dp))
+                    Column {
+                        Text(
+                            text = currentServer.label.ifEmpty { "strfry relay" },
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                        )
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(
+                                Icons.Filled.CheckCircle,
+                                contentDescription = null,
+                                modifier = Modifier.size(14.dp),
+                                tint =
+                                    when (currentServer.status) {
+                                        VpsServerStatus.ACTIVE -> MaterialTheme.colorScheme.primary
+                                        VpsServerStatus.PENDING -> MaterialTheme.colorScheme.tertiary
+                                        else -> MaterialTheme.colorScheme.error
+                                    },
+                            )
+                            Spacer(Modifier.width(4.dp))
+                            Text(
+                                text =
+                                    currentServer.status.name
+                                        .lowercase()
+                                        .replaceFirstChar { it.uppercase() },
+                                style = MaterialTheme.typography.bodySmall,
+                            )
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(16.dp))
+                HorizontalDivider()
+                Spacer(Modifier.height(16.dp))
+
+                InfoRow(stringRes(com.vitorpamplona.amethyst.R.string.server_id_label), currentServer.id)
+                InfoRow(stringRes(com.vitorpamplona.amethyst.R.string.ipv4_label), currentServer.ipv4)
+                if (currentServer.ipv6.isNotEmpty()) {
+                    InfoRow(stringRes(com.vitorpamplona.amethyst.R.string.ipv6_label), currentServer.ipv6)
+                }
+                InfoRow(stringRes(com.vitorpamplona.amethyst.R.string.region_label), currentServer.region)
+                InfoRow(stringRes(com.vitorpamplona.amethyst.R.string.os_label), currentServer.os)
+
+                if (currentServer.status == VpsServerStatus.ACTIVE && currentServer.ipv4.isNotEmpty()) {
+                    Spacer(Modifier.height(16.dp))
+                    HorizontalDivider()
+                    Spacer(Modifier.height(16.dp))
+
+                    Text(
+                        text = stringRes(com.vitorpamplona.amethyst.R.string.relay_url_label),
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Spacer(Modifier.height(4.dp))
+
+                    val relayUrl = currentServer.relayUrl ?: "ws://${currentServer.ipv4}"
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = relayUrl,
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontFamily = FontFamily.Monospace,
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.weight(1f),
+                        )
+                        IconButton(onClick = {
+                            clipboardManager.setText(AnnotatedString(relayUrl))
+                        }) {
+                            Icon(Icons.Filled.ContentCopy, contentDescription = "Copy")
+                        }
+                    }
+                }
+            }
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            OutlinedButton(
+                onClick = { viewModel.refreshServerStatus() },
+                modifier = Modifier.weight(1f),
+                enabled = !isLoading,
+            ) {
+                Icon(Icons.Filled.Refresh, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(4.dp))
+                Text(stringRes(com.vitorpamplona.amethyst.R.string.refresh))
+            }
+
+            Button(
+                onClick = { showDeleteConfirm = true },
+                modifier = Modifier.weight(1f),
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error),
+                enabled = !isLoading,
+            ) {
+                Icon(Icons.Filled.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(Modifier.width(4.dp))
+                Text(stringRes(com.vitorpamplona.amethyst.R.string.delete_server))
+            }
+        }
+
+        error?.let {
+            Spacer(Modifier.height(8.dp))
+            Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+        }
+
+        if (currentServer.status == VpsServerStatus.ACTIVE) {
+            Spacer(Modifier.height(24.dp))
+
+            Card(
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+            ) {
+                Column(Modifier.padding(16.dp)) {
+                    Text(
+                        text = stringRes(com.vitorpamplona.amethyst.R.string.next_steps_title),
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        text = stringRes(com.vitorpamplona.amethyst.R.string.next_steps_description),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+
+        if (currentServer.status == VpsServerStatus.PENDING) {
+            Spacer(Modifier.height(16.dp))
+
+            Card(
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer),
+            ) {
+                Row(Modifier.padding(16.dp), verticalAlignment = Alignment.CenterVertically) {
+                    CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+                    Spacer(Modifier.width(12.dp))
+                    Text(
+                        text = stringRes(com.vitorpamplona.amethyst.R.string.server_provisioning),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            }
+        }
+    }
+
+    if (showDeleteConfirm) {
+        AlertDialog(
+            onDismissRequest = { showDeleteConfirm = false },
+            title = { Text(stringRes(com.vitorpamplona.amethyst.R.string.delete_server_confirm_title)) },
+            text = { Text(stringRes(com.vitorpamplona.amethyst.R.string.delete_server_confirm_message)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showDeleteConfirm = false
+                        viewModel.deleteServer()
+                    },
+                ) {
+                    Text(
+                        stringRes(com.vitorpamplona.amethyst.R.string.delete),
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteConfirm = false }) {
+                    Text(stringRes(com.vitorpamplona.amethyst.R.string.cancel))
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun InfoRow(
+    label: String,
+    value: String,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.width(80.dp),
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodySmall,
+            fontFamily = FontFamily.Monospace,
+        )
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/deployment/RelayDeploymentViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/deployment/RelayDeploymentViewModel.kt
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.deployment
+
+import androidx.compose.runtime.Stable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.vitorpamplona.amethyst.service.vps.StrfryDeployScript
+import com.vitorpamplona.amethyst.service.vps.VpsPlan
+import com.vitorpamplona.amethyst.service.vps.VpsProvider
+import com.vitorpamplona.amethyst.service.vps.VpsProviderInfo
+import com.vitorpamplona.amethyst.service.vps.VpsRegion
+import com.vitorpamplona.amethyst.service.vps.VpsServer
+import com.vitorpamplona.amethyst.service.vps.VpsServerStatus
+import com.vitorpamplona.amethyst.service.vps.VultrProvider
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+enum class DeploymentStep {
+    PROVIDER_SELECTION,
+    API_KEY_INPUT,
+    PLAN_SELECTION,
+    CONFIGURE_RELAY,
+    DEPLOYING,
+    MANAGEMENT,
+}
+
+@Stable
+class RelayDeploymentViewModel(
+    private val userPubkeyHex: String,
+) : ViewModel() {
+    private val providers: Map<String, VpsProvider> =
+        mapOf(
+            "vultr" to VultrProvider(),
+        )
+
+    private val _currentStep = MutableStateFlow(DeploymentStep.PROVIDER_SELECTION)
+    val currentStep: StateFlow<DeploymentStep> = _currentStep
+
+    private val _availableProviders = MutableStateFlow(providers.values.map { it.info })
+    val availableProviders: StateFlow<List<VpsProviderInfo>> = _availableProviders
+
+    private val _selectedProvider = MutableStateFlow<VpsProvider?>(null)
+    val selectedProvider: StateFlow<VpsProvider?> = _selectedProvider
+
+    private val _apiKey = MutableStateFlow("")
+    val apiKey: StateFlow<String> = _apiKey
+
+    private val _isValidatingKey = MutableStateFlow(false)
+    val isValidatingKey: StateFlow<Boolean> = _isValidatingKey
+
+    private val _regions = MutableStateFlow<List<VpsRegion>>(emptyList())
+    val regions: StateFlow<List<VpsRegion>> = _regions
+
+    private val _plans = MutableStateFlow<List<VpsPlan>>(emptyList())
+    val plans: StateFlow<List<VpsPlan>> = _plans
+
+    private val _selectedRegion = MutableStateFlow<VpsRegion?>(null)
+    val selectedRegion: StateFlow<VpsRegion?> = _selectedRegion
+
+    private val _selectedPlan = MutableStateFlow<VpsPlan?>(null)
+    val selectedPlan: StateFlow<VpsPlan?> = _selectedPlan
+
+    private val _relayName = MutableStateFlow("My Nostr Relay")
+    val relayName: StateFlow<String> = _relayName
+
+    private val _relayDescription = MutableStateFlow("A personal Nostr relay powered by strfry")
+    val relayDescription: StateFlow<String> = _relayDescription
+
+    private val _domain = MutableStateFlow("")
+    val domain: StateFlow<String> = _domain
+
+    private val _deployedServer = MutableStateFlow<VpsServer?>(null)
+    val deployedServer: StateFlow<VpsServer?> = _deployedServer
+
+    private val _existingServers = MutableStateFlow<List<VpsServer>>(emptyList())
+    val existingServers: StateFlow<List<VpsServer>> = _existingServers
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error
+
+    private val _deploymentLog = MutableStateFlow<List<String>>(emptyList())
+    val deploymentLog: StateFlow<List<String>> = _deploymentLog
+
+    private var statusPollingJob: Job? = null
+
+    fun selectProvider(providerId: String) {
+        _selectedProvider.value = providers[providerId]
+        _currentStep.value = DeploymentStep.API_KEY_INPUT
+        _error.value = null
+    }
+
+    fun updateApiKey(key: String) {
+        _apiKey.value = key
+    }
+
+    fun validateAndProceed() {
+        val provider = _selectedProvider.value ?: return
+        val key = _apiKey.value.trim()
+        if (key.isEmpty()) {
+            _error.value = "API key cannot be empty"
+            return
+        }
+
+        _isValidatingKey.value = true
+        _error.value = null
+
+        viewModelScope.launch {
+            val valid = provider.validateApiKey(key)
+            _isValidatingKey.value = false
+
+            if (valid) {
+                loadPlansAndRegions()
+                loadExistingServers()
+                _currentStep.value = DeploymentStep.PLAN_SELECTION
+            } else {
+                _error.value = "Invalid API key. Please check and try again."
+            }
+        }
+    }
+
+    private fun loadPlansAndRegions() {
+        val provider = _selectedProvider.value ?: return
+        val key = _apiKey.value.trim()
+
+        viewModelScope.launch {
+            _isLoading.value = true
+            provider.listRegions(key).onSuccess { _regions.value = it }
+            provider.listPlans(key).onSuccess { _plans.value = it }
+            _isLoading.value = false
+        }
+    }
+
+    private fun loadExistingServers() {
+        val provider = _selectedProvider.value ?: return
+        val key = _apiKey.value.trim()
+
+        viewModelScope.launch {
+            provider.listServers(key).onSuccess {
+                _existingServers.value = it
+            }
+        }
+    }
+
+    fun selectRegion(region: VpsRegion) {
+        _selectedRegion.value = region
+    }
+
+    fun selectPlan(plan: VpsPlan) {
+        _selectedPlan.value = plan
+    }
+
+    fun updateRelayName(name: String) {
+        _relayName.value = name
+    }
+
+    fun updateRelayDescription(description: String) {
+        _relayDescription.value = description
+    }
+
+    fun updateDomain(d: String) {
+        _domain.value = d
+    }
+
+    fun proceedToConfigure() {
+        if (_selectedRegion.value == null || _selectedPlan.value == null) {
+            _error.value = "Please select a region and plan"
+            return
+        }
+        _error.value = null
+        _currentStep.value = DeploymentStep.CONFIGURE_RELAY
+    }
+
+    fun deploy() {
+        val provider = _selectedProvider.value ?: return
+        val key = _apiKey.value.trim()
+        val region = _selectedRegion.value ?: return
+        val plan = _selectedPlan.value ?: return
+
+        _error.value = null
+        _deploymentLog.value = listOf("Starting deployment...")
+        _currentStep.value = DeploymentStep.DEPLOYING
+
+        viewModelScope.launch {
+            addLog("Generating strfry configuration...")
+
+            val domainValue = _domain.value.trim().ifEmpty { null }
+            val userData =
+                StrfryDeployScript.generate(
+                    relayName = _relayName.value,
+                    relayDescription = _relayDescription.value,
+                    adminPubkey = userPubkeyHex,
+                    domain = domainValue,
+                )
+
+            addLog("Creating server in ${region.city}, ${region.country}...")
+            addLog("Plan: ${plan.specsDisplay} (${plan.monthlyPriceDisplay})")
+
+            val result =
+                provider.createServer(
+                    apiKey = key,
+                    region = region.id,
+                    plan = plan.id,
+                    label = "strfry-relay",
+                    userData = userData,
+                )
+
+            result
+                .onSuccess { server ->
+                    _deployedServer.value = server
+                    addLog("Server created! ID: ${server.id}")
+                    addLog("Waiting for server to become active...")
+                    startStatusPolling(server.id)
+                }.onFailure { e ->
+                    addLog("ERROR: ${e.message}")
+                    _error.value = e.message
+                }
+        }
+    }
+
+    private fun startStatusPolling(serverId: String) {
+        statusPollingJob?.cancel()
+        statusPollingJob =
+            viewModelScope.launch {
+                val provider = _selectedProvider.value ?: return@launch
+                val key = _apiKey.value.trim()
+                var attempts = 0
+
+                while (attempts < 60) {
+                    delay(10_000)
+                    attempts++
+
+                    provider.getServer(key, serverId).onSuccess { server ->
+                        _deployedServer.value = server
+
+                        when (server.status) {
+                            VpsServerStatus.ACTIVE -> {
+                                addLog("Server is active! IP: ${server.ipv4}")
+                                addLog("strfry is being installed (this takes a few minutes)...")
+                                addLog("Your relay will be available at: ws://${server.ipv4}")
+                                if (_domain.value.isNotEmpty()) {
+                                    addLog("Once DNS is configured: wss://${_domain.value}")
+                                }
+                                _currentStep.value = DeploymentStep.MANAGEMENT
+                                return@launch
+                            }
+
+                            VpsServerStatus.PENDING -> {
+                                if (attempts % 3 == 0) {
+                                    addLog("Still provisioning... (${attempts * 10}s)")
+                                }
+                            }
+
+                            else -> {
+                                addLog("Server status: ${server.status}")
+                            }
+                        }
+                    }
+                }
+                addLog("Timed out waiting for server. Check your provider dashboard.")
+                _currentStep.value = DeploymentStep.MANAGEMENT
+            }
+    }
+
+    fun refreshServerStatus() {
+        val provider = _selectedProvider.value ?: return
+        val key = _apiKey.value.trim()
+        val server = _deployedServer.value ?: return
+
+        viewModelScope.launch {
+            _isLoading.value = true
+            provider.getServer(key, server.id).onSuccess {
+                _deployedServer.value = it
+            }
+            _isLoading.value = false
+        }
+    }
+
+    fun deleteServer() {
+        val provider = _selectedProvider.value ?: return
+        val key = _apiKey.value.trim()
+        val server = _deployedServer.value ?: return
+
+        viewModelScope.launch {
+            _isLoading.value = true
+            _error.value = null
+
+            provider
+                .deleteServer(key, server.id)
+                .onSuccess {
+                    _deployedServer.value = null
+                    _currentStep.value = DeploymentStep.PLAN_SELECTION
+                    loadExistingServers()
+                }.onFailure { e ->
+                    _error.value = "Failed to delete server: ${e.message}"
+                }
+
+            _isLoading.value = false
+        }
+    }
+
+    fun manageExistingServer(server: VpsServer) {
+        _deployedServer.value = server
+        _currentStep.value = DeploymentStep.MANAGEMENT
+    }
+
+    fun goBack() {
+        _error.value = null
+        when (_currentStep.value) {
+            DeploymentStep.API_KEY_INPUT -> {
+                _currentStep.value = DeploymentStep.PROVIDER_SELECTION
+            }
+
+            DeploymentStep.PLAN_SELECTION -> {
+                _currentStep.value = DeploymentStep.API_KEY_INPUT
+            }
+
+            DeploymentStep.CONFIGURE_RELAY -> {
+                _currentStep.value = DeploymentStep.PLAN_SELECTION
+            }
+
+            DeploymentStep.MANAGEMENT -> {
+                _deployedServer.value = null
+                _currentStep.value = DeploymentStep.PLAN_SELECTION
+            }
+
+            else -> {}
+        }
+    }
+
+    fun clearError() {
+        _error.value = null
+    }
+
+    private fun addLog(message: String) {
+        _deploymentLog.value = _deploymentLog.value + message
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        statusPollingJob?.cancel()
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AllSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AllSettingsScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Bolt
 import androidx.compose.material.icons.outlined.CloudUpload
 import androidx.compose.material.icons.outlined.DeleteForever
+import androidx.compose.material.icons.outlined.Dns
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.outlined.History
 import androidx.compose.material.icons.outlined.Key
@@ -96,6 +97,13 @@ fun AllSettingsScreen(
                 iconPainterRef = 4,
                 tint = tint,
                 onClick = { nav.nav(Route.EditRelays) },
+            )
+            HorizontalDivider()
+            SettingsNavigationRow(
+                title = R.string.deploy_relay,
+                icon = Icons.Outlined.Dns,
+                tint = tint,
+                onClick = { nav.nav(Route.DeployRelay) },
             )
             HorizontalDivider()
             SettingsNavigationRow(

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -2105,4 +2105,44 @@
     <string name="relay_members_removed">%1$d members removed from relay</string>
     <string name="relay_join_request">Relay join request</string>
     <string name="relay_leave_request">Relay leave request</string>
+
+    <!-- Relay Deployment -->
+    <string name="deploy_relay">Deploy Relay</string>
+    <string name="deploy_relay_subtitle">Deploy your own Nostr relay on a Virtual Private Server. Choose a provider, pick a plan, and have a strfry relay running in minutes.</string>
+    <string name="choose_provider">Choose a VPS Provider</string>
+    <string name="what_is_strfry">What is strfry?</string>
+    <string name="strfry_description">strfry is a high-performance Nostr relay written in C++. It uses minimal resources and can handle thousands of concurrent connections. Your relay will be automatically configured and ready to use.</string>
+    <string name="accepts_crypto">Accepts cryptocurrency</string>
+    <string name="enter_api_key_title">%1$s API Key</string>
+    <string name="enter_api_key_description">Enter your API key from %1$s. You can create one in your account dashboard.</string>
+    <string name="api_key">API Key</string>
+    <string name="validate_and_continue">Validate &amp; Continue</string>
+    <string name="api_key_security_note">Your API key is stored only in memory and never saved to disk or sent to any server other than your chosen VPS provider.</string>
+    <string name="existing_servers">Your Existing Relay Servers</string>
+    <string name="deploy_new_relay">Deploy a New Relay</string>
+    <string name="select_region">Select Region</string>
+    <string name="select_plan">Select Plan</string>
+    <string name="continue_button">Continue</string>
+    <string name="configure_relay">Configure Your Relay</string>
+    <string name="deployment_summary">Deployment Summary</string>
+    <string name="relay_name">Relay Name</string>
+    <string name="relay_description_label">Description</string>
+    <string name="domain_optional">Domain (optional)</string>
+    <string name="domain_hint">If you have a domain, point its DNS A record to the server IP. SSL will be configured automatically via Let\'s Encrypt.</string>
+    <string name="deploy_now">Deploy Now</string>
+    <string name="deploying_relay">Deploying Your Relay</string>
+    <string name="server_management">Server Management</string>
+    <string name="server_id_label">Server ID</string>
+    <string name="ipv4_label">IPv4</string>
+    <string name="ipv6_label">IPv6</string>
+    <string name="region_label">Region</string>
+    <string name="os_label">OS</string>
+    <string name="relay_url_label">Relay URL</string>
+    <string name="delete">Delete</string>
+    <string name="delete_server">Delete Server</string>
+    <string name="delete_server_confirm_title">Delete Server?</string>
+    <string name="delete_server_confirm_message">This will permanently destroy the server and all data on it. This action cannot be undone. You will stop being charged for it.</string>
+    <string name="next_steps_title">Next Steps</string>
+    <string name="next_steps_description">1. strfry is being installed (takes 3-5 minutes after the server is active)\n2. Add this relay URL to your relay list in Amethyst settings\n3. If you set up a domain, point its DNS to the server IP\n4. Use the Relay Management screen to configure access policies</string>
+    <string name="server_provisioning">Server is being provisioned. This usually takes 1-2 minutes.</string>
 </resources>


### PR DESCRIPTION
Add a complete workflow for deploying a strfry Nostr relay on a Virtual
Private Server directly from Amethyst. Users can pick a VPS provider
(Vultr, which accepts cryptocurrency), enter their API key, choose a
server region and plan, configure relay metadata, deploy with one tap,
and manage or delete the server afterward.

New files:
- VpsProvider.kt: Provider abstraction with data models
- VultrProvider.kt: Vultr API client implementation
- StrfryDeployScript.kt: Cloud-init script generator for strfry
- RelayDeploymentViewModel.kt: State management for deployment wizard
- RelayDeploymentScreen.kt: Multi-step UI (provider selection, API key,
  plan selection, relay config, deployment progress, server management)

Integration:
- Added DeployRelay route and navigation entry
- Added "Deploy Relay" option in AllSettingsScreen under relay setup
- Added all necessary string resources

https://claude.ai/code/session_01TdZAjYQTqrkJrmzDncmCBi