### PR TITLE
feat: convert toast message classes from Int to StringResource

### DIFF
--- a/amethyst/build.gradle
+++ b/amethyst/build.gradle
@@ -246,6 +246,7 @@ dependencies {
 
     implementation project(path: ':quartz')
     implementation project(path: ':commons')
+    implementation libs.jetbrains.compose.components.resources
     implementation project(path: ':ammolite')
     implementation libs.androidx.core.ktx
     implementation libs.androidx.activity.compose

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/InformationDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/InformationDialog.kt
@@ -44,6 +44,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.ui.components.toasts.LegacyThrowableToastMsg
+import com.vitorpamplona.amethyst.ui.components.toasts.LegacyThrowableToastMsg2
 import com.vitorpamplona.amethyst.ui.components.toasts.ThrowableToastMsg
 import com.vitorpamplona.amethyst.ui.components.toasts.ThrowableToastMsg2
 import com.vitorpamplona.amethyst.ui.components.util.setText
@@ -51,6 +53,7 @@ import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.Size16dp
 import com.vitorpamplona.amethyst.ui.theme.StdHorzSpacer
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
 import java.io.PrintWriter
 import java.io.StringWriter
 
@@ -72,12 +75,58 @@ fun InformationDialog(
             writer.toString()
         }
 
-    InformationDialog(title = stringRes(obj.titleResId), textContent = str, moreInfo = stack, buttonColors, onDismiss)
+    InformationDialog(title = stringResource(obj.titleRes), textContent = str, moreInfo = stack, buttonColors, onDismiss)
 }
 
 @Composable
 fun InformationDialog(
     obj: ThrowableToastMsg2,
+    buttonColors: ButtonColors = ButtonDefaults.buttonColors(),
+    onDismiss: () -> Unit,
+) {
+    val str = stringResource(obj.descriptionRes)
+
+    val stack =
+        remember(obj) {
+            val writer = StringWriter()
+            writer.append("\n")
+
+            obj.throwable.printStackTrace(PrintWriter(writer))
+
+            writer.toString()
+        }
+
+    InformationDialog(title = stringResource(obj.titleRes), textContent = str, moreInfo = stack, buttonColors, onDismiss)
+}
+
+// Legacy Int-based overloads (will be removed after full migration)
+
+@Suppress("DEPRECATION")
+@Composable
+fun InformationDialog(
+    obj: LegacyThrowableToastMsg,
+    buttonColors: ButtonColors = ButtonDefaults.buttonColors(),
+    onDismiss: () -> Unit,
+) {
+    val str = obj.msg ?: obj.throwable.localizedMessage ?: obj.throwable.message ?: obj.throwable.javaClass.simpleName
+
+    val stack =
+        remember(obj) {
+            val writer = StringWriter()
+            writer.append("\n")
+
+            obj.throwable.printStackTrace(PrintWriter(writer))
+
+            writer.toString()
+        }
+
+    InformationDialog(title = stringRes(obj.titleResId), textContent = str, moreInfo = stack, buttonColors, onDismiss)
+}
+
+@Suppress("DEPRECATION")
+@Composable
+fun InformationDialog(
+    obj: LegacyThrowableToastMsg2,
     buttonColors: ButtonColors = ButtonDefaults.buttonColors(),
     onDismiss: () -> Unit,
 ) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ReusableZapButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ReusableZapButton.kt
@@ -45,6 +45,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.error_dialog_zap_error
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.ZapPaymentHandler
@@ -136,7 +138,7 @@ fun ReusableZapButton(
                 onError = { _, message, toUser ->
                     scope.launch {
                         zappingProgress = 0f
-                        accountViewModel.toastManager.toast(R.string.error_dialog_zap_error, message, toUser)
+                        accountViewModel.toastManager.toast(Res.string.error_dialog_zap_error, message, toUser)
                     }
                 },
                 onPayViaIntent = {
@@ -144,7 +146,7 @@ fun ReusableZapButton(
                         val payable = it.first()
                         payViaIntent(payable.invoice, context, { }) {
                             zappingProgress = 0f
-                            accountViewModel.toastManager.toast(R.string.error_dialog_zap_error, UserBasedErrorMessage(it, payable.info.user))
+                            accountViewModel.toastManager.toast(Res.string.error_dialog_zap_error, UserBasedErrorMessage(it, payable.info.user))
                         }
                     } else {
                         val uid = Uuid.random().toString()
@@ -173,7 +175,7 @@ fun ReusableZapButton(
                 onError = { _, message, user ->
                     scope.launch {
                         zappingProgress = 0f
-                        accountViewModel.toastManager.toast(R.string.error_dialog_zap_error, message, user)
+                        accountViewModel.toastManager.toast(Res.string.error_dialog_zap_error, message, user)
                     }
                 },
                 onProgress = {
@@ -184,7 +186,7 @@ fun ReusableZapButton(
                         val payable = it.first()
                         payViaIntent(payable.invoice, context, { }) {
                             zappingProgress = 0f
-                            accountViewModel.toastManager.toast(R.string.error_dialog_zap_error, UserBasedErrorMessage(it, payable.info.user))
+                            accountViewModel.toastManager.toast(Res.string.error_dialog_zap_error, UserBasedErrorMessage(it, payable.info.user))
                         }
                     } else {
                         val uid = Uuid.random().toString()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
@@ -77,6 +77,9 @@ import coil3.compose.SubcomposeAsyncImageContent
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.media_added
+import com.vitorpamplona.amethyst.commons.resources.media_added_to_profile_gallery
 import com.vitorpamplona.amethyst.commons.richtext.BaseMediaContent
 import com.vitorpamplona.amethyst.commons.richtext.MediaLocalImage
 import com.vitorpamplona.amethyst.commons.richtext.MediaLocalVideo
@@ -796,7 +799,7 @@ fun ShareMediaAction(
                                 val n19 = Nip19Parser.uriToRoute(postNostrUri)?.entity as? NEvent
                                 if (n19 != null) {
                                     accountViewModel.addMediaToGallery(n19.hex, videoUri, n19.relay.getOrNull(0), blurhash, dim, hash, mimeType)
-                                    accountViewModel.toastManager.toast(R.string.media_added, R.string.media_added_to_profile_gallery)
+                                    accountViewModel.toastManager.toast(Res.string.media_added, Res.string.media_added_to_profile_gallery)
                                 }
                             }
                             onDismiss()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/DisplayErrorMessages.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/DisplayErrorMessages.kt
@@ -28,6 +28,7 @@ import com.vitorpamplona.amethyst.ui.components.toasts.multiline.MultiUserErrorM
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun DisplayErrorMessages(
@@ -39,40 +40,22 @@ fun DisplayErrorMessages(
 
     openDialogMsg.value?.let { obj ->
         when (obj) {
+            // New StringResource-based types
             is ResourceToastMsg -> {
                 if (obj.params != null) {
                     InformationDialog(
-                        stringRes(obj.titleResId),
-                        stringRes(obj.resourceId, *obj.params),
+                        stringResource(obj.titleRes),
+                        stringResource(obj.descRes, *obj.params),
                     ) {
                         toastManager.clearToasts()
                     }
                 } else {
                     InformationDialog(
-                        stringRes(obj.titleResId),
-                        stringRes(obj.resourceId),
+                        stringResource(obj.titleRes),
+                        stringResource(obj.descRes),
                     ) {
                         toastManager.clearToasts()
                     }
-                }
-            }
-
-            is StringToastMsg -> {
-                InformationDialog(
-                    obj.title,
-                    obj.msg,
-                ) {
-                    toastManager.clearToasts()
-                }
-            }
-
-            is ActionableStringToastMsg -> {
-                InformationDialog(
-                    obj.title,
-                    obj.msg,
-                ) {
-                    obj.action()
-                    toastManager.clearToasts()
                 }
             }
 
@@ -90,6 +73,65 @@ fun DisplayErrorMessages(
 
             is MultiErrorToastMsg -> {
                 MultiUserErrorMessageDialog(obj, accountViewModel, nav)
+            }
+
+            // Legacy Int-based types (will be removed after full migration)
+            is LegacyResourceToastMsg -> {
+                @Suppress("DEPRECATION")
+                if (obj.params != null) {
+                    InformationDialog(
+                        stringRes(obj.titleResId),
+                        stringRes(obj.resourceId, *obj.params),
+                    ) {
+                        toastManager.clearToasts()
+                    }
+                } else {
+                    InformationDialog(
+                        stringRes(obj.titleResId),
+                        stringRes(obj.resourceId),
+                    ) {
+                        toastManager.clearToasts()
+                    }
+                }
+            }
+
+            is LegacyThrowableToastMsg -> {
+                @Suppress("DEPRECATION")
+                InformationDialog(obj) {
+                    toastManager.clearToasts()
+                }
+            }
+
+            is LegacyThrowableToastMsg2 -> {
+                @Suppress("DEPRECATION")
+                InformationDialog(obj) {
+                    toastManager.clearToasts()
+                }
+            }
+
+            is LegacyMultiErrorToastMsg -> {
+                @Suppress("DEPRECATION")
+                MultiUserErrorMessageDialog(obj, accountViewModel, nav)
+            }
+
+            // String-based types
+            is StringToastMsg -> {
+                InformationDialog(
+                    obj.title,
+                    obj.msg,
+                ) {
+                    toastManager.clearToasts()
+                }
+            }
+
+            is ActionableStringToastMsg -> {
+                InformationDialog(
+                    obj.title,
+                    obj.msg,
+                ) {
+                    obj.action()
+                    toastManager.clearToasts()
+                }
             }
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/LegacyToastMsg.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/LegacyToastMsg.kt
@@ -18,18 +18,46 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.components.toasts.multiline
+package com.vitorpamplona.amethyst.ui.components.toasts
 
 import androidx.compose.runtime.Immutable
 import com.vitorpamplona.amethyst.model.User
-import com.vitorpamplona.amethyst.ui.components.toasts.ToastMsg
+import com.vitorpamplona.amethyst.ui.components.toasts.multiline.UserBasedErrorMessage
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
-import org.jetbrains.compose.resources.StringResource
 
+/**
+ * Legacy Int-based toast message classes.
+ * These will be removed once all callers are migrated to StringResource.
+ */
+@Deprecated("Use ResourceToastMsg with StringResource")
 @Immutable
-class MultiErrorToastMsg(
-    val titleRes: StringResource,
+class LegacyResourceToastMsg(
+    val titleResId: Int,
+    val resourceId: Int,
+    val params: Array<out String>? = null,
+) : ToastMsg()
+
+@Deprecated("Use ThrowableToastMsg with StringResource")
+@Immutable
+class LegacyThrowableToastMsg(
+    val titleResId: Int,
+    val msg: String? = null,
+    val throwable: Throwable,
+) : ToastMsg()
+
+@Deprecated("Use ThrowableToastMsg2 with StringResource")
+@Immutable
+class LegacyThrowableToastMsg2(
+    val titleResId: Int,
+    val description: Int,
+    val throwable: Throwable,
+) : ToastMsg()
+
+@Deprecated("Use MultiErrorToastMsg with StringResource")
+@Immutable
+class LegacyMultiErrorToastMsg(
+    val titleResId: Int,
 ) : ToastMsg() {
     val errors = MutableStateFlow<List<UserBasedErrorMessage>>(emptyList())
 
@@ -46,8 +74,3 @@ class MultiErrorToastMsg(
         }
     }
 }
-
-class UserBasedErrorMessage(
-    val error: String,
-    val user: User?,
-)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ResourceToastMsg.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ResourceToastMsg.kt
@@ -21,10 +21,11 @@
 package com.vitorpamplona.amethyst.ui.components.toasts
 
 import androidx.compose.runtime.Immutable
+import org.jetbrains.compose.resources.StringResource
 
 @Immutable
 class ResourceToastMsg(
-    val titleResId: Int,
-    val resourceId: Int,
+    val titleRes: StringResource,
+    val descRes: StringResource,
     val params: Array<out String>? = null,
 ) : ToastMsg()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ThrowableToastMsg.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ThrowableToastMsg.kt
@@ -21,17 +21,18 @@
 package com.vitorpamplona.amethyst.ui.components.toasts
 
 import androidx.compose.runtime.Immutable
+import org.jetbrains.compose.resources.StringResource
 
 @Immutable
 class ThrowableToastMsg(
-    val titleResId: Int,
+    val titleRes: StringResource,
     val msg: String? = null,
     val throwable: Throwable,
 ) : ToastMsg()
 
 @Immutable
 class ThrowableToastMsg2(
-    val titleResId: Int,
-    val description: Int,
+    val titleRes: StringResource,
+    val descriptionRes: StringResource,
     val throwable: Throwable,
 ) : ToastMsg()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ToastManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ToastManager.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.ui.components.toasts.multiline.MultiErrorToastMsg
 import com.vitorpamplona.amethyst.ui.components.toasts.multiline.UserBasedErrorMessage
 import kotlinx.coroutines.flow.MutableStateFlow
+import org.jetbrains.compose.resources.StringResource
 
 @Stable
 class ToastManager {
@@ -49,59 +50,125 @@ class ToastManager {
         toasts.tryEmit(ActionableStringToastMsg(title, message, action))
     }
 
+    // --- StringResource-based overloads (KMP) ---
+
+    fun toast(
+        titleRes: StringResource,
+        descRes: StringResource,
+    ) {
+        toasts.tryEmit(ResourceToastMsg(titleRes, descRes))
+    }
+
+    fun toast(
+        titleRes: StringResource,
+        message: String?,
+        throwable: Throwable,
+    ) {
+        toasts.tryEmit(ThrowableToastMsg(titleRes, message, throwable))
+    }
+
+    fun toast(
+        titleRes: StringResource,
+        descriptionRes: StringResource,
+        throwable: Throwable,
+    ) {
+        toasts.tryEmit(ThrowableToastMsg2(titleRes, descriptionRes, throwable))
+    }
+
+    fun toast(
+        titleRes: StringResource,
+        descRes: StringResource,
+        vararg params: String,
+    ) {
+        toasts.tryEmit(ResourceToastMsg(titleRes, descRes, params))
+    }
+
+    fun toast(
+        titleRes: StringResource,
+        message: String,
+        user: User?,
+    ) {
+        val current = toasts.value
+        if (current is MultiErrorToastMsg && current.titleRes == titleRes) {
+            current.add(message, user)
+        } else {
+            toasts.tryEmit(MultiErrorToastMsg(titleRes).also { it.add(message, user) })
+        }
+    }
+
+    fun toast(
+        titleRes: StringResource,
+        data: UserBasedErrorMessage,
+    ) {
+        val current = toasts.value
+        if (current is MultiErrorToastMsg && current.titleRes == titleRes) {
+            current.add(data)
+        } else {
+            toasts.tryEmit(MultiErrorToastMsg(titleRes).also { it.add(data) })
+        }
+    }
+
+    // --- Deprecated Int-based overloads (will be removed after full migration) ---
+
+    @Deprecated("Use StringResource overload", ReplaceWith("toast(titleRes, descRes)"))
     fun toast(
         titleResId: Int,
         resourceId: Int,
     ) {
-        toasts.tryEmit(ResourceToastMsg(titleResId, resourceId))
+        toasts.tryEmit(LegacyResourceToastMsg(titleResId, resourceId))
     }
 
+    @Deprecated("Use StringResource overload", ReplaceWith("toast(titleRes, message, throwable)"))
     fun toast(
         titleResId: Int,
         message: String?,
         throwable: Throwable,
     ) {
-        toasts.tryEmit(ThrowableToastMsg(titleResId, message, throwable))
+        toasts.tryEmit(LegacyThrowableToastMsg(titleResId, message, throwable))
     }
 
+    @Deprecated("Use StringResource overload", ReplaceWith("toast(titleRes, descriptionRes, throwable)"))
     fun toast(
         titleResId: Int,
         description: Int,
         throwable: Throwable,
     ) {
-        toasts.tryEmit(ThrowableToastMsg2(titleResId, description, throwable))
+        toasts.tryEmit(LegacyThrowableToastMsg2(titleResId, description, throwable))
     }
 
+    @Deprecated("Use StringResource overload", ReplaceWith("toast(titleRes, descRes, *params)"))
     fun toast(
         titleResId: Int,
         resourceId: Int,
         vararg params: String,
     ) {
-        toasts.tryEmit(ResourceToastMsg(titleResId, resourceId, params))
+        toasts.tryEmit(LegacyResourceToastMsg(titleResId, resourceId, params))
     }
 
+    @Deprecated("Use StringResource overload", ReplaceWith("toast(titleRes, message, user)"))
     fun toast(
         titleResId: Int,
         message: String,
         user: User?,
     ) {
         val current = toasts.value
-        if (current is MultiErrorToastMsg && current.titleResId == titleResId) {
+        if (current is LegacyMultiErrorToastMsg && current.titleResId == titleResId) {
             current.add(message, user)
         } else {
-            toasts.tryEmit(MultiErrorToastMsg(titleResId).also { it.add(message, user) })
+            toasts.tryEmit(LegacyMultiErrorToastMsg(titleResId).also { it.add(message, user) })
         }
     }
 
+    @Deprecated("Use StringResource overload", ReplaceWith("toast(titleRes, data)"))
     fun toast(
         titleResId: Int,
         data: UserBasedErrorMessage,
     ) {
         val current = toasts.value
-        if (current is MultiErrorToastMsg && current.titleResId == titleResId) {
+        if (current is LegacyMultiErrorToastMsg && current.titleResId == titleResId) {
             current.add(data)
         } else {
-            toasts.tryEmit(MultiErrorToastMsg(titleResId).also { it.add(data) })
+            toasts.tryEmit(LegacyMultiErrorToastMsg(titleResId).also { it.add(data) })
         }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/multiline/ErrorList.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/multiline/ErrorList.kt
@@ -42,8 +42,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.error_dialog_zap_error
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.User
+import com.vitorpamplona.amethyst.ui.components.toasts.LegacyMultiErrorToastMsg
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.routeToMessage
@@ -81,7 +84,7 @@ fun ErrorListPreview() {
         }
     }
 
-    val model = MultiErrorToastMsg(R.string.error_dialog_zap_error)
+    val model = MultiErrorToastMsg(Res.string.error_dialog_zap_error)
     model.add("Could not fetch invoice from https://minibits.cash/.well-known/lnurlp/victorieeman: There are too many unpaid invoices for this name.", user1)
     model.add("No Wallets found to pay a lightning invoice. Please install a Lightning wallet to use zaps.", user2)
     model.add("Could not fetch invoice", user3)
@@ -152,6 +155,24 @@ fun ErrorRow(
         Row(Modifier.weight(1f)) {
             SelectionContainer {
                 Text(errorState.error)
+            }
+        }
+    }
+}
+
+@Suppress("DEPRECATION")
+@Composable
+fun LegacyErrorList(
+    model: LegacyMultiErrorToastMsg,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    val errorState by model.errors.collectAsStateWithLifecycle()
+    LazyColumn {
+        itemsIndexed(errorState) { index, it ->
+            ErrorRow(it, accountViewModel, nav)
+            if (index < errorState.size - 1) {
+                HorizontalDivider(thickness = DividerThickness)
             }
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/multiline/MultiUserErrorMessageDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/multiline/MultiUserErrorMessageDialog.kt
@@ -31,8 +31,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.error_dialog_zap_error
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.User
+import com.vitorpamplona.amethyst.ui.components.toasts.LegacyMultiErrorToastMsg
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -44,6 +47,7 @@ import com.vitorpamplona.amethyst.ui.theme.ThemeComparisonColumn
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 @Preview
@@ -63,7 +67,7 @@ fun MultiUserErrorMessageContentPreview() {
         }
     }
 
-    val model = MultiErrorToastMsg(R.string.error_dialog_zap_error)
+    val model = MultiErrorToastMsg(Res.string.error_dialog_zap_error)
     model.add("Could not fetch invoice from https://minibits.cash/.well-known/lnurlp/victorieeman: There are too many unpaid invoices for this name.", user1)
     model.add("No Wallets found to pay a lightning invoice. Please install a Lightning wallet to use zaps.", user2)
     model.add("Could not fetch invoice", user3)
@@ -85,9 +89,38 @@ fun MultiUserErrorMessageDialog(
 ) {
     AlertDialog(
         onDismissRequest = accountViewModel.toastManager::clearToasts,
-        title = { Text(stringRes(model.titleResId)) },
+        title = { Text(stringResource(model.titleRes)) },
         text = {
             ErrorList(model, accountViewModel, nav)
+        },
+        confirmButton = {
+            Button(
+                onClick = accountViewModel.toastManager::clearToasts,
+                contentPadding = PaddingValues(horizontal = Size16dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Done,
+                    contentDescription = null,
+                )
+                Spacer(StdHorzSpacer)
+                Text(stringRes(R.string.error_dialog_button_ok))
+            }
+        },
+    )
+}
+
+@Suppress("DEPRECATION")
+@Composable
+fun MultiUserErrorMessageDialog(
+    model: LegacyMultiErrorToastMsg,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    AlertDialog(
+        onDismissRequest = accountViewModel.toastManager::clearToasts,
+        title = { Text(stringRes(model.titleResId)) },
+        text = {
+            LegacyErrorList(model, accountViewModel, nav)
         },
         confirmButton = {
             Button(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
@@ -103,6 +103,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.emojicoder.EmojiCoder
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.error_dialog_zap_error
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.ReactionRowAction
 import com.vitorpamplona.amethyst.model.ReactionRowItem
@@ -1195,7 +1197,7 @@ fun ZapReaction(
                             onError = { _, message, user ->
                                 scope.launch {
                                     zappingProgress = 0f
-                                    accountViewModel.toastManager.toast(R.string.error_dialog_zap_error, message, user)
+                                    accountViewModel.toastManager.toast(Res.string.error_dialog_zap_error, message, user)
                                 }
                             },
                             onPayViaIntent = {
@@ -1203,7 +1205,7 @@ fun ZapReaction(
                                     val payable = it.first()
                                     payViaIntent(payable.invoice, context, { }) { error ->
                                         zappingProgress = 0f
-                                        accountViewModel.toastManager.toast(R.string.error_dialog_zap_error, UserBasedErrorMessage(error, payable.info.user))
+                                        accountViewModel.toastManager.toast(Res.string.error_dialog_zap_error, UserBasedErrorMessage(error, payable.info.user))
                                     }
                                 } else {
                                     val uid = Uuid.random().toString()
@@ -1240,7 +1242,7 @@ fun ZapReaction(
                 onError = { _, message, user ->
                     scope.launch {
                         zappingProgress = 0f
-                        accountViewModel.toastManager.toast(R.string.error_dialog_zap_error, message, user)
+                        accountViewModel.toastManager.toast(Res.string.error_dialog_zap_error, message, user)
                     }
                 },
                 onProgress = { scope.launch(Dispatchers.Main) { zappingProgress = it } },
@@ -1249,7 +1251,7 @@ fun ZapReaction(
                         val payable = it.first()
                         payViaIntent(payable.invoice, context, { }) { error ->
                             zappingProgress = 0f
-                            accountViewModel.toastManager.toast(R.string.error_dialog_zap_error, UserBasedErrorMessage(error, payable.info.user))
+                            accountViewModel.toastManager.toast(Res.string.error_dialog_zap_error, UserBasedErrorMessage(error, payable.info.user))
                         }
                     } else {
                         val uid = Uuid.random().toString()
@@ -1267,7 +1269,7 @@ fun ZapReaction(
                 onError = { _, message, user ->
                     scope.launch {
                         zappingProgress = 0f
-                        accountViewModel.toastManager.toast(R.string.error_dialog_zap_error, message, user)
+                        accountViewModel.toastManager.toast(Res.string.error_dialog_zap_error, message, user)
                     }
                 },
                 onProgress = { scope.launch(Dispatchers.Main) { zappingProgress = it } },
@@ -1276,7 +1278,7 @@ fun ZapReaction(
                         val payable = it.first()
                         payViaIntent(payable.invoice, context, { }) { error ->
                             zappingProgress = 0f
-                            accountViewModel.toastManager.toast(R.string.error_dialog_zap_error, UserBasedErrorMessage(error, payable.info.user))
+                            accountViewModel.toastManager.toast(Res.string.error_dialog_zap_error, UserBasedErrorMessage(error, payable.info.user))
                         }
                     } else {
                         val uid = Uuid.random().toString()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Torrent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Torrent.kt
@@ -48,7 +48,10 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.torrent_failure
+import com.vitorpamplona.amethyst.commons.resources.torrent_no_apps
+import com.vitorpamplona.amethyst.commons.resources.torrent_no_info
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.service.countToHumanReadableBytes
@@ -221,11 +224,11 @@ fun DisplayFileList(
                             intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                             context.startActivity(intent)
                         } else {
-                            accountViewModel.toastManager.toast(R.string.torrent_failure, R.string.torrent_no_info)
+                            accountViewModel.toastManager.toast(Res.string.torrent_failure, Res.string.torrent_no_info)
                         }
                     } catch (e: Exception) {
                         if (e is CancellationException) throw e
-                        accountViewModel.toastManager.toast(R.string.torrent_failure, R.string.torrent_no_apps)
+                        accountViewModel.toastManager.toast(Res.string.torrent_failure, Res.string.torrent_no_apps)
                     }
                 },
                 Modifier.size(Size30dp),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -49,6 +49,8 @@ import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
 import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatChannel
 import com.vitorpamplona.amethyst.commons.model.nip53LiveActivities.LiveActivitiesChannel
 import com.vitorpamplona.amethyst.commons.model.observables.CreatedAtComparator
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.failed_to_save_the_video
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
 import com.vitorpamplona.amethyst.commons.ui.notifications.CardFeedState
 import com.vitorpamplona.amethyst.logTime
@@ -1866,7 +1868,7 @@ class AccountViewModel(
                     }
                 },
                 onError = {
-                    toastManager.toast(R.string.failed_to_save_the_video, null, it)
+                    toastManager.toast(Res.string.failed_to_save_the_video, null, it)
                 },
             )
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/NewGroupDMScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/NewGroupDMScreen.kt
@@ -74,6 +74,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.messages_cant_upload_explainer
+import com.vitorpamplona.amethyst.commons.resources.messages_cant_upload_title
 import com.vitorpamplona.amethyst.commons.richtext.BaseMediaContent
 import com.vitorpamplona.amethyst.commons.richtext.EncryptedMediaUrlImage
 import com.vitorpamplona.amethyst.commons.richtext.EncryptedMediaUrlVideo
@@ -421,7 +424,7 @@ private fun BottomRowActions(
             }
         } else {
             IconButton(
-                onClick = { accountViewModel.toastManager.toast(R.string.messages_cant_upload_title, R.string.messages_cant_upload_explainer) },
+                onClick = { accountViewModel.toastManager.toast(Res.string.messages_cant_upload_title, Res.string.messages_cant_upload_explainer) },
             ) {
                 Icon(
                     imageVector = Icons.Default.AddPhotoAlternate,
@@ -439,7 +442,7 @@ private fun BottomRowActions(
         } else {
             IconButton(
                 onClick = {
-                    accountViewModel.toastManager.toast(R.string.messages_cant_upload_title, R.string.messages_cant_upload_explainer)
+                    accountViewModel.toastManager.toast(Res.string.messages_cant_upload_title, Res.string.messages_cant_upload_explainer)
                 },
             ) {
                 Icon(
@@ -458,7 +461,7 @@ private fun BottomRowActions(
         } else {
             IconButton(
                 onClick = {
-                    accountViewModel.toastManager.toast(R.string.messages_cant_upload_title, R.string.messages_cant_upload_explainer)
+                    accountViewModel.toastManager.toast(Res.string.messages_cant_upload_title, Res.string.messages_cant_upload_explainer)
                 },
             ) {
                 Icon(

--- a/commons/src/commonMain/composeResources/values/strings.xml
+++ b/commons/src/commonMain/composeResources/values/strings.xml
@@ -54,4 +54,15 @@
     <!-- Accessibility -->
     <string name="accessibility_user_avatar">User avatar</string>
     <string name="accessibility_navigate">Navigate</string>
+
+    <!-- Toast Messages -->
+    <string name="error_dialog_zap_error">Unable to send zap</string>
+    <string name="failed_to_save_the_video">Failed to save the video</string>
+    <string name="media_added">Media added</string>
+    <string name="media_added_to_profile_gallery">Media added to your Profile Gallery</string>
+    <string name="messages_cant_upload_explainer">Insert the destination of the message first</string>
+    <string name="messages_cant_upload_title">Can\'t Upload</string>
+    <string name="torrent_failure">Failed to open file</string>
+    <string name="torrent_no_apps">No torrent apps installed to open and download the file.</string>
+    <string name="torrent_no_info">Event doesn\'t have enough information to build a magnet link</string>
 </resources>


### PR DESCRIPTION
## Summary

Convert `ResourceToastMsg`, `ThrowableToastMsg`, `ThrowableToastMsg2`, and `MultiErrorToastMsg` from Android `Int` resource IDs to KMP `StringResource`.

## Approach

Since there are ~50 callers across the codebase, this PR uses a **backward-compatible approach**:

- **New classes** (`ResourceToastMsg`, `ThrowableToastMsg`, etc.) now use `StringResource`
- **Legacy classes** (`LegacyResourceToastMsg`, etc.) are added with `@Deprecated` annotations to keep existing callers working
- `ToastManager` has both new `StringResource` overloads and deprecated `Int` overloads
- `DisplayErrorMessages` handles both new and legacy types

## Migrated (19 call sites)

- `ReactionsRow.kt` — 6 zap error toasts
- `ReusableZapButton.kt` — 4 zap error toasts  
- `Torrent.kt` — 2 torrent toasts
- `ZoomableContentView.kt` — 1 media added toast
- `AccountViewModel.kt` — 1 video save toast
- `NewGroupDMScreen.kt` — 3 upload toasts
- Preview functions in `ErrorList.kt` and `MultiUserErrorMessageDialog.kt`

## Changes

- Added 9 string resources to `commons/composeResources/values/strings.xml`
- Added `compose-resources` dependency to amethyst module
- New `LegacyToastMsg.kt` with deprecated Int-based classes
- Updated `DisplayErrorMessages`, `InformationDialog`, `MultiUserErrorMessageDialog` to handle both types

## Build

`compilePlayDebugKotlin` passes ✅

## Follow-up

Remaining ~30 Int-based callers can be migrated incrementally by replacing `R.string.xxx` → `Res.string.xxx` and removing the legacy classes once all are converted.