### PR TITLE
Add dismiss functionality to inbox relay card

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
@@ -130,6 +130,7 @@ private object PrefKeys {
     const val LOGIN_WITH_EXTERNAL_SIGNER = "login_with_external_signer"
     const val SIGNER_PACKAGE_NAME = "signer_package_name"
     const val HAS_DONATED_IN_VERSION = "has_donated_in_version"
+    const val DISMISSED_INBOX_RELAY_CARD = "dismissed_inbox_relay_card"
     const val PENDING_ATTESTATIONS = "pending_attestations"
 
     const val ALL_ACCOUNT_INFO = "all_saved_accounts_info"
@@ -389,6 +390,7 @@ object LocalPreferences {
                         JsonMapper.toJson(regularMap),
                     )
                     putStringSet(PrefKeys.HAS_DONATED_IN_VERSION, settings.hasDonatedInVersion.value)
+                    putBoolean(PrefKeys.DISMISSED_INBOX_RELAY_CARD, settings.dismissedInboxRelayCard.value)
 
                     putString(
                         PrefKeys.PENDING_ATTESTATIONS,
@@ -473,6 +475,7 @@ object LocalPreferences {
                     val hideBlockAlertDialog = getBoolean(PrefKeys.HIDE_BLOCK_ALERT_DIALOG, false)
                     val hideNIP17WarningDialog = getBoolean(PrefKeys.HIDE_NIP_17_WARNING_DIALOG, false)
                     val hasDonatedInVersion = getStringSet(PrefKeys.HAS_DONATED_IN_VERSION, null) ?: setOf()
+                    val dismissedInboxRelayCard = getBoolean(PrefKeys.DISMISSED_INBOX_RELAY_CARD, false)
                     val localRelayServers = getStringSet(PrefKeys.LOCAL_RELAY_SERVERS, null) ?: setOf()
 
                     val defaultHomeFollowListStr = getString(PrefKeys.DEFAULT_HOME_FOLLOW_LIST, null)
@@ -594,6 +597,7 @@ object LocalPreferences {
                         backupTrustProviderList = latestTrustProviderList.await(),
                         lastReadPerRoute = MutableStateFlow(lastReadPerRoute.await()),
                         hasDonatedInVersion = MutableStateFlow(hasDonatedInVersion),
+                        dismissedInboxRelayCard = MutableStateFlow(dismissedInboxRelayCard),
                         pendingAttestations = MutableStateFlow(pendingAttestations.await()),
                         backupNipA3PaymentTargets = latestPaymentTargets.await(),
                     )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -2149,6 +2149,8 @@ class Account(
 
     fun markDonatedInThisVersion() = settings.markDonatedInThisVersion(BuildConfig.VERSION_NAME)
 
+    fun dismissInboxRelayCard() = settings.dismissInboxRelayCard()
+
     init {
         Log.d("AccountRegisterObservers", "Init")
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -193,6 +193,7 @@ class AccountSettings(
     var backupTrustProviderList: TrustProviderListEvent? = null,
     val lastReadPerRoute: MutableStateFlow<Map<String, MutableStateFlow<Long>>> = MutableStateFlow(mapOf()),
     val hasDonatedInVersion: MutableStateFlow<Set<String>> = MutableStateFlow(setOf()),
+    val dismissedInboxRelayCard: MutableStateFlow<Boolean> = MutableStateFlow(false),
     val pendingAttestations: MutableStateFlow<Map<HexKey, String>> = MutableStateFlow(mapOf()),
     var backupNipA3PaymentTargets: PaymentTargetsEvent? = null,
 ) : EphemeralChatRepository,
@@ -677,6 +678,17 @@ class AccountSettings(
             return true
         }
         return false
+    }
+
+    // ----
+    // inbox relay card
+    // ----
+
+    fun dismissInboxRelayCard() {
+        if (!dismissedInboxRelayCard.value) {
+            dismissedInboxRelayCard.value = true
+            saveAccountSettings()
+        }
     }
 
     // ----

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -1126,6 +1126,8 @@ class AccountViewModel(
 
     fun markDonatedInThisVersion() = account.markDonatedInThisVersion()
 
+    fun dismissInboxRelayCard() = account.dismissInboxRelayCard()
+
     fun dontTranslateFrom() = account.settings.syncedSettings.languages.dontTranslateFrom.value
 
     fun translateTo() = account.settings.syncedSettings.languages.translateTo.value

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/AddOutboxRelayCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/AddOutboxRelayCard.kt
@@ -56,6 +56,7 @@ import com.vitorpamplona.amethyst.ui.theme.imageModifier
 fun AddOutboxRelayCardPreview() {
     ThemeComparisonColumn {
         AddInboxRelayCard(
+            onDismiss = {},
             accountViewModel = mockAccountViewModel(),
             nav = EmptyNav(),
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/AddInboxRelayCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/AddInboxRelayCard.kt
@@ -20,11 +20,14 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -41,10 +44,12 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.note.CloseIcon
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.mockAccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.BigPadding
+import com.vitorpamplona.amethyst.ui.theme.Size20Modifier
 import com.vitorpamplona.amethyst.ui.theme.StdPadding
 import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
 import com.vitorpamplona.amethyst.ui.theme.ThemeComparisonColumn
@@ -55,6 +60,7 @@ import com.vitorpamplona.amethyst.ui.theme.imageModifier
 fun AddInboxRelayCardPreview() {
     ThemeComparisonColumn {
         AddInboxRelayCard(
+            onDismiss = {},
             accountViewModel = mockAccountViewModel(),
             nav = EmptyNav(),
         )
@@ -66,11 +72,17 @@ fun ObserveInboxRelayListAndDisplayIfNotFound(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
+    val dismissed by accountViewModel.account.settings.dismissedInboxRelayCard
+        .collectAsStateWithLifecycle()
+
+    if (dismissed) return
+
     val inboxRelayList by accountViewModel.account.nip65RelayList.inboxFlowNoDefaults
         .collectAsStateWithLifecycle()
 
     if (inboxRelayList.isEmpty()) {
         AddInboxRelayCard(
+            onDismiss = { accountViewModel.dismissInboxRelayCard() },
             accountViewModel = accountViewModel,
             nav = nav,
         )
@@ -79,6 +91,7 @@ fun ObserveInboxRelayListAndDisplayIfNotFound(
 
 @Composable
 fun AddInboxRelayCard(
+    onDismiss: () -> Unit,
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
@@ -89,15 +102,27 @@ fun AddInboxRelayCard(
             Column(
                 modifier = BigPadding,
             ) {
-                // Title
-                Text(
-                    text = stringRes(id = R.string.inbox_relays_not_found),
-                    style =
-                        TextStyle(
-                            fontSize = 20.sp,
-                            fontWeight = FontWeight.Bold,
-                        ),
-                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text(
+                        text = stringRes(id = R.string.inbox_relays_not_found),
+                        modifier = Modifier.weight(1f),
+                        style =
+                            TextStyle(
+                                fontSize = 20.sp,
+                                fontWeight = FontWeight.Bold,
+                            ),
+                    )
+
+                    IconButton(
+                        modifier = Size20Modifier,
+                        onClick = onDismiss,
+                    ) {
+                        CloseIcon()
+                    }
+                }
 
                 Spacer(modifier = StdVertSpacer)
 


### PR DESCRIPTION
## Summary
Added the ability for users to dismiss the "Add Inbox Relay" card, with the dismissal state persisted across app sessions.

## Key Changes
- **UI Enhancement**: Modified `AddInboxRelayCard` to include a close button (IconButton with CloseIcon) in the title row, allowing users to dismiss the card
- **State Management**: 
  - Added `dismissedInboxRelayCard` StateFlow to `AccountSettings` to track dismissal state
  - Implemented `dismissInboxRelayCard()` method in `AccountSettings`, `Account`, and `AccountViewModel` to handle dismissal logic
- **Persistence**: Added `DISMISSED_INBOX_RELAY_CARD` preference key to `LocalPreferences` to save and restore the dismissal state across app restarts
- **Display Logic**: Updated `ObserveInboxRelayListAndDisplayIfNotFound` to check the dismissal state and skip rendering the card if previously dismissed
- **Preview Updates**: Updated preview functions to include the new `onDismiss` parameter

## Implementation Details
- The close button is positioned at the end of a Row with `Arrangement.SpaceBetween` to align it to the right of the title
- The dismissal state is saved to local preferences when `dismissInboxRelayCard()` is called
- The card will not be displayed if either inbox relays are already configured OR the user has dismissed the card

https://claude.ai/code/session_0122rGSpXBcirzFNMpXjw3SH