### PR TITLE
feat: add richtext + Vico deps to commons, move markdownStyle/chartStyle

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/markdown/RenderContentAsMarkdown.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/markdown/RenderContentAsMarkdown.kt
@@ -42,6 +42,7 @@ import com.halilibo.richtext.ui.material3.RichText
 import com.vitorpamplona.amethyst.commons.model.EmptyTagList
 import com.vitorpamplona.amethyst.commons.model.ImmutableListOfLists
 import com.vitorpamplona.amethyst.commons.preview.UrlInfoItem
+import com.vitorpamplona.amethyst.commons.ui.theme.markdownStyle
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.UrlCachedPreviewer
 import com.vitorpamplona.amethyst.ui.components.UrlPreviewState
@@ -51,7 +52,6 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.mockAccountViewModel
 import com.vitorpamplona.amethyst.ui.theme.MarkdownTextStyle
 import com.vitorpamplona.amethyst.ui.theme.ThemeComparisonRow
-import com.vitorpamplona.amethyst.ui.theme.markdownStyle
 import com.vitorpamplona.amethyst.ui.uriToRoute
 import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
 import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationSummaryView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationSummaryView.kt
@@ -38,9 +38,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.patrykandpatrick.vico.compose.common.ProvideVicoTheme
+import com.vitorpamplona.amethyst.commons.ui.theme.chartStyle
 import com.vitorpamplona.amethyst.ui.note.UserReactionsRow
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications.chart.ShowChart
-import com.vitorpamplona.amethyst.ui.theme.chartStyle
 
 @Composable
 fun SummaryBar(state: NotificationSummaryState) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/theme/Theme.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/theme/Theme.kt
@@ -46,20 +46,9 @@ import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.TextLinkStyles
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.em
-import androidx.compose.ui.unit.sp
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.halilibo.richtext.ui.BlockQuoteGutter.BarGutter
-import com.halilibo.richtext.ui.RichTextStyle
-import com.halilibo.richtext.ui.resolveDefaults
-import com.patrykandpatrick.vico.compose.common.VicoTheme
-import com.patrykandpatrick.vico.compose.common.VicoTheme.CandlestickCartesianLayerColors
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.model.ThemeType
 
@@ -287,121 +276,7 @@ val lightBlackTagModifier =
         .background(LightColorPalette.onBackground)
         .padding(horizontal = 5.dp)
 
-val RichTextDefaults = RichTextStyle().resolveDefaults()
-
-val MarkDownStyleOnDark =
-    RichTextDefaults.copy(
-        paragraphSpacing = DefaultParagraphSpacing,
-        headingStyle = DefaultHeadingStyle,
-        listStyle =
-            RichTextDefaults.listStyle?.copy(
-                itemSpacing = 10.sp,
-            ),
-        blockQuoteGutter =
-            BarGutter(
-                startMargin = 4.sp,
-                barWidth = 3.sp,
-                endMargin = 8.sp,
-                color = { DarkColorPalette.primary.copy(alpha = 0.45f) },
-            ),
-        codeBlockStyle =
-            RichTextDefaults.codeBlockStyle?.copy(
-                textStyle =
-                    TextStyle(
-                        fontFamily = FontFamily.Monospace,
-                        fontSize = Font14SP,
-                        lineHeight = 1.45.em,
-                    ),
-                modifier =
-                    Modifier
-                        .padding(vertical = 4.dp)
-                        .fillMaxWidth()
-                        .clip(shape = QuoteBorder)
-                        .border(1.dp, DarkSubtleBorder, QuoteBorder)
-                        .background(DarkColorPalette.onSurface.copy(alpha = 0.05f))
-                        .padding(horizontal = 16.dp, vertical = 12.dp),
-            ),
-        tableStyle =
-            RichTextDefaults.tableStyle?.copy(
-                borderColor = DarkSubtleBorder,
-                borderStrokeWidth = 1f,
-                cellPadding = 10.sp,
-            ),
-        stringStyle =
-            RichTextDefaults.stringStyle?.copy(
-                linkStyle =
-                    TextLinkStyles(
-                        style =
-                            SpanStyle(
-                                color = DarkColorPalette.primary,
-                            ),
-                    ),
-                codeStyle =
-                    SpanStyle(
-                        fontFamily = FontFamily.Monospace,
-                        fontSize = Font14SP,
-                        background = DarkColorPalette.onSurface.copy(alpha = 0.22f),
-                        letterSpacing = 0.3.sp,
-                    ),
-            ),
-    )
-
-val MarkDownStyleOnLight =
-    RichTextDefaults.copy(
-        paragraphSpacing = DefaultParagraphSpacing,
-        headingStyle = DefaultHeadingStyle,
-        listStyle =
-            RichTextDefaults.listStyle?.copy(
-                itemSpacing = 10.sp,
-            ),
-        blockQuoteGutter =
-            BarGutter(
-                startMargin = 4.sp,
-                barWidth = 3.sp,
-                endMargin = 8.sp,
-                color = { LightColorPalette.primary.copy(alpha = 0.45f) },
-            ),
-        codeBlockStyle =
-            RichTextDefaults.codeBlockStyle?.copy(
-                textStyle =
-                    TextStyle(
-                        fontFamily = FontFamily.Monospace,
-                        fontSize = Font14SP,
-                        lineHeight = 1.45.em,
-                    ),
-                modifier =
-                    Modifier
-                        .padding(vertical = 4.dp)
-                        .fillMaxWidth()
-                        .clip(shape = QuoteBorder)
-                        .border(1.dp, LightSubtleBorder, QuoteBorder)
-                        .background(LightColorPalette.onSurface.copy(alpha = 0.05f))
-                        .padding(horizontal = 16.dp, vertical = 12.dp),
-            ),
-        tableStyle =
-            RichTextDefaults.tableStyle?.copy(
-                borderColor = LightSubtleBorder,
-                borderStrokeWidth = 1f,
-                cellPadding = 10.sp,
-            ),
-        stringStyle =
-            RichTextDefaults.stringStyle?.copy(
-                linkStyle =
-                    TextLinkStyles(
-                        style =
-                            SpanStyle(
-                                color = LightColorPalette.primary,
-                            ),
-                    ),
-                codeStyle =
-                    SpanStyle(
-                        fontFamily = FontFamily.Monospace,
-                        fontSize = Font14SP,
-                        background = LightColorPalette.onSurface.copy(alpha = 0.12f),
-                        letterSpacing = 0.3.sp,
-                    ),
-            ),
-    )
+// markdownStyle is now provided by commons ThemeExtensions
 
 val ColorScheme.isLight: Boolean
     get() = primary == Purple500
@@ -469,8 +344,7 @@ val ColorScheme.allGoodColor: Color
 val ColorScheme.fundraiserProgressColor: Color
     get() = if (isLight) LightFundraiserProgressColor else DarkFundraiserProgressColor
 
-val ColorScheme.markdownStyle: RichTextStyle
-    get() = if (isLight) MarkDownStyleOnLight else MarkDownStyleOnDark
+// markdownStyle is now provided by commons ThemeExtensions
 
 @Suppress("ModifierFactoryExtensionFunction")
 val ColorScheme.imageModifier: Modifier
@@ -524,34 +398,7 @@ val ColorScheme.newItemBubbleModifier: Modifier
 val ColorScheme.blackTagModifier: Modifier
     get() = if (isLight) lightBlackTagModifier else darkBlackTagModifier
 
-val chartLightColors =
-    VicoTheme(
-        candlestickCartesianLayerColors =
-            CandlestickCartesianLayerColors(
-                Color(0xff0ac285),
-                Color(0xff000000),
-                Color(0xffe8304f),
-            ),
-        columnCartesianLayerColors = listOf(Color(0xff3287ff), Color(0xff0ac285), Color(0xffffab02)),
-        lineColor = Color(0xffbcbfc2),
-        textColor = Color(0xff000000),
-    )
-
-val chartDarkColors =
-    VicoTheme(
-        candlestickCartesianLayerColors =
-            CandlestickCartesianLayerColors(
-                Color(0xff0ac285),
-                Color(0xffffffff),
-                Color(0xffe8304f),
-            ),
-        columnCartesianLayerColors = listOf(Color(0xff3287ff), Color(0xff0ac285), Color(0xffffab02)),
-        lineColor = Color(0xff494c50),
-        textColor = Color(0xffffffff),
-    )
-
-val ColorScheme.chartStyle: VicoTheme
-    get() = if (isLight) chartLightColors else chartDarkColors
+// chartStyle is now provided by commons ThemeExtensions
 
 @Composable
 fun AmethystTheme(content: @Composable () -> Unit) {

--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -77,6 +77,10 @@ kotlin {
                 implementation(libs.markdown.commonmark)
                 implementation(libs.markdown.ui)
                 implementation(libs.markdown.ui.material3)
+
+                // Charting (Vico - Compose Multiplatform)
+                implementation(libs.vico.charts.compose)
+                implementation(libs.vico.charts.m3)
             }
         }
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/theme/Shape.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/theme/Shape.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.unit.dp
+
+val QuoteBorder = RoundedCornerShape(15.dp)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/theme/ThemeExtensions.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/theme/ThemeExtensions.kt
@@ -20,9 +20,28 @@
  */
 package com.vitorpamplona.amethyst.commons.ui.theme
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ColorScheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.halilibo.richtext.ui.BlockQuoteGutter.BarGutter
+import com.halilibo.richtext.ui.RichTextStyle
+import com.halilibo.richtext.ui.resolveDefaults
+import com.patrykandpatrick.vico.compose.common.VicoTheme
+import com.patrykandpatrick.vico.compose.common.VicoTheme.CandlestickCartesianLayerColors
 
 /**
  * Determines if the color scheme is light mode.
@@ -36,3 +55,106 @@ val ColorScheme.isLight: Boolean
  */
 val ColorScheme.onBackgroundColorFilter: ColorFilter
     get() = ColorFilter.tint(onBackground)
+
+// --- Markdown style ---
+
+private val RichTextDefaults = RichTextStyle().resolveDefaults()
+
+/**
+ * Creates a [RichTextStyle] themed to this [ColorScheme].
+ * Dynamically derives border/background/link colors from the scheme so it
+ * works for any light or dark palette without hard-coding color values.
+ */
+val ColorScheme.markdownStyle: RichTextStyle
+    get() {
+        val subtleBorderAlpha = if (isLight) 0.05f else 0.12f
+        val codeBackgroundAlpha = if (isLight) 0.12f else 0.22f
+        val subtleBorder = onSurface.copy(alpha = subtleBorderAlpha)
+
+        return RichTextDefaults.copy(
+            paragraphSpacing = DefaultParagraphSpacing,
+            headingStyle = DefaultHeadingStyle,
+            listStyle =
+                RichTextDefaults.listStyle?.copy(
+                    itemSpacing = 10.sp,
+                ),
+            blockQuoteGutter =
+                BarGutter(
+                    startMargin = 4.sp,
+                    barWidth = 3.sp,
+                    endMargin = 8.sp,
+                    color = { primary.copy(alpha = 0.45f) },
+                ),
+            codeBlockStyle =
+                RichTextDefaults.codeBlockStyle?.copy(
+                    textStyle =
+                        TextStyle(
+                            fontFamily = FontFamily.Monospace,
+                            fontSize = Font14SP,
+                            lineHeight = 1.45.em,
+                        ),
+                    modifier =
+                        Modifier
+                            .padding(vertical = 4.dp)
+                            .fillMaxWidth()
+                            .clip(shape = QuoteBorder)
+                            .border(1.dp, subtleBorder, QuoteBorder)
+                            .background(onSurface.copy(alpha = 0.05f))
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                ),
+            tableStyle =
+                RichTextDefaults.tableStyle?.copy(
+                    borderColor = subtleBorder,
+                    borderStrokeWidth = 1f,
+                    cellPadding = 10.sp,
+                ),
+            stringStyle =
+                RichTextDefaults.stringStyle?.copy(
+                    linkStyle =
+                        TextLinkStyles(
+                            style =
+                                SpanStyle(
+                                    color = primary,
+                                ),
+                        ),
+                    codeStyle =
+                        SpanStyle(
+                            fontFamily = FontFamily.Monospace,
+                            fontSize = Font14SP,
+                            background = onSurface.copy(alpha = codeBackgroundAlpha),
+                            letterSpacing = 0.3.sp,
+                        ),
+                ),
+        )
+    }
+
+// --- Chart style ---
+
+private val chartLightColors =
+    VicoTheme(
+        candlestickCartesianLayerColors =
+            CandlestickCartesianLayerColors(
+                Color(0xff0ac285),
+                Color(0xff000000),
+                Color(0xffe8304f),
+            ),
+        columnCartesianLayerColors = listOf(Color(0xff3287ff), Color(0xff0ac285), Color(0xffffab02)),
+        lineColor = Color(0xffbcbfc2),
+        textColor = Color(0xff000000),
+    )
+
+private val chartDarkColors =
+    VicoTheme(
+        candlestickCartesianLayerColors =
+            CandlestickCartesianLayerColors(
+                Color(0xff0ac285),
+                Color(0xffffffff),
+                Color(0xffe8304f),
+            ),
+        columnCartesianLayerColors = listOf(Color(0xff3287ff), Color(0xff0ac285), Color(0xffffab02)),
+        lineColor = Color(0xff494c50),
+        textColor = Color(0xffffffff),
+    )
+
+val ColorScheme.chartStyle: VicoTheme
+    get() = if (isLight) chartLightColors else chartDarkColors

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/theme/Type.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/theme/Type.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.halilibo.richtext.ui.HeadingStyle
+
+val Font14SP = 14.sp
+
+val MarkdownTextStyle = TextStyle(lineHeight = 1.50.em)
+
+val DefaultParagraphSpacing: TextUnit = 20.sp
+
+private val DefaultTypography = Typography()
+
+internal val DefaultHeadingStyle: HeadingStyle = { level, textStyle ->
+    when (level) {
+        0 -> {
+            DefaultTypography.displayLarge.copy(
+                fontSize = 32.sp,
+                lineHeight = 40.sp,
+                fontWeight = FontWeight.Bold,
+                letterSpacing = (-0.5).sp,
+            )
+        }
+
+        1 -> {
+            DefaultTypography.displayMedium.copy(
+                fontSize = 26.sp,
+                lineHeight = 34.sp,
+                fontWeight = FontWeight.Bold,
+                letterSpacing = (-0.25).sp,
+            )
+        }
+
+        2 -> {
+            DefaultTypography.displaySmall.copy(
+                fontSize = 22.sp,
+                lineHeight = 30.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+
+        3 -> {
+            DefaultTypography.displaySmall.copy(
+                fontSize = 20.sp,
+                lineHeight = 28.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+
+        4 -> {
+            DefaultTypography.headlineLarge.copy(
+                fontSize = 18.sp,
+                lineHeight = 24.sp,
+                fontWeight = FontWeight.Medium,
+            )
+        }
+
+        5 -> {
+            DefaultTypography.headlineMedium.copy(
+                fontSize = 16.sp,
+                lineHeight = 22.sp,
+                fontWeight = FontWeight.Medium,
+            )
+        }
+
+        6 -> {
+            DefaultTypography.headlineSmall.copy(
+                fontSize = 15.sp,
+                lineHeight = 20.sp,
+                fontWeight = FontWeight.Medium,
+            )
+        }
+
+        else -> {
+            textStyle
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add richtext and Vico charting library dependencies to the commons module and move `markdownStyle` + `chartStyle` theme extensions from the amethyst app module to commons.

## Changes

### commons module
- **build.gradle.kts**: Add Vico charting library (`compose` + `compose-m3`) to `commonMain` dependencies. Vico 3.x natively supports Compose Multiplatform. Richtext (markdown) deps were already present.
- **ThemeExtensions.kt**: Add `markdownStyle` and `chartStyle` as `ColorScheme` extensions. The `markdownStyle` is refactored to dynamically derive colors from the `ColorScheme` (border alpha, code background, link color) instead of referencing hard-coded palette instances, making it theme-agnostic and KMP-ready.
- **Type.kt** (new): Shared typography constants (`Font14SP`, `DefaultParagraphSpacing`, `DefaultHeadingStyle`, `MarkdownTextStyle`).
- **Shape.kt** (new): Shared `QuoteBorder` shape used by markdown code block styling.

### amethyst module
- **Theme.kt**: Remove `RichTextDefaults`, `MarkDownStyleOnDark`, `MarkDownStyleOnLight`, `markdownStyle`, `chartLightColors`, `chartDarkColors`, and `chartStyle` (now in commons). Clean up unused imports.
- **RenderContentAsMarkdown.kt**: Update import to `commons.ui.theme.markdownStyle`.
- **NotificationSummaryView.kt**: Update import to `commons.ui.theme.chartStyle`.

## Build verification
- `:commons:compileKotlinJvm` ✅
- `:amethyst:compilePlayDebugKotlin` ✅
- `spotlessCheck` ✅