### PR TITLE
Fix group call handling for answer/reject events

### DIFF
--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
@@ -215,9 +215,12 @@ class CallManager(
             }
 
             is CallState.IncomingCall -> {
-                // Another device of this user answered the call — stop ringing.
                 if (callId != current.callId) return
-                transitionToEnded(current.callId, current.peerPubKeys(), EndReason.ANSWERED_ELSEWHERE)
+                if (answeringPeer == signer.pubKey) {
+                    // Another device of this user answered the call — stop ringing.
+                    transitionToEnded(current.callId, current.peerPubKeys(), EndReason.ANSWERED_ELSEWHERE)
+                }
+                // Otherwise another group member answered — we keep ringing.
             }
 
             is CallState.Connected -> {
@@ -273,9 +276,12 @@ class CallManager(
             }
 
             is CallState.IncomingCall -> {
-                // Another device of this user rejected the call — stop ringing.
                 if (callId != current.callId) return
-                transitionToEnded(current.callId, current.peerPubKeys(), EndReason.REJECTED)
+                if (rejectingPeer == signer.pubKey) {
+                    // Another device of this user rejected the call — stop ringing.
+                    transitionToEnded(current.callId, current.peerPubKeys(), EndReason.REJECTED)
+                }
+                // Otherwise another group member rejected — we keep ringing.
             }
 
             else -> {


### PR DESCRIPTION
## Summary
Updated call state handling to distinguish between the current user's own devices and other group members when processing answer and reject events during incoming calls.

## Key Changes
- **Answer event handling**: Modified `IncomingCall` state to only transition to `ANSWERED_ELSEWHERE` when the answering peer is the current user's own device. When another group member answers, the call continues ringing for the current user.
- **Reject event handling**: Modified `IncomingCall` state to only transition to `REJECTED` when the rejecting peer is the current user's own device. When another group member rejects, the call continues ringing for the current user.

## Implementation Details
- Added peer identity checks (`answeringPeer == signer.pubKey` and `rejectingPeer == signer.pubKey`) before transitioning call state
- Preserves existing call ID validation checks
- Maintains backward compatibility for single-device scenarios while properly supporting group calls where multiple users may answer or reject independently

https://claude.ai/code/session_01EYzWB93PZRqw15QuQadCf4