### PR TITLE
Exclude current user from peer lists in call UI

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallScreen.kt
@@ -132,11 +132,15 @@ fun CallScreen(
             }
 
             is CallState.Offering -> {
+                val otherMembers =
+                    remember(state.peerPubKeys) {
+                        state.peerPubKeys - accountViewModel.account.signer.pubKey
+                    }
                 if (isInPipMode) {
-                    PipCallUI(peerPubKeys = state.peerPubKeys, statusText = stringRes(R.string.call_calling), accountViewModel = accountViewModel)
+                    PipCallUI(peerPubKeys = otherMembers, statusText = stringRes(R.string.call_calling), accountViewModel = accountViewModel)
                 } else {
                     CallInProgressUI(
-                        peerPubKeys = state.peerPubKeys,
+                        peerPubKeys = otherMembers,
                         statusText = stringRes(R.string.call_calling),
                         accountViewModel = accountViewModel,
                         onHangup = { scope.launch { callManager.hangup() } },
@@ -202,9 +206,13 @@ fun CallScreen(
             }
 
             is CallState.Ended -> {
+                val otherMembers =
+                    remember(state.peerPubKeys) {
+                        state.peerPubKeys - accountViewModel.account.signer.pubKey
+                    }
                 if (!isInPipMode) {
                     CallInProgressUI(
-                        peerPubKeys = state.peerPubKeys,
+                        peerPubKeys = otherMembers,
                         statusText = stringRes(R.string.call_ended),
                         accountViewModel = accountViewModel,
                         onHangup = { onCallEnded() },
@@ -451,6 +459,10 @@ private fun ConnectedCallUI(
         }
 
         // If no video or peer stopped sharing, show avatar
+        val otherMembers =
+            remember(state.allPeerPubKeys) {
+                state.allPeerPubKeys - accountViewModel.account.signer.pubKey
+            }
         if (!isRemoteVideoActive) {
             Column(
                 modifier = Modifier.fillMaxSize(),
@@ -458,13 +470,13 @@ private fun ConnectedCallUI(
                 verticalArrangement = Arrangement.Center,
             ) {
                 GroupCallPictures(
-                    peerPubKeys = state.allPeerPubKeys,
+                    peerPubKeys = otherMembers,
                     size = 120.dp,
                     accountViewModel = accountViewModel,
                 )
                 Spacer(modifier = Modifier.height(16.dp))
                 GroupCallNames(
-                    peerPubKeys = state.allPeerPubKeys,
+                    peerPubKeys = otherMembers,
                     accountViewModel = accountViewModel,
                     textColor = Color.White,
                 )
@@ -690,6 +702,10 @@ private fun PipConnectedCallUI(
             }
         }
 
+        val otherMembers =
+            remember(state.allPeerPubKeys) {
+                state.allPeerPubKeys - accountViewModel.account.signer.pubKey
+            }
         if (!isRemoteVideoActive) {
             // Show small avatar + timer in PiP
             Column(
@@ -698,7 +714,7 @@ private fun PipConnectedCallUI(
                 verticalArrangement = Arrangement.Center,
             ) {
                 GroupCallPictures(
-                    peerPubKeys = state.allPeerPubKeys,
+                    peerPubKeys = otherMembers,
                     size = 48.dp,
                     accountViewModel = accountViewModel,
                 )


### PR DESCRIPTION
## Summary
This PR fixes an issue where the current user's public key was being included in peer lists displayed during calls, causing the user to see themselves in group call UIs.

## Key Changes
- Filter out the current user's public key from `peerPubKeys` and `allPeerPubKeys` before passing to UI components
- Applied filtering in four locations:
  - `CallState.Offering` state (both PiP and regular UI modes)
  - `CallState.Ended` state
  - `ConnectedCallUI` function (for avatar and name displays)
  - `PipConnectedCallUI` function (for PiP mode avatar display)

## Implementation Details
- Used `remember()` composable with proper dependency tracking to memoize the filtered peer lists
- Filtering is done using Kotlin's set subtraction operator: `state.peerPubKeys - accountViewModel.account.signer.pubKey`
- This ensures the current user is excluded from all peer displays while maintaining proper recomposition when peer lists change

https://claude.ai/code/session_01PFzKU8Y3nUQXhshA3MT5EM