### PR TITLE
feat: move UserFeedViewModel, StringFeedViewModel, ServerName to commons (batch 2)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/mediaServers/ServerName.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/mediaServers/ServerName.kt
@@ -20,30 +20,8 @@
  */
 package com.vitorpamplona.amethyst.ui.actions.mediaServers
 
-import kotlinx.serialization.Serializable
+// Re-export from commons for backwards compatibility
+typealias ServerName = com.vitorpamplona.amethyst.commons.model.mediaServers.ServerName
+typealias ServerType = com.vitorpamplona.amethyst.commons.model.mediaServers.ServerType
 
-@Serializable
-data class ServerName(
-    val name: String,
-    val baseUrl: String,
-    val type: ServerType = ServerType.Blossom,
-)
-
-enum class ServerType {
-    Blossom,
-    NIP95,
-    NIP96,
-}
-
-val DEFAULT_MEDIA_SERVERS: List<ServerName> =
-    listOf(
-        ServerName("Nostr.Build", "https://blossom.band/", ServerType.Blossom),
-        ServerName("24242.io", "https://24242.io/", ServerType.Blossom),
-        ServerName("Azzamo", "https://blossom.azzamo.media", ServerType.Blossom),
-        ServerName("YakiHonne", "https://blossom.yakihonne.com/", ServerType.Blossom),
-        ServerName("Primal", "https://blossom.primal.net/", ServerType.Blossom),
-        ServerName("Sovbit", "https://cdn.sovbit.host", ServerType.Blossom),
-        ServerName("Nostr.Download", "https://nostr.download", ServerType.Blossom),
-        ServerName("Satellite (Paid)", "https://cdn.satellite.earth", ServerType.Blossom),
-        ServerName("NostrMedia (Paid)", "https://nostrmedia.com", ServerType.Blossom),
-    )
+val DEFAULT_MEDIA_SERVERS = com.vitorpamplona.amethyst.commons.model.mediaServers.DEFAULT_MEDIA_SERVERS

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/UserFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/UserFeedView.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.commons.viewmodels.UserFeedState
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.feeds.FeedEmpty
 import com.vitorpamplona.amethyst.ui.feeds.FeedError

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/UserFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/UserFeedViewModel.kt
@@ -20,104 +20,17 @@
  */
 package com.vitorpamplona.amethyst.ui.screen
 
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.Stable
-import androidx.compose.runtime.mutableStateOf
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.vitorpamplona.amethyst.commons.ui.feeds.InvalidatableContent
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.User
-import com.vitorpamplona.amethyst.service.BundledUpdate
-import com.vitorpamplona.amethyst.service.checkNotInMainThread
 import com.vitorpamplona.amethyst.ui.dal.FeedFilter
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications.equalImmutableLists
-import com.vitorpamplona.quartz.utils.Log
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 
-@Stable
-open class UserFeedViewModel(
-    val dataSource: FeedFilter<User>,
-) : ViewModel(),
-    InvalidatableContent {
-    private val _feedContent = MutableStateFlow<UserFeedState>(UserFeedState.Loading)
-    val feedContent = _feedContent.asStateFlow()
+// Re-export from commons for backwards compatibility
+typealias UserFeedViewModel = com.vitorpamplona.amethyst.commons.viewmodels.UserFeedViewModel
 
-    private fun refresh() {
-        viewModelScope.launch(Dispatchers.IO) { refreshSuspended() }
-    }
-
-    override val isRefreshing: MutableState<Boolean> = mutableStateOf(false)
-
-    private fun refreshSuspended() {
-        checkNotInMainThread()
-
-        try {
-            isRefreshing.value = true
-
-            val notes = dataSource.loadTop().toImmutableList()
-
-            val oldNotesState = _feedContent.value
-            if (oldNotesState is UserFeedState.Loaded) {
-                // Using size as a proxy for has changed.
-                if (!equalImmutableLists(notes, oldNotesState.feed.value)) {
-                    updateFeed(notes)
-                }
-            } else {
-                updateFeed(notes)
-            }
-        } finally {
-            isRefreshing.value = false
-        }
-    }
-
-    private fun updateFeed(notes: ImmutableList<User>) {
-        val currentState = _feedContent.value
-        if (notes.isEmpty()) {
-            _feedContent.tryEmit(UserFeedState.Empty)
-        } else if (currentState is UserFeedState.Loaded) {
-            // updates the current list
-            currentState.feed.tryEmit(notes)
-        } else {
-            _feedContent.tryEmit(UserFeedState.Loaded(MutableStateFlow(notes)))
-        }
-    }
-
-    private val bundler = BundledUpdate(250, Dispatchers.IO)
-
-    override fun invalidateData(ignoreIfDoing: Boolean) {
-        bundler.invalidate(ignoreIfDoing) {
-            // adds the time to perform the refresh into this delay
-            // holding off new updates in case of heavy refresh routines.
-            refreshSuspended()
-        }
-    }
-
-    init {
-        Log.d("Init") { "${this.javaClass.simpleName}" }
-        viewModelScope.launch(Dispatchers.IO) {
-            LocalCache.live.newEventBundles.collect { newNotes ->
-                Log.d("Rendering Metrics") { "Update feeds: ${this@UserFeedViewModel.javaClass.simpleName} with ${newNotes.size}" }
-                invalidateData()
-            }
-        }
-
-        viewModelScope.launch(Dispatchers.IO) {
-            LocalCache.live.deletedEventBundles.collect { newNotes ->
-                Log.d("Rendering Metrics") { "Delete from feeds: ${this@UserFeedViewModel.javaClass.simpleName} with ${newNotes.size}" }
-                invalidateData()
-            }
-        }
-    }
-
-    override fun onCleared() {
-        Log.d("Init") { "OnCleared: ${this.javaClass.simpleName}" }
-        bundler.cancel()
-        super.onCleared()
-    }
-}
+/**
+ * Android-specific UserFeedViewModel base class that provides LocalCache as the cache provider.
+ * Subclasses can extend this to automatically use LocalCache without passing cacheProvider.
+ */
+abstract class AndroidUserFeedViewModel(
+    dataSource: FeedFilter<User>,
+) : UserFeedViewModel(dataSource, LocalCache)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/followPacks/feed/dal/FollowPackMembersUserFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/followPacks/feed/dal/FollowPackMembersUserFeedViewModel.kt
@@ -24,12 +24,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.AddressableNote
+import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.ui.screen.UserFeedViewModel
 
 class FollowPackMembersUserFeedViewModel(
     val followPackNote: AddressableNote,
     val account: Account,
-) : UserFeedViewModel(FollowPackMembersFeedFilter(followPackNote, account)) {
+) : UserFeedViewModel(FollowPackMembersFeedFilter(followPackNote, account), LocalCache) {
     class Factory(
         val followPackNote: AddressableNote,
         val account: Account,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedView.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.viewmodels.StringFeedState
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.feeds.FeedError
 import com.vitorpamplona.amethyst.ui.feeds.LoadingFeed

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedViewModel.kt
@@ -20,102 +20,16 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings
 
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.Stable
-import androidx.compose.runtime.mutableStateOf
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.vitorpamplona.amethyst.commons.ui.feeds.InvalidatableContent
 import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.service.BundledUpdate
-import com.vitorpamplona.amethyst.service.checkNotInMainThread
 import com.vitorpamplona.amethyst.ui.dal.FeedFilter
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications.equalImmutableLists
-import com.vitorpamplona.quartz.utils.Log
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 
-@Stable
-open class StringFeedViewModel(
-    val dataSource: FeedFilter<String>,
-) : ViewModel(),
-    InvalidatableContent {
-    private val _feedContent = MutableStateFlow<StringFeedState>(StringFeedState.Loading)
-    val feedContent = _feedContent.asStateFlow()
+// Re-export from commons for backwards compatibility
+typealias StringFeedViewModel = com.vitorpamplona.amethyst.commons.viewmodels.StringFeedViewModel
 
-    override val isRefreshing: MutableState<Boolean> = mutableStateOf(false)
-
-    private fun refresh() {
-        viewModelScope.launch(Dispatchers.IO) { refreshSuspended() }
-    }
-
-    private fun refreshSuspended() {
-        checkNotInMainThread()
-
-        try {
-            isRefreshing.value = true
-
-            val notes = dataSource.loadTop().toImmutableList()
-
-            val oldNotesState = _feedContent.value
-            if (oldNotesState is StringFeedState.Loaded) {
-                // Using size as a proxy for has changed.
-                if (!equalImmutableLists(notes, oldNotesState.feed.value)) {
-                    updateFeed(notes)
-                }
-            } else {
-                updateFeed(notes)
-            }
-        } finally {
-            isRefreshing.value = false
-        }
-    }
-
-    private fun updateFeed(notes: ImmutableList<String>) {
-        val currentState = _feedContent.value
-        if (notes.isEmpty()) {
-            _feedContent.tryEmit(StringFeedState.Empty)
-        } else if (currentState is StringFeedState.Loaded) {
-            // updates the current list
-            currentState.feed.tryEmit(notes)
-        } else {
-            _feedContent.tryEmit(StringFeedState.Loaded(MutableStateFlow(notes)))
-        }
-    }
-
-    private val bundler = BundledUpdate(250, Dispatchers.IO)
-
-    override fun invalidateData(ignoreIfDoing: Boolean) {
-        bundler.invalidate(ignoreIfDoing) {
-            // adds the time to perform the refresh into this delay
-            // holding off new updates in case of heavy refresh routines.
-            refreshSuspended()
-        }
-    }
-
-    init {
-        Log.d("Init", this.javaClass.simpleName)
-        viewModelScope.launch(Dispatchers.IO) {
-            LocalCache.live.newEventBundles.collect { newNotes ->
-                Log.d("Rendering Metrics") { "Update feeds: ${this@StringFeedViewModel.javaClass.simpleName} with ${newNotes.size}" }
-                invalidateData()
-            }
-        }
-        viewModelScope.launch(Dispatchers.IO) {
-            LocalCache.live.deletedEventBundles.collect { newNotes ->
-                Log.d("Rendering Metrics") { "Delete feeds: ${this@StringFeedViewModel.javaClass.simpleName} with ${newNotes.size}" }
-                invalidateData()
-            }
-        }
-    }
-
-    override fun onCleared() {
-        Log.d("Init") { "OnCleared: ${this.javaClass.simpleName}" }
-        bundler.cancel()
-        super.onCleared()
-    }
-}
+/**
+ * Android-specific StringFeedViewModel base class that provides LocalCache as the cache provider.
+ * Subclasses can extend this to automatically use LocalCache without passing cacheProvider.
+ */
+abstract class AndroidStringFeedViewModel(
+    dataSource: FeedFilter<String>,
+) : StringFeedViewModel(dataSource, LocalCache)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/dal/HiddenAccountsFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/dal/HiddenAccountsFeedViewModel.kt
@@ -23,11 +23,12 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.dal
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.vitorpamplona.amethyst.model.Account
+import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.ui.screen.UserFeedViewModel
 
 class HiddenAccountsFeedViewModel(
     val account: Account,
-) : UserFeedViewModel(HiddenAccountsFeedFilter(account)) {
+) : UserFeedViewModel(HiddenAccountsFeedFilter(account), LocalCache) {
     class Factory(
         val account: Account,
     ) : ViewModelProvider.Factory {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/dal/HiddenWordsFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/dal/HiddenWordsFeedViewModel.kt
@@ -23,12 +23,14 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.dal
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.vitorpamplona.amethyst.model.Account
+import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.StringFeedViewModel
 
 class HiddenWordsFeedViewModel(
     val account: Account,
 ) : StringFeedViewModel(
         HiddenWordsFeedFilter(account),
+        LocalCache,
     ) {
     class Factory(
         val account: Account,

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/mediaServers/ServerName.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/mediaServers/ServerName.kt
@@ -18,21 +18,32 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings
+package com.vitorpamplona.amethyst.commons.model.mediaServers
 
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.serialization.Serializable
 
-sealed class StringFeedState {
-    object Loading : StringFeedState()
+@Serializable
+data class ServerName(
+    val name: String,
+    val baseUrl: String,
+    val type: ServerType = ServerType.Blossom,
+)
 
-    class Loaded(
-        val feed: MutableStateFlow<ImmutableList<String>>,
-    ) : StringFeedState()
-
-    object Empty : StringFeedState()
-
-    class FeedError(
-        val errorMessage: String,
-    ) : StringFeedState()
+enum class ServerType {
+    Blossom,
+    NIP95,
+    NIP96,
 }
+
+val DEFAULT_MEDIA_SERVERS: List<ServerName> =
+    listOf(
+        ServerName("Nostr.Build", "https://blossom.band/", ServerType.Blossom),
+        ServerName("24242.io", "https://24242.io/", ServerType.Blossom),
+        ServerName("Azzamo", "https://blossom.azzamo.media", ServerType.Blossom),
+        ServerName("YakiHonne", "https://blossom.yakihonne.com/", ServerType.Blossom),
+        ServerName("Primal", "https://blossom.primal.net/", ServerType.Blossom),
+        ServerName("Sovbit", "https://cdn.sovbit.host", ServerType.Blossom),
+        ServerName("Nostr.Download", "https://nostr.download", ServerType.Blossom),
+        ServerName("Satellite (Paid)", "https://cdn.satellite.earth", ServerType.Blossom),
+        ServerName("NostrMedia (Paid)", "https://nostrmedia.com", ServerType.Blossom),
+    )

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/StringFeedState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/StringFeedState.kt
@@ -18,28 +18,21 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen
+package com.vitorpamplona.amethyst.commons.viewmodels
 
-import androidx.compose.runtime.Stable
-import com.vitorpamplona.amethyst.model.User
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.MutableStateFlow
 
-@Stable
-sealed class UserFeedState {
-    @Stable
-    object Loading : UserFeedState()
+sealed class StringFeedState {
+    object Loading : StringFeedState()
 
-    @Stable
     class Loaded(
-        val feed: MutableStateFlow<ImmutableList<User>>,
-    ) : UserFeedState()
+        val feed: MutableStateFlow<ImmutableList<String>>,
+    ) : StringFeedState()
 
-    @Stable
-    object Empty : UserFeedState()
+    object Empty : StringFeedState()
 
-    @Stable
     class FeedError(
         val errorMessage: String,
-    ) : UserFeedState()
+    ) : StringFeedState()
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/StringFeedViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/StringFeedViewModel.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.viewmodels
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+import com.vitorpamplona.amethyst.commons.service.BundledUpdate
+import com.vitorpamplona.amethyst.commons.threading.checkNotInMainThread
+import com.vitorpamplona.amethyst.commons.ui.feeds.FeedFilter
+import com.vitorpamplona.amethyst.commons.ui.feeds.InvalidatableContent
+import com.vitorpamplona.amethyst.commons.utils.equalImmutableLists
+import com.vitorpamplona.quartz.utils.Log
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+@Stable
+open class StringFeedViewModel(
+    val dataSource: FeedFilter<String>,
+    val cacheProvider: ICacheProvider,
+) : ViewModel(),
+    InvalidatableContent {
+    private val _feedContent = MutableStateFlow<StringFeedState>(StringFeedState.Loading)
+    val feedContent = _feedContent.asStateFlow()
+
+    override val isRefreshing: MutableState<Boolean> = mutableStateOf(false)
+
+    private fun refresh() {
+        viewModelScope.launch(Dispatchers.IO) { refreshSuspended() }
+    }
+
+    private fun refreshSuspended() {
+        checkNotInMainThread()
+
+        try {
+            isRefreshing.value = true
+
+            val notes = dataSource.loadTop().toImmutableList()
+
+            val oldNotesState = _feedContent.value
+            if (oldNotesState is StringFeedState.Loaded) {
+                // Using size as a proxy for has changed.
+                if (!equalImmutableLists(notes, oldNotesState.feed.value)) {
+                    updateFeed(notes)
+                }
+            } else {
+                updateFeed(notes)
+            }
+        } finally {
+            isRefreshing.value = false
+        }
+    }
+
+    private fun updateFeed(notes: ImmutableList<String>) {
+        val currentState = _feedContent.value
+        if (notes.isEmpty()) {
+            _feedContent.tryEmit(StringFeedState.Empty)
+        } else if (currentState is StringFeedState.Loaded) {
+            // updates the current list
+            currentState.feed.tryEmit(notes)
+        } else {
+            _feedContent.tryEmit(StringFeedState.Loaded(MutableStateFlow(notes)))
+        }
+    }
+
+    private val bundler = BundledUpdate(250, Dispatchers.IO)
+
+    override fun invalidateData(ignoreIfDoing: Boolean) {
+        bundler.invalidate(ignoreIfDoing) {
+            // adds the time to perform the refresh into this delay
+            // holding off new updates in case of heavy refresh routines.
+            refreshSuspended()
+        }
+    }
+
+    init {
+        Log.d("Init") { "${this::class.simpleName}" }
+        viewModelScope.launch(Dispatchers.IO) {
+            cacheProvider.getEventStream().newEventBundles.collect { newNotes ->
+                Log.d("Rendering Metrics") { "Update feeds: ${this@StringFeedViewModel::class.simpleName} with ${newNotes.size}" }
+                invalidateData()
+            }
+        }
+        viewModelScope.launch(Dispatchers.IO) {
+            cacheProvider.getEventStream().deletedEventBundles.collect { newNotes ->
+                Log.d("Rendering Metrics") { "Delete feeds: ${this@StringFeedViewModel::class.simpleName} with ${newNotes.size}" }
+                invalidateData()
+            }
+        }
+    }
+
+    override fun onCleared() {
+        Log.d("Init") { "OnCleared: ${this::class.simpleName}" }
+        bundler.cancel()
+        super.onCleared()
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/UserFeedState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/UserFeedState.kt
@@ -18,21 +18,28 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.dal
+package com.vitorpamplona.amethyst.commons.viewmodels
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import com.vitorpamplona.amethyst.model.Account
-import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.ui.screen.UserFeedViewModel
+import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.model.User
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.coroutines.flow.MutableStateFlow
 
-class SpammerAccountsFeedViewModel(
-    val account: Account,
-) : UserFeedViewModel(SpammerAccountsFeedFilter(account), LocalCache) {
-    class Factory(
-        val account: Account,
-    ) : ViewModelProvider.Factory {
-        @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(modelClass: Class<T>): T = SpammerAccountsFeedViewModel(account) as T
-    }
+@Stable
+sealed class UserFeedState {
+    @Stable
+    object Loading : UserFeedState()
+
+    @Stable
+    class Loaded(
+        val feed: MutableStateFlow<ImmutableList<User>>,
+    ) : UserFeedState()
+
+    @Stable
+    object Empty : UserFeedState()
+
+    @Stable
+    class FeedError(
+        val errorMessage: String,
+    ) : UserFeedState()
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/UserFeedViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/UserFeedViewModel.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.viewmodels
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+import com.vitorpamplona.amethyst.commons.service.BundledUpdate
+import com.vitorpamplona.amethyst.commons.threading.checkNotInMainThread
+import com.vitorpamplona.amethyst.commons.ui.feeds.FeedFilter
+import com.vitorpamplona.amethyst.commons.ui.feeds.InvalidatableContent
+import com.vitorpamplona.amethyst.commons.utils.equalImmutableLists
+import com.vitorpamplona.quartz.utils.Log
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+@Stable
+open class UserFeedViewModel(
+    val dataSource: FeedFilter<User>,
+    val cacheProvider: ICacheProvider,
+) : ViewModel(),
+    InvalidatableContent {
+    private val _feedContent = MutableStateFlow<UserFeedState>(UserFeedState.Loading)
+    val feedContent = _feedContent.asStateFlow()
+
+    private fun refresh() {
+        viewModelScope.launch(Dispatchers.IO) { refreshSuspended() }
+    }
+
+    override val isRefreshing: MutableState<Boolean> = mutableStateOf(false)
+
+    private fun refreshSuspended() {
+        checkNotInMainThread()
+
+        try {
+            isRefreshing.value = true
+
+            val notes = dataSource.loadTop().toImmutableList()
+
+            val oldNotesState = _feedContent.value
+            if (oldNotesState is UserFeedState.Loaded) {
+                // Using size as a proxy for has changed.
+                if (!equalImmutableLists(notes, oldNotesState.feed.value)) {
+                    updateFeed(notes)
+                }
+            } else {
+                updateFeed(notes)
+            }
+        } finally {
+            isRefreshing.value = false
+        }
+    }
+
+    private fun updateFeed(notes: ImmutableList<User>) {
+        val currentState = _feedContent.value
+        if (notes.isEmpty()) {
+            _feedContent.tryEmit(UserFeedState.Empty)
+        } else if (currentState is UserFeedState.Loaded) {
+            // updates the current list
+            currentState.feed.tryEmit(notes)
+        } else {
+            _feedContent.tryEmit(UserFeedState.Loaded(MutableStateFlow(notes)))
+        }
+    }
+
+    private val bundler = BundledUpdate(250, Dispatchers.IO)
+
+    override fun invalidateData(ignoreIfDoing: Boolean) {
+        bundler.invalidate(ignoreIfDoing) {
+            // adds the time to perform the refresh into this delay
+            // holding off new updates in case of heavy refresh routines.
+            refreshSuspended()
+        }
+    }
+
+    init {
+        Log.d("Init") { "${this::class.simpleName}" }
+        viewModelScope.launch(Dispatchers.IO) {
+            cacheProvider.getEventStream().newEventBundles.collect { newNotes ->
+                Log.d("Rendering Metrics") { "Update feeds: ${this@UserFeedViewModel::class.simpleName} with ${newNotes.size}" }
+                invalidateData()
+            }
+        }
+
+        viewModelScope.launch(Dispatchers.IO) {
+            cacheProvider.getEventStream().deletedEventBundles.collect { newNotes ->
+                Log.d("Rendering Metrics") { "Delete from feeds: ${this@UserFeedViewModel::class.simpleName} with ${newNotes.size}" }
+                invalidateData()
+            }
+        }
+    }
+
+    override fun onCleared() {
+        Log.d("Init") { "OnCleared: ${this::class.simpleName}" }
+        bundler.cancel()
+        super.onCleared()
+    }
+}


### PR DESCRIPTION
## Summary

Move 5 types from the Android app module to the KMP commons module for cross-platform reuse (iOS/Desktop).

### What moved to commons:

| Type | Commons location |
|------|-----------------|
| **ServerName** data class | `commons/model/mediaServers/ServerName.kt` |
| **ServerType** enum | `commons/model/mediaServers/ServerName.kt` |
| **DEFAULT_MEDIA_SERVERS** | `commons/model/mediaServers/ServerName.kt` |
| **UserFeedState** sealed class | `commons/viewmodels/UserFeedState.kt` |
| **UserFeedViewModel** | `commons/viewmodels/UserFeedViewModel.kt` |
| **StringFeedState** sealed class | `commons/viewmodels/StringFeedState.kt` |
| **StringFeedViewModel** | `commons/viewmodels/StringFeedViewModel.kt` |

### Approach:
- ViewModels take `ICacheProvider` parameter instead of using `LocalCache` singleton directly
- Android subclasses (`SpammerAccountsFeedViewModel`, `HiddenAccountsFeedViewModel`, `FollowPackMembersUserFeedViewModel`, `HiddenWordsFeedViewModel`) updated to pass `LocalCache`
- Typealias re-exports in original packages for `UserFeedViewModel` and `StringFeedViewModel` (backward compatible)
- Replaced `javaClass.simpleName` with `this::class.simpleName` for KMP compatibility
- Follows pattern from #2247 (Tor ViewModel migration)

### Build verified:
- `:commons:compileKotlinJvm` ✅
- `:amethyst:compilePlayDebugKotlin` ✅