### PR TITLE
Add Marmot MLS group messaging UI and integration

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -2335,6 +2335,11 @@ class Account(
         if (marmotManager != null) {
             scope.launch(Dispatchers.IO) {
                 marmotManager.restoreAll()
+                // Sync MIP-01 metadata from restored groups to chatrooms
+                marmotManager.activeGroupIds().forEach { groupId ->
+                    val chatroom = marmotGroupList.getOrCreateGroup(groupId)
+                    marmotManager.syncMetadataTo(groupId, chatroom)
+                }
             }
         }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -1732,6 +1732,60 @@ class Account(
     }
 
     /**
+     * Fetch a user's KeyPackage from relays and add them to a Marmot group.
+     * Returns a status message describing the outcome.
+     */
+    @OptIn(kotlin.io.encoding.ExperimentalEncodingApi::class)
+    suspend fun fetchKeyPackageAndAddMember(
+        nostrGroupId: HexKey,
+        memberPubKey: HexKey,
+    ): String {
+        val manager = marmotManager ?: return "Error: Marmot not initialized"
+        if (!isWriteable()) return "Error: Account is read-only"
+
+        // Build filter for the member's KeyPackages
+        val filter = manager.subscriptionManager.keyPackageFilter(memberPubKey)
+        val relays = outboxRelays.flow.value
+
+        // Query across outbox relays
+        val filterMap = relays.associateWith { listOf(filter) }
+
+        val event =
+            client.fetchFirst(
+                filters = filterMap,
+            )
+
+        if (event == null) {
+            return "Error: No KeyPackage found for this user. They may not have published one yet."
+        }
+
+        if (event !is com.vitorpamplona.quartz.marmot.mip00KeyPackages.KeyPackageEvent) {
+            return "Error: Unexpected event type received"
+        }
+
+        val keyPackageBase64 = event.keyPackageBase64()
+        if (keyPackageBase64.isBlank()) {
+            return "Error: KeyPackage event has empty content"
+        }
+
+        val keyPackageBytes =
+            kotlin.io.encoding.Base64
+                .decode(keyPackageBase64)
+        val keyPackageEventId = event.id
+        val groupRelays = relays.toList()
+
+        addMarmotGroupMember(
+            nostrGroupId = nostrGroupId,
+            memberPubKey = memberPubKey,
+            keyPackageBytes = keyPackageBytes,
+            keyPackageEventId = keyPackageEventId,
+            groupRelays = groupRelays,
+        )
+
+        return "Success: Member added to group"
+    }
+
+    /**
      * Add a member to a Marmot MLS group.
      * Publishes the commit GroupEvent, then sends the Welcome gift wrap.
      */

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -1804,6 +1804,21 @@ class Account(
         manager.createGroup(nostrGroupId)
     }
 
+    /**
+     * Leave a Marmot MLS group.
+     * Publishes the SelfRemove proposal and removes local state.
+     */
+    suspend fun leaveMarmotGroup(
+        nostrGroupId: HexKey,
+        groupRelays: Set<NormalizedRelayUrl>,
+    ) {
+        val manager = marmotManager ?: return
+        if (!isWriteable()) return
+
+        val outbound = manager.leaveGroup(nostrGroupId)
+        client.publish(outbound.signedEvent, groupRelays)
+    }
+
     suspend fun createStatus(newStatus: String) = sendMyPublicAndPrivateOutbox(UserStatusAction.create(newStatus, signer))
 
     suspend fun publishCallSignaling(wrap: EphemeralGiftWrapEvent) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -376,6 +376,9 @@ class Account(
     val draftsDecryptionCache = DraftEventCache(signer)
 
     override val chatroomList = cache.getOrCreateChatroomList(signer.pubKey)
+    override val marmotGroupList =
+        com.vitorpamplona.amethyst.commons.model.marmotGroups
+            .MarmotGroupList()
 
     val newNotesPreProcessor = EventProcessor(this, cache)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -71,6 +71,8 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.list.metadat
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.membershipManagement.ArticleBookmarkListManagementScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.membershipManagement.PostBookmarkListManagementScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.old.OldBookmarkListScreen
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup.AddMemberScreen
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup.CreateGroupScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup.MarmotGroupChatScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup.MarmotGroupInfoScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup.MarmotGroupListScreen
@@ -288,6 +290,9 @@ fun BuildNavigation(
         composableFromEnd<Route.MarmotGroupList> { MarmotGroupListScreen(accountViewModel, nav) }
         composableFromEndArgs<Route.MarmotGroupChat> { MarmotGroupChatScreen(it.nostrGroupId, accountViewModel, nav) }
         composableFromEndArgs<Route.MarmotGroupInfo> { MarmotGroupInfoScreen(it.nostrGroupId, accountViewModel, nav) }
+
+        composableFromBottom<Route.CreateMarmotGroup> { CreateGroupScreen(accountViewModel, nav) }
+        composableFromBottomArgs<Route.MarmotGroupAddMember> { AddMemberScreen(it.nostrGroupId, accountViewModel, nav) }
 
         composableFromEndArgs<Route.PublicChatChannel> {
             PublicChatChannelScreen(it.id, it.draftId, it.replyTo, accountViewModel, nav)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -71,6 +71,8 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.list.metadat
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.membershipManagement.ArticleBookmarkListManagementScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.membershipManagement.PostBookmarkListManagementScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.old.OldBookmarkListScreen
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup.MarmotGroupChatScreen
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup.MarmotGroupListScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.privateDM.ChatroomByAuthorScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.privateDM.ChatroomScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.privateDM.send.NewGroupDMScreen
@@ -281,6 +283,9 @@ fun BuildNavigation(
 
         composableFromEndArgs<Route.Room> { ChatroomScreen(it.toKey(), it.message, it.replyId, it.draftId, it.expiresDays, accountViewModel, nav) }
         composableFromEndArgs<Route.RoomByAuthor> { ChatroomByAuthorScreen(it.id, null, accountViewModel, nav) }
+
+        composableFromEnd<Route.MarmotGroupList> { MarmotGroupListScreen(accountViewModel, nav) }
+        composableFromEndArgs<Route.MarmotGroupChat> { MarmotGroupChatScreen(it.nostrGroupId, accountViewModel, nav) }
 
         composableFromEndArgs<Route.PublicChatChannel> {
             PublicChatChannelScreen(it.id, it.draftId, it.replyTo, accountViewModel, nav)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -72,6 +72,7 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.membershipMa
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.membershipManagement.PostBookmarkListManagementScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.old.OldBookmarkListScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup.MarmotGroupChatScreen
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup.MarmotGroupInfoScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup.MarmotGroupListScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.privateDM.ChatroomByAuthorScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.privateDM.ChatroomScreen
@@ -286,6 +287,7 @@ fun BuildNavigation(
 
         composableFromEnd<Route.MarmotGroupList> { MarmotGroupListScreen(accountViewModel, nav) }
         composableFromEndArgs<Route.MarmotGroupChat> { MarmotGroupChatScreen(it.nostrGroupId, accountViewModel, nav) }
+        composableFromEndArgs<Route.MarmotGroupInfo> { MarmotGroupInfoScreen(it.nostrGroupId, accountViewModel, nav) }
 
         composableFromEndArgs<Route.PublicChatChannel> {
             PublicChatChannelScreen(it.id, it.draftId, it.replyTo, accountViewModel, nav)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
@@ -273,6 +273,12 @@ sealed class Route {
         val nostrGroupId: String,
     ) : Route()
 
+    @Serializable object CreateMarmotGroup : Route()
+
+    @Serializable data class MarmotGroupAddMember(
+        val nostrGroupId: String,
+    ) : Route()
+
     @Serializable data class NewGroupDM(
         val message: String? = null,
         val attachment: String? = null,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
@@ -263,6 +263,12 @@ sealed class Route {
         val id: String? = null,
     ) : Route()
 
+    @Serializable object MarmotGroupList : Route()
+
+    @Serializable data class MarmotGroupChat(
+        val nostrGroupId: String,
+    ) : Route()
+
     @Serializable data class NewGroupDM(
         val message: String? = null,
         val attachment: String? = null,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
@@ -269,6 +269,10 @@ sealed class Route {
         val nostrGroupId: String,
     ) : Route()
 
+    @Serializable data class MarmotGroupInfo(
+        val nostrGroupId: String,
+    ) : Route()
+
     @Serializable data class NewGroupDM(
         val message: String? = null,
         val attachment: String? = null,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -1464,6 +1464,13 @@ class AccountViewModel(
         account.publishMarmotKeyPackage()
     }
 
+    suspend fun leaveMarmotGroup(nostrGroupId: String) {
+        val relays = account.outboxRelays.flow.value
+        account.leaveMarmotGroup(nostrGroupId, relays)
+    }
+
+    fun marmotGroupMembers(nostrGroupId: String): List<com.vitorpamplona.amethyst.commons.marmot.GroupMemberInfo> = account.marmotManager?.memberPubkeys(nostrGroupId) ?: emptyList()
+
     override fun onCleared() {
         Log.d("AccountViewModel", "onCleared")
         callController?.cleanup()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -1471,6 +1471,11 @@ class AccountViewModel(
 
     fun marmotGroupMembers(nostrGroupId: String): List<com.vitorpamplona.amethyst.commons.marmot.GroupMemberInfo> = account.marmotManager?.memberPubkeys(nostrGroupId) ?: emptyList()
 
+    suspend fun addMarmotGroupMember(
+        nostrGroupId: String,
+        memberPubKey: String,
+    ): String = account.fetchKeyPackageAndAddMember(nostrGroupId, memberPubKey)
+
     override fun onCleared() {
         Log.d("AccountViewModel", "onCleared")
         callController?.cleanup()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -1440,6 +1440,30 @@ class AccountViewModel(
         }
     }
 
+    // --- Marmot Group Messaging ---
+
+    suspend fun sendMarmotGroupMessage(
+        nostrGroupId: String,
+        text: String,
+    ) {
+        val template =
+            com.vitorpamplona.quartz.nip01Core.signers.eventTemplate<com.vitorpamplona.quartz.nip01Core.core.Event>(
+                kind = 9,
+                description = text,
+            )
+        val innerEvent = account.signer.sign<com.vitorpamplona.quartz.nip01Core.core.Event>(template)
+        val relays = account.outboxRelays.flow.value
+        account.sendMarmotGroupMessage(nostrGroupId, innerEvent, relays)
+    }
+
+    suspend fun createMarmotGroup(nostrGroupId: String) {
+        account.createMarmotGroup(nostrGroupId)
+    }
+
+    suspend fun publishMarmotKeyPackage() {
+        account.publishMarmotKeyPackage()
+    }
+
     override fun onCleared() {
         Log.d("AccountViewModel", "onCleared")
         callController?.cleanup()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/DecryptAndIndexProcessor.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/DecryptAndIndexProcessor.kt
@@ -475,6 +475,9 @@ class GroupEventHandler(
                     if (cache.justConsume(innerEvent, null, false)) {
                         val innerNote = cache.getOrCreateNote(innerEvent.id)
                         innerNote.event = innerEvent
+
+                        // Track the message in the Marmot group chatroom
+                        account.marmotGroupList.addMessage(result.groupId, innerNote)
                     }
                 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/DecryptAndIndexProcessor.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/DecryptAndIndexProcessor.kt
@@ -326,6 +326,10 @@ class GiftWrapEventHandler(
             is WelcomeResult.Joined -> {
                 Log.d("GiftWrapEventHandler", "Joined Marmot group ${result.nostrGroupId}")
 
+                // Sync MIP-01 metadata from group extensions to chatroom
+                val chatroom = account.marmotGroupList.getOrCreateGroup(result.nostrGroupId)
+                manager.syncMetadataTo(result.nostrGroupId, chatroom)
+
                 // Rotate KeyPackages if needed
                 if (result.needsKeyPackageRotation) {
                     account.publishMarmotKeyPackages()
@@ -483,6 +487,9 @@ class GroupEventHandler(
 
                 is GroupEventResult.CommitProcessed -> {
                     Log.d("GroupEventHandler", "Commit processed for group ${result.groupId}, epoch=${result.newEpoch}")
+                    // Sync MIP-01 metadata after epoch advance (extensions may have changed)
+                    val chatroom = account.marmotGroupList.getOrCreateGroup(result.groupId)
+                    manager.syncMetadataTo(result.groupId, chatroom)
                 }
 
                 is GroupEventResult.CommitPending -> {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/AddMemberDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/AddMemberDialog.kt
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip19Bech32.Nip19Parser
+import com.vitorpamplona.quartz.nip19Bech32.entities.NProfile
+import com.vitorpamplona.quartz.nip19Bech32.entities.NPub
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+@Composable
+fun AddMemberDialog(
+    nostrGroupId: HexKey,
+    accountViewModel: AccountViewModel,
+    onDismiss: () -> Unit,
+) {
+    var memberInput by remember { mutableStateOf("") }
+    var statusMessage by remember { mutableStateOf<String?>(null) }
+    var isAdding by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Add Member") },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = memberInput,
+                    onValueChange = {
+                        memberInput = it
+                        statusMessage = null
+                    },
+                    label = { Text("npub or hex pubkey") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                )
+                Text(
+                    "Enter the member's npub or hex public key. " +
+                        "They must have published a KeyPackage (kind:30443) to be added.",
+                    modifier = Modifier.padding(top = 8.dp),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+                if (statusMessage != null) {
+                    Text(
+                        text = statusMessage!!,
+                        modifier = Modifier.padding(top = 8.dp),
+                        style = MaterialTheme.typography.bodySmall,
+                        color =
+                            if (statusMessage!!.startsWith("Error")) {
+                                MaterialTheme.colorScheme.error
+                            } else {
+                                MaterialTheme.colorScheme.primary
+                            },
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    isAdding = true
+                    statusMessage = "Looking up KeyPackage..."
+                    scope.launch(Dispatchers.IO) {
+                        try {
+                            val pubkey = resolvePubkey(memberInput)
+                            if (pubkey == null) {
+                                statusMessage = "Error: Invalid public key format"
+                                isAdding = false
+                                return@launch
+                            }
+                            statusMessage = "Fetching KeyPackage for ${pubkey.take(8)}..."
+                            // TODO: Fetch KeyPackage from relays and call addMarmotGroupMember
+                            // For now, show that the flow would proceed here
+                            statusMessage = "Error: KeyPackage fetch not yet implemented. " +
+                                "The member's KeyPackage (kind:30443) must be fetched from relays."
+                            isAdding = false
+                        } catch (e: Exception) {
+                            statusMessage = "Error: ${e.message}"
+                            isAdding = false
+                        }
+                    }
+                },
+                enabled = !isAdding && memberInput.isNotBlank(),
+            ) {
+                Text(if (isAdding) "Adding..." else "Add")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        },
+    )
+}
+
+private fun resolvePubkey(input: String): HexKey? {
+    val trimmed = input.trim()
+
+    // Try hex pubkey
+    if (trimmed.length == 64 && trimmed.all { it in '0'..'9' || it in 'a'..'f' }) {
+        return trimmed
+    }
+
+    // Try bech32 (npub / nprofile)
+    val entity =
+        Nip19Parser.uriToRoute("nostr:$trimmed")?.entity
+            ?: Nip19Parser.uriToRoute(trimmed)?.entity
+    return when (entity) {
+        is NPub -> entity.hex
+        is NProfile -> entity.hex
+        else -> null
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/AddMemberScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/AddMemberScreen.kt
@@ -21,13 +21,14 @@
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -36,6 +37,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.topbars.ActionTopBar
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip19Bech32.Nip19Parser
@@ -45,55 +48,22 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 @Composable
-fun AddMemberDialog(
+fun AddMemberScreen(
     nostrGroupId: HexKey,
     accountViewModel: AccountViewModel,
-    onDismiss: () -> Unit,
+    nav: INav,
 ) {
     var memberInput by remember { mutableStateOf("") }
     var statusMessage by remember { mutableStateOf<String?>(null) }
     var isAdding by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
 
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text("Add Member") },
-        text = {
-            Column {
-                OutlinedTextField(
-                    value = memberInput,
-                    onValueChange = {
-                        memberInput = it
-                        statusMessage = null
-                    },
-                    label = { Text("npub or hex pubkey") },
-                    modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                )
-                Text(
-                    "Enter the member's npub or hex public key. " +
-                        "They must have published a KeyPackage (kind:30443) to be added.",
-                    modifier = Modifier.padding(top = 8.dp),
-                    style = MaterialTheme.typography.bodySmall,
-                )
-                if (statusMessage != null) {
-                    Text(
-                        text = statusMessage!!,
-                        modifier = Modifier.padding(top = 8.dp),
-                        style = MaterialTheme.typography.bodySmall,
-                        color =
-                            if (statusMessage!!.startsWith("Error")) {
-                                MaterialTheme.colorScheme.error
-                            } else {
-                                MaterialTheme.colorScheme.primary
-                            },
-                    )
-                }
-            }
-        },
-        confirmButton = {
-            TextButton(
-                onClick = {
+    Scaffold(
+        topBar = {
+            ActionTopBar(
+                postRes = com.vitorpamplona.amethyst.R.string.add,
+                onCancel = { nav.popBack() },
+                onPost = {
                     isAdding = true
                     statusMessage = "Looking up KeyPackage..."
                     scope.launch(Dispatchers.IO) {
@@ -106,8 +76,8 @@ fun AddMemberDialog(
                             }
                             statusMessage = "Fetching KeyPackage for ${pubkey.take(8)}..."
                             // TODO: Fetch KeyPackage from relays and call addMarmotGroupMember
-                            // For now, show that the flow would proceed here
-                            statusMessage = "Error: KeyPackage fetch not yet implemented. " +
+                            statusMessage =
+                                "Error: KeyPackage fetch not yet implemented. " +
                                 "The member's KeyPackage (kind:30443) must be fetched from relays."
                             isAdding = false
                         } catch (e: Exception) {
@@ -116,28 +86,67 @@ fun AddMemberDialog(
                         }
                     }
                 },
-                enabled = !isAdding && memberInput.isNotBlank(),
-            ) {
-                Text(if (isAdding) "Adding..." else "Add")
-            }
+                isActive = { !isAdding && memberInput.isNotBlank() },
+            )
         },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text("Cancel")
+    ) { padding ->
+        Column(
+            modifier =
+                Modifier
+                    .padding(padding)
+                    .consumeWindowInsets(padding)
+                    .imePadding()
+                    .padding(horizontal = 16.dp),
+        ) {
+            Text(
+                text = "Add Member",
+                style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier.padding(top = 16.dp, bottom = 8.dp),
+            )
+
+            OutlinedTextField(
+                value = memberInput,
+                onValueChange = {
+                    memberInput = it
+                    statusMessage = null
+                },
+                label = { Text("npub or hex pubkey") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+            )
+
+            Text(
+                "Enter the member's npub or hex public key. " +
+                    "They must have published a KeyPackage (kind:30443) to be added.",
+                modifier = Modifier.padding(top = 12.dp),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            if (statusMessage != null) {
+                Text(
+                    text = statusMessage!!,
+                    modifier = Modifier.padding(top = 12.dp),
+                    style = MaterialTheme.typography.bodySmall,
+                    color =
+                        if (statusMessage!!.startsWith("Error")) {
+                            MaterialTheme.colorScheme.error
+                        } else {
+                            MaterialTheme.colorScheme.primary
+                        },
+                )
             }
-        },
-    )
+        }
+    }
 }
 
 private fun resolvePubkey(input: String): HexKey? {
     val trimmed = input.trim()
 
-    // Try hex pubkey
     if (trimmed.length == 64 && trimmed.all { it in '0'..'9' || it in 'a'..'f' }) {
         return trimmed
     }
 
-    // Try bech32 (npub / nprofile)
     val entity =
         Nip19Parser.uriToRoute("nostr:$trimmed")?.entity
             ?: Nip19Parser.uriToRoute(trimmed)?.entity

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/AddMemberScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/AddMemberScreen.kt
@@ -21,8 +21,11 @@
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
@@ -30,20 +33,25 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.ActionTopBar
+import com.vitorpamplona.amethyst.ui.note.UserPicture
+import com.vitorpamplona.amethyst.ui.note.creators.userSuggestions.ShowUserSuggestionList
+import com.vitorpamplona.amethyst.ui.note.creators.userSuggestions.UserSuggestionState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.theme.SuggestionListDefaultHeightPage
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
-import com.vitorpamplona.quartz.nip19Bech32.Nip19Parser
-import com.vitorpamplona.quartz.nip19Bech32.entities.NProfile
-import com.vitorpamplona.quartz.nip19Bech32.entities.NPub
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
@@ -53,10 +61,20 @@ fun AddMemberScreen(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    var memberInput by remember { mutableStateOf("") }
+    var searchInput by remember { mutableStateOf("") }
+    var selectedUser by remember { mutableStateOf<User?>(null) }
     var statusMessage by remember { mutableStateOf<String?>(null) }
     var isAdding by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
+
+    val userSuggestions =
+        remember {
+            UserSuggestionState(accountViewModel.account, accountViewModel.nip05ClientBuilder())
+        }
+
+    DisposableEffect(Unit) {
+        onDispose { userSuggestions.reset() }
+    }
 
     Scaffold(
         topBar = {
@@ -64,14 +82,13 @@ fun AddMemberScreen(
                 postRes = com.vitorpamplona.amethyst.R.string.add,
                 onCancel = { nav.popBack() },
                 onPost = {
-                    isAdding = true
-                    val pubkey = resolvePubkey(memberInput)
+                    val pubkey = selectedUser?.pubkeyHex
                     if (pubkey == null) {
-                        statusMessage = "Error: Invalid public key format"
+                        statusMessage = "Error: No user selected"
                         return@ActionTopBar
                     }
                     isAdding = true
-                    statusMessage = "Fetching KeyPackage for ${pubkey.take(8)}..."
+                    statusMessage = "Fetching KeyPackage..."
                     scope.launch(Dispatchers.IO) {
                         try {
                             val result =
@@ -88,7 +105,7 @@ fun AddMemberScreen(
                         }
                     }
                 },
-                isActive = { !isAdding && memberInput.isNotBlank() },
+                isActive = { !isAdding && selectedUser != null },
             )
         },
     ) { padding ->
@@ -97,38 +114,47 @@ fun AddMemberScreen(
                 Modifier
                     .padding(padding)
                     .consumeWindowInsets(padding)
-                    .imePadding()
-                    .padding(horizontal = 16.dp),
+                    .imePadding(),
         ) {
-            Text(
-                text = "Add Member",
-                style = MaterialTheme.typography.headlineSmall,
-                modifier = Modifier.padding(top = 16.dp, bottom = 8.dp),
-            )
+            // Selected user display
+            if (selectedUser != null) {
+                SelectedUserRow(
+                    user = selectedUser!!,
+                    accountViewModel = accountViewModel,
+                    nav = nav,
+                    onClear = {
+                        selectedUser = null
+                        statusMessage = null
+                    },
+                )
+            }
 
+            // Search field
             OutlinedTextField(
-                value = memberInput,
-                onValueChange = {
-                    memberInput = it
+                value = searchInput,
+                onValueChange = { newValue ->
+                    searchInput = newValue
                     statusMessage = null
+                    if (newValue.length > 2) {
+                        userSuggestions.processCurrentWord(newValue)
+                    } else {
+                        userSuggestions.reset()
+                    }
                 },
-                label = { Text("npub or hex pubkey") },
-                modifier = Modifier.fillMaxWidth(),
+                label = { Text("Search users") },
+                placeholder = { Text("Name, npub, or NIP-05") },
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
                 singleLine = true,
-            )
-
-            Text(
-                "Enter the member's npub or hex public key. " +
-                    "They must have published a KeyPackage (kind:30443) to be added.",
-                modifier = Modifier.padding(top = 12.dp),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                enabled = selectedUser == null && !isAdding,
             )
 
             if (statusMessage != null) {
                 Text(
                     text = statusMessage!!,
-                    modifier = Modifier.padding(top = 12.dp),
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                     style = MaterialTheme.typography.bodySmall,
                     color =
                         if (statusMessage!!.startsWith("Error")) {
@@ -138,23 +164,70 @@ fun AddMemberScreen(
                         },
                 )
             }
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            // User suggestion list
+            if (selectedUser == null && searchInput.length > 2) {
+                ShowUserSuggestionList(
+                    userSuggestions = userSuggestions,
+                    onSelect = { user ->
+                        selectedUser = user
+                        searchInput = ""
+                        userSuggestions.reset()
+                    },
+                    accountViewModel = accountViewModel,
+                    modifier = SuggestionListDefaultHeightPage,
+                    onEmpty = {
+                        Text(
+                            "They must have published a KeyPackage (kind:30443) to be added.",
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    },
+                )
+            }
         }
     }
 }
 
-private fun resolvePubkey(input: String): HexKey? {
-    val trimmed = input.trim()
-
-    if (trimmed.length == 64 && trimmed.all { it in '0'..'9' || it in 'a'..'f' }) {
-        return trimmed
-    }
-
-    val entity =
-        Nip19Parser.uriToRoute("nostr:$trimmed")?.entity
-            ?: Nip19Parser.uriToRoute(trimmed)?.entity
-    return when (entity) {
-        is NPub -> entity.hex
-        is NProfile -> entity.hex
-        else -> null
+@Composable
+private fun SelectedUserRow(
+    user: User,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+    onClear: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        UserPicture(
+            userHex = user.pubkeyHex,
+            size = 40.dp,
+            accountViewModel = accountViewModel,
+            nav = nav,
+        )
+        Column(
+            modifier = Modifier.weight(1f).padding(start = 12.dp),
+        ) {
+            Text(
+                text = user.toBestDisplayName(),
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                text = "${user.pubkeyHex.take(16)}...",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        androidx.compose.material3.TextButton(onClick = onClear) {
+            Text("Clear")
+        }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/AddMemberScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/AddMemberScreen.kt
@@ -65,21 +65,23 @@ fun AddMemberScreen(
                 onCancel = { nav.popBack() },
                 onPost = {
                     isAdding = true
-                    statusMessage = "Looking up KeyPackage..."
+                    val pubkey = resolvePubkey(memberInput)
+                    if (pubkey == null) {
+                        statusMessage = "Error: Invalid public key format"
+                        return@ActionTopBar
+                    }
+                    isAdding = true
+                    statusMessage = "Fetching KeyPackage for ${pubkey.take(8)}..."
                     scope.launch(Dispatchers.IO) {
                         try {
-                            val pubkey = resolvePubkey(memberInput)
-                            if (pubkey == null) {
-                                statusMessage = "Error: Invalid public key format"
+                            val result =
+                                accountViewModel.addMarmotGroupMember(nostrGroupId, pubkey)
+                            statusMessage = result
+                            if (result.startsWith("Success")) {
+                                nav.popBack()
+                            } else {
                                 isAdding = false
-                                return@launch
                             }
-                            statusMessage = "Fetching KeyPackage for ${pubkey.take(8)}..."
-                            // TODO: Fetch KeyPackage from relays and call addMarmotGroupMember
-                            statusMessage =
-                                "Error: KeyPackage fetch not yet implemented. " +
-                                "The member's KeyPackage (kind:30443) must be fetched from relays."
-                            isAdding = false
                         } catch (e: Exception) {
                             statusMessage = "Error: ${e.message}"
                             isAdding = false

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/CreateGroupDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/CreateGroupDialog.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlin.random.Random
+
+@Composable
+fun CreateGroupDialog(
+    accountViewModel: AccountViewModel,
+    onDismiss: () -> Unit,
+    onGroupCreated: (HexKey) -> Unit,
+) {
+    var groupName by remember { mutableStateOf("") }
+    var isCreating by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Create Marmot Group") },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = groupName,
+                    onValueChange = { groupName = it },
+                    label = { Text("Group Name") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                )
+                Text(
+                    "A new MLS group will be created. You can add members after.",
+                    modifier = Modifier.padding(top = 8.dp),
+                    style = androidx.compose.material3.MaterialTheme.typography.bodySmall,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    isCreating = true
+                    scope.launch(Dispatchers.IO) {
+                        val nostrGroupId = Random.nextBytes(32).joinToString("") { "%02x".format(it) }
+                        accountViewModel.createMarmotGroup(nostrGroupId)
+                        // Set display name locally
+                        if (groupName.isNotBlank()) {
+                            accountViewModel.account.marmotGroupList
+                                .getOrCreateGroup(nostrGroupId)
+                                .displayName.value = groupName
+                        }
+                        onGroupCreated(nostrGroupId)
+                    }
+                },
+                enabled = !isCreating,
+            ) {
+                Text(if (isCreating) "Creating..." else "Create")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        },
+    )
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/CreateGroupScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/CreateGroupScreen.kt
@@ -21,12 +21,14 @@
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -35,66 +37,72 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.routes.Route
+import com.vitorpamplona.amethyst.ui.navigation.topbars.CreatingTopBar
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
-import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlin.random.Random
 
 @Composable
-fun CreateGroupDialog(
+fun CreateGroupScreen(
     accountViewModel: AccountViewModel,
-    onDismiss: () -> Unit,
-    onGroupCreated: (HexKey) -> Unit,
+    nav: INav,
 ) {
     var groupName by remember { mutableStateOf("") }
     var isCreating by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
 
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text("Create Marmot Group") },
-        text = {
-            Column {
-                OutlinedTextField(
-                    value = groupName,
-                    onValueChange = { groupName = it },
-                    label = { Text("Group Name") },
-                    modifier = Modifier.fillMaxWidth(),
-                    singleLine = true,
-                )
-                Text(
-                    "A new MLS group will be created. You can add members after.",
-                    modifier = Modifier.padding(top = 8.dp),
-                    style = androidx.compose.material3.MaterialTheme.typography.bodySmall,
-                )
-            }
-        },
-        confirmButton = {
-            TextButton(
-                onClick = {
+    Scaffold(
+        topBar = {
+            CreatingTopBar(
+                onCancel = { nav.popBack() },
+                onPost = {
                     isCreating = true
                     scope.launch(Dispatchers.IO) {
                         val nostrGroupId = Random.nextBytes(32).joinToString("") { "%02x".format(it) }
                         accountViewModel.createMarmotGroup(nostrGroupId)
-                        // Set display name locally
                         if (groupName.isNotBlank()) {
                             accountViewModel.account.marmotGroupList
                                 .getOrCreateGroup(nostrGroupId)
                                 .displayName.value = groupName
                         }
-                        onGroupCreated(nostrGroupId)
+                        nav.nav(Route.MarmotGroupChat(nostrGroupId))
                     }
                 },
-                enabled = !isCreating,
-            ) {
-                Text(if (isCreating) "Creating..." else "Create")
-            }
+                isActive = { !isCreating },
+            )
         },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text("Cancel")
-            }
-        },
-    )
+    ) { padding ->
+        Column(
+            modifier =
+                Modifier
+                    .padding(padding)
+                    .consumeWindowInsets(padding)
+                    .imePadding()
+                    .padding(horizontal = 16.dp),
+        ) {
+            Text(
+                text = "Create Marmot Group",
+                style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier.padding(top = 16.dp, bottom = 8.dp),
+            )
+
+            OutlinedTextField(
+                value = groupName,
+                onValueChange = { groupName = it },
+                label = { Text("Group Name") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+            )
+
+            Text(
+                "A new MLS group will be created. You can add members after.",
+                modifier = Modifier.padding(top = 12.dp),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupChatScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupChatScreen.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.GroupAdd
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.ui.layouts.DisappearingScaffold
+import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MarmotGroupChatScreen(
+    nostrGroupId: HexKey,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    val chatroom =
+        remember(nostrGroupId) {
+            accountViewModel.account.marmotGroupList.getOrCreateGroup(nostrGroupId)
+        }
+    val displayName by chatroom.displayName.collectAsStateWithLifecycle()
+    val memberCount by chatroom.memberCount.collectAsStateWithLifecycle()
+    var showAddMemberDialog by remember { mutableStateOf(false) }
+
+    DisappearingScaffold(
+        isInvertedLayout = true,
+        topBar = {
+            TopAppBar(
+                navigationIcon = {
+                    IconButton(onClick = { nav.popBack() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+                title = {
+                    Column {
+                        Text(displayName ?: "Marmot Group")
+                        if (memberCount > 0) {
+                            Text(
+                                text = "$memberCount members",
+                                style = androidx.compose.material3.MaterialTheme.typography.bodySmall,
+                            )
+                        }
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { showAddMemberDialog = true }) {
+                        Icon(
+                            imageVector = Icons.Default.GroupAdd,
+                            contentDescription = "Add Member",
+                        )
+                    }
+                },
+            )
+        },
+        accountViewModel = accountViewModel,
+    ) {
+        Column(Modifier.padding(it).consumeWindowInsets(it).statusBarsPadding()) {
+            MarmotGroupChatView(
+                nostrGroupId = nostrGroupId,
+                accountViewModel = accountViewModel,
+                nav = nav,
+            )
+        }
+    }
+
+    if (showAddMemberDialog) {
+        AddMemberDialog(
+            nostrGroupId = nostrGroupId,
+            accountViewModel = accountViewModel,
+            onDismiss = { showAddMemberDialog = false },
+        )
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupChatScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupChatScreen.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.padding
@@ -41,6 +42,7 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.ui.layouts.DisappearingScaffold
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 
@@ -72,7 +74,12 @@ fun MarmotGroupChatScreen(
                     }
                 },
                 title = {
-                    Column {
+                    Column(
+                        modifier =
+                            Modifier.clickable {
+                                nav.nav(Route.MarmotGroupInfo(nostrGroupId))
+                            },
+                    ) {
                         Text(displayName ?: "Marmot Group")
                         if (memberCount > 0) {
                             Text(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupChatScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupChatScreen.kt
@@ -31,13 +31,12 @@ import androidx.compose.material.icons.filled.GroupAdd
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.ui.layouts.DisappearingScaffold
@@ -59,7 +58,6 @@ fun MarmotGroupChatScreen(
         }
     val displayName by chatroom.displayName.collectAsStateWithLifecycle()
     val memberCount by chatroom.memberCount.collectAsStateWithLifecycle()
-    var showAddMemberDialog by remember { mutableStateOf(false) }
 
     DisappearingScaffold(
         isInvertedLayout = true,
@@ -84,13 +82,13 @@ fun MarmotGroupChatScreen(
                         if (memberCount > 0) {
                             Text(
                                 text = "$memberCount members",
-                                style = androidx.compose.material3.MaterialTheme.typography.bodySmall,
+                                style = MaterialTheme.typography.bodySmall,
                             )
                         }
                     }
                 },
                 actions = {
-                    IconButton(onClick = { showAddMemberDialog = true }) {
+                    IconButton(onClick = { nav.nav(Route.MarmotGroupAddMember(nostrGroupId)) }) {
                         Icon(
                             imageVector = Icons.Default.GroupAdd,
                             contentDescription = "Add Member",
@@ -108,13 +106,5 @@ fun MarmotGroupChatScreen(
                 nav = nav,
             )
         }
-    }
-
-    if (showAddMemberDialog) {
-        AddMemberDialog(
-            nostrGroupId = nostrGroupId,
-            accountViewModel = accountViewModel,
-            onDismiss = { showAddMemberDialog = false },
-        )
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupChatView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupChatView.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.clearText
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.vitorpamplona.amethyst.ui.feeds.WatchLifecycleAndUpdateModel
+import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.feed.RefreshingChatroomFeedView
+import com.vitorpamplona.amethyst.ui.theme.DoubleVertSpacer
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+@Composable
+fun MarmotGroupChatView(
+    nostrGroupId: HexKey,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    val feedViewModel: MarmotGroupFeedViewModel =
+        viewModel(
+            key = nostrGroupId + "MarmotGroupFeedViewModel",
+            factory =
+                MarmotGroupFeedViewModel.Factory(
+                    nostrGroupId,
+                    accountViewModel.account,
+                ),
+        )
+
+    WatchLifecycleAndUpdateModel(feedViewModel)
+
+    Column(Modifier.fillMaxHeight()) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxHeight()
+                    .padding(vertical = 0.dp)
+                    .weight(1f, true),
+        ) {
+            RefreshingChatroomFeedView(
+                feedContentState = feedViewModel.feedState,
+                accountViewModel = accountViewModel,
+                nav = nav,
+                routeForLastRead = "MarmotGroup/$nostrGroupId",
+                onWantsToReply = { },
+                onWantsToEditDraft = { },
+            )
+        }
+
+        Spacer(modifier = DoubleVertSpacer)
+
+        MarmotGroupMessageComposer(
+            nostrGroupId = nostrGroupId,
+            accountViewModel = accountViewModel,
+            onMessageSent = {
+                feedViewModel.feedState.sendToTop()
+            },
+        )
+    }
+}
+
+@Composable
+fun MarmotGroupMessageComposer(
+    nostrGroupId: HexKey,
+    accountViewModel: AccountViewModel,
+    onMessageSent: suspend () -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+    val messageState = remember { TextFieldState() }
+
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        OutlinedTextField(
+            state = messageState,
+            modifier = Modifier.weight(1f),
+            placeholder = { Text("Message") },
+            lineLimits =
+                androidx.compose.foundation.text.input.TextFieldLineLimits
+                    .MultiLine(maxHeightInLines = 4),
+        )
+        IconButton(
+            onClick = {
+                val text = messageState.text.toString().trim()
+                if (text.isNotEmpty()) {
+                    scope.launch(Dispatchers.IO) {
+                        accountViewModel.sendMarmotGroupMessage(nostrGroupId, text)
+                        messageState.clearText()
+                        onMessageSent()
+                    }
+                }
+            },
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.Send,
+                contentDescription = "Send",
+            )
+        }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupFeedViewModel.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.vitorpamplona.amethyst.commons.ui.feeds.MarmotGroupFeedFilter
+import com.vitorpamplona.amethyst.commons.viewmodels.ListChangeFeedViewModel
+import com.vitorpamplona.amethyst.model.Account
+import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+
+class MarmotGroupFeedViewModel(
+    nostrGroupId: HexKey,
+    account: Account,
+) : ListChangeFeedViewModel(
+        MarmotGroupFeedFilter(nostrGroupId, account.marmotGroupList, account),
+        LocalCache,
+    ) {
+    class Factory(
+        val nostrGroupId: HexKey,
+        val account: Account,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T = MarmotGroupFeedViewModel(nostrGroupId, account) as T
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupInfoScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupInfoScreen.kt
@@ -80,7 +80,6 @@ fun MarmotGroupInfoScreen(
     val displayName by chatroom.displayName.collectAsStateWithLifecycle()
     var members by remember { mutableStateOf(emptyList<GroupMemberInfo>()) }
     var showLeaveDialog by remember { mutableStateOf(false) }
-    var showAddMemberDialog by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
     val myPubkey = accountViewModel.account.signer.pubKey
 
@@ -102,7 +101,7 @@ fun MarmotGroupInfoScreen(
                 },
                 title = { Text("Group Info") },
                 actions = {
-                    IconButton(onClick = { showAddMemberDialog = true }) {
+                    IconButton(onClick = { nav.nav(Route.MarmotGroupAddMember(nostrGroupId)) }) {
                         Icon(
                             imageVector = Icons.Default.GroupAdd,
                             contentDescription = "Add Member",
@@ -216,14 +215,6 @@ fun MarmotGroupInfoScreen(
                 nav.nav(Route.MarmotGroupList)
             },
             onDismiss = { showLeaveDialog = false },
-        )
-    }
-
-    if (showAddMemberDialog) {
-        AddMemberDialog(
-            nostrGroupId = nostrGroupId,
-            accountViewModel = accountViewModel,
-            onDismiss = { showAddMemberDialog = false },
         )
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupInfoScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupInfoScreen.kt
@@ -27,14 +27,12 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material.icons.filled.GroupAdd
-import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -61,7 +59,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.commons.marmot.GroupMemberInfo
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
+import com.vitorpamplona.amethyst.ui.note.UserPicture
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.LoadUser
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -170,9 +170,8 @@ fun MarmotGroupInfoScreen(
                 MemberRow(
                     member = member,
                     isMe = member.pubkey == myPubkey,
-                    onClick = {
-                        nav.nav(Route.Profile(member.pubkey))
-                    },
+                    accountViewModel = accountViewModel,
+                    nav = nav,
                 )
                 HorizontalDivider()
             }
@@ -223,36 +222,40 @@ fun MarmotGroupInfoScreen(
 fun MemberRow(
     member: GroupMemberInfo,
     isMe: Boolean,
-    onClick: () -> Unit,
+    accountViewModel: AccountViewModel,
+    nav: INav,
 ) {
     Row(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .clickable(onClick = onClick)
+                .clickable { nav.nav(Route.Profile(member.pubkey)) }
                 .padding(horizontal = 16.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        Icon(
-            imageVector = Icons.Default.Person,
-            contentDescription = null,
-            modifier = Modifier.size(36.dp),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        UserPicture(
+            userHex = member.pubkey,
+            size = 36.dp,
+            accountViewModel = accountViewModel,
+            nav = nav,
         )
         Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text =
-                    if (isMe) {
-                        "${member.pubkey.take(16)}... (you)"
-                    } else {
-                        "${member.pubkey.take(16)}..."
-                    },
-                style = MaterialTheme.typography.bodyMedium,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                fontWeight = if (isMe) FontWeight.Bold else FontWeight.Normal,
-            )
+            LoadUser(baseUserHex = member.pubkey, accountViewModel = accountViewModel) { user ->
+                val displayName = user?.toBestDisplayName() ?: "${member.pubkey.take(16)}..."
+                Text(
+                    text =
+                        if (isMe) {
+                            "$displayName (you)"
+                        } else {
+                            displayName
+                        },
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    fontWeight = if (isMe) FontWeight.Bold else FontWeight.Normal,
+                )
+            }
             Text(
                 text = "Leaf #${member.leafIndex}",
                 style = MaterialTheme.typography.bodySmall,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupInfoScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupInfoScreen.kt
@@ -78,6 +78,9 @@ fun MarmotGroupInfoScreen(
             accountViewModel.account.marmotGroupList.getOrCreateGroup(nostrGroupId)
         }
     val displayName by chatroom.displayName.collectAsStateWithLifecycle()
+    val groupDescription by chatroom.description.collectAsStateWithLifecycle()
+    val adminPubkeys by chatroom.adminPubkeys.collectAsStateWithLifecycle()
+    val groupRelays by chatroom.relays.collectAsStateWithLifecycle()
     var members by remember { mutableStateOf(emptyList<GroupMemberInfo>()) }
     var showLeaveDialog by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
@@ -130,18 +133,28 @@ fun MarmotGroupInfoScreen(
                         style = MaterialTheme.typography.headlineSmall,
                         fontWeight = FontWeight.Bold,
                     )
+                    if (!groupDescription.isNullOrEmpty()) {
+                        Text(
+                            text = groupDescription!!,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(top = 4.dp),
+                        )
+                    }
                     Text(
                         text = "${members.size} members",
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(top = 4.dp),
                     )
-                    Text(
-                        text = "Group ID: ${nostrGroupId.take(16)}...",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(top = 2.dp),
-                    )
+                    if (groupRelays.isNotEmpty()) {
+                        Text(
+                            text = "Relays: ${groupRelays.joinToString(", ")}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(top = 2.dp),
+                        )
+                    }
                     val epoch = accountViewModel.account.marmotManager?.groupEpoch(nostrGroupId)
                     if (epoch != null) {
                         Text(
@@ -170,6 +183,7 @@ fun MarmotGroupInfoScreen(
                 MemberRow(
                     member = member,
                     isMe = member.pubkey == myPubkey,
+                    isAdmin = member.pubkey in adminPubkeys,
                     accountViewModel = accountViewModel,
                     nav = nav,
                 )
@@ -222,6 +236,7 @@ fun MarmotGroupInfoScreen(
 fun MemberRow(
     member: GroupMemberInfo,
     isMe: Boolean,
+    isAdmin: Boolean,
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
@@ -243,24 +258,19 @@ fun MemberRow(
         Column(modifier = Modifier.weight(1f)) {
             LoadUser(baseUserHex = member.pubkey, accountViewModel = accountViewModel) { user ->
                 val displayName = user?.toBestDisplayName() ?: "${member.pubkey.take(16)}..."
+                val suffix =
+                    buildString {
+                        if (isMe) append(" (you)")
+                        if (isAdmin) append(" - admin")
+                    }
                 Text(
-                    text =
-                        if (isMe) {
-                            "$displayName (you)"
-                        } else {
-                            displayName
-                        },
+                    text = "$displayName$suffix",
                     style = MaterialTheme.typography.bodyMedium,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
-                    fontWeight = if (isMe) FontWeight.Bold else FontWeight.Normal,
+                    fontWeight = if (isMe || isAdmin) FontWeight.Bold else FontWeight.Normal,
                 )
             }
-            Text(
-                text = "Leaf #${member.leafIndex}",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
         }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupInfoScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupInfoScreen.kt
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ExitToApp
+import androidx.compose.material.icons.filled.GroupAdd
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.commons.marmot.GroupMemberInfo
+import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.routes.Route
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MarmotGroupInfoScreen(
+    nostrGroupId: HexKey,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    val chatroom =
+        remember(nostrGroupId) {
+            accountViewModel.account.marmotGroupList.getOrCreateGroup(nostrGroupId)
+        }
+    val displayName by chatroom.displayName.collectAsStateWithLifecycle()
+    var members by remember { mutableStateOf(emptyList<GroupMemberInfo>()) }
+    var showLeaveDialog by remember { mutableStateOf(false) }
+    var showAddMemberDialog by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+    val myPubkey = accountViewModel.account.signer.pubKey
+
+    LaunchedEffect(nostrGroupId) {
+        members = accountViewModel.marmotGroupMembers(nostrGroupId)
+        chatroom.memberCount.value = members.size
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                navigationIcon = {
+                    IconButton(onClick = { nav.popBack() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+                title = { Text("Group Info") },
+                actions = {
+                    IconButton(onClick = { showAddMemberDialog = true }) {
+                        Icon(
+                            imageVector = Icons.Default.GroupAdd,
+                            contentDescription = "Add Member",
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        LazyColumn(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+        ) {
+            // Group header section
+            item {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                ) {
+                    Text(
+                        text = displayName ?: "Group ${nostrGroupId.take(8)}...",
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Text(
+                        text = "${members.size} members",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                    Text(
+                        text = "Group ID: ${nostrGroupId.take(16)}...",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 2.dp),
+                    )
+                    val epoch = accountViewModel.account.marmotManager?.groupEpoch(nostrGroupId)
+                    if (epoch != null) {
+                        Text(
+                            text = "Epoch: $epoch",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(top = 2.dp),
+                        )
+                    }
+                }
+                HorizontalDivider()
+            }
+
+            // Members section header
+            item {
+                Text(
+                    text = "Members",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                )
+            }
+
+            // Member list
+            items(members, key = { it.leafIndex }) { member ->
+                MemberRow(
+                    member = member,
+                    isMe = member.pubkey == myPubkey,
+                    onClick = {
+                        nav.nav(Route.Profile(member.pubkey))
+                    },
+                )
+                HorizontalDivider()
+            }
+
+            // Leave group section
+            item {
+                HorizontalDivider(modifier = Modifier.padding(top = 8.dp))
+                Row(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .clickable { showLeaveDialog = true }
+                            .padding(horizontal = 16.dp, vertical = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ExitToApp,
+                        contentDescription = "Leave Group",
+                        tint = MaterialTheme.colorScheme.error,
+                    )
+                    Text(
+                        text = "Leave Group",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+        }
+    }
+
+    if (showLeaveDialog) {
+        LeaveGroupDialog(
+            groupName = displayName ?: "this group",
+            onConfirm = {
+                showLeaveDialog = false
+                scope.launch(Dispatchers.IO) {
+                    accountViewModel.leaveMarmotGroup(nostrGroupId)
+                }
+                nav.nav(Route.MarmotGroupList)
+            },
+            onDismiss = { showLeaveDialog = false },
+        )
+    }
+
+    if (showAddMemberDialog) {
+        AddMemberDialog(
+            nostrGroupId = nostrGroupId,
+            accountViewModel = accountViewModel,
+            onDismiss = { showAddMemberDialog = false },
+        )
+    }
+}
+
+@Composable
+fun MemberRow(
+    member: GroupMemberInfo,
+    isMe: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Icon(
+            imageVector = Icons.Default.Person,
+            contentDescription = null,
+            modifier = Modifier.size(36.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text =
+                    if (isMe) {
+                        "${member.pubkey.take(16)}... (you)"
+                    } else {
+                        "${member.pubkey.take(16)}..."
+                    },
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                fontWeight = if (isMe) FontWeight.Bold else FontWeight.Normal,
+            )
+            Text(
+                text = "Leaf #${member.leafIndex}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+fun LeaveGroupDialog(
+    groupName: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Leave Group") },
+        text = {
+            Text("Are you sure you want to leave \"$groupName\"? You will no longer receive messages from this group.")
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text("Leave", color = MaterialTheme.colorScheme.error)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        },
+    )
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupListScreen.kt
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.VpnKey
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupChatroom
+import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.routes.Route
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MarmotGroupListScreen(
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    var showCreateGroupDialog by remember { mutableStateOf(false) }
+    var groupList by remember { mutableStateOf(listOf<Pair<HexKey, MarmotGroupChatroom>>()) }
+    val scope = rememberCoroutineScope()
+
+    // Load group list
+    LaunchedEffect(Unit) {
+        loadGroupList(accountViewModel, onUpdate = { groupList = it })
+    }
+
+    // Listen for group list changes
+    LaunchedEffect(Unit) {
+        accountViewModel.account.marmotGroupList.groupListChanges.collect {
+            loadGroupList(accountViewModel, onUpdate = { groupList = it })
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                navigationIcon = {
+                    IconButton(onClick = { nav.popBack() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+                title = { Text("Marmot Groups") },
+                actions = {
+                    IconButton(
+                        onClick = {
+                            scope.launch(Dispatchers.IO) {
+                                accountViewModel.publishMarmotKeyPackage()
+                            }
+                        },
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.VpnKey,
+                            contentDescription = "Publish KeyPackage",
+                        )
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showCreateGroupDialog = true }) {
+                Icon(Icons.Default.Add, contentDescription = "Create Group")
+            }
+        },
+    ) { padding ->
+        if (groupList.isEmpty()) {
+            Box(
+                modifier = Modifier.fillMaxSize().padding(padding),
+                contentAlignment = Alignment.Center,
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        "No groups yet",
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    Text(
+                        "Publish your KeyPackage to receive invitations.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                }
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize().padding(padding),
+            ) {
+                items(groupList, key = { it.first }) { (groupId, chatroom) ->
+                    MarmotGroupListItem(
+                        groupId = groupId,
+                        chatroom = chatroom,
+                        onClick = {
+                            nav.nav(Route.MarmotGroupChat(groupId))
+                        },
+                    )
+                    HorizontalDivider()
+                }
+            }
+        }
+    }
+
+    if (showCreateGroupDialog) {
+        CreateGroupDialog(
+            accountViewModel = accountViewModel,
+            onDismiss = { showCreateGroupDialog = false },
+            onGroupCreated = { groupId ->
+                showCreateGroupDialog = false
+                nav.nav(Route.MarmotGroupChat(groupId))
+            },
+        )
+    }
+}
+
+private fun loadGroupList(
+    accountViewModel: AccountViewModel,
+    onUpdate: (List<Pair<HexKey, MarmotGroupChatroom>>) -> Unit,
+) {
+    val groups = mutableListOf<Pair<HexKey, MarmotGroupChatroom>>()
+    accountViewModel.account.marmotGroupList.rooms.forEach { key, chatroom ->
+        groups.add(key to chatroom)
+    }
+    // Also add groups from MarmotManager that might not have messages yet
+    accountViewModel.account.marmotManager?.activeGroupIds()?.forEach { groupId ->
+        if (groups.none { it.first == groupId }) {
+            groups.add(groupId to accountViewModel.account.marmotGroupList.getOrCreateGroup(groupId))
+        }
+    }
+    groups.sortByDescending { it.second.newestMessage?.createdAt() ?: 0L }
+    onUpdate(groups)
+}
+
+@Composable
+fun MarmotGroupListItem(
+    groupId: HexKey,
+    chatroom: MarmotGroupChatroom,
+    onClick: () -> Unit,
+) {
+    val displayName by chatroom.displayName.collectAsStateWithLifecycle()
+    val newestMessage = chatroom.newestMessage
+
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = displayName ?: "Group ${groupId.take(8)}...",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (newestMessage != null) {
+                Text(
+                    text = newestMessage.event?.content ?: "",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(top = 2.dp),
+                )
+            } else {
+                Text(
+                    text = "No messages yet",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 2.dp),
+                )
+            }
+        }
+        Column(horizontalAlignment = Alignment.End) {
+            Text(
+                text = "${chatroom.messages.size} msgs",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupListScreen.kt
@@ -70,7 +70,6 @@ fun MarmotGroupListScreen(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    var showCreateGroupDialog by remember { mutableStateOf(false) }
     var groupList by remember { mutableStateOf(listOf<Pair<HexKey, MarmotGroupChatroom>>()) }
     val scope = rememberCoroutineScope()
 
@@ -115,7 +114,7 @@ fun MarmotGroupListScreen(
             )
         },
         floatingActionButton = {
-            FloatingActionButton(onClick = { showCreateGroupDialog = true }) {
+            FloatingActionButton(onClick = { nav.nav(Route.CreateMarmotGroup) }) {
                 Icon(Icons.Default.Add, contentDescription = "Create Group")
             }
         },
@@ -154,17 +153,6 @@ fun MarmotGroupListScreen(
                 }
             }
         }
-    }
-
-    if (showCreateGroupDialog) {
-        CreateGroupDialog(
-            accountViewModel = accountViewModel,
-            onDismiss = { showCreateGroupDialog = false },
-            onGroupCreated = { groupId ->
-                showCreateGroupDialog = false
-                nav.nav(Route.MarmotGroupChat(groupId))
-            },
-        )
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChannelFabColumn.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChannelFabColumn.kt
@@ -103,6 +103,25 @@ fun ChannelFabColumn(nav: INav) {
                 }
 
                 Spacer(modifier = Modifier.height(20.dp))
+
+                FloatingActionButton(
+                    onClick = {
+                        nav.nav(Route.MarmotGroupList)
+                        isOpen = false
+                    },
+                    modifier = Size55Modifier,
+                    shape = CircleShape,
+                    containerColor = MaterialTheme.colorScheme.primary,
+                ) {
+                    Text(
+                        text = "MLS\nGroups",
+                        color = Color.White,
+                        textAlign = TextAlign.Center,
+                        fontSize = Font12SP,
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(20.dp))
             }
         }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/dal/ChatroomListKnownFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/dal/ChatroomListKnownFeedFilter.kt
@@ -77,7 +77,12 @@ class ChatroomListKnownFeedFilter(
                         .firstOrNull()
                 }
 
-        return (privateMessages + publicChannels + ephemeralChats).sortedWith(DefaultFeedOrder)
+        val marmotGroups =
+            account.marmotGroupList.rooms.mapNotNull { _, chatroom ->
+                chatroom.newestMessage
+            }
+
+        return (privateMessages + publicChannels + ephemeralChats + marmotGroups).sortedWith(DefaultFeedOrder)
     }
 
     override fun updateListWith(

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/marmot/MarmotManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/marmot/MarmotManager.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.commons.marmot
 
+import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupChatroom
 import com.vitorpamplona.quartz.marmot.GroupEventResult
 import com.vitorpamplona.quartz.marmot.MarmotInboundProcessor
 import com.vitorpamplona.quartz.marmot.MarmotOutboundProcessor
@@ -31,6 +32,7 @@ import com.vitorpamplona.quartz.marmot.WelcomeResult
 import com.vitorpamplona.quartz.marmot.mip00KeyPackages.KeyPackageEvent
 import com.vitorpamplona.quartz.marmot.mip00KeyPackages.KeyPackageRotationManager
 import com.vitorpamplona.quartz.marmot.mip00KeyPackages.KeyPackageUtils
+import com.vitorpamplona.quartz.marmot.mip01Groups.MarmotGroupData
 import com.vitorpamplona.quartz.marmot.mip02Welcome.WelcomeEvent
 import com.vitorpamplona.quartz.marmot.mip03GroupMessages.GroupEvent
 import com.vitorpamplona.quartz.marmot.mls.group.MlsGroupManager
@@ -287,6 +289,37 @@ class MarmotManager(
      * Get the current epoch for a group.
      */
     fun groupEpoch(nostrGroupId: HexKey): Long? = groupManager.getGroup(nostrGroupId)?.epoch
+
+    /**
+     * Get the MIP-01 group metadata from the MLS GroupContext extensions.
+     * Returns null if the group doesn't exist or has no MarmotGroupData extension.
+     */
+    fun groupMetadata(nostrGroupId: HexKey): MarmotGroupData? {
+        val group = groupManager.getGroup(nostrGroupId) ?: return null
+        return MarmotGroupData.fromExtensions(group.extensions)
+    }
+
+    /**
+     * Sync MIP-01 metadata and member info from the MLS group into a [MarmotGroupChatroom].
+     * Call after joining a group, processing a commit, or restoring from storage.
+     */
+    fun syncMetadataTo(
+        nostrGroupId: HexKey,
+        chatroom: MarmotGroupChatroom,
+    ) {
+        val metadata = groupMetadata(nostrGroupId)
+        if (metadata != null) {
+            if (metadata.name.isNotEmpty()) {
+                chatroom.displayName.value = metadata.name
+            }
+            if (metadata.description.isNotEmpty()) {
+                chatroom.description.value = metadata.description
+            }
+            chatroom.adminPubkeys.value = metadata.adminPubkeys
+            chatroom.relays.value = metadata.relays
+        }
+        chatroom.memberCount.value = memberCount(nostrGroupId)
+    }
 }
 
 /**

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/marmot/MarmotManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/marmot/MarmotManager.kt
@@ -35,6 +35,7 @@ import com.vitorpamplona.quartz.marmot.mip02Welcome.WelcomeEvent
 import com.vitorpamplona.quartz.marmot.mip03GroupMessages.GroupEvent
 import com.vitorpamplona.quartz.marmot.mls.group.MlsGroupManager
 import com.vitorpamplona.quartz.marmot.mls.group.MlsGroupStateStore
+import com.vitorpamplona.quartz.marmot.mls.tree.Credential
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.hexToByteArray
@@ -254,4 +255,44 @@ class MarmotManager(
      * Get all active group IDs.
      */
     fun activeGroupIds(): Set<HexKey> = groupManager.activeGroupIds()
+
+    // --- Group Info ---
+
+    /**
+     * Get the member count for a group.
+     */
+    fun memberCount(nostrGroupId: HexKey): Int = groupManager.getGroup(nostrGroupId)?.memberCount ?: 0
+
+    /**
+     * Get the member list for a group.
+     * Returns leaf index and Nostr pubkey (extracted from BasicCredential) for each member.
+     */
+    fun memberPubkeys(nostrGroupId: HexKey): List<GroupMemberInfo> {
+        val group = groupManager.getGroup(nostrGroupId) ?: return emptyList()
+        return group.members().mapNotNull { (leafIndex, leafNode) ->
+            val pubkey =
+                when (val cred = leafNode.credential) {
+                    is Credential.Basic -> cred.identity.toHexKey()
+                    else -> null
+                }
+            if (pubkey != null) {
+                GroupMemberInfo(leafIndex = leafIndex, pubkey = pubkey)
+            } else {
+                null
+            }
+        }
+    }
+
+    /**
+     * Get the current epoch for a group.
+     */
+    fun groupEpoch(nostrGroupId: HexKey): Long? = groupManager.getGroup(nostrGroupId)?.epoch
 }
+
+/**
+ * Information about a member in a Marmot MLS group.
+ */
+data class GroupMemberInfo(
+    val leafIndex: Int,
+    val pubkey: HexKey,
+)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.commons.model
 
+import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupList
 import com.vitorpamplona.amethyst.commons.model.privateChats.ChatroomList
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
@@ -100,6 +101,9 @@ interface IAccount {
 
     /** Chatroom list for private DM conversations */
     val chatroomList: ChatroomList
+
+    /** Marmot MLS group chat list */
+    val marmotGroupList: MarmotGroupList
 
     /** Whether a note is acceptable (not hidden, not blocked, etc.) */
     fun isAcceptable(note: Note): Boolean

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/marmotGroups/MarmotGroupChatroom.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/marmotGroups/MarmotGroupChatroom.kt
@@ -42,6 +42,9 @@ class MarmotGroupChatroom(
 ) : NotesGatherer {
     var messages: Set<Note> = setOf()
     var displayName = MutableStateFlow<String?>(null)
+    var description = MutableStateFlow<String?>(null)
+    var adminPubkeys = MutableStateFlow<List<HexKey>>(emptyList())
+    var relays = MutableStateFlow<List<String>>(emptyList())
     var memberCount = MutableStateFlow(0)
     var newestMessage: Note? = null
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/marmotGroups/MarmotGroupChatroom.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/marmotGroups/MarmotGroupChatroom.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model.marmotGroups
+
+import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.model.Channel.Companion.DefaultFeedOrder
+import com.vitorpamplona.amethyst.commons.model.ListChange
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.model.NotesGatherer
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import java.lang.ref.WeakReference
+
+/**
+ * Represents a Marmot MLS group chat room.
+ * Tracks decrypted inner messages for a single group.
+ * Follows the same pattern as [com.vitorpamplona.amethyst.commons.model.privateChats.Chatroom].
+ */
+@Stable
+class MarmotGroupChatroom(
+    val nostrGroupId: HexKey,
+) : NotesGatherer {
+    var messages: Set<Note> = setOf()
+    var displayName = MutableStateFlow<String?>(null)
+    var memberCount = MutableStateFlow(0)
+    var newestMessage: Note? = null
+
+    private var changesFlow: WeakReference<MutableSharedFlow<ListChange<Note>>> = WeakReference(null)
+
+    fun changesFlow(): MutableSharedFlow<ListChange<Note>> {
+        val current = changesFlow.get()
+        if (current != null) return current
+        val new = MutableSharedFlow<ListChange<Note>>(0, 100, BufferOverflow.DROP_OLDEST)
+        changesFlow = WeakReference(new)
+        return new
+    }
+
+    override fun removeNote(note: Note) {
+        removeMessageSync(note)
+    }
+
+    @Synchronized
+    fun addMessageSync(msg: Note): Boolean {
+        if (msg !in messages) {
+            messages = messages + msg
+            msg.addGatherer(this)
+
+            val createdAt = msg.createdAt() ?: 0L
+            if (createdAt > (newestMessage?.createdAt() ?: 0L)) {
+                newestMessage = msg
+            }
+
+            changesFlow.get()?.tryEmit(ListChange.Addition(msg))
+            return true
+        }
+        return false
+    }
+
+    @Synchronized
+    fun removeMessageSync(msg: Note): Boolean {
+        if (msg in messages) {
+            messages = messages - msg
+            msg.removeGatherer(this)
+
+            if (msg == newestMessage) {
+                newestMessage = messages.maxByOrNull { it.createdAt() ?: 0L }
+            }
+
+            changesFlow.get()?.tryEmit(ListChange.Deletion(msg))
+            return true
+        }
+        return false
+    }
+
+    fun pruneMessagesToTheLatestOnly(): Set<Note> {
+        val sorted = messages.sortedWith(DefaultFeedOrder)
+        val toKeep =
+            sorted.take(100).toSet() +
+                sorted.filter { it.flowSet?.isInUse() ?: false }
+
+        val toRemove = messages.minus(toKeep)
+        messages = toKeep
+
+        changesFlow.get()?.tryEmit(ListChange.SetDeletion<Note>(toRemove))
+        return toRemove
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/marmotGroups/MarmotGroupList.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/marmotGroups/MarmotGroupList.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model.marmotGroups
+
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.utils.cache.LargeCache
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+/**
+ * Tracks all Marmot MLS group chatrooms for an account.
+ * Follows the same pattern as [com.vitorpamplona.amethyst.commons.model.privateChats.ChatroomList].
+ */
+class MarmotGroupList {
+    var rooms = LargeCache<HexKey, MarmotGroupChatroom>()
+        private set
+
+    private val _groupListChanges = MutableSharedFlow<HexKey>(0, 20, BufferOverflow.DROP_OLDEST)
+    val groupListChanges = _groupListChanges
+
+    fun getOrCreateGroup(nostrGroupId: HexKey): MarmotGroupChatroom = rooms.getOrCreate(nostrGroupId) { MarmotGroupChatroom(nostrGroupId) }
+
+    fun addMessage(
+        nostrGroupId: HexKey,
+        msg: Note,
+    ) {
+        val chatroom = getOrCreateGroup(nostrGroupId)
+        if (chatroom.addMessageSync(msg)) {
+            _groupListChanges.tryEmit(nostrGroupId)
+        }
+    }
+
+    fun removeMessage(
+        nostrGroupId: HexKey,
+        msg: Note,
+    ) {
+        val chatroom = getOrCreateGroup(nostrGroupId)
+        if (chatroom.removeMessageSync(msg)) {
+            _groupListChanges.tryEmit(nostrGroupId)
+        }
+    }
+
+    fun allGroupIds(): List<HexKey> {
+        val result = mutableListOf<HexKey>()
+        rooms.forEach { key, _ -> result.add(key) }
+        return result
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/MarmotGroupFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/MarmotGroupFeedFilter.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.feeds
+
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupList
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+
+/**
+ * Feed filter for messages within a single Marmot MLS group.
+ * Retrieves decrypted inner events from the [MarmotGroupList].
+ */
+class MarmotGroupFeedFilter(
+    val nostrGroupId: HexKey,
+    val marmotGroupList: MarmotGroupList,
+    val account: IAccount,
+) : AdditiveFeedFilter<Note>(),
+    ChangesFlowFilter<Note> {
+    fun chatroom() = marmotGroupList.getOrCreateGroup(nostrGroupId)
+
+    override fun changesFlow() = chatroom().changesFlow()
+
+    override fun feedKey(): String = nostrGroupId
+
+    override fun feed(): List<Note> =
+        chatroom()
+            .messages
+            .filter { account.isAcceptable(it) }
+            .sortedWith(DefaultFeedOrder)
+
+    override fun applyFilter(newItems: Set<Note>): Set<Note> {
+        val chatroom = chatroom()
+        return newItems.filter { it in chatroom.messages && account.isAcceptable(it) }.toSet()
+    }
+
+    override fun sort(items: Set<Note>): List<Note> = items.sortedWith(DefaultFeedOrder)
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/MarmotGroupFeedViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/MarmotGroupFeedViewModel.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.viewmodels
+
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupList
+import com.vitorpamplona.amethyst.commons.ui.feeds.MarmotGroupFeedFilter
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+
+/**
+ * ViewModel for a single Marmot group conversation feed.
+ * Exposes the decrypted inner messages for the group.
+ */
+class MarmotGroupFeedViewModel(
+    val nostrGroupId: HexKey,
+    val account: IAccount,
+    marmotGroupList: MarmotGroupList,
+    cacheProvider: ICacheProvider,
+) : ListChangeFeedViewModel(
+        MarmotGroupFeedFilter(nostrGroupId, marmotGroupList, account),
+        cacheProvider,
+    )

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/model/DesktopIAccount.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/model/DesktopIAccount.kt
@@ -118,6 +118,9 @@ class DesktopIAccount(
     override val spammersHashCodes: Set<Int> = emptySet()
 
     override val chatroomList: ChatroomList = ChatroomList(accountState.pubKeyHex)
+    override val marmotGroupList =
+        com.vitorpamplona.amethyst.commons.model.marmotGroups
+            .MarmotGroupList()
 
     override val nip47SignerState: INwcSignerState =
         object : INwcSignerState {

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/marmot/mip01Groups/MarmotGroupData.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/marmot/mip01Groups/MarmotGroupData.kt
@@ -21,7 +21,10 @@
 package com.vitorpamplona.quartz.marmot.mip01Groups
 
 import androidx.compose.runtime.Immutable
+import com.vitorpamplona.quartz.marmot.mls.codec.TlsReader
+import com.vitorpamplona.quartz.marmot.mls.tree.Extension
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.core.toHexKey
 
 /**
  * Marmot Group Data Extension (MIP-01) — extension ID 0xF2EE.
@@ -91,5 +94,86 @@ data class MarmotGroupData(
 
         /** MLS extension type identifier for marmot_group_data */
         const val EXTENSION_ID: UShort = 0xF2EEu
+        const val EXTENSION_ID_INT: Int = 0xF2EE
+
+        /**
+         * Find and decode the MarmotGroupData extension from a list of MLS extensions.
+         * Returns null if no extension with type 0xF2EE is present.
+         */
+        fun fromExtensions(extensions: List<Extension>): MarmotGroupData? {
+            val ext = extensions.find { it.extensionType == EXTENSION_ID_INT } ?: return null
+            return decodeTls(ext.extensionData)
+        }
+
+        /**
+         * Decode MarmotGroupData from TLS wire format bytes.
+         *
+         * Wire format:
+         * ```
+         * uint16 version
+         * opaque nostr_group_id[32]
+         * opaque name<0..2^16-1>
+         * opaque description<0..2^16-1>
+         * opaque admin_pubkeys<0..2^16-1>   // concatenated 32-byte keys
+         * RelayUrl relays<0..2^16-1>        // length-prefixed UTF-8 strings
+         * opaque image_hash<0..32>
+         * opaque image_key<0..32>
+         * opaque image_nonce<0..12>
+         * opaque image_upload_key<0..32>
+         * ```
+         */
+        fun decodeTls(data: ByteArray): MarmotGroupData? =
+            try {
+                val reader = TlsReader(data)
+                val version = reader.readUint16()
+
+                val nostrGroupIdBytes = reader.readBytes(32)
+                val nostrGroupId = nostrGroupIdBytes.toHexKey()
+
+                val nameBytes = reader.readOpaque2()
+                val name = nameBytes.decodeToString()
+
+                val descriptionBytes = reader.readOpaque2()
+                val description = descriptionBytes.decodeToString()
+
+                // Admin pubkeys: concatenated 32-byte keys within a length-prefixed block
+                val adminBlock = reader.readOpaque2()
+                val adminPubkeys = mutableListOf<HexKey>()
+                var i = 0
+                while (i + 32 <= adminBlock.size) {
+                    adminPubkeys.add(adminBlock.copyOfRange(i, i + 32).toHexKey())
+                    i += 32
+                }
+
+                // Relays: length-prefixed block of length-prefixed UTF-8 strings
+                val relaysBlock = reader.readOpaque2()
+                val relays = mutableListOf<String>()
+                val relayReader = TlsReader(relaysBlock)
+                while (relayReader.hasRemaining) {
+                    val relayBytes = relayReader.readOpaque2()
+                    relays.add(relayBytes.decodeToString())
+                }
+
+                // Optional fields — read if remaining
+                val imageHash = if (reader.hasRemaining) reader.readOpaque2().takeIf { it.isNotEmpty() }?.toHexKey() else null
+                val imageKey = if (reader.hasRemaining) reader.readOpaque2().takeIf { it.isNotEmpty() } else null
+                val imageNonce = if (reader.hasRemaining) reader.readOpaque2().takeIf { it.isNotEmpty() } else null
+                val imageUploadKey = if (reader.hasRemaining) reader.readOpaque2().takeIf { it.isNotEmpty() } else null
+
+                MarmotGroupData(
+                    version = version,
+                    nostrGroupId = nostrGroupId,
+                    name = name,
+                    description = description,
+                    adminPubkeys = adminPubkeys,
+                    relays = relays,
+                    imageHash = imageHash,
+                    imageKey = imageKey,
+                    imageNonce = imageNonce,
+                    imageUploadKey = imageUploadKey,
+                )
+            } catch (e: Exception) {
+                null
+            }
     }
 }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/marmot/mls/group/MlsGroup.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/marmot/mls/group/MlsGroup.kt
@@ -107,6 +107,7 @@ class MlsGroup private constructor(
     val groupId: ByteArray get() = groupContext.groupId
     val epoch: Long get() = groupContext.epoch
     val leafIndex: Int get() = myLeafIndex
+    val extensions: List<com.vitorpamplona.quartz.marmot.mls.tree.Extension> get() = groupContext.extensions
 
     // --- State Persistence ---
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive UI support for Marmot MLS (Messaging Layer Security) group messaging to Amethyst. It includes new screens for viewing and managing group chats, creating groups, adding members, and sending encrypted messages within groups.

## Key Changes

### New UI Screens
- **MarmotGroupListScreen**: Main screen displaying all Marmot groups with message previews, member counts, and group creation/management options
- **MarmotGroupChatScreen**: Individual group chat screen with message history and composer
- **MarmotGroupChatView**: Reusable chat view component for displaying group messages and composing new messages
- **CreateGroupDialog**: Dialog for creating new Marmot groups with custom names
- **AddMemberDialog**: Dialog for adding members to groups via npub or hex public key, with KeyPackage lookup

### Data Models
- **MarmotGroupChatroom**: Represents a single MLS group chat room, tracking decrypted messages, display name, and member count (follows same pattern as existing Chatroom model)
- **MarmotGroupList**: Container for managing all Marmot group chatrooms for an account
- **MarmotGroupFeedFilter**: Feed filter for retrieving and filtering messages within a specific Marmot group

### ViewModels
- **MarmotGroupFeedViewModel**: ViewModel for managing the feed state of a single Marmot group conversation
- **MarmotGroupFeedViewModel (commons)**: Base ViewModel implementation for Marmot group feeds

### Integration Points
- Added `sendMarmotGroupMessage()`, `createMarmotGroup()`, and `publishMarmotKeyPackage()` methods to AccountViewModel
- Added MarmotGroupList to IAccount interface and Account implementation
- Added navigation routes for MarmotGroupList and MarmotGroupChat
- Integrated Marmot groups into AppNavigation with proper screen routing
- Added "MLS Groups" FAB button to ChannelFabColumn for quick access
- Updated ChatroomListKnownFeedFilter to include Marmot groups in the known chatroom list
- Added message processing in DecryptAndIndexProcessor for handling decrypted Marmot group messages

## Notable Implementation Details
- Marmot groups are displayed with newest message first, sorted by creation timestamp
- Empty state messaging guides users to publish their KeyPackage before receiving invitations
- Group display names are stored locally in MutableStateFlow for reactive UI updates
- Message composer supports multi-line input with a 4-line height limit
- Member addition requires the target user to have published a KeyPackage (kind:30443)
- Groups are lazily created and cached to support both active groups and groups with pending messages

https://claude.ai/code/session_0194SxKfAU61PY92eqP4cCXM