### PR TITLE
Add periodic ticker to re-evaluate open polls after close date

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/OpenPollsState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/OpenPollsState.kt
@@ -29,12 +29,14 @@ import com.vitorpamplona.quartz.nip88Polls.poll.PollEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlin.time.Duration.Companion.minutes
 
 @Stable
 class OpenPollsState(
@@ -47,14 +49,23 @@ class OpenPollsState(
             authors = listOf(account.pubKey),
         )
 
+    // Periodic ticker to re-evaluate polls after their close date passes
+    private val ticker =
+        flow {
+            while (true) {
+                emit(Unit)
+                delay(1.minutes)
+            }
+        }
+
     val flow: StateFlow<List<Note>> =
         combine(
             account.cache
-                .observeNotes(filter)
-                .map { notes -> filterOpenPolls(notes) },
+                .observeNotes(filter),
             account.settings.dismissedPollNoteIds,
-        ) { polls, dismissed ->
-            polls.filter { it.idHex !in dismissed }
+            ticker,
+        ) { notes, dismissed, _ ->
+            filterOpenPolls(notes).filter { it.idHex !in dismissed }
         }.flowOn(Dispatchers.IO)
             .stateIn(
                 scope,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/OpenPollsState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/OpenPollsState.kt
@@ -36,7 +36,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.stateIn
-import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.hours
 
 @Stable
 class OpenPollsState(
@@ -54,7 +54,7 @@ class OpenPollsState(
         flow {
             while (true) {
                 emit(Unit)
-                delay(1.minutes)
+                delay(1.hours)
             }
         }
 


### PR DESCRIPTION
## Summary
This change adds a periodic ticker mechanism to the OpenPollsState to ensure that polls are re-evaluated after their close dates pass, allowing the UI to reflect the correct poll status without requiring manual refresh.

## Key Changes
- Added a `ticker` flow that emits a signal every hour to trigger re-evaluation of polls
- Refactored the `combine` flow to include the ticker as a third source, ensuring the poll list is recalculated periodically
- Moved the `filterOpenPolls()` logic into the combine operation to ensure it's applied with each ticker emission
- Updated imports to include `delay` and `flow` from kotlinx.coroutines, and added `Duration.Companion.hours` for time specification

## Implementation Details
- The ticker uses an infinite loop with a 1-hour delay between emissions, providing a reasonable balance between responsiveness and resource usage
- The combine operation now takes three sources: the notes cache, dismissed poll IDs, and the ticker signal
- The filtering logic remains the same but is now executed on each ticker emission, ensuring closed polls are properly removed from the displayed list

https://claude.ai/code/session_01VY9FRuzHzwTVrePaJiHuHx