### PR TITLE
Handle peer rejections in incoming group calls

### DIFF
--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
@@ -342,7 +342,20 @@ class CallManager(
             is CallState.IncomingCall -> {
                 if (callId != current.callId) return
                 if (rejectingPeer == signer.pubKey) {
+                    // Own rejection from another device
                     transitionToEnded(current.callId, current.peerPubKeys(), EndReason.REJECTED)
+                } else if (rejectingPeer == current.callerPubKey) {
+                    // Caller rejected/cancelled the call
+                    transitionToEnded(current.callId, current.groupMembers, EndReason.PEER_REJECTED)
+                } else {
+                    // Another group member rejected — remove them from the group
+                    val remaining = current.groupMembers - rejectingPeer
+                    if (remaining.size <= 1) {
+                        // Only us left, no one to call with
+                        transitionToEnded(current.callId, current.groupMembers, EndReason.PEER_REJECTED)
+                    } else {
+                        _state.value = current.copy(groupMembers = remaining)
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
Enhanced the incoming call rejection handling to properly manage different rejection scenarios in group calls, including rejections from the caller, other group members, and the user's own devices.

## Key Changes
- Added clarifying comment for self-rejection from another device
- Added handling for caller rejection/cancellation of incoming calls
- Added logic to remove group members who reject the call:
  - If only the user remains after removal, end the call with `PEER_REJECTED` reason
  - Otherwise, update the group members list and continue the call with remaining participants

## Implementation Details
The updated logic now distinguishes between three rejection scenarios:
1. **Own rejection** (`rejectingPeer == signer.pubKey`): User rejected from another device
2. **Caller rejection** (`rejectingPeer == current.callerPubKey`): The call initiator cancelled/rejected
3. **Group member rejection**: Another participant rejected, requiring removal from the group and potential call termination if no viable participants remain

https://claude.ai/code/session_01PMwKCEU1fRDGNQ8WdX8CFW