### PR TITLE
Add routing support for Poll and ZapPoll draft edits

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/RouteMaker.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/RouteMaker.kt
@@ -30,6 +30,7 @@ import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.quartz.experimental.ephemChat.chat.EphemeralChatEvent
 import com.vitorpamplona.quartz.experimental.ephemChat.chat.RoomId
+import com.vitorpamplona.quartz.experimental.zapPolls.ZapPollEvent
 import com.vitorpamplona.quartz.nip01Core.core.AddressableEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -51,6 +52,7 @@ import com.vitorpamplona.quartz.nip59Giftwrap.wraps.GiftWrapEvent
 import com.vitorpamplona.quartz.nip72ModCommunities.definition.CommunityDefinitionEvent
 import com.vitorpamplona.quartz.nip73ExternalIds.location.isGeohashedScoped
 import com.vitorpamplona.quartz.nip73ExternalIds.topics.isHashtagScoped
+import com.vitorpamplona.quartz.nip88Polls.poll.PollEvent
 import com.vitorpamplona.quartz.nip89AppHandlers.definition.AppDefinitionEvent
 import com.vitorpamplona.quartz.nip99Classifieds.ClassifiedsEvent
 import com.vitorpamplona.quartz.nipA4PublicMessages.PublicMessageEvent
@@ -349,6 +351,14 @@ suspend fun routeEditDraftTo(
                 parentId = noteEvent.id,
                 draftId = note.idHex,
             )
+        }
+
+        is PollEvent -> {
+            Route.NewPoll(draft = note.idHex)
+        }
+
+        is ZapPollEvent -> {
+            Route.NewPoll(draft = note.idHex)
         }
 
         is CommentEvent -> {


### PR DESCRIPTION
## Summary
Added support for routing poll-related draft edits to the NewPoll screen in the route maker.

## Key Changes
- Added imports for `PollEvent` and `ZapPollEvent` classes
- Extended `routeEditDraftTo()` function to handle poll event types by routing them to `Route.NewPoll` with the draft note ID
- Added handling for both standard polls (`PollEvent`) and zap polls (`ZapPollEvent`)

## Implementation Details
When a user attempts to edit a draft that is a poll or zap poll event, the application now correctly routes to the NewPoll screen instead of falling through to other handlers. Both event types are treated identically, routing to the same `Route.NewPoll` destination with the draft's hex ID.

https://claude.ai/code/session_01WedCekkgCwNVCq2ybSTvqE