### PR TITLE
feat: move Icons.kt + ParticipantListBuilder to commons

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -426,7 +426,7 @@ object LocalCache : ILocalCache, ICacheProvider {
 
     fun getNoteIfExists(key: ETag): Note? = notes.get(key.eventId)
 
-    fun getPublicChatChannelIfExists(key: String): PublicChatChannel? = publicChatChannels.get(key)
+    override fun getPublicChatChannelIfExists(key: String): PublicChatChannel? = publicChatChannels.get(key)
 
     fun getEphemeralChatChannelIfExists(key: RoomId): EphemeralChatChannel? = ephemeralChannels.get(key)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/ParticipantListBuilder.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/ParticipantListBuilder.kt
@@ -20,97 +20,11 @@
  */
 package com.vitorpamplona.amethyst.model
 
-import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.amethyst.commons.model.participants.ParticipantListBuilder as CommonsParticipantListBuilder
 
-class ParticipantListBuilder {
-    private fun addFollowsThatDirectlyParticipateOnToSet(
-        baseNote: Note,
-        followingSet: Set<HexKey>?,
-        set: MutableSet<User>,
-    ) {
-        baseNote.author?.let { author ->
-            if (author !in set && (followingSet == null || author.pubkeyHex in followingSet)) {
-                set.add(author)
-            }
-        }
-
-        // Breaks these searchers down to avoid the memory use of creating multiple lists
-        baseNote.replies.forEach { reply ->
-            reply.author?.let { author ->
-                if (author !in set && (followingSet == null || author.pubkeyHex in followingSet)) {
-                    set.add(author)
-                }
-            }
-        }
-
-        baseNote.boosts.forEach { boost ->
-            boost.author?.let { author ->
-                if (author !in set && (followingSet == null || author.pubkeyHex in followingSet)) {
-                    set.add(author)
-                }
-            }
-        }
-
-        baseNote.zaps.forEach { zapPair ->
-            zapPair.key.author?.let { author ->
-                if (author !in set && (followingSet == null || author.pubkeyHex in followingSet)) {
-                    set.add(author)
-                }
-            }
-        }
-
-        baseNote.reactions.forEach { reactionSet ->
-            reactionSet.value.forEach { reaction ->
-                reaction.author?.let { author ->
-                    if (author !in set && (followingSet == null || author.pubkeyHex in followingSet)) {
-                        set.add(author)
-                    }
-                }
-            }
-        }
-    }
-
-    fun followsThatParticipateOnDirect(
-        baseNote: Note?,
-        followingSet: Set<HexKey>?,
-    ): Set<User> {
-        if (baseNote == null) return mutableSetOf()
-
-        val set = mutableSetOf<User>()
-        addFollowsThatDirectlyParticipateOnToSet(baseNote, followingSet, set)
-        return set
-    }
-
-    fun followsThatParticipateOn(
-        baseNote: Note?,
-        followingSet: Set<HexKey>?,
-    ): Set<User> {
-        if (baseNote == null) return mutableSetOf()
-
-        val mySet = mutableSetOf<User>()
-        addFollowsThatDirectlyParticipateOnToSet(baseNote, followingSet, mySet)
-
-        baseNote.replies.forEach { addFollowsThatDirectlyParticipateOnToSet(it, followingSet, mySet) }
-
-        baseNote.boosts.forEach {
-            it.replyTo?.forEach { addFollowsThatDirectlyParticipateOnToSet(it, followingSet, mySet) }
-        }
-
-        LocalCache.getPublicChatChannelIfExists(baseNote.idHex)?.notes?.forEach { key, it ->
-            addFollowsThatDirectlyParticipateOnToSet(it, followingSet, mySet)
-        }
-
-        return mySet
-    }
-
-    fun countFollowsThatParticipateOn(
-        baseNote: Note?,
-        followingSet: Set<HexKey>?,
-    ): Int {
-        if (baseNote == null) return 0
-
-        val list = followsThatParticipateOn(baseNote, followingSet)
-
-        return list.size
-    }
-}
+/**
+ * Android-side convenience wrapper that creates a ParticipantListBuilder
+ * backed by LocalCache's ICacheProvider.
+ */
+@Suppress("ktlint:standard:function-naming")
+fun ParticipantListBuilder(): CommonsParticipantListBuilder = CommonsParticipantListBuilder(LocalCache)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/Icons.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/Icons.kt
@@ -20,206 +20,116 @@
  */
 package com.vitorpamplona.amethyst.ui.note
 
+// Re-export all commons icons so existing callers don't need to change their imports.
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.OpenInNew
-import androidx.compose.material.icons.automirrored.outlined.OpenInNew
 import androidx.compose.material.icons.filled.Bolt
-import androidx.compose.material.icons.filled.Cancel
-import androidx.compose.material.icons.filled.Clear
-import androidx.compose.material.icons.filled.ContentCopy
-import androidx.compose.material.icons.filled.DownloadForOffline
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
-import androidx.compose.material.icons.filled.Link
-import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material.icons.filled.PushPin
-import androidx.compose.material.icons.filled.Share
-import androidx.compose.material.icons.outlined.AddReaction
-import androidx.compose.material.icons.outlined.Close
-import androidx.compose.material.icons.outlined.Mic
-import androidx.compose.material.icons.outlined.PlayCircle
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
-import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.commons.hashtags.Amethyst
-import com.vitorpamplona.amethyst.commons.hashtags.Cashu
-import com.vitorpamplona.amethyst.commons.hashtags.CustomHashTagIcons
-import com.vitorpamplona.amethyst.commons.icons.Following
-import com.vitorpamplona.amethyst.commons.icons.Like
-import com.vitorpamplona.amethyst.commons.icons.Liked
-import com.vitorpamplona.amethyst.commons.icons.Reply
-import com.vitorpamplona.amethyst.commons.icons.Repost
-import com.vitorpamplona.amethyst.commons.icons.Reposted
-import com.vitorpamplona.amethyst.commons.icons.Search
 import com.vitorpamplona.amethyst.commons.icons.Zap
 import com.vitorpamplona.amethyst.ui.stringRes
-import com.vitorpamplona.amethyst.ui.theme.BitcoinOrange
-import com.vitorpamplona.amethyst.ui.theme.Size19Modifier
 import com.vitorpamplona.amethyst.ui.theme.Size20Modifier
-import com.vitorpamplona.amethyst.ui.theme.Size30Modifier
 import com.vitorpamplona.amethyst.ui.theme.grayText
-import com.vitorpamplona.amethyst.ui.theme.placeholderText
 import com.vitorpamplona.amethyst.ui.theme.subtleButton
+import com.vitorpamplona.amethyst.commons.ui.note.AmethystIcon as CommonsAmethystIcon
+import com.vitorpamplona.amethyst.commons.ui.note.ArrowBackIcon as CommonsArrowBackIcon
+import com.vitorpamplona.amethyst.commons.ui.note.CancelIcon as CommonsCancelIcon
+import com.vitorpamplona.amethyst.commons.ui.note.CashuIcon as CommonsCashuIcon
+import com.vitorpamplona.amethyst.commons.ui.note.ChangeReactionIcon as CommonsChangeReactionIcon
+import com.vitorpamplona.amethyst.commons.ui.note.ClearTextIcon as CommonsClearTextIcon
+import com.vitorpamplona.amethyst.commons.ui.note.CloseIcon as CommonsCloseIcon
+import com.vitorpamplona.amethyst.commons.ui.note.CommentIcon as CommonsCommentIcon
+import com.vitorpamplona.amethyst.commons.ui.note.CopyIcon as CommonsCopyIcon
+import com.vitorpamplona.amethyst.commons.ui.note.DownloadForOfflineIcon as CommonsDownloadForOfflineIcon
+import com.vitorpamplona.amethyst.commons.ui.note.EnablePiP as CommonsEnablePiP
+import com.vitorpamplona.amethyst.commons.ui.note.FollowingIcon as CommonsFollowingIcon
+import com.vitorpamplona.amethyst.commons.ui.note.LightningAddressIcon as CommonsLightningAddressIcon
+import com.vitorpamplona.amethyst.commons.ui.note.LikeIcon as CommonsLikeIcon
+import com.vitorpamplona.amethyst.commons.ui.note.LikedIcon as CommonsLikedIcon
+import com.vitorpamplona.amethyst.commons.ui.note.LinkIcon as CommonsLinkIcon
+import com.vitorpamplona.amethyst.commons.ui.note.OpenInNewIcon as CommonsOpenInNewIcon
+import com.vitorpamplona.amethyst.commons.ui.note.PinIcon as CommonsPinIcon
+import com.vitorpamplona.amethyst.commons.ui.note.PlayIcon as CommonsPlayIcon
+import com.vitorpamplona.amethyst.commons.ui.note.RepostIcon as CommonsRepostIcon
+import com.vitorpamplona.amethyst.commons.ui.note.RepostedIcon as CommonsRepostedIcon
+import com.vitorpamplona.amethyst.commons.ui.note.SearchIcon as CommonsSearchIcon
+import com.vitorpamplona.amethyst.commons.ui.note.ShareIcon as CommonsShareIcon
+import com.vitorpamplona.amethyst.commons.ui.note.VerticalDotsIcon as CommonsVerticalDotsIcon
+import com.vitorpamplona.amethyst.commons.ui.note.VoiceReplyIcon as CommonsVoiceReplyIcon
+import com.vitorpamplona.amethyst.commons.ui.note.ZappedIcon as CommonsZappedIcon
+
+// ---- Delegated composables (thin wrappers for source compatibility) ----
 
 @Composable
-fun AmethystIcon(iconSize: Dp) {
-    Icon(
-        imageVector = CustomHashTagIcons.Amethyst,
-        contentDescription = stringRes(id = R.string.app_logo),
-        modifier = Modifier.size(iconSize),
-        tint = Color.Unspecified,
-    )
-}
+fun AmethystIcon(iconSize: Dp) = CommonsAmethystIcon(iconSize)
 
 @Composable
-fun FollowingIcon(modifier: Modifier) {
-    Icon(
-        imageVector = Following,
-        contentDescription = stringRes(id = R.string.following),
-        modifier = modifier,
-        tint = Color.Unspecified,
-    )
-}
+fun FollowingIcon(modifier: Modifier) = CommonsFollowingIcon(modifier)
 
 @Composable
-fun ArrowBackIcon(tint: Color = MaterialTheme.colorScheme.grayText) {
-    Icon(
-        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-        contentDescription = stringRes(R.string.back),
-        tint = tint,
-    )
-}
+fun ArrowBackIcon(tint: Color = MaterialTheme.colorScheme.grayText) = CommonsArrowBackIcon(tint)
 
 @Composable
 fun DownloadForOfflineIcon(
     iconSize: Dp,
     tint: Color = MaterialTheme.colorScheme.primary,
-) {
-    Icon(
-        imageVector = Icons.Default.DownloadForOffline,
-        contentDescription = stringRes(id = R.string.accessibility_download_for_offline),
-        modifier = remember(iconSize) { Modifier.size(iconSize) },
-        tint = tint,
-    )
-}
+) = CommonsDownloadForOfflineIcon(iconSize, tint)
 
 @Composable
 fun LikedIcon(
     modifier: Modifier,
     tint: Color = Color.Unspecified,
-) {
-    Icon(
-        imageVector = Liked,
-        contentDescription = stringRes(id = R.string.like_description),
-        modifier = modifier,
-        tint = tint,
-    )
-}
+) = CommonsLikedIcon(modifier, tint)
 
 @Composable
 fun ChangeReactionIcon(
     modifier: Modifier,
     tint: Color = Color.Unspecified,
-) {
-    Icon(
-        imageVector = Icons.Outlined.AddReaction,
-        contentDescription = stringRes(id = R.string.change_reaction),
-        modifier = modifier,
-        tint = tint,
-    )
-}
+) = CommonsChangeReactionIcon(modifier, tint)
 
 @Composable
 fun LikeIcon(
     iconSizeModifier: Modifier,
     grayTint: Color,
-) {
-    Icon(
-        imageVector = Like,
-        contentDescription = stringRes(id = R.string.like_description),
-        modifier = iconSizeModifier,
-        tint = grayTint,
-    )
-}
+) = CommonsLikeIcon(iconSizeModifier, grayTint)
 
 @Composable
 fun RepostIcon(
     modifier: Modifier,
     tint: Color = Color.Unspecified,
-) {
-    Icon(
-        imageVector = Repost,
-        contentDescription = stringRes(id = R.string.boost_or_quote_description),
-        modifier = modifier,
-        tint = tint,
-    )
-}
+) = CommonsRepostIcon(modifier, tint)
 
 @Composable
 fun RepostedIcon(
     modifier: Modifier,
     tint: Color = Color.Unspecified,
-) {
-    Icon(
-        imageVector = Reposted,
-        contentDescription = stringRes(id = R.string.boost_or_quote_description),
-        modifier = modifier,
-        tint = tint,
-    )
-}
+) = CommonsRepostedIcon(modifier, tint)
 
 @Composable
 fun LightningAddressIcon(
     modifier: Modifier,
     tint: Color = Color.Unspecified,
-) {
-    Icon(
-        imageVector = Icons.Default.Bolt,
-        contentDescription = stringRes(R.string.lightning_address),
-        tint = tint,
-        modifier = modifier,
-    )
-}
+) = CommonsLightningAddressIcon(modifier, tint)
 
 @Composable
-fun ZappedIcon(iconSize: Dp) {
-    ZappedIcon(modifier = remember(iconSize) { Modifier.size(iconSize) })
-}
+fun ZappedIcon(iconSize: Dp) = CommonsZappedIcon(iconSize)
 
 @Composable
-fun ZappedIcon(modifier: Modifier) {
-    ZapIcon(modifier = modifier, BitcoinOrange)
-}
-
-@Preview
-@Composable
-fun ReactionRowIconPreview() {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        CommentIcon(Size20Modifier, Color.Unspecified)
-        RepostedIcon(Size20Modifier)
-        LikeIcon(Size20Modifier, Color.Unspecified)
-        OutlinedZapIcon(Size20Modifier)
-        ZapIcon(Size20Modifier)
-        ZappedIcon(Size20Modifier)
-        ShareIcon(Size20Modifier, Color.Unspecified)
-    }
-}
+fun ZappedIcon(modifier: Modifier) = CommonsZappedIcon(modifier)
 
 @Composable
 fun ZapIcon(
     modifier: Modifier,
     tint: Color = Color.Unspecified,
-    contentDescriptor: Int = R.string.zap_description,
+    contentDescriptor: Int = com.vitorpamplona.amethyst.R.string.zap_description,
 ) {
     Icon(
         imageVector = Icons.Default.Bolt,
@@ -233,7 +143,7 @@ fun ZapIcon(
 fun OutlinedZapIcon(
     modifier: Modifier,
     tint: Color = Color.Unspecified,
-    contentDescriptor: Int = R.string.zap_description,
+    contentDescriptor: Int = com.vitorpamplona.amethyst.R.string.zap_description,
 ) {
     Icon(
         imageVector = Zap,
@@ -247,42 +157,16 @@ fun OutlinedZapIcon(
 fun ShareIcon(
     modifier: Modifier,
     tint: Color = Color.Unspecified,
-) {
-    Icon(
-        imageVector = Icons.Default.Share,
-        modifier = modifier,
-        contentDescription = stringRes(R.string.share_or_save),
-        tint = tint,
-    )
-}
+) = CommonsShareIcon(modifier, tint)
 
 @Composable
-fun CashuIcon(modifier: Modifier) {
-    Icon(
-        imageVector = CustomHashTagIcons.Cashu,
-        stringRes(R.string.cashu),
-        tint = Color.Unspecified,
-        modifier = modifier,
-    )
-}
+fun CashuIcon(modifier: Modifier) = CommonsCashuIcon(modifier)
 
 @Composable
-fun CopyIcon(modifier: Modifier) {
-    Icon(
-        imageVector = Icons.Default.ContentCopy,
-        stringRes(id = R.string.copy_to_clipboard),
-        modifier = modifier,
-    )
-}
+fun CopyIcon(modifier: Modifier) = CommonsCopyIcon(modifier)
 
 @Composable
-fun OpenInNewIcon(modifier: Modifier) {
-    Icon(
-        imageVector = Icons.AutoMirrored.Filled.OpenInNew,
-        stringRes(id = R.string.copy_to_clipboard),
-        modifier = modifier,
-    )
-}
+fun OpenInNewIcon(modifier: Modifier) = CommonsOpenInNewIcon(modifier)
 
 @Composable
 fun ExpandLessIcon(
@@ -314,126 +198,66 @@ fun ExpandMoreIcon(
 fun VoiceReplyIcon(
     iconSizeModifier: Modifier,
     tint: Color,
-) {
-    Icon(
-        imageVector = Icons.Outlined.Mic,
-        contentDescription = stringRes(id = R.string.record_a_message),
-        tint = tint,
-        modifier = iconSizeModifier,
-    )
-}
+) = CommonsVoiceReplyIcon(iconSizeModifier, tint)
 
 @Composable
 fun CommentIcon(
     iconSizeModifier: Modifier,
     tint: Color,
-) {
-    Icon(
-        imageVector = Reply,
-        contentDescription = stringRes(id = R.string.reply_description),
-        modifier = iconSizeModifier,
-        tint = tint,
-    )
-}
+) = CommonsCommentIcon(iconSizeModifier, tint)
 
 @Composable
-fun CancelIcon() {
-    Icon(
-        imageVector = Icons.Default.Cancel,
-        contentDescription = stringRes(id = R.string.cancel),
-        modifier = Size30Modifier,
-        tint = MaterialTheme.colorScheme.placeholderText,
-    )
-}
+fun CancelIcon() = CommonsCancelIcon()
 
 @Composable
-fun CloseIcon() {
-    Icon(
-        imageVector = Icons.Outlined.Close,
-        contentDescription = stringRes(id = R.string.cancel),
-        modifier = Size20Modifier,
-    )
-}
+fun CloseIcon() = CommonsCloseIcon()
 
 @Composable
 fun SearchIcon(
     modifier: Modifier,
     tint: Color = Color.Unspecified,
-) {
-    Icon(
-        imageVector = Search,
-        contentDescription = stringRes(id = R.string.search_button),
-        modifier = modifier,
-        tint = tint,
-    )
-}
+) = CommonsSearchIcon(modifier, tint)
 
 @Composable
 fun PlayIcon(
     modifier: Modifier,
     tint: Color,
-) {
-    Icon(
-        imageVector = Icons.Outlined.PlayCircle,
-        contentDescription = stringRes(id = R.string.accessibility_play_username),
-        modifier = modifier,
-        tint = tint,
-    )
-}
+) = CommonsPlayIcon(modifier, tint)
 
 @Composable
 fun PinIcon(
     modifier: Modifier,
     tint: Color,
-) {
-    Icon(
-        imageVector = Icons.Default.PushPin,
-        contentDescription = stringRes(id = R.string.accessibility_pushpin),
-        modifier = modifier,
-        tint = tint,
-    )
-}
+) = CommonsPinIcon(modifier, tint)
 
 @Composable
 fun EnablePiP(
     modifier: Modifier,
     tint: Color,
-) {
-    Icon(
-        imageVector = Icons.AutoMirrored.Outlined.OpenInNew,
-        contentDescription = stringRes(id = R.string.enter_picture_in_picture),
-        modifier = modifier,
-        tint = tint,
-    )
-}
+) = CommonsEnablePiP(modifier, tint)
 
 @Composable
-fun ClearTextIcon() {
-    Icon(
-        imageVector = Icons.Default.Clear,
-        contentDescription = stringRes(R.string.clear),
-    )
-}
+fun ClearTextIcon() = CommonsClearTextIcon()
 
 @Composable
 fun LinkIcon(
     modifier: Modifier,
     tint: Color,
-) {
-    Icon(
-        imageVector = Icons.Default.Link,
-        contentDescription = stringRes(R.string.website),
-        modifier = modifier,
-        tint = tint,
-    )
-}
+) = CommonsLinkIcon(modifier, tint)
 
 @Composable
-fun VerticalDotsIcon() {
-    Icon(
-        imageVector = Icons.Default.MoreVert,
-        contentDescription = stringRes(id = R.string.note_options),
-        modifier = Size19Modifier,
-        tint = MaterialTheme.colorScheme.placeholderText,
-    )
+fun VerticalDotsIcon() = CommonsVerticalDotsIcon()
+
+@Preview
+@Composable
+fun ReactionRowIconPreview() {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        CommentIcon(Size20Modifier, Color.Unspecified)
+        RepostedIcon(Size20Modifier)
+        LikeIcon(Size20Modifier, Color.Unspecified)
+        OutlinedZapIcon(Size20Modifier)
+        ZapIcon(Size20Modifier)
+        ZappedIcon(Size20Modifier)
+        ShareIcon(Size20Modifier, Color.Unspecified)
+    }
 }

--- a/commons/src/commonMain/composeResources/values/strings.xml
+++ b/commons/src/commonMain/composeResources/values/strings.xml
@@ -54,4 +54,28 @@
     <!-- Accessibility -->
     <string name="accessibility_user_avatar">User avatar</string>
     <string name="accessibility_navigate">Navigate</string>
+    <string name="accessibility_download_for_offline">Download</string>
+    <string name="accessibility_play_username">Play username as audio</string>
+    <string name="accessibility_pushpin">Pushpin</string>
+
+    <!-- Icons -->
+    <string name="app_logo">App Logo</string>
+    <string name="following"> Following</string>
+    <string name="back">Back</string>
+    <string name="like_description">Like</string>
+    <string name="change_reaction">Change Quick Reactions</string>
+    <string name="boost_or_quote_description">Boost Or Quote</string>
+    <string name="lightning_address">Lightning Address</string>
+    <string name="zap_description">Zap</string>
+    <string name="share_or_save">Share or Save</string>
+    <string name="cashu">Cashu Token</string>
+    <string name="copy_to_clipboard">Copy to clipboard</string>
+    <string name="record_a_message">Record a message</string>
+    <string name="reply_description">Reply</string>
+    <string name="cancel">Cancel</string>
+    <string name="search_button">Search local and remote records</string>
+    <string name="enter_picture_in_picture">Start video in a popup</string>
+    <string name="clear">Clear</string>
+    <string name="website">Website</string>
+    <string name="note_options">Note options</string>
 </resources>

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/cache/ICacheProvider.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/cache/ICacheProvider.kt
@@ -24,6 +24,7 @@ import com.vitorpamplona.amethyst.commons.model.AddressableNote
 import com.vitorpamplona.amethyst.commons.model.Channel
 import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatChannel
 import com.vitorpamplona.quartz.nip01Core.core.Address
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -135,4 +136,13 @@ interface ICacheProvider {
     fun getOrCreateUser(pubkey: HexKey): User?
 
     fun justConsumeMyOwnEvent(event: Event): Boolean
+
+    /**
+     * Gets a PublicChatChannel by key if it exists.
+     * Used by ParticipantListBuilder to find channel participants.
+     *
+     * @param key The channel's key (note id hex)
+     * @return The PublicChatChannel if found, null otherwise
+     */
+    fun getPublicChatChannelIfExists(key: String): PublicChatChannel? = null
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/participants/ParticipantListBuilder.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/participants/ParticipantListBuilder.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model.participants
+
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+
+class ParticipantListBuilder(
+    private val cacheProvider: ICacheProvider,
+) {
+    private fun addFollowsThatDirectlyParticipateOnToSet(
+        baseNote: Note,
+        followingSet: Set<HexKey>?,
+        set: MutableSet<User>,
+    ) {
+        baseNote.author?.let { author ->
+            if (author !in set && (followingSet == null || author.pubkeyHex in followingSet)) {
+                set.add(author)
+            }
+        }
+
+        // Breaks these searchers down to avoid the memory use of creating multiple lists
+        baseNote.replies.forEach { reply ->
+            reply.author?.let { author ->
+                if (author !in set && (followingSet == null || author.pubkeyHex in followingSet)) {
+                    set.add(author)
+                }
+            }
+        }
+
+        baseNote.boosts.forEach { boost ->
+            boost.author?.let { author ->
+                if (author !in set && (followingSet == null || author.pubkeyHex in followingSet)) {
+                    set.add(author)
+                }
+            }
+        }
+
+        baseNote.zaps.forEach { zapPair ->
+            zapPair.key.author?.let { author ->
+                if (author !in set && (followingSet == null || author.pubkeyHex in followingSet)) {
+                    set.add(author)
+                }
+            }
+        }
+
+        baseNote.reactions.forEach { reactionSet ->
+            reactionSet.value.forEach { reaction ->
+                reaction.author?.let { author ->
+                    if (author !in set && (followingSet == null || author.pubkeyHex in followingSet)) {
+                        set.add(author)
+                    }
+                }
+            }
+        }
+    }
+
+    fun followsThatParticipateOnDirect(
+        baseNote: Note?,
+        followingSet: Set<HexKey>?,
+    ): Set<User> {
+        if (baseNote == null) return mutableSetOf()
+
+        val set = mutableSetOf<User>()
+        addFollowsThatDirectlyParticipateOnToSet(baseNote, followingSet, set)
+        return set
+    }
+
+    fun followsThatParticipateOn(
+        baseNote: Note?,
+        followingSet: Set<HexKey>?,
+    ): Set<User> {
+        if (baseNote == null) return mutableSetOf()
+
+        val mySet = mutableSetOf<User>()
+        addFollowsThatDirectlyParticipateOnToSet(baseNote, followingSet, mySet)
+
+        baseNote.replies.forEach { addFollowsThatDirectlyParticipateOnToSet(it, followingSet, mySet) }
+
+        baseNote.boosts.forEach {
+            it.replyTo?.forEach { addFollowsThatDirectlyParticipateOnToSet(it, followingSet, mySet) }
+        }
+
+        cacheProvider.getPublicChatChannelIfExists(baseNote.idHex)?.notes?.forEach { key, it ->
+            addFollowsThatDirectlyParticipateOnToSet(it, followingSet, mySet)
+        }
+
+        return mySet
+    }
+
+    fun countFollowsThatParticipateOn(
+        baseNote: Note?,
+        followingSet: Set<HexKey>?,
+    ): Int {
+        if (baseNote == null) return 0
+
+        val list = followsThatParticipateOn(baseNote, followingSet)
+
+        return list.size
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/Icons.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/Icons.kt
@@ -1,0 +1,452 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.note
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
+import androidx.compose.material.icons.automirrored.outlined.OpenInNew
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.DownloadForOffline
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.PushPin
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.outlined.AddReaction
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.Mic
+import androidx.compose.material.icons.outlined.PlayCircle
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.vitorpamplona.amethyst.commons.hashtags.Amethyst
+import com.vitorpamplona.amethyst.commons.hashtags.Cashu
+import com.vitorpamplona.amethyst.commons.hashtags.CustomHashTagIcons
+import com.vitorpamplona.amethyst.commons.icons.Following
+import com.vitorpamplona.amethyst.commons.icons.Like
+import com.vitorpamplona.amethyst.commons.icons.Liked
+import com.vitorpamplona.amethyst.commons.icons.Reply
+import com.vitorpamplona.amethyst.commons.icons.Repost
+import com.vitorpamplona.amethyst.commons.icons.Reposted
+import com.vitorpamplona.amethyst.commons.icons.Search
+import com.vitorpamplona.amethyst.commons.icons.Zap
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.accessibility_download_for_offline
+import com.vitorpamplona.amethyst.commons.resources.accessibility_play_username
+import com.vitorpamplona.amethyst.commons.resources.accessibility_pushpin
+import com.vitorpamplona.amethyst.commons.resources.app_logo
+import com.vitorpamplona.amethyst.commons.resources.back
+import com.vitorpamplona.amethyst.commons.resources.boost_or_quote_description
+import com.vitorpamplona.amethyst.commons.resources.cancel
+import com.vitorpamplona.amethyst.commons.resources.cashu
+import com.vitorpamplona.amethyst.commons.resources.change_reaction
+import com.vitorpamplona.amethyst.commons.resources.clear
+import com.vitorpamplona.amethyst.commons.resources.copy_to_clipboard
+import com.vitorpamplona.amethyst.commons.resources.enter_picture_in_picture
+import com.vitorpamplona.amethyst.commons.resources.following
+import com.vitorpamplona.amethyst.commons.resources.lightning_address
+import com.vitorpamplona.amethyst.commons.resources.like_description
+import com.vitorpamplona.amethyst.commons.resources.note_options
+import com.vitorpamplona.amethyst.commons.resources.record_a_message
+import com.vitorpamplona.amethyst.commons.resources.reply_description
+import com.vitorpamplona.amethyst.commons.resources.search_button
+import com.vitorpamplona.amethyst.commons.resources.share_or_save
+import com.vitorpamplona.amethyst.commons.resources.website
+import com.vitorpamplona.amethyst.commons.resources.zap_description
+import com.vitorpamplona.amethyst.commons.ui.theme.BitcoinOrange
+import com.vitorpamplona.amethyst.commons.ui.theme.grayText
+import com.vitorpamplona.amethyst.commons.ui.theme.placeholderText
+import com.vitorpamplona.amethyst.commons.ui.theme.subtleButton
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+
+/** Standard icon size modifiers, matching the Android-side Shape.kt values. */
+val Size19Modifier = Modifier.size(19.dp)
+val Size20Modifier = Modifier.size(20.dp)
+val Size30Modifier = Modifier.size(30.dp)
+
+private val Dp19 = 19.dp
+private val Dp20 = 20.dp
+private val Dp30 = 30.dp
+
+@Composable
+fun AmethystIcon(iconSize: Dp) {
+    Icon(
+        imageVector = CustomHashTagIcons.Amethyst,
+        contentDescription = stringResource(Res.string.app_logo),
+        modifier = Modifier.size(iconSize),
+        tint = Color.Unspecified,
+    )
+}
+
+@Composable
+fun FollowingIcon(modifier: Modifier) {
+    Icon(
+        imageVector = Following,
+        contentDescription = stringResource(Res.string.following),
+        modifier = modifier,
+        tint = Color.Unspecified,
+    )
+}
+
+@Composable
+fun ArrowBackIcon(tint: Color = MaterialTheme.colorScheme.grayText) {
+    Icon(
+        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+        contentDescription = stringResource(Res.string.back),
+        tint = tint,
+    )
+}
+
+@Composable
+fun DownloadForOfflineIcon(
+    iconSize: Dp,
+    tint: Color = MaterialTheme.colorScheme.primary,
+) {
+    Icon(
+        imageVector = Icons.Default.DownloadForOffline,
+        contentDescription = stringResource(Res.string.accessibility_download_for_offline),
+        modifier = remember(iconSize) { Modifier.size(iconSize) },
+        tint = tint,
+    )
+}
+
+@Composable
+fun LikedIcon(
+    modifier: Modifier,
+    tint: Color = Color.Unspecified,
+) {
+    Icon(
+        imageVector = Liked,
+        contentDescription = stringResource(Res.string.like_description),
+        modifier = modifier,
+        tint = tint,
+    )
+}
+
+@Composable
+fun ChangeReactionIcon(
+    modifier: Modifier,
+    tint: Color = Color.Unspecified,
+) {
+    Icon(
+        imageVector = Icons.Outlined.AddReaction,
+        contentDescription = stringResource(Res.string.change_reaction),
+        modifier = modifier,
+        tint = tint,
+    )
+}
+
+@Composable
+fun LikeIcon(
+    iconSizeModifier: Modifier,
+    grayTint: Color,
+) {
+    Icon(
+        imageVector = Like,
+        contentDescription = stringResource(Res.string.like_description),
+        modifier = iconSizeModifier,
+        tint = grayTint,
+    )
+}
+
+@Composable
+fun RepostIcon(
+    modifier: Modifier,
+    tint: Color = Color.Unspecified,
+) {
+    Icon(
+        imageVector = Repost,
+        contentDescription = stringResource(Res.string.boost_or_quote_description),
+        modifier = modifier,
+        tint = tint,
+    )
+}
+
+@Composable
+fun RepostedIcon(
+    modifier: Modifier,
+    tint: Color = Color.Unspecified,
+) {
+    Icon(
+        imageVector = Reposted,
+        contentDescription = stringResource(Res.string.boost_or_quote_description),
+        modifier = modifier,
+        tint = tint,
+    )
+}
+
+@Composable
+fun LightningAddressIcon(
+    modifier: Modifier,
+    tint: Color = Color.Unspecified,
+) {
+    Icon(
+        imageVector = Icons.Default.Bolt,
+        contentDescription = stringResource(Res.string.lightning_address),
+        tint = tint,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun ZappedIcon(iconSize: Dp) {
+    ZappedIcon(modifier = remember(iconSize) { Modifier.size(iconSize) })
+}
+
+@Composable
+fun ZappedIcon(modifier: Modifier) {
+    ZapIcon(modifier = modifier, BitcoinOrange)
+}
+
+@Composable
+fun ZapIcon(
+    modifier: Modifier,
+    tint: Color = Color.Unspecified,
+    contentDescriptor: StringResource = Res.string.zap_description,
+) {
+    Icon(
+        imageVector = Icons.Default.Bolt,
+        contentDescription = stringResource(contentDescriptor),
+        tint = tint,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun OutlinedZapIcon(
+    modifier: Modifier,
+    tint: Color = Color.Unspecified,
+    contentDescriptor: StringResource = Res.string.zap_description,
+) {
+    Icon(
+        imageVector = Zap,
+        contentDescription = stringResource(contentDescriptor),
+        tint = tint,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun ShareIcon(
+    modifier: Modifier,
+    tint: Color = Color.Unspecified,
+) {
+    Icon(
+        imageVector = Icons.Default.Share,
+        modifier = modifier,
+        contentDescription = stringResource(Res.string.share_or_save),
+        tint = tint,
+    )
+}
+
+@Composable
+fun CashuIcon(modifier: Modifier) {
+    Icon(
+        imageVector = CustomHashTagIcons.Cashu,
+        stringResource(Res.string.cashu),
+        tint = Color.Unspecified,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun CopyIcon(modifier: Modifier) {
+    Icon(
+        imageVector = Icons.Default.ContentCopy,
+        stringResource(Res.string.copy_to_clipboard),
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun OpenInNewIcon(modifier: Modifier) {
+    Icon(
+        imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+        stringResource(Res.string.copy_to_clipboard),
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun ExpandLessIcon(
+    modifier: Modifier,
+    contentDescriptor: StringResource,
+) {
+    Icon(
+        imageVector = Icons.Default.ExpandLess,
+        contentDescription = stringResource(contentDescriptor),
+        modifier = modifier,
+        tint = MaterialTheme.colorScheme.subtleButton,
+    )
+}
+
+@Composable
+fun ExpandMoreIcon(
+    modifier: Modifier,
+    contentDescriptor: StringResource,
+) {
+    Icon(
+        imageVector = Icons.Default.ExpandMore,
+        contentDescription = stringResource(contentDescriptor),
+        modifier = modifier,
+        tint = MaterialTheme.colorScheme.subtleButton,
+    )
+}
+
+@Composable
+fun VoiceReplyIcon(
+    iconSizeModifier: Modifier,
+    tint: Color,
+) {
+    Icon(
+        imageVector = Icons.Outlined.Mic,
+        contentDescription = stringResource(Res.string.record_a_message),
+        tint = tint,
+        modifier = iconSizeModifier,
+    )
+}
+
+@Composable
+fun CommentIcon(
+    iconSizeModifier: Modifier,
+    tint: Color,
+) {
+    Icon(
+        imageVector = Reply,
+        contentDescription = stringResource(Res.string.reply_description),
+        modifier = iconSizeModifier,
+        tint = tint,
+    )
+}
+
+@Composable
+fun CancelIcon() {
+    Icon(
+        imageVector = Icons.Default.Cancel,
+        contentDescription = stringResource(Res.string.cancel),
+        modifier = Size30Modifier,
+        tint = MaterialTheme.colorScheme.placeholderText,
+    )
+}
+
+@Composable
+fun CloseIcon() {
+    Icon(
+        imageVector = Icons.Outlined.Close,
+        contentDescription = stringResource(Res.string.cancel),
+        modifier = Size20Modifier,
+    )
+}
+
+@Composable
+fun SearchIcon(
+    modifier: Modifier,
+    tint: Color = Color.Unspecified,
+) {
+    Icon(
+        imageVector = Search,
+        contentDescription = stringResource(Res.string.search_button),
+        modifier = modifier,
+        tint = tint,
+    )
+}
+
+@Composable
+fun PlayIcon(
+    modifier: Modifier,
+    tint: Color,
+) {
+    Icon(
+        imageVector = Icons.Outlined.PlayCircle,
+        contentDescription = stringResource(Res.string.accessibility_play_username),
+        modifier = modifier,
+        tint = tint,
+    )
+}
+
+@Composable
+fun PinIcon(
+    modifier: Modifier,
+    tint: Color,
+) {
+    Icon(
+        imageVector = Icons.Default.PushPin,
+        contentDescription = stringResource(Res.string.accessibility_pushpin),
+        modifier = modifier,
+        tint = tint,
+    )
+}
+
+@Composable
+fun EnablePiP(
+    modifier: Modifier,
+    tint: Color,
+) {
+    Icon(
+        imageVector = Icons.AutoMirrored.Outlined.OpenInNew,
+        contentDescription = stringResource(Res.string.enter_picture_in_picture),
+        modifier = modifier,
+        tint = tint,
+    )
+}
+
+@Composable
+fun ClearTextIcon() {
+    Icon(
+        imageVector = Icons.Default.Clear,
+        contentDescription = stringResource(Res.string.clear),
+    )
+}
+
+@Composable
+fun LinkIcon(
+    modifier: Modifier,
+    tint: Color,
+) {
+    Icon(
+        imageVector = Icons.Default.Link,
+        contentDescription = stringResource(Res.string.website),
+        modifier = modifier,
+        tint = tint,
+    )
+}
+
+@Composable
+fun VerticalDotsIcon() {
+    Icon(
+        imageVector = Icons.Default.MoreVert,
+        contentDescription = stringResource(Res.string.note_options),
+        modifier = Size19Modifier,
+        tint = MaterialTheme.colorScheme.placeholderText,
+    )
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/theme/ThemeExtensions.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/theme/ThemeExtensions.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.commons.ui.theme
 
 import androidx.compose.material3.ColorScheme
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.luminance
 
@@ -36,3 +37,24 @@ val ColorScheme.isLight: Boolean
  */
 val ColorScheme.onBackgroundColorFilter: ColorFilter
     get() = ColorFilter.tint(onBackground)
+
+/**
+ * Gray text color for less important UI elements.
+ * Uses onSurface with 52% opacity.
+ */
+val ColorScheme.grayText: Color
+    get() = onSurface.copy(alpha = 0.52f)
+
+/**
+ * Placeholder text color.
+ * Uses onSurface with 42% opacity.
+ */
+val ColorScheme.placeholderText: Color
+    get() = onSurface.copy(alpha = 0.42f)
+
+/**
+ * Subtle button tint.
+ * Uses onSurface with 22% opacity.
+ */
+val ColorScheme.subtleButton: Color
+    get() = onSurface.copy(alpha = 0.22f)


### PR DESCRIPTION
## Summary

Move **Icons.kt** and **ParticipantListBuilder** from the Android app module to the KMP commons module, making them available for iOS/desktop targets.

### Icons.kt
- `stringRes(R.string.xxx)` → `stringResource(Res.string.xxx)` (Compose Multiplatform resources)
- Theme extensions (`grayText`, `placeholderText`, `subtleButton`) added to commons `ThemeExtensions.kt`
- `Size19Modifier`, `Size20Modifier`, `Size30Modifier` defined in commons
- Android `@Preview` kept in the Android-side wrapper
- Android-side `Icons.kt` retained as thin delegation layer for full source compatibility (no caller changes needed)

### ParticipantListBuilder
- `LocalCache` singleton replaced with `ICacheProvider` constructor parameter (dependency injection)
- `getPublicChatChannelIfExists()` added to `ICacheProvider` interface (default `null` impl)
- `LocalCache.getPublicChatChannelIfExists` marked `override`
- Android-side factory function `ParticipantListBuilder()` auto-injects `LocalCache` — zero caller changes needed

### New resources
- 20 icon-related strings added to commons `strings.xml`

### Build verified
- `:commons:compileAndroidMain` ✅
- `:amethyst:compilePlayDebugKotlin` ✅
- `spotlessApply` ✅