### PR TITLE
Fix call UI to exclude current user from peer list

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallScreen.kt
@@ -168,11 +168,15 @@ fun CallScreen(
             }
 
             is CallState.Connecting -> {
+                val otherMembers =
+                    remember(state.peerPubKeys) {
+                        state.peerPubKeys - accountViewModel.account.signer.pubKey
+                    }
                 if (isInPipMode) {
-                    PipCallUI(peerPubKeys = state.peerPubKeys, statusText = stringRes(R.string.call_connecting), accountViewModel = accountViewModel)
+                    PipCallUI(peerPubKeys = otherMembers, statusText = stringRes(R.string.call_connecting), accountViewModel = accountViewModel)
                 } else {
                     CallInProgressUI(
-                        peerPubKeys = state.peerPubKeys,
+                        peerPubKeys = otherMembers,
                         statusText = stringRes(R.string.call_connecting),
                         accountViewModel = accountViewModel,
                         onHangup = { scope.launch { callManager.hangup() } },
@@ -892,7 +896,7 @@ private fun GroupCallPictures(
 private fun GroupCallNames(
     peerPubKeys: Set<String>,
     accountViewModel: AccountViewModel,
-    textColor: Color = Color.Unspecified,
+    textColor: Color = MaterialTheme.colorScheme.onSurface,
 ) {
     val userList = remember(peerPubKeys) { peerPubKeys.toList() }
 


### PR DESCRIPTION
## Summary
Fixed the call screen UI to properly exclude the current user from the displayed peer list during calls, and improved the default text color styling in group call names.

## Key Changes
- **Exclude current user from peer display**: In the `CallState.Connecting` state, the peer list is now filtered to remove the current account's public key before being passed to UI components. This prevents the user from seeing themselves in the participant list.
- **Apply filtered peer list to both UI modes**: The filtered `otherMembers` list is now used in both `PipCallUI` (Picture-in-Picture mode) and `CallInProgressUI` components.
- **Improve default text color**: Changed the default `textColor` parameter in `GroupCallNames` from `Color.Unspecified` to `MaterialTheme.colorScheme.onSurface` for better visual consistency with the Material Design theme.

## Implementation Details
The filtering is done using Kotlin's set subtraction operator (`-`) within a `remember` block to ensure the computation is only performed when `state.peerPubKeys` changes, maintaining proper Compose recomposition behavior.

https://claude.ai/code/session_016sDH1SL7P8aXhcyFaFtzYu