### PR TITLE
Refactor Marmot group chat UI with improved message composer

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupChatView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupChatView.kt
@@ -20,33 +20,37 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.clearText
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.Send
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.ui.components.ThinPaddingTextField
 import com.vitorpamplona.amethyst.ui.feeds.WatchLifecycleAndUpdateModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.feed.RefreshingChatroomFeedView
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.utils.ThinSendButton
+import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.DoubleVertSpacer
+import com.vitorpamplona.amethyst.ui.theme.EditFieldBorder
+import com.vitorpamplona.amethyst.ui.theme.EditFieldModifier
+import com.vitorpamplona.amethyst.ui.theme.EditFieldTrailingIconModifier
+import com.vitorpamplona.amethyst.ui.theme.placeholderText
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -107,39 +111,39 @@ fun MarmotGroupMessageComposer(
 ) {
     val scope = rememberCoroutineScope()
     val messageState = remember { TextFieldState() }
+    val canPost by remember { derivedStateOf { messageState.text.isNotBlank() } }
 
-    Row(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 8.dp, vertical = 4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
-        OutlinedTextField(
+    Column(modifier = EditFieldModifier) {
+        ThinPaddingTextField(
             state = messageState,
-            modifier = Modifier.weight(1f),
-            placeholder = { Text("Message") },
-            lineLimits =
-                androidx.compose.foundation.text.input.TextFieldLineLimits
-                    .MultiLine(maxHeightInLines = 4),
-        )
-        IconButton(
-            onClick = {
-                val text = messageState.text.toString().trim()
-                if (text.isNotEmpty()) {
-                    scope.launch(Dispatchers.IO) {
-                        accountViewModel.sendMarmotGroupMessage(nostrGroupId, text)
-                        messageState.clearText()
-                        onMessageSent()
+            modifier = Modifier.fillMaxWidth(),
+            shape = EditFieldBorder,
+            placeholder = {
+                Text(
+                    text = stringRes(R.string.reply_here),
+                    color = MaterialTheme.colorScheme.placeholderText,
+                )
+            },
+            trailingIcon = {
+                ThinSendButton(
+                    isActive = canPost,
+                    modifier = EditFieldTrailingIconModifier,
+                ) {
+                    val text = messageState.text.toString().trim()
+                    if (text.isNotEmpty()) {
+                        scope.launch(Dispatchers.IO) {
+                            accountViewModel.sendMarmotGroupMessage(nostrGroupId, text)
+                            messageState.clearText()
+                            onMessageSent()
+                        }
                     }
                 }
             },
-        ) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.Send,
-                contentDescription = "Send",
-            )
-        }
+            colors =
+                TextFieldDefaults.colors(
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent,
+                ),
+        )
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupListScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
@@ -128,7 +129,7 @@ fun MarmotGroupListScreen(
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
         floatingActionButton = {
-            FloatingActionButton(onClick = { nav.nav(Route.CreateMarmotGroup) }) {
+            FloatingActionButton(onClick = { nav.nav(Route.CreateMarmotGroup) }, shape = CircleShape) {
                 Icon(Icons.Default.Add, contentDescription = "Create Group")
             }
         },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupListScreen.kt
@@ -41,6 +41,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -72,6 +74,8 @@ fun MarmotGroupListScreen(
 ) {
     var groupList by remember { mutableStateOf(listOf<Pair<HexKey, MarmotGroupChatroom>>()) }
     val scope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
+    var isPublishing by remember { mutableStateOf(false) }
 
     // Load group list
     LaunchedEffect(Unit) {
@@ -99,9 +103,18 @@ fun MarmotGroupListScreen(
                 title = { Text("Marmot Groups") },
                 actions = {
                     IconButton(
+                        enabled = !isPublishing,
                         onClick = {
+                            isPublishing = true
                             scope.launch(Dispatchers.IO) {
-                                accountViewModel.publishMarmotKeyPackage()
+                                try {
+                                    accountViewModel.publishMarmotKeyPackage()
+                                    snackbarHostState.showSnackbar("KeyPackage published successfully")
+                                } catch (e: Exception) {
+                                    snackbarHostState.showSnackbar("Failed to publish KeyPackage: ${e.message}")
+                                } finally {
+                                    isPublishing = false
+                                }
                             }
                         },
                     ) {
@@ -113,6 +126,7 @@ fun MarmotGroupListScreen(
                 },
             )
         },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         floatingActionButton = {
             FloatingActionButton(onClick = { nav.nav(Route.CreateMarmotGroup) }) {
                 Icon(Icons.Default.Add, contentDescription = "Create Group")
@@ -130,7 +144,7 @@ fun MarmotGroupListScreen(
                         style = MaterialTheme.typography.titleMedium,
                     )
                     Text(
-                        "Publish your KeyPackage to receive invitations.",
+                        "Tap the key icon above to publish your KeyPackage and receive invitations.",
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(top = 4.dp),


### PR DESCRIPTION
## Summary
Refactored the Marmot group chat message composer and list screen to use reusable UI components and improve user experience with better feedback and state management.

## Key Changes

**MarmotGroupChatView.kt:**
- Replaced custom `Row`-based message composer with `ThinPaddingTextField` component for consistent styling
- Replaced manual `IconButton` + `Icon` send button with reusable `ThinSendButton` component
- Added `derivedStateOf` to track message composition state (`canPost`)
- Updated imports to use theme constants (`EditFieldModifier`, `EditFieldBorder`, `EditFieldTrailingIconModifier`, `placeholderText`)
- Changed placeholder text to use string resource (`R.string.reply_here`)
- Improved text field styling with transparent indicators and proper color theming

**MarmotGroupListScreen.kt:**
- Added `SnackbarHostState` and snackbar UI feedback for KeyPackage publishing operations
- Implemented loading state management with `isPublishing` flag to disable button during operation
- Added try-catch error handling with user-facing error messages via snackbar
- Updated empty state message to be more instructive ("Tap the key icon above...")
- Applied `CircleShape` to FloatingActionButton for consistent design
- Added proper state cleanup in finally block

## Notable Implementation Details
- The message composer now uses derived state to efficiently track whether the message field is non-blank, enabling/disabling the send button
- KeyPackage publishing now provides immediate user feedback through snackbar notifications for both success and error cases
- UI components are disabled during async operations to prevent duplicate submissions

https://claude.ai/code/session_013dhfy18dfuSYN8khXiLLBb