### PR TITLE
Preload bookmark events to improve scrolling performance

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/default/BookmarkListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/default/BookmarkListScreen.kt
@@ -31,8 +31,10 @@ import androidx.compose.material3.SecondaryScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -40,6 +42,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.EventFinderQueryState
 import com.vitorpamplona.amethyst.ui.layouts.DisappearingScaffold
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.TopBarWithBackButton
@@ -89,6 +92,9 @@ fun BookmarkListScreen(
     LaunchedEffect(pinState) {
         pinnedNotesFeedViewModel.invalidateData()
     }
+
+    // Preload all bookmarked and pinned events so they don't load one-by-one when scrolling
+    PreloadBookmarkEvents(bookmarkState, pinState, accountViewModel)
 
     RenderBookmarkScreen(publicFeedViewModel, privateFeedViewModel, pinnedNotesFeedViewModel, accountViewModel, nav)
 }
@@ -168,6 +174,31 @@ private fun RenderBookmarkScreen(
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun PreloadBookmarkEvents(
+    bookmarkState: com.vitorpamplona.amethyst.commons.model.nip51Lists.BookmarkListState.BookmarkList?,
+    pinState: List<com.vitorpamplona.amethyst.model.Note>?,
+    accountViewModel: AccountViewModel,
+) {
+    val eventFinder = accountViewModel.dataSources().eventFinder
+    val account = accountViewModel.account
+
+    val queries =
+        remember(bookmarkState, pinState) {
+            val allNotes = (bookmarkState?.public.orEmpty() + bookmarkState?.private.orEmpty() + pinState.orEmpty())
+            allNotes
+                .filter { it.event == null }
+                .map { EventFinderQueryState(it, account) }
+        }
+
+    DisposableEffect(queries) {
+        eventFinder.subscribe(queries)
+        onDispose {
+            eventFinder.unsubscribe(queries)
         }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/old/OldBookmarkListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/old/OldBookmarkListScreen.kt
@@ -36,8 +36,10 @@ import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -45,6 +47,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.EventFinderQueryState
 import com.vitorpamplona.amethyst.ui.layouts.DisappearingScaffold
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.TopBarWithBackButton
@@ -80,6 +83,9 @@ fun OldBookmarkListScreen(
         publicFeedViewModel.invalidateData()
         privateFeedViewModel.invalidateData()
     }
+
+    // Preload all bookmarked events so they don't load one-by-one when scrolling
+    PreloadOldBookmarkEvents(bookmarkState, accountViewModel)
 
     RenderOldBookmarkScreen(publicFeedViewModel, privateFeedViewModel, accountViewModel, nav)
 }
@@ -169,6 +175,30 @@ private fun RenderOldBookmarkScreen(
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun PreloadOldBookmarkEvents(
+    bookmarkState: com.vitorpamplona.amethyst.commons.model.nip51Lists.OldBookmarkListState.BookmarkList?,
+    accountViewModel: AccountViewModel,
+) {
+    val eventFinder = accountViewModel.dataSources().eventFinder
+    val account = accountViewModel.account
+
+    val queries =
+        remember(bookmarkState) {
+            val allNotes = bookmarkState?.public.orEmpty() + bookmarkState?.private.orEmpty()
+            allNotes
+                .filter { it.event == null }
+                .map { EventFinderQueryState(it, account) }
+        }
+
+    DisposableEffect(queries) {
+        eventFinder.subscribe(queries)
+        onDispose {
+            eventFinder.unsubscribe(queries)
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR improves the performance of bookmark list screens by preloading all bookmarked and pinned events upfront, preventing them from loading one-by-one during scrolling.

## Key Changes
- Added `PreloadBookmarkEvents` composable to `BookmarkListScreen.kt` that subscribes to event queries for all bookmarked and pinned notes that haven't been loaded yet
- Added `PreloadOldBookmarkEvents` composable to `OldBookmarkListScreen.kt` with similar functionality for the legacy bookmark list implementation
- Both composables use `DisposableEffect` to properly manage subscription lifecycle, subscribing when queries are created and unsubscribing when the composable is disposed
- Imported necessary Compose runtime utilities: `DisposableEffect`, `remember`, and `EventFinderQueryState`

## Implementation Details
- The preload composables filter notes to only query those where `event == null` (not yet loaded)
- Queries are memoized using `remember` to avoid unnecessary recomputations
- The event finder from `accountViewModel.dataSources()` is used to batch subscribe to all missing events
- This approach ensures events are fetched in parallel rather than sequentially as users scroll through the list

https://claude.ai/code/session_01C8gevBfB8vLDFoBW3hnPeU