### PR TITLE
Improve sorting stability by adding secondary sort keys

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/DiscoverMarketplaceFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/DiscoverMarketplaceFeedFilter.kt
@@ -75,5 +75,5 @@ open class DiscoverMarketplaceFeedFilter(
         }
     }
 
-    override fun sort(items: Set<Note>): List<Note> = items.sortedWith(compareBy({ it.createdAt() }, { it.idHex })).reversed()
+    override fun sort(items: Set<Note>): List<Note> = items.sortedWith(compareByDescending<Note> { it.createdAt() }.thenBy { it.idHex })
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/CardFeedContentState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/CardFeedContentState.kt
@@ -262,8 +262,7 @@ class CardFeedContentState(
                         val sortedList =
                             singleList
                                 .get(string)
-                                ?.sortedWith(compareBy({ it.createdAt() }, { it.idHex }))
-                                ?.reversed()
+                                ?.sortedWith(compareByDescending<Note> { it.createdAt() }.thenBy { it.idHex })
 
                         sortedList?.chunked(30)?.map { chunk ->
                             MultiSetCard(
@@ -293,8 +292,7 @@ class CardFeedContentState(
                         ZapUserSetCard(
                             user.key,
                             zaps
-                                .sortedWith(compareBy({ it.createdAt() }, { it.idHex() }))
-                                .reversed()
+                                .sortedWith(compareByDescending<Note> { it.createdAt() }.thenBy { it.idHex() })
                                 .toImmutableList(),
                         )
                     }
@@ -318,8 +316,7 @@ class CardFeedContentState(
                 }
 
         return (multiCards + textNoteCards + userZaps)
-            .sortedWith(compareBy({ it.createdAt() }, { it.id() }))
-            .reversed()
+            .sortedWith(compareByDescending<Card> { it.createdAt() }.thenBy { it.id() })
     }
 
     private fun updateFeed(notes: ImmutableList<Card>) {
@@ -383,8 +380,7 @@ class CardFeedContentState(
                 val updatedCards =
                     (oldNotesState.feed.value.list + newCards)
                         .distinctBy { it.id() }
-                        .sortedWith(compareBy({ it.createdAt() }, { it.id() }))
-                        .reversed()
+                        .sortedWith(compareByDescending<Card> { it.createdAt() }.thenBy { it.id() })
                         .take(localFilter.limit())
                         .toImmutableList()
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/OpenPollsState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/OpenPollsState.kt
@@ -80,6 +80,6 @@ class OpenPollsState(
                         false
                     }
                 }
-            }.sortedByDescending { it.createdAt() }
+            }.sortedWith(compareByDescending<Note> { it.createdAt() }.thenBy { it.idHex })
     }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/search/SearchResultFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/search/SearchResultFilter.kt
@@ -53,7 +53,7 @@ object SearchResultFilter {
         }
 
         // Sort by createdAt descending
-        return result.sortedByDescending { it.createdAt }
+        return result.sortedWith(compareByDescending<Event> { it.createdAt }.thenBy { it.id })
     }
 
     fun isReply(event: Event): Boolean = event.kind == 1 && event.tags.any { it.size >= 2 && it[0] == "e" }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/search/SearchResultSorter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/search/SearchResultSorter.kt
@@ -33,16 +33,16 @@ object SearchResultSorter {
     ): List<Event> =
         when (order) {
             SearchSortOrder.NEWEST -> {
-                events.sortedByDescending { it.createdAt }
+                events.sortedWith(compareByDescending<Event> { it.createdAt }.thenBy { it.id })
             }
 
             SearchSortOrder.OLDEST -> {
-                events.sortedBy { it.createdAt }
+                events.sortedWith(compareBy<Event> { it.createdAt }.thenBy { it.id })
             }
 
             SearchSortOrder.RELEVANCE -> {
                 if (searchText.isBlank()) {
-                    events.sortedByDescending { it.createdAt }
+                    events.sortedWith(compareByDescending<Event> { it.createdAt }.thenBy { it.id })
                 } else {
                     events.sortedByDescending { scoreEvent(it, searchText) }
                 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/notifications/CardFeedState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/notifications/CardFeedState.kt
@@ -75,4 +75,4 @@ sealed class CardFeedState {
  */
 val DefaultCardComparator: Comparator<Card> =
     compareByDescending<Card> { it.createdAt() }
-        .thenByDescending { it.id() }
+        .thenBy { it.id() }

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/ReadsScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/ReadsScreen.kt
@@ -196,7 +196,7 @@ fun ReadsScreen(
         remember {
             EventCollectionState<LongTextNoteEvent>(
                 getId = { it.id },
-                sortComparator = compareByDescending { it.publishedAt() ?: it.createdAt },
+                sortComparator = compareByDescending<LongTextNoteEvent> { it.publishedAt() ?: it.createdAt }.thenBy { it.id },
                 maxSize = 100,
                 scope = scope,
             )

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/UserProfileScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/UserProfileScreen.kt
@@ -829,7 +829,7 @@ fun UserProfileScreen(
                             }
                         } else {
                             items(
-                                articleEvents.sortedByDescending { it.publishedAt() ?: it.createdAt },
+                                articleEvents.sortedWith(compareByDescending<LongTextNoteEvent> { it.publishedAt() ?: it.createdAt }.thenBy { it.id }),
                                 key = { "art-${it.id}" },
                             ) { article ->
                                 LongFormCard(
@@ -871,7 +871,7 @@ fun UserProfileScreen(
                             }
                         } else {
                             items(
-                                highlightEvents.sortedByDescending { it.createdAt },
+                                highlightEvents.sortedWith(compareByDescending<HighlightEvent> { it.createdAt }.thenBy { it.id }),
                                 key = { "hl-${it.id}" },
                             ) { highlight ->
                                 PublishedHighlightCard(


### PR DESCRIPTION
## Summary
This PR improves the stability and consistency of sorting operations across the codebase by adding secondary sort keys (typically `id` or `idHex`) to all primary sorts. This ensures deterministic ordering when items have the same primary sort value (e.g., same `createdAt` timestamp).

## Key Changes
- **CardFeedContentState.kt**: Replaced `.sortedWith(compareBy(...)).reversed()` patterns with `compareByDescending<T> { ... }.thenBy { id }` for more efficient and stable sorting
- **SearchResultSorter.kt**: Added secondary `id` sort key to NEWEST, OLDEST, and RELEVANCE (when blank) search result orderings
- **UserProfileScreen.kt**: Added secondary `id` sort key to article and highlight event sorting
- **DiscoverMarketplaceFeedFilter.kt**: Simplified marketplace feed sorting using `compareByDescending` with secondary key
- **OpenPollsState.kt**: Added secondary `idHex` sort key to poll sorting
- **SearchResultFilter.kt**: Added secondary `id` sort key to search result filtering
- **CardFeedState.kt**: Changed `DefaultCardComparator` secondary sort from `thenByDescending` to `thenBy` for consistency
- **ReadsScreen.kt**: Added secondary `id` sort key to long-form article sorting

## Implementation Details
- All changes maintain the primary sort order (descending by creation time where applicable)
- Secondary sorts use `id`/`idHex` in ascending order to provide stable, deterministic ordering
- Replaced less efficient patterns like `sortedWith(compareBy(...)).reversed()` with direct `compareByDescending` calls
- This ensures consistent results when multiple items share the same timestamp, improving predictability and testability

https://claude.ai/code/session_01RvuyPf1x9wLf2DCgsSXLGz