### PR TITLE
Set explicit surface color for Card in notification feed

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/CardFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/CardFeedView.kt
@@ -35,6 +35,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -185,6 +186,7 @@ private fun FeedLoaded(
                 Row(modifier = Modifier.padding(start = Size10dp, end = Size10dp, bottom = Size10dp)) {
                     Card(
                         modifier = MaterialTheme.colorScheme.imageModifier,
+                        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
                     ) {
                         Row(
                             modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
## Summary
Updated the Card component in the notification feed to explicitly set its container color to the Material theme's surface color.

## Changes
- Added `CardDefaults` import from `androidx.compose.material3`
- Set `colors` parameter on the Card composable with `CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)`

## Details
This change ensures the Card in the FeedLoaded notification view uses the theme's surface color explicitly rather than relying on default Card styling. This provides better consistency with the Material Design 3 color scheme and allows for more predictable theming behavior across different color configurations.

https://claude.ai/code/session_012ErcSBhXugYCRAwHRXrFr7