### PR TITLE
Handle WebRTC offer glare in call renegotiation

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallController.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallController.kt
@@ -539,11 +539,37 @@ class CallController(
         Log.d(TAG) { "Renegotiation offer from ${peerPubKey.take(8)}, sdpLength=${sdpOffer.length}" }
 
         scope.launch {
-            ps.session.setRemoteDescription(SessionDescription(SessionDescription.Type.OFFER, sdpOffer))
-            ps.session.createAnswer { sdp ->
-                scope.launch {
-                    callManager.sendRenegotiationAnswer(sdp.description, peerPubKey)
+            val signalingState = ps.session.getSignalingState()
+
+            if (signalingState == PeerConnection.SignalingState.HAVE_LOCAL_OFFER) {
+                // Glare: both sides sent offers simultaneously.
+                // Use pubkey comparison as tiebreaker — higher pubkey wins.
+                val myPubKey = signerProvider().pubKey
+                if (myPubKey > peerPubKey) {
+                    Log.d(TAG) { "Glare with ${peerPubKey.take(8)}: I win (my offer takes priority), ignoring remote offer" }
+                    return@launch
                 }
+                Log.d(TAG) { "Glare with ${peerPubKey.take(8)}: I lose, rolling back my offer" }
+                ps.session.rollback {
+                    scope.launch {
+                        applyRenegotiationOffer(ps, peerPubKey, sdpOffer)
+                    }
+                }
+            } else {
+                applyRenegotiationOffer(ps, peerPubKey, sdpOffer)
+            }
+        }
+    }
+
+    private fun applyRenegotiationOffer(
+        ps: PeerSessionState,
+        peerPubKey: HexKey,
+        sdpOffer: String,
+    ) {
+        ps.session.setRemoteDescription(SessionDescription(SessionDescription.Type.OFFER, sdpOffer))
+        ps.session.createAnswer { sdp ->
+            scope.launch {
+                callManager.sendRenegotiationAnswer(sdp.description, peerPubKey)
             }
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/WebRtcCallSession.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/WebRtcCallSession.kt
@@ -257,6 +257,32 @@ class WebRtcCallSession(
 
     fun getSignalingState(): PeerConnection.SignalingState? = peerConnection?.signalingState()
 
+    /**
+     * Rolls back a local offer so an incoming remote offer can be accepted
+     * (WebRTC offe glare handling).
+     */
+    fun rollback(onDone: () -> Unit) {
+        val rollbackSdp = SessionDescription(SessionDescription.Type.ROLLBACK, "")
+        peerConnection?.setLocalDescription(
+            object : SdpObserver {
+                override fun onCreateSuccess(sdp: SessionDescription?) {}
+
+                override fun onCreateFailure(error: String?) {}
+
+                override fun onSetSuccess() {
+                    Log.d(TAG) { "Rollback SUCCESS" }
+                    onDone()
+                }
+
+                override fun onSetFailure(error: String?) {
+                    Log.e(TAG, "Rollback FAILED: $error")
+                    error?.let { onError("Rollback failed: $it") }
+                }
+            },
+            rollbackSdp,
+        )
+    }
+
     fun dispose() {
         peerConnection?.close()
         peerConnection?.dispose()


### PR DESCRIPTION
## Summary
Implements proper handling of WebRTC offer glare (simultaneous offer collision) during call renegotiation. When both peers send offers at the same time, the connection enters an invalid state. This fix detects glare conditions and uses public key comparison as a deterministic tiebreaker to resolve the conflict.

## Key Changes
- **CallController.kt**: Modified `onRenegotiationOffer()` to detect glare by checking the peer connection's signaling state
  - When both sides have sent offers simultaneously (`HAVE_LOCAL_OFFER` state), compare public keys to determine which offer should proceed
  - The peer with the higher public key wins and keeps their offer; the other rolls back
  - Extracted offer application logic into a new `applyRenegotiationOffer()` helper method for reusability

- **WebRtcCallSession.kt**: Added `rollback()` method to handle WebRTC offer rollback
  - Implements the WebRTC rollback mechanism by setting a `ROLLBACK` type SessionDescription
  - Includes proper error handling and logging for rollback success/failure
  - Executes a callback when rollback completes to allow subsequent offer processing

## Implementation Details
- Uses deterministic public key comparison (`myPubKey > peerPubKey`) as the glare tiebreaker, ensuring both peers make the same decision
- Maintains proper async/coroutine flow with `scope.launch` for non-blocking operations
- Includes comprehensive logging to track glare detection and resolution

https://claude.ai/code/session_01XLbnNVx3GDhHrPZKPXfFdD