### PR TITLE
Add multi-device call state synchronization

### DIFF
--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
@@ -108,6 +108,12 @@ class CallManager(
         _state.value = CallState.Connecting(current.callId, current.callerPubKey, current.callType)
         cancelTimeout()
         publishEvent(result.wrap)
+
+        // Notify other devices of this user that the call was answered here.
+        // This gift-wraps an answer event to our own pubkey so other logged-in
+        // devices see it and stop ringing.
+        val selfNotify = factory.createCallAnswer(sdpAnswer, signer.pubKey, current.callId, signer)
+        publishEvent(selfNotify.wrap)
     }
 
     suspend fun rejectCall() {
@@ -117,6 +123,10 @@ class CallManager(
         val result = factory.createReject(current.callerPubKey, current.callId, signer = signer)
         transitionToEnded(current.callId, current.callerPubKey, EndReason.REJECTED)
         publishEvent(result.wrap)
+
+        // Notify other devices of this user that the call was rejected here.
+        val selfNotify = factory.createReject(signer.pubKey, current.callId, signer = signer)
+        publishEvent(selfNotify.wrap)
     }
 
     fun onCallAnswered(event: CallAnswerEvent) {
@@ -129,6 +139,12 @@ class CallManager(
                 _state.value = CallState.Connecting(current.callId, current.peerPubKey, current.callType)
                 cancelTimeout()
                 onAnswerReceived?.invoke(event)
+            }
+
+            is CallState.IncomingCall -> {
+                // Another device of this user answered the call — stop ringing.
+                if (callId != current.callId) return
+                transitionToEnded(current.callId, current.callerPubKey, EndReason.ANSWERED_ELSEWHERE)
             }
 
             is CallState.Connected -> {
@@ -145,10 +161,24 @@ class CallManager(
 
     fun onCallRejected(event: CallRejectEvent) {
         val current = _state.value
-        if (current !is CallState.Offering) return
-        if (event.callId() != current.callId) return
+        val callId = event.callId()
 
-        transitionToEnded(current.callId, current.peerPubKey, EndReason.PEER_REJECTED)
+        when (current) {
+            is CallState.Offering -> {
+                if (callId != current.callId) return
+                transitionToEnded(current.callId, current.peerPubKey, EndReason.PEER_REJECTED)
+            }
+
+            is CallState.IncomingCall -> {
+                // Another device of this user rejected the call — stop ringing.
+                if (callId != current.callId) return
+                transitionToEnded(current.callId, current.callerPubKey, EndReason.REJECTED)
+            }
+
+            else -> {
+                return
+            }
+        }
     }
 
     fun onIceCandidate(event: CallIceCandidateEvent) {

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallState.kt
@@ -68,4 +68,5 @@ enum class EndReason {
     ERROR,
     PEER_HANGUP,
     PEER_REJECTED,
+    ANSWERED_ELSEWHERE,
 }


### PR DESCRIPTION
## Summary
This PR adds support for synchronizing call state across multiple devices of the same user. When a call is answered or rejected on one device, other logged-in devices are now notified so they can stop ringing and update their UI accordingly.

## Key Changes
- **Answer notification**: When a call is answered, a self-notified answer event is published to inform other devices of the user that the call was handled
- **Reject notification**: When a call is rejected, a self-notified reject event is published to other devices
- **Incoming call state handling**: Added logic to handle answer and reject events while in `IncomingCall` state, allowing devices to detect when another device has already handled the call
- **New end reason**: Added `ANSWERED_ELSEWHERE` to the `EndReason` enum to distinguish calls ended because another device answered them
- **Improved rejection handling**: Refactored `onCallRejected()` to use a when statement that handles both `Offering` and `IncomingCall` states

## Implementation Details
- Self-notifications are gift-wrapped to the user's own pubkey, ensuring only their devices receive these messages
- The multi-device logic is triggered in both `answerCall()` and `rejectCall()` methods
- When receiving answer/reject events in `IncomingCall` state, the call transitions to `Ended` with the appropriate reason, stopping the ringing on other devices

https://claude.ai/code/session_01X9juzyPYWqxRMCgDWEw8R1