### PR TITLE
Improve peer disconnection handling in calls

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallController.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallController.kt
@@ -729,12 +729,17 @@ class CallController(
 
     private fun onPeerDisconnected(peerPubKey: HexKey) {
         Log.d(TAG) { "Peer ${peerPubKey.take(8)} disconnected (ICE FAILED)" }
-        // If all peers disconnected, hang up
-        val sessionStates = peerSessions.map { (key, ps) -> "${key.take(8)}=${ps.session.getSignalingState()}" }
+        // If all peers disconnected, hang up.
+        // A session counts as "not active" if it is the one that just failed,
+        // if it was already closed, or if it never received a remote description
+        // (e.g. the peer rejected before answering).
+        val sessionStates = peerSessions.map { (key, ps) -> "${key.take(8)}=${ps.session.getSignalingState()},remoteSet=${ps.remoteDescriptionSet.get()}" }
         Log.d(TAG) { "onPeerDisconnected: checking remaining sessions: $sessionStates" }
         val allDisconnected =
             peerSessions.keys.all { key ->
-                key == peerPubKey || peerSessions[key]?.session?.getSignalingState() == PeerConnection.SignalingState.CLOSED
+                key == peerPubKey ||
+                    peerSessions[key]?.session?.getSignalingState() == PeerConnection.SignalingState.CLOSED ||
+                    peerSessions[key]?.remoteDescriptionSet?.get() != true
             }
         if (allDisconnected) {
             Log.d(TAG) { "onPeerDisconnected: all peers disconnected, hanging up" }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
@@ -349,6 +349,7 @@ class CallManager(
                     transitionToEnded(current.callId, current.peerPubKeys, EndReason.PEER_REJECTED)
                 } else {
                     _state.value = current.copy(peerPubKeys = remaining)
+                    onPeerLeft?.invoke(rejectingPeer)
                 }
             }
 
@@ -356,12 +357,14 @@ class CallManager(
                 if (callId != current.callId) return
                 _state.value =
                     current.copy(pendingPeerPubKeys = current.pendingPeerPubKeys - rejectingPeer)
+                onPeerLeft?.invoke(rejectingPeer)
             }
 
             is CallState.Connected -> {
                 if (callId != current.callId) return
                 _state.value =
                     current.copy(pendingPeerPubKeys = current.pendingPeerPubKeys - rejectingPeer)
+                onPeerLeft?.invoke(rejectingPeer)
             }
 
             is CallState.IncomingCall -> {


### PR DESCRIPTION
## Summary
This PR improves the handling of peer disconnections and rejections in call management by better tracking remote description state and ensuring proper callbacks are invoked when peers leave.

## Key Changes

- **CallController**: Enhanced `onPeerDisconnected()` logic to consider a session as inactive not only when it's closed, but also when it never received a remote description (e.g., peer rejected before answering). This prevents premature call termination when a peer rejects before the connection is fully established.
  - Added `remoteDescriptionSet` state to session status logging for better debugging
  - Updated `allDisconnected` check to include peers that never set a remote description

- **CallManager**: Added missing `onPeerLeft` callback invocations when peers reject or leave during different call states (Active, Connecting, and Connected states). This ensures UI and other listeners are properly notified of peer departures.

## Implementation Details

The fix addresses a scenario where a peer rejection before answering would incorrectly trigger a full call hangup. By checking whether a remote description was ever set, the system can now distinguish between:
- Peers that actively disconnected from an established connection
- Peers that rejected before the connection was fully negotiated
- Peers that already had their sessions closed

This allows multi-party calls to continue when some peers reject early, while still properly terminating the call when all peers have genuinely disconnected.

https://claude.ai/code/session_01UXaFKmHVPDyTzfHL8fkSw1