### PR TITLE
Improve Tor bootstrap resilience and WebSocket connection handling

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/okhttp/OkHttpClientFactory.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/okhttp/OkHttpClientFactory.kt
@@ -46,10 +46,16 @@ class OkHttpClientFactory(
             .addNetworkInterceptor(keyDecryptor)
             .build()
 
+    private var lastProxy: Proxy? = null
+
     fun buildHttpClient(
         proxy: Proxy?,
         timeoutSeconds: Int,
     ): OkHttpClient {
+        if (proxy != lastProxy) {
+            rootClient.connectionPool.evictAll()
+            lastProxy = proxy
+        }
         val seconds = if (proxy != null) timeoutSeconds * 3 else timeoutSeconds
         return rootClient
             .newBuilder()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/okhttp/OkHttpClientFactoryForRelays.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/okhttp/OkHttpClientFactoryForRelays.kt
@@ -37,6 +37,7 @@ class OkHttpClientFactoryForRelays(
         const val DEFAULT_IS_MOBILE: Boolean = false
         const val DEFAULT_TIMEOUT_ON_WIFI_SECS: Int = 10
         const val DEFAULT_TIMEOUT_ON_MOBILE_SECS: Int = 30
+        const val WEBSOCKET_PING_INTERVAL_SECS: Long = 120
 
         private fun isEmulator(): Boolean =
             Build.FINGERPRINT.startsWith("generic") ||
@@ -76,10 +77,16 @@ class OkHttpClientFactoryForRelays(
             .addInterceptor(DefaultContentTypeInterceptor(userAgent))
             .build()
 
+    private var lastProxy: Proxy? = null
+
     fun buildHttpClient(
         proxy: Proxy?,
         timeoutSeconds: Int,
     ): OkHttpClient {
+        if (proxy != lastProxy) {
+            rootClient.connectionPool.evictAll()
+            lastProxy = proxy
+        }
         val seconds = if (proxy != null) timeoutSeconds * 3 else timeoutSeconds
         return rootClient
             .newBuilder()
@@ -87,6 +94,7 @@ class OkHttpClientFactoryForRelays(
             .connectTimeout(Duration.ofSeconds(seconds.toLong()))
             .readTimeout(Duration.ofSeconds(seconds.toLong() * 3))
             .writeTimeout(Duration.ofSeconds(seconds.toLong() * 3))
+            .pingInterval(Duration.ofSeconds(WEBSOCKET_PING_INTERVAL_SECS))
             .build()
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorService.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorService.kt
@@ -54,6 +54,34 @@ class TorService(
     private val _status = MutableStateFlow<TorServiceStatus>(TorServiceStatus.Off)
     val status: StateFlow<TorServiceStatus> = _status.asStateFlow()
 
+    private fun artiDataDir() = File(context.filesDir, "arti")
+
+    /**
+     * Clears the Arti cache directory (consensus, relay descriptors) while
+     * preserving the state directory (guard selection). This forces a fresh
+     * consensus download on the next bootstrap, preventing stale cached data
+     * from causing circuit failures.
+     */
+    private fun clearArtiCache() {
+        val cacheDir = File(artiDataDir(), "cache")
+        if (cacheDir.exists()) {
+            cacheDir.deleteRecursively()
+            Log.d("TorService") { "Cleared Arti cache directory" }
+        }
+    }
+
+    /**
+     * Clears all Arti persistent data (state + cache). Used as a last resort
+     * when initialization fails, to recover from corrupted state.
+     */
+    private fun clearAllArtiData() {
+        val dataDir = artiDataDir()
+        if (dataDir.exists()) {
+            dataDir.deleteRecursively()
+            Log.d("TorService") { "Cleared all Arti data" }
+        }
+    }
+
     /**
      * Initialize the TorClient (once) and start the SOCKS proxy.
      * Must be called from a coroutine on [Dispatchers.IO].
@@ -90,12 +118,21 @@ class TorService(
                     }
                 }
 
-                val dataDir = File(context.filesDir, "arti").absolutePath
+                // Clear cached consensus/descriptors so Arti bootstraps with
+                // fresh network data, preventing stale guards/circuits.
+                clearArtiCache()
+
+                val dataDir = artiDataDir().absolutePath
                 Log.d("TorService") { "Initializing Arti with data dir: $dataDir" }
 
-                val initResult = ArtiNative.initialize(dataDir)
+                var initResult = ArtiNative.initialize(dataDir)
                 if (initResult != 0) {
-                    Log.e("TorService") { "Failed to initialize Arti: error $initResult" }
+                    Log.e("TorService") { "Failed to initialize Arti: error $initResult, clearing data and retrying" }
+                    clearAllArtiData()
+                    initResult = ArtiNative.initialize(dataDir)
+                }
+                if (initResult != 0) {
+                    Log.e("TorService") { "Failed to initialize Arti on retry: error $initResult" }
                     initialized.set(false)
                     _status.value = TorServiceStatus.Off
                     return@withContext

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/single/basic/BasicRelayClient.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/single/basic/BasicRelayClient.kt
@@ -228,7 +228,7 @@ open class BasicRelayClient(
     }
 
     fun dontTryAgainForALongTime() {
-        delayToConnectInSeconds = TimeUtils.ONE_DAY
+        delayToConnectInSeconds = TimeUtils.FIVE_MINUTES
     }
 
     override fun sendOrConnectAndSync(cmd: Command) {


### PR DESCRIPTION
## Summary
This PR enhances the reliability of Tor connectivity and WebSocket connections by implementing better error recovery for Arti initialization, adding connection pool management for proxy changes, and configuring WebSocket ping intervals.

## Key Changes

- **Tor Service Improvements**
  - Added `clearArtiCache()` to remove stale consensus and relay descriptors while preserving guard state, ensuring fresh network data on bootstrap
  - Added `clearAllArtiData()` for complete data cleanup as a recovery mechanism
  - Implemented retry logic with data clearing: if Arti initialization fails, the service now clears all persistent data and retries before giving up
  - This prevents circuit failures caused by corrupted or stale cached state

- **OkHttp Connection Pool Management**
  - Added proxy change detection in both `OkHttpClientFactory` and `OkHttpClientFactoryForRelays`
  - When proxy changes, the connection pool is now evicted to prevent connection reuse with the wrong proxy
  - This ensures proper connection isolation when switching between direct and Tor connections

- **WebSocket Reliability**
  - Added `WEBSOCKET_PING_INTERVAL_SECS` constant (120 seconds) to `OkHttpClientFactoryForRelays`
  - Configured ping intervals on WebSocket connections to maintain connection health and detect stale connections

- **Relay Connection Timeout**
  - Reduced `dontTryAgainForALongTime()` delay from one day to five minutes in `BasicRelayClient`
  - Allows faster recovery when relay connections fail, improving user experience during network issues

## Implementation Details
The Arti initialization now follows a graceful degradation pattern: clear cache first, then if initialization still fails, perform a full data wipe and retry. This balances performance (preserving guard selection when possible) with reliability (complete reset as fallback).

https://claude.ai/code/session_01VFAypytKGzdmuoJAXrb72G