### PR TITLE
Add maximum hashtag limit security filter

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -143,6 +143,7 @@ import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
+import com.vitorpamplona.quartz.nip01Core.tags.hashtags.countHashtags
 import com.vitorpamplona.quartz.nip01Core.tags.hashtags.hashtags
 import com.vitorpamplona.quartz.nip01Core.tags.people.taggedUserIds
 import com.vitorpamplona.quartz.nip01Core.tags.references.references
@@ -446,6 +447,12 @@ class Account(
 
     suspend fun updateShowSensitiveContent(show: Boolean?) {
         if (settings.updateShowSensitiveContent(show)) {
+            sendNewAppSpecificData()
+        }
+    }
+
+    suspend fun updateMaxHashtagLimit(limit: Int) {
+        if (settings.updateMaxHashtagLimit(limit)) {
             sendNewAppSpecificData()
         }
     }
@@ -2024,10 +2031,16 @@ class Account(
 
     fun isKnown(user: HexKey): Boolean = user in allFollows.flow.value.authors
 
+    private fun hasExcessiveHashtags(note: Note): Boolean {
+        val limit = settings.syncedSettings.security.maxHashtagLimit.value
+        return limit > 0 && (note.event?.countHashtags() ?: 0) > limit
+    }
+
     override fun isAcceptable(note: Note): Boolean {
         return note.author?.let { isAcceptable(it) } ?: true &&
             // if user hasn't hided this author
             isAcceptableDirect(note) &&
+            !hasExcessiveHashtags(note) &&
             (
                 (note.event !is RepostEvent && note.event !is GenericRepostEvent) ||
                     (

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -753,4 +753,12 @@ class AccountSettings(
         } else {
             false
         }
+
+    fun updateMaxHashtagLimit(limit: Int): Boolean =
+        if (syncedSettings.security.updateMaxHashtagLimit(limit)) {
+            saveAccountSettings()
+            true
+        } else {
+            false
+        }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettings.kt
@@ -53,6 +53,7 @@ class AccountSyncedSettings(
             MutableStateFlow(internalSettings.security.showSensitiveContent),
             internalSettings.security.warnAboutPostsWithReports,
             MutableStateFlow(internalSettings.security.filterSpamFromStrangers),
+            MutableStateFlow(internalSettings.security.maxHashtagLimit),
         )
 
     fun toInternal(): AccountSyncedSettingsInternal =
@@ -74,6 +75,7 @@ class AccountSyncedSettings(
                     security.showSensitiveContent.value,
                     security.warnAboutPostsWithReports,
                     security.filterSpamFromStrangers.value,
+                    security.maxHashtagLimit.value,
                 ),
         )
 
@@ -119,6 +121,10 @@ class AccountSyncedSettings(
 
         if (security.warnAboutPostsWithReports != syncedSettingsInternal.security.warnAboutPostsWithReports) {
             security.warnAboutPostsWithReports = syncedSettingsInternal.security.warnAboutPostsWithReports
+        }
+
+        if (security.maxHashtagLimit.value != syncedSettingsInternal.security.maxHashtagLimit) {
+            security.maxHashtagLimit.tryEmit(syncedSettingsInternal.security.maxHashtagLimit)
         }
     }
 
@@ -204,6 +210,7 @@ class AccountSecurityPreferences(
     val showSensitiveContent: MutableStateFlow<Boolean?> = MutableStateFlow(null),
     var warnAboutPostsWithReports: Boolean = true,
     var filterSpamFromStrangers: MutableStateFlow<Boolean> = MutableStateFlow(true),
+    val maxHashtagLimit: MutableStateFlow<Int> = MutableStateFlow(5),
 ) {
     fun updateShowSensitiveContent(show: Boolean?): Boolean {
         if (showSensitiveContent.value != show) {
@@ -224,6 +231,14 @@ class AccountSecurityPreferences(
     fun updateFilterSpam(filterSpam: Boolean): Boolean =
         if (filterSpam != filterSpamFromStrangers.value) {
             filterSpamFromStrangers.tryEmit(filterSpam)
+            true
+        } else {
+            false
+        }
+
+    fun updateMaxHashtagLimit(limit: Int): Boolean =
+        if (maxHashtagLimit.value != limit) {
+            maxHashtagLimit.update { limit }
             true
         } else {
             false

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettingsInternal.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettingsInternal.kt
@@ -105,4 +105,5 @@ class AccountSecurityPreferencesInternal(
     val showSensitiveContent: Boolean? = null,
     var warnAboutPostsWithReports: Boolean = true,
     var filterSpamFromStrangers: Boolean = true,
+    val maxHashtagLimit: Int = 5,
 )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/HiddenUsersState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/HiddenUsersState.kt
@@ -52,6 +52,7 @@ class HiddenUsersState(
         muteList: List<MuteTag>,
         transientHiddenUsers: Set<String>,
         showSensitiveContent: Boolean?,
+        maxHashtagLimit: Int,
     ): LiveHiddenUsers {
         val hiddenUsers = blockList.mapNotNullTo(mutableSetOf()) { if (it is UserTag) it.pubKey else null } + muteList.mapNotNull { if (it is UserTag) it.pubKey else null }
         val hiddenWords = blockList.mapNotNullTo(mutableSetOf()) { if (it is WordTag) it.word else null } + muteList.mapNotNull { if (it is WordTag) it.word else null }
@@ -64,6 +65,7 @@ class HiddenUsersState(
             hiddenUsers = hiddenUsers,
             spammers = transientHiddenUsers,
             hiddenWords = hiddenWords,
+            maxHashtagLimit = maxHashtagLimit,
         )
     }
 
@@ -73,9 +75,10 @@ class HiddenUsersState(
             muteList,
             transientHiddenUsers,
             settings.syncedSettings.security.showSensitiveContent,
-        ) { blockList, muteList, transientHiddenUsers, showSensitiveContent ->
+            settings.syncedSettings.security.maxHashtagLimit,
+        ) { blockList, muteList, transientHiddenUsers, showSensitiveContent, maxHashtagLimit ->
             checkNotInMainThread()
-            emit(assembleLiveHiddenUsers(blockList, muteList, transientHiddenUsers, showSensitiveContent))
+            emit(assembleLiveHiddenUsers(blockList, muteList, transientHiddenUsers, showSensitiveContent, maxHashtagLimit))
         }.onStart {
             emit(
                 assembleLiveHiddenUsers(
@@ -83,6 +86,7 @@ class HiddenUsersState(
                     muteList.value,
                     transientHiddenUsers.value,
                     settings.syncedSettings.security.showSensitiveContent.value,
+                    settings.syncedSettings.security.maxHashtagLimit.value,
                 ),
             )
         }.flowOn(Dispatchers.IO)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/FilterByListParams.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/FilterByListParams.kt
@@ -29,6 +29,7 @@ import com.vitorpamplona.quartz.nip01Core.core.Address
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip01Core.tags.hashtags.countHashtags
 import com.vitorpamplona.quartz.nip51Lists.muteList.MuteListEvent
 import com.vitorpamplona.quartz.nip51Lists.peopleList.PeopleListEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
@@ -42,6 +43,8 @@ class FilterByListParams(
     fun isNotHidden(userHex: String) = !(hiddenLists.hiddenUsers.contains(userHex) || hiddenLists.spammers.contains(userHex))
 
     fun isNotInTheFuture(noteEvent: Event) = noteEvent.createdAt <= now
+
+    fun hasExcessiveHashtags(noteEvent: Event) = hiddenLists.maxHashtagLimit > 0 && noteEvent.countHashtags() > hiddenLists.maxHashtagLimit
 
     fun isEventInList(noteEvent: Event): Boolean {
         if (followLists == null) return false
@@ -70,7 +73,8 @@ class FilterByListParams(
         comingFrom: List<NormalizedRelayUrl>,
     ) = ((isGlobal(comingFrom)) || isEventInList(noteEvent)) &&
         (isHiddenList || isNotHidden(noteEvent.pubKey)) &&
-        isNotInTheFuture(noteEvent)
+        isNotInTheFuture(noteEvent) &&
+        !hasExcessiveHashtags(noteEvent)
 
     fun match(
         address: Address?,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -1152,6 +1152,8 @@ class AccountViewModel(
 
     fun updateShowSensitiveContent(show: Boolean?) = launchSigner { account.updateShowSensitiveContent(show) }
 
+    fun updateMaxHashtagLimit(limit: Int) = launchSigner { account.updateMaxHashtagLimit(limit) }
+
     fun changeReactionTypes(
         reactionSet: List<String>,
         onDone: () -> Unit,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/SecurityFiltersScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/SecurityFiltersScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
@@ -264,6 +265,34 @@ private fun HeaderOptions(accountViewModel: AccountViewModel) {
                 onSelect = {
                     accountViewModel.updateShowSensitiveContent(parseWarningType(it).prefCode)
                 },
+            )
+        }
+
+        SettingsRow(
+            R.string.max_hashtag_limit_title,
+            R.string.max_hashtag_limit_explainer,
+        ) {
+            var maxHashtags by remember {
+                mutableStateOf(
+                    accountViewModel.account.settings.syncedSettings.security.maxHashtagLimit.value.let {
+                        if (it == 0) "" else it.toString()
+                    },
+                )
+            }
+
+            OutlinedTextField(
+                value = maxHashtags,
+                onValueChange = {
+                    maxHashtags = it
+                    accountViewModel.updateMaxHashtagLimit(it.toIntOrNull() ?: 0)
+                },
+                keyboardOptions =
+                    KeyboardOptions.Default.copy(
+                        keyboardType = KeyboardType.Number,
+                        imeAction = ImeAction.Done,
+                    ),
+                singleLine = true,
+                modifier = Modifier.padding(start = 8.dp),
             )
         }
     }

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -834,6 +834,8 @@
     <string name="warn_when_posts_have_reports_from_your_follows_explainer">Shows a warning message when posts have 5 or more reports from your follows</string>
     <string name="show_sensitive_content_title">Show sensitive content</string>
     <string name="show_sensitive_content_explainer">Shows a warning message when the author of the post marked it as sensitive</string>
+    <string name="max_hashtag_limit_title">Max hashtags per post</string>
+    <string name="max_hashtag_limit_explainer">Hides posts with more hashtags than this limit. Set to 0 to disable</string>
 
     <string name="new_reaction_symbol">New Reaction Symbol</string>
     <string name="no_reaction_type_setup_long_press_to_change">No reaction types pre-selected for this user. Long press on the heart button to change</string>

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
@@ -59,6 +59,7 @@ data class LiveHiddenUsers(
     val hiddenUsers: Set<String> = emptySet(),
     val spammers: Set<String> = emptySet(),
     val hiddenWords: Set<String> = emptySet(),
+    val maxHashtagLimit: Int = 5,
 ) {
     fun isUserHidden(userHex: String) = hiddenUsers.contains(userHex) || spammers.contains(userHex)
 }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/tags/hashtags/EventExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/tags/hashtags/EventExt.kt
@@ -24,6 +24,8 @@ import com.vitorpamplona.quartz.nip01Core.core.Event
 
 fun Event.anyHashTag(onEach: (str: String) -> Boolean) = tags.anyHashTag(onEach)
 
+fun Event.countHashtags() = tags.countHashtags()
+
 fun Event.hasHashtags() = tags.hasHashtags()
 
 fun Event.hashtags() = tags.hashtags()


### PR DESCRIPTION
## Summary
This PR adds a new security feature that allows users to filter out posts containing excessive hashtags. Users can set a maximum hashtag limit per post, and any posts exceeding this limit will be hidden from their feed.

## Key Changes
- **UI Settings Screen**: Added a new settings row in `SecurityFiltersScreen` to allow users to configure the maximum hashtag limit with a numeric input field
- **Security Preferences**: Extended `AccountSecurityPreferences` and `AccountSecurityPreferencesInternal` with a new `maxHashtagLimit` property (default: 5)
- **Settings Persistence**: Updated `AccountSyncedSettings` to include `maxHashtagLimit` in synced settings serialization/deserialization
- **Filtering Logic**: 
  - Added `hasExcessiveHashtags()` check in `Account.isAcceptable()` to filter posts during feed generation
  - Added `hasExcessiveHashtags()` check in `FilterByListParams` for list-based filtering
- **Hashtag Counting**: Added `countHashtags()` extension function to `Event` class for counting hashtags in posts
- **Account Updates**: Added `updateMaxHashtagLimit()` method to `Account`, `AccountSettings`, and `AccountViewModel` to handle setting changes
- **Hidden Users State**: Updated `HiddenUsersState` to track and emit `maxHashtagLimit` changes
- **Localization**: Added English strings for the new setting title and explainer

## Implementation Details
- The feature uses a `MutableStateFlow<Int>` to track the limit, allowing reactive updates across the app
- A limit of 0 disables the filter entirely
- The hashtag count is performed at filtering time using the new `countHashtags()` utility function
- Settings are synced with the user's account and persisted across sessions

https://claude.ai/code/session_01NMVypgGSU9EjQA7hZ9uvjD