### PR TITLE
feat: add IAccountViewModel interface in commons for KMP migration

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -175,14 +175,15 @@ import kotlinx.coroutines.withContext
 
 @Stable
 class AccountViewModel(
-    val account: Account,
+    override val account: Account,
     val settings: UiSettingsState,
     val torSettings: TorSettingsFlow,
     val dataSources: RelaySubscriptionsCoordinator,
     val httpClientBuilder: IRoleBasedHttpClientBuilder,
     val nip05ClientBuilder: () -> INip05Client,
 ) : ViewModel(),
-    Dao {
+    Dao,
+    com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel {
     var firstRoute: Route? = null
 
     val toastManager = ToastManager()
@@ -418,9 +419,9 @@ class AccountViewModel(
             Route.Notification() to notificationHasNewItemsFlow,
         )
 
-    fun isWriteable(): Boolean = account.isWriteable()
+    override fun isWriteable(): Boolean = account.isWriteable()
 
-    fun userProfile(): User = account.userProfile()
+    override fun userProfile(): User = account.userProfile()
 
     fun reactToOrDelete(
         note: Note,
@@ -842,10 +843,10 @@ class AccountViewModel(
         )
     }
 
-    fun report(
+    override fun report(
         note: Note,
         type: ReportType,
-        content: String = "",
+        content: String,
     ) = launchSigner { account.report(note, type, content) }
 
     fun report(
@@ -1007,13 +1008,13 @@ class AccountViewModel(
         }
     }
 
-    fun broadcast(note: Note) = launchSigner { account.broadcast(note) }
+    override fun broadcast(note: Note) = launchSigner { account.broadcast(note) }
 
     fun timestamp(note: Note) = launchSigner { account.otsState.timestamp(note) }
 
-    fun delete(notes: List<Note>) = launchSigner { account.delete(notes) }
+    override fun delete(notes: List<Note>) = launchSigner { account.delete(notes) }
 
-    fun delete(note: Note) = launchSigner { account.delete(note) }
+    override fun delete(note: Note) = launchSigner { account.delete(note) }
 
     fun requestToVanish(
         relays: List<NormalizedRelayUrl>,
@@ -1026,9 +1027,9 @@ class AccountViewModel(
         createdAt: Long,
     ) = launchSigner { account.requestToVanishFromEverywhere(reason, createdAt) }
 
-    fun cachedDecrypt(note: Note): String? = account.cachedDecryptContent(note)
+    override fun cachedDecrypt(note: Note): String? = account.cachedDecryptContent(note)
 
-    fun decrypt(
+    override fun decrypt(
         note: Note,
         onReady: (String) -> Unit,
     ) = launchSigner {
@@ -1081,79 +1082,79 @@ class AccountViewModel(
         community: AddressableNote,
     ) = launchSigner { account.approveCommunityPost(post, community) }
 
-    fun follow(community: AddressableNote) = launchSigner { account.follow(community) }
+    override fun follow(community: AddressableNote) = launchSigner { account.follow(community) }
 
-    fun follow(channel: PublicChatChannel) = launchSigner { account.follow(channel) }
+    override fun follow(channel: PublicChatChannel) = launchSigner { account.follow(channel) }
 
-    fun follow(channel: EphemeralChatChannel) = launchSigner { account.follow(channel) }
+    override fun follow(channel: EphemeralChatChannel) = launchSigner { account.follow(channel) }
 
-    fun unfollow(community: AddressableNote) = launchSigner { account.unfollow(community) }
+    override fun unfollow(community: AddressableNote) = launchSigner { account.unfollow(community) }
 
-    fun unfollow(channel: PublicChatChannel) = launchSigner { account.unfollow(channel) }
+    override fun unfollow(channel: PublicChatChannel) = launchSigner { account.unfollow(channel) }
 
-    fun unfollow(channel: EphemeralChatChannel) = launchSigner { account.unfollow(channel) }
+    override fun unfollow(channel: EphemeralChatChannel) = launchSigner { account.unfollow(channel) }
 
-    fun follow(users: List<User>) = launchSigner { account.follow(users) }
+    override fun follow(users: List<User>) = launchSigner { account.follow(users) }
 
-    fun follow(user: User) = launchSigner { account.follow(user) }
+    override fun follow(user: User) = launchSigner { account.follow(user) }
 
-    fun unfollow(user: User) = launchSigner { account.unfollow(user) }
+    override fun unfollow(user: User) = launchSigner { account.unfollow(user) }
 
-    fun followGeohash(tag: String) = launchSigner { account.followGeohash(tag) }
+    override fun followGeohash(tag: String) = launchSigner { account.followGeohash(tag) }
 
-    fun unfollowGeohash(tag: String) = launchSigner { account.unfollowGeohash(tag) }
+    override fun unfollowGeohash(tag: String) = launchSigner { account.unfollowGeohash(tag) }
 
-    fun followHashtag(tag: String) = launchSigner { account.followHashtag(tag) }
+    override fun followHashtag(tag: String) = launchSigner { account.followHashtag(tag) }
 
-    fun unfollowHashtag(tag: String) = launchSigner { account.unfollowHashtag(tag) }
+    override fun unfollowHashtag(tag: String) = launchSigner { account.unfollowHashtag(tag) }
 
-    fun followRelayFeed(url: NormalizedRelayUrl) = launchSigner { account.followRelayFeed(url) }
+    override fun followRelayFeed(url: NormalizedRelayUrl) = launchSigner { account.followRelayFeed(url) }
 
-    fun unfollowRelayFeed(url: NormalizedRelayUrl) = launchSigner { account.unfollowRelayFeed(url) }
+    override fun unfollowRelayFeed(url: NormalizedRelayUrl) = launchSigner { account.unfollowRelayFeed(url) }
 
-    fun showWord(word: String) = launchSigner { account.showWord(word) }
+    override fun showWord(word: String) = launchSigner { account.showWord(word) }
 
-    fun hideWord(word: String) = launchSigner { account.hideWord(word) }
+    override fun hideWord(word: String) = launchSigner { account.hideWord(word) }
 
-    fun isLoggedUser(pubkeyHex: HexKey?): Boolean = account.signer.pubKey == pubkeyHex
+    override fun isLoggedUser(pubkeyHex: HexKey?): Boolean = account.signer.pubKey == pubkeyHex
 
-    fun isLoggedUser(user: User?): Boolean = isLoggedUser(user?.pubkeyHex)
+    override fun isLoggedUser(user: User?): Boolean = isLoggedUser(user?.pubkeyHex)
 
-    fun isFollowing(user: User?): Boolean {
+    override fun isFollowing(user: User?): Boolean {
         if (user == null) return false
         return account.isFollowing(user)
     }
 
-    fun isFollowing(user: HexKey): Boolean = account.isFollowing(user)
+    override fun isFollowing(user: HexKey): Boolean = account.isFollowing(user)
 
-    fun markDonatedInThisVersion() = account.markDonatedInThisVersion()
+    override fun markDonatedInThisVersion() = account.markDonatedInThisVersion()
 
-    fun dismissPollNotification(noteId: String) = account.dismissPollNotification(noteId)
+    override fun dismissPollNotification(noteId: String) = account.dismissPollNotification(noteId)
 
-    fun hasViewedPollResults(noteId: String) = account.hasViewedPollResults(noteId)
+    override fun hasViewedPollResults(noteId: String) = account.hasViewedPollResults(noteId)
 
-    fun markPollResultsViewed(
+    override fun markPollResultsViewed(
         noteId: String,
         pollEndsAt: Long?,
     ) = account.markPollResultsViewed(noteId, pollEndsAt)
 
-    fun dontTranslateFrom() = account.settings.syncedSettings.languages.dontTranslateFrom.value
+    override fun dontTranslateFrom() = account.settings.syncedSettings.languages.dontTranslateFrom.value
 
-    fun translateTo() = account.settings.syncedSettings.languages.translateTo.value
+    override fun translateTo() = account.settings.syncedSettings.languages.translateTo.value
 
-    fun defaultZapType() = account.settings.syncedSettings.zaps.defaultZapType.value
+    override fun defaultZapType() = account.settings.syncedSettings.zaps.defaultZapType.value
 
-    fun showSensitiveContent(): MutableStateFlow<Boolean?> = account.settings.syncedSettings.security.showSensitiveContent
+    override fun showSensitiveContent(): MutableStateFlow<Boolean?> = account.settings.syncedSettings.security.showSensitiveContent
 
-    fun zapAmountChoicesFlow() = account.settings.syncedSettings.zaps.zapAmountChoices
+    override fun zapAmountChoicesFlow() = account.settings.syncedSettings.zaps.zapAmountChoices
 
-    fun zapAmountChoices() = zapAmountChoicesFlow().value
+    override fun zapAmountChoices() = zapAmountChoicesFlow().value
 
-    fun reactionChoicesFlow() = account.settings.syncedSettings.reactions.reactionChoices
+    override fun reactionChoicesFlow() = account.settings.syncedSettings.reactions.reactionChoices
 
-    fun reactionChoices() = reactionChoicesFlow().value
+    override fun reactionChoices() = reactionChoicesFlow().value
 
-    fun filterSpamFromStrangers() = account.settings.syncedSettings.security.filterSpamFromStrangers
+    override fun filterSpamFromStrangers() = account.settings.syncedSettings.security.filterSpamFromStrangers
 
     fun toggleSendKind0ToLocalRelay(enabled: Boolean) = launchSigner { account.updateSendKind0EventsToLocalRelay(enabled) }
 
@@ -1199,19 +1200,19 @@ class AccountViewModel(
 
     fun updateTranslateTo(languageCode: String) = launchSigner { account.updateTranslateTo(languageCode) }
 
-    fun prefer(
+    override fun prefer(
         source: String,
         target: String,
         preference: String,
     ) = launchSigner { account.prefer(source, target, preference) }
 
-    fun show(user: User) = launchSigner { account.showUser(user.pubkeyHex) }
+    override fun show(user: User) = launchSigner { account.showUser(user.pubkeyHex) }
 
-    fun hide(user: User) = launchSigner { account.hideUser(user.pubkeyHex) }
+    override fun hide(user: User) = launchSigner { account.hideUser(user.pubkeyHex) }
 
-    fun hide(word: String) = launchSigner { account.hideWord(word) }
+    override fun hide(word: String) = launchSigner { account.hideWord(word) }
 
-    fun showUser(pubkeyHex: String) = launchSigner { account.showUser(pubkeyHex) }
+    override fun showUser(pubkeyHex: String) = launchSigner { account.showUser(pubkeyHex) }
 
     fun createStatus(newStatus: String) = launchSigner { account.createStatus(newStatus) }
 
@@ -1242,17 +1243,17 @@ class AccountViewModel(
         return note.getReactionBy(userProfile())
     }
 
-    fun runOnIO(runOnIO: suspend () -> Unit) {
+    override fun runOnIO(runOnIO: suspend () -> Unit) {
         viewModelScope.launch(Dispatchers.IO) { runOnIO() }
     }
 
-    fun checkGetOrCreateUser(key: HexKey): User? = LocalCache.checkGetOrCreateUser(key)
+    override fun checkGetOrCreateUser(key: HexKey): User? = LocalCache.checkGetOrCreateUser(key)
 
     override suspend fun getOrCreateUser(hex: HexKey): User = LocalCache.getOrCreateUser(hex)
 
-    fun getUserIfExists(hex: HexKey): User? = LocalCache.getUserIfExists(hex)
+    override fun getUserIfExists(hex: HexKey): User? = LocalCache.getUserIfExists(hex)
 
-    fun checkGetOrCreateNote(key: HexKey): Note? = LocalCache.checkGetOrCreateNote(key)
+    override fun checkGetOrCreateNote(key: HexKey): Note? = LocalCache.checkGetOrCreateNote(key)
 
     override suspend fun getOrCreateNote(hex: HexKey): Note = LocalCache.getOrCreateNote(hex)
 
@@ -1267,7 +1268,7 @@ class AccountViewModel(
         return note
     }
 
-    fun getNoteIfExists(hex: HexKey): Note? = LocalCache.getNoteIfExists(hex)
+    override fun getNoteIfExists(hex: HexKey): Note? = LocalCache.getNoteIfExists(hex)
 
     /**
      * Fixes author and relay hints in MarkedETag list by looking up notes from cache.

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/IAccountViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/IAccountViewModel.kt
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.screen.loggedIn
+
+import com.vitorpamplona.amethyst.commons.model.AddressableNote
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
+import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatChannel
+import com.vitorpamplona.quartz.nip01Core.core.Address
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Platform-agnostic interface for AccountViewModel.
+ *
+ * Exposes the most commonly used members of AccountViewModel using only
+ * commons-compatible types. Composables and ViewModels in the commons module
+ * can depend on this interface instead of the concrete Android AccountViewModel,
+ * enabling incremental migration to KMP.
+ *
+ * Members are ordered by usage frequency (most-referenced first).
+ */
+interface IAccountViewModel {
+    // ── core properties (475+ usages) ─────────────────────────────────
+
+    /** The underlying account abstraction. */
+    val account: IAccount
+
+    // ── identity helpers (50-20 usages) ───────────────────────────────
+
+    /** Current user's profile. */
+    fun userProfile(): User
+
+    /** Whether the account can sign events. */
+    fun isWriteable(): Boolean
+
+    /** Whether the given pubkey is the logged-in user. */
+    fun isLoggedUser(pubkeyHex: HexKey?): Boolean
+
+    /** Whether the given user is the logged-in user. */
+    fun isLoggedUser(user: User?): Boolean
+
+    /** Whether the logged-in user follows the given user. */
+    fun isFollowing(user: User?): Boolean
+
+    /** Whether the logged-in user follows the given pubkey. */
+    fun isFollowing(user: HexKey): Boolean
+
+    // ── cache access (33-10 usages) ──────────────────────────────────
+
+    /** Get a note from cache if it exists. */
+    fun getNoteIfExists(hex: HexKey): Note?
+
+    /** Get or create a user in cache. */
+    fun checkGetOrCreateUser(key: HexKey): User?
+
+    /** Get a user from cache if it exists. */
+    fun getUserIfExists(hex: HexKey): User?
+
+    /** Get or create a note in cache. */
+    fun checkGetOrCreateNote(key: HexKey): Note?
+
+    /** Get or create an addressable note in cache. */
+    fun getOrCreateAddressableNote(address: Address): AddressableNote
+
+    // ── coroutine helpers ─────────────────────────────────────────────
+
+    /** Launch a coroutine on IO. */
+    fun runOnIO(runOnIO: suspend () -> Unit)
+
+    // ── follow / unfollow (10-8 usages each) ─────────────────────────
+
+    fun follow(user: User)
+
+    fun follow(users: List<User>)
+
+    fun follow(community: AddressableNote)
+
+    fun follow(channel: PublicChatChannel)
+
+    fun follow(channel: EphemeralChatChannel)
+
+    fun unfollow(user: User)
+
+    fun unfollow(community: AddressableNote)
+
+    fun unfollow(channel: PublicChatChannel)
+
+    fun unfollow(channel: EphemeralChatChannel)
+
+    fun followHashtag(tag: String)
+
+    fun unfollowHashtag(tag: String)
+
+    fun followGeohash(tag: String)
+
+    fun unfollowGeohash(tag: String)
+
+    fun followRelayFeed(url: NormalizedRelayUrl)
+
+    fun unfollowRelayFeed(url: NormalizedRelayUrl)
+
+    // ── note actions (7-10 usages each) ──────────────────────────────
+
+    fun broadcast(note: Note)
+
+    fun delete(note: Note)
+
+    fun delete(notes: List<Note>)
+
+    fun hide(user: User)
+
+    fun show(user: User)
+
+    fun hide(word: String)
+
+    fun showWord(word: String)
+
+    fun hideWord(word: String)
+
+    fun showUser(pubkeyHex: String)
+
+    fun report(
+        note: Note,
+        type: com.vitorpamplona.quartz.nip56Reports.ReportType,
+        content: String,
+    )
+
+    // ── settings accessors (9+ usages) ───────────────────────────────
+
+    fun showSensitiveContent(): MutableStateFlow<Boolean?>
+
+    fun zapAmountChoices(): List<Long>
+
+    fun zapAmountChoicesFlow(): StateFlow<List<Long>>
+
+    fun reactionChoices(): List<String>
+
+    fun reactionChoicesFlow(): StateFlow<List<String>>
+
+    fun defaultZapType(): com.vitorpamplona.quartz.nip57Zaps.LnZapEvent.ZapType
+
+    fun dontTranslateFrom(): Set<String>
+
+    fun translateTo(): String
+
+    fun filterSpamFromStrangers(): MutableStateFlow<Boolean>
+
+    // ── misc (5-9 usages) ────────────────────────────────────────────
+
+    fun prefer(
+        source: String,
+        target: String,
+        preference: String,
+    )
+
+    /** Decrypt a note's content from cache or null. */
+    fun cachedDecrypt(note: Note): String?
+
+    /** Decrypt a note's content, calling onReady when done. */
+    fun decrypt(
+        note: Note,
+        onReady: (String) -> Unit,
+    )
+
+    fun markDonatedInThisVersion(): Boolean
+
+    fun dismissPollNotification(noteId: String)
+
+    fun hasViewedPollResults(noteId: String): Boolean
+
+    fun markPollResultsViewed(
+        noteId: String,
+        pollEndsAt: Long?,
+    )
+}


### PR DESCRIPTION
## Summary

Add a platform-agnostic `IAccountViewModel` interface in the `commons` module that abstracts the most-used members of `AccountViewModel`. This enables composables and ViewModels in commons to depend on the interface rather than the concrete Android `AccountViewModel` class.

## Changes

- **New: `IAccountViewModel` interface** in `commons/src/commonMain/.../ui/screen/loggedIn/`
  - 40+ members covering identity, cache access, follow/unfollow, note actions, settings, and decryption
  - All types are commons-compatible (`IAccount`, `User`, `Note`, `AddressableNote`, quartz types)
- **`AccountViewModel` now implements `IAccountViewModel`** alongside `ViewModel` and `Dao`
  - Added `override` modifiers to all matching members
  - Covariant property override: `val account: Account` satisfies `val account: IAccount`

## Interface members (by usage frequency)

| Category | Members |
|---|---|
| Core properties | `account`, `userProfile()`, `isWriteable()` |
| Identity | `isLoggedUser()`, `isFollowing()` |
| Cache access | `getNoteIfExists`, `checkGetOrCreateUser`, `checkGetOrCreateNote`, `getOrCreateAddressableNote` |
| Follow/unfollow | Users, communities, channels, hashtags, geohashes, relay feeds |
| Note actions | `broadcast`, `delete`, `hide`, `show`, `report` |
| Settings | `zapAmountChoices`, `reactionChoices`, `showSensitiveContent`, `filterSpamFromStrangers` |
| Decryption | `cachedDecrypt`, `decrypt` |
| Misc | `prefer`, `markDonatedInThisVersion`, poll notification helpers |

## What this enables

With `IAccountViewModel` available in commons, composables can be incrementally migrated:
1. Change parameter type from `AccountViewModel` → `IAccountViewModel`
2. Move composable file from `amethyst` → `commons`
3. No changes needed at call sites (AccountViewModel IS-A IAccountViewModel)

## Build verification

- `:commons:compileKotlinJvm` ✅
- `:amethyst:compilePlayDebugKotlin` ✅
- `spotlessCheck` ✅