### PR TITLE
Improve call handling: busy rejection, peer tracking, and ICE state

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/WebRtcCallSession.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/WebRtcCallSession.kt
@@ -112,7 +112,10 @@ class WebRtcCallSession(
                             }
 
                             PeerConnection.IceConnectionState.DISCONNECTED -> {
-                                onDisconnected()
+                                // DISCONNECTED is often transient (network switch, brief
+                                // packet loss). WebRTC will transition to FAILED if
+                                // recovery is impossible, so we only act on FAILED above.
+                                Log.d(TAG) { "ICE disconnected (transient, waiting for recovery or FAILED)" }
                             }
 
                             else -> {}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
@@ -110,7 +110,15 @@ class CallManager(
 
         if (!isFollowing(callerPubKey)) return
 
-        if (_state.value !is CallState.Idle) return
+        if (_state.value !is CallState.Idle) {
+            // Already in a call — send a "busy" reject so the caller gets
+            // immediate feedback instead of waiting for the 60s timeout.
+            scope.launch {
+                val result = factory.createReject(callerPubKey, callId, "busy", signer = signer)
+                publishEvent(result.wrap)
+            }
+            return
+        }
 
         val groupMembers = event.groupMembers()
 
@@ -341,12 +349,12 @@ class CallManager(
             }
 
             is CallState.Connecting -> {
-                peerPubKeys = current.peerPubKeys
+                peerPubKeys = current.peerPubKeys + current.pendingPeerPubKeys
                 callId = current.callId
             }
 
             is CallState.Connected -> {
-                peerPubKeys = current.peerPubKeys
+                peerPubKeys = current.allPeerPubKeys
                 callId = current.callId
             }
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nipACWebRtcCalls/WebRtcCallFactory.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nipACWebRtcCalls/WebRtcCallFactory.kt
@@ -157,13 +157,17 @@ class WebRtcCallFactory {
         reason: String = "",
         signer: NostrSigner,
     ): GroupResult {
-        val template = CallHangupEvent.build(peerPubKeys.first(), callId, reason)
-        val signed = signer.sign(template)
+        // Each peer gets its own signed hangup with the correct `p` tag
+        // targeting that specific recipient.
+        var firstSigned: Event? = null
         val wraps =
             peerPubKeys.map { pubKey ->
+                val template = CallHangupEvent.build(pubKey, callId, reason)
+                val signed = signer.sign(template)
+                if (firstSigned == null) firstSigned = signed
                 GiftWrapEvent.create(event = signed, recipientPubKey = pubKey, expirationDelta = WRAP_EXPIRATION_SECONDS)
             }
-        return GroupResult(signed, wraps)
+        return GroupResult(firstSigned!!, wraps)
     }
 
     /**


### PR DESCRIPTION
## Summary
This PR improves the reliability and user experience of the call system by implementing proper busy call rejection, fixing peer tracking during connection states, and refining ICE disconnection handling.

## Key Changes

- **Busy Call Rejection**: When receiving an incoming call while already in a call, the system now sends an immediate "busy" reject message to the caller instead of letting them wait for a 60-second timeout. This provides immediate feedback to the caller.

- **Peer Tracking Fix**: Updated peer tracking logic to include pending peers during the `Connecting` state and all peers during the `Connected` state, ensuring accurate peer management throughout the call lifecycle.

- **Hangup Event Generation**: Modified `createHangup()` to generate individual signed hangup events for each peer with the correct `p` tag targeting that specific recipient, rather than reusing a single signed event. This ensures proper recipient-specific event signing.

- **ICE Disconnection Handling**: Changed the handling of `DISCONNECTED` ICE connection state to log and wait rather than immediately triggering disconnection logic. This accounts for transient network issues (e.g., network switches, brief packet loss) and allows WebRTC to attempt recovery or transition to `FAILED` state if recovery is impossible.

## Implementation Details

- The busy rejection is launched asynchronously within the call manager's scope to avoid blocking the state check
- Peer tracking now properly distinguishes between actively connecting peers and fully connected peers
- ICE state handling now follows WebRTC best practices by only acting on terminal states (`FAILED`) rather than transient states (`DISCONNECTED`)

https://claude.ai/code/session_01HpowdWMK77pA35ABn9XWpD