### PR TITLE
fix: wrap suspend calls in runTest in MarmotSubscriptionManagerTest

### DIFF
--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/marmot/MarmotSubscriptionManagerTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/marmot/MarmotSubscriptionManagerTest.kt
@@ -105,15 +105,16 @@ class MarmotSubscriptionManagerTest {
         }
 
     @Test
-    fun testGiftWrapFilter() {
-        val manager = MarmotSubscriptionManager(userPubKey)
-        val filter = manager.giftWrapFilter()
+    fun testGiftWrapFilter() =
+        runTest {
+            val manager = MarmotSubscriptionManager(userPubKey)
+            val filter = manager.giftWrapFilter()
 
-        assertEquals(listOf(GiftWrapEvent.KIND), filter.kinds)
-        assertNotNull(filter.tags)
-        assertEquals(listOf(userPubKey), filter.tags["p"])
-        assertNull(filter.since)
-    }
+            assertEquals(listOf(GiftWrapEvent.KIND), filter.kinds)
+            assertNotNull(filter.tags)
+            assertEquals(listOf(userPubKey), filter.tags["p"])
+            assertNull(filter.since)
+        }
 
     @Test
     fun testGiftWrapFilterWithSince() =
@@ -154,14 +155,15 @@ class MarmotSubscriptionManagerTest {
         }
 
     @Test
-    fun testBuildFiltersWithNoGroupsHasGiftWrapAndKeyPackage() {
-        val manager = MarmotSubscriptionManager(userPubKey)
-        val allFilters = manager.buildFilters()
+    fun testBuildFiltersWithNoGroupsHasGiftWrapAndKeyPackage() =
+        runTest {
+            val manager = MarmotSubscriptionManager(userPubKey)
+            val allFilters = manager.buildFilters()
 
-        // Gift wrap filter + own key package filter
-        assertEquals(2, allFilters.size)
-        assertEquals(listOf(GiftWrapEvent.KIND), allFilters[0].kinds)
-    }
+            // Gift wrap filter + own key package filter
+            assertEquals(2, allFilters.size)
+            assertEquals(listOf(GiftWrapEvent.KIND), allFilters[0].kinds)
+        }
 
     @Test
     fun testKeyPackageFilter() {


### PR DESCRIPTION
## Summary

`testGiftWrapFilter()` and `testBuildFiltersWithNoGroupsHasGiftWrapAndKeyPackage()` call suspend functions (`giftWrapFilter()`, `buildFilters()`) without a coroutine scope.

This compiles on JVM but fails on Kotlin/Native iOS targets:

```
e: Suspend function 'suspend fun giftWrapFilter(): Filter' can only be
   called from a coroutine or another suspend function.
```

### Fix

Wrap both test bodies in `runTest {}` (already imported in the file) to fix the compile error on all KMP targets.

### Verification

- `spotlessCheck` ✅
- `:quartz:compileTestKotlinIosSimulatorArm64` ✅ (previously failed)
- `:quartz:jvmTest` ✅ (no regression)