### PR TITLE
Improve video call quality with 720p resolution and bitrate limiting

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/WebRtcCallSession.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/WebRtcCallSession.kt
@@ -164,7 +164,15 @@ class WebRtcCallSession(
         videoSource = peerConnectionFactory?.createVideoSource(false)
         localVideoTrack =
             peerConnectionFactory?.createVideoTrack("video0", videoSource).also {
-                peerConnection?.addTrack(it)
+                val sender = peerConnection?.addTrack(it)
+                // Set max bitrate to 1.5 Mbps for good 720p quality
+                sender?.let { s ->
+                    val params = s.parameters
+                    params.encodings.forEach { encoding ->
+                        encoding.maxBitrateBps = 1_500_000
+                    }
+                    s.parameters = params
+                }
             }
         startCamera()
     }
@@ -183,7 +191,7 @@ class WebRtcCallSession(
                     context,
                     source.capturerObserver,
                 )
-                it.startCapture(640, 480, 30)
+                it.startCapture(1280, 720, 30)
             }
     }
 


### PR DESCRIPTION
## Summary
Enhanced video call quality by upgrading the camera capture resolution to 720p and implementing bitrate limiting to ensure optimal streaming performance.

## Key Changes
- **Camera Resolution**: Increased video capture resolution from 640x480 to 1280x720 (720p) for better video quality
- **Bitrate Limiting**: Added maximum bitrate constraint of 1.5 Mbps on the RTC sender to maintain good 720p quality while preventing excessive bandwidth usage
- **Implementation**: Captured the RTC sender returned by `addTrack()` and configured its encoding parameters to enforce the bitrate limit

## Notable Details
- The bitrate limit of 1.5 Mbps is specifically tuned for 720p quality streaming
- The bitrate configuration is applied to all encodings in the sender's parameters
- These changes ensure consistent video quality across different network conditions while maintaining reasonable bandwidth consumption

https://claude.ai/code/session_01Co48ZKvPT5GX3mAjGHkNza