### PR TITLE
Remove LiveChessGameChallengeEvent from home feed filters

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/dal/HomeNewThreadFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/dal/HomeNewThreadFeedFilter.kt
@@ -43,7 +43,6 @@ import com.vitorpamplona.quartz.nip18Reposts.RepostEvent
 import com.vitorpamplona.quartz.nip22Comments.CommentEvent
 import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
 import com.vitorpamplona.quartz.nip54Wiki.WikiNoteEvent
-import com.vitorpamplona.quartz.nip64Chess.challenge.offer.LiveChessGameChallengeEvent
 import com.vitorpamplona.quartz.nip64Chess.end.LiveChessGameEndEvent
 import com.vitorpamplona.quartz.nip64Chess.game.ChessGameEvent
 import com.vitorpamplona.quartz.nip84Highlights.HighlightEvent
@@ -62,7 +61,6 @@ class HomeNewThreadFeedFilter(
                 WikiNoteEvent.KIND,
                 ClassifiedsEvent.KIND,
                 LongTextNoteEvent.KIND,
-                LiveChessGameChallengeEvent.KIND,
                 LiveChessGameEndEvent.KIND,
                 AttestationEvent.KIND,
             )
@@ -130,7 +128,6 @@ class HomeNewThreadFeedFilter(
                 noteEvent is VoiceEvent ||
                 noteEvent is AudioHeaderEvent ||
                 noteEvent is ChessGameEvent ||
-                noteEvent is LiveChessGameChallengeEvent ||
                 noteEvent is LiveChessGameEndEvent ||
                 noteEvent is AttestationEvent ||
                 noteEvent is AttestationRequestEvent ||

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/datasource/nip64Chess/FilterHomePostsByChess.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/datasource/nip64Chess/FilterHomePostsByChess.kt
@@ -24,14 +24,12 @@ import com.vitorpamplona.amethyst.model.topNavFeeds.chess.ChessTopNavPerRelayFil
 import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
-import com.vitorpamplona.quartz.nip64Chess.challenge.offer.LiveChessGameChallengeEvent
 import com.vitorpamplona.quartz.nip64Chess.end.LiveChessGameEndEvent
 import com.vitorpamplona.quartz.nip64Chess.game.ChessGameEvent
 
 val ChessPostsKinds =
     listOf(
         ChessGameEvent.KIND, // Completed games (Kind 64)
-        LiveChessGameChallengeEvent.KIND, // Challenges (Kind 30064)
         LiveChessGameEndEvent.KIND, // Game endings (Kind 30067)
     )
 


### PR DESCRIPTION
## Summary
Removes support for displaying chess game challenge events (Kind 30064) in the home feed by eliminating all references to `LiveChessGameChallengeEvent` from the feed filtering logic.

## Changes
- **HomeNewThreadFeedFilter.kt**: Removed the import and all references to `LiveChessGameChallengeEvent`
  - Removed import statement
  - Removed `LiveChessGameChallengeEvent.KIND` from the kinds list
  - Removed the `noteEvent is LiveChessGameChallengeEvent` type check from the filtering logic

- **FilterHomePostsByChess.kt**: Removed chess challenge event kind from the chess posts filter
  - Removed import statement
  - Removed `LiveChessGameChallengeEvent.KIND` from the `ChessPostsKinds` list

## Impact
Chess game challenge events will no longer be included in home feed results. Only completed games (Kind 64) and game endings (Kind 30067) will be displayed.

https://claude.ai/code/session_01XiWkVxXQBnLPTbeswL3y4c