### PR TITLE
feat: expand IAccount interface for ViewModel migration

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.amethyst.BuildConfig
 import com.vitorpamplona.amethyst.LocalPreferences
 import com.vitorpamplona.amethyst.commons.marmot.MarmotManager
 import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.LiveHiddenUsers
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatListDecryptionCache
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatListState
@@ -332,12 +333,13 @@ class Account(
     val followLists = FollowListsState(signer, cache, scope)
 
     val hiddenUsers = HiddenUsersState(muteList.flow, blockPeopleList.flow, scope, settings)
+    override val liveHiddenUsers: StateFlow<LiveHiddenUsers> get() = hiddenUsers.flow
 
     val labeledBookmarkLists = LabeledBookmarkListsState(signer, cache, scope)
-    val oldBookmarkState = OldBookmarkListState(signer, cache, scope)
-    val bookmarkState = BookmarkListState(signer, cache, scope)
+    override val oldBookmarkState = OldBookmarkListState(signer, cache, scope)
+    override val bookmarkState = BookmarkListState(signer, cache, scope)
     val pinState = PinListState(signer, cache, scope)
-    val emoji = EmojiPackState(signer, cache, scope)
+    override val emoji = EmojiPackState(signer, cache, scope)
 
     val vanish = VanishRequestsState(signer, cache, client, scope)
 
@@ -386,7 +388,7 @@ class Account(
 
     val otsState = OtsState(signer, cache, otsResolverBuilder, scope, settings)
 
-    val marmotManager: MarmotManager? = mlsGroupStateStore?.let { MarmotManager(signer, it) }
+    override val marmotManager: MarmotManager? = mlsGroupStateStore?.let { MarmotManager(signer, it) }
 
     val paymentTargetsState = NipA3PaymentTargetsState(signer, cache, scope, settings)
 
@@ -1433,7 +1435,7 @@ class Account(
         }
     }
 
-    suspend fun deleteDraftIgnoreErrors(draftTag: String) {
+    override suspend fun deleteDraftIgnoreErrors(draftTag: String) {
         try {
             deleteDraftInner(draftTag)
         } catch (e: Exception) {
@@ -2269,13 +2271,13 @@ class Account(
             false
         }
 
-    fun isFollowing(user: User): Boolean = user.pubkeyHex in followingKeySet()
+    override fun isFollowing(user: User): Boolean = user.pubkeyHex in followingKeySet()
 
-    fun isFollowing(user: HexKey): Boolean = user in followingKeySet()
+    override fun isFollowing(userHex: HexKey): Boolean = userHex in followingKeySet()
 
-    fun isKnown(user: User): Boolean = user.pubkeyHex in allFollows.flow.value.authors
+    override fun isKnown(user: User): Boolean = user.pubkeyHex in allFollows.flow.value.authors
 
-    fun isKnown(user: HexKey): Boolean = user in allFollows.flow.value.authors
+    override fun isKnown(userHex: HexKey): Boolean = userHex in allFollows.flow.value.authors
 
     private fun hasExcessiveHashtags(note: Note): Boolean {
         val limit = settings.syncedSettings.security.maxHashtagLimit.value
@@ -2364,14 +2366,14 @@ class Account(
 
     suspend fun savePaymentTargets(targets: List<PaymentTarget>) = sendMyPublicAndPrivateOutbox(paymentTargetsState.savePaymentTargets(targets))
 
-    fun markAsRead(
+    override fun markAsRead(
         route: String,
         timestampInSecs: Long,
     ) = settings.markAsRead(route, timestampInSecs)
 
     fun loadLastRead(route: String): Long = settings.lastReadPerRoute.value[route]?.value ?: 0
 
-    fun loadLastReadFlow(route: String) = settings.getLastReadFlow(route)
+    override fun loadLastReadFlow(route: String) = settings.getLastReadFlow(route)
 
     fun hasDonatedInThisVersion() = settings.hasDonatedInVersion(BuildConfig.VERSION_NAME)
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
@@ -20,7 +20,11 @@
  */
 package com.vitorpamplona.amethyst.commons.model
 
+import com.vitorpamplona.amethyst.commons.marmot.MarmotManager
 import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupList
+import com.vitorpamplona.amethyst.commons.model.nip30CustomEmojis.EmojiPackState
+import com.vitorpamplona.amethyst.commons.model.nip51Lists.BookmarkListState
+import com.vitorpamplona.amethyst.commons.model.nip51Lists.OldBookmarkListState
 import com.vitorpamplona.amethyst.commons.model.privateChats.ChatroomList
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
@@ -34,6 +38,7 @@ import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Response
 import com.vitorpamplona.quartz.nip57Zaps.IPrivateZapsDecryptionCache
 import com.vitorpamplona.quartz.nip59Giftwrap.wraps.GiftWrapEvent
 import com.vitorpamplona.quartz.utils.DualCase
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Interface for NIP-47 wallet connect signer state.
@@ -119,4 +124,45 @@ interface IAccount {
 
     /** Broadcast pre-created gift wraps (e.g. reactions within group DMs) */
     suspend fun sendGiftWraps(wraps: List<GiftWrapEvent>)
+
+    // --- Members added for ViewModel migration ---
+
+    /** Bookmark list state (NIP-51 kind 10003) */
+    val bookmarkState: BookmarkListState
+
+    /** Old bookmark list state (NIP-51 kind 30001 "bookmark") */
+    val oldBookmarkState: OldBookmarkListState
+
+    /** Custom emoji pack state (NIP-30) */
+    val emoji: EmojiPackState
+
+    /** Marmot MLS group manager (null when MLS unavailable) */
+    val marmotManager: MarmotManager?
+
+    /** Live hidden-users state as a flow for UI observation */
+    val liveHiddenUsers: StateFlow<LiveHiddenUsers>
+
+    /** Whether the given user is in the follow (kind 3) list */
+    fun isFollowing(user: User): Boolean
+
+    /** Whether the given hex-key user is in the follow (kind 3) list */
+    fun isFollowing(userHex: String): Boolean
+
+    /** Whether the given user appears in any follow/people list */
+    fun isKnown(user: User): Boolean
+
+    /** Whether the given hex-key user appears in any follow/people list */
+    fun isKnown(userHex: String): Boolean
+
+    /** Mark a route as read at the given timestamp. Returns true if updated. */
+    fun markAsRead(
+        route: String,
+        timestampInSecs: Long,
+    ): Boolean
+
+    /** Observe last-read timestamp for a route */
+    fun loadLastReadFlow(route: String): StateFlow<Long>
+
+    /** Delete a draft event by tag, swallowing errors */
+    suspend fun deleteDraftIgnoreErrors(draftTag: String)
 }


### PR DESCRIPTION
## Summary

Expand the `IAccount` interface in `commons` with additional members that ViewModels frequently access. This is a step toward enabling ViewModels to depend on `IAccount` (interface) rather than the concrete `Account` class, which is required for KMP/iOS migration.

## Added Members

All members added have KMP-compatible types (defined in commons or quartz) and are referenced by 5+ UI files:

| Member | Type | UI References |
|--------|------|:---:|
| `bookmarkState` | `BookmarkListState` | 11 |
| `oldBookmarkState` | `OldBookmarkListState` | 6 |
| `emoji` | `EmojiPackState` | 9 |
| `marmotManager` | `MarmotManager?` | 7 |
| `liveHiddenUsers` | `StateFlow<LiveHiddenUsers>` | 40 |
| `isFollowing(User/String)` | `Boolean` | 8 |
| `isKnown(User/String)` | `Boolean` | 5 |
| `markAsRead(route, ts)` | `Boolean` | 5 |
| `loadLastReadFlow(route)` | `StateFlow<Long>` | 7 |
| `deleteDraftIgnoreErrors(tag)` | `suspend` | 14 |

## Not Included (yet)

- `kind3FollowList` — amethyst has its own `Kind3FollowListState` that differs from the commons one; needs type unification first
- `settings` / `cache` / `client` / `scope` — heavily used but complex; better as separate PRs
- `liveHomeFollowLists` / `liveDiscoveryFollowLists` — depends on `IFeedTopNavFilter` not yet in commons

## Build

``:commons:compileKotlinJvm`` and ``:amethyst:compilePlayDebugKotlin`` pass. spotlessApply clean.