### PR TITLE
Fix call state handling to prevent missed cleanup due to StateFlow conflation

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallController.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallController.kt
@@ -155,7 +155,13 @@ class CallController(
                 when (state) {
                     is CallState.IncomingCall -> {
                         withContext(Dispatchers.IO) { audioManager.startRinging() }
-                        showIncomingCallNotification(state.callerPubKey)
+                        // Launch notification in a separate coroutine so that
+                        // long-running network I/O (profile picture download)
+                        // does not block the state collector.  StateFlow is
+                        // conflated — if the collector is suspended when the
+                        // state transitions Ended → Idle, the Ended emission
+                        // is lost and cleanup/stopRinging never runs.
+                        scope.launch { showIncomingCallNotification(state.callerPubKey) }
                     }
 
                     is CallState.Offering -> {
@@ -178,7 +184,14 @@ class CallController(
                         cleanup()
                     }
 
-                    else -> {}
+                    is CallState.Idle -> {
+                        // Safety net: ensure ringing and notifications are
+                        // stopped even if the Ended state was missed due to
+                        // StateFlow conflation.
+                        audioManager.stopRinging()
+                        audioManager.stopRingbackTone()
+                        NotificationUtils.cancelCallNotification(context)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
This PR fixes a race condition in the call controller where state transitions could be missed due to StateFlow conflation, causing ringing and notifications to persist after a call ends.

## Key Changes
- **Deferred notification launch**: Wrapped `showIncomingCallNotification()` in a separate coroutine scope to prevent long-running network I/O (profile picture downloads) from blocking the state collector
- **Added Idle state handler**: Implemented a safety net in the `CallState.Idle` case to ensure cleanup operations (`stopRinging()`, `stopRingbackTone()`, and notification cancellation) always execute, even if the `CallState.Ended` emission was missed

## Implementation Details
The issue occurs because StateFlow is conflated—if the state collector is suspended during a long-running operation, intermediate state emissions can be lost. Specifically, if the state transitions from `Ended` → `Idle` while the collector is blocked, the `Ended` state's cleanup logic never runs.

The fix uses two complementary approaches:
1. **Non-blocking notification**: Launching the notification in a separate coroutine prevents the collector from being suspended by network I/O
2. **Defensive cleanup**: The `Idle` state handler acts as a safety net to guarantee cleanup runs, compensating for any missed `Ended` state transitions

https://claude.ai/code/session_01NfyLNgR4d8yjnxaQJ6FUt5