### PR TITLE
Clamp PiP aspect ratio to Android system limits

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/pip/PictureInPicture.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/pip/PictureInPicture.kt
@@ -26,6 +26,14 @@ import android.graphics.Rect
 import android.os.Build
 import android.util.Rational
 
+private const val MIN_PIP_RATIO = 0.42f
+private const val MAX_PIP_RATIO = 2.39f
+
+private fun Float.toPipRational(): Rational {
+    val clamped = coerceIn(MIN_PIP_RATIO, MAX_PIP_RATIO)
+    return Rational((clamped * 1000).toInt(), 1000)
+}
+
 fun makePipParams(
     ratio: Float?,
     bounds: Rect?,
@@ -37,7 +45,7 @@ fun makePipParams(
                 setAutoEnterEnabled(true)
             }
             bounds?.let { setSourceRectHint(bounds) }
-            ratio?.let { setAspectRatio(Rational((it * 1000).toInt(), 1000)) }
+            ratio?.let { setAspectRatio(it.toPipRational()) }
         }.build()
 
 fun Activity.makePipParams(
@@ -60,5 +68,5 @@ fun Activity.makePipParams(
                 ),
             )
             bounds?.let { setSourceRectHint(bounds) }
-            ratio?.let { setAspectRatio(Rational((it * 1000).toInt(), 1000)) }
+            ratio?.let { setAspectRatio(it.toPipRational()) }
         }.build()


### PR DESCRIPTION
## Summary
Refactored Picture-in-Picture (PiP) aspect ratio handling to enforce Android system constraints and improve code reusability.

## Key Changes
- Added constants for minimum (0.42) and maximum (2.39) PiP aspect ratio limits based on Android system requirements
- Extracted aspect ratio conversion logic into a new `Float.toPipRational()` extension function that:
  - Clamps the input ratio to valid bounds
  - Converts the clamped value to an Android `Rational` object
- Updated both `makePipParams()` function overloads to use the new extension function instead of inline conversion logic

## Implementation Details
- The clamping ensures that aspect ratios outside Android's supported range are automatically adjusted to the nearest valid value
- The extension function centralizes the conversion logic, reducing code duplication and making future ratio adjustments easier to maintain
- No functional changes to the public API; this is purely an internal refactoring with added validation

https://claude.ai/code/session_018uqcACcXpLQxwzVFhePisJ