### PR TITLE
Exclude current user from group call member displays

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallScreen.kt
@@ -145,8 +145,12 @@ fun CallScreen(
             }
 
             is CallState.IncomingCall -> {
+                val otherMembers =
+                    remember(state.groupMembers) {
+                        state.groupMembers - accountViewModel.account.signer.pubKey
+                    }
                 if (isInPipMode) {
-                    PipCallUI(peerPubKeys = state.groupMembers, statusText = stringRes(R.string.call_incoming), accountViewModel = accountViewModel)
+                    PipCallUI(peerPubKeys = otherMembers, statusText = stringRes(R.string.call_incoming), accountViewModel = accountViewModel)
                 } else {
                     val isVideoCall = state.callType == com.vitorpamplona.quartz.nipACWebRtcCalls.tags.CallType.VIDEO
                     val acceptWithPermission =
@@ -154,7 +158,7 @@ fun CallScreen(
                             callController?.acceptIncomingCall(state.sdpOffer)
                         }
                     IncomingCallUI(
-                        groupMembers = state.groupMembers,
+                        groupMembers = otherMembers,
                         callType = state.callType,
                         accountViewModel = accountViewModel,
                         onAccept = acceptWithPermission,


### PR DESCRIPTION
## Summary
This change filters out the current user's public key from the group members list displayed during incoming calls, ensuring that users don't see themselves in the participant list.

## Key Changes
- Added a computed `otherMembers` variable that removes the current account's public key from `state.groupMembers`
- Updated both `PipCallUI` and `IncomingCallUI` to use the filtered `otherMembers` list instead of the full `state.groupMembers`
- Used `remember()` to memoize the filtering operation based on `state.groupMembers` changes

## Implementation Details
The filtering is performed using Kotlin's set subtraction operator (`-`) to exclude the current user's public key from the group members. This ensures a consistent user experience where the current user is never displayed as a participant in their own incoming call UI.

https://claude.ai/code/session_01F4LLE1PZ84oNURN8RQwNuc