### PR TITLE
Add drag-to-reorder functionality for relay lists

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/AllRelayListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/AllRelayListScreen.kt
@@ -68,6 +68,7 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayExporter
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayListCollection
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayZipExporter
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.rememberRelayDragState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.connected.ConnectedRelayListViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.connected.renderConnectedItems
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.dm.DMRelayListViewModel
@@ -201,6 +202,67 @@ fun MappedAllRelayListView(
     val indexerCounts by indexerViewModel.countResults.collectAsStateWithLifecycle()
     val searchCounts by searchViewModel.countResults.collectAsStateWithLifecycle()
 
+    val homeDragState =
+        rememberRelayDragState(
+            onMove = { from, to -> nip65ViewModel.moveHomeRelay(from, to) },
+            itemCount = { homeFeedState.size },
+        )
+    val notifDragState =
+        rememberRelayDragState(
+            onMove = { from, to -> nip65ViewModel.moveNotifRelay(from, to) },
+            itemCount = { notifFeedState.size },
+        )
+    val dmDragState =
+        rememberRelayDragState(
+            onMove = { from, to -> dmViewModel.moveRelay(from, to) },
+            itemCount = { dmFeedState.size },
+        )
+    val privateOutboxDragState =
+        rememberRelayDragState(
+            onMove = { from, to -> privateOutboxViewModel.moveRelay(from, to) },
+            itemCount = { privateOutboxFeedState.size },
+        )
+    val proxyDragState =
+        rememberRelayDragState(
+            onMove = { from, to -> proxyViewModel.moveRelay(from, to) },
+            itemCount = { proxyRelays.size },
+        )
+    val broadcastDragState =
+        rememberRelayDragState(
+            onMove = { from, to -> broadcastViewModel.moveRelay(from, to) },
+            itemCount = { broadcastRelays.size },
+        )
+    val indexerDragState =
+        rememberRelayDragState(
+            onMove = { from, to -> indexerViewModel.moveRelay(from, to) },
+            itemCount = { indexerRelays.size },
+        )
+    val searchDragState =
+        rememberRelayDragState(
+            onMove = { from, to -> searchViewModel.moveRelay(from, to) },
+            itemCount = { searchFeedState.size },
+        )
+    val localDragState =
+        rememberRelayDragState(
+            onMove = { from, to -> localViewModel.moveRelay(from, to) },
+            itemCount = { localFeedState.size },
+        )
+    val trustedDragState =
+        rememberRelayDragState(
+            onMove = { from, to -> trustedViewModel.moveRelay(from, to) },
+            itemCount = { trustedFeedState.size },
+        )
+    val feedsDragState =
+        rememberRelayDragState(
+            onMove = { from, to -> relayFeedsViewModel.moveRelay(from, to) },
+            itemCount = { relayFeedsFeedState.size },
+        )
+    val blockedDragState =
+        rememberRelayDragState(
+            onMove = { from, to -> blockedViewModel.moveRelay(from, to) },
+            itemCount = { blockedFeedState.size },
+        )
+
     Scaffold(
         topBar = {
             SavingTopBar(
@@ -274,7 +336,7 @@ fun MappedAllRelayListView(
                     SettingsCategoryFirstModifier,
                 )
             }
-            renderNip65HomeItems(homeFeedState, nip65ViewModel, accountViewModel, nav, outboxCounts)
+            renderNip65HomeItems(homeFeedState, nip65ViewModel, accountViewModel, nav, outboxCounts, homeDragState)
 
             item {
                 SettingsCategory(
@@ -283,7 +345,7 @@ fun MappedAllRelayListView(
                     SettingsCategorySpacingModifier,
                 )
             }
-            renderNip65NotifItems(notifFeedState, nip65ViewModel, accountViewModel, nav, inboxCounts)
+            renderNip65NotifItems(notifFeedState, nip65ViewModel, accountViewModel, nav, inboxCounts, notifDragState)
 
             item {
                 SettingsCategoryWithButton(
@@ -295,7 +357,7 @@ fun MappedAllRelayListView(
                     },
                 )
             }
-            renderDMItems(dmFeedState, dmViewModel, accountViewModel, nav, dmCounts)
+            renderDMItems(dmFeedState, dmViewModel, accountViewModel, nav, dmCounts, dmDragState)
 
             item {
                 SettingsCategory(
@@ -304,7 +366,7 @@ fun MappedAllRelayListView(
                     SettingsCategorySpacingModifier,
                 )
             }
-            renderPrivateOutboxItems(privateOutboxFeedState, privateOutboxViewModel, accountViewModel, nav, privateHomeCounts)
+            renderPrivateOutboxItems(privateOutboxFeedState, privateOutboxViewModel, accountViewModel, nav, privateHomeCounts, privateOutboxDragState)
 
             item {
                 SettingsCategory(
@@ -313,7 +375,7 @@ fun MappedAllRelayListView(
                     SettingsCategorySpacingModifier,
                 )
             }
-            renderProxyItems(proxyRelays, proxyViewModel, accountViewModel, nav, proxyCounts)
+            renderProxyItems(proxyRelays, proxyViewModel, accountViewModel, nav, proxyCounts, proxyDragState)
 
             item {
                 SettingsCategory(
@@ -322,7 +384,7 @@ fun MappedAllRelayListView(
                     SettingsCategorySpacingModifier,
                 )
             }
-            renderBroadcastItems(broadcastRelays, broadcastViewModel, accountViewModel, nav)
+            renderBroadcastItems(broadcastRelays, broadcastViewModel, accountViewModel, nav, broadcastDragState)
 
             item {
                 SettingsCategoryWithButton(
@@ -333,7 +395,7 @@ fun MappedAllRelayListView(
                     ResetIndexerRelays(indexerViewModel)
                 }
             }
-            renderIndexerItems(indexerRelays, indexerViewModel, accountViewModel, nav, indexerCounts)
+            renderIndexerItems(indexerRelays, indexerViewModel, accountViewModel, nav, indexerCounts, indexerDragState)
 
             item {
                 SettingsCategoryWithButton(
@@ -344,7 +406,7 @@ fun MappedAllRelayListView(
                     ResetSearchRelays(searchViewModel)
                 }
             }
-            renderSearchItems(searchFeedState, searchViewModel, accountViewModel, nav, searchCounts)
+            renderSearchItems(searchFeedState, searchViewModel, accountViewModel, nav, searchCounts, searchDragState)
 
             item {
                 SettingsCategory(
@@ -371,7 +433,7 @@ fun MappedAllRelayListView(
                     )
                 }
             }
-            renderLocalItems(localFeedState, localViewModel, accountViewModel, nav)
+            renderLocalItems(localFeedState, localViewModel, accountViewModel, nav, localDragState)
 
             item {
                 SettingsCategory(
@@ -380,7 +442,7 @@ fun MappedAllRelayListView(
                     SettingsCategorySpacingModifier,
                 )
             }
-            renderTrustedItems(trustedFeedState, trustedViewModel, accountViewModel, nav)
+            renderTrustedItems(trustedFeedState, trustedViewModel, accountViewModel, nav, trustedDragState)
 
             item {
                 SettingsCategory(
@@ -389,7 +451,7 @@ fun MappedAllRelayListView(
                     SettingsCategorySpacingModifier,
                 )
             }
-            renderRelayFeedsItems(relayFeedsFeedState, relayFeedsViewModel, accountViewModel, nav)
+            renderRelayFeedsItems(relayFeedsFeedState, relayFeedsViewModel, accountViewModel, nav, feedsDragState)
 
             item {
                 SettingsCategory(
@@ -398,7 +460,7 @@ fun MappedAllRelayListView(
                     SettingsCategorySpacingModifier,
                 )
             }
-            renderBlockedItems(blockedFeedState, blockedViewModel, accountViewModel, nav)
+            renderBlockedItems(blockedFeedState, blockedViewModel, accountViewModel, nav, blockedDragState)
 
             item {
                 SettingsCategory(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/AllRelayListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/AllRelayListScreen.kt
@@ -47,7 +47,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
@@ -331,8 +330,6 @@ fun MappedAllRelayListView(
                 Modifier
                     .fillMaxSize()
                     .padding(
-                        start = 10.dp,
-                        end = 10.dp,
                         top = pad.calculateTopPadding(),
                         bottom = pad.calculateBottomPadding(),
                     ).consumeWindowInsets(pad)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/AllRelayListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/AllRelayListScreen.kt
@@ -316,8 +316,17 @@ fun MappedAllRelayListView(
             )
         },
     ) { pad ->
+        val anyDragging =
+            homeDragState.isDragging || notifDragState.isDragging ||
+                dmDragState.isDragging || privateOutboxDragState.isDragging ||
+                proxyDragState.isDragging || broadcastDragState.isDragging ||
+                indexerDragState.isDragging || searchDragState.isDragging ||
+                localDragState.isDragging || trustedDragState.isDragging ||
+                feedsDragState.isDragging || blockedDragState.isDragging
+
         LazyColumn(
             contentPadding = FeedPadding,
+            userScrollEnabled = !anyDragging,
             modifier =
                 Modifier
                     .fillMaxSize()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/blocked/BlockedRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/blocked/BlockedRelayListView.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -34,9 +35,10 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoDialog
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.DraggableRelayList
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayDragState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayUrlEditField
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.rememberRelayDragState
 import com.vitorpamplona.amethyst.ui.theme.FeedPadding
 import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
 
@@ -48,14 +50,18 @@ fun BlockedRelayList(
     nav: INav,
 ) {
     val feedState by postViewModel.relays.collectAsStateWithLifecycle()
-
     val newNav = rememberExtendedNav(nav, onClose)
+    val dragState =
+        rememberRelayDragState(
+            onMove = { from, to -> postViewModel.moveRelay(from, to) },
+            itemCount = { feedState.size },
+        )
 
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
         ) {
-            renderBlockedItems(feedState, postViewModel, accountViewModel, newNav)
+            renderBlockedItems(feedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }
     }
 }
@@ -65,21 +71,18 @@ fun LazyListScope.renderBlockedItems(
     postViewModel: BlockedRelayListViewModel,
     accountViewModel: AccountViewModel,
     nav: INav,
+    dragState: RelayDragState? = null,
 ) {
-    item(key = "Blocked_draggable_list") {
-        DraggableRelayList(
-            items = feedState,
-            onMove = { from, to -> postViewModel.moveRelay(from, to) },
-        ) { _, item, dragModifier ->
-            BasicRelaySetupInfoDialog(
-                item,
-                onDelete = { postViewModel.deleteRelay(item) },
-                nip11CachedRetriever = Amethyst.instance.nip11Cache,
-                dragModifier = dragModifier,
-                accountViewModel = accountViewModel,
-                nav = nav,
-            )
-        }
+    itemsIndexed(feedState, key = { _, item -> "Blocked" + item.relay.url }) { index, item ->
+        BasicRelaySetupInfoDialog(
+            item,
+            onDelete = { postViewModel.deleteRelay(item) },
+            nip11CachedRetriever = Amethyst.instance.nip11Cache,
+            index = index,
+            dragState = dragState,
+            accountViewModel = accountViewModel,
+            nav = nav,
+        )
     }
 
     item {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/blocked/BlockedRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/blocked/BlockedRelayListView.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -35,6 +34,7 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoDialog
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.DraggableRelayList
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayUrlEditField
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
 import com.vitorpamplona.amethyst.ui.theme.FeedPadding
@@ -66,14 +66,20 @@ fun LazyListScope.renderBlockedItems(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    itemsIndexed(feedState, key = { _, item -> "Blocked" + item.relay.url }) { index, item ->
-        BasicRelaySetupInfoDialog(
-            item,
-            onDelete = { postViewModel.deleteRelay(item) },
-            nip11CachedRetriever = Amethyst.instance.nip11Cache,
-            accountViewModel = accountViewModel,
-            nav = nav,
-        )
+    item(key = "Blocked_draggable_list") {
+        DraggableRelayList(
+            items = feedState,
+            onMove = { from, to -> postViewModel.moveRelay(from, to) },
+        ) { _, item, dragModifier ->
+            BasicRelaySetupInfoDialog(
+                item,
+                onDelete = { postViewModel.deleteRelay(item) },
+                nip11CachedRetriever = Amethyst.instance.nip11Cache,
+                dragModifier = dragModifier,
+                accountViewModel = accountViewModel,
+                nav = nav,
+            )
+        }
     }
 
     item {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/blocked/BlockedRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/blocked/BlockedRelayListView.kt
@@ -60,6 +60,7 @@ fun BlockedRelayList(
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
+            userScrollEnabled = !dragState.isDragging,
         ) {
             renderBlockedItems(feedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/broadcast/BroadcastRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/broadcast/BroadcastRelayListView.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -34,9 +35,10 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoDialog
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.DraggableRelayList
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayDragState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayUrlEditField
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.rememberRelayDragState
 import com.vitorpamplona.amethyst.ui.theme.FeedPadding
 import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
 
@@ -48,14 +50,18 @@ fun BroadcastRelayList(
     nav: INav,
 ) {
     val feedState by postViewModel.relays.collectAsStateWithLifecycle()
-
     val newNav = rememberExtendedNav(nav, onClose)
+    val dragState =
+        rememberRelayDragState(
+            onMove = { from, to -> postViewModel.moveRelay(from, to) },
+            itemCount = { feedState.size },
+        )
 
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
         ) {
-            renderBroadcastItems(feedState, postViewModel, accountViewModel, newNav)
+            renderBroadcastItems(feedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }
     }
 }
@@ -65,21 +71,18 @@ fun LazyListScope.renderBroadcastItems(
     postViewModel: BroadcastRelayListViewModel,
     accountViewModel: AccountViewModel,
     nav: INav,
+    dragState: RelayDragState? = null,
 ) {
-    item(key = "Broadcast_draggable_list") {
-        DraggableRelayList(
-            items = feedState,
-            onMove = { from, to -> postViewModel.moveRelay(from, to) },
-        ) { _, item, dragModifier ->
-            BasicRelaySetupInfoDialog(
-                item,
-                onDelete = { postViewModel.deleteRelay(item) },
-                nip11CachedRetriever = Amethyst.instance.nip11Cache,
-                dragModifier = dragModifier,
-                accountViewModel = accountViewModel,
-                nav = nav,
-            )
-        }
+    itemsIndexed(feedState, key = { _, item -> "Broadcast" + item.relay.url }) { index, item ->
+        BasicRelaySetupInfoDialog(
+            item,
+            onDelete = { postViewModel.deleteRelay(item) },
+            nip11CachedRetriever = Amethyst.instance.nip11Cache,
+            index = index,
+            dragState = dragState,
+            accountViewModel = accountViewModel,
+            nav = nav,
+        )
     }
 
     item {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/broadcast/BroadcastRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/broadcast/BroadcastRelayListView.kt
@@ -60,6 +60,7 @@ fun BroadcastRelayList(
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
+            userScrollEnabled = !dragState.isDragging,
         ) {
             renderBroadcastItems(feedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/broadcast/BroadcastRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/broadcast/BroadcastRelayListView.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -35,6 +34,7 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoDialog
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.DraggableRelayList
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayUrlEditField
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
 import com.vitorpamplona.amethyst.ui.theme.FeedPadding
@@ -66,14 +66,20 @@ fun LazyListScope.renderBroadcastItems(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    itemsIndexed(feedState, key = { _, item -> "Broadcast" + item.relay.url }) { index, item ->
-        BasicRelaySetupInfoDialog(
-            item,
-            onDelete = { postViewModel.deleteRelay(item) },
-            accountViewModel = accountViewModel,
-            nip11CachedRetriever = Amethyst.instance.nip11Cache,
-            nav = nav,
-        )
+    item(key = "Broadcast_draggable_list") {
+        DraggableRelayList(
+            items = feedState,
+            onMove = { from, to -> postViewModel.moveRelay(from, to) },
+        ) { _, item, dragModifier ->
+            BasicRelaySetupInfoDialog(
+                item,
+                onDelete = { postViewModel.deleteRelay(item) },
+                nip11CachedRetriever = Amethyst.instance.nip11Cache,
+                dragModifier = dragModifier,
+                accountViewModel = accountViewModel,
+                nav = nav,
+            )
+        }
     }
 
     item {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoClickableRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoClickableRow.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DragIndicator
@@ -112,7 +113,7 @@ fun BasicRelaySetupInfoClickableRow(
             modifier = modifier,
         ) {
             if (dragState != null && index >= 0) {
-                val handleModifier = Modifier.size(24.dp).relayDragHandle(index, dragState)
+                val handleModifier = Modifier.height(24.dp).relayDragHandle(index, dragState)
                 Icon(
                     Icons.Default.DragIndicator,
                     contentDescription = stringRes(R.string.relay_reorder),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoClickableRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoClickableRow.kt
@@ -112,13 +112,11 @@ fun BasicRelaySetupInfoClickableRow(
             modifier = modifier,
         ) {
             if (dragState != null && index >= 0) {
+                val handleModifier = Modifier.size(24.dp).relayDragHandle(index, dragState)
                 Icon(
                     Icons.Default.DragIndicator,
                     contentDescription = stringRes(R.string.relay_reorder),
-                    modifier =
-                        Modifier
-                            .size(24.dp)
-                            .relayDragHandle(index, dragState),
+                    modifier = handleModifier,
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoClickableRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoClickableRow.kt
@@ -71,36 +71,54 @@ fun BasicRelaySetupInfoClickableRow(
     onClick: () -> Unit,
     nip11CachedRetriever: Nip11CachedRetriever,
     modifier: Modifier = Modifier,
-    dragModifier: Modifier = Modifier,
+    index: Int = -1,
+    dragState: RelayDragState? = null,
     countResult: RelayCountResult? = null,
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
     val clipboardManager = LocalClipboard.current
     val scope = rememberCoroutineScope()
-    Column(
-        Modifier
-            .fillMaxWidth()
-            .combinedClickable(
-                onClick = onClick,
-                onLongClick = {
-                    scope.launch {
-                        clipboardManager.setText(item.relay.url)
-                    }
-                },
-            ),
-    ) {
+
+    val itemModifier =
+        if (dragState != null && index >= 0) {
+            Modifier
+                .fillMaxWidth()
+                .draggableRelayItem(index, dragState)
+                .combinedClickable(
+                    onClick = onClick,
+                    onLongClick = {
+                        scope.launch {
+                            clipboardManager.setText(item.relay.url)
+                        }
+                    },
+                )
+        } else {
+            Modifier
+                .fillMaxWidth()
+                .combinedClickable(
+                    onClick = onClick,
+                    onLongClick = {
+                        scope.launch {
+                            clipboardManager.setText(item.relay.url)
+                        }
+                    },
+                )
+        }
+
+    Column(itemModifier) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = modifier,
         ) {
-            if (dragModifier != Modifier) {
+            if (dragState != null && index >= 0) {
                 Icon(
                     Icons.Default.DragIndicator,
                     contentDescription = stringRes(R.string.relay_reorder),
                     modifier =
-                        dragModifier
-                            .size(24.dp),
+                        Modifier
+                            .size(24.dp)
+                            .relayDragHandle(index, dragState),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoClickableRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoClickableRow.kt
@@ -28,7 +28,12 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DragIndicator
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -36,6 +41,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.nip11RelayInfo.Nip11CachedRetriever
 import com.vitorpamplona.amethyst.model.nip11RelayInfo.loadRelayInfo
@@ -65,6 +71,7 @@ fun BasicRelaySetupInfoClickableRow(
     onClick: () -> Unit,
     nip11CachedRetriever: Nip11CachedRetriever,
     modifier: Modifier = Modifier,
+    dragModifier: Modifier = Modifier,
     countResult: RelayCountResult? = null,
     accountViewModel: AccountViewModel,
     nav: INav,
@@ -87,6 +94,17 @@ fun BasicRelaySetupInfoClickableRow(
             verticalAlignment = Alignment.CenterVertically,
             modifier = modifier,
         ) {
+            if (dragModifier != Modifier) {
+                Icon(
+                    Icons.Default.DragIndicator,
+                    contentDescription = stringRes(R.string.relay_reorder),
+                    modifier =
+                        dragModifier
+                            .size(24.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
             val iconUrlFromRelayInfoDoc by loadRelayInfo(item.relay, nip11CachedRetriever)
 
             RenderRelayIcon(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoDialog.kt
@@ -25,7 +25,7 @@ import com.vitorpamplona.amethyst.model.nip11RelayInfo.Nip11CachedRetriever
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
-import com.vitorpamplona.amethyst.ui.theme.HalfVertPadding
+import com.vitorpamplona.amethyst.ui.theme.HorzHalfVertPadding
 
 @Composable
 fun BasicRelaySetupInfoDialog(
@@ -45,7 +45,7 @@ fun BasicRelaySetupInfoDialog(
         onDelete = onDelete,
         onClick = { nav.nav(Route.RelayInfo(item.relay.url)) },
         nip11CachedRetriever = nip11CachedRetriever,
-        modifier = HalfVertPadding,
+        modifier = HorzHalfVertPadding,
         index = index,
         dragState = dragState,
         countResult = countResult,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoDialog.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import com.vitorpamplona.amethyst.model.nip11RelayInfo.Nip11CachedRetriever
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
@@ -33,6 +34,7 @@ fun BasicRelaySetupInfoDialog(
     nip11CachedRetriever: Nip11CachedRetriever,
     onDelete: ((BasicRelaySetupInfo) -> Unit)?,
     countResult: RelayCountResult? = null,
+    dragModifier: Modifier = Modifier,
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
@@ -44,6 +46,7 @@ fun BasicRelaySetupInfoDialog(
         onClick = { nav.nav(Route.RelayInfo(item.relay.url)) },
         nip11CachedRetriever = nip11CachedRetriever,
         modifier = HalfVertPadding,
+        dragModifier = dragModifier,
         countResult = countResult,
         accountViewModel = accountViewModel,
         nav = nav,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoDialog.kt
@@ -21,7 +21,6 @@
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import com.vitorpamplona.amethyst.model.nip11RelayInfo.Nip11CachedRetriever
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
@@ -34,7 +33,8 @@ fun BasicRelaySetupInfoDialog(
     nip11CachedRetriever: Nip11CachedRetriever,
     onDelete: ((BasicRelaySetupInfo) -> Unit)?,
     countResult: RelayCountResult? = null,
-    dragModifier: Modifier = Modifier,
+    index: Int = -1,
+    dragState: RelayDragState? = null,
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
@@ -46,7 +46,8 @@ fun BasicRelaySetupInfoDialog(
         onClick = { nav.nav(Route.RelayInfo(item.relay.url)) },
         nip11CachedRetriever = nip11CachedRetriever,
         modifier = HalfVertPadding,
-        dragModifier = dragModifier,
+        index = index,
+        dragState = dragState,
         countResult = countResult,
         accountViewModel = accountViewModel,
         nav = nav,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoModel.kt
@@ -152,6 +152,18 @@ abstract class BasicRelaySetupInfoModel : ViewModel() {
         hasModified = true
     }
 
+    fun moveRelay(
+        from: Int,
+        to: Int,
+    ) {
+        _relays.update { list ->
+            list.toMutableList().apply {
+                add(to, removeAt(from))
+            }
+        }
+        hasModified = true
+    }
+
     fun deleteAll() {
         _relays.update { relays -> emptyList() }
         hasModified = true

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoModel.kt
@@ -132,8 +132,6 @@ abstract class BasicRelaySetupInfoModel : ViewModel() {
                             .useTor(it),
                 )
             }.distinctBy { it.relay }
-            .sortedBy { it.relayStat.receivedBytes }
-            .reversed()
     }
 
     fun clear() {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/DraggableRelayList.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/DraggableRelayList.kt
@@ -22,10 +22,8 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
@@ -38,106 +36,112 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.zIndex
 
-@Composable
-fun DraggableRelayList(
-    items: List<BasicRelaySetupInfo>,
-    onMove: (from: Int, to: Int) -> Unit,
-    modifier: Modifier = Modifier,
-    content: @Composable (
-        index: Int,
-        item: BasicRelaySetupInfo,
-        dragModifier: Modifier,
-    ) -> Unit,
+@Stable
+class RelayDragState(
+    val onMove: (from: Int, to: Int) -> Unit,
+    val itemCount: () -> Int,
 ) {
-    var draggedItemIndex by remember { mutableIntStateOf(-1) }
-    var dragOffset by remember { mutableFloatStateOf(0f) }
-    val itemHeights = remember { mutableStateMapOf<Int, Float>() }
+    var draggedItemIndex by mutableIntStateOf(-1)
+    var dragOffset by mutableFloatStateOf(0f)
+    val itemHeights = mutableStateMapOf<Int, Float>()
 
-    Column(modifier = modifier.fillMaxWidth()) {
-        items.forEachIndexed { index, item ->
-            val isDragging = draggedItemIndex == index
-            val targetElevation = if (isDragging) 8f else 0f
-            val animatedElevation by animateFloatAsState(
-                targetValue = targetElevation,
-                label = "dragElevation",
-            )
+    fun onDragStart(index: Int) {
+        draggedItemIndex = index
+        dragOffset = 0f
+    }
 
-            Box(
-                modifier =
-                    Modifier
-                        .zIndex(if (isDragging) 1f else 0f)
-                        .onGloballyPositioned { coordinates ->
-                            itemHeights[index] = coordinates.size.height.toFloat()
-                        }.graphicsLayer {
-                            translationY = if (isDragging) dragOffset else 0f
-                            shadowElevation = animatedElevation
-                            if (isDragging) {
-                                scaleX = 1.02f
-                                scaleY = 1.02f
-                            }
-                        },
-            ) {
-                val dragModifier =
-                    Modifier.pointerInput(Unit) {
-                        detectDragGestures(
-                            onDragStart = {
-                                draggedItemIndex = index
-                                dragOffset = 0f
-                            },
-                            onDrag = { change, dragAmount ->
-                                change.consume()
-                                dragOffset += dragAmount.y
+    fun onDrag(dragAmount: Float) {
+        dragOffset += dragAmount
 
-                                val currentIndex = draggedItemIndex
-                                if (currentIndex < 0) return@detectDragGestures
+        val currentIndex = draggedItemIndex
+        if (currentIndex < 0) return
 
-                                // Check if we should swap with the item above
-                                if (dragOffset < 0 && currentIndex > 0) {
-                                    val aboveHeight = itemHeights[currentIndex - 1] ?: 0f
-                                    if (-dragOffset > aboveHeight / 2f) {
-                                        onMove(currentIndex, currentIndex - 1)
+        // Check if we should swap with the item above
+        if (dragOffset < 0 && currentIndex > 0) {
+            val aboveHeight = itemHeights[currentIndex - 1] ?: 0f
+            if (-dragOffset > aboveHeight / 2f) {
+                onMove(currentIndex, currentIndex - 1)
 
-                                        // Transfer heights
-                                        val h1 = itemHeights[currentIndex]
-                                        val h2 = itemHeights[currentIndex - 1]
-                                        if (h1 != null) itemHeights[currentIndex - 1] = h1
-                                        if (h2 != null) itemHeights[currentIndex] = h2
+                val h1 = itemHeights[currentIndex]
+                val h2 = itemHeights[currentIndex - 1]
+                if (h1 != null) itemHeights[currentIndex - 1] = h1
+                if (h2 != null) itemHeights[currentIndex] = h2
 
-                                        dragOffset += aboveHeight
-                                        draggedItemIndex = currentIndex - 1
-                                    }
-                                }
+                dragOffset += aboveHeight
+                draggedItemIndex = currentIndex - 1
+            }
+        }
 
-                                // Check if we should swap with the item below
-                                if (dragOffset > 0 && currentIndex < items.lastIndex) {
-                                    val belowHeight = itemHeights[currentIndex + 1] ?: 0f
-                                    if (dragOffset > belowHeight / 2f) {
-                                        onMove(currentIndex, currentIndex + 1)
+        // Check if we should swap with the item below
+        if (dragOffset > 0 && currentIndex < itemCount() - 1) {
+            val belowHeight = itemHeights[currentIndex + 1] ?: 0f
+            if (dragOffset > belowHeight / 2f) {
+                onMove(currentIndex, currentIndex + 1)
 
-                                        // Transfer heights
-                                        val h1 = itemHeights[currentIndex]
-                                        val h2 = itemHeights[currentIndex + 1]
-                                        if (h1 != null) itemHeights[currentIndex + 1] = h1
-                                        if (h2 != null) itemHeights[currentIndex] = h2
+                val h1 = itemHeights[currentIndex]
+                val h2 = itemHeights[currentIndex + 1]
+                if (h1 != null) itemHeights[currentIndex + 1] = h1
+                if (h2 != null) itemHeights[currentIndex] = h2
 
-                                        dragOffset -= belowHeight
-                                        draggedItemIndex = currentIndex + 1
-                                    }
-                                }
-                            },
-                            onDragEnd = {
-                                draggedItemIndex = -1
-                                dragOffset = 0f
-                            },
-                            onDragCancel = {
-                                draggedItemIndex = -1
-                                dragOffset = 0f
-                            },
-                        )
-                    }
-
-                content(index, item, dragModifier)
+                dragOffset -= belowHeight
+                draggedItemIndex = currentIndex + 1
             }
         }
     }
+
+    fun onDragEnd() {
+        draggedItemIndex = -1
+        dragOffset = 0f
+    }
 }
+
+@Composable
+fun rememberRelayDragState(
+    onMove: (from: Int, to: Int) -> Unit,
+    itemCount: () -> Int,
+): RelayDragState =
+    remember(onMove, itemCount) {
+        RelayDragState(onMove, itemCount)
+    }
+
+@Composable
+fun Modifier.draggableRelayItem(
+    index: Int,
+    dragState: RelayDragState,
+): Modifier {
+    val isDragging = dragState.draggedItemIndex == index
+    val targetElevation = if (isDragging) 8f else 0f
+    val animatedElevation by animateFloatAsState(
+        targetValue = targetElevation,
+        label = "dragElevation",
+    )
+
+    return this
+        .zIndex(if (isDragging) 1f else 0f)
+        .onGloballyPositioned { coordinates ->
+            dragState.itemHeights[index] = coordinates.size.height.toFloat()
+        }.graphicsLayer {
+            translationY = if (isDragging) dragState.dragOffset else 0f
+            shadowElevation = animatedElevation
+            if (isDragging) {
+                scaleX = 1.02f
+                scaleY = 1.02f
+            }
+        }
+}
+
+fun Modifier.relayDragHandle(
+    index: Int,
+    dragState: RelayDragState,
+): Modifier =
+    this.pointerInput(index) {
+        detectDragGestures(
+            onDragStart = { dragState.onDragStart(index) },
+            onDrag = { change, dragAmount ->
+                change.consume()
+                dragState.onDrag(dragAmount.y)
+            },
+            onDragEnd = { dragState.onDragEnd() },
+            onDragCancel = { dragState.onDragEnd() },
+        )
+    }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/DraggableRelayList.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/DraggableRelayList.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
@@ -131,13 +132,17 @@ fun Modifier.draggableRelayItem(
         }
 }
 
+@Composable
 fun Modifier.relayDragHandle(
     index: Int,
     dragState: RelayDragState,
-): Modifier =
-    this.pointerInput(index) {
+): Modifier {
+    // rememberUpdatedState keeps the index current without restarting
+    // the pointerInput scope (which would cancel the in-progress gesture)
+    val currentIndex by rememberUpdatedState(index)
+    return this.pointerInput(dragState) {
         detectDragGestures(
-            onDragStart = { dragState.onDragStart(index) },
+            onDragStart = { dragState.onDragStart(currentIndex) },
             onDrag = { change, dragAmount ->
                 change.consume()
                 dragState.onDrag(dragAmount.y)
@@ -146,3 +151,4 @@ fun Modifier.relayDragHandle(
             onDragCancel = { dragState.onDragEnd() },
         )
     }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/DraggableRelayList.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/DraggableRelayList.kt
@@ -44,6 +44,7 @@ class RelayDragState(
     var draggedItemIndex by mutableIntStateOf(-1)
     var dragOffset by mutableFloatStateOf(0f)
     val itemHeights = mutableStateMapOf<Int, Float>()
+    val isDragging: Boolean get() = draggedItemIndex >= 0
 
     fun onDragStart(index: Int) {
         draggedItemIndex = index

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/DraggableRelayList.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/DraggableRelayList.kt
@@ -71,6 +71,7 @@ class RelayDragState(
 
                 dragOffset += aboveHeight
                 draggedItemIndex = currentIndex - 1
+                return
             }
         }
 
@@ -87,6 +88,7 @@ class RelayDragState(
 
                 dragOffset -= belowHeight
                 draggedItemIndex = currentIndex + 1
+                return
             }
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/DraggableRelayList.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/DraggableRelayList.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.zIndex
+
+@Composable
+fun DraggableRelayList(
+    items: List<BasicRelaySetupInfo>,
+    onMove: (from: Int, to: Int) -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable (
+        index: Int,
+        item: BasicRelaySetupInfo,
+        dragModifier: Modifier,
+    ) -> Unit,
+) {
+    var draggedItemIndex by remember { mutableIntStateOf(-1) }
+    var dragOffset by remember { mutableFloatStateOf(0f) }
+    val itemHeights = remember { mutableStateMapOf<Int, Float>() }
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        items.forEachIndexed { index, item ->
+            val isDragging = draggedItemIndex == index
+            val targetElevation = if (isDragging) 8f else 0f
+            val animatedElevation by animateFloatAsState(
+                targetValue = targetElevation,
+                label = "dragElevation",
+            )
+
+            Box(
+                modifier =
+                    Modifier
+                        .zIndex(if (isDragging) 1f else 0f)
+                        .onGloballyPositioned { coordinates ->
+                            itemHeights[index] = coordinates.size.height.toFloat()
+                        }.graphicsLayer {
+                            translationY = if (isDragging) dragOffset else 0f
+                            shadowElevation = animatedElevation
+                            if (isDragging) {
+                                scaleX = 1.02f
+                                scaleY = 1.02f
+                            }
+                        },
+            ) {
+                val dragModifier =
+                    Modifier.pointerInput(Unit) {
+                        detectDragGestures(
+                            onDragStart = {
+                                draggedItemIndex = index
+                                dragOffset = 0f
+                            },
+                            onDrag = { change, dragAmount ->
+                                change.consume()
+                                dragOffset += dragAmount.y
+
+                                val currentIndex = draggedItemIndex
+                                if (currentIndex < 0) return@detectDragGestures
+
+                                // Check if we should swap with the item above
+                                if (dragOffset < 0 && currentIndex > 0) {
+                                    val aboveHeight = itemHeights[currentIndex - 1] ?: 0f
+                                    if (-dragOffset > aboveHeight / 2f) {
+                                        onMove(currentIndex, currentIndex - 1)
+
+                                        // Transfer heights
+                                        val h1 = itemHeights[currentIndex]
+                                        val h2 = itemHeights[currentIndex - 1]
+                                        if (h1 != null) itemHeights[currentIndex - 1] = h1
+                                        if (h2 != null) itemHeights[currentIndex] = h2
+
+                                        dragOffset += aboveHeight
+                                        draggedItemIndex = currentIndex - 1
+                                    }
+                                }
+
+                                // Check if we should swap with the item below
+                                if (dragOffset > 0 && currentIndex < items.lastIndex) {
+                                    val belowHeight = itemHeights[currentIndex + 1] ?: 0f
+                                    if (dragOffset > belowHeight / 2f) {
+                                        onMove(currentIndex, currentIndex + 1)
+
+                                        // Transfer heights
+                                        val h1 = itemHeights[currentIndex]
+                                        val h2 = itemHeights[currentIndex + 1]
+                                        if (h1 != null) itemHeights[currentIndex + 1] = h1
+                                        if (h2 != null) itemHeights[currentIndex] = h2
+
+                                        dragOffset -= belowHeight
+                                        draggedItemIndex = currentIndex + 1
+                                    }
+                                }
+                            },
+                            onDragEnd = {
+                                draggedItemIndex = -1
+                                dragOffset = 0f
+                            },
+                            onDragCancel = {
+                                draggedItemIndex = -1
+                                dragOffset = 0f
+                            },
+                        )
+                    }
+
+                content(index, item, dragModifier)
+            }
+        }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/dm/DMRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/dm/DMRelayListView.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -35,6 +34,7 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoDialog
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.DraggableRelayList
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayCountResult
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayUrlEditField
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
@@ -68,15 +68,21 @@ fun LazyListScope.renderDMItems(
     nav: INav,
     countResults: Map<NormalizedRelayUrl, RelayCountResult> = emptyMap(),
 ) {
-    itemsIndexed(feedState, key = { _, item -> "DM" + item.relay.url }) { index, item ->
-        BasicRelaySetupInfoDialog(
-            item,
-            onDelete = { postViewModel.deleteRelay(item) },
-            nip11CachedRetriever = Amethyst.instance.nip11Cache,
-            countResult = countResults[item.relay],
-            accountViewModel = accountViewModel,
-            nav = nav,
-        )
+    item(key = "DM_draggable_list") {
+        DraggableRelayList(
+            items = feedState,
+            onMove = { from, to -> postViewModel.moveRelay(from, to) },
+        ) { _, item, dragModifier ->
+            BasicRelaySetupInfoDialog(
+                item,
+                onDelete = { postViewModel.deleteRelay(item) },
+                nip11CachedRetriever = Amethyst.instance.nip11Cache,
+                countResult = countResults[item.relay],
+                dragModifier = dragModifier,
+                accountViewModel = accountViewModel,
+                nav = nav,
+            )
+        }
     }
 
     item {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/dm/DMRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/dm/DMRelayListView.kt
@@ -62,6 +62,7 @@ fun DMRelayList(
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
+            userScrollEnabled = !dragState.isDragging,
         ) {
             renderDMItems(feedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/dm/DMRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/dm/DMRelayListView.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -34,10 +35,11 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoDialog
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.DraggableRelayList
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayCountResult
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayDragState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayUrlEditField
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.rememberRelayDragState
 import com.vitorpamplona.amethyst.ui.theme.FeedPadding
 import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
@@ -51,12 +53,17 @@ fun DMRelayList(
 ) {
     val newNav = rememberExtendedNav(nav, onClose)
     val feedState by postViewModel.relays.collectAsStateWithLifecycle()
+    val dragState =
+        rememberRelayDragState(
+            onMove = { from, to -> postViewModel.moveRelay(from, to) },
+            itemCount = { feedState.size },
+        )
 
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
         ) {
-            renderDMItems(feedState, postViewModel, accountViewModel, newNav)
+            renderDMItems(feedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }
     }
 }
@@ -67,22 +74,19 @@ fun LazyListScope.renderDMItems(
     accountViewModel: AccountViewModel,
     nav: INav,
     countResults: Map<NormalizedRelayUrl, RelayCountResult> = emptyMap(),
+    dragState: RelayDragState? = null,
 ) {
-    item(key = "DM_draggable_list") {
-        DraggableRelayList(
-            items = feedState,
-            onMove = { from, to -> postViewModel.moveRelay(from, to) },
-        ) { _, item, dragModifier ->
-            BasicRelaySetupInfoDialog(
-                item,
-                onDelete = { postViewModel.deleteRelay(item) },
-                nip11CachedRetriever = Amethyst.instance.nip11Cache,
-                countResult = countResults[item.relay],
-                dragModifier = dragModifier,
-                accountViewModel = accountViewModel,
-                nav = nav,
-            )
-        }
+    itemsIndexed(feedState, key = { _, item -> "DM" + item.relay.url }) { index, item ->
+        BasicRelaySetupInfoDialog(
+            item,
+            onDelete = { postViewModel.deleteRelay(item) },
+            nip11CachedRetriever = Amethyst.instance.nip11Cache,
+            countResult = countResults[item.relay],
+            index = index,
+            dragState = dragState,
+            accountViewModel = accountViewModel,
+            nav = nav,
+        )
     }
 
     item {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/feeds/RelayFeedsListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/feeds/RelayFeedsListView.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -35,6 +34,7 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoDialog
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.DraggableRelayList
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayUrlEditField
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
 import com.vitorpamplona.amethyst.ui.theme.FeedPadding
@@ -66,14 +66,20 @@ fun LazyListScope.renderRelayFeedsItems(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    itemsIndexed(feedState, key = { _, item -> "RelayFeeds" + item.relay.url }) { index, item ->
-        BasicRelaySetupInfoDialog(
-            item,
-            onDelete = { postViewModel.deleteRelay(item) },
-            nip11CachedRetriever = Amethyst.instance.nip11Cache,
-            accountViewModel = accountViewModel,
-            nav = nav,
-        )
+    item(key = "RelayFeeds_draggable_list") {
+        DraggableRelayList(
+            items = feedState,
+            onMove = { from, to -> postViewModel.moveRelay(from, to) },
+        ) { _, item, dragModifier ->
+            BasicRelaySetupInfoDialog(
+                item,
+                onDelete = { postViewModel.deleteRelay(item) },
+                nip11CachedRetriever = Amethyst.instance.nip11Cache,
+                dragModifier = dragModifier,
+                accountViewModel = accountViewModel,
+                nav = nav,
+            )
+        }
     }
 
     item {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/feeds/RelayFeedsListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/feeds/RelayFeedsListView.kt
@@ -60,6 +60,7 @@ fun RelayFeedsList(
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
+            userScrollEnabled = !dragState.isDragging,
         ) {
             renderRelayFeedsItems(feedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/feeds/RelayFeedsListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/feeds/RelayFeedsListView.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -34,9 +35,10 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoDialog
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.DraggableRelayList
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayDragState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayUrlEditField
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.rememberRelayDragState
 import com.vitorpamplona.amethyst.ui.theme.FeedPadding
 import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
 
@@ -48,14 +50,18 @@ fun RelayFeedsList(
     nav: INav,
 ) {
     val feedState by postViewModel.relays.collectAsStateWithLifecycle()
-
     val newNav = rememberExtendedNav(nav, onClose)
+    val dragState =
+        rememberRelayDragState(
+            onMove = { from, to -> postViewModel.moveRelay(from, to) },
+            itemCount = { feedState.size },
+        )
 
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
         ) {
-            renderRelayFeedsItems(feedState, postViewModel, accountViewModel, newNav)
+            renderRelayFeedsItems(feedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }
     }
 }
@@ -65,21 +71,18 @@ fun LazyListScope.renderRelayFeedsItems(
     postViewModel: RelayFeedsListViewModel,
     accountViewModel: AccountViewModel,
     nav: INav,
+    dragState: RelayDragState? = null,
 ) {
-    item(key = "RelayFeeds_draggable_list") {
-        DraggableRelayList(
-            items = feedState,
-            onMove = { from, to -> postViewModel.moveRelay(from, to) },
-        ) { _, item, dragModifier ->
-            BasicRelaySetupInfoDialog(
-                item,
-                onDelete = { postViewModel.deleteRelay(item) },
-                nip11CachedRetriever = Amethyst.instance.nip11Cache,
-                dragModifier = dragModifier,
-                accountViewModel = accountViewModel,
-                nav = nav,
-            )
-        }
+    itemsIndexed(feedState, key = { _, item -> "RelayFeeds" + item.relay.url }) { index, item ->
+        BasicRelaySetupInfoDialog(
+            item,
+            onDelete = { postViewModel.deleteRelay(item) },
+            nip11CachedRetriever = Amethyst.instance.nip11Cache,
+            index = index,
+            dragState = dragState,
+            accountViewModel = accountViewModel,
+            nav = nav,
+        )
     }
 
     item {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/indexer/IndexerRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/indexer/IndexerRelayListView.kt
@@ -62,6 +62,7 @@ fun IndexerRelayList(
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
+            userScrollEnabled = !dragState.isDragging,
         ) {
             renderIndexerItems(feedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/indexer/IndexerRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/indexer/IndexerRelayListView.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -35,6 +34,7 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoDialog
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.DraggableRelayList
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayCountResult
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayUrlEditField
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
@@ -69,15 +69,21 @@ fun LazyListScope.renderIndexerItems(
     nav: INav,
     countResults: Map<NormalizedRelayUrl, RelayCountResult> = emptyMap(),
 ) {
-    itemsIndexed(feedState, key = { _, item -> "Indexer" + item.relay.url }) { index, item ->
-        BasicRelaySetupInfoDialog(
-            item,
-            onDelete = { postViewModel.deleteRelay(item) },
-            nip11CachedRetriever = Amethyst.instance.nip11Cache,
-            countResult = countResults[item.relay],
-            accountViewModel = accountViewModel,
-            nav = nav,
-        )
+    item(key = "Indexer_draggable_list") {
+        DraggableRelayList(
+            items = feedState,
+            onMove = { from, to -> postViewModel.moveRelay(from, to) },
+        ) { _, item, dragModifier ->
+            BasicRelaySetupInfoDialog(
+                item,
+                onDelete = { postViewModel.deleteRelay(item) },
+                nip11CachedRetriever = Amethyst.instance.nip11Cache,
+                countResult = countResults[item.relay],
+                dragModifier = dragModifier,
+                accountViewModel = accountViewModel,
+                nav = nav,
+            )
+        }
     }
 
     item {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/indexer/IndexerRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/indexer/IndexerRelayListView.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -34,10 +35,11 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoDialog
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.DraggableRelayList
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayCountResult
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayDragState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayUrlEditField
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.rememberRelayDragState
 import com.vitorpamplona.amethyst.ui.theme.FeedPadding
 import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
@@ -50,14 +52,18 @@ fun IndexerRelayList(
     nav: INav,
 ) {
     val feedState by postViewModel.relays.collectAsStateWithLifecycle()
-
     val newNav = rememberExtendedNav(nav, onClose)
+    val dragState =
+        rememberRelayDragState(
+            onMove = { from, to -> postViewModel.moveRelay(from, to) },
+            itemCount = { feedState.size },
+        )
 
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
         ) {
-            renderIndexerItems(feedState, postViewModel, accountViewModel, newNav)
+            renderIndexerItems(feedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }
     }
 }
@@ -68,22 +74,19 @@ fun LazyListScope.renderIndexerItems(
     accountViewModel: AccountViewModel,
     nav: INav,
     countResults: Map<NormalizedRelayUrl, RelayCountResult> = emptyMap(),
+    dragState: RelayDragState? = null,
 ) {
-    item(key = "Indexer_draggable_list") {
-        DraggableRelayList(
-            items = feedState,
-            onMove = { from, to -> postViewModel.moveRelay(from, to) },
-        ) { _, item, dragModifier ->
-            BasicRelaySetupInfoDialog(
-                item,
-                onDelete = { postViewModel.deleteRelay(item) },
-                nip11CachedRetriever = Amethyst.instance.nip11Cache,
-                countResult = countResults[item.relay],
-                dragModifier = dragModifier,
-                accountViewModel = accountViewModel,
-                nav = nav,
-            )
-        }
+    itemsIndexed(feedState, key = { _, item -> "Indexer" + item.relay.url }) { index, item ->
+        BasicRelaySetupInfoDialog(
+            item,
+            onDelete = { postViewModel.deleteRelay(item) },
+            nip11CachedRetriever = Amethyst.instance.nip11Cache,
+            countResult = countResults[item.relay],
+            index = index,
+            dragState = dragState,
+            accountViewModel = accountViewModel,
+            nav = nav,
+        )
     }
 
     item {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/local/LocalRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/local/LocalRelayListView.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -34,9 +35,10 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoDialog
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.DraggableRelayList
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayDragState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayUrlEditField
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.rememberRelayDragState
 import com.vitorpamplona.amethyst.ui.theme.FeedPadding
 import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
 
@@ -49,12 +51,17 @@ fun LocalRelayList(
 ) {
     val newNav = rememberExtendedNav(nav, onClose)
     val feedState by postViewModel.relays.collectAsStateWithLifecycle()
+    val dragState =
+        rememberRelayDragState(
+            onMove = { from, to -> postViewModel.moveRelay(from, to) },
+            itemCount = { feedState.size },
+        )
 
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
         ) {
-            renderLocalItems(feedState, postViewModel, accountViewModel, newNav)
+            renderLocalItems(feedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }
     }
 }
@@ -64,21 +71,18 @@ fun LazyListScope.renderLocalItems(
     postViewModel: LocalRelayListViewModel,
     accountViewModel: AccountViewModel,
     nav: INav,
+    dragState: RelayDragState? = null,
 ) {
-    item(key = "Local_draggable_list") {
-        DraggableRelayList(
-            items = feedState,
-            onMove = { from, to -> postViewModel.moveRelay(from, to) },
-        ) { _, item, dragModifier ->
-            BasicRelaySetupInfoDialog(
-                item,
-                onDelete = { postViewModel.deleteRelay(item) },
-                nip11CachedRetriever = Amethyst.instance.nip11Cache,
-                dragModifier = dragModifier,
-                accountViewModel = accountViewModel,
-                nav = nav,
-            )
-        }
+    itemsIndexed(feedState, key = { _, item -> "Local" + item.relay.url }) { index, item ->
+        BasicRelaySetupInfoDialog(
+            item,
+            onDelete = { postViewModel.deleteRelay(item) },
+            nip11CachedRetriever = Amethyst.instance.nip11Cache,
+            index = index,
+            dragState = dragState,
+            accountViewModel = accountViewModel,
+            nav = nav,
+        )
     }
 
     item {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/local/LocalRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/local/LocalRelayListView.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -35,6 +34,7 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoDialog
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.DraggableRelayList
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayUrlEditField
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
 import com.vitorpamplona.amethyst.ui.theme.FeedPadding
@@ -65,14 +65,20 @@ fun LazyListScope.renderLocalItems(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    itemsIndexed(feedState, key = { _, item -> "Local" + item.relay.url }) { index, item ->
-        BasicRelaySetupInfoDialog(
-            item,
-            onDelete = { postViewModel.deleteRelay(item) },
-            nip11CachedRetriever = Amethyst.instance.nip11Cache,
-            accountViewModel = accountViewModel,
-            nav = nav,
-        )
+    item(key = "Local_draggable_list") {
+        DraggableRelayList(
+            items = feedState,
+            onMove = { from, to -> postViewModel.moveRelay(from, to) },
+        ) { _, item, dragModifier ->
+            BasicRelaySetupInfoDialog(
+                item,
+                onDelete = { postViewModel.deleteRelay(item) },
+                nip11CachedRetriever = Amethyst.instance.nip11Cache,
+                dragModifier = dragModifier,
+                accountViewModel = accountViewModel,
+                nav = nav,
+            )
+        }
     }
 
     item {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/local/LocalRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/local/LocalRelayListView.kt
@@ -60,6 +60,7 @@ fun LocalRelayList(
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
+            userScrollEnabled = !dragState.isDragging,
         ) {
             renderLocalItems(feedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip37/PrivateOutboxRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip37/PrivateOutboxRelayListView.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -35,6 +34,7 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoDialog
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.DraggableRelayList
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayCountResult
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayUrlEditField
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
@@ -68,15 +68,21 @@ fun LazyListScope.renderPrivateOutboxItems(
     nav: INav,
     countResults: Map<NormalizedRelayUrl, RelayCountResult> = emptyMap(),
 ) {
-    itemsIndexed(feedState, key = { _, item -> "Outbox" + item.relay.url }) { index, item ->
-        BasicRelaySetupInfoDialog(
-            item,
-            onDelete = { postViewModel.deleteRelay(item) },
-            nip11CachedRetriever = Amethyst.instance.nip11Cache,
-            countResult = countResults[item.relay],
-            accountViewModel = accountViewModel,
-            nav = nav,
-        )
+    item(key = "Outbox_draggable_list") {
+        DraggableRelayList(
+            items = feedState,
+            onMove = { from, to -> postViewModel.moveRelay(from, to) },
+        ) { _, item, dragModifier ->
+            BasicRelaySetupInfoDialog(
+                item,
+                onDelete = { postViewModel.deleteRelay(item) },
+                nip11CachedRetriever = Amethyst.instance.nip11Cache,
+                countResult = countResults[item.relay],
+                dragModifier = dragModifier,
+                accountViewModel = accountViewModel,
+                nav = nav,
+            )
+        }
     }
 
     item {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip37/PrivateOutboxRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip37/PrivateOutboxRelayListView.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -34,10 +35,11 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoDialog
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.DraggableRelayList
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayCountResult
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayDragState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayUrlEditField
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.rememberRelayDragState
 import com.vitorpamplona.amethyst.ui.theme.FeedPadding
 import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
@@ -51,12 +53,17 @@ fun PrivateOutboxRelayList(
 ) {
     val newNav = rememberExtendedNav(nav, onClose)
     val feedState by postViewModel.relays.collectAsStateWithLifecycle()
+    val dragState =
+        rememberRelayDragState(
+            onMove = { from, to -> postViewModel.moveRelay(from, to) },
+            itemCount = { feedState.size },
+        )
 
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
         ) {
-            renderPrivateOutboxItems(feedState, postViewModel, accountViewModel, newNav)
+            renderPrivateOutboxItems(feedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }
     }
 }
@@ -67,22 +74,19 @@ fun LazyListScope.renderPrivateOutboxItems(
     accountViewModel: AccountViewModel,
     nav: INav,
     countResults: Map<NormalizedRelayUrl, RelayCountResult> = emptyMap(),
+    dragState: RelayDragState? = null,
 ) {
-    item(key = "Outbox_draggable_list") {
-        DraggableRelayList(
-            items = feedState,
-            onMove = { from, to -> postViewModel.moveRelay(from, to) },
-        ) { _, item, dragModifier ->
-            BasicRelaySetupInfoDialog(
-                item,
-                onDelete = { postViewModel.deleteRelay(item) },
-                nip11CachedRetriever = Amethyst.instance.nip11Cache,
-                countResult = countResults[item.relay],
-                dragModifier = dragModifier,
-                accountViewModel = accountViewModel,
-                nav = nav,
-            )
-        }
+    itemsIndexed(feedState, key = { _, item -> "Outbox" + item.relay.url }) { index, item ->
+        BasicRelaySetupInfoDialog(
+            item,
+            onDelete = { postViewModel.deleteRelay(item) },
+            nip11CachedRetriever = Amethyst.instance.nip11Cache,
+            countResult = countResults[item.relay],
+            index = index,
+            dragState = dragState,
+            accountViewModel = accountViewModel,
+            nav = nav,
+        )
     }
 
     item {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip37/PrivateOutboxRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip37/PrivateOutboxRelayListView.kt
@@ -62,6 +62,7 @@ fun PrivateOutboxRelayList(
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
+            userScrollEnabled = !dragState.isDragging,
         ) {
             renderPrivateOutboxItems(feedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip65/Nip65RelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip65/Nip65RelayListView.kt
@@ -70,6 +70,7 @@ fun Nip65RelayList(
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
+            userScrollEnabled = !homeDragState.isDragging && !notifDragState.isDragging,
         ) {
             renderNip65HomeItems(homeFeedState, postViewModel, accountViewModel, newNav, dragState = homeDragState)
             renderNip65NotifItems(notifFeedState, postViewModel, accountViewModel, newNav, dragState = notifDragState)
@@ -95,6 +96,7 @@ fun Nip65InboxRelayList(
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
+            userScrollEnabled = !dragState.isDragging,
         ) {
             renderNip65NotifItems(notifFeedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }
@@ -119,6 +121,7 @@ fun Nip65OutboxRelayList(
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
+            userScrollEnabled = !dragState.isDragging,
         ) {
             renderNip65HomeItems(homeFeedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip65/Nip65RelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip65/Nip65RelayListView.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -35,6 +34,7 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoDialog
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.DraggableRelayList
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayCountResult
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayUrlEditField
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
@@ -111,15 +111,21 @@ fun LazyListScope.renderNip65HomeItems(
     nav: INav,
     countResults: Map<NormalizedRelayUrl, RelayCountResult> = emptyMap(),
 ) {
-    itemsIndexed(feedState, key = { _, item -> "Nip65Home" + item.relay.url }) { index, item ->
-        BasicRelaySetupInfoDialog(
-            item,
-            onDelete = { postViewModel.deleteHomeRelay(item) },
-            nip11CachedRetriever = Amethyst.instance.nip11Cache,
-            countResult = countResults[item.relay],
-            accountViewModel = accountViewModel,
-            nav = nav,
-        )
+    item(key = "Nip65Home_draggable_list") {
+        DraggableRelayList(
+            items = feedState,
+            onMove = { from, to -> postViewModel.moveHomeRelay(from, to) },
+        ) { _, item, dragModifier ->
+            BasicRelaySetupInfoDialog(
+                item,
+                onDelete = { postViewModel.deleteHomeRelay(item) },
+                nip11CachedRetriever = Amethyst.instance.nip11Cache,
+                countResult = countResults[item.relay],
+                dragModifier = dragModifier,
+                accountViewModel = accountViewModel,
+                nav = nav,
+            )
+        }
     }
 
     item {
@@ -139,15 +145,21 @@ fun LazyListScope.renderNip65NotifItems(
     nav: INav,
     countResults: Map<NormalizedRelayUrl, RelayCountResult> = emptyMap(),
 ) {
-    itemsIndexed(feedState, key = { _, item -> "Nip65Notif" + item.relay.url }) { index, item ->
-        BasicRelaySetupInfoDialog(
-            item,
-            onDelete = { postViewModel.deleteNotifRelay(item) },
-            nip11CachedRetriever = Amethyst.instance.nip11Cache,
-            countResult = countResults[item.relay],
-            accountViewModel = accountViewModel,
-            nav = nav,
-        )
+    item(key = "Nip65Notif_draggable_list") {
+        DraggableRelayList(
+            items = feedState,
+            onMove = { from, to -> postViewModel.moveNotifRelay(from, to) },
+        ) { _, item, dragModifier ->
+            BasicRelaySetupInfoDialog(
+                item,
+                onDelete = { postViewModel.deleteNotifRelay(item) },
+                nip11CachedRetriever = Amethyst.instance.nip11Cache,
+                countResult = countResults[item.relay],
+                dragModifier = dragModifier,
+                accountViewModel = accountViewModel,
+                nav = nav,
+            )
+        }
     }
 
     item {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip65/Nip65RelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip65/Nip65RelayListView.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -34,10 +35,11 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoDialog
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.DraggableRelayList
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayCountResult
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayDragState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayUrlEditField
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.rememberRelayDragState
 import com.vitorpamplona.amethyst.ui.theme.FeedPadding
 import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
@@ -54,12 +56,23 @@ fun Nip65RelayList(
     val homeFeedState by postViewModel.homeRelays.collectAsStateWithLifecycle()
     val notifFeedState by postViewModel.notificationRelays.collectAsStateWithLifecycle()
 
+    val homeDragState =
+        rememberRelayDragState(
+            onMove = { from, to -> postViewModel.moveHomeRelay(from, to) },
+            itemCount = { homeFeedState.size },
+        )
+    val notifDragState =
+        rememberRelayDragState(
+            onMove = { from, to -> postViewModel.moveNotifRelay(from, to) },
+            itemCount = { notifFeedState.size },
+        )
+
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
         ) {
-            renderNip65HomeItems(homeFeedState, postViewModel, accountViewModel, newNav)
-            renderNip65NotifItems(notifFeedState, postViewModel, accountViewModel, newNav)
+            renderNip65HomeItems(homeFeedState, postViewModel, accountViewModel, newNav, dragState = homeDragState)
+            renderNip65NotifItems(notifFeedState, postViewModel, accountViewModel, newNav, dragState = notifDragState)
         }
     }
 }
@@ -72,14 +85,18 @@ fun Nip65InboxRelayList(
     nav: INav,
 ) {
     val newNav = rememberExtendedNav(nav, onClose)
-
     val notifFeedState by postViewModel.notificationRelays.collectAsStateWithLifecycle()
+    val dragState =
+        rememberRelayDragState(
+            onMove = { from, to -> postViewModel.moveNotifRelay(from, to) },
+            itemCount = { notifFeedState.size },
+        )
 
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
         ) {
-            renderNip65NotifItems(notifFeedState, postViewModel, accountViewModel, newNav)
+            renderNip65NotifItems(notifFeedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }
     }
 }
@@ -92,14 +109,18 @@ fun Nip65OutboxRelayList(
     nav: INav,
 ) {
     val newNav = rememberExtendedNav(nav, onClose)
-
     val homeFeedState by postViewModel.homeRelays.collectAsStateWithLifecycle()
+    val dragState =
+        rememberRelayDragState(
+            onMove = { from, to -> postViewModel.moveHomeRelay(from, to) },
+            itemCount = { homeFeedState.size },
+        )
 
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
         ) {
-            renderNip65HomeItems(homeFeedState, postViewModel, accountViewModel, newNav)
+            renderNip65HomeItems(homeFeedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }
     }
 }
@@ -110,22 +131,19 @@ fun LazyListScope.renderNip65HomeItems(
     accountViewModel: AccountViewModel,
     nav: INav,
     countResults: Map<NormalizedRelayUrl, RelayCountResult> = emptyMap(),
+    dragState: RelayDragState? = null,
 ) {
-    item(key = "Nip65Home_draggable_list") {
-        DraggableRelayList(
-            items = feedState,
-            onMove = { from, to -> postViewModel.moveHomeRelay(from, to) },
-        ) { _, item, dragModifier ->
-            BasicRelaySetupInfoDialog(
-                item,
-                onDelete = { postViewModel.deleteHomeRelay(item) },
-                nip11CachedRetriever = Amethyst.instance.nip11Cache,
-                countResult = countResults[item.relay],
-                dragModifier = dragModifier,
-                accountViewModel = accountViewModel,
-                nav = nav,
-            )
-        }
+    itemsIndexed(feedState, key = { _, item -> "Nip65Home" + item.relay.url }) { index, item ->
+        BasicRelaySetupInfoDialog(
+            item,
+            onDelete = { postViewModel.deleteHomeRelay(item) },
+            nip11CachedRetriever = Amethyst.instance.nip11Cache,
+            countResult = countResults[item.relay],
+            index = index,
+            dragState = dragState,
+            accountViewModel = accountViewModel,
+            nav = nav,
+        )
     }
 
     item {
@@ -144,22 +162,19 @@ fun LazyListScope.renderNip65NotifItems(
     accountViewModel: AccountViewModel,
     nav: INav,
     countResults: Map<NormalizedRelayUrl, RelayCountResult> = emptyMap(),
+    dragState: RelayDragState? = null,
 ) {
-    item(key = "Nip65Notif_draggable_list") {
-        DraggableRelayList(
-            items = feedState,
-            onMove = { from, to -> postViewModel.moveNotifRelay(from, to) },
-        ) { _, item, dragModifier ->
-            BasicRelaySetupInfoDialog(
-                item,
-                onDelete = { postViewModel.deleteNotifRelay(item) },
-                nip11CachedRetriever = Amethyst.instance.nip11Cache,
-                countResult = countResults[item.relay],
-                dragModifier = dragModifier,
-                accountViewModel = accountViewModel,
-                nav = nav,
-            )
-        }
+    itemsIndexed(feedState, key = { _, item -> "Nip65Notif" + item.relay.url }) { index, item ->
+        BasicRelaySetupInfoDialog(
+            item,
+            onDelete = { postViewModel.deleteNotifRelay(item) },
+            nip11CachedRetriever = Amethyst.instance.nip11Cache,
+            countResult = countResults[item.relay],
+            index = index,
+            dragState = dragState,
+            accountViewModel = accountViewModel,
+            nav = nav,
+        )
     }
 
     item {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip65/Nip65RelayListViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip65/Nip65RelayListViewModel.kt
@@ -176,8 +176,6 @@ class Nip65RelayListViewModel : ViewModel() {
             relayList
                 .map { relaySetupInfoBuilder(it) }
                 .distinctBy { it.relay }
-                .sortedBy { it.relayStat.receivedBytes }
-                .reversed()
         }
 
         _notificationRelays.update {
@@ -186,8 +184,6 @@ class Nip65RelayListViewModel : ViewModel() {
             relayList
                 .map { relaySetupInfoBuilder(it) }
                 .distinctBy { it.relay }
-                .sortedBy { it.relayStat.receivedBytes }
-                .reversed()
         }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip65/Nip65RelayListViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip65/Nip65RelayListViewModel.kt
@@ -215,6 +215,18 @@ class Nip65RelayListViewModel : ViewModel() {
         _homeRelays.update { it.replace(relay, relay.copy(paidRelay = paid)) }
     }
 
+    fun moveHomeRelay(
+        from: Int,
+        to: Int,
+    ) {
+        _homeRelays.update { list ->
+            list.toMutableList().apply {
+                add(to, removeAt(from))
+            }
+        }
+        hasModified = true
+    }
+
     fun addNotifRelay(relay: BasicRelaySetupInfo) {
         if (_notificationRelays.value.any { it.relay == relay.relay }) return
 
@@ -229,6 +241,18 @@ class Nip65RelayListViewModel : ViewModel() {
 
     fun deleteNotifAll() {
         _notificationRelays.update { relays -> emptyList() }
+        hasModified = true
+    }
+
+    fun moveNotifRelay(
+        from: Int,
+        to: Int,
+    ) {
+        _notificationRelays.update { list ->
+            list.toMutableList().apply {
+                add(to, removeAt(from))
+            }
+        }
         hasModified = true
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/proxy/ProxyRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/proxy/ProxyRelayListView.kt
@@ -62,6 +62,7 @@ fun ProxyRelayList(
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
+            userScrollEnabled = !dragState.isDragging,
         ) {
             renderProxyItems(feedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/proxy/ProxyRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/proxy/ProxyRelayListView.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -34,10 +35,11 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoDialog
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.DraggableRelayList
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayCountResult
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayDragState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayUrlEditField
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.rememberRelayDragState
 import com.vitorpamplona.amethyst.ui.theme.FeedPadding
 import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
@@ -50,14 +52,18 @@ fun ProxyRelayList(
     nav: INav,
 ) {
     val feedState by postViewModel.relays.collectAsStateWithLifecycle()
-
     val newNav = rememberExtendedNav(nav, onClose)
+    val dragState =
+        rememberRelayDragState(
+            onMove = { from, to -> postViewModel.moveRelay(from, to) },
+            itemCount = { feedState.size },
+        )
 
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
         ) {
-            renderProxyItems(feedState, postViewModel, accountViewModel, newNav)
+            renderProxyItems(feedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }
     }
 }
@@ -68,22 +74,19 @@ fun LazyListScope.renderProxyItems(
     accountViewModel: AccountViewModel,
     nav: INav,
     countResults: Map<NormalizedRelayUrl, RelayCountResult> = emptyMap(),
+    dragState: RelayDragState? = null,
 ) {
-    item(key = "Proxy_draggable_list") {
-        DraggableRelayList(
-            items = feedState,
-            onMove = { from, to -> postViewModel.moveRelay(from, to) },
-        ) { _, item, dragModifier ->
-            BasicRelaySetupInfoDialog(
-                item,
-                onDelete = { postViewModel.deleteRelay(item) },
-                nip11CachedRetriever = Amethyst.instance.nip11Cache,
-                countResult = countResults[item.relay],
-                dragModifier = dragModifier,
-                accountViewModel = accountViewModel,
-                nav = nav,
-            )
-        }
+    itemsIndexed(feedState, key = { _, item -> "Proxy" + item.relay.url }) { index, item ->
+        BasicRelaySetupInfoDialog(
+            item,
+            onDelete = { postViewModel.deleteRelay(item) },
+            nip11CachedRetriever = Amethyst.instance.nip11Cache,
+            countResult = countResults[item.relay],
+            index = index,
+            dragState = dragState,
+            accountViewModel = accountViewModel,
+            nav = nav,
+        )
     }
 
     item {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/proxy/ProxyRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/proxy/ProxyRelayListView.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -35,6 +34,7 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoDialog
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.DraggableRelayList
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayCountResult
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayUrlEditField
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
@@ -69,15 +69,21 @@ fun LazyListScope.renderProxyItems(
     nav: INav,
     countResults: Map<NormalizedRelayUrl, RelayCountResult> = emptyMap(),
 ) {
-    itemsIndexed(feedState, key = { _, item -> "Proxy" + item.relay.url }) { index, item ->
-        BasicRelaySetupInfoDialog(
-            item,
-            onDelete = { postViewModel.deleteRelay(item) },
-            nip11CachedRetriever = Amethyst.instance.nip11Cache,
-            countResult = countResults[item.relay],
-            accountViewModel = accountViewModel,
-            nav = nav,
-        )
+    item(key = "Proxy_draggable_list") {
+        DraggableRelayList(
+            items = feedState,
+            onMove = { from, to -> postViewModel.moveRelay(from, to) },
+        ) { _, item, dragModifier ->
+            BasicRelaySetupInfoDialog(
+                item,
+                onDelete = { postViewModel.deleteRelay(item) },
+                nip11CachedRetriever = Amethyst.instance.nip11Cache,
+                countResult = countResults[item.relay],
+                dragModifier = dragModifier,
+                accountViewModel = accountViewModel,
+                nav = nav,
+            )
+        }
     }
 
     item {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/search/SearchRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/search/SearchRelayListView.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -35,6 +34,7 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoDialog
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.DraggableRelayList
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayCountResult
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayUrlEditField
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
@@ -69,15 +69,21 @@ fun LazyListScope.renderSearchItems(
     nav: INav,
     countResults: Map<NormalizedRelayUrl, RelayCountResult> = emptyMap(),
 ) {
-    itemsIndexed(feedState, key = { _, item -> "Search" + item.relay.url }) { index, item ->
-        BasicRelaySetupInfoDialog(
-            item,
-            onDelete = { postViewModel.deleteRelay(item) },
-            nip11CachedRetriever = Amethyst.instance.nip11Cache,
-            countResult = countResults[item.relay],
-            accountViewModel = accountViewModel,
-            nav = nav,
-        )
+    item(key = "Search_draggable_list") {
+        DraggableRelayList(
+            items = feedState,
+            onMove = { from, to -> postViewModel.moveRelay(from, to) },
+        ) { _, item, dragModifier ->
+            BasicRelaySetupInfoDialog(
+                item,
+                onDelete = { postViewModel.deleteRelay(item) },
+                nip11CachedRetriever = Amethyst.instance.nip11Cache,
+                countResult = countResults[item.relay],
+                dragModifier = dragModifier,
+                accountViewModel = accountViewModel,
+                nav = nav,
+            )
+        }
     }
 
     item {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/search/SearchRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/search/SearchRelayListView.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -34,10 +35,11 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoDialog
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.DraggableRelayList
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayCountResult
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayDragState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayUrlEditField
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.rememberRelayDragState
 import com.vitorpamplona.amethyst.ui.theme.FeedPadding
 import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
@@ -50,14 +52,18 @@ fun SearchRelayList(
     nav: INav,
 ) {
     val feedState by postViewModel.relays.collectAsStateWithLifecycle()
-
     val newNav = rememberExtendedNav(nav, onClose)
+    val dragState =
+        rememberRelayDragState(
+            onMove = { from, to -> postViewModel.moveRelay(from, to) },
+            itemCount = { feedState.size },
+        )
 
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
         ) {
-            renderSearchItems(feedState, postViewModel, accountViewModel, newNav)
+            renderSearchItems(feedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }
     }
 }
@@ -68,22 +74,19 @@ fun LazyListScope.renderSearchItems(
     accountViewModel: AccountViewModel,
     nav: INav,
     countResults: Map<NormalizedRelayUrl, RelayCountResult> = emptyMap(),
+    dragState: RelayDragState? = null,
 ) {
-    item(key = "Search_draggable_list") {
-        DraggableRelayList(
-            items = feedState,
-            onMove = { from, to -> postViewModel.moveRelay(from, to) },
-        ) { _, item, dragModifier ->
-            BasicRelaySetupInfoDialog(
-                item,
-                onDelete = { postViewModel.deleteRelay(item) },
-                nip11CachedRetriever = Amethyst.instance.nip11Cache,
-                countResult = countResults[item.relay],
-                dragModifier = dragModifier,
-                accountViewModel = accountViewModel,
-                nav = nav,
-            )
-        }
+    itemsIndexed(feedState, key = { _, item -> "Search" + item.relay.url }) { index, item ->
+        BasicRelaySetupInfoDialog(
+            item,
+            onDelete = { postViewModel.deleteRelay(item) },
+            nip11CachedRetriever = Amethyst.instance.nip11Cache,
+            countResult = countResults[item.relay],
+            index = index,
+            dragState = dragState,
+            accountViewModel = accountViewModel,
+            nav = nav,
+        )
     }
 
     item {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/search/SearchRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/search/SearchRelayListView.kt
@@ -62,6 +62,7 @@ fun SearchRelayList(
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
+            userScrollEnabled = !dragState.isDragging,
         ) {
             renderSearchItems(feedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/trusted/TrustedRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/trusted/TrustedRelayListView.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -34,9 +35,10 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoDialog
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.DraggableRelayList
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayDragState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayUrlEditField
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.rememberRelayDragState
 import com.vitorpamplona.amethyst.ui.theme.FeedPadding
 import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
 
@@ -48,14 +50,18 @@ fun TrustedRelayList(
     nav: INav,
 ) {
     val feedState by postViewModel.relays.collectAsStateWithLifecycle()
-
     val newNav = rememberExtendedNav(nav, onClose)
+    val dragState =
+        rememberRelayDragState(
+            onMove = { from, to -> postViewModel.moveRelay(from, to) },
+            itemCount = { feedState.size },
+        )
 
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
         ) {
-            renderTrustedItems(feedState, postViewModel, accountViewModel, newNav)
+            renderTrustedItems(feedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }
     }
 }
@@ -65,21 +71,18 @@ fun LazyListScope.renderTrustedItems(
     postViewModel: TrustedRelayListViewModel,
     accountViewModel: AccountViewModel,
     nav: INav,
+    dragState: RelayDragState? = null,
 ) {
-    item(key = "Trusted_draggable_list") {
-        DraggableRelayList(
-            items = feedState,
-            onMove = { from, to -> postViewModel.moveRelay(from, to) },
-        ) { _, item, dragModifier ->
-            BasicRelaySetupInfoDialog(
-                item,
-                onDelete = { postViewModel.deleteRelay(item) },
-                nip11CachedRetriever = Amethyst.instance.nip11Cache,
-                dragModifier = dragModifier,
-                accountViewModel = accountViewModel,
-                nav = nav,
-            )
-        }
+    itemsIndexed(feedState, key = { _, item -> "Trusted" + item.relay.url }) { index, item ->
+        BasicRelaySetupInfoDialog(
+            item,
+            onDelete = { postViewModel.deleteRelay(item) },
+            nip11CachedRetriever = Amethyst.instance.nip11Cache,
+            index = index,
+            dragState = dragState,
+            accountViewModel = accountViewModel,
+            nav = nav,
+        )
     }
 
     item {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/trusted/TrustedRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/trusted/TrustedRelayListView.kt
@@ -60,6 +60,7 @@ fun TrustedRelayList(
     Row(verticalAlignment = Alignment.CenterVertically) {
         LazyColumn(
             contentPadding = FeedPadding,
+            userScrollEnabled = !dragState.isDragging,
         ) {
             renderTrustedItems(feedState, postViewModel, accountViewModel, newNav, dragState = dragState)
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/trusted/TrustedRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/trusted/TrustedRelayListView.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -35,6 +34,7 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoDialog
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.DraggableRelayList
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayUrlEditField
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
 import com.vitorpamplona.amethyst.ui.theme.FeedPadding
@@ -66,14 +66,20 @@ fun LazyListScope.renderTrustedItems(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    itemsIndexed(feedState, key = { _, item -> "Trusted" + item.relay.url }) { index, item ->
-        BasicRelaySetupInfoDialog(
-            item,
-            onDelete = { postViewModel.deleteRelay(item) },
-            nip11CachedRetriever = Amethyst.instance.nip11Cache,
-            accountViewModel = accountViewModel,
-            nav = nav,
-        )
+    item(key = "Trusted_draggable_list") {
+        DraggableRelayList(
+            items = feedState,
+            onMove = { from, to -> postViewModel.moveRelay(from, to) },
+        ) { _, item, dragModifier ->
+            BasicRelaySetupInfoDialog(
+                item,
+                onDelete = { postViewModel.deleteRelay(item) },
+                nip11CachedRetriever = Amethyst.instance.nip11Cache,
+                dragModifier = dragModifier,
+                accountViewModel = accountViewModel,
+                nav = nav,
+            )
+        }
     }
 
     item {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/theme/Shape.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/theme/Shape.kt
@@ -155,6 +155,8 @@ val HalfVertPadding = Modifier.padding(vertical = 5.dp)
 val HorzPadding = Modifier.padding(horizontal = 10.dp)
 val VertPadding = Modifier.padding(vertical = 10.dp)
 
+val HorzHalfVertPadding = Modifier.padding(horizontal = 10.dp, vertical = 5.dp)
+
 val DoubleHorzPadding = Modifier.padding(horizontal = 20.dp)
 val DoubleVertPadding = Modifier.padding(vertical = 20.dp)
 

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -1506,6 +1506,7 @@
 
     <string name="dm_upload">DM Upload</string>
     <string name="relay_settings">Relay Settings</string>
+    <string name="relay_reorder">Reorder relay</string>
     <string name="public_home_section">Public Outbox/Home Relays</string>
     <string name="public_home_section_explainer_profile">User is posting his content to these relays</string>
     <string name="public_home_section_explainer">This relay type stores all your content. Amethyst will send your posts here and others will use these relays to find your content. Insert between 1–3 relays. They can be personal relays, paid relays or public relays.</string>


### PR DESCRIPTION
## Summary
This PR adds drag-and-drop reordering capability to relay lists throughout the application. Users can now reorder relays within each relay category by dragging them up or down, with visual feedback during the drag operation.

## Key Changes

- **New `DraggableRelayList.kt`**: Introduces a reusable drag state management system with:
  - `RelayDragState` class to track dragging state, offsets, and item heights
  - `draggableRelayItem()` modifier for visual feedback (elevation, scale, translation)
  - `relayDragHandle()` modifier to detect drag gestures with a drag indicator icon
  - `rememberRelayDragState()` composable for state creation

- **Updated relay list views**: Added drag state initialization and integration across all relay categories:
  - NIP-65 (Home/Notification relays)
  - DM relays
  - Private Outbox relays
  - Proxy, Broadcast, Indexer, Search relays
  - Local, Trusted, Feeds, Blocked relays

- **Enhanced `BasicRelaySetupInfoClickableRow.kt`**: 
  - Added drag handle icon (DragIndicator) display when dragging is enabled
  - Integrated `draggableRelayItem()` modifier for visual feedback
  - Made drag functionality optional via `dragState` parameter

- **ViewModel updates**: Added `moveRelay()` and `moveHomeRelay()`/`moveNotifRelay()` methods to:
  - `Nip65RelayListViewModel`
  - `BasicRelaySetupInfoModel` (base class for other relay view models)
  - Removed automatic sorting by `receivedBytes` to preserve user-defined order

- **UI/UX improvements**:
  - Disabled LazyColumn scrolling during drag operations to prevent conflicts
  - Added visual feedback: elevation, scale, and z-index changes during drag
  - Smooth animation of elevation changes
  - Drag indicator icon with appropriate styling

## Implementation Details

- The drag state tracks item heights to calculate when to swap adjacent items (at 50% threshold)
- Drag offset is adjusted after swaps to maintain smooth continuous dragging
- `rememberUpdatedState()` is used in the drag handle to keep the index current without restarting gesture detection
- All relay lists now disable automatic sorting to preserve manual reordering

https://claude.ai/code/session_01RVM5kEJGrCaJTaP3GmVHDd