### PR TITLE
feat: add IAccountViewModel interface to commons with IToastManager

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ToastManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ToastManager.kt
@@ -21,27 +21,28 @@
 package com.vitorpamplona.amethyst.ui.components.toasts
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.ui.components.toasts.IToastManager
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.ui.components.toasts.multiline.MultiErrorToastMsg
 import com.vitorpamplona.amethyst.ui.components.toasts.multiline.UserBasedErrorMessage
 import kotlinx.coroutines.flow.MutableStateFlow
 
 @Stable
-class ToastManager {
+class ToastManager : IToastManager {
     val toasts = MutableStateFlow<ToastMsg?>(null)
 
-    fun clearToasts() {
+    override fun clearToasts() {
         toasts.tryEmit(null)
     }
 
-    fun toast(
+    override fun toast(
         title: String,
         message: String,
     ) {
         toasts.tryEmit(StringToastMsg(title, message))
     }
 
-    fun toast(
+    override fun toast(
         title: String,
         message: String,
         action: () -> Unit,
@@ -49,14 +50,14 @@ class ToastManager {
         toasts.tryEmit(ActionableStringToastMsg(title, message, action))
     }
 
-    fun toast(
+    override fun toast(
         titleResId: Int,
         resourceId: Int,
     ) {
         toasts.tryEmit(ResourceToastMsg(titleResId, resourceId))
     }
 
-    fun toast(
+    override fun toast(
         titleResId: Int,
         message: String?,
         throwable: Throwable,
@@ -64,7 +65,7 @@ class ToastManager {
         toasts.tryEmit(ThrowableToastMsg(titleResId, message, throwable))
     }
 
-    fun toast(
+    override fun toast(
         titleResId: Int,
         description: Int,
         throwable: Throwable,
@@ -72,7 +73,7 @@ class ToastManager {
         toasts.tryEmit(ThrowableToastMsg2(titleResId, description, throwable))
     }
 
-    fun toast(
+    override fun toast(
         titleResId: Int,
         resourceId: Int,
         vararg params: String,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -51,6 +51,7 @@ import com.vitorpamplona.amethyst.commons.model.nip53LiveActivities.LiveActiviti
 import com.vitorpamplona.amethyst.commons.model.observables.CreatedAtComparator
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
 import com.vitorpamplona.amethyst.commons.ui.notifications.CardFeedState
+import com.vitorpamplona.amethyst.commons.viewmodels.IAccountViewModel
 import com.vitorpamplona.amethyst.logTime
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.AccountSettings
@@ -175,17 +176,18 @@ import kotlinx.coroutines.withContext
 
 @Stable
 class AccountViewModel(
-    val account: Account,
+    override val account: Account,
     val settings: UiSettingsState,
     val torSettings: TorSettingsFlow,
     val dataSources: RelaySubscriptionsCoordinator,
     val httpClientBuilder: IRoleBasedHttpClientBuilder,
     val nip05ClientBuilder: () -> INip05Client,
 ) : ViewModel(),
-    Dao {
+    Dao,
+    IAccountViewModel {
     var firstRoute: Route? = null
 
-    val toastManager = ToastManager()
+    override val toastManager = ToastManager()
     val broadcastTracker = BroadcastTracker()
     val feedStates = AccountFeedContentStates(account, viewModelScope)
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/toasts/IToastManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/toasts/IToastManager.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.components.toasts
+
+/**
+ * Platform-agnostic toast manager interface for KMP.
+ *
+ * Android implementation uses resource IDs and Android-specific toast types.
+ * Other platforms can provide their own notification mechanisms.
+ */
+interface IToastManager {
+    fun clearToasts()
+
+    fun toast(
+        title: String,
+        message: String,
+    )
+
+    fun toast(
+        title: String,
+        message: String,
+        action: () -> Unit,
+    )
+
+    fun toast(
+        titleResId: Int,
+        resourceId: Int,
+    )
+
+    fun toast(
+        titleResId: Int,
+        message: String?,
+        throwable: Throwable,
+    )
+
+    fun toast(
+        titleResId: Int,
+        description: Int,
+        throwable: Throwable,
+    )
+
+    fun toast(
+        titleResId: Int,
+        resourceId: Int,
+        vararg params: String,
+    )
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/IAccountViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/IAccountViewModel.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.viewmodels
+
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.ui.components.toasts.IToastManager
+
+/**
+ * Platform-agnostic interface for the account view model.
+ *
+ * Android's [AccountViewModel] implements this directly.
+ * iOS/Desktop can provide their own implementations backed
+ * by the same Nostr account primitives.
+ */
+interface IAccountViewModel {
+    /** The logged-in Nostr account. */
+    val account: IAccount
+
+    /** Toast/snackbar manager for surfacing transient messages. */
+    val toastManager: IToastManager
+}


### PR DESCRIPTION
## Summary

Introduces `IAccountViewModel` to the commons module — a platform-agnostic interface that exposes:
- `account: IAccount` — the logged-in Nostr account
- `toastManager: IToastManager` — toast/snackbar notification manager

Android's `AccountViewModel` now implements `IAccountViewModel`, enabling KMP iOS/Desktop code to depend on the interface without pulling in Android-specific types.

## Changes
- **New:** `commons/.../viewmodels/IAccountViewModel.kt`
- **Modified:** `AccountViewModel.kt` — implements `IAccountViewModel`, adds `override` to `account` and `toastManager`

## Depends on
- PR #2259 (`IToastManager` extraction) — included via merge

Build verified: `:commons:compileKotlinJvm` + `:amethyst:compilePlayDebugKotlin` ✅