### PR TITLE
Fix audio cleanup and call state handling on Activity destroy

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallAudioManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallAudioManager.kt
@@ -118,8 +118,11 @@ class CallAudioManager(
     }
 
     fun stopRingbackTone() {
-        ringbackTone?.stopTone()
-        ringbackTone?.release()
+        try {
+            ringbackTone?.stopTone()
+            ringbackTone?.release()
+        } catch (_: Exception) {
+        }
         ringbackTone = null
     }
 
@@ -355,7 +358,10 @@ class CallAudioManager(
     }
 
     private fun stopRingtone() {
-        ringtone?.stop()
+        try {
+            ringtone?.stop()
+        } catch (_: Exception) {
+        }
         ringtone = null
     }
 
@@ -376,7 +382,10 @@ class CallAudioManager(
     }
 
     private fun stopVibration() {
-        vibrator?.cancel()
+        try {
+            vibrator?.cancel()
+        } catch (_: Exception) {
+        }
         vibrator = null
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallActivity.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallActivity.kt
@@ -207,8 +207,28 @@ class CallActivity : AppCompatActivity() {
         }
     }
 
+    @OptIn(DelicateCoroutinesApi::class)
     override fun onDestroy() {
         unregisterPipReceiver()
+
+        // Safety net: if the Activity is destroyed while a call is still
+        // ringing/offering, ensure the call is hung up so audio stops.
+        val manager = ActiveCallHolder.callManager
+        when (manager?.state?.value) {
+            is CallState.IncomingCall -> {
+                GlobalScope.launch { manager.rejectCall() }
+            }
+
+            is CallState.Offering,
+            is CallState.Connecting,
+            is CallState.Connected,
+            -> {
+                GlobalScope.launch { manager.hangup() }
+            }
+
+            else -> {}
+        }
+
         super.onDestroy()
     }
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
@@ -505,9 +505,12 @@ class CallManager(
             }
         }
 
+        // Transition immediately so the UI stops ringing/ringback before
+        // the (potentially slow) signing + relay publish completes.
+        transitionToEnded(callId, peerPubKeys, EndReason.HANGUP)
+
         val result = factory.createGroupHangup(peerPubKeys, callId, signer = signer)
         result.wraps.forEach { publishEvent(it) }
-        transitionToEnded(callId, peerPubKeys, EndReason.HANGUP)
     }
 
     fun onPeerHangup(event: CallHangupEvent) {


### PR DESCRIPTION
## Summary
This PR improves the reliability of call cleanup when the CallActivity is destroyed, and adds defensive error handling for audio resource management.

## Key Changes

- **CallActivity.onDestroy()**: Added safety net logic to ensure calls are properly hung up or rejected when the Activity is destroyed while a call is active. This prevents audio from continuing to play after the UI is gone.
  - Rejects incoming calls
  - Hangs up calls in Offering, Connecting, or Connected states
  - Uses GlobalScope to launch async cleanup operations

- **CallAudioManager**: Added try-catch blocks around audio resource cleanup to prevent crashes from exceptions during:
  - `stopRingbackTone()`: Wraps stopTone() and release() calls
  - `stopRingtone()`: Wraps stop() call
  - `stopVibration()`: Wraps cancel() call

- **CallManager.hangup()**: Reordered operations to transition call state to Ended immediately before publishing hangup events. This ensures the UI stops showing ringing/ringback states before the potentially slow signing and relay publish operations complete.

## Implementation Details

- Added `@OptIn(DelicateCoroutinesApi::class)` annotation to CallActivity.onDestroy() due to GlobalScope usage
- Exception handling in audio cleanup is intentionally silent to prevent cascading failures during shutdown
- State transition happens before event publishing to provide immediate UI feedback

https://claude.ai/code/session_01Rip2HPCbF48PPFDiB2X5ik