### PR TITLE
show toast while downloading video for sharing

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
@@ -833,6 +833,7 @@ fun ShareMediaAction(
                                         enabled = !isDownloadingVideo.value,
                                     ) {
                                         isDownloadingVideo.value = true
+                                        accountViewModel.toastManager.toast(R.string.share_video, R.string.downloading_video_for_sharing)
                                         scope.launch {
                                             shareVideoFile(
                                                 context = context,


### PR DESCRIPTION
Display a "Downloading video…" toast when the user taps share on a remote video, so they know the download is in progress before the share sheet appears. Uses the existing `downloading_video_for_sharing` string resource that was already translated in multiple locales.

fix for #2134 

