### PR TITLE
fix(quartz): snapshot LargeCache entries in forEach to prevent ConcurrentModificationException

### DIFF
--- a/quartz/src/appleMain/kotlin/com/vitorpamplona/quartz/utils/cache/LargeCache.apple.kt
+++ b/quartz/src/appleMain/kotlin/com/vitorpamplona/quartz/utils/cache/LargeCache.apple.kt
@@ -85,7 +85,10 @@ actual class LargeCache<K, V> : ICacheOperations<K, V> {
     actual override fun size(): Int = concurrentMap.size
 
     actual override fun forEach(consumer: ICacheBiConsumer<K, V>) {
-        concurrentMap.forEach { consumer.accept(it.key, it.value) }
+        // Take a snapshot of entries to avoid ConcurrentModificationException
+        // when the map is modified during iteration (e.g., NostrClient.syncFilters
+        // iterating while subscriptions are added from another coroutine).
+        concurrentMap.entries.toList().forEach { consumer.accept(it.key, it.value) }
     }
 
     actual override fun filter(consumer: CacheCollectors.BiFilter<K, V>): List<V> =

--- a/quartz/src/linuxMain/kotlin/com/vitorpamplona/quartz/utils/cache/LargeCache.linux.kt
+++ b/quartz/src/linuxMain/kotlin/com/vitorpamplona/quartz/utils/cache/LargeCache.linux.kt
@@ -88,7 +88,8 @@ actual class LargeCache<K, V> : ICacheOperations<K, V> {
     actual override fun size(): Int = withMap { it.size }
 
     actual override fun forEach(consumer: ICacheBiConsumer<K, V>) {
-        withMap { map -> map.forEach { consumer.accept(it.key, it.value) } }
+        // Snapshot entries to avoid ConcurrentModificationException
+        withMap { map -> map.entries.toList() }.forEach { consumer.accept(it.key, it.value) }
     }
 
     actual override fun filter(consumer: CacheCollectors.BiFilter<K, V>): List<V> = withMap { map -> map.filter { consumer.filter(it.key, it.value) }.values.toList() }


### PR DESCRIPTION
## Problem

`LargeCache.forEach()` on Apple (iOS/macOS) and Linux targets iterates the underlying map directly. When another coroutine modifies the map during iteration (e.g., `NostrClient.syncFilters` running while subscriptions are added), a `ConcurrentModificationException` is thrown.

**On JVM/Android:** Not an issue — `ConcurrentSkipListMap` handles concurrent iteration safely.

**On Kotlin/Native (iOS):** This is fatal. K/N calls `abort()` for any unhandled coroutine exception, crashing the app immediately after account creation when relays connect and subscriptions start syncing.

## Root Cause

`PoolRequests.syncState()` calls `LargeCache.forEach()` to iterate all subscriptions. Simultaneously, another coroutine adds/removes subscriptions, modifying the same map. The Apple implementation uses `CacheMap` from `io.github.charlietap.cachemap`, whose `forEach` doesn't protect against concurrent modification. The Linux implementation uses a plain `LinkedHashMap` with the same issue.

## Fix

Call `.entries.toList()` before iterating to create a snapshot, matching the JVM behavior where concurrent modifications during iteration are tolerated.

**Apple:** `concurrentMap.entries.toList().forEach { ... }`
**Linux:** `withMap { map -> map.entries.toList() }.forEach { ... }`

## Stack trace (iOS)
```
kotlin.ConcurrentModificationException
  at HashMap.Itr.checkForComodification
  at LargeCache.forEach
  at PoolRequests.syncState
  at NostrClient.syncFilters
```

## Testing
- Verified on iOS simulator (iPhone 17 Pro) — no more crashes on account creation
- Apple and Linux targets affected; JVM/Android unaffected