### PR TITLE
Reorganize settings: move sensitive options to "Danger Zone" section

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AllSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AllSettingsScreen.kt
@@ -140,29 +140,6 @@ fun AllSettingsScreen(
                 tint = tint,
                 onClick = { nav.nav(Route.UserSettings) },
             )
-            accountViewModel.account.settings.keyPair.privKey?.let {
-                HorizontalDivider()
-                SettingsNavigationRow(
-                    title = R.string.backup_keys,
-                    icon = Icons.Outlined.Key,
-                    tint = tint,
-                    onClick = { nav.nav(Route.AccountBackup) },
-                )
-                HorizontalDivider()
-                SettingsNavigationRow(
-                    title = R.string.request_to_vanish,
-                    icon = Icons.Outlined.DeleteForever,
-                    tint = tint,
-                    onClick = { nav.nav(Route.RequestToVanish) },
-                )
-            }
-            HorizontalDivider()
-            SettingsNavigationRow(
-                title = R.string.vanish_history,
-                icon = Icons.Outlined.History,
-                tint = tint,
-                onClick = { nav.nav(Route.VanishEvents) },
-            )
             HorizontalDivider(thickness = 4.dp)
             SettingsSectionHeader(R.string.app_settings)
             SettingsNavigationRow(
@@ -199,6 +176,30 @@ fun AllSettingsScreen(
                 icon = Icons.Outlined.ThumbUp,
                 tint = tint,
                 onClick = { nav.nav(Route.ReactionsSettings) },
+            )
+            HorizontalDivider(thickness = 4.dp)
+            SettingsSectionHeader(R.string.danger_zone)
+            accountViewModel.account.settings.keyPair.privKey?.let {
+                SettingsNavigationRow(
+                    title = R.string.backup_keys,
+                    icon = Icons.Outlined.Key,
+                    tint = tint,
+                    onClick = { nav.nav(Route.AccountBackup) },
+                )
+                HorizontalDivider()
+                SettingsNavigationRow(
+                    title = R.string.request_to_vanish,
+                    icon = Icons.Outlined.DeleteForever,
+                    tint = tint,
+                    onClick = { nav.nav(Route.RequestToVanish) },
+                )
+                HorizontalDivider()
+            }
+            SettingsNavigationRow(
+                title = R.string.vanish_history,
+                icon = Icons.Outlined.History,
+                tint = tint,
+                onClick = { nav.nav(Route.VanishEvents) },
             )
         }
     }

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -997,6 +997,7 @@
     <string name="settings">Settings</string>
     <string name="account_settings">Account Settings</string>
     <string name="app_settings">App Settings</string>
+    <string name="danger_zone">Danger Zone</string>
     <string name="connectivity_type_always">Always</string>
     <string name="connectivity_type_wifi_only">Wifi-only</string>
     <string name="connectivity_type_unmetered_wifi_only">Unmetered WiFi</string>


### PR DESCRIPTION
## Summary
Reorganized the settings screen to improve UX by grouping sensitive account operations into a dedicated "Danger Zone" section, making it clearer that these are potentially destructive actions.

## Key Changes
- Moved backup keys, request to vanish, and vanish history options from the main settings area to a new "Danger Zone" section
- Added a new "Danger Zone" section header with visual separation (4.dp divider) from app settings
- Reordered settings so that general app settings appear before sensitive operations
- Added `danger_zone` string resource for the new section header

## Implementation Details
- The sensitive options (backup keys, request to vanish, vanish history) are now grouped together under a dedicated section
- The conditional rendering for private key-dependent options (`privKey?.let`) is preserved
- Visual hierarchy is improved with section headers and dividers to clearly separate general settings from potentially destructive actions

https://claude.ai/code/session_01UMEzMjGBZkTpNVebFA6XXN