### PR TITLE
feat: move NavigationEffects to commons module

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -41,6 +41,11 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.call.CallState
+import com.vitorpamplona.amethyst.commons.ui.navigation.composableArgs
+import com.vitorpamplona.amethyst.commons.ui.navigation.composableFromBottom
+import com.vitorpamplona.amethyst.commons.ui.navigation.composableFromBottomArgs
+import com.vitorpamplona.amethyst.commons.ui.navigation.composableFromEnd
+import com.vitorpamplona.amethyst.commons.ui.navigation.composableFromEndArgs
 import com.vitorpamplona.amethyst.service.call.CallSessionBridge
 import com.vitorpamplona.amethyst.service.crashreports.DisplayCrashMessages
 import com.vitorpamplona.amethyst.service.relayClient.notifyCommand.compose.DisplayNotifyMessages
@@ -51,7 +56,6 @@ import com.vitorpamplona.amethyst.ui.broadcast.DisplayBroadcastProgress
 import com.vitorpamplona.amethyst.ui.call.CallActivity
 import com.vitorpamplona.amethyst.ui.components.getActivity
 import com.vitorpamplona.amethyst.ui.components.toasts.DisplayErrorMessages
-import com.vitorpamplona.amethyst.ui.navigation.composableFromEnd
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.navigation.navs.rememberNav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route

--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -56,6 +56,9 @@ kotlin {
                 implementation(libs.jetbrains.compose.material.icons.extended)
                 implementation(libs.jetbrains.compose.ui.tooling.preview)
 
+                // Navigation Compose (KMP since 2.8.0)
+                implementation(libs.androidx.navigation.compose)
+
                 // Lifecycle ViewModel (KMP since 2.8.0)
                 implementation(libs.androidx.lifecycle.viewmodel.compose)
                 implementation(libs.androidx.lifecycle.runtime.compose)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/navigation/NavigationEffects.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/navigation/NavigationEffects.kt
@@ -18,7 +18,7 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.navigation
+package com.vitorpamplona.amethyst.commons.ui.navigation
 
 import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.animation.core.tween


### PR DESCRIPTION
Move NavigationEffects.kt (navigation animation utilities) from the amethyst app module to the commons KMP module, now that navigation-compose is KMP-ready (2.8+).

### Changes
- Add `navigation-compose` dependency to `commons/build.gradle.kts`
- Move `NavigationEffects.kt` to `commons/src/commonMain/.../ui/navigation/`
- Update `AppNavigation.kt` imports to use commons package

### Build verified
- `:commons:compileKotlinJvm` ✅
- `:amethyst:compilePlayDebugKotlin` ✅
- `spotlessCheck` ✅

### Note
RememberNavs.kt cannot move yet — it depends on Nav/INav/ObservableNav which reference the app-specific Route sealed class (via BookmarkType). Will be unblocked once Route is extracted to commons.