### PR TITLE
fix: prevent share dialog from being dismissed by control auto-hide

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/controls/RenderTopButtons.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/controls/RenderTopButtons.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -128,10 +127,6 @@ fun RenderTopButtons(
         rememberSaveMediaAction { context ->
             accountViewModel.saveMediaToGallery(mediaData.videoUri, mediaData.mimeType, context)
         }
-
-    LaunchedEffect(controllerVisible.value) {
-        if (!controllerVisible.value) shareDialogVisible.value = false
-    }
 
     Row(modifier) {
         if (onZoomClick != null) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
@@ -95,7 +95,6 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import net.engawapg.lib.zoomable.rememberZoomState
 import net.engawapg.lib.zoomable.zoomable
 
@@ -143,6 +142,7 @@ private fun DialogContent(
 ) {
     val pagerState: PagerState = rememberPagerState { allImages.size }
     val controllerVisible = remember { mutableStateOf(true) }
+    val sharePopupExpanded = remember { mutableStateOf(false) }
 
     LaunchedEffect(key1 = pagerState, key2 = imageUrl) {
         launch {
@@ -151,11 +151,19 @@ private fun DialogContent(
                 pagerState.scrollToPage(page)
             }
         }
-        launch(Dispatchers.IO) {
+        launch {
             delay(2000)
-            withContext(Dispatchers.Main) {
+            if (!sharePopupExpanded.value) {
                 controllerVisible.value = false
             }
+        }
+    }
+
+    // Re-trigger auto-hide after the share dialog is dismissed
+    LaunchedEffect(sharePopupExpanded.value) {
+        if (!sharePopupExpanded.value && controllerVisible.value) {
+            delay(2000)
+            controllerVisible.value = false
         }
     }
 
@@ -164,7 +172,9 @@ private fun DialogContent(
             .fillMaxSize()
             .clickable(
                 onClick = {
-                    controllerVisible.value = !controllerVisible.value
+                    if (!sharePopupExpanded.value) {
+                        controllerVisible.value = !controllerVisible.value
+                    }
                 },
             ),
         Alignment.TopCenter,
@@ -227,10 +237,8 @@ private fun DialogContent(
 
                 allImages.getOrNull(pagerState.currentPage)?.let { myContent ->
                     if (myContent is MediaUrlImage || myContent is MediaLocalImage) {
-                        val popupExpanded = remember { mutableStateOf(false) }
-
                         OutlinedButton(
-                            onClick = { popupExpanded.value = true },
+                            onClick = { sharePopupExpanded.value = true },
                             contentPadding = PaddingValues(horizontal = Size5dp),
                             colors = ButtonDefaults.outlinedButtonColors().copy(containerColor = MaterialTheme.colorScheme.background),
                         ) {
@@ -240,7 +248,7 @@ private fun DialogContent(
                                 contentDescription = stringRes(R.string.quick_action_share),
                             )
 
-                            ShareMediaAction(accountViewModel = accountViewModel, popupExpanded = popupExpanded, myContent, onDismiss = { popupExpanded.value = false })
+                            ShareMediaAction(accountViewModel = accountViewModel, popupExpanded = sharePopupExpanded, myContent, onDismiss = { sharePopupExpanded.value = false })
                         }
 
                         if (myContent !is MediaUrlContent || !isLiveStreaming(myContent.url)) {


### PR DESCRIPTION
This has been annoying me for a long time. Trying to share media, hit share button but before I choose next option the dialogue hides. This fixes it.

## Summary
- Fixes issue where the share popup in the fullscreen media dialog was being dismissed when the controls auto-hide timer fired
- Hoists the `sharePopupExpanded` state to the `DialogContent` level so auto-hide logic can check whether the share dialog is open before hiding controls
- Re-triggers the 2-second auto-hide timer after the share dialog is dismissed
- Prevents tap-to-toggle from firing while the share popup is open
- Removes the `LaunchedEffect` in `RenderTopButtons` that was force-closing the share dialog when controls hid

## Test plan
- [x] Open a fullscreen image and tap the share button — popup should stay visible even after controls auto-hide timer
- [x] Dismiss the share popup — controls should auto-hide after 2 seconds
- [x] Tap anywhere while share popup is open — controls should not toggle
- [x] Verify normal auto-hide still works when share popup is never opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)