### PR TITLE
feat: add navigation-compose to commons for KMP

### DIFF
--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -56,6 +56,9 @@ kotlin {
                 implementation(libs.jetbrains.compose.material.icons.extended)
                 implementation(libs.jetbrains.compose.ui.tooling.preview)
 
+                // Navigation (KMP - JetBrains Compose Multiplatform)
+                implementation(libs.jetbrains.compose.navigation)
+
                 // Lifecycle ViewModel (KMP since 2.8.0)
                 implementation(libs.androidx.lifecycle.viewmodel.compose)
                 implementation(libs.androidx.lifecycle.runtime.compose)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,6 +44,7 @@ mockk = "1.14.9"
 kotlinx-coroutines-test = "1.10.2"
 negentropyKmp = "v1.0.2"
 netUrlencoderLibVersion = "1.6.0"
+jetbrainsNavigationCompose = "2.9.2"
 navigationCompose = "2.9.7"
 okhttp = "5.3.2"
 runner = "1.7.0"
@@ -137,6 +138,7 @@ jetbrains-compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", 
 jetbrains-compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "jetbrainsCompose" }
 jetbrains-compose-ui-tooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "jetbrainsCompose" }
 jetbrains-compose-ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "jetbrainsCompose" }
+jetbrains-compose-navigation = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "jetbrainsNavigationCompose" }
 google-mlkit-genai-proofreading = { group = "com.google.mlkit", name = "genai-proofreading", version.ref = "genaiProofreading" }
 google-mlkit-genai-prompt = { group = "com.google.mlkit", name = "genai-prompt", version.ref = "genaiPrompt" }
 google-mlkit-genai-rewriting = { group = "com.google.mlkit", name = "genai-rewriting", version.ref = "genaiRewriting" }


### PR DESCRIPTION
## Summary

Add JetBrains Compose Multiplatform `navigation-compose` (2.9.2) dependency to the commons module.

## Changes

- Added `jetbrainsNavigationCompose = "2.9.2"` version to `libs.versions.toml`
- Added `jetbrains-compose-navigation` library entry (`org.jetbrains.androidx.navigation:navigation-compose`)
- Added `implementation(libs.jetbrains.compose.navigation)` to commons `commonMain` dependencies

## Why

`NavigationEffects.kt` and `RememberNavs.kt` in the amethyst module depend on `androidx.navigation` APIs (`NavGraphBuilder`, `composable()`, `rememberNavController()`, `toRoute()`). The JetBrains Compose Multiplatform navigation library provides KMP-compatible versions of these same APIs, enabling these files to be moved from the Android-only amethyst module to the KMP commons module.

## Build Verification

- ✅ `:commons:compileKotlinJvm` — passed
- ✅ `:amethyst:compilePlayDebugKotlin` — passed  
- ✅ `spotlessCheck` — passed

## Note

JB navigation-compose 2.9.2 is the latest available; the project's Android-only `androidx.navigation:navigation-compose` remains at 2.9.7. On Android, Gradle resolves to the higher version. The KMP version provides the same API surface needed for the migration.