### PR TITLE
Improve video call detection to include active video streams

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallScreen.kt
@@ -412,7 +412,10 @@ private fun ConnectedCallUI(
     val isAudioMuted by (callController?.isAudioMuted ?: defaultFalse).collectAsState()
     val isVideoEnabled by (callController?.isVideoEnabled ?: defaultTrue).collectAsState()
     val currentAudioRoute by (callController?.audioRoute ?: defaultRoute).collectAsState()
-    val isVideoCall = state.callType == com.vitorpamplona.quartz.nipACWebRtcCalls.tags.CallType.VIDEO
+    val hasActiveVideo =
+        state.callType == com.vitorpamplona.quartz.nipACWebRtcCalls.tags.CallType.VIDEO ||
+            isVideoEnabled ||
+            remoteVideoTracks.isNotEmpty()
 
     var showAddParticipant by remember { mutableStateOf(false) }
 
@@ -439,7 +442,7 @@ private fun ConnectedCallUI(
                 state.allPeerPubKeys - accountViewModel.account.signer.pubKey
             }
 
-        if (isVideoCall) {
+        if (hasActiveVideo) {
             // Video call: always show the peer grid with video for active peers, avatar for inactive
             PeerVideoGrid(
                 peerPubKeys = otherMembers,
@@ -802,7 +805,11 @@ private fun PipConnectedCallUI(
     val activePeerVideos by (callController?.activePeerVideos ?: emptySetFlow).collectAsState()
     val defaultFalse = remember { kotlinx.coroutines.flow.MutableStateFlow(false) }
     val isRemoteVideoActive by (callController?.isRemoteVideoActive ?: defaultFalse).collectAsState()
-    val isVideoCall = state.callType == com.vitorpamplona.quartz.nipACWebRtcCalls.tags.CallType.VIDEO
+    val isVideoEnabled by (callController?.isVideoEnabled ?: defaultFalse).collectAsState()
+    val hasActiveVideo =
+        state.callType == com.vitorpamplona.quartz.nipACWebRtcCalls.tags.CallType.VIDEO ||
+            isVideoEnabled ||
+            remoteVideoTracks.isNotEmpty()
 
     val otherMembers =
         remember(state.allPeerPubKeys) {
@@ -815,8 +822,8 @@ private fun PipConnectedCallUI(
                 .fillMaxSize()
                 .background(Color.Black),
     ) {
-        if (isVideoCall) {
-            // Video call: show first active peer's video or avatar
+        if (hasActiveVideo) {
+            // Video active: show first active peer's video or avatar
             val firstActivePeer = otherMembers.firstOrNull { it in activePeerVideos }
             val activeTrack = firstActivePeer?.let { remoteVideoTracks[it] }
             if (activeTrack != null) {


### PR DESCRIPTION
## Summary
Updated video call detection logic to account for active video streams beyond just the initial call type, ensuring the UI properly displays video components when video is enabled or active peer videos are present.

## Key Changes
- Renamed `isVideoCall` to `hasActiveVideo` in both `ConnectedCallUI` and `PipConnectedCallUI` composables for clarity
- Enhanced video detection logic to check three conditions:
  - Call type is VIDEO
  - Video is currently enabled (`isVideoEnabled`)
  - Remote video tracks are actively being received (`remoteVideoTracks.isNotEmpty()`)
- Added `isVideoEnabled` state collection in `PipConnectedCallUI` to support the new detection logic
- Updated comment in `PipConnectedCallUI` from "Video call" to "Video active" to reflect the new semantics

## Implementation Details
The change ensures that video UI components are displayed whenever there's active video content, not just when the call was initially established as a video call. This handles scenarios where:
- Video is enabled mid-call on an audio call
- Remote participants have active video streams
- Call type alone doesn't accurately reflect current video state

https://claude.ai/code/session_015TvWJoAEsfc2ohiRoT9sTr