### PR TITLE
feat: add IUiSettingsState + IToastManager to IAccountViewModel

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.amethyst.BuildConfig
 import com.vitorpamplona.amethyst.LocalPreferences
 import com.vitorpamplona.amethyst.commons.marmot.MarmotManager
 import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.LiveHiddenUsers
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatListDecryptionCache
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatListState
@@ -332,12 +333,13 @@ class Account(
     val followLists = FollowListsState(signer, cache, scope)
 
     val hiddenUsers = HiddenUsersState(muteList.flow, blockPeopleList.flow, scope, settings)
+    override val liveHiddenUsers: StateFlow<LiveHiddenUsers> get() = hiddenUsers.flow
 
     val labeledBookmarkLists = LabeledBookmarkListsState(signer, cache, scope)
-    val oldBookmarkState = OldBookmarkListState(signer, cache, scope)
-    val bookmarkState = BookmarkListState(signer, cache, scope)
+    override val oldBookmarkState = OldBookmarkListState(signer, cache, scope)
+    override val bookmarkState = BookmarkListState(signer, cache, scope)
     val pinState = PinListState(signer, cache, scope)
-    val emoji = EmojiPackState(signer, cache, scope)
+    override val emoji = EmojiPackState(signer, cache, scope)
 
     val vanish = VanishRequestsState(signer, cache, client, scope)
 
@@ -386,7 +388,7 @@ class Account(
 
     val otsState = OtsState(signer, cache, otsResolverBuilder, scope, settings)
 
-    val marmotManager: MarmotManager? = mlsGroupStateStore?.let { MarmotManager(signer, it) }
+    override val marmotManager: MarmotManager? = mlsGroupStateStore?.let { MarmotManager(signer, it) }
 
     val paymentTargetsState = NipA3PaymentTargetsState(signer, cache, scope, settings)
 
@@ -1433,7 +1435,7 @@ class Account(
         }
     }
 
-    suspend fun deleteDraftIgnoreErrors(draftTag: String) {
+    override suspend fun deleteDraftIgnoreErrors(draftTag: String) {
         try {
             deleteDraftInner(draftTag)
         } catch (e: Exception) {
@@ -2269,13 +2271,13 @@ class Account(
             false
         }
 
-    fun isFollowing(user: User): Boolean = user.pubkeyHex in followingKeySet()
+    override fun isFollowing(user: User): Boolean = user.pubkeyHex in followingKeySet()
 
-    fun isFollowing(user: HexKey): Boolean = user in followingKeySet()
+    override fun isFollowing(userHex: HexKey): Boolean = userHex in followingKeySet()
 
-    fun isKnown(user: User): Boolean = user.pubkeyHex in allFollows.flow.value.authors
+    override fun isKnown(user: User): Boolean = user.pubkeyHex in allFollows.flow.value.authors
 
-    fun isKnown(user: HexKey): Boolean = user in allFollows.flow.value.authors
+    override fun isKnown(userHex: HexKey): Boolean = userHex in allFollows.flow.value.authors
 
     private fun hasExcessiveHashtags(note: Note): Boolean {
         val limit = settings.syncedSettings.security.maxHashtagLimit.value
@@ -2364,14 +2366,14 @@ class Account(
 
     suspend fun savePaymentTargets(targets: List<PaymentTarget>) = sendMyPublicAndPrivateOutbox(paymentTargetsState.savePaymentTargets(targets))
 
-    fun markAsRead(
+    override fun markAsRead(
         route: String,
         timestampInSecs: Long,
     ) = settings.markAsRead(route, timestampInSecs)
 
     fun loadLastRead(route: String): Long = settings.lastReadPerRoute.value[route]?.value ?: 0
 
-    fun loadLastReadFlow(route: String) = settings.getLastReadFlow(route)
+    override fun loadLastReadFlow(route: String) = settings.getLastReadFlow(route)
 
     fun hasDonatedInThisVersion() = settings.hasDonatedInVersion(BuildConfig.VERSION_NAME)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ToastManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ToastManager.kt
@@ -21,27 +21,28 @@
 package com.vitorpamplona.amethyst.ui.components.toasts
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.ui.components.toasts.IToastManager
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.ui.components.toasts.multiline.MultiErrorToastMsg
 import com.vitorpamplona.amethyst.ui.components.toasts.multiline.UserBasedErrorMessage
 import kotlinx.coroutines.flow.MutableStateFlow
 
 @Stable
-class ToastManager {
+class ToastManager : IToastManager {
     val toasts = MutableStateFlow<ToastMsg?>(null)
 
-    fun clearToasts() {
+    override fun clearToasts() {
         toasts.tryEmit(null)
     }
 
-    fun toast(
+    override fun toast(
         title: String,
         message: String,
     ) {
         toasts.tryEmit(StringToastMsg(title, message))
     }
 
-    fun toast(
+    override fun toast(
         title: String,
         message: String,
         action: () -> Unit,
@@ -49,14 +50,14 @@ class ToastManager {
         toasts.tryEmit(ActionableStringToastMsg(title, message, action))
     }
 
-    fun toast(
+    override fun toast(
         titleResId: Int,
         resourceId: Int,
     ) {
         toasts.tryEmit(ResourceToastMsg(titleResId, resourceId))
     }
 
-    fun toast(
+    override fun toast(
         titleResId: Int,
         message: String?,
         throwable: Throwable,
@@ -64,7 +65,7 @@ class ToastManager {
         toasts.tryEmit(ThrowableToastMsg(titleResId, message, throwable))
     }
 
-    fun toast(
+    override fun toast(
         titleResId: Int,
         description: Int,
         throwable: Throwable,
@@ -72,7 +73,7 @@ class ToastManager {
         toasts.tryEmit(ThrowableToastMsg2(titleResId, description, throwable))
     }
 
-    fun toast(
+    override fun toast(
         titleResId: Int,
         resourceId: Int,
         vararg params: String,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/UiSettingsState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/UiSettingsState.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.ui.screen
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.ui.screen.IUiSettingsState
 import com.vitorpamplona.amethyst.model.BooleanType
 import com.vitorpamplona.amethyst.model.ConnectivityType
 import com.vitorpamplona.amethyst.model.FeatureSetType
@@ -35,10 +36,10 @@ import kotlinx.coroutines.flow.stateIn
 @Stable
 class UiSettingsState(
     val uiSettingsFlow: UiSettingsFlow,
-    val isMobileOrMeteredConnection: StateFlow<Boolean>,
+    override val isMobileOrMeteredConnection: StateFlow<Boolean>,
     val scope: CoroutineScope,
-) {
-    val showProfilePictures =
+) : IUiSettingsState {
+    override val showProfilePictures =
         combine(
             uiSettingsFlow.automaticallyShowProfilePictures,
             isMobileOrMeteredConnection,
@@ -58,7 +59,7 @@ class UiSettingsState(
             },
         )
 
-    val showUrlPreview =
+    override val showUrlPreview =
         combine(
             uiSettingsFlow.automaticallyShowUrlPreview,
             isMobileOrMeteredConnection,
@@ -78,7 +79,7 @@ class UiSettingsState(
             },
         )
 
-    val startVideoPlayback =
+    override val startVideoPlayback =
         combine(
             uiSettingsFlow.automaticallyStartPlayback,
             isMobileOrMeteredConnection,
@@ -98,7 +99,7 @@ class UiSettingsState(
             },
         )
 
-    val showImages =
+    override val showImages =
         combine(
             uiSettingsFlow.automaticallyShowImages,
             isMobileOrMeteredConnection,
@@ -118,25 +119,25 @@ class UiSettingsState(
             },
         )
 
-    fun modernGalleryStyle() =
+    override fun modernGalleryStyle() =
         when (uiSettingsFlow.gallerySet.value) {
             ProfileGalleryType.CLASSIC -> false
             ProfileGalleryType.MODERN -> true
         }
 
-    fun isPerformanceMode() = uiSettingsFlow.featureSet.value == FeatureSetType.PERFORMANCE
+    override fun isPerformanceMode() = uiSettingsFlow.featureSet.value == FeatureSetType.PERFORMANCE
 
-    fun isNotPerformanceMode() = uiSettingsFlow.featureSet.value != FeatureSetType.PERFORMANCE
+    override fun isNotPerformanceMode() = uiSettingsFlow.featureSet.value != FeatureSetType.PERFORMANCE
 
-    fun isCompleteUIMode() = uiSettingsFlow.featureSet.value == FeatureSetType.COMPLETE
+    override fun isCompleteUIMode() = uiSettingsFlow.featureSet.value == FeatureSetType.COMPLETE
 
-    fun isImmersiveScrollingActive() = uiSettingsFlow.automaticallyHideNavigationBars.value == BooleanType.ALWAYS
+    override fun isImmersiveScrollingActive() = uiSettingsFlow.automaticallyHideNavigationBars.value == BooleanType.ALWAYS
 
-    fun showProfilePictures() = showProfilePictures.value
+    override fun showProfilePictures() = showProfilePictures.value
 
-    fun showUrlPreview() = showUrlPreview.value
+    override fun showUrlPreview() = showUrlPreview.value
 
-    fun startVideoPlayback() = startVideoPlayback.value
+    override fun startVideoPlayback() = startVideoPlayback.value
 
-    fun showImages() = showImages.value
+    override fun showImages() = showImages.value
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -175,14 +175,15 @@ import kotlinx.coroutines.withContext
 
 @Stable
 class AccountViewModel(
-    val account: Account,
+    override val account: Account,
     val settings: UiSettingsState,
     val torSettings: TorSettingsFlow,
     val dataSources: RelaySubscriptionsCoordinator,
     val httpClientBuilder: IRoleBasedHttpClientBuilder,
     val nip05ClientBuilder: () -> INip05Client,
 ) : ViewModel(),
-    Dao {
+    Dao,
+    com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel {
     var firstRoute: Route? = null
 
     val toastManager = ToastManager()
@@ -418,9 +419,9 @@ class AccountViewModel(
             Route.Notification() to notificationHasNewItemsFlow,
         )
 
-    fun isWriteable(): Boolean = account.isWriteable()
+    override fun isWriteable(): Boolean = account.isWriteable()
 
-    fun userProfile(): User = account.userProfile()
+    override fun userProfile(): User = account.userProfile()
 
     fun reactToOrDelete(
         note: Note,
@@ -842,10 +843,10 @@ class AccountViewModel(
         )
     }
 
-    fun report(
+    override fun report(
         note: Note,
         type: ReportType,
-        content: String = "",
+        content: String,
     ) = launchSigner { account.report(note, type, content) }
 
     fun report(
@@ -1007,13 +1008,13 @@ class AccountViewModel(
         }
     }
 
-    fun broadcast(note: Note) = launchSigner { account.broadcast(note) }
+    override fun broadcast(note: Note) = launchSigner { account.broadcast(note) }
 
     fun timestamp(note: Note) = launchSigner { account.otsState.timestamp(note) }
 
-    fun delete(notes: List<Note>) = launchSigner { account.delete(notes) }
+    override fun delete(notes: List<Note>) = launchSigner { account.delete(notes) }
 
-    fun delete(note: Note) = launchSigner { account.delete(note) }
+    override fun delete(note: Note) = launchSigner { account.delete(note) }
 
     fun requestToVanish(
         relays: List<NormalizedRelayUrl>,
@@ -1026,9 +1027,9 @@ class AccountViewModel(
         createdAt: Long,
     ) = launchSigner { account.requestToVanishFromEverywhere(reason, createdAt) }
 
-    fun cachedDecrypt(note: Note): String? = account.cachedDecryptContent(note)
+    override fun cachedDecrypt(note: Note): String? = account.cachedDecryptContent(note)
 
-    fun decrypt(
+    override fun decrypt(
         note: Note,
         onReady: (String) -> Unit,
     ) = launchSigner {
@@ -1081,79 +1082,79 @@ class AccountViewModel(
         community: AddressableNote,
     ) = launchSigner { account.approveCommunityPost(post, community) }
 
-    fun follow(community: AddressableNote) = launchSigner { account.follow(community) }
+    override fun follow(community: AddressableNote) = launchSigner { account.follow(community) }
 
-    fun follow(channel: PublicChatChannel) = launchSigner { account.follow(channel) }
+    override fun follow(channel: PublicChatChannel) = launchSigner { account.follow(channel) }
 
-    fun follow(channel: EphemeralChatChannel) = launchSigner { account.follow(channel) }
+    override fun follow(channel: EphemeralChatChannel) = launchSigner { account.follow(channel) }
 
-    fun unfollow(community: AddressableNote) = launchSigner { account.unfollow(community) }
+    override fun unfollow(community: AddressableNote) = launchSigner { account.unfollow(community) }
 
-    fun unfollow(channel: PublicChatChannel) = launchSigner { account.unfollow(channel) }
+    override fun unfollow(channel: PublicChatChannel) = launchSigner { account.unfollow(channel) }
 
-    fun unfollow(channel: EphemeralChatChannel) = launchSigner { account.unfollow(channel) }
+    override fun unfollow(channel: EphemeralChatChannel) = launchSigner { account.unfollow(channel) }
 
-    fun follow(users: List<User>) = launchSigner { account.follow(users) }
+    override fun follow(users: List<User>) = launchSigner { account.follow(users) }
 
-    fun follow(user: User) = launchSigner { account.follow(user) }
+    override fun follow(user: User) = launchSigner { account.follow(user) }
 
-    fun unfollow(user: User) = launchSigner { account.unfollow(user) }
+    override fun unfollow(user: User) = launchSigner { account.unfollow(user) }
 
-    fun followGeohash(tag: String) = launchSigner { account.followGeohash(tag) }
+    override fun followGeohash(tag: String) = launchSigner { account.followGeohash(tag) }
 
-    fun unfollowGeohash(tag: String) = launchSigner { account.unfollowGeohash(tag) }
+    override fun unfollowGeohash(tag: String) = launchSigner { account.unfollowGeohash(tag) }
 
-    fun followHashtag(tag: String) = launchSigner { account.followHashtag(tag) }
+    override fun followHashtag(tag: String) = launchSigner { account.followHashtag(tag) }
 
-    fun unfollowHashtag(tag: String) = launchSigner { account.unfollowHashtag(tag) }
+    override fun unfollowHashtag(tag: String) = launchSigner { account.unfollowHashtag(tag) }
 
-    fun followRelayFeed(url: NormalizedRelayUrl) = launchSigner { account.followRelayFeed(url) }
+    override fun followRelayFeed(url: NormalizedRelayUrl) = launchSigner { account.followRelayFeed(url) }
 
-    fun unfollowRelayFeed(url: NormalizedRelayUrl) = launchSigner { account.unfollowRelayFeed(url) }
+    override fun unfollowRelayFeed(url: NormalizedRelayUrl) = launchSigner { account.unfollowRelayFeed(url) }
 
-    fun showWord(word: String) = launchSigner { account.showWord(word) }
+    override fun showWord(word: String) = launchSigner { account.showWord(word) }
 
-    fun hideWord(word: String) = launchSigner { account.hideWord(word) }
+    override fun hideWord(word: String) = launchSigner { account.hideWord(word) }
 
-    fun isLoggedUser(pubkeyHex: HexKey?): Boolean = account.signer.pubKey == pubkeyHex
+    override fun isLoggedUser(pubkeyHex: HexKey?): Boolean = account.signer.pubKey == pubkeyHex
 
-    fun isLoggedUser(user: User?): Boolean = isLoggedUser(user?.pubkeyHex)
+    override fun isLoggedUser(user: User?): Boolean = isLoggedUser(user?.pubkeyHex)
 
-    fun isFollowing(user: User?): Boolean {
+    override fun isFollowing(user: User?): Boolean {
         if (user == null) return false
         return account.isFollowing(user)
     }
 
-    fun isFollowing(user: HexKey): Boolean = account.isFollowing(user)
+    override fun isFollowing(user: HexKey): Boolean = account.isFollowing(user)
 
-    fun markDonatedInThisVersion() = account.markDonatedInThisVersion()
+    override fun markDonatedInThisVersion() = account.markDonatedInThisVersion()
 
-    fun dismissPollNotification(noteId: String) = account.dismissPollNotification(noteId)
+    override fun dismissPollNotification(noteId: String) = account.dismissPollNotification(noteId)
 
-    fun hasViewedPollResults(noteId: String) = account.hasViewedPollResults(noteId)
+    override fun hasViewedPollResults(noteId: String) = account.hasViewedPollResults(noteId)
 
-    fun markPollResultsViewed(
+    override fun markPollResultsViewed(
         noteId: String,
         pollEndsAt: Long?,
     ) = account.markPollResultsViewed(noteId, pollEndsAt)
 
-    fun dontTranslateFrom() = account.settings.syncedSettings.languages.dontTranslateFrom.value
+    override fun dontTranslateFrom() = account.settings.syncedSettings.languages.dontTranslateFrom.value
 
-    fun translateTo() = account.settings.syncedSettings.languages.translateTo.value
+    override fun translateTo() = account.settings.syncedSettings.languages.translateTo.value
 
-    fun defaultZapType() = account.settings.syncedSettings.zaps.defaultZapType.value
+    override fun defaultZapType() = account.settings.syncedSettings.zaps.defaultZapType.value
 
-    fun showSensitiveContent(): MutableStateFlow<Boolean?> = account.settings.syncedSettings.security.showSensitiveContent
+    override fun showSensitiveContent(): MutableStateFlow<Boolean?> = account.settings.syncedSettings.security.showSensitiveContent
 
-    fun zapAmountChoicesFlow() = account.settings.syncedSettings.zaps.zapAmountChoices
+    override fun zapAmountChoicesFlow() = account.settings.syncedSettings.zaps.zapAmountChoices
 
-    fun zapAmountChoices() = zapAmountChoicesFlow().value
+    override fun zapAmountChoices() = zapAmountChoicesFlow().value
 
-    fun reactionChoicesFlow() = account.settings.syncedSettings.reactions.reactionChoices
+    override fun reactionChoicesFlow() = account.settings.syncedSettings.reactions.reactionChoices
 
-    fun reactionChoices() = reactionChoicesFlow().value
+    override fun reactionChoices() = reactionChoicesFlow().value
 
-    fun filterSpamFromStrangers() = account.settings.syncedSettings.security.filterSpamFromStrangers
+    override fun filterSpamFromStrangers() = account.settings.syncedSettings.security.filterSpamFromStrangers
 
     fun toggleSendKind0ToLocalRelay(enabled: Boolean) = launchSigner { account.updateSendKind0EventsToLocalRelay(enabled) }
 
@@ -1199,19 +1200,19 @@ class AccountViewModel(
 
     fun updateTranslateTo(languageCode: String) = launchSigner { account.updateTranslateTo(languageCode) }
 
-    fun prefer(
+    override fun prefer(
         source: String,
         target: String,
         preference: String,
     ) = launchSigner { account.prefer(source, target, preference) }
 
-    fun show(user: User) = launchSigner { account.showUser(user.pubkeyHex) }
+    override fun show(user: User) = launchSigner { account.showUser(user.pubkeyHex) }
 
-    fun hide(user: User) = launchSigner { account.hideUser(user.pubkeyHex) }
+    override fun hide(user: User) = launchSigner { account.hideUser(user.pubkeyHex) }
 
-    fun hide(word: String) = launchSigner { account.hideWord(word) }
+    override fun hide(word: String) = launchSigner { account.hideWord(word) }
 
-    fun showUser(pubkeyHex: String) = launchSigner { account.showUser(pubkeyHex) }
+    override fun showUser(pubkeyHex: String) = launchSigner { account.showUser(pubkeyHex) }
 
     fun createStatus(newStatus: String) = launchSigner { account.createStatus(newStatus) }
 
@@ -1242,17 +1243,17 @@ class AccountViewModel(
         return note.getReactionBy(userProfile())
     }
 
-    fun runOnIO(runOnIO: suspend () -> Unit) {
+    override fun runOnIO(runOnIO: suspend () -> Unit) {
         viewModelScope.launch(Dispatchers.IO) { runOnIO() }
     }
 
-    fun checkGetOrCreateUser(key: HexKey): User? = LocalCache.checkGetOrCreateUser(key)
+    override fun checkGetOrCreateUser(key: HexKey): User? = LocalCache.checkGetOrCreateUser(key)
 
     override suspend fun getOrCreateUser(hex: HexKey): User = LocalCache.getOrCreateUser(hex)
 
-    fun getUserIfExists(hex: HexKey): User? = LocalCache.getUserIfExists(hex)
+    override fun getUserIfExists(hex: HexKey): User? = LocalCache.getUserIfExists(hex)
 
-    fun checkGetOrCreateNote(key: HexKey): Note? = LocalCache.checkGetOrCreateNote(key)
+    override fun checkGetOrCreateNote(key: HexKey): Note? = LocalCache.checkGetOrCreateNote(key)
 
     override suspend fun getOrCreateNote(hex: HexKey): Note = LocalCache.getOrCreateNote(hex)
 
@@ -1267,7 +1268,7 @@ class AccountViewModel(
         return note
     }
 
-    fun getNoteIfExists(hex: HexKey): Note? = LocalCache.getNoteIfExists(hex)
+    override fun getNoteIfExists(hex: HexKey): Note? = LocalCache.getNoteIfExists(hex)
 
     /**
      * Fixes author and relay hints in MarkedETag list by looking up notes from cache.

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -176,7 +176,7 @@ import kotlinx.coroutines.withContext
 @Stable
 class AccountViewModel(
     override val account: Account,
-    val settings: UiSettingsState,
+    override val settings: UiSettingsState,
     val torSettings: TorSettingsFlow,
     val dataSources: RelaySubscriptionsCoordinator,
     val httpClientBuilder: IRoleBasedHttpClientBuilder,
@@ -186,7 +186,7 @@ class AccountViewModel(
     com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel {
     var firstRoute: Route? = null
 
-    val toastManager = ToastManager()
+    override val toastManager = ToastManager()
     val broadcastTracker = BroadcastTracker()
     val feedStates = AccountFeedContentStates(account, viewModelScope)
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
@@ -20,7 +20,11 @@
  */
 package com.vitorpamplona.amethyst.commons.model
 
+import com.vitorpamplona.amethyst.commons.marmot.MarmotManager
 import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupList
+import com.vitorpamplona.amethyst.commons.model.nip30CustomEmojis.EmojiPackState
+import com.vitorpamplona.amethyst.commons.model.nip51Lists.BookmarkListState
+import com.vitorpamplona.amethyst.commons.model.nip51Lists.OldBookmarkListState
 import com.vitorpamplona.amethyst.commons.model.privateChats.ChatroomList
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
@@ -34,6 +38,7 @@ import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Response
 import com.vitorpamplona.quartz.nip57Zaps.IPrivateZapsDecryptionCache
 import com.vitorpamplona.quartz.nip59Giftwrap.wraps.GiftWrapEvent
 import com.vitorpamplona.quartz.utils.DualCase
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Interface for NIP-47 wallet connect signer state.
@@ -119,4 +124,45 @@ interface IAccount {
 
     /** Broadcast pre-created gift wraps (e.g. reactions within group DMs) */
     suspend fun sendGiftWraps(wraps: List<GiftWrapEvent>)
+
+    // --- Members added for ViewModel migration ---
+
+    /** Bookmark list state (NIP-51 kind 10003) */
+    val bookmarkState: BookmarkListState
+
+    /** Old bookmark list state (NIP-51 kind 30001 "bookmark") */
+    val oldBookmarkState: OldBookmarkListState
+
+    /** Custom emoji pack state (NIP-30) */
+    val emoji: EmojiPackState
+
+    /** Marmot MLS group manager (null when MLS unavailable) */
+    val marmotManager: MarmotManager?
+
+    /** Live hidden-users state as a flow for UI observation */
+    val liveHiddenUsers: StateFlow<LiveHiddenUsers>
+
+    /** Whether the given user is in the follow (kind 3) list */
+    fun isFollowing(user: User): Boolean
+
+    /** Whether the given hex-key user is in the follow (kind 3) list */
+    fun isFollowing(userHex: String): Boolean
+
+    /** Whether the given user appears in any follow/people list */
+    fun isKnown(user: User): Boolean
+
+    /** Whether the given hex-key user appears in any follow/people list */
+    fun isKnown(userHex: String): Boolean
+
+    /** Mark a route as read at the given timestamp. Returns true if updated. */
+    fun markAsRead(
+        route: String,
+        timestampInSecs: Long,
+    ): Boolean
+
+    /** Observe last-read timestamp for a route */
+    fun loadLastReadFlow(route: String): StateFlow<Long>
+
+    /** Delete a draft event by tag, swallowing errors */
+    suspend fun deleteDraftIgnoreErrors(draftTag: String)
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/toasts/IToastManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/toasts/IToastManager.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.components.toasts
+
+/**
+ * Platform-agnostic toast manager interface for KMP.
+ *
+ * Android implementation uses resource IDs and Android-specific toast types.
+ * Other platforms can provide their own notification mechanisms.
+ */
+interface IToastManager {
+    fun clearToasts()
+
+    fun toast(
+        title: String,
+        message: String,
+    )
+
+    fun toast(
+        title: String,
+        message: String,
+        action: () -> Unit,
+    )
+
+    fun toast(
+        titleResId: Int,
+        resourceId: Int,
+    )
+
+    fun toast(
+        titleResId: Int,
+        message: String?,
+        throwable: Throwable,
+    )
+
+    fun toast(
+        titleResId: Int,
+        description: Int,
+        throwable: Throwable,
+    )
+
+    fun toast(
+        titleResId: Int,
+        resourceId: Int,
+        vararg params: String,
+    )
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/IUiSettingsState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/IUiSettingsState.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.screen
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Platform-agnostic interface for UI settings state.
+ *
+ * Exposes connectivity-aware display settings and feature-set mode queries.
+ * Composables in the commons module can depend on this interface instead of
+ * the concrete Android UiSettingsState class.
+ */
+interface IUiSettingsState {
+    // ── connectivity-aware display settings (StateFlow<Boolean>) ─────
+
+    /** Whether to show profile pictures (respects connectivity/user preference). */
+    val showProfilePictures: StateFlow<Boolean>
+
+    /** Whether to show URL previews (respects connectivity/user preference). */
+    val showUrlPreview: StateFlow<Boolean>
+
+    /** Whether to auto-start video playback (respects connectivity/user preference). */
+    val startVideoPlayback: StateFlow<Boolean>
+
+    /** Whether to show images inline (respects connectivity/user preference). */
+    val showImages: StateFlow<Boolean>
+
+    /** Whether the device is on a mobile/metered connection. */
+    val isMobileOrMeteredConnection: StateFlow<Boolean>
+
+    // ── feature-set mode queries ─────────────────────────────────────
+
+    /** True when the UI is in performance (minimal) mode. */
+    fun isPerformanceMode(): Boolean
+
+    /** True when the UI is NOT in performance mode. */
+    fun isNotPerformanceMode(): Boolean
+
+    /** True when the UI is in complete (all features) mode. */
+    fun isCompleteUIMode(): Boolean
+
+    /** True when immersive scrolling (auto-hide nav bars) is active. */
+    fun isImmersiveScrollingActive(): Boolean
+
+    /** True when the modern gallery style is selected. */
+    fun modernGalleryStyle(): Boolean
+
+    // ── convenience snapshot accessors ───────────────────────────────
+
+    /** Snapshot of [showProfilePictures]. */
+    fun showProfilePictures(): Boolean
+
+    /** Snapshot of [showUrlPreview]. */
+    fun showUrlPreview(): Boolean
+
+    /** Snapshot of [startVideoPlayback]. */
+    fun startVideoPlayback(): Boolean
+
+    /** Snapshot of [showImages]. */
+    fun showImages(): Boolean
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/IAccountViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/IAccountViewModel.kt
@@ -26,6 +26,8 @@ import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.amethyst.commons.model.User
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
 import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatChannel
+import com.vitorpamplona.amethyst.commons.ui.components.toasts.IToastManager
+import com.vitorpamplona.amethyst.commons.ui.screen.IUiSettingsState
 import com.vitorpamplona.quartz.nip01Core.core.Address
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
@@ -47,6 +49,12 @@ interface IAccountViewModel {
 
     /** The underlying account abstraction. */
     val account: IAccount
+
+    /** UI settings (connectivity-aware display preferences). 78 usages / 37 files. */
+    val settings: IUiSettingsState
+
+    /** Toast/snackbar manager. 119 usages / 48 files. */
+    val toastManager: IToastManager
 
     // ── identity helpers (50-20 usages) ───────────────────────────────
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/IAccountViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/IAccountViewModel.kt
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.screen.loggedIn
+
+import com.vitorpamplona.amethyst.commons.model.AddressableNote
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
+import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatChannel
+import com.vitorpamplona.quartz.nip01Core.core.Address
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Platform-agnostic interface for AccountViewModel.
+ *
+ * Exposes the most commonly used members of AccountViewModel using only
+ * commons-compatible types. Composables and ViewModels in the commons module
+ * can depend on this interface instead of the concrete Android AccountViewModel,
+ * enabling incremental migration to KMP.
+ *
+ * Members are ordered by usage frequency (most-referenced first).
+ */
+interface IAccountViewModel {
+    // ── core properties (475+ usages) ─────────────────────────────────
+
+    /** The underlying account abstraction. */
+    val account: IAccount
+
+    // ── identity helpers (50-20 usages) ───────────────────────────────
+
+    /** Current user's profile. */
+    fun userProfile(): User
+
+    /** Whether the account can sign events. */
+    fun isWriteable(): Boolean
+
+    /** Whether the given pubkey is the logged-in user. */
+    fun isLoggedUser(pubkeyHex: HexKey?): Boolean
+
+    /** Whether the given user is the logged-in user. */
+    fun isLoggedUser(user: User?): Boolean
+
+    /** Whether the logged-in user follows the given user. */
+    fun isFollowing(user: User?): Boolean
+
+    /** Whether the logged-in user follows the given pubkey. */
+    fun isFollowing(user: HexKey): Boolean
+
+    // ── cache access (33-10 usages) ──────────────────────────────────
+
+    /** Get a note from cache if it exists. */
+    fun getNoteIfExists(hex: HexKey): Note?
+
+    /** Get or create a user in cache. */
+    fun checkGetOrCreateUser(key: HexKey): User?
+
+    /** Get a user from cache if it exists. */
+    fun getUserIfExists(hex: HexKey): User?
+
+    /** Get or create a note in cache. */
+    fun checkGetOrCreateNote(key: HexKey): Note?
+
+    /** Get or create an addressable note in cache. */
+    fun getOrCreateAddressableNote(address: Address): AddressableNote
+
+    // ── coroutine helpers ─────────────────────────────────────────────
+
+    /** Launch a coroutine on IO. */
+    fun runOnIO(runOnIO: suspend () -> Unit)
+
+    // ── follow / unfollow (10-8 usages each) ─────────────────────────
+
+    fun follow(user: User)
+
+    fun follow(users: List<User>)
+
+    fun follow(community: AddressableNote)
+
+    fun follow(channel: PublicChatChannel)
+
+    fun follow(channel: EphemeralChatChannel)
+
+    fun unfollow(user: User)
+
+    fun unfollow(community: AddressableNote)
+
+    fun unfollow(channel: PublicChatChannel)
+
+    fun unfollow(channel: EphemeralChatChannel)
+
+    fun followHashtag(tag: String)
+
+    fun unfollowHashtag(tag: String)
+
+    fun followGeohash(tag: String)
+
+    fun unfollowGeohash(tag: String)
+
+    fun followRelayFeed(url: NormalizedRelayUrl)
+
+    fun unfollowRelayFeed(url: NormalizedRelayUrl)
+
+    // ── note actions (7-10 usages each) ──────────────────────────────
+
+    fun broadcast(note: Note)
+
+    fun delete(note: Note)
+
+    fun delete(notes: List<Note>)
+
+    fun hide(user: User)
+
+    fun show(user: User)
+
+    fun hide(word: String)
+
+    fun showWord(word: String)
+
+    fun hideWord(word: String)
+
+    fun showUser(pubkeyHex: String)
+
+    fun report(
+        note: Note,
+        type: com.vitorpamplona.quartz.nip56Reports.ReportType,
+        content: String,
+    )
+
+    // ── settings accessors (9+ usages) ───────────────────────────────
+
+    fun showSensitiveContent(): MutableStateFlow<Boolean?>
+
+    fun zapAmountChoices(): List<Long>
+
+    fun zapAmountChoicesFlow(): StateFlow<List<Long>>
+
+    fun reactionChoices(): List<String>
+
+    fun reactionChoicesFlow(): StateFlow<List<String>>
+
+    fun defaultZapType(): com.vitorpamplona.quartz.nip57Zaps.LnZapEvent.ZapType
+
+    fun dontTranslateFrom(): Set<String>
+
+    fun translateTo(): String
+
+    fun filterSpamFromStrangers(): MutableStateFlow<Boolean>
+
+    // ── misc (5-9 usages) ────────────────────────────────────────────
+
+    fun prefer(
+        source: String,
+        target: String,
+        preference: String,
+    )
+
+    /** Decrypt a note's content from cache or null. */
+    fun cachedDecrypt(note: Note): String?
+
+    /** Decrypt a note's content, calling onReady when done. */
+    fun decrypt(
+        note: Note,
+        onReady: (String) -> Unit,
+    )
+
+    fun markDonatedInThisVersion(): Boolean
+
+    fun dismissPollNotification(noteId: String)
+
+    fun hasViewedPollResults(noteId: String): Boolean
+
+    fun markPollResultsViewed(
+        noteId: String,
+        pollEndsAt: Long?,
+    )
+}


### PR DESCRIPTION
## Summary

Expand the IAccountViewModel interface with two high-frequency members that composables need for KMP migration:

### New interfaces in commons

- **IUiSettingsState** — connectivity-aware display settings (showProfilePictures, showUrlPreview, showImages, startVideoPlayback) + feature-set mode queries (isPerformanceMode, isCompleteUIMode, isImmersiveScrollingActive, modernGalleryStyle)
- **IToastManager** — platform-agnostic toast/snackbar notifications

### IAccountViewModel additions

- `val settings: IUiSettingsState` (used in 37 files / 78 usages)
- `val toastManager: IToastManager` (used in 48 files / 119 usages)

### IAccount expansions

- bookmarkState, oldBookmarkState, emoji, marmotManager, liveHiddenUsers
- isFollowing, isKnown, markAsRead, loadLastReadFlow, deleteDraftIgnoreErrors

### Implementation

- `UiSettingsState` implements `IUiSettingsState`
- `ToastManager` implements `IToastManager`
- `Account` implements expanded `IAccount`
- `AccountViewModel` implements updated `IAccountViewModel`

### Build

Both `:commons:compileKotlinJvm` and `:amethyst:compilePlayDebugKotlin` pass.

### Impact

Unblocks migration of ~85+ composables that depend on `accountViewModel.settings` and `accountViewModel.toastManager` to use the interface instead of the concrete type.