### PR TITLE
Move Event Sync and Import Follows to Settings screen

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerContent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerContent.kt
@@ -62,7 +62,6 @@ import androidx.compose.material.icons.outlined.Photo
 import androidx.compose.material.icons.outlined.PlayCircle
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.SmartDisplay
-import androidx.compose.material.icons.outlined.Sync
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -626,22 +625,6 @@ fun ListContent(
                 route = Route.Chess,
             )
         }
-
-        NavigationRow(
-            title = R.string.event_sync_title,
-            icon = Icons.Outlined.Sync,
-            tint = MaterialTheme.colorScheme.onBackground,
-            nav = nav,
-            route = Route.EventSync,
-        )
-
-        NavigationRow(
-            title = R.string.route_import_follows,
-            icon = Icons.Outlined.GroupAdd,
-            tint = MaterialTheme.colorScheme.onBackground,
-            nav = nav,
-            route = Route.ImportFollowsSelectUser,
-        )
 
         IconRowRelays(
             accountViewModel = accountViewModel,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AllSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AllSettingsScreen.kt
@@ -34,11 +34,13 @@ import androidx.compose.material.icons.outlined.Bolt
 import androidx.compose.material.icons.outlined.CloudUpload
 import androidx.compose.material.icons.outlined.DeleteForever
 import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material.icons.outlined.GroupAdd
 import androidx.compose.material.icons.outlined.History
 import androidx.compose.material.icons.outlined.Key
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Security
 import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material.icons.outlined.Sync
 import androidx.compose.material.icons.outlined.ThumbUp
 import androidx.compose.material.icons.outlined.Translate
 import androidx.compose.material3.HorizontalDivider
@@ -97,6 +99,20 @@ fun AllSettingsScreen(
                 iconPainterRef = 4,
                 tint = tint,
                 onClick = { nav.nav(Route.EditRelays) },
+            )
+            HorizontalDivider()
+            SettingsNavigationRow(
+                title = R.string.event_sync_title,
+                icon = Icons.Outlined.Sync,
+                tint = tint,
+                onClick = { nav.nav(Route.EventSync) },
+            )
+            HorizontalDivider()
+            SettingsNavigationRow(
+                title = R.string.route_import_follows,
+                icon = Icons.Outlined.GroupAdd,
+                tint = tint,
+                onClick = { nav.nav(Route.ImportFollowsSelectUser) },
             )
             HorizontalDivider()
             SettingsNavigationRow(


### PR DESCRIPTION
## Summary
Relocated the Event Sync and Import Follows navigation items from the drawer menu to the Settings screen for better organization and discoverability.

## Key Changes
- Removed `NavigationRow` entries for Event Sync and Import Follows from `DrawerContent.kt`
- Added these navigation items to `AllSettingsScreen.kt` as `SettingsNavigationRow` components
- Updated imports in `AllSettingsScreen.kt` to include `Sync` and `GroupAdd` icons
- Removed unused `Sync` icon import from `DrawerContent.kt`

## Implementation Details
- Both navigation items are now positioned in the Settings screen with proper dividers
- The navigation routes (`Route.EventSync` and `Route.ImportFollowsSelectUser`) remain unchanged
- Uses the same tint color scheme as other settings navigation rows for visual consistency

https://claude.ai/code/session_017bgasTSsMRR9aepmAsKEzR