### PR TITLE
Add permission handling for accepting calls from notifications

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallActivity.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallActivity.kt
@@ -33,6 +33,7 @@ import android.os.Bundle
 import android.util.Rational
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.lifecycleScope
@@ -54,6 +55,16 @@ class CallActivity : AppCompatActivity() {
     // Tracks whether we entered PiP at least once, so we can distinguish
     // "user swiped PiP away" from "user pressed Home from full-screen call".
     private var wasInPipMode = false
+
+    // Launcher for requesting call permissions when accepting from notification
+    private val permissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { results ->
+            if (hasCallPermissions(this, isVideo = pendingAcceptIsVideo)) {
+                acceptCall()
+            }
+        }
+
+    private var pendingAcceptIsVideo = false
 
     private val pipActionReceiver =
         object : BroadcastReceiver() {
@@ -142,6 +153,21 @@ class CallActivity : AppCompatActivity() {
         com.vitorpamplona.amethyst.service.notifications.NotificationUtils
             .cancelCallNotification(this)
 
+        val callManager = ActiveCallHolder.callManager ?: return
+        val state = callManager.state.value
+        if (state !is CallState.IncomingCall) return
+
+        val isVideo = state.callType == com.vitorpamplona.quartz.nipACWebRtcCalls.tags.CallType.VIDEO
+        pendingAcceptIsVideo = isVideo
+
+        if (hasCallPermissions(this, isVideo)) {
+            acceptCall()
+        } else {
+            permissionLauncher.launch(buildCallPermissions(isVideo))
+        }
+    }
+
+    private fun acceptCall() {
         val callController = ActiveCallHolder.callController ?: return
         val callManager = ActiveCallHolder.callManager ?: return
         val state = callManager.state.value


### PR DESCRIPTION
## Summary
This change adds proper permission handling when accepting incoming calls from notifications. Previously, the app would attempt to accept calls without verifying that the necessary permissions (microphone, camera for video calls) were granted, which could cause crashes or unexpected behavior.

## Key Changes
- Added `permissionLauncher` using `ActivityResultContracts.RequestMultiplePermissions()` to handle permission requests
- Extracted call acceptance logic into a separate `acceptCall()` method to allow deferred execution after permissions are granted
- Added `pendingAcceptIsVideo` flag to track whether the pending call is a video call (needed for determining which permissions to request)
- Modified the notification-triggered acceptance flow to:
  - Check if required permissions are already granted
  - If granted, immediately accept the call
  - If not granted, request permissions via the launcher before accepting
- Added import for `ActivityResultContracts`

## Implementation Details
- The permission check uses the existing `hasCallPermissions()` utility function with the `isVideo` flag to determine if camera permission is needed
- The `buildCallPermissions()` function is used to construct the appropriate permission list based on call type
- The actual call acceptance logic remains unchanged; it's now just deferred until permissions are confirmed

https://claude.ai/code/session_0193KQShzBh4puYh74dHgSbE