### PR TITLE
Implement Tor SOCKS port retry logic with dynamic port allocation

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorManager.kt
@@ -98,5 +98,5 @@ class TorManager(
 
     fun isSocksReady() = status.value is TorServiceStatus.Active
 
-    fun socksPort(): Int = (status.value as? TorServiceStatus.Active)?.port ?: 19050
+    fun socksPort(): Int = (status.value as? TorServiceStatus.Active)?.port ?: 17392
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorService.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorService.kt
@@ -30,7 +30,8 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
 
-private const val DEFAULT_SOCKS_PORT = 19050
+private const val DEFAULT_SOCKS_PORT = 17392
+private const val MAX_PORT_RETRIES = 10
 
 /**
  * Manages the Arti Tor client via custom JNI bindings.
@@ -46,7 +47,7 @@ private const val DEFAULT_SOCKS_PORT = 19050
 class TorService(
     val context: Context,
 ) {
-    private val socksPort = DEFAULT_SOCKS_PORT
+    private var socksPort = DEFAULT_SOCKS_PORT
     private val initialized = AtomicBoolean(false)
     private val proxyRunning = AtomicBoolean(false)
 
@@ -101,10 +102,22 @@ class TorService(
                 }
             }
 
-            // Start the SOCKS proxy (can be called multiple times safely)
-            val proxyResult = ArtiNative.startSocksProxy(socksPort)
-            if (proxyResult != 0) {
-                Log.e("TorService") { "Failed to start SOCKS proxy: error $proxyResult" }
+            // Start the SOCKS proxy, retrying on next port if address is in use
+            var port = socksPort
+            var started = false
+            for (attempt in 0 until MAX_PORT_RETRIES) {
+                val proxyResult = ArtiNative.startSocksProxy(port)
+                if (proxyResult == 0) {
+                    socksPort = port
+                    started = true
+                    break
+                }
+                Log.w("TorService") { "Port $port in use, trying ${port + 1}" }
+                port++
+            }
+
+            if (!started) {
+                Log.e("TorService") { "Failed to start SOCKS proxy after $MAX_PORT_RETRIES attempts" }
                 _status.value = TorServiceStatus.Off
                 return@withContext
             }


### PR DESCRIPTION
## Summary
This PR adds resilient port allocation for the Tor SOCKS proxy by implementing automatic retry logic when the default port is in use. The default SOCKS port has also been changed from 19050 to 17392.

## Key Changes
- **Port retry mechanism**: Added `MAX_PORT_RETRIES` constant (10 attempts) to automatically try consecutive ports if the initial port is unavailable
- **Dynamic port allocation**: Changed `socksPort` from a `val` to a `var` to allow updating it when a successful port is found
- **Improved error handling**: Enhanced logging to distinguish between individual port failures (warnings) and complete failure after all retries (error)
- **Default port update**: Changed default SOCKS port from 19050 to 17392 in both `TorService` and `TorManager`

## Implementation Details
- The retry loop attempts to start the SOCKS proxy on consecutive ports, starting from the default
- When `ArtiNative.startSocksProxy()` returns 0 (success), the `socksPort` is updated and the loop breaks
- If all retry attempts fail, the service transitions to `TorServiceStatus.Off` with an appropriate error message
- The fallback port in `TorManager.socksPort()` was also updated to match the new default

https://claude.ai/code/session_01JEzjceY3ZaCHz5kL4DsKic