### PR TITLE
feat(commons): KMP concurrency primitive wrappers

### DIFF
--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -70,6 +70,9 @@ kotlin {
                 // Immutable collections
                 api(libs.kotlinx.collections.immutable)
 
+                // Atomic operations (KMP-compatible)
+                implementation(libs.kotlinx.atomicfu)
+
                 // Compose Multiplatform Resources
                 implementation(libs.jetbrains.compose.components.resources)
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/PeerSessionManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/PeerSessionManager.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.commons.call
 
+import com.vitorpamplona.amethyst.commons.concurrency.kmpSynchronized
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 
 /**
@@ -58,7 +59,7 @@ class PeerSessionManager(
         peerPubKey: HexKey,
         session: PeerSession,
     ): SessionEntry =
-        synchronized(lock) {
+        kmpSynchronized(lock) {
             val globalPending = globalPendingIce.remove(peerPubKey) ?: emptyList()
             val entry = SessionEntry(session)
             entry.pendingIceCandidates.addAll(globalPending)
@@ -66,17 +67,17 @@ class PeerSessionManager(
             entry
         }
 
-    fun getSession(peerPubKey: HexKey): SessionEntry? = synchronized(lock) { sessions[peerPubKey] }
+    fun getSession(peerPubKey: HexKey): SessionEntry? = kmpSynchronized(lock) { sessions[peerPubKey] }
 
-    fun hasSession(peerPubKey: HexKey): Boolean = synchronized(lock) { sessions.containsKey(peerPubKey) }
+    fun hasSession(peerPubKey: HexKey): Boolean = kmpSynchronized(lock) { sessions.containsKey(peerPubKey) }
 
     fun removeSession(peerPubKey: HexKey): SessionEntry? =
-        synchronized(lock) {
+        kmpSynchronized(lock) {
             globalPendingIce.remove(peerPubKey)
             sessions.remove(peerPubKey)
         }
 
-    fun allSessionKeys(): Set<HexKey> = synchronized(lock) { sessions.keys.toSet() }
+    fun allSessionKeys(): Set<HexKey> = kmpSynchronized(lock) { sessions.keys.toSet() }
 
     // ---- ICE candidate routing (two-layer buffering) ----
 
@@ -92,7 +93,7 @@ class PeerSessionManager(
         senderPubKey: HexKey,
         candidate: IceCandidateData,
     ): IceRouteAction =
-        synchronized(lock) {
+        kmpSynchronized(lock) {
             val entry = sessions[senderPubKey]
             when {
                 entry != null && entry.remoteDescriptionSet -> {
@@ -117,21 +118,21 @@ class PeerSessionManager(
      * Called after setRemoteDescription succeeds.
      */
     fun flushPendingIceCandidates(peerPubKey: HexKey): Int {
-        val candidates: List<IceCandidateData>
-        val entry: SessionEntry
-        synchronized(lock) {
-            entry = sessions[peerPubKey] ?: return 0
-            entry.remoteDescriptionSet = true
-            candidates = entry.pendingIceCandidates.toList()
-            entry.pendingIceCandidates.clear()
-        }
+        val (entry, candidates) =
+            kmpSynchronized(lock) {
+                val e = sessions[peerPubKey] ?: return 0
+                e.remoteDescriptionSet = true
+                val c = e.pendingIceCandidates.toList()
+                e.pendingIceCandidates.clear()
+                Pair(e, c)
+            }
         candidates.forEach { entry.session.addIceCandidate(it) }
         return candidates.size
     }
 
-    fun globalPendingCount(peerPubKey: HexKey): Int = synchronized(lock) { globalPendingIce[peerPubKey]?.size ?: 0 }
+    fun globalPendingCount(peerPubKey: HexKey): Int = kmpSynchronized(lock) { globalPendingIce[peerPubKey]?.size ?: 0 }
 
-    fun sessionPendingCount(peerPubKey: HexKey): Int = synchronized(lock) { sessions[peerPubKey]?.pendingIceCandidates?.size ?: 0 }
+    fun sessionPendingCount(peerPubKey: HexKey): Int = kmpSynchronized(lock) { sessions[peerPubKey]?.pendingIceCandidates?.size ?: 0 }
 
     // ---- Renegotiation glare handling ----
 
@@ -147,7 +148,7 @@ class PeerSessionManager(
         remoteSdpOffer: String,
         onAcceptRemote: (SessionEntry) -> Unit,
     ): GlareResolution {
-        val entry = synchronized(lock) { sessions[peerPubKey] } ?: return GlareResolution.NO_SESSION
+        val entry = kmpSynchronized(lock) { sessions[peerPubKey] } ?: return GlareResolution.NO_SESSION
 
         val signalingState = entry.session.getSignalingState()
         if (signalingState != SignalingState.HAVE_LOCAL_OFFER) {
@@ -184,7 +185,7 @@ class PeerSessionManager(
         peerPubKey: HexKey,
         sdpAnswer: String,
     ): AnswerRouteAction {
-        val entry = synchronized(lock) { sessions[peerPubKey] } ?: return AnswerRouteAction.NO_SESSION
+        val entry = kmpSynchronized(lock) { sessions[peerPubKey] } ?: return AnswerRouteAction.NO_SESSION
 
         val signalingState = entry.session.getSignalingState()
         if (signalingState != SignalingState.HAVE_LOCAL_OFFER) {
@@ -199,12 +200,13 @@ class PeerSessionManager(
     // ---- Cleanup ----
 
     fun disposeAll() {
-        val entries: List<SessionEntry>
-        synchronized(lock) {
-            entries = sessions.values.toList()
-            sessions.clear()
-            globalPendingIce.clear()
-        }
+        val entries =
+            kmpSynchronized(lock) {
+                val list = sessions.values.toList()
+                sessions.clear()
+                globalPendingIce.clear()
+                list
+            }
         for (entry in entries) {
             entry.session.dispose()
         }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/AcceptedGamesRegistry.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/AcceptedGamesRegistry.kt
@@ -20,6 +20,8 @@
  */
 package com.vitorpamplona.amethyst.commons.chess
 
+import com.vitorpamplona.amethyst.commons.concurrency.kmpSynchronized
+
 /**
  * Global registry of accepted game IDs.
  *
@@ -32,25 +34,25 @@ object AcceptedGamesRegistry {
     private val lock = Any()
 
     fun markAsAccepted(gameId: String) {
-        synchronized(lock) {
+        kmpSynchronized(lock) {
             acceptedGameIds.add(gameId)
         }
     }
 
     fun wasAccepted(gameId: String): Boolean =
-        synchronized(lock) {
+        kmpSynchronized(lock) {
             acceptedGameIds.contains(gameId)
         }
 
     fun clear() {
-        synchronized(lock) {
+        kmpSynchronized(lock) {
             acceptedGameIds.clear()
         }
     }
 
     /** Remove old entries - call periodically to prevent memory leak */
     fun clearOldEntries(keepGameIds: Set<String>) {
-        synchronized(lock) {
+        kmpSynchronized(lock) {
             acceptedGameIds.retainAll(keepGameIds)
         }
     }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/ChessEventCollector.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/ChessEventCollector.kt
@@ -20,6 +20,8 @@
  */
 package com.vitorpamplona.amethyst.commons.chess
 
+import com.vitorpamplona.amethyst.commons.concurrency.concurrentMutableMapOf
+import com.vitorpamplona.amethyst.commons.concurrency.concurrentMutableSetOf
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip64Chess.jester.JesterEvent
 import com.vitorpamplona.quartz.nip64Chess.jester.JesterGameEvents
@@ -29,7 +31,6 @@ import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Collects and aggregates Jester chess events for a game from any source.
@@ -68,10 +69,10 @@ class ChessEventCollector(
     val startEvent: StateFlow<JesterEvent?> = _startEvent.asStateFlow()
 
     // Move events (deduplicated by event ID)
-    private val moves = ConcurrentHashMap<String, JesterEvent>()
+    private val moves = concurrentMutableMapOf<String, JesterEvent>()
 
     // Track all processed event IDs for fast deduplication
-    private val processedEventIds = ConcurrentHashMap.newKeySet<String>()
+    private val processedEventIds = concurrentMutableSetOf<String>()
 
     // Flow that emits when any event is added (for reactive updates)
     private val _eventCount = MutableStateFlow(0)
@@ -218,7 +219,7 @@ class ChessEventCollector(
  * such as in a chess lobby or when spectating multiple games.
  */
 class ChessEventCollectorManager {
-    private val collectors = ConcurrentHashMap<String, ChessEventCollector>()
+    private val collectors = concurrentMutableMapOf<String, ChessEventCollector>()
 
     /**
      * Get or create a collector for a game.

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/ChessLobbyLogic.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/ChessLobbyLogic.kt
@@ -20,6 +20,9 @@
  */
 package com.vitorpamplona.amethyst.commons.chess
 
+import com.vitorpamplona.amethyst.commons.concurrency.concurrentMutableMapOf
+import com.vitorpamplona.amethyst.commons.concurrency.kmpSynchronized
+import com.vitorpamplona.amethyst.commons.concurrency.synchronizedMutableSetOf
 import com.vitorpamplona.quartz.nip64Chess.ChessGameEnd
 import com.vitorpamplona.quartz.nip64Chess.ChessMoveEvent
 import com.vitorpamplona.quartz.nip64Chess.Color
@@ -130,17 +133,17 @@ class ChessLobbyLogic(
     val state = ChessLobbyState(userPubkey, scope)
 
     private val dismissedGameIds: MutableSet<String> =
-        java.util.Collections.synchronizedSet(
+        synchronizedMutableSetOf(
             dismissedStorage?.load(userPubkey)?.toMutableSet() ?: mutableSetOf(),
         )
 
     // Track when games were last loaded to prevent duplicate fetches
     // (e.g., discoverUserGames loads a game, then polling immediately re-fetches it)
-    private val recentlyLoadedGames = java.util.concurrent.ConcurrentHashMap<String, Long>()
+    private val recentlyLoadedGames = concurrentMutableMapOf<String, Long>()
 
     // Dedup incoming events (same event delivered by multiple relays)
     // Bounded LRU: evict oldest when exceeding capacity
-    private val seenEventIds = java.util.Collections.synchronizedSet(LinkedHashSet<String>())
+    private val seenEventIds = synchronizedMutableSetOf<String>()
     private val seenEventIdsMax = 500
 
     private val pollingDelegate =
@@ -207,7 +210,7 @@ class ChessLobbyLogic(
         if (!event.isStartEvent() && !event.isMoveEvent()) return
 
         // Dedup: skip if we already processed this event ID (multiple relays deliver same event)
-        synchronized(seenEventIds) {
+        kmpSynchronized(seenEventIds) {
             if (!seenEventIds.add(event.id)) return
             if (seenEventIds.size > seenEventIdsMax) {
                 seenEventIds.iterator().let {

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/ChessLobbyState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/ChessLobbyState.kt
@@ -24,12 +24,12 @@ import androidx.compose.runtime.Immutable
 import com.vitorpamplona.quartz.nip64Chess.Color
 import com.vitorpamplona.quartz.nip64Chess.GameStatus
 import com.vitorpamplona.quartz.nip64Chess.LiveChessGameState
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Challenge expiry: 24 hours
@@ -247,7 +247,7 @@ class ChessLobbyState(
 
     // State version counter - increments on every game state update
     // UI can observe this to force recomposition when internal state changes
-    private val stateVersionCounter = AtomicLong(0)
+    private val stateVersionCounter = atomic(0L)
     private val _stateVersion = MutableStateFlow(0L)
     val stateVersion: StateFlow<Long> = _stateVersion.asStateFlow()
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/ChessRelayFetchHelper.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/ChessRelayFetchHelper.kt
@@ -20,6 +20,8 @@
  */
 package com.vitorpamplona.amethyst.commons.chess
 
+import com.vitorpamplona.amethyst.commons.concurrency.concurrentMutableMapOf
+import com.vitorpamplona.amethyst.commons.concurrency.concurrentMutableSetOf
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.reqs.SubscriptionListener
@@ -28,7 +30,6 @@ import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.withTimeoutOrNull
-import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Progress callback for relay fetch operations
@@ -74,10 +75,10 @@ class ChessRelayFetchHelper(
     ): List<Event> {
         if (filters.isEmpty()) return emptyList()
 
-        val events = ConcurrentHashMap<String, Event>()
+        val events = concurrentMutableMapOf<String, Event>()
         val relayCount = filters.keys.size
-        val eoseReceived = ConcurrentHashMap.newKeySet<NormalizedRelayUrl>()
-        val relayEventCounts = ConcurrentHashMap<NormalizedRelayUrl, Int>()
+        val eoseReceived = concurrentMutableSetOf<NormalizedRelayUrl>()
+        val relayEventCounts = concurrentMutableMapOf<NormalizedRelayUrl, Int>()
         val allEose = CompletableDeferred<Unit>()
         val subId = newSubId()
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/concurrency/ConcurrentCollections.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/concurrency/ConcurrentCollections.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.concurrency
+
+/**
+ * Creates a thread-safe [MutableMap].
+ * On JVM/Android, backed by [java.util.concurrent.ConcurrentHashMap].
+ */
+expect fun <K, V> concurrentMutableMapOf(): MutableMap<K, V>
+
+/**
+ * Creates a thread-safe [MutableSet] backed by a concurrent map.
+ * On JVM/Android, backed by [java.util.concurrent.ConcurrentHashMap.newKeySet].
+ */
+expect fun <T> concurrentMutableSetOf(): MutableSet<T>
+
+/**
+ * Creates a thread-safe sorted [MutableSet].
+ * On JVM/Android, backed by [java.util.concurrent.ConcurrentSkipListSet].
+ */
+expect fun <T> concurrentSortedSetOf(comparator: Comparator<T>): MutableSet<T>
+
+/**
+ * Creates a thread-safe [MutableSet] backed by a synchronized wrapper.
+ * On JVM/Android, backed by [java.util.Collections.synchronizedSet].
+ */
+expect fun <T> synchronizedMutableSetOf(): MutableSet<T>
+
+/**
+ * Creates a thread-safe [MutableSet] backed by a synchronized wrapper,
+ * initialized with the given elements.
+ * On JVM/Android, backed by [java.util.Collections.synchronizedSet].
+ */
+expect fun <T> synchronizedMutableSetOf(elements: MutableSet<T>): MutableSet<T>

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/concurrency/DispatchersIO.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/concurrency/DispatchersIO.kt
@@ -18,19 +18,12 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.search
+package com.vitorpamplona.amethyst.commons.concurrency
 
-import com.vitorpamplona.amethyst.commons.concurrency.kmpSynchronized
+import kotlinx.coroutines.CoroutineDispatcher
 
-class EventDeduplicator {
-    private val lock = Any()
-    private val seenIds = mutableSetOf<String>()
-
-    fun tryAdd(id: String): Boolean = kmpSynchronized(lock) { seenIds.add(id) }
-
-    fun contains(id: String): Boolean = kmpSynchronized(lock) { id in seenIds }
-
-    fun clear() = kmpSynchronized(lock) { seenIds.clear() }
-
-    val size: Int get() = kmpSynchronized(lock) { seenIds.size }
-}
+/**
+ * Multiplatform equivalent of [kotlinx.coroutines.Dispatchers.IO].
+ * On JVM/Android, delegates to [kotlinx.coroutines.Dispatchers.IO].
+ */
+expect val Dispatchers_IO: CoroutineDispatcher

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/concurrency/Synchronized.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/concurrency/Synchronized.kt
@@ -18,19 +18,13 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.search
+package com.vitorpamplona.amethyst.commons.concurrency
 
-import com.vitorpamplona.amethyst.commons.concurrency.kmpSynchronized
-
-class EventDeduplicator {
-    private val lock = Any()
-    private val seenIds = mutableSetOf<String>()
-
-    fun tryAdd(id: String): Boolean = kmpSynchronized(lock) { seenIds.add(id) }
-
-    fun contains(id: String): Boolean = kmpSynchronized(lock) { id in seenIds }
-
-    fun clear() = kmpSynchronized(lock) { seenIds.clear() }
-
-    val size: Int get() = kmpSynchronized(lock) { seenIds.size }
-}
+/**
+ * Multiplatform wrapper for synchronized blocks.
+ * On JVM/Android, delegates to [kotlin.synchronized].
+ */
+expect inline fun <T> kmpSynchronized(
+    lock: Any,
+    block: () -> T,
+): T

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/concurrency/WeakRef.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/concurrency/WeakRef.kt
@@ -18,19 +18,14 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.search
+package com.vitorpamplona.amethyst.commons.concurrency
 
-import com.vitorpamplona.amethyst.commons.concurrency.kmpSynchronized
-
-class EventDeduplicator {
-    private val lock = Any()
-    private val seenIds = mutableSetOf<String>()
-
-    fun tryAdd(id: String): Boolean = kmpSynchronized(lock) { seenIds.add(id) }
-
-    fun contains(id: String): Boolean = kmpSynchronized(lock) { id in seenIds }
-
-    fun clear() = kmpSynchronized(lock) { seenIds.clear() }
-
-    val size: Int get() = kmpSynchronized(lock) { seenIds.size }
+/**
+ * Multiplatform wrapper for weak references.
+ * On JVM/Android, backed by [java.lang.ref.WeakReference].
+ */
+expect class WeakRef<T : Any>(
+    value: T,
+) {
+    fun get(): T?
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Channel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Channel.kt
@@ -21,13 +21,13 @@
 package com.vitorpamplona.amethyst.commons.model
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.concurrency.WeakRef
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.utils.cache.LargeCache
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import java.lang.ref.WeakReference
 
 @Stable
 abstract class Channel : NotesGatherer {
@@ -41,13 +41,13 @@ abstract class Channel : NotesGatherer {
 
     private var relays = mapOf<NormalizedRelayUrl, Counter>()
 
-    private var changesFlow: WeakReference<MutableSharedFlow<ListChange<Note>>> = WeakReference(null)
+    private var changesFlow: WeakRef<MutableSharedFlow<ListChange<Note>>>? = null
 
     fun changesFlow(): MutableSharedFlow<ListChange<Note>> {
-        val current = changesFlow.get()
+        val current = changesFlow?.get()
         if (current != null) return current
         val new = MutableSharedFlow<ListChange<Note>>(0, 10, BufferOverflow.DROP_OLDEST)
-        changesFlow = WeakReference(new)
+        changesFlow = WeakRef(new)
         return new
     }
 
@@ -107,7 +107,7 @@ abstract class Channel : NotesGatherer {
                 addRelay(relay)
             }
 
-            changesFlow.get()?.tryEmit(ListChange.Addition(note))
+            changesFlow?.get()?.tryEmit(ListChange.Addition(note))
 
             flowSet?.notes?.invalidateData()
         }
@@ -122,7 +122,7 @@ abstract class Channel : NotesGatherer {
                 lastNote = notes.values().sortedWith(DefaultFeedOrder).firstOrNull()
             }
 
-            changesFlow.get()?.tryEmit(ListChange.Deletion(note))
+            changesFlow?.get()?.tryEmit(ListChange.Deletion(note))
 
             flowSet?.notes?.invalidateData()
         }
@@ -140,7 +140,7 @@ abstract class Channel : NotesGatherer {
 
         toBeRemoved.forEach { notes.remove(it.idHex) }
 
-        changesFlow.get()?.tryEmit(ListChange.SetDeletion(toBeRemoved.toSet()))
+        changesFlow?.get()?.tryEmit(ListChange.SetDeletion(toBeRemoved.toSet()))
 
         flowSet?.notes?.invalidateData()
 
@@ -156,7 +156,7 @@ abstract class Channel : NotesGatherer {
 
         hidden.forEach { notes.remove(it.idHex) }
 
-        changesFlow.get()?.tryEmit(ListChange.SetDeletion(hidden))
+        changesFlow?.get()?.tryEmit(ListChange.SetDeletion(hidden))
 
         flowSet?.notes?.invalidateData()
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/emphChat/EphemeralChatListState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/emphChat/EphemeralChatListState.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.commons.model.emphChat
 
+import com.vitorpamplona.amethyst.commons.concurrency.Dispatchers_IO
 import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.amethyst.commons.model.NoteState
 import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
@@ -29,7 +30,6 @@ import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -73,7 +73,7 @@ class EphemeralChatListState(
                 emit(ephemeralChatListWithBackup(noteState.note))
             }.onStart {
                 emit(ephemeralChatListWithBackup(ephemeralChatListNote))
-            }.flowOn(Dispatchers.IO)
+            }.flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
@@ -116,12 +116,12 @@ class EphemeralChatListState(
         settings.ephemeralChatList()?.let { event ->
             Log.d("AccountRegisterObservers", "Loading saved ephemeral chat list")
             @OptIn(DelicateCoroutinesApi::class)
-            scope.launch(Dispatchers.IO) {
+            scope.launch(Dispatchers_IO) {
                 cache.justConsumeMyOwnEvent(event)
             }
         }
 
-        scope.launch(Dispatchers.IO) {
+        scope.launch(Dispatchers_IO) {
             Log.d("AccountRegisterObservers", "EphemeralChatList Collector Start")
             getEphemeralChatListFlow().collect { noteState ->
                 Log.d("AccountRegisterObservers") { "EphemeralChatList List for ${signer.pubKey}" }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/marmotGroups/MarmotGroupChatroom.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/marmotGroups/MarmotGroupChatroom.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.commons.model.marmotGroups
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.concurrency.WeakRef
 import com.vitorpamplona.amethyst.commons.model.Channel.Companion.DefaultFeedOrder
 import com.vitorpamplona.amethyst.commons.model.ListChange
 import com.vitorpamplona.amethyst.commons.model.Note
@@ -29,7 +30,6 @@ import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import java.lang.ref.WeakReference
 
 /**
  * Represents a Marmot MLS group chat room.
@@ -49,13 +49,13 @@ class MarmotGroupChatroom(
     var newestMessage: Note? = null
     val unreadCount = MutableStateFlow(0)
 
-    private var changesFlow: WeakReference<MutableSharedFlow<ListChange<Note>>> = WeakReference(null)
+    private var changesFlow: WeakRef<MutableSharedFlow<ListChange<Note>>>? = null
 
     fun changesFlow(): MutableSharedFlow<ListChange<Note>> {
-        val current = changesFlow.get()
+        val current = changesFlow?.get()
         if (current != null) return current
         val new = MutableSharedFlow<ListChange<Note>>(0, 100, BufferOverflow.DROP_OLDEST)
-        changesFlow = WeakReference(new)
+        changesFlow = WeakRef(new)
         return new
     }
 
@@ -75,7 +75,7 @@ class MarmotGroupChatroom(
             }
 
             unreadCount.value += 1
-            changesFlow.get()?.tryEmit(ListChange.Addition(msg))
+            changesFlow?.get()?.tryEmit(ListChange.Addition(msg))
             return true
         }
         return false
@@ -91,7 +91,7 @@ class MarmotGroupChatroom(
                 newestMessage = messages.maxByOrNull { it.createdAt() ?: 0L }
             }
 
-            changesFlow.get()?.tryEmit(ListChange.Deletion(msg))
+            changesFlow?.get()?.tryEmit(ListChange.Deletion(msg))
             return true
         }
         return false
@@ -110,7 +110,7 @@ class MarmotGroupChatroom(
         val toRemove = messages.minus(toKeep)
         messages = toKeep
 
-        changesFlow.get()?.tryEmit(ListChange.SetDeletion<Note>(toRemove))
+        changesFlow?.get()?.tryEmit(ListChange.SetDeletion<Note>(toRemove))
         return toRemove
     }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip01Core/UserRelaysCache.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip01Core/UserRelaysCache.kt
@@ -21,10 +21,11 @@
 package com.vitorpamplona.amethyst.commons.model.nip01Core
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.concurrency.WeakRef
+import com.vitorpamplona.amethyst.commons.concurrency.kmpSynchronized
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.isLocalHost
 import kotlinx.coroutines.flow.MutableStateFlow
-import java.lang.ref.WeakReference
 
 @Stable
 data class RelayInfo(
@@ -52,11 +53,11 @@ val DefaultOrder =
 @Stable
 class UserRelaysCache {
     var data: Map<NormalizedRelayUrl, RelayInfo> = mapOf()
-    private var flow: WeakReference<MutableStateFlow<Wrapper>>? = null
+    private var flow: WeakRef<MutableStateFlow<Wrapper>>? = null
 
     fun flow() =
-        flow?.get() ?: synchronized(this) {
-            flow?.get() ?: MutableStateFlow(Wrapper(data)).also { flow = WeakReference(it) }
+        flow?.get() ?: kmpSynchronized(this) {
+            flow?.get() ?: MutableStateFlow(Wrapper(data)).also { flow = WeakRef(it) }
         }
 
     fun add(

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip02FollowList/Kind3FollowListState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip02FollowList/Kind3FollowListState.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.commons.model.nip02FollowList
 
 import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.commons.concurrency.Dispatchers_IO
 import com.vitorpamplona.amethyst.commons.model.NoteState
 import com.vitorpamplona.amethyst.commons.model.User
 import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
@@ -31,7 +32,6 @@ import com.vitorpamplona.quartz.nip02FollowList.tags.ContactTag
 import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
@@ -68,7 +68,7 @@ class Kind3FollowListState(
 
     val flow =
         innerFlow
-            .flowOn(Dispatchers.IO)
+            .flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
@@ -83,7 +83,7 @@ class Kind3FollowListState(
                 kind3Follows.authors.mapNotNull {
                     runCatching { cache.getOrCreateUser(it) }.getOrNull()
                 }
-            }.flowOn(Dispatchers.IO)
+            }.flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
@@ -164,11 +164,11 @@ class Kind3FollowListState(
             Log.d("AccountRegisterObservers") { "Loading saved ${it.tags.size} contacts" }
 
             @OptIn(DelicateCoroutinesApi::class)
-            scope.launch(Dispatchers.IO) { cache.justConsumeMyOwnEvent(it) }
+            scope.launch(Dispatchers_IO) { cache.justConsumeMyOwnEvent(it) }
         }
 
         // saves contact list for the next time.
-        scope.launch(Dispatchers.IO) {
+        scope.launch(Dispatchers_IO) {
             Log.d("AccountRegisterObservers", "Kind 3 Collector Start")
             getFollowListFlow().collect {
                 Log.d("AccountRegisterObservers") { "Updating Kind 3 ${signer.pubKey}" }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip28PublicChats/PublicChatListState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip28PublicChats/PublicChatListState.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.commons.model.nip28PublicChats
 
+import com.vitorpamplona.amethyst.commons.concurrency.Dispatchers_IO
 import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.amethyst.commons.model.NoteState
 import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
@@ -30,7 +31,6 @@ import com.vitorpamplona.quartz.nip28PublicChat.list.tags.ChannelTag
 import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -75,7 +75,7 @@ class PublicChatListState(
                 emit(publicChatListWithBackup(noteState.note))
             }.onStart {
                 emit(publicChatListWithBackup(publicChatListNote))
-            }.flowOn(Dispatchers.IO)
+            }.flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
@@ -89,7 +89,7 @@ class PublicChatListState(
                 it.mapTo(mutableSetOf()) { it.eventId }
             }.onStart {
                 emit(flow.value.mapTo(mutableSetOf()) { it.eventId })
-            }.flowOn(Dispatchers.IO)
+            }.flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
@@ -131,12 +131,12 @@ class PublicChatListState(
         settings.channelList()?.let { event ->
             Log.d("AccountRegisterObservers") { "Loading saved channel list ${event.toJson()}" }
             @OptIn(DelicateCoroutinesApi::class)
-            scope.launch(Dispatchers.IO) {
+            scope.launch(Dispatchers_IO) {
                 cache.justConsumeMyOwnEvent(event)
             }
         }
 
-        scope.launch(Dispatchers.IO) {
+        scope.launch(Dispatchers_IO) {
             Log.d("AccountRegisterObservers", "Channel List Collector Start")
             getChannelListFlow().collect {
                 Log.d("AccountRegisterObservers") { "Channel List for ${signer.pubKey}" }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip30CustomEmojis/EmojiPackState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip30CustomEmojis/EmojiPackState.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.commons.model.nip30CustomEmojis
 
+import com.vitorpamplona.amethyst.commons.concurrency.Dispatchers_IO
 import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.amethyst.commons.model.NoteState
 import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
@@ -29,7 +30,6 @@ import com.vitorpamplona.quartz.nip30CustomEmoji.pack.EmojiPackEvent
 import com.vitorpamplona.quartz.nip30CustomEmoji.selection.EmojiPackSelectionEvent
 import com.vitorpamplona.quartz.nip30CustomEmoji.taggedEmojis
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -74,7 +74,7 @@ class EmojiPackState(
                 emit(convertEmojiSelectionPack(it.note.event as? EmojiPackSelectionEvent))
             }.onStart {
                 emit(convertEmojiSelectionPack(getEmojiPackSelection()))
-            }.flowOn(Dispatchers.IO)
+            }.flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
@@ -119,7 +119,7 @@ class EmojiPackState(
                         )?.map { it.value }?.toTypedArray() ?: emptyArray(),
                     ),
                 )
-            }.flowOn(Dispatchers.IO)
+            }.flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip51Lists/BookmarkListState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip51Lists/BookmarkListState.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.commons.model.nip51Lists
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.concurrency.Dispatchers_IO
 import com.vitorpamplona.amethyst.commons.model.AddressableNote
 import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.amethyst.commons.model.NoteState
@@ -31,7 +32,6 @@ import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.AddressBookmark
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.BookmarkIdTag
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.EventBookmark
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -80,7 +80,7 @@ class BookmarkListState(
             }.onStart {
                 emit(publicBookmarks(bookmarkList))
             }.debounce(100)
-            .flowOn(Dispatchers.IO)
+            .flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
@@ -95,7 +95,7 @@ class BookmarkListState(
             }.onStart {
                 emit(privateBookmarks(bookmarkList))
             }.debounce(100)
-            .flowOn(Dispatchers.IO)
+            .flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
@@ -109,7 +109,7 @@ class BookmarkListState(
                     .mapNotNull {
                         if (it is EventBookmark) it.eventId else null
                     }.toSet()
-            }.flowOn(Dispatchers.IO)
+            }.flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
@@ -123,7 +123,7 @@ class BookmarkListState(
                     .mapNotNull {
                         if (it is AddressBookmark) it.address else null
                     }.toSet()
-            }.flowOn(Dispatchers.IO)
+            }.flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
@@ -137,7 +137,7 @@ class BookmarkListState(
                     .mapNotNull {
                         if (it is EventBookmark) it.eventId else null
                     }.toSet()
-            }.flowOn(Dispatchers.IO)
+            }.flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
@@ -151,7 +151,7 @@ class BookmarkListState(
                     .mapNotNull {
                         if (it is AddressBookmark) it.address else null
                     }.toSet()
-            }.flowOn(Dispatchers.IO)
+            }.flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
@@ -187,7 +187,7 @@ class BookmarkListState(
             emit(bookmarkList(private, public))
         }.onStart {
             emit(bookmarkList(privateBookmarks.value, publicBookmarks.value))
-        }.flowOn(Dispatchers.IO)
+        }.flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip51Lists/OldBookmarkListState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip51Lists/OldBookmarkListState.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.commons.model.nip51Lists
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.concurrency.Dispatchers_IO
 import com.vitorpamplona.amethyst.commons.model.AddressableNote
 import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.amethyst.commons.model.NoteState
@@ -31,7 +32,6 @@ import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.AddressBookmark
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.BookmarkIdTag
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.EventBookmark
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -80,7 +80,7 @@ class OldBookmarkListState(
             }.onStart {
                 emit(publicBookmarks(bookmarkList))
             }.debounce(100)
-            .flowOn(Dispatchers.IO)
+            .flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
@@ -95,7 +95,7 @@ class OldBookmarkListState(
             }.onStart {
                 emit(privateBookmarks(bookmarkList))
             }.debounce(100)
-            .flowOn(Dispatchers.IO)
+            .flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
@@ -109,7 +109,7 @@ class OldBookmarkListState(
                     .mapNotNull {
                         if (it is EventBookmark) it.eventId else null
                     }.toSet()
-            }.flowOn(Dispatchers.IO)
+            }.flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
@@ -123,7 +123,7 @@ class OldBookmarkListState(
                     .mapNotNull {
                         if (it is AddressBookmark) it.address else null
                     }.toSet()
-            }.flowOn(Dispatchers.IO)
+            }.flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
@@ -137,7 +137,7 @@ class OldBookmarkListState(
                     .mapNotNull {
                         if (it is EventBookmark) it.eventId else null
                     }.toSet()
-            }.flowOn(Dispatchers.IO)
+            }.flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
@@ -151,7 +151,7 @@ class OldBookmarkListState(
                     .mapNotNull {
                         if (it is AddressBookmark) it.address else null
                     }.toSet()
-            }.flowOn(Dispatchers.IO)
+            }.flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
@@ -187,7 +187,7 @@ class OldBookmarkListState(
             emit(bookmarkList(private, public))
         }.onStart {
             emit(bookmarkList(privateBookmarks.value, publicBookmarks.value))
-        }.flowOn(Dispatchers.IO)
+        }.flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip65RelayList/Nip65RelayListState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip65RelayList/Nip65RelayListState.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.commons.model.nip65RelayList
 
+import com.vitorpamplona.amethyst.commons.concurrency.Dispatchers_IO
 import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.amethyst.commons.model.NoteState
 import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
@@ -30,7 +31,6 @@ import com.vitorpamplona.quartz.nip65RelayList.tags.AdvertisedRelayInfo
 import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flowOn
@@ -72,7 +72,7 @@ class Nip65RelayListState(
         getNIP65RelayListFlow()
             .map { normalizeNIP65WriteRelayListWithBackup(it.note) }
             .onStart { emit(normalizeNIP65WriteRelayListWithBackup(nip65ListNote)) }
-            .flowOn(Dispatchers.IO)
+            .flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
@@ -83,7 +83,7 @@ class Nip65RelayListState(
         getNIP65RelayListFlow()
             .map { normalizeNIP65ReadRelayListWithBackup(it.note) }
             .onStart { emit(normalizeNIP65ReadRelayListWithBackup(nip65ListNote)) }
-            .flowOn(Dispatchers.IO)
+            .flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
@@ -94,7 +94,7 @@ class Nip65RelayListState(
         getNIP65RelayListFlow()
             .map { normalizeNIP65WriteRelayListNoDefaults(it.note) }
             .onStart { emit(normalizeNIP65WriteRelayListNoDefaults(nip65ListNote)) }
-            .flowOn(Dispatchers.IO)
+            .flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
@@ -105,7 +105,7 @@ class Nip65RelayListState(
         getNIP65RelayListFlow()
             .map { normalizeNIP65ReadRelayListNoDefaults(it.note) }
             .onStart { emit(normalizeNIP65ReadRelayListNoDefaults(nip65ListNote)) }
-            .flowOn(Dispatchers.IO)
+            .flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
@@ -116,7 +116,7 @@ class Nip65RelayListState(
         getNIP65RelayListFlow()
             .map { normalizeNIP65AllRelayListWithBackupNoDefaults(it.note) }
             .onStart { emit(normalizeNIP65AllRelayListWithBackupNoDefaults(nip65ListNote)) }
-            .flowOn(Dispatchers.IO)
+            .flowOn(Dispatchers_IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
@@ -144,10 +144,10 @@ class Nip65RelayListState(
         settings.backupNIP65RelayList?.let {
             Log.d("AccountRegisterObservers") { "Loading saved nip65 relay list ${it.toJson()}" }
             @OptIn(DelicateCoroutinesApi::class)
-            scope.launch(Dispatchers.IO) { cache.justConsumeMyOwnEvent(it) }
+            scope.launch(Dispatchers_IO) { cache.justConsumeMyOwnEvent(it) }
         }
 
-        scope.launch(Dispatchers.IO) {
+        scope.launch(Dispatchers_IO) {
             Log.d("AccountRegisterObservers", "NIP-65 Relay List Collector Start")
             getNIP65RelayListFlow().collect {
                 Log.d("AccountRegisterObservers") { "Updating NIP-65 List for ${signer.pubKey}" }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/observables/EventListMatchingFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/observables/EventListMatchingFilter.kt
@@ -20,13 +20,12 @@
  */
 package com.vitorpamplona.amethyst.commons.model.observables
 
+import com.vitorpamplona.amethyst.commons.concurrency.concurrentSortedSetOf
 import com.vitorpamplona.amethyst.commons.model.AddressableNote
 import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.quartz.nip01Core.core.AddressableEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
-import java.util.SortedSet
-import java.util.concurrent.ConcurrentSkipListSet
 
 /**
  * Creates a list of events (regular and addressable)
@@ -35,11 +34,11 @@ import java.util.concurrent.ConcurrentSkipListSet
  */
 class EventListMatchingFilter<T : Event>(
     private val filter: Filter,
-    private val atOnce: (filter: Filter) -> SortedSet<Note>,
+    private val atOnce: (filter: Filter) -> Collection<Note>,
     private val update: (List<T>) -> Unit,
 ) : Observable {
     // Keeping this here blocks it from being cleared from memory
-    var currentResults: ConcurrentSkipListSet<Note> = ConcurrentSkipListSet(CreatedAtIdHexComparator)
+    var currentResults: MutableSet<Note> = concurrentSortedSetOf(CreatedAtIdHexComparator)
 
     @Suppress("UNCHECKED_CAST")
     override fun new(
@@ -74,7 +73,7 @@ class EventListMatchingFilter<T : Event>(
 
     @Suppress("UNCHECKED_CAST")
     fun init() {
-        currentResults = ConcurrentSkipListSet(atOnce(filter))
+        currentResults = concurrentSortedSetOf(CreatedAtIdHexComparator).also { it.addAll(atOnce(filter)) }
         update(currentResults.mapNotNull { it.event as? T })
     }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/observables/NoteListMatchingFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/observables/NoteListMatchingFilter.kt
@@ -20,13 +20,12 @@
  */
 package com.vitorpamplona.amethyst.commons.model.observables
 
+import com.vitorpamplona.amethyst.commons.concurrency.concurrentSortedSetOf
 import com.vitorpamplona.amethyst.commons.model.AddressableNote
 import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.quartz.nip01Core.core.AddressableEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
-import java.util.SortedSet
-import java.util.concurrent.ConcurrentSkipListSet
 
 /**
  * Creates a list of notes (regular and addressable)
@@ -36,10 +35,10 @@ import java.util.concurrent.ConcurrentSkipListSet
  */
 class NoteListMatchingFilter(
     private val filter: Filter,
-    private val atOnce: (filter: Filter) -> SortedSet<Note>,
+    private val atOnce: (filter: Filter) -> Collection<Note>,
     private val update: (List<Note>) -> Unit,
 ) : Observable {
-    var currentResults: ConcurrentSkipListSet<Note> = ConcurrentSkipListSet(CreatedAtIdHexComparator)
+    var currentResults: MutableSet<Note> = concurrentSortedSetOf(CreatedAtIdHexComparator)
 
     override fun new(
         event: Event,
@@ -66,7 +65,7 @@ class NoteListMatchingFilter(
     }
 
     fun init() {
-        currentResults = ConcurrentSkipListSet(atOnce(filter))
+        currentResults = concurrentSortedSetOf(CreatedAtIdHexComparator).also { it.addAll(atOnce(filter)) }
         update(currentResults.toList())
     }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/privateChats/Chatroom.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/privateChats/Chatroom.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.commons.model.privateChats
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.concurrency.WeakRef
 import com.vitorpamplona.amethyst.commons.model.Channel.Companion.DefaultFeedOrder
 import com.vitorpamplona.amethyst.commons.model.ListChange
 import com.vitorpamplona.amethyst.commons.model.Note
@@ -33,7 +34,6 @@ import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import java.lang.ref.WeakReference
 
 @Stable
 class Chatroom : NotesGatherer {
@@ -44,13 +44,13 @@ class Chatroom : NotesGatherer {
     var ownerSentMessage: Boolean = false
     var newestMessage: Note? = null
 
-    private var changesFlow: WeakReference<MutableSharedFlow<ListChange<Note>>> = WeakReference(null)
+    private var changesFlow: WeakRef<MutableSharedFlow<ListChange<Note>>>? = null
 
     fun changesFlow(): MutableSharedFlow<ListChange<Note>> {
-        val current = changesFlow.get()
+        val current = changesFlow?.get()
         if (current != null) return current
         val new = MutableSharedFlow<ListChange<Note>>(0, 100, BufferOverflow.DROP_OLDEST)
-        changesFlow = WeakReference(new)
+        changesFlow = WeakRef(new)
         return new
     }
 
@@ -82,7 +82,7 @@ class Chatroom : NotesGatherer {
                 subjectCreatedAt = msg.createdAt()
             }
 
-            changesFlow.get()?.tryEmit(ListChange.Addition(msg))
+            changesFlow?.get()?.tryEmit(ListChange.Addition(msg))
 
             return true
         }
@@ -114,7 +114,7 @@ class Chatroom : NotesGatherer {
                     }
             }
 
-            changesFlow.get()?.tryEmit(ListChange.Deletion(msg))
+            changesFlow?.get()?.tryEmit(ListChange.Deletion(msg))
 
             return true
         }
@@ -138,7 +138,7 @@ class Chatroom : NotesGatherer {
         val toRemove = messages.minus(toKeep)
         messages = toKeep
 
-        changesFlow.get()?.tryEmit(ListChange.SetDeletion<Note>(toRemove))
+        changesFlow?.get()?.tryEmit(ListChange.SetDeletion<Note>(toRemove))
 
         return toRemove
     }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/trustedAssertions/UserCardsCache.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/trustedAssertions/UserCardsCache.kt
@@ -20,13 +20,13 @@
  */
 package com.vitorpamplona.amethyst.commons.model.trustedAssertions
 
+import com.vitorpamplona.amethyst.commons.concurrency.Dispatchers_IO
 import com.vitorpamplona.amethyst.commons.model.AddressableNote
 import com.vitorpamplona.amethyst.commons.model.User
 import com.vitorpamplona.amethyst.commons.model.UserDependencies
 import com.vitorpamplona.amethyst.commons.relays.EOSERelayList
 import com.vitorpamplona.amethyst.commons.util.PlatformNumberFormatter
 import com.vitorpamplona.quartz.nip85TrustedAssertions.users.ContactCardEvent
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combineTransform
 import kotlinx.coroutines.flow.emitAll
@@ -104,7 +104,7 @@ class UserCardsCache : UserDependencies {
             }
         }.map {
             (it?.note?.event as? ContactCardEvent)?.rank()
-        }.flowOn(Dispatchers.IO)
+        }.flowOn(Dispatchers_IO)
 
     private val formatter = PlatformNumberFormatter()
 
@@ -138,5 +138,5 @@ class UserCardsCache : UserDependencies {
             } else {
                 "--"
             }
-        }.flowOn(Dispatchers.IO)
+        }.flowOn(Dispatchers_IO)
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/composeSubscriptionManagers/ComposeSubscriptionManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/composeSubscriptionManagers/ComposeSubscriptionManager.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.commons.relayClient.composeSubscriptionManagers
 
 import androidx.compose.runtime.Stable
-import java.util.concurrent.ConcurrentHashMap
+import com.vitorpamplona.amethyst.commons.concurrency.concurrentMutableMapOf
 
 /**
  *  This allows composables to directly register their queries
@@ -32,7 +32,7 @@ import java.util.concurrent.ConcurrentHashMap
 abstract class ComposeSubscriptionManager<T> :
     ComposeSubscriptionManagerControls,
     Subscribable<T> {
-    private var composeSubscriptions: ConcurrentHashMap<T, T> = ConcurrentHashMap()
+    private var composeSubscriptions: MutableMap<T, T> = concurrentMutableMapOf()
 
     // This is called by main. Keep it really fast.
     override fun subscribe(query: T?) {

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/composeSubscriptionManagers/MutableComposeSubscriptionManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/composeSubscriptionManagers/MutableComposeSubscriptionManager.kt
@@ -21,12 +21,12 @@
 package com.vitorpamplona.amethyst.commons.relayClient.composeSubscriptionManagers
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.concurrency.concurrentMutableMapOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import java.util.concurrent.ConcurrentHashMap
 
 /**
  *  This allows composables to directly register their queries
@@ -41,7 +41,7 @@ import java.util.concurrent.ConcurrentHashMap
 abstract class MutableComposeSubscriptionManager<T : MutableQueryState>(
     val scope: CoroutineScope,
 ) : ComposeSubscriptionManagerControls {
-    private var composeSubscriptions: ConcurrentHashMap<T, Job?> = ConcurrentHashMap()
+    private var composeSubscriptions: MutableMap<T, Job?> = concurrentMutableMapOf()
 
     // This is called by main. Keep it really fast.
     fun subscribe(query: T?) {

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/eoseManagers/BaseEoseManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/eoseManagers/BaseEoseManager.kt
@@ -20,12 +20,12 @@
  */
 package com.vitorpamplona.amethyst.commons.relayClient.eoseManagers
 
+import com.vitorpamplona.amethyst.commons.concurrency.Dispatchers_IO
 import com.vitorpamplona.amethyst.commons.service.BundledUpdate
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.reqs.SubscriptionListener
 import com.vitorpamplona.quartz.nip01Core.relay.client.single.newSubId
 import com.vitorpamplona.quartz.nip01Core.relay.client.subscriptions.SubscriptionController
-import kotlinx.coroutines.Dispatchers
 
 abstract class BaseEoseManager<T>(
     val client: INostrClient,
@@ -43,7 +43,7 @@ abstract class BaseEoseManager<T>(
     fun dismissSubscription(subId: String) = orchestrator.dismissSubscription(subId)
 
     // Refreshes observers in batches.
-    private val bundler = BundledUpdate(sampleTime, Dispatchers.IO)
+    private val bundler = BundledUpdate(sampleTime, Dispatchers_IO)
 
     override fun invalidateFilters(ignoreIfDoing: Boolean) {
         bundler.invalidate(ignoreIfDoing, ::forceInvalidate)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relays/EOSECache.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relays/EOSECache.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.commons.relays
 
+import com.vitorpamplona.amethyst.commons.concurrency.kmpSynchronized
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 
 /**
@@ -40,7 +41,7 @@ open class EOSECache<K : Any>(
         relayUrl: NormalizedRelayUrl,
         time: Long,
     ) {
-        synchronized(lock) {
+        kmpSynchronized(lock) {
             val relayList = cache[key]
             if (relayList == null) {
                 // Evict oldest if at capacity
@@ -57,7 +58,7 @@ open class EOSECache<K : Any>(
     }
 
     fun since(key: K): SincePerRelayMap? =
-        synchronized(lock) {
+        kmpSynchronized(lock) {
             cache[key]?.relayList?.toMutableMap()
         }
 
@@ -68,18 +69,18 @@ open class EOSECache<K : Any>(
     ) = addOrUpdate(key, relayUrl, time)
 
     fun remove(key: K) {
-        synchronized(lock) {
+        kmpSynchronized(lock) {
             cache.remove(key)
         }
     }
 
     fun clear() {
-        synchronized(lock) {
+        kmpSynchronized(lock) {
             cache.clear()
         }
     }
 
-    fun size(): Int = synchronized(lock) { cache.size }
+    fun size(): Int = kmpSynchronized(lock) { cache.size }
 }
 
 /**
@@ -99,7 +100,7 @@ open class EOSETwoLevelCache<K1 : Any, K2 : Any>(
         relayUrl: NormalizedRelayUrl,
         time: Long,
     ) {
-        synchronized(lock) {
+        kmpSynchronized(lock) {
             val innerCache = cache[outerKey]
             if (innerCache == null) {
                 // Evict oldest if at capacity
@@ -119,7 +120,7 @@ open class EOSETwoLevelCache<K1 : Any, K2 : Any>(
         outerKey: K1,
         innerKey: K2,
     ): SincePerRelayMap? =
-        synchronized(lock) {
+        kmpSynchronized(lock) {
             cache[outerKey]?.since(innerKey)
         }
 
@@ -131,13 +132,13 @@ open class EOSETwoLevelCache<K1 : Any, K2 : Any>(
     ) = addOrUpdate(outerKey, innerKey, relayUrl, time)
 
     fun removeOuter(key: K1) {
-        synchronized(lock) {
+        kmpSynchronized(lock) {
             cache.remove(key)
         }
     }
 
     fun clear() {
-        synchronized(lock) {
+        kmpSynchronized(lock) {
             cache.clear()
         }
     }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/service/BundledUpdate.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/service/BundledUpdate.kt
@@ -20,11 +20,11 @@
  */
 package com.vitorpamplona.amethyst.commons.service
 
+import com.vitorpamplona.amethyst.commons.concurrency.Dispatchers_IO
 import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
@@ -37,7 +37,7 @@ import kotlinx.coroutines.withContext
 /** This class is designed to have a waiting time between two calls of invalidate */
 class BundledUpdate(
     val delay: Long,
-    val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    val dispatcher: CoroutineDispatcher = Dispatchers_IO,
 ) {
     // Exists to avoid exceptions stopping the coroutine
     val exceptionHandler =
@@ -62,7 +62,7 @@ class BundledUpdate(
 /** This class is designed to have a waiting time between two calls of invalidate */
 class BasicBundledUpdate(
     val delay: Long,
-    val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    val dispatcher: CoroutineDispatcher = Dispatchers_IO,
     val scope: CoroutineScope,
 ) {
     private val mutex = Mutex()
@@ -105,7 +105,7 @@ class BasicBundledUpdate(
 /** This class is designed to have a waiting time between two calls of invalidate */
 class BundledInsert<T>(
     val delay: Long,
-    val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    val dispatcher: CoroutineDispatcher = Dispatchers_IO,
 ) {
     // Exists to avoid exceptions stopping the coroutine
     val exceptionHandler =
@@ -130,7 +130,7 @@ class BundledInsert<T>(
 /** This class is designed to have a waiting time between two calls of invalidate */
 class BasicBundledInsert<T>(
     val delay: Long,
-    val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    val dispatcher: CoroutineDispatcher = Dispatchers_IO,
     val scope: CoroutineScope,
 ) {
     private val mutex = Mutex()

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/FeedContentState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/FeedContentState.kt
@@ -23,6 +23,7 @@ package com.vitorpamplona.amethyst.commons.ui.feeds
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateOf
+import com.vitorpamplona.amethyst.commons.concurrency.Dispatchers_IO
 import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.commons.service.BasicBundledInsert
@@ -34,7 +35,6 @@ import com.vitorpamplona.quartz.utils.flattenToSet
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
@@ -63,7 +63,7 @@ class FeedContentState(
         if (scrollToTopPending) return
 
         scrollToTopPending = true
-        viewModelScope.launch(Dispatchers.IO) { _scrollToTop.emit(_scrollToTop.value + 1) }
+        viewModelScope.launch(Dispatchers_IO) { _scrollToTop.emit(_scrollToTop.value + 1) }
     }
 
     suspend fun sentToTop() {
@@ -71,7 +71,7 @@ class FeedContentState(
     }
 
     private fun refresh() {
-        viewModelScope.launch(Dispatchers.IO) { refreshSuspended() }
+        viewModelScope.launch(Dispatchers_IO) { refreshSuspended() }
     }
 
     fun visibleNotes(): List<Note> {
@@ -186,11 +186,11 @@ class FeedContentState(
         }
     }
 
-    private val bundler = BasicBundledUpdate(250, Dispatchers.IO, viewModelScope)
-    private val bundlerInsert = BasicBundledInsert<Set<Note>>(250, Dispatchers.IO, viewModelScope)
+    private val bundler = BasicBundledUpdate(250, Dispatchers_IO, viewModelScope)
+    private val bundlerInsert = BasicBundledInsert<Set<Note>>(250, Dispatchers_IO, viewModelScope)
 
     override fun invalidateData(ignoreIfDoing: Boolean) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(Dispatchers_IO) {
             bundler.invalidate(ignoreIfDoing) {
                 // adds the time to perform the refresh into this delay
                 // holding off new updates in case of heavy refresh routines.

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/FeedViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/FeedViewModel.kt
@@ -23,13 +23,13 @@ package com.vitorpamplona.amethyst.commons.viewmodels
 import androidx.compose.runtime.Stable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.vitorpamplona.amethyst.commons.concurrency.Dispatchers_IO
 import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedContentState
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedFilter
 import com.vitorpamplona.amethyst.commons.ui.feeds.InvalidatableContent
 import com.vitorpamplona.quartz.utils.Log
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 @Stable
@@ -50,14 +50,14 @@ abstract class FeedViewModel(
 
     init {
         Log.d("Init") { "Starting new Model: ${this::class.simpleName}" }
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(Dispatchers_IO) {
             cacheProvider.getEventStream().newEventBundles.collect { newNotes ->
                 Log.d("Rendering Metrics") { "Update feeds: ${this@FeedViewModel::class.simpleName} with ${newNotes.size}" }
                 feedState.updateFeedWith(newNotes)
             }
         }
 
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(Dispatchers_IO) {
             cacheProvider.getEventStream().deletedEventBundles.collect { newNotes ->
                 Log.d("Rendering Metrics") { "Delete from feeds: ${this@FeedViewModel::class.simpleName} with ${newNotes.size}" }
                 feedState.deleteFromFeed(newNotes)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/ListChangeFeedViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/ListChangeFeedViewModel.kt
@@ -23,6 +23,7 @@ package com.vitorpamplona.amethyst.commons.viewmodels
 import androidx.compose.runtime.Stable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.vitorpamplona.amethyst.commons.concurrency.Dispatchers_IO
 import com.vitorpamplona.amethyst.commons.model.ListChange
 import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
@@ -30,7 +31,6 @@ import com.vitorpamplona.amethyst.commons.ui.feeds.ChangesFlowFilter
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedContentState
 import com.vitorpamplona.amethyst.commons.ui.feeds.InvalidatableContent
 import com.vitorpamplona.quartz.utils.Log
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 @Stable
@@ -48,10 +48,10 @@ abstract class ListChangeFeedViewModel(
     init {
         Log.d("Init") { "Starting new Model: ${this::class.simpleName}" }
         // Trigger initial load so empty rooms show Empty instead of Loading
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(Dispatchers_IO) {
             feedState.invalidateData(ignoreIfDoing = false)
         }
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(Dispatchers_IO) {
             localFilter.changesFlow().collect {
                 Log.d("Init") { "Collecting changes to: ${this@ListChangeFeedViewModel::class.simpleName}" }
                 when (it) {

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/thread/LevelFeedViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/thread/LevelFeedViewModel.kt
@@ -27,13 +27,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewModelScope
+import com.vitorpamplona.amethyst.commons.concurrency.Dispatchers_IO
 import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.amethyst.commons.model.ThreadLevelCalculator
 import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedFilter
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
 import com.vitorpamplona.amethyst.commons.viewmodels.FeedViewModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -84,7 +84,7 @@ abstract class LevelFeedViewModel(
                         MutableStateFlow(mapOf())
                     },
                 )
-            }.flowOn(Dispatchers.IO)
+            }.flowOn(Dispatchers_IO)
             .stateIn(
                 viewModelScope,
                 SharingStarted.WhileSubscribed(5000),

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/concurrency/ConcurrentCollections.jvmAndroid.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/concurrency/ConcurrentCollections.jvmAndroid.kt
@@ -18,19 +18,18 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.search
+package com.vitorpamplona.amethyst.commons.concurrency
 
-import com.vitorpamplona.amethyst.commons.concurrency.kmpSynchronized
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentSkipListSet
 
-class EventDeduplicator {
-    private val lock = Any()
-    private val seenIds = mutableSetOf<String>()
+actual fun <K, V> concurrentMutableMapOf(): MutableMap<K, V> = ConcurrentHashMap()
 
-    fun tryAdd(id: String): Boolean = kmpSynchronized(lock) { seenIds.add(id) }
+actual fun <T> concurrentMutableSetOf(): MutableSet<T> = ConcurrentHashMap.newKeySet()
 
-    fun contains(id: String): Boolean = kmpSynchronized(lock) { id in seenIds }
+actual fun <T> concurrentSortedSetOf(comparator: Comparator<T>): MutableSet<T> = ConcurrentSkipListSet(comparator)
 
-    fun clear() = kmpSynchronized(lock) { seenIds.clear() }
+actual fun <T> synchronizedMutableSetOf(): MutableSet<T> = Collections.synchronizedSet(LinkedHashSet())
 
-    val size: Int get() = kmpSynchronized(lock) { seenIds.size }
-}
+actual fun <T> synchronizedMutableSetOf(elements: MutableSet<T>): MutableSet<T> = Collections.synchronizedSet(elements)

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/concurrency/DispatchersIO.jvmAndroid.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/concurrency/DispatchersIO.jvmAndroid.kt
@@ -18,19 +18,9 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.search
+package com.vitorpamplona.amethyst.commons.concurrency
 
-import com.vitorpamplona.amethyst.commons.concurrency.kmpSynchronized
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 
-class EventDeduplicator {
-    private val lock = Any()
-    private val seenIds = mutableSetOf<String>()
-
-    fun tryAdd(id: String): Boolean = kmpSynchronized(lock) { seenIds.add(id) }
-
-    fun contains(id: String): Boolean = kmpSynchronized(lock) { id in seenIds }
-
-    fun clear() = kmpSynchronized(lock) { seenIds.clear() }
-
-    val size: Int get() = kmpSynchronized(lock) { seenIds.size }
-}
+actual val Dispatchers_IO: CoroutineDispatcher = Dispatchers.IO

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/concurrency/Synchronized.jvmAndroid.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/concurrency/Synchronized.jvmAndroid.kt
@@ -18,19 +18,10 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.search
+package com.vitorpamplona.amethyst.commons.concurrency
 
-import com.vitorpamplona.amethyst.commons.concurrency.kmpSynchronized
-
-class EventDeduplicator {
-    private val lock = Any()
-    private val seenIds = mutableSetOf<String>()
-
-    fun tryAdd(id: String): Boolean = kmpSynchronized(lock) { seenIds.add(id) }
-
-    fun contains(id: String): Boolean = kmpSynchronized(lock) { id in seenIds }
-
-    fun clear() = kmpSynchronized(lock) { seenIds.clear() }
-
-    val size: Int get() = kmpSynchronized(lock) { seenIds.size }
-}
+@Suppress("NOTHING_TO_INLINE")
+actual inline fun <T> kmpSynchronized(
+    lock: Any,
+    block: () -> T,
+): T = kotlin.synchronized(lock, block)

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/concurrency/WeakRef.jvmAndroid.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/concurrency/WeakRef.jvmAndroid.kt
@@ -18,19 +18,14 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.search
+package com.vitorpamplona.amethyst.commons.concurrency
 
-import com.vitorpamplona.amethyst.commons.concurrency.kmpSynchronized
+import java.lang.ref.WeakReference
 
-class EventDeduplicator {
-    private val lock = Any()
-    private val seenIds = mutableSetOf<String>()
+actual class WeakRef<T : Any> actual constructor(
+    value: T,
+) {
+    private val ref = WeakReference(value)
 
-    fun tryAdd(id: String): Boolean = kmpSynchronized(lock) { seenIds.add(id) }
-
-    fun contains(id: String): Boolean = kmpSynchronized(lock) { id in seenIds }
-
-    fun clear() = kmpSynchronized(lock) { seenIds.clear() }
-
-    val size: Int get() = kmpSynchronized(lock) { seenIds.size }
+    actual fun get(): T? = ref.get()
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ javaKeyring = "1.0.4"
 junit = "4.13.2"
 kchesslib = "1.0.5"
 kotlin = "2.3.20"
+kotlinxAtomicfu = "0.27.0"
 kotlinxCollectionsImmutable = "0.4.0"
 kotlinxCoroutinesCore = "1.10.2"
 kotlinxSerialization = "1.10.0"
@@ -146,6 +147,7 @@ jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackso
 java-keyring = { group = "com.github.javakeyring", name = "java-keyring", version.ref = "javaKeyring" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kchesslib = { module = "io.github.cvb941:kchesslib", version.ref = "kchesslib" }
+kotlinx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "kotlinxAtomicfu" }
 kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesCore" }
 kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinxCoroutinesCore" }


### PR DESCRIPTION
## KMP Concurrency Primitive Wrappers

Wraps all JVM-specific concurrency primitives in `commons/src/commonMain` behind `expect`/`actual` declarations, preparing commons for future iOS/native targets without downgrading any thread safety.

**Zero behavior changes.** All JVM actuals delegate to the same classes that were used before.

### New wrappers in `com.vitorpamplona.amethyst.commons.concurrency`

| Wrapper | JVM Actual | Usage |
|---------|-----------|-------|
| `concurrentMutableMapOf<K,V>()` | `ConcurrentHashMap()` | 5 files |
| `concurrentMutableSetOf<T>()` | `ConcurrentHashMap.newKeySet()` | 2 files |
| `concurrentSortedSetOf(comparator)` | `ConcurrentSkipListSet(comparator)` | 2 files |
| `synchronizedMutableSetOf()` | `Collections.synchronizedSet(LinkedHashSet())` | 1 file |
| `WeakRef<T>(value)` / `.get()` | `java.lang.ref.WeakReference` | 4 files |
| `Dispatchers_IO` | `Dispatchers.IO` | 14 files (51 usages) |
| `kmpSynchronized(lock) { }` | `kotlin.synchronized()` | 6 files (31 usages) |
| `kotlinx.atomicfu.atomic(0L)` | replaces `AtomicLong` directly | 1 file |

### What this enables (future PRs)

Once native `actual` implementations are added (e.g., `NSRecursiveLock` for synchronized, `kotlin.native.ref.WeakReference` for WeakRef, atomicfu for atomics), the commons module can compile for iOS targets without any concurrency regressions.

### Changes

- 40 files changed, +437/-160 lines
- All expect declarations in `commons/src/commonMain/.../concurrency/`
- All JVM actuals in `commons/src/jvmAndroid/.../concurrency/`
- Added `kotlinx-atomicfu:0.27.0` to version catalog
- `spotlessApply` ✅
- `assemblePlayDebug` ✅
- All tests pass ✅