### PR TITLE
Fix intermittent test failure, DesktopFeedFilters.kt

### DIFF
--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/feeds/DesktopFeedFilters.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/feeds/DesktopFeedFilters.kt
@@ -117,7 +117,7 @@ class DesktopThreadFilter(
         val seen = LinkedHashSet<Note>()
         seen.add(root)
         collectReplies(root, seen)
-        return seen.sortedWith(compareBy { it.createdAt() ?: 0 })
+        return seen.sortedWith(compareBy { it.createdAt() ?: 0L })
     }
 
     private fun collectReplies(


### PR DESCRIPTION
It's a long shot but this could be causing ClassCastException during GC

 ?: 0L forces Long regardless of nullability, so all comparisons are Long vs Long — no cast issue.