### PR TITLE
Disable hardware acceleration for profile picture image loading

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallController.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallController.kt
@@ -507,7 +507,12 @@ class CallController(
             callerUser?.profilePicture()?.let { pictureUrl ->
                 withContext(Dispatchers.IO) {
                     try {
-                        val request = ImageRequest.Builder(context).data(pictureUrl).build()
+                        val request =
+                            ImageRequest
+                                .Builder(context)
+                                .data(pictureUrl)
+                                .allowHardware(false)
+                                .build()
                         val result = ImageLoader(context).execute(request)
                         (result.image?.asDrawable(context.resources) as? android.graphics.drawable.BitmapDrawable)?.bitmap
                     } catch (_: Exception) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
@@ -644,7 +644,12 @@ class EventNotificationConsumer(
             callerUser?.profilePicture()?.let { pictureUrl ->
                 kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
                     try {
-                        val request = ImageRequest.Builder(applicationContext).data(pictureUrl).build()
+                        val request =
+                            ImageRequest
+                                .Builder(applicationContext)
+                                .data(pictureUrl)
+                                .allowHardware(false)
+                                .build()
                         val result = ImageLoader(applicationContext).execute(request)
                         (result.image?.asDrawable(applicationContext.resources) as? BitmapDrawable)?.bitmap
                     } catch (_: Exception) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationUtils.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationUtils.kt
@@ -272,7 +272,12 @@ object NotificationUtils {
     ): Bitmap? =
         withContext(Dispatchers.IO) {
             try {
-                val request = ImageRequest.Builder(applicationContext).data(pictureUrl).build()
+                val request =
+                    ImageRequest
+                        .Builder(applicationContext)
+                        .data(pictureUrl)
+                        .allowHardware(false)
+                        .build()
                 val imageLoader = SingletonImageLoader.get(applicationContext)
                 val result = imageLoader.execute(request)
                 (result.image?.asDrawable(applicationContext.resources) as? BitmapDrawable)?.bitmap


### PR DESCRIPTION
## Summary
This PR disables hardware acceleration when loading profile pictures in image requests across the call and notification services. This ensures that loaded images are rendered as software bitmaps rather than hardware-accelerated drawables.

## Key Changes
- Added `.allowHardware(false)` configuration to `ImageRequest.Builder` in three locations:
  - `CallController.kt`: Profile picture loading for call UI
  - `EventNotificationConsumer.kt`: Profile picture loading for call notifications
  - `NotificationUtils.kt`: Profile picture loading for notification display

## Implementation Details
The change applies consistently across all profile picture image loading operations that convert the result to a `BitmapDrawable`. By disabling hardware acceleration at the image request level, we ensure that the resulting drawables are always software-backed bitmaps, which may be necessary for compatibility with certain rendering contexts or to avoid hardware buffer limitations in notification and call UI scenarios.

https://claude.ai/code/session_018y75qshU48REuHXxLH3Tmb