### PR TITLE
Add relay feed support and refactor feed filtering logic

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -408,6 +408,7 @@ class Account(
             followsRelays = defaultGlobalRelays.flow,
             blockedRelays = blockedRelayList.flow,
             proxyRelays = proxyRelayList.flow,
+            relayFeeds = relayFeedsList.flow,
             caches = feedDecryptionCaches,
             signer = signer,
             scope = scope,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/FeedTopNavFilterState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/FeedTopNavFilterState.kt
@@ -30,6 +30,7 @@ import com.vitorpamplona.amethyst.model.topNavFeeds.allUserFollows.Kind3UserFoll
 import com.vitorpamplona.amethyst.model.topNavFeeds.aroundMe.AroundMeFeedFlow
 import com.vitorpamplona.amethyst.model.topNavFeeds.chess.ChessFeedFlow
 import com.vitorpamplona.amethyst.model.topNavFeeds.global.GlobalFeedFlow
+import com.vitorpamplona.amethyst.model.topNavFeeds.hashtag.HashtagFeedFlow
 import com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.NoteFeedFlow
 import com.vitorpamplona.amethyst.model.topNavFeeds.relay.RelayFeedFlow
 import com.vitorpamplona.amethyst.model.topNavFeeds.unknown.UnknownFeedFlow
@@ -135,7 +136,7 @@ class FeedTopNavFilterState(
             }
 
             is TopFilter.Hashtag -> {
-                UnknownFeedFlow(listName)
+                HashtagFeedFlow(listName.tag, followsRelays, proxyRelays)
             }
 
             is TopFilter.Relay -> {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/FeedTopNavFilterState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/FeedTopNavFilterState.kt
@@ -35,6 +35,7 @@ import com.vitorpamplona.amethyst.model.topNavFeeds.relay.RelayFeedFlow
 import com.vitorpamplona.amethyst.model.topNavFeeds.unknown.UnknownFeedFlow
 import com.vitorpamplona.amethyst.service.location.LocationState
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.normalizeRelayUrl
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -137,7 +138,7 @@ class FeedTopNavFilterState(
             }
 
             is TopFilter.Relay -> {
-                RelayFeedFlow(NormalizedRelayUrl(listName.url))
+                RelayFeedFlow(listName.url.normalizeRelayUrl())
             }
         }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/FeedTopNavFilterState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/FeedTopNavFilterState.kt
@@ -57,6 +57,7 @@ class FeedTopNavFilterState(
     val followsRelays: StateFlow<Set<NormalizedRelayUrl>>,
     val blockedRelays: StateFlow<Set<NormalizedRelayUrl>>,
     val proxyRelays: StateFlow<Set<NormalizedRelayUrl>>,
+    val relayFeeds: StateFlow<Set<NormalizedRelayUrl>>,
     val caches: FeedDecryptionCaches,
     val signer: NostrSigner,
     val scope: CoroutineScope,
@@ -64,7 +65,7 @@ class FeedTopNavFilterState(
     fun loadFlowsFor(listName: TopFilter): IFeedFlowsType =
         when (listName) {
             TopFilter.Global -> {
-                GlobalFeedFlow(followsRelays, proxyRelays)
+                GlobalFeedFlow(followsRelays, proxyRelays, relayFeeds)
             }
 
             TopFilter.AllFollows -> {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/FeedTopNavFilterState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/FeedTopNavFilterState.kt
@@ -31,6 +31,7 @@ import com.vitorpamplona.amethyst.model.topNavFeeds.aroundMe.AroundMeFeedFlow
 import com.vitorpamplona.amethyst.model.topNavFeeds.chess.ChessFeedFlow
 import com.vitorpamplona.amethyst.model.topNavFeeds.global.GlobalFeedFlow
 import com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.NoteFeedFlow
+import com.vitorpamplona.amethyst.model.topNavFeeds.relay.RelayFeedFlow
 import com.vitorpamplona.amethyst.model.topNavFeeds.unknown.UnknownFeedFlow
 import com.vitorpamplona.amethyst.service.location.LocationState
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
@@ -136,7 +137,7 @@ class FeedTopNavFilterState(
             }
 
             is TopFilter.Relay -> {
-                UnknownFeedFlow(listName)
+                RelayFeedFlow(NormalizedRelayUrl(listName.url))
             }
         }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/FeedTopNavFilterState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/FeedTopNavFilterState.kt
@@ -28,12 +28,12 @@ import com.vitorpamplona.amethyst.model.topNavFeeds.allFollows.AllFollowsFeedFlo
 import com.vitorpamplona.amethyst.model.topNavFeeds.allUserFollows.AllUserFollowsFeedFlow
 import com.vitorpamplona.amethyst.model.topNavFeeds.allUserFollows.Kind3UserFollowsFeedFlow
 import com.vitorpamplona.amethyst.model.topNavFeeds.aroundMe.AroundMeFeedFlow
+import com.vitorpamplona.amethyst.model.topNavFeeds.aroundMe.GeohashFeedFlow
 import com.vitorpamplona.amethyst.model.topNavFeeds.chess.ChessFeedFlow
 import com.vitorpamplona.amethyst.model.topNavFeeds.global.GlobalFeedFlow
 import com.vitorpamplona.amethyst.model.topNavFeeds.hashtag.HashtagFeedFlow
 import com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.NoteFeedFlow
 import com.vitorpamplona.amethyst.model.topNavFeeds.relay.RelayFeedFlow
-import com.vitorpamplona.amethyst.model.topNavFeeds.unknown.UnknownFeedFlow
 import com.vitorpamplona.amethyst.service.location.LocationState
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.normalizeRelayUrl
@@ -132,7 +132,7 @@ class FeedTopNavFilterState(
             }
 
             is TopFilter.Geohash -> {
-                UnknownFeedFlow(listName)
+                GeohashFeedFlow(listName.tag, followsRelays, proxyRelays)
             }
 
             is TopFilter.Hashtag -> {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/aroundMe/GeohashFeedFlow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/aroundMe/GeohashFeedFlow.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.model.topNavFeeds.aroundMe
+
+import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedFlowsType
+import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+
+class GeohashFeedFlow(
+    val geohash: String,
+    val outboxRelays: StateFlow<Set<NormalizedRelayUrl>>,
+    val proxyRelays: StateFlow<Set<NormalizedRelayUrl>>,
+) : IFeedFlowsType {
+    fun buildFilter(relays: Set<NormalizedRelayUrl>) = LocationTopNavFilter(setOf(geohash), relays)
+
+    override fun flow(): Flow<IFeedTopNavFilter> =
+        combine(outboxRelays, proxyRelays) { outbox, proxy ->
+            if (proxy.isNotEmpty()) buildFilter(proxy) else buildFilter(outbox)
+        }
+
+    override fun startValue(): LocationTopNavFilter =
+        if (proxyRelays.value.isNotEmpty()) {
+            buildFilter(proxyRelays.value)
+        } else {
+            buildFilter(outboxRelays.value)
+        }
+
+    override suspend fun startValue(collector: FlowCollector<IFeedTopNavFilter>) {
+        collector.emit(startValue())
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/global/GlobalFeedFlow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/global/GlobalFeedFlow.kt
@@ -30,8 +30,9 @@ import kotlinx.coroutines.flow.StateFlow
 class GlobalFeedFlow(
     val outboxRelays: StateFlow<Set<NormalizedRelayUrl>>,
     val proxyRelays: StateFlow<Set<NormalizedRelayUrl>>,
+    val relayFeeds: StateFlow<Set<NormalizedRelayUrl>>,
 ) : IFeedFlowsType {
-    val default = GlobalTopNavFilter(outboxRelays, proxyRelays)
+    val default = GlobalTopNavFilter(outboxRelays, proxyRelays, relayFeeds)
 
     override fun flow() = MutableStateFlow(default)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/global/GlobalTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/global/GlobalTopNavFilter.kt
@@ -34,17 +34,18 @@ import kotlinx.coroutines.flow.combine
 class GlobalTopNavFilter(
     val outboxRelays: StateFlow<Set<NormalizedRelayUrl>>,
     val proxyRelays: StateFlow<Set<NormalizedRelayUrl>>,
+    val relayFeeds: StateFlow<Set<NormalizedRelayUrl>>,
 ) : IFeedTopNavFilter {
     override fun matchAuthor(pubkey: HexKey): Boolean = true
 
     override fun match(noteEvent: Event) = true
 
     override fun toPerRelayFlow(cache: LocalCache): Flow<GlobalTopNavPerRelayFilterSet> =
-        combine(outboxRelays, proxyRelays) { outboxRelays, proxyRelays ->
+        combine(outboxRelays, proxyRelays, relayFeeds) { outboxRelays, proxyRelays, relayFeeds ->
             if (proxyRelays.isNotEmpty()) {
                 GlobalTopNavPerRelayFilterSet(proxyRelays.associateWith { GlobalTopNavPerRelayFilter })
             } else {
-                GlobalTopNavPerRelayFilterSet(outboxRelays.associateWith { GlobalTopNavPerRelayFilter })
+                GlobalTopNavPerRelayFilterSet((relayFeeds + outboxRelays).associateWith { GlobalTopNavPerRelayFilter })
             }
         }
 
@@ -52,6 +53,6 @@ class GlobalTopNavFilter(
         if (proxyRelays.value.isNotEmpty()) {
             GlobalTopNavPerRelayFilterSet(proxyRelays.value.associateWith { GlobalTopNavPerRelayFilter })
         } else {
-            GlobalTopNavPerRelayFilterSet(outboxRelays.value.associateWith { GlobalTopNavPerRelayFilter })
+            GlobalTopNavPerRelayFilterSet((relayFeeds.value + outboxRelays.value).associateWith { GlobalTopNavPerRelayFilter })
         }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/hashtag/HashtagFeedFlow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/hashtag/HashtagFeedFlow.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.model.topNavFeeds.hashtag
+
+import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedFlowsType
+import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+
+class HashtagFeedFlow(
+    val hashtag: String,
+    val outboxRelays: StateFlow<Set<NormalizedRelayUrl>>,
+    val proxyRelays: StateFlow<Set<NormalizedRelayUrl>>,
+) : IFeedFlowsType {
+    fun buildFilter(relays: Set<NormalizedRelayUrl>) = HashtagTopNavFilter(setOf(hashtag), relays)
+
+    override fun flow(): Flow<IFeedTopNavFilter> =
+        combine(outboxRelays, proxyRelays) { outbox, proxy ->
+            if (proxy.isNotEmpty()) buildFilter(proxy) else buildFilter(outbox)
+        }
+
+    override fun startValue(): HashtagTopNavFilter =
+        if (proxyRelays.value.isNotEmpty()) {
+            buildFilter(proxyRelays.value)
+        } else {
+            buildFilter(outboxRelays.value)
+        }
+
+    override suspend fun startValue(collector: FlowCollector<IFeedTopNavFilter>) {
+        collector.emit(startValue())
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/relay/RelayFeedFlow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/relay/RelayFeedFlow.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.model.topNavFeeds.relay
+
+import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedFlowsType
+import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class RelayFeedFlow(
+    val relayUrl: NormalizedRelayUrl,
+) : IFeedFlowsType {
+    val default = RelayTopNavFilter(relayUrl)
+
+    override fun flow() = MutableStateFlow(default)
+
+    override fun startValue(): RelayTopNavFilter = default
+
+    override suspend fun startValue(collector: FlowCollector<IFeedTopNavFilter>) {
+        collector.emit(startValue())
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/relay/RelayTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/relay/RelayTopNavFilter.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.model.topNavFeeds.relay
+
+import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+@Immutable
+class RelayTopNavFilter(
+    val relayUrl: NormalizedRelayUrl,
+) : IFeedTopNavFilter {
+    override fun matchAuthor(pubkey: HexKey): Boolean = true
+
+    override fun match(noteEvent: Event) = true
+
+    override fun toPerRelayFlow(cache: LocalCache): Flow<RelayTopNavPerRelayFilterSet> = flowOf(RelayTopNavPerRelayFilterSet(relayUrl))
+
+    override fun startValue(cache: LocalCache): RelayTopNavPerRelayFilterSet = RelayTopNavPerRelayFilterSet(relayUrl)
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/relay/RelayTopNavPerRelayFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/relay/RelayTopNavPerRelayFilter.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.model.topNavFeeds.relay
+
+import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavPerRelayFilter
+
+@Immutable
+object RelayTopNavPerRelayFilter : IFeedTopNavPerRelayFilter

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/relay/RelayTopNavPerRelayFilterSet.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/relay/RelayTopNavPerRelayFilterSet.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.model.topNavFeeds.relay
+
+import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavPerRelayFilterSet
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+
+class RelayTopNavPerRelayFilterSet(
+    val relayUrl: NormalizedRelayUrl,
+) : IFeedTopNavPerRelayFilterSet

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/FilterByListParams.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/FilterByListParams.kt
@@ -47,36 +47,44 @@ class FilterByListParams(
 
     fun hasExcessiveHashtags(noteEvent: Event) = hiddenLists.maxHashtagLimit > 0 && noteEvent.countHashtags() > hiddenLists.maxHashtagLimit
 
-    fun isEventInList(noteEvent: Event): Boolean {
-        if (followLists == null) return false
-
-        return followLists.match(noteEvent)
-    }
-
     fun isAuthorInFollows(author: HexKey): Boolean {
         if (followLists == null) return false
 
         return followLists.matchAuthor(author)
     }
 
-    fun isAuthorInFollows(address: Address): Boolean {
+    fun isGlobal() = followLists is GlobalTopNavFilter
+
+    private fun applyTopFilter(
+        comingFrom: List<NormalizedRelayUrl>,
+        noteEvent: Event,
+    ): Boolean {
         if (followLists == null) return false
 
-        return followLists.matchAuthor(address.pubKeyHex)
+        return when (followLists) {
+            is GlobalTopNavFilter -> true
+            is RelayTopNavFilter -> comingFrom.contains(followLists.relayUrl)
+            else -> followLists.match(noteEvent)
+        }
     }
 
-    fun isGlobal(comingFrom: List<NormalizedRelayUrl>) =
-        followLists is GlobalTopNavFilter &&
-            comingFrom.any { followLists.outboxRelays.value.contains(it) }
+    private fun applyTopFilter(
+        comingFrom: List<NormalizedRelayUrl>,
+        address: Address,
+    ): Boolean {
+        if (followLists == null) return false
 
-    fun isFromRelay(comingFrom: List<NormalizedRelayUrl>) =
-        followLists is RelayTopNavFilter &&
-            comingFrom.contains(followLists.relayUrl)
+        return when (followLists) {
+            is GlobalTopNavFilter -> true
+            is RelayTopNavFilter -> comingFrom.contains(followLists.relayUrl)
+            else -> followLists.matchAuthor(address.pubKeyHex)
+        }
+    }
 
     fun match(
         noteEvent: Event,
         comingFrom: List<NormalizedRelayUrl>,
-    ) = ((isGlobal(comingFrom)) || isFromRelay(comingFrom) || isEventInList(noteEvent)) &&
+    ) = (applyTopFilter(comingFrom, noteEvent)) &&
         (isHiddenList || isNotHidden(noteEvent.pubKey)) &&
         isNotInTheFuture(noteEvent) &&
         !hasExcessiveHashtags(noteEvent)
@@ -85,7 +93,7 @@ class FilterByListParams(
         address: Address?,
         comingFrom: List<NormalizedRelayUrl>,
     ) = address != null &&
-        (isGlobal(comingFrom) || isFromRelay(comingFrom) || isAuthorInFollows(address)) &&
+        (applyTopFilter(comingFrom, address)) &&
         (isHiddenList || isNotHidden(address.pubKeyHex))
 
     companion object {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/FilterByListParams.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/FilterByListParams.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.global.GlobalTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.muted.MutedAuthorsByOutboxTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.muted.MutedAuthorsByProxyTopNavFilter
+import com.vitorpamplona.amethyst.model.topNavFeeds.relay.RelayTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Address
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -68,10 +69,14 @@ class FilterByListParams(
         followLists is GlobalTopNavFilter &&
             comingFrom.any { followLists.outboxRelays.value.contains(it) }
 
+    fun isFromRelay(comingFrom: List<NormalizedRelayUrl>) =
+        followLists is RelayTopNavFilter &&
+            comingFrom.contains(followLists.relayUrl)
+
     fun match(
         noteEvent: Event,
         comingFrom: List<NormalizedRelayUrl>,
-    ) = ((isGlobal(comingFrom)) || isEventInList(noteEvent)) &&
+    ) = ((isGlobal(comingFrom)) || isFromRelay(comingFrom) || isEventInList(noteEvent)) &&
         (isHiddenList || isNotHidden(noteEvent.pubKey)) &&
         isNotInTheFuture(noteEvent) &&
         !hasExcessiveHashtags(noteEvent)
@@ -80,7 +85,7 @@ class FilterByListParams(
         address: Address?,
         comingFrom: List<NormalizedRelayUrl>,
     ) = address != null &&
-        (isGlobal(comingFrom) || isAuthorInFollows(address)) &&
+        (isGlobal(comingFrom) || isFromRelay(comingFrom) || isAuthorInFollows(address)) &&
         (isHiddenList || isNotHidden(address.pubKeyHex))
 
     companion object {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/FilterByListParams.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/FilterByListParams.kt
@@ -62,7 +62,6 @@ class FilterByListParams(
         if (followLists == null) return false
 
         return when (followLists) {
-            is GlobalTopNavFilter -> true
             is RelayTopNavFilter -> comingFrom.contains(followLists.relayUrl)
             else -> followLists.match(noteEvent)
         }
@@ -75,7 +74,6 @@ class FilterByListParams(
         if (followLists == null) return false
 
         return when (followLists) {
-            is GlobalTopNavFilter -> true
             is RelayTopNavFilter -> comingFrom.contains(followLists.relayUrl)
             else -> followLists.matchAuthor(address.pubKeyHex)
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/FeedFilterSpinner.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/FeedFilterSpinner.kt
@@ -122,7 +122,7 @@ fun FeedFilterSpinner(
     var selected by
         remember(placeholderCode, options) {
             mutableStateOf(
-                options.firstOrNull { it.code == placeholderCode },
+                options.firstOrNull { it.code.code == placeholderCode.code },
             )
         }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/TopNavFilterState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/TopNavFilterState.kt
@@ -173,7 +173,6 @@ class TopNavFilterState(
                 FeedDefinition(
                     TopFilter.Relay(relayUrl.url),
                     RelayName(relayUrl),
-                    route = Route.RelayFeed(relayUrl.url),
                 )
             }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/TopNavFilterState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/TopNavFilterState.kt
@@ -146,7 +146,6 @@ class TopNavFilterState(
                 FeedDefinition(
                     TopFilter.Hashtag(it),
                     HashtagName(it),
-                    route = Route.Hashtag(it),
                 )
             }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/TopNavFilterState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/TopNavFilterState.kt
@@ -154,7 +154,6 @@ class TopNavFilterState(
                 FeedDefinition(
                     TopFilter.Geohash(it),
                     GeoHashName(it),
-                    route = Route.Geohash(it),
                 )
             }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/HomeScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/HomeScreen.kt
@@ -118,7 +118,7 @@ fun HomeScreen(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    WatchAccountForHomeScreen(newThreadsFeedState, repliesFeedState, accountViewModel)
+    WatchAccountForHomeScreen(liveFeedState, newThreadsFeedState, repliesFeedState, accountViewModel)
 
     WatchLifecycleAndUpdateModel(liveFeedState)
     WatchLifecycleAndUpdateModel(newThreadsFeedState)
@@ -441,6 +441,7 @@ fun CrossfadeCheckIfVideoIsOnline(
 
 @Composable
 fun WatchAccountForHomeScreen(
+    liveFeedState: ChannelFeedContentState,
     newThreadsFeedState: FeedContentState,
     repliesFeedState: FeedContentState,
     accountViewModel: AccountViewModel,
@@ -450,6 +451,7 @@ fun WatchAccountForHomeScreen(
     LaunchedEffect(accountViewModel, homeFollowList) {
         newThreadsFeedState.checkKeysInvalidateDataAndSendToTop()
         repliesFeedState.checkKeysInvalidateDataAndSendToTop()
+        liveFeedState.checkKeysInvalidateDataAndSendToTop()
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/datasource/nip01Core/FilterHomePostsByRelay.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/datasource/nip01Core/FilterHomePostsByRelay.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip01Core
+
+import com.vitorpamplona.amethyst.model.topNavFeeds.relay.RelayTopNavPerRelayFilterSet
+import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip65Follows.HomePostsConversationKinds
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip65Follows.HomePostsNewThreadKinds1
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip65Follows.HomePostsNewThreadKinds2
+import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
+import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
+
+fun filterHomePostsByRelay(
+    relayFilter: RelayTopNavPerRelayFilterSet,
+    since: SincePerRelayMap?,
+    newThreadSince: Long?,
+    repliesSince: Long?,
+): List<RelayBasedFilter> {
+    val relayUrl = relayFilter.relayUrl
+    val sinceTime = since?.get(relayUrl)?.time
+
+    return listOf(
+        RelayBasedFilter(
+            relay = relayUrl,
+            filter =
+                Filter(
+                    kinds = HomePostsNewThreadKinds1,
+                    limit = 50,
+                    since = sinceTime ?: newThreadSince,
+                ),
+        ),
+        RelayBasedFilter(
+            relay = relayUrl,
+            filter =
+                Filter(
+                    kinds = HomePostsNewThreadKinds2,
+                    limit = 5,
+                    since = sinceTime ?: newThreadSince,
+                ),
+        ),
+        RelayBasedFilter(
+            relay = relayUrl,
+            filter =
+                Filter(
+                    kinds = HomePostsConversationKinds,
+                    limit = 50,
+                    since = sinceTime ?: repliesSince,
+                ),
+        ),
+    )
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/datasource/nip01Core/FilterHomePostsByRelay.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/datasource/nip01Core/FilterHomePostsByRelay.kt
@@ -43,7 +43,7 @@ fun filterHomePostsByRelay(
             filter =
                 Filter(
                     kinds = HomePostsNewThreadKinds1,
-                    limit = 50,
+                    limit = 500,
                     since = sinceTime ?: newThreadSince,
                 ),
         ),
@@ -52,7 +52,7 @@ fun filterHomePostsByRelay(
             filter =
                 Filter(
                     kinds = HomePostsNewThreadKinds2,
-                    limit = 5,
+                    limit = 100,
                     since = sinceTime ?: newThreadSince,
                 ),
         ),
@@ -61,7 +61,7 @@ fun filterHomePostsByRelay(
             filter =
                 Filter(
                     kinds = HomePostsConversationKinds,
-                    limit = 50,
+                    limit = 500,
                     since = sinceTime ?: repliesSince,
                 ),
         ),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/datasource/nip65Follows/HomeOutboxEventsEoseManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/datasource/nip65Follows/HomeOutboxEventsEoseManager.kt
@@ -31,12 +31,14 @@ import com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.allcommunities.All
 import com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.author.AuthorsTopNavPerRelayFilterSet
 import com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.community.SingleCommunityTopNavPerRelayFilterSet
 import com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.muted.MutedAuthorsTopNavPerRelayFilterSet
+import com.vitorpamplona.amethyst.model.topNavFeeds.relay.RelayTopNavPerRelayFilterSet
 import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUserAndFollowListEoseManager
 import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.HomeQueryState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip01Core.filterHomePostsByGeohashes
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip01Core.filterHomePostsByGlobal
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip01Core.filterHomePostsByHashtags
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip01Core.filterHomePostsByRelay
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip64Chess.filterHomePostsByChess
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip72Communities.filterHomePostsByAllCommunities
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip72Communities.filterHomePostsByCommunity
@@ -70,6 +72,7 @@ class HomeOutboxEventsEoseManager(
             is HashtagTopNavPerRelayFilterSet -> filterHomePostsByHashtags(feedSettings, since, newThreadSince)
             is LocationTopNavPerRelayFilterSet -> filterHomePostsByGeohashes(feedSettings, since, newThreadSince)
             is MutedAuthorsTopNavPerRelayFilterSet -> filterHomePostsByAuthors(feedSettings, since, newThreadSince, repliesSince)
+            is RelayTopNavPerRelayFilterSet -> filterHomePostsByRelay(feedSettings, since, newThreadSince, repliesSince)
             is SingleCommunityTopNavPerRelayFilterSet -> filterHomePostsByCommunity(feedSettings, since, newThreadSince)
             else -> emptyList()
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationFeedFilter.kt
@@ -194,7 +194,7 @@ class NotificationFeedFilter(
 
         return noteEvent?.kind in NOTIFICATION_KINDS &&
             (noteEvent is LnZapEvent || notifAuthor != loggedInUserHex) &&
-            (isChessEvent || filterParams.isGlobal(it.relays) || notifAuthor == null || filterParams.isAuthorInFollows(notifAuthor)) &&
+            (isChessEvent || filterParams.isGlobal() || notifAuthor == null || filterParams.isAuthorInFollows(notifAuthor)) &&
             noteEvent?.isTaggedUser(loggedInUserHex) ?: false &&
             (filterParams.isHiddenList || notifAuthor == null || !account.isHidden(notifAuthor)) &&
             (noteEvent !is PrivateDmEvent || !account.isDecryptedContentHidden(noteEvent)) &&


### PR DESCRIPTION
## Summary
This PR introduces support for relay-based feeds and refactors the feed filtering architecture to properly handle relay-specific content filtering alongside existing global, hashtag, and location-based feeds.

## Key Changes

- **New Relay Feed Support**: Added `RelayFeedFlow`, `RelayTopNavFilter`, and related classes to enable browsing content from specific relays
  - `RelayFeedFlow`: Manages relay feed state and flow
  - `RelayTopNavFilter`: Implements filtering logic for relay-specific content
  - `RelayTopNavPerRelayFilterSet` and `RelayTopNavPerRelayFilter`: Per-relay filter implementations

- **New Feed Flow Classes**: Added `HashtagFeedFlow` and `GeohashFeedFlow` to consolidate feed flow logic
  - Both follow the same pattern of combining outbox and proxy relays with fallback logic
  - Enables consistent handling of hashtag and location-based feeds

- **Relay Filter Generation**: Added `filterHomePostsByRelay()` function to generate relay-specific filters for home posts
  - Supports three filter types: new threads (two kinds), and conversation replies
  - Properly handles `since` timestamps per relay

- **Refactored FilterByListParams**: Simplified and improved relay filtering logic
  - Introduced `applyTopFilter()` methods to handle relay-specific filtering
  - Removed `isGlobal(comingFrom)` in favor of more explicit relay checking
  - Added `isGlobal()` method for simpler global feed detection
  - Improved separation of concerns between relay and non-relay filtering

- **Updated GlobalTopNavFilter and GlobalFeedFlow**: Added `relayFeeds` state flow to track relay-based feeds
  - Ensures relay feeds are properly included in global feed calculations

- **Updated HomeScreen**: Modified `WatchAccountForHomeScreen` to include `liveFeedState` parameter for better state management

- **Removed Unknown Feed Flow**: Replaced with more specific feed flow implementations

## Implementation Details

- All new relay feed classes follow the established `IFeedFlowsType` and `IFeedTopNavFilter` interfaces
- Relay filtering properly respects the relay URL when determining if content should be included
- The architecture maintains backward compatibility while extending support for relay-specific browsing
- Feed flow classes consistently use `combine()` to merge outbox and proxy relay states with proxy relay preference

https://claude.ai/code/session_01PZLLjE7MWh7PPz1woVqmxM