### PR TITLE
Fix mention styling by deferring style application until after text mutations

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/UrlUserTagOutputTransformation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/UrlUserTagOutputTransformation.kt
@@ -41,6 +41,11 @@ class UrlUserTagOutputTransformation(
         val mentionRegex = Regex("(?:@|nostr:)(?:npub1[a-z0-9]{58}|nprofile1[a-z0-9]+)")
         val matches = mentionRegex.findAll(text).toList().reversed()
 
+        // Phase 1: Replace all mentions (reverse order keeps indices valid for replace).
+        // Collect replacement info because addStyle must be called after all text mutations.
+        // (originalStart, originalMatchLength, displayNameLength)
+        val replacements = mutableListOf<Triple<Int, Int, Int>>()
+
         for (match in matches) {
             try {
                 val bech32 =
@@ -52,16 +57,20 @@ class UrlUserTagOutputTransformation(
                 val displayName = "@${user.toBestDisplayName()}"
 
                 replace(match.range.first, match.range.last + 1, displayName)
-
-                // Apply color styling to the replaced display name
-                addStyle(
-                    SpanStyle(color = color, textDecoration = TextDecoration.None),
-                    match.range.first,
-                    match.range.first + displayName.length,
-                )
+                replacements.add(Triple(match.range.first, match.range.last + 1 - match.range.first, displayName.length))
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
             }
+        }
+
+        // Phase 2: Apply styles after all text mutations are finalized.
+        // Iterate in forward document order, tracking cumulative shift from prior replacements.
+        val style = SpanStyle(color = color, textDecoration = TextDecoration.None)
+        var cumulativeShift = 0
+        for ((originalStart, originalLen, newLen) in replacements.reversed()) {
+            val adjustedStart = originalStart + cumulativeShift
+            addStyle(style, adjustedStart, adjustedStart + newLen)
+            cumulativeShift += newLen - originalLen
         }
 
         // Highlight URLs in remaining text


### PR DESCRIPTION
## Summary
Fixed a bug in mention replacement where styles were being applied immediately during text mutations, causing incorrect style positions. The fix separates text replacement from style application into two distinct phases.

## Key Changes
- **Phase 1 (Text Replacement)**: Collect all mention replacements and their metadata (original position, original length, new display name length) instead of applying styles immediately
- **Phase 2 (Style Application)**: Apply styles after all text mutations are complete, using cumulative shift tracking to calculate correct adjusted positions in the final document

## Implementation Details
- Replacements are processed in reverse order (as before) to keep indices valid during text mutations
- Style application iterates through replacements in reverse order while tracking cumulative position shifts from prior replacements
- This ensures that `addStyle()` is called with correct positions that correspond to the final mutated text, rather than intermediate states
- The fix prevents style positions from becoming misaligned when multiple replacements occur in the same text

https://claude.ai/code/session_01SSsxsfJLbRiesBBhQFEVUd