### PR TITLE
feat: migrate remaining legacy toast callers to StringResource

### DIFF
--- a/amethyst/build.gradle
+++ b/amethyst/build.gradle
@@ -246,6 +246,7 @@ dependencies {
 
     implementation project(path: ':quartz')
     implementation project(path: ':commons')
+    implementation libs.jetbrains.compose.components.resources
     implementation project(path: ':ammolite')
     implementation libs.androidx.core.ktx
     implementation libs.androidx.activity.compose

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/blossom/bud10/OpenBlossomUriAsIntent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/blossom/bud10/OpenBlossomUriAsIntent.kt
@@ -23,13 +23,16 @@ package com.vitorpamplona.amethyst.service.uploads.blossom.bud10
 import android.content.Context
 import android.content.Intent
 import androidx.core.net.toUri
-import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.no_blossom_apps_found_description
+import com.vitorpamplona.amethyst.commons.resources.no_blossom_apps_found_title
+import org.jetbrains.compose.resources.StringResource
 import kotlin.coroutines.cancellation.CancellationException
 
 fun openBlossomUriAsIntent(
     context: Context,
     blossomUri: String,
-    onError: (Int, Int) -> Unit,
+    onError: (StringResource, StringResource) -> Unit,
 ) {
     try {
         val intent = Intent(Intent.ACTION_VIEW, blossomUri.toUri())
@@ -38,6 +41,6 @@ fun openBlossomUriAsIntent(
         context.startActivity(intent)
     } catch (e: Exception) {
         if (e is CancellationException) throw e
-        onError(R.string.no_blossom_apps_found_title, R.string.no_blossom_apps_found_description)
+        onError(Res.string.no_blossom_apps_found_title, Res.string.no_blossom_apps_found_description)
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/InformationDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/InformationDialog.kt
@@ -44,6 +44,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.ui.components.toasts.LegacyThrowableToastMsg
+import com.vitorpamplona.amethyst.ui.components.toasts.LegacyThrowableToastMsg2
 import com.vitorpamplona.amethyst.ui.components.toasts.ThrowableToastMsg
 import com.vitorpamplona.amethyst.ui.components.toasts.ThrowableToastMsg2
 import com.vitorpamplona.amethyst.ui.components.util.setText
@@ -51,6 +53,7 @@ import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.Size16dp
 import com.vitorpamplona.amethyst.ui.theme.StdHorzSpacer
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
 import java.io.PrintWriter
 import java.io.StringWriter
 
@@ -72,12 +75,58 @@ fun InformationDialog(
             writer.toString()
         }
 
-    InformationDialog(title = stringRes(obj.titleResId), textContent = str, moreInfo = stack, buttonColors, onDismiss)
+    InformationDialog(title = stringResource(obj.titleRes), textContent = str, moreInfo = stack, buttonColors, onDismiss)
 }
 
 @Composable
 fun InformationDialog(
     obj: ThrowableToastMsg2,
+    buttonColors: ButtonColors = ButtonDefaults.buttonColors(),
+    onDismiss: () -> Unit,
+) {
+    val str = stringResource(obj.descriptionRes)
+
+    val stack =
+        remember(obj) {
+            val writer = StringWriter()
+            writer.append("\n")
+
+            obj.throwable.printStackTrace(PrintWriter(writer))
+
+            writer.toString()
+        }
+
+    InformationDialog(title = stringResource(obj.titleRes), textContent = str, moreInfo = stack, buttonColors, onDismiss)
+}
+
+// Legacy Int-based overloads (will be removed after full migration)
+
+@Suppress("DEPRECATION")
+@Composable
+fun InformationDialog(
+    obj: LegacyThrowableToastMsg,
+    buttonColors: ButtonColors = ButtonDefaults.buttonColors(),
+    onDismiss: () -> Unit,
+) {
+    val str = obj.msg ?: obj.throwable.localizedMessage ?: obj.throwable.message ?: obj.throwable.javaClass.simpleName
+
+    val stack =
+        remember(obj) {
+            val writer = StringWriter()
+            writer.append("\n")
+
+            obj.throwable.printStackTrace(PrintWriter(writer))
+
+            writer.toString()
+        }
+
+    InformationDialog(title = stringRes(obj.titleResId), textContent = str, moreInfo = stack, buttonColors, onDismiss)
+}
+
+@Suppress("DEPRECATION")
+@Composable
+fun InformationDialog(
+    obj: LegacyThrowableToastMsg2,
     buttonColors: ButtonColors = ButtonDefaults.buttonColors(),
     onDismiss: () -> Unit,
 ) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ClickableUrl.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ClickableUrl.kt
@@ -25,12 +25,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.style.TextOverflow
 import com.vitorpamplona.amethyst.service.uploads.blossom.bud10.openBlossomUriAsIntent
+import org.jetbrains.compose.resources.StringResource
 
 @Composable
 fun ClickableUrl(
     urlText: String,
     url: String,
-    onError: (Int, Int) -> Unit = { _, _ -> },
+    onError: (StringResource, StringResource) -> Unit = { _, _ -> },
 ) {
     val uri = LocalUriHandler.current
     val context = LocalContext.current

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ReusableZapButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ReusableZapButton.kt
@@ -46,7 +46,9 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.draft_note
 import com.vitorpamplona.amethyst.commons.resources.error_dialog_zap_error
+import com.vitorpamplona.amethyst.commons.resources.it_s_not_possible_to_zap_to_a_draft_note
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.ZapPaymentHandler
@@ -287,8 +289,8 @@ private fun handleZapClick(
 ) {
     if (baseNote.isDraft()) {
         accountViewModel.toastManager.toast(
-            R.string.draft_note,
-            R.string.it_s_not_possible_to_zap_to_a_draft_note,
+            Res.string.draft_note,
+            Res.string.it_s_not_possible_to_zap_to_a_draft_note,
         )
         return
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ReusableZapButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ReusableZapButton.kt
@@ -45,6 +45,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.error_dialog_zap_error
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.ZapPaymentHandler
@@ -136,7 +138,7 @@ fun ReusableZapButton(
                 onError = { _, message, toUser ->
                     scope.launch {
                         zappingProgress = 0f
-                        accountViewModel.toastManager.toast(R.string.error_dialog_zap_error, message, toUser)
+                        accountViewModel.toastManager.toast(Res.string.error_dialog_zap_error, message, toUser)
                     }
                 },
                 onPayViaIntent = {
@@ -144,7 +146,7 @@ fun ReusableZapButton(
                         val payable = it.first()
                         payViaIntent(payable.invoice, context, { }) {
                             zappingProgress = 0f
-                            accountViewModel.toastManager.toast(R.string.error_dialog_zap_error, UserBasedErrorMessage(it, payable.info.user))
+                            accountViewModel.toastManager.toast(Res.string.error_dialog_zap_error, UserBasedErrorMessage(it, payable.info.user))
                         }
                     } else {
                         val uid = Uuid.random().toString()
@@ -173,7 +175,7 @@ fun ReusableZapButton(
                 onError = { _, message, user ->
                     scope.launch {
                         zappingProgress = 0f
-                        accountViewModel.toastManager.toast(R.string.error_dialog_zap_error, message, user)
+                        accountViewModel.toastManager.toast(Res.string.error_dialog_zap_error, message, user)
                     }
                 },
                 onProgress = {
@@ -184,7 +186,7 @@ fun ReusableZapButton(
                         val payable = it.first()
                         payViaIntent(payable.invoice, context, { }) {
                             zappingProgress = 0f
-                            accountViewModel.toastManager.toast(R.string.error_dialog_zap_error, UserBasedErrorMessage(it, payable.info.user))
+                            accountViewModel.toastManager.toast(Res.string.error_dialog_zap_error, UserBasedErrorMessage(it, payable.info.user))
                         }
                     } else {
                         val uid = Uuid.random().toString()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
@@ -72,6 +72,9 @@ import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.failed_to_save_the_image
+import com.vitorpamplona.amethyst.commons.resources.failed_to_save_the_video
 import com.vitorpamplona.amethyst.commons.richtext.BaseMediaContent
 import com.vitorpamplona.amethyst.commons.richtext.MediaLocalImage
 import com.vitorpamplona.amethyst.commons.richtext.MediaLocalVideo
@@ -328,7 +331,7 @@ private suspend fun saveMediaToGallery(
     val isImage = content is MediaUrlImage || content is MediaLocalImage
 
     val success = if (isImage) R.string.image_saved_to_the_gallery else R.string.video_saved_to_the_gallery
-    val failure = if (isImage) R.string.failed_to_save_the_image else R.string.failed_to_save_the_video
+    val failure = if (isImage) Res.string.failed_to_save_the_image else Res.string.failed_to_save_the_video
 
     if (content is MediaUrlContent) {
         MediaSaverToDisk.downloadAndSave(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
@@ -126,6 +126,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.coroutines.executeAsync
 import okio.sink
+import org.jetbrains.compose.resources.StringResource
 import java.io.File
 import java.io.IOException
 
@@ -582,7 +583,7 @@ fun WaitAndDisplay(content: @Composable (AnimatedVisibilityScope.() -> Unit)) {
 @Composable
 fun DisplayUrlWithLoadingSymbol(
     content: BaseMediaContent,
-    onError: (Int, Int) -> Unit = { _, _ -> },
+    onError: (StringResource, StringResource) -> Unit = { _, _ -> },
 ) {
     val uri = LocalUriHandler.current
 
@@ -650,7 +651,7 @@ fun DisplayUrlWithLoadingSymbol(
 @Composable
 fun DisplayUrlWithLoadingSymbol(
     url: String,
-    onError: (Int, Int) -> Unit = { _, _ -> },
+    onError: (StringResource, StringResource) -> Unit = { _, _ -> },
 ) {
     val uri = LocalUriHandler.current
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
@@ -77,6 +77,9 @@ import coil3.compose.SubcomposeAsyncImageContent
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.media_added
+import com.vitorpamplona.amethyst.commons.resources.media_added_to_profile_gallery
 import com.vitorpamplona.amethyst.commons.richtext.BaseMediaContent
 import com.vitorpamplona.amethyst.commons.richtext.MediaLocalImage
 import com.vitorpamplona.amethyst.commons.richtext.MediaLocalVideo
@@ -796,7 +799,7 @@ fun ShareMediaAction(
                                 val n19 = Nip19Parser.uriToRoute(postNostrUri)?.entity as? NEvent
                                 if (n19 != null) {
                                     accountViewModel.addMediaToGallery(n19.hex, videoUri, n19.relay.getOrNull(0), blurhash, dim, hash, mimeType)
-                                    accountViewModel.toastManager.toast(R.string.media_added, R.string.media_added_to_profile_gallery)
+                                    accountViewModel.toastManager.toast(Res.string.media_added, Res.string.media_added_to_profile_gallery)
                                 }
                             }
                             onDismiss()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/DisplayErrorMessages.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/DisplayErrorMessages.kt
@@ -28,6 +28,7 @@ import com.vitorpamplona.amethyst.ui.components.toasts.multiline.MultiUserErrorM
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun DisplayErrorMessages(
@@ -39,40 +40,22 @@ fun DisplayErrorMessages(
 
     openDialogMsg.value?.let { obj ->
         when (obj) {
+            // New StringResource-based types
             is ResourceToastMsg -> {
                 if (obj.params != null) {
                     InformationDialog(
-                        stringRes(obj.titleResId),
-                        stringRes(obj.resourceId, *obj.params),
+                        stringResource(obj.titleRes),
+                        stringResource(obj.descRes, *obj.params),
                     ) {
                         toastManager.clearToasts()
                     }
                 } else {
                     InformationDialog(
-                        stringRes(obj.titleResId),
-                        stringRes(obj.resourceId),
+                        stringResource(obj.titleRes),
+                        stringResource(obj.descRes),
                     ) {
                         toastManager.clearToasts()
                     }
-                }
-            }
-
-            is StringToastMsg -> {
-                InformationDialog(
-                    obj.title,
-                    obj.msg,
-                ) {
-                    toastManager.clearToasts()
-                }
-            }
-
-            is ActionableStringToastMsg -> {
-                InformationDialog(
-                    obj.title,
-                    obj.msg,
-                ) {
-                    obj.action()
-                    toastManager.clearToasts()
                 }
             }
 
@@ -90,6 +73,65 @@ fun DisplayErrorMessages(
 
             is MultiErrorToastMsg -> {
                 MultiUserErrorMessageDialog(obj, accountViewModel, nav)
+            }
+
+            // Legacy Int-based types (will be removed after full migration)
+            is LegacyResourceToastMsg -> {
+                @Suppress("DEPRECATION")
+                if (obj.params != null) {
+                    InformationDialog(
+                        stringRes(obj.titleResId),
+                        stringRes(obj.resourceId, *obj.params),
+                    ) {
+                        toastManager.clearToasts()
+                    }
+                } else {
+                    InformationDialog(
+                        stringRes(obj.titleResId),
+                        stringRes(obj.resourceId),
+                    ) {
+                        toastManager.clearToasts()
+                    }
+                }
+            }
+
+            is LegacyThrowableToastMsg -> {
+                @Suppress("DEPRECATION")
+                InformationDialog(obj) {
+                    toastManager.clearToasts()
+                }
+            }
+
+            is LegacyThrowableToastMsg2 -> {
+                @Suppress("DEPRECATION")
+                InformationDialog(obj) {
+                    toastManager.clearToasts()
+                }
+            }
+
+            is LegacyMultiErrorToastMsg -> {
+                @Suppress("DEPRECATION")
+                MultiUserErrorMessageDialog(obj, accountViewModel, nav)
+            }
+
+            // String-based types
+            is StringToastMsg -> {
+                InformationDialog(
+                    obj.title,
+                    obj.msg,
+                ) {
+                    toastManager.clearToasts()
+                }
+            }
+
+            is ActionableStringToastMsg -> {
+                InformationDialog(
+                    obj.title,
+                    obj.msg,
+                ) {
+                    obj.action()
+                    toastManager.clearToasts()
+                }
             }
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/LegacyToastMsg.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/LegacyToastMsg.kt
@@ -18,18 +18,46 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.components.toasts.multiline
+package com.vitorpamplona.amethyst.ui.components.toasts
 
 import androidx.compose.runtime.Immutable
 import com.vitorpamplona.amethyst.model.User
-import com.vitorpamplona.amethyst.ui.components.toasts.ToastMsg
+import com.vitorpamplona.amethyst.ui.components.toasts.multiline.UserBasedErrorMessage
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
-import org.jetbrains.compose.resources.StringResource
 
+/**
+ * Legacy Int-based toast message classes.
+ * These will be removed once all callers are migrated to StringResource.
+ */
+@Deprecated("Use ResourceToastMsg with StringResource")
 @Immutable
-class MultiErrorToastMsg(
-    val titleRes: StringResource,
+class LegacyResourceToastMsg(
+    val titleResId: Int,
+    val resourceId: Int,
+    val params: Array<out String>? = null,
+) : ToastMsg()
+
+@Deprecated("Use ThrowableToastMsg with StringResource")
+@Immutable
+class LegacyThrowableToastMsg(
+    val titleResId: Int,
+    val msg: String? = null,
+    val throwable: Throwable,
+) : ToastMsg()
+
+@Deprecated("Use ThrowableToastMsg2 with StringResource")
+@Immutable
+class LegacyThrowableToastMsg2(
+    val titleResId: Int,
+    val description: Int,
+    val throwable: Throwable,
+) : ToastMsg()
+
+@Deprecated("Use MultiErrorToastMsg with StringResource")
+@Immutable
+class LegacyMultiErrorToastMsg(
+    val titleResId: Int,
 ) : ToastMsg() {
     val errors = MutableStateFlow<List<UserBasedErrorMessage>>(emptyList())
 
@@ -46,8 +74,3 @@ class MultiErrorToastMsg(
         }
     }
 }
-
-class UserBasedErrorMessage(
-    val error: String,
-    val user: User?,
-)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ResourceToastMsg.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ResourceToastMsg.kt
@@ -21,10 +21,11 @@
 package com.vitorpamplona.amethyst.ui.components.toasts
 
 import androidx.compose.runtime.Immutable
+import org.jetbrains.compose.resources.StringResource
 
 @Immutable
 class ResourceToastMsg(
-    val titleResId: Int,
-    val resourceId: Int,
+    val titleRes: StringResource,
+    val descRes: StringResource,
     val params: Array<out String>? = null,
 ) : ToastMsg()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ThrowableToastMsg.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ThrowableToastMsg.kt
@@ -21,17 +21,18 @@
 package com.vitorpamplona.amethyst.ui.components.toasts
 
 import androidx.compose.runtime.Immutable
+import org.jetbrains.compose.resources.StringResource
 
 @Immutable
 class ThrowableToastMsg(
-    val titleResId: Int,
+    val titleRes: StringResource,
     val msg: String? = null,
     val throwable: Throwable,
 ) : ToastMsg()
 
 @Immutable
 class ThrowableToastMsg2(
-    val titleResId: Int,
-    val description: Int,
+    val titleRes: StringResource,
+    val descriptionRes: StringResource,
     val throwable: Throwable,
 ) : ToastMsg()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ToastManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ToastManager.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.ui.components.toasts.multiline.MultiErrorToastMsg
 import com.vitorpamplona.amethyst.ui.components.toasts.multiline.UserBasedErrorMessage
 import kotlinx.coroutines.flow.MutableStateFlow
+import org.jetbrains.compose.resources.StringResource
 
 @Stable
 class ToastManager {
@@ -49,59 +50,125 @@ class ToastManager {
         toasts.tryEmit(ActionableStringToastMsg(title, message, action))
     }
 
+    // --- StringResource-based overloads (KMP) ---
+
+    fun toast(
+        titleRes: StringResource,
+        descRes: StringResource,
+    ) {
+        toasts.tryEmit(ResourceToastMsg(titleRes, descRes))
+    }
+
+    fun toast(
+        titleRes: StringResource,
+        message: String?,
+        throwable: Throwable,
+    ) {
+        toasts.tryEmit(ThrowableToastMsg(titleRes, message, throwable))
+    }
+
+    fun toast(
+        titleRes: StringResource,
+        descriptionRes: StringResource,
+        throwable: Throwable,
+    ) {
+        toasts.tryEmit(ThrowableToastMsg2(titleRes, descriptionRes, throwable))
+    }
+
+    fun toast(
+        titleRes: StringResource,
+        descRes: StringResource,
+        vararg params: String,
+    ) {
+        toasts.tryEmit(ResourceToastMsg(titleRes, descRes, params))
+    }
+
+    fun toast(
+        titleRes: StringResource,
+        message: String,
+        user: User?,
+    ) {
+        val current = toasts.value
+        if (current is MultiErrorToastMsg && current.titleRes == titleRes) {
+            current.add(message, user)
+        } else {
+            toasts.tryEmit(MultiErrorToastMsg(titleRes).also { it.add(message, user) })
+        }
+    }
+
+    fun toast(
+        titleRes: StringResource,
+        data: UserBasedErrorMessage,
+    ) {
+        val current = toasts.value
+        if (current is MultiErrorToastMsg && current.titleRes == titleRes) {
+            current.add(data)
+        } else {
+            toasts.tryEmit(MultiErrorToastMsg(titleRes).also { it.add(data) })
+        }
+    }
+
+    // --- Deprecated Int-based overloads (will be removed after full migration) ---
+
+    @Deprecated("Use StringResource overload", ReplaceWith("toast(titleRes, descRes)"))
     fun toast(
         titleResId: Int,
         resourceId: Int,
     ) {
-        toasts.tryEmit(ResourceToastMsg(titleResId, resourceId))
+        toasts.tryEmit(LegacyResourceToastMsg(titleResId, resourceId))
     }
 
+    @Deprecated("Use StringResource overload", ReplaceWith("toast(titleRes, message, throwable)"))
     fun toast(
         titleResId: Int,
         message: String?,
         throwable: Throwable,
     ) {
-        toasts.tryEmit(ThrowableToastMsg(titleResId, message, throwable))
+        toasts.tryEmit(LegacyThrowableToastMsg(titleResId, message, throwable))
     }
 
+    @Deprecated("Use StringResource overload", ReplaceWith("toast(titleRes, descriptionRes, throwable)"))
     fun toast(
         titleResId: Int,
         description: Int,
         throwable: Throwable,
     ) {
-        toasts.tryEmit(ThrowableToastMsg2(titleResId, description, throwable))
+        toasts.tryEmit(LegacyThrowableToastMsg2(titleResId, description, throwable))
     }
 
+    @Deprecated("Use StringResource overload", ReplaceWith("toast(titleRes, descRes, *params)"))
     fun toast(
         titleResId: Int,
         resourceId: Int,
         vararg params: String,
     ) {
-        toasts.tryEmit(ResourceToastMsg(titleResId, resourceId, params))
+        toasts.tryEmit(LegacyResourceToastMsg(titleResId, resourceId, params))
     }
 
+    @Deprecated("Use StringResource overload", ReplaceWith("toast(titleRes, message, user)"))
     fun toast(
         titleResId: Int,
         message: String,
         user: User?,
     ) {
         val current = toasts.value
-        if (current is MultiErrorToastMsg && current.titleResId == titleResId) {
+        if (current is LegacyMultiErrorToastMsg && current.titleResId == titleResId) {
             current.add(message, user)
         } else {
-            toasts.tryEmit(MultiErrorToastMsg(titleResId).also { it.add(message, user) })
+            toasts.tryEmit(LegacyMultiErrorToastMsg(titleResId).also { it.add(message, user) })
         }
     }
 
+    @Deprecated("Use StringResource overload", ReplaceWith("toast(titleRes, data)"))
     fun toast(
         titleResId: Int,
         data: UserBasedErrorMessage,
     ) {
         val current = toasts.value
-        if (current is MultiErrorToastMsg && current.titleResId == titleResId) {
+        if (current is LegacyMultiErrorToastMsg && current.titleResId == titleResId) {
             current.add(data)
         } else {
-            toasts.tryEmit(MultiErrorToastMsg(titleResId).also { it.add(data) })
+            toasts.tryEmit(LegacyMultiErrorToastMsg(titleResId).also { it.add(data) })
         }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/multiline/ErrorList.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/multiline/ErrorList.kt
@@ -42,8 +42,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.error_dialog_zap_error
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.User
+import com.vitorpamplona.amethyst.ui.components.toasts.LegacyMultiErrorToastMsg
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.routeToMessage
@@ -81,7 +84,7 @@ fun ErrorListPreview() {
         }
     }
 
-    val model = MultiErrorToastMsg(R.string.error_dialog_zap_error)
+    val model = MultiErrorToastMsg(Res.string.error_dialog_zap_error)
     model.add("Could not fetch invoice from https://minibits.cash/.well-known/lnurlp/victorieeman: There are too many unpaid invoices for this name.", user1)
     model.add("No Wallets found to pay a lightning invoice. Please install a Lightning wallet to use zaps.", user2)
     model.add("Could not fetch invoice", user3)
@@ -152,6 +155,24 @@ fun ErrorRow(
         Row(Modifier.weight(1f)) {
             SelectionContainer {
                 Text(errorState.error)
+            }
+        }
+    }
+}
+
+@Suppress("DEPRECATION")
+@Composable
+fun LegacyErrorList(
+    model: LegacyMultiErrorToastMsg,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    val errorState by model.errors.collectAsStateWithLifecycle()
+    LazyColumn {
+        itemsIndexed(errorState) { index, it ->
+            ErrorRow(it, accountViewModel, nav)
+            if (index < errorState.size - 1) {
+                HorizontalDivider(thickness = DividerThickness)
             }
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/multiline/MultiUserErrorMessageDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/multiline/MultiUserErrorMessageDialog.kt
@@ -31,8 +31,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.error_dialog_zap_error
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.User
+import com.vitorpamplona.amethyst.ui.components.toasts.LegacyMultiErrorToastMsg
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -44,6 +47,7 @@ import com.vitorpamplona.amethyst.ui.theme.ThemeComparisonColumn
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 @Preview
@@ -63,7 +67,7 @@ fun MultiUserErrorMessageContentPreview() {
         }
     }
 
-    val model = MultiErrorToastMsg(R.string.error_dialog_zap_error)
+    val model = MultiErrorToastMsg(Res.string.error_dialog_zap_error)
     model.add("Could not fetch invoice from https://minibits.cash/.well-known/lnurlp/victorieeman: There are too many unpaid invoices for this name.", user1)
     model.add("No Wallets found to pay a lightning invoice. Please install a Lightning wallet to use zaps.", user2)
     model.add("Could not fetch invoice", user3)
@@ -85,9 +89,38 @@ fun MultiUserErrorMessageDialog(
 ) {
     AlertDialog(
         onDismissRequest = accountViewModel.toastManager::clearToasts,
-        title = { Text(stringRes(model.titleResId)) },
+        title = { Text(stringResource(model.titleRes)) },
         text = {
             ErrorList(model, accountViewModel, nav)
+        },
+        confirmButton = {
+            Button(
+                onClick = accountViewModel.toastManager::clearToasts,
+                contentPadding = PaddingValues(horizontal = Size16dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Done,
+                    contentDescription = null,
+                )
+                Spacer(StdHorzSpacer)
+                Text(stringRes(R.string.error_dialog_button_ok))
+            }
+        },
+    )
+}
+
+@Suppress("DEPRECATION")
+@Composable
+fun MultiUserErrorMessageDialog(
+    model: LegacyMultiErrorToastMsg,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    AlertDialog(
+        onDismissRequest = accountViewModel.toastManager::clearToasts,
+        title = { Text(stringRes(model.titleResId)) },
+        text = {
+            LegacyErrorList(model, accountViewModel, nav)
         },
         confirmButton = {
             Button(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -39,8 +39,10 @@ import androidx.core.content.IntentCompat
 import androidx.core.util.Consumer
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.call.CallState
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.invalid_nip19_uri
+import com.vitorpamplona.amethyst.commons.resources.invalid_nip19_uri_description
 import com.vitorpamplona.amethyst.service.call.CallSessionBridge
 import com.vitorpamplona.amethyst.service.crashreports.DisplayCrashMessages
 import com.vitorpamplona.amethyst.service.relayClient.notifyCommand.compose.DisplayNotifyMessages
@@ -526,8 +528,8 @@ private fun NavigateIfIntentRequested(
                     actionableNextPage = null
                 } else {
                     accountViewModel.toastManager.toast(
-                        R.string.invalid_nip19_uri,
-                        R.string.invalid_nip19_uri_description,
+                        Res.string.invalid_nip19_uri,
+                        Res.string.invalid_nip19_uri_description,
                         intentNextPage,
                     )
                 }
@@ -583,8 +585,8 @@ private fun NavigateIfIntentRequested(
                                 scope.launch {
                                     delay(1000)
                                     accountViewModel.toastManager.toast(
-                                        R.string.invalid_nip19_uri,
-                                        R.string.invalid_nip19_uri_description,
+                                        Res.string.invalid_nip19_uri,
+                                        Res.string.invalid_nip19_uri_description,
                                         uri,
                                     )
                                 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
@@ -103,6 +103,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.emojicoder.EmojiCoder
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.error_dialog_zap_error
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.ReactionRowAction
 import com.vitorpamplona.amethyst.model.ReactionRowItem
@@ -1195,7 +1197,7 @@ fun ZapReaction(
                             onError = { _, message, user ->
                                 scope.launch {
                                     zappingProgress = 0f
-                                    accountViewModel.toastManager.toast(R.string.error_dialog_zap_error, message, user)
+                                    accountViewModel.toastManager.toast(Res.string.error_dialog_zap_error, message, user)
                                 }
                             },
                             onPayViaIntent = {
@@ -1203,7 +1205,7 @@ fun ZapReaction(
                                     val payable = it.first()
                                     payViaIntent(payable.invoice, context, { }) { error ->
                                         zappingProgress = 0f
-                                        accountViewModel.toastManager.toast(R.string.error_dialog_zap_error, UserBasedErrorMessage(error, payable.info.user))
+                                        accountViewModel.toastManager.toast(Res.string.error_dialog_zap_error, UserBasedErrorMessage(error, payable.info.user))
                                     }
                                 } else {
                                     val uid = Uuid.random().toString()
@@ -1240,7 +1242,7 @@ fun ZapReaction(
                 onError = { _, message, user ->
                     scope.launch {
                         zappingProgress = 0f
-                        accountViewModel.toastManager.toast(R.string.error_dialog_zap_error, message, user)
+                        accountViewModel.toastManager.toast(Res.string.error_dialog_zap_error, message, user)
                     }
                 },
                 onProgress = { scope.launch(Dispatchers.Main) { zappingProgress = it } },
@@ -1249,7 +1251,7 @@ fun ZapReaction(
                         val payable = it.first()
                         payViaIntent(payable.invoice, context, { }) { error ->
                             zappingProgress = 0f
-                            accountViewModel.toastManager.toast(R.string.error_dialog_zap_error, UserBasedErrorMessage(error, payable.info.user))
+                            accountViewModel.toastManager.toast(Res.string.error_dialog_zap_error, UserBasedErrorMessage(error, payable.info.user))
                         }
                     } else {
                         val uid = Uuid.random().toString()
@@ -1267,7 +1269,7 @@ fun ZapReaction(
                 onError = { _, message, user ->
                     scope.launch {
                         zappingProgress = 0f
-                        accountViewModel.toastManager.toast(R.string.error_dialog_zap_error, message, user)
+                        accountViewModel.toastManager.toast(Res.string.error_dialog_zap_error, message, user)
                     }
                 },
                 onProgress = { scope.launch(Dispatchers.Main) { zappingProgress = it } },
@@ -1276,7 +1278,7 @@ fun ZapReaction(
                         val payable = it.first()
                         payViaIntent(payable.invoice, context, { }) { error ->
                             zappingProgress = 0f
-                            accountViewModel.toastManager.toast(R.string.error_dialog_zap_error, UserBasedErrorMessage(error, payable.info.user))
+                            accountViewModel.toastManager.toast(Res.string.error_dialog_zap_error, UserBasedErrorMessage(error, payable.info.user))
                         }
                     } else {
                         val uid = Uuid.random().toString()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
@@ -104,7 +104,17 @@ import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.emojicoder.EmojiCoder
 import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.draft_note
 import com.vitorpamplona.amethyst.commons.resources.error_dialog_zap_error
+import com.vitorpamplona.amethyst.commons.resources.it_s_not_possible_to_react_to_a_draft_note
+import com.vitorpamplona.amethyst.commons.resources.it_s_not_possible_to_reply_to_a_draft_note
+import com.vitorpamplona.amethyst.commons.resources.it_s_not_possible_to_zap_to_a_draft_note
+import com.vitorpamplona.amethyst.commons.resources.login_with_a_private_key_to_be_able_to_reply
+import com.vitorpamplona.amethyst.commons.resources.login_with_a_private_key_to_be_able_to_send_zaps
+import com.vitorpamplona.amethyst.commons.resources.login_with_a_private_key_to_like_posts
+import com.vitorpamplona.amethyst.commons.resources.no_reaction_type_setup_long_press_to_change
+import com.vitorpamplona.amethyst.commons.resources.no_reactions_setup
+import com.vitorpamplona.amethyst.commons.resources.read_only_user
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.ReactionRowAction
 import com.vitorpamplona.amethyst.model.ReactionRowItem
@@ -810,16 +820,16 @@ fun ReplyReaction(
         onClick = {
             if (baseNote.isDraft()) {
                 accountViewModel.toastManager.toast(
-                    R.string.draft_note,
-                    R.string.it_s_not_possible_to_reply_to_a_draft_note,
+                    Res.string.draft_note,
+                    Res.string.it_s_not_possible_to_reply_to_a_draft_note,
                 )
             } else {
                 if (accountViewModel.isWriteable()) {
                     onPress()
                 } else {
                     accountViewModel.toastManager.toast(
-                        R.string.read_only_user,
-                        R.string.login_with_a_private_key_to_be_able_to_reply,
+                        Res.string.read_only_user,
+                        Res.string.login_with_a_private_key_to_be_able_to_reply,
                     )
                 }
             }
@@ -1129,8 +1139,8 @@ private fun likeClick(
 ) {
     if (baseNote.isDraft()) {
         accountViewModel.toastManager.toast(
-            R.string.draft_note,
-            R.string.it_s_not_possible_to_react_to_a_draft_note,
+            Res.string.draft_note,
+            Res.string.it_s_not_possible_to_react_to_a_draft_note,
         )
         return
     }
@@ -1138,13 +1148,13 @@ private fun likeClick(
     val choices = accountViewModel.reactionChoices()
     if (choices.isEmpty()) {
         accountViewModel.toastManager.toast(
-            R.string.no_reactions_setup,
-            R.string.no_reaction_type_setup_long_press_to_change,
+            Res.string.no_reactions_setup,
+            Res.string.no_reaction_type_setup_long_press_to_change,
         )
     } else if (!accountViewModel.isWriteable()) {
         accountViewModel.toastManager.toast(
-            R.string.read_only_user,
-            R.string.login_with_a_private_key_to_like_posts,
+            Res.string.read_only_user,
+            Res.string.login_with_a_private_key_to_like_posts,
         )
     } else if (choices.size == 1) {
         onWantsToSignReaction()
@@ -1353,8 +1363,8 @@ fun zapClick(
 ) {
     if (baseNote.isDraft()) {
         accountViewModel.toastManager.toast(
-            R.string.draft_note,
-            R.string.it_s_not_possible_to_zap_to_a_draft_note,
+            Res.string.draft_note,
+            Res.string.it_s_not_possible_to_zap_to_a_draft_note,
         )
         return
     }
@@ -1365,8 +1375,8 @@ fun zapClick(
         onCustomAmount()
     } else if (!accountViewModel.isWriteable()) {
         accountViewModel.toastManager.toast(
-            R.string.error_dialog_zap_error,
-            R.string.login_with_a_private_key_to_be_able_to_send_zaps,
+            Res.string.error_dialog_zap_error,
+            Res.string.login_with_a_private_key_to_be_able_to_send_zaps,
         )
     } else if (choices.size == 1) {
         onZapStarts()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/UpdateZapAmountDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/UpdateZapAmountDialog.kt
@@ -102,6 +102,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.couldnt_find_nwc_wallets
+import com.vitorpamplona.amethyst.commons.resources.couldnt_find_nwc_wallets_description
+import com.vitorpamplona.amethyst.commons.resources.invalid_nip47_uri_description
+import com.vitorpamplona.amethyst.commons.resources.invalid_nip47_uri_title
 import com.vitorpamplona.amethyst.ui.components.TextSpinner
 import com.vitorpamplona.amethyst.ui.components.TitleExplainer
 import com.vitorpamplona.amethyst.ui.components.util.getText
@@ -429,8 +434,8 @@ fun UpdateZapAmountContent(
                         onClose()
                     } catch (_: IllegalArgumentException) {
                         accountViewModel.toastManager.toast(
-                            R.string.couldnt_find_nwc_wallets,
-                            R.string.couldnt_find_nwc_wallets_description,
+                            Res.string.couldnt_find_nwc_wallets,
+                            Res.string.couldnt_find_nwc_wallets_description,
                         )
                     }
                 },
@@ -455,8 +460,8 @@ fun UpdateZapAmountContent(
                             clipText?.let { postViewModel.copyFromClipboard(it) }
                         } catch (e: IllegalArgumentException) {
                             accountViewModel.toastManager.toast(
-                                R.string.invalid_nip47_uri_title,
-                                R.string.invalid_nip47_uri_description,
+                                Res.string.invalid_nip47_uri_title,
+                                Res.string.invalid_nip47_uri_description,
                                 clipText ?: "",
                             )
                         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/UserCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/UserCompose.kt
@@ -34,6 +34,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.login_with_a_private_key_to_be_able_to_follow
+import com.vitorpamplona.amethyst.commons.resources.login_with_a_private_key_to_be_able_to_unfollow
+import com.vitorpamplona.amethyst.commons.resources.read_only_user
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.observeAccountIsHiddenUser
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserAboutMe
@@ -102,8 +106,8 @@ fun ShowFollowingOrUnfollowingButton(
         UnfollowButton(true) {
             if (!accountViewModel.isWriteable()) {
                 accountViewModel.toastManager.toast(
-                    R.string.read_only_user,
-                    R.string.login_with_a_private_key_to_be_able_to_unfollow,
+                    Res.string.read_only_user,
+                    Res.string.login_with_a_private_key_to_be_able_to_unfollow,
                 )
             } else {
                 accountViewModel.unfollow(baseAuthor)
@@ -113,8 +117,8 @@ fun ShowFollowingOrUnfollowingButton(
         FollowButton(R.string.follow, true) {
             if (!accountViewModel.isWriteable()) {
                 accountViewModel.toastManager.toast(
-                    R.string.read_only_user,
-                    R.string.login_with_a_private_key_to_be_able_to_follow,
+                    Res.string.read_only_user,
+                    Res.string.login_with_a_private_key_to_be_able_to_follow,
                 )
             } else {
                 accountViewModel.follow(baseAuthor)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapCustomDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapCustomDialog.kt
@@ -72,6 +72,8 @@ import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.error_dialog_zap_error
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
@@ -451,7 +453,7 @@ fun DisplayPayable(
         PayButton(isActive = !paid.value) {
             payViaIntent(payable.invoice, context, { paid.value = true }) {
                 accountViewModel.toastManager.toast(
-                    R.string.error_dialog_zap_error,
+                    Res.string.error_dialog_zap_error,
                     UserBasedErrorMessage(it, payable.info.user),
                 )
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapPollNote.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapPollNote.kt
@@ -78,6 +78,13 @@ import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.model.EmptyTagList
 import com.vitorpamplona.amethyst.commons.model.ImmutableListOfLists
 import com.vitorpamplona.amethyst.commons.model.toImmutableListOfLists
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.login_with_a_private_key_to_be_able_to_send_zaps
+import com.vitorpamplona.amethyst.commons.resources.one_vote_per_user_on_atomic_votes
+import com.vitorpamplona.amethyst.commons.resources.poll_author_no_vote
+import com.vitorpamplona.amethyst.commons.resources.poll_is_closed_explainer
+import com.vitorpamplona.amethyst.commons.resources.poll_unable_to_vote
+import com.vitorpamplona.amethyst.commons.resources.read_only_user
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
@@ -550,24 +557,24 @@ fun ZapVote(
                 onClick = {
                     if (!accountViewModel.isWriteable()) {
                         accountViewModel.toastManager.toast(
-                            R.string.read_only_user,
-                            R.string.login_with_a_private_key_to_be_able_to_send_zaps,
+                            Res.string.read_only_user,
+                            Res.string.login_with_a_private_key_to_be_able_to_send_zaps,
                         )
                     } else if (pollViewModel.isPollClosed()) {
                         accountViewModel.toastManager.toast(
-                            R.string.poll_unable_to_vote,
-                            R.string.poll_is_closed_explainer,
+                            Res.string.poll_unable_to_vote,
+                            Res.string.poll_is_closed_explainer,
                         )
                     } else if (isLoggedUser) {
                         accountViewModel.toastManager.toast(
-                            R.string.poll_unable_to_vote,
-                            R.string.poll_author_no_vote,
+                            Res.string.poll_unable_to_vote,
+                            Res.string.poll_author_no_vote,
                         )
                     } else if (pollViewModel.isVoteAmountAtomic() && poolOption.zappedByLoggedIn.value) {
                         // only allow one vote per option when min==max, i.e. atomic vote amount specified
                         accountViewModel.toastManager.toast(
-                            R.string.poll_unable_to_vote,
-                            R.string.one_vote_per_user_on_atomic_votes,
+                            Res.string.poll_unable_to_vote,
+                            Res.string.one_vote_per_user_on_atomic_votes,
                         )
                         return@combinedClickable
                     } else if (

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DisplayOts.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DisplayOts.kt
@@ -30,6 +30,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.ots_info_description
+import com.vitorpamplona.amethyst.commons.resources.ots_info_title
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.components.buildLinkString
 import com.vitorpamplona.amethyst.ui.note.LoadOts
@@ -64,8 +67,8 @@ fun DisplayOts(
                 text =
                     buildLinkString(stringRes(R.string.existed_since, timeStr)) {
                         accountViewModel.toastManager.toast(
-                            R.string.ots_info_title,
-                            R.string.ots_info_description,
+                            Res.string.ots_info_title,
+                            Res.string.ots_info_description,
                             SimpleDateFormat.getDateTimeInstance().format(Date(unixtimestamp * 1000)),
                         )
                     },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Torrent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Torrent.kt
@@ -48,7 +48,10 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.torrent_failure
+import com.vitorpamplona.amethyst.commons.resources.torrent_no_apps
+import com.vitorpamplona.amethyst.commons.resources.torrent_no_info
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.service.countToHumanReadableBytes
@@ -221,11 +224,11 @@ fun DisplayFileList(
                             intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                             context.startActivity(intent)
                         } else {
-                            accountViewModel.toastManager.toast(R.string.torrent_failure, R.string.torrent_no_info)
+                            accountViewModel.toastManager.toast(Res.string.torrent_failure, Res.string.torrent_no_info)
                         }
                     } catch (e: Exception) {
                         if (e is CancellationException) throw e
-                        accountViewModel.toastManager.toast(R.string.torrent_failure, R.string.torrent_no_apps)
+                        accountViewModel.toastManager.toast(Res.string.torrent_failure, Res.string.torrent_no_apps)
                     }
                 },
                 Modifier.size(Size30dp),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -49,6 +49,8 @@ import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
 import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatChannel
 import com.vitorpamplona.amethyst.commons.model.nip53LiveActivities.LiveActivitiesChannel
 import com.vitorpamplona.amethyst.commons.model.observables.CreatedAtComparator
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.failed_to_save_the_video
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
 import com.vitorpamplona.amethyst.commons.ui.notifications.CardFeedState
 import com.vitorpamplona.amethyst.logTime
@@ -1866,7 +1868,7 @@ class AccountViewModel(
                     }
                 },
                 onError = {
-                    toastManager.toast(R.string.failed_to_save_the_video, null, it)
+                    toastManager.toast(Res.string.failed_to_save_the_video, null, it)
                 },
             )
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -50,7 +50,17 @@ import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatChann
 import com.vitorpamplona.amethyst.commons.model.nip53LiveActivities.LiveActivitiesChannel
 import com.vitorpamplona.amethyst.commons.model.observables.CreatedAtComparator
 import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.draft_note
 import com.vitorpamplona.amethyst.commons.resources.failed_to_save_the_video
+import com.vitorpamplona.amethyst.commons.resources.it_s_not_possible_to_quote_to_a_draft_note
+import com.vitorpamplona.amethyst.commons.resources.login_with_a_private_key_to_be_able_to_boost_posts
+import com.vitorpamplona.amethyst.commons.resources.login_with_a_private_key_to_be_able_to_sign_events
+import com.vitorpamplona.amethyst.commons.resources.read_only_user
+import com.vitorpamplona.amethyst.commons.resources.signer_illegal_state_exception_description
+import com.vitorpamplona.amethyst.commons.resources.signer_not_found_exception
+import com.vitorpamplona.amethyst.commons.resources.signer_not_found_exception_description
+import com.vitorpamplona.amethyst.commons.resources.unauthorized_exception
+import com.vitorpamplona.amethyst.commons.resources.unauthorized_exception_description
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
 import com.vitorpamplona.amethyst.commons.ui.notifications.CardFeedState
 import com.vitorpamplona.amethyst.logTime
@@ -1043,18 +1053,18 @@ class AccountViewModel(
                 action()
             } catch (_: SignerExceptions.ReadOnlyException) {
                 toastManager.toast(
-                    R.string.read_only_user,
-                    R.string.login_with_a_private_key_to_be_able_to_sign_events,
+                    Res.string.read_only_user,
+                    Res.string.login_with_a_private_key_to_be_able_to_sign_events,
                 )
             } catch (_: SignerExceptions.UnauthorizedDecryptionException) {
                 toastManager.toast(
-                    R.string.unauthorized_exception,
-                    R.string.unauthorized_exception_description,
+                    Res.string.unauthorized_exception,
+                    Res.string.unauthorized_exception_description,
                 )
             } catch (_: SignerExceptions.SignerNotFoundException) {
                 toastManager.toast(
-                    R.string.signer_not_found_exception,
-                    R.string.signer_not_found_exception_description,
+                    Res.string.signer_not_found_exception,
+                    Res.string.signer_not_found_exception_description,
                 )
             } catch (e: SignerExceptions.TimedOutException) {
                 Log.w("AccountViewModel", "TimedOutException", e)
@@ -1070,8 +1080,8 @@ class AccountViewModel(
                 Log.w("AccountViewModel", "TimedOutRunningOnBackgroundWithoutAutomaticPermissionExceptionException", e)
             } catch (e: IllegalStateException) {
                 toastManager.toast(
-                    R.string.signer_not_found_exception,
-                    R.string.signer_illegal_state_exception_description,
+                    Res.string.signer_not_found_exception,
+                    Res.string.signer_illegal_state_exception_description,
                     e,
                 )
             }
@@ -1576,8 +1586,8 @@ class AccountViewModel(
     ) {
         if (baseNote.isDraft()) {
             toastManager.toast(
-                R.string.draft_note,
-                R.string.it_s_not_possible_to_quote_to_a_draft_note,
+                Res.string.draft_note,
+                Res.string.it_s_not_possible_to_quote_to_a_draft_note,
             )
             return
         }
@@ -1593,8 +1603,8 @@ class AccountViewModel(
             }
         } else {
             toastManager.toast(
-                R.string.read_only_user,
-                R.string.login_with_a_private_key_to_be_able_to_boost_posts,
+                Res.string.read_only_user,
+                Res.string.login_with_a_private_key_to_be_able_to_boost_posts,
             )
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/LoggedInPage.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/LoggedInPage.kt
@@ -40,7 +40,9 @@ import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.LocalPreferences
-import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.error_opening_external_signer
+import com.vitorpamplona.amethyst.commons.resources.error_opening_external_signer_description
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.service.notifications.PushNotificationUtils
 import com.vitorpamplona.amethyst.service.relayClient.authCommand.compose.RelayAuthSubscription
@@ -203,8 +205,8 @@ private fun ListenToExternalSignerIfNeeded(accountViewModel: AccountViewModel) {
                     launcher.launch(intent)
                 } catch (e: ActivityNotFoundException) {
                     accountViewModel.toastManager.toast(
-                        R.string.error_opening_external_signer,
-                        R.string.error_opening_external_signer_description,
+                        Res.string.error_opening_external_signer,
+                        Res.string.error_opening_external_signer_description,
                     )
                     throw e
                 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/list/metadata/BookmarkGroupMetadataScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/list/metadata/BookmarkGroupMetadataScreen.kt
@@ -43,6 +43,9 @@ import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.login_with_a_private_key_to_be_able_to_sign_events
+import com.vitorpamplona.amethyst.commons.resources.read_only_user
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectSingleFromGallery
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.CreatingTopBar
@@ -145,8 +148,8 @@ fun BookmarkGroupMetadataTopBar(
                     nav.popBack()
                 } catch (e: SignerExceptions.ReadOnlyException) {
                     accountViewModel.toastManager.toast(
-                        R.string.read_only_user,
-                        R.string.login_with_a_private_key_to_be_able_to_sign_events,
+                        Res.string.read_only_user,
+                        Res.string.login_with_a_private_key_to_be_able_to_sign_events,
                     )
                 }
             },
@@ -165,8 +168,8 @@ fun BookmarkGroupMetadataTopBar(
                     nav.popBack()
                 } catch (e: SignerExceptions.ReadOnlyException) {
                     accountViewModel.toastManager.toast(
-                        R.string.read_only_user,
-                        R.string.login_with_a_private_key_to_be_able_to_sign_events,
+                        Res.string.read_only_user,
+                        Res.string.login_with_a_private_key_to_be_able_to_sign_events,
                     )
                 }
             },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/NewGroupDMScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/NewGroupDMScreen.kt
@@ -74,6 +74,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.messages_cant_upload_explainer
+import com.vitorpamplona.amethyst.commons.resources.messages_cant_upload_title
 import com.vitorpamplona.amethyst.commons.richtext.BaseMediaContent
 import com.vitorpamplona.amethyst.commons.richtext.EncryptedMediaUrlImage
 import com.vitorpamplona.amethyst.commons.richtext.EncryptedMediaUrlVideo
@@ -421,7 +424,7 @@ private fun BottomRowActions(
             }
         } else {
             IconButton(
-                onClick = { accountViewModel.toastManager.toast(R.string.messages_cant_upload_title, R.string.messages_cant_upload_explainer) },
+                onClick = { accountViewModel.toastManager.toast(Res.string.messages_cant_upload_title, Res.string.messages_cant_upload_explainer) },
             ) {
                 Icon(
                     imageVector = Icons.Default.AddPhotoAlternate,
@@ -439,7 +442,7 @@ private fun BottomRowActions(
         } else {
             IconButton(
                 onClick = {
-                    accountViewModel.toastManager.toast(R.string.messages_cant_upload_title, R.string.messages_cant_upload_explainer)
+                    accountViewModel.toastManager.toast(Res.string.messages_cant_upload_title, Res.string.messages_cant_upload_explainer)
                 },
             ) {
                 Icon(
@@ -458,7 +461,7 @@ private fun BottomRowActions(
         } else {
             IconButton(
                 onClick = {
-                    accountViewModel.toastManager.toast(R.string.messages_cant_upload_title, R.string.messages_cant_upload_explainer)
+                    accountViewModel.toastManager.toast(Res.string.messages_cant_upload_title, Res.string.messages_cant_upload_explainer)
                 },
             ) {
                 Icon(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/nip28PublicChat/metadata/ChannelMetadataScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/nip28PublicChat/metadata/ChannelMetadataScreen.kt
@@ -49,6 +49,9 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatChannel
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.login_with_a_private_key_to_be_able_to_sign_events
+import com.vitorpamplona.amethyst.commons.resources.read_only_user
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectSingleFromGallery
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -154,8 +157,8 @@ private fun ChannelMetadataScaffold(
                             nav.popBack()
                         } catch (e: SignerExceptions.ReadOnlyException) {
                             accountViewModel.toastManager.toast(
-                                R.string.read_only_user,
-                                R.string.login_with_a_private_key_to_be_able_to_sign_events,
+                                Res.string.read_only_user,
+                                Res.string.login_with_a_private_key_to_be_able_to_sign_events,
                             )
                         }
                     },
@@ -174,8 +177,8 @@ private fun ChannelMetadataScaffold(
                             nav.popBack()
                         } catch (e: SignerExceptions.ReadOnlyException) {
                             accountViewModel.toastManager.toast(
-                                R.string.read_only_user,
-                                R.string.login_with_a_private_key_to_be_able_to_sign_events,
+                                Res.string.read_only_user,
+                                Res.string.login_with_a_private_key_to_be_able_to_sign_events,
                             )
                         }
                     },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/geohash/GeoHashScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/geohash/GeoHashScreen.kt
@@ -29,7 +29,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.login_with_a_private_key_to_be_able_to_follow
+import com.vitorpamplona.amethyst.commons.resources.login_with_a_private_key_to_be_able_to_unfollow
+import com.vitorpamplona.amethyst.commons.resources.read_only_user
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserIsFollowingGeohash
 import com.vitorpamplona.amethyst.ui.feeds.WatchLifecycleAndUpdateModel
 import com.vitorpamplona.amethyst.ui.layouts.DisappearingScaffold
@@ -138,8 +141,8 @@ fun GeoHashActionOptions(
         UnfollowButton {
             if (!accountViewModel.isWriteable()) {
                 accountViewModel.toastManager.toast(
-                    R.string.read_only_user,
-                    R.string.login_with_a_private_key_to_be_able_to_unfollow,
+                    Res.string.read_only_user,
+                    Res.string.login_with_a_private_key_to_be_able_to_unfollow,
                 )
             } else {
                 accountViewModel.unfollowGeohash(tag)
@@ -149,8 +152,8 @@ fun GeoHashActionOptions(
         FollowButton {
             if (!accountViewModel.isWriteable()) {
                 accountViewModel.toastManager.toast(
-                    R.string.read_only_user,
-                    R.string.login_with_a_private_key_to_be_able_to_follow,
+                    Res.string.read_only_user,
+                    Res.string.login_with_a_private_key_to_be_able_to_follow,
                 )
             } else {
                 accountViewModel.followGeohash(tag)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/HashtagScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/HashtagScreen.kt
@@ -34,7 +34,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.login_with_a_private_key_to_be_able_to_follow
+import com.vitorpamplona.amethyst.commons.resources.login_with_a_private_key_to_be_able_to_unfollow
+import com.vitorpamplona.amethyst.commons.resources.read_only_user
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserIsFollowingHashtag
 import com.vitorpamplona.amethyst.ui.feeds.WatchLifecycleAndUpdateModel
 import com.vitorpamplona.amethyst.ui.layouts.DisappearingScaffold
@@ -151,8 +154,8 @@ fun HashtagActionOptions(
         UnfollowButton {
             if (!accountViewModel.isWriteable()) {
                 accountViewModel.toastManager.toast(
-                    R.string.read_only_user,
-                    R.string.login_with_a_private_key_to_be_able_to_unfollow,
+                    Res.string.read_only_user,
+                    Res.string.login_with_a_private_key_to_be_able_to_unfollow,
                 )
             } else {
                 accountViewModel.unfollowHashtag(tag)
@@ -162,8 +165,8 @@ fun HashtagActionOptions(
         FollowButton {
             if (!accountViewModel.isWriteable()) {
                 accountViewModel.toastManager.toast(
-                    R.string.read_only_user,
-                    R.string.login_with_a_private_key_to_be_able_to_follow,
+                    Res.string.read_only_user,
+                    Res.string.login_with_a_private_key_to_be_able_to_follow,
                 )
             } else {
                 accountViewModel.followHashtag(tag)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/metadata/FollowPackMetadataScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/metadata/FollowPackMetadataScreen.kt
@@ -44,6 +44,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.login_with_a_private_key_to_be_able_to_sign_events
+import com.vitorpamplona.amethyst.commons.resources.read_only_user
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectSingleFromGallery
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -169,8 +172,8 @@ fun FollowPackMetadataTopBar(
                     nav.popBack()
                 } catch (e: SignerExceptions.ReadOnlyException) {
                     accountViewModel.toastManager.toast(
-                        R.string.read_only_user,
-                        R.string.login_with_a_private_key_to_be_able_to_sign_events,
+                        Res.string.read_only_user,
+                        Res.string.login_with_a_private_key_to_be_able_to_sign_events,
                     )
                 }
             },
@@ -189,8 +192,8 @@ fun FollowPackMetadataTopBar(
                     nav.popBack()
                 } catch (e: SignerExceptions.ReadOnlyException) {
                     accountViewModel.toastManager.toast(
-                        R.string.read_only_user,
-                        R.string.login_with_a_private_key_to_be_able_to_sign_events,
+                        Res.string.read_only_user,
+                        Res.string.login_with_a_private_key_to_be_able_to_sign_events,
                     )
                 }
             },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/metadata/PeopleListMetadataScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/metadata/PeopleListMetadataScreen.kt
@@ -44,6 +44,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.login_with_a_private_key_to_be_able_to_sign_events
+import com.vitorpamplona.amethyst.commons.resources.read_only_user
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectSingleFromGallery
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -169,8 +172,8 @@ fun PeopleListMetadataTopBar(
                     nav.popBack()
                 } catch (e: SignerExceptions.ReadOnlyException) {
                     accountViewModel.toastManager.toast(
-                        R.string.read_only_user,
-                        R.string.login_with_a_private_key_to_be_able_to_sign_events,
+                        Res.string.read_only_user,
+                        Res.string.login_with_a_private_key_to_be_able_to_sign_events,
                     )
                 }
             },
@@ -189,8 +192,8 @@ fun PeopleListMetadataTopBar(
                     nav.popBack()
                 } catch (e: SignerExceptions.ReadOnlyException) {
                     accountViewModel.toastManager.toast(
-                        R.string.read_only_user,
-                        R.string.login_with_a_private_key_to_be_able_to_sign_events,
+                        Res.string.read_only_user,
+                        Res.string.login_with_a_private_key_to_be_able_to_sign_events,
                     )
                 }
             },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/DisplayFollowUnfollowButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/DisplayFollowUnfollowButton.kt
@@ -23,6 +23,10 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.header
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.login_with_a_private_key_to_be_able_to_follow
+import com.vitorpamplona.amethyst.commons.resources.login_with_a_private_key_to_be_able_to_unfollow
+import com.vitorpamplona.amethyst.commons.resources.read_only_user
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserIsFollowing
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -41,8 +45,8 @@ fun DisplayFollowUnfollowButton(
         UnfollowButton(isInProfileActions = true) {
             if (!accountViewModel.isWriteable()) {
                 accountViewModel.toastManager.toast(
-                    R.string.read_only_user,
-                    R.string.login_with_a_private_key_to_be_able_to_unfollow,
+                    Res.string.read_only_user,
+                    Res.string.login_with_a_private_key_to_be_able_to_unfollow,
                 )
             } else {
                 accountViewModel.unfollow(baseUser)
@@ -53,8 +57,8 @@ fun DisplayFollowUnfollowButton(
             FollowButton(R.string.follow_back, isInProfileActions = true) {
                 if (!accountViewModel.isWriteable()) {
                     accountViewModel.toastManager.toast(
-                        R.string.read_only_user,
-                        R.string.login_with_a_private_key_to_be_able_to_follow,
+                        Res.string.read_only_user,
+                        Res.string.login_with_a_private_key_to_be_able_to_follow,
                     )
                 } else {
                     accountViewModel.follow(baseUser)
@@ -64,8 +68,8 @@ fun DisplayFollowUnfollowButton(
             FollowButton(R.string.follow, isInProfileActions = true) {
                 if (!accountViewModel.isWriteable()) {
                     accountViewModel.toastManager.toast(
-                        R.string.read_only_user,
-                        R.string.login_with_a_private_key_to_be_able_to_follow,
+                        Res.string.read_only_user,
+                        Res.string.login_with_a_private_key_to_be_able_to_follow,
                     )
                 } else {
                     accountViewModel.follow(baseUser)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relay/RelayFeedScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relay/RelayFeedScreen.kt
@@ -28,7 +28,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.login_with_a_private_key_to_be_able_to_follow
+import com.vitorpamplona.amethyst.commons.resources.login_with_a_private_key_to_be_able_to_unfollow
+import com.vitorpamplona.amethyst.commons.resources.read_only_user
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserIsFollowingRelay
 import com.vitorpamplona.amethyst.ui.feeds.WatchLifecycleAndUpdateModel
 import com.vitorpamplona.amethyst.ui.layouts.DisappearingScaffold
@@ -127,8 +130,8 @@ fun RelayFeedActionOptions(
         UnfollowButton {
             if (!accountViewModel.isWriteable()) {
                 accountViewModel.toastManager.toast(
-                    R.string.read_only_user,
-                    R.string.login_with_a_private_key_to_be_able_to_unfollow,
+                    Res.string.read_only_user,
+                    Res.string.login_with_a_private_key_to_be_able_to_unfollow,
                 )
             } else {
                 accountViewModel.unfollowRelayFeed(relayUrl)
@@ -138,8 +141,8 @@ fun RelayFeedActionOptions(
         FollowButton {
             if (!accountViewModel.isWriteable()) {
                 accountViewModel.toastManager.toast(
-                    R.string.read_only_user,
-                    R.string.login_with_a_private_key_to_be_able_to_follow,
+                    Res.string.read_only_user,
+                    Res.string.login_with_a_private_key_to_be_able_to_follow,
                 )
             } else {
                 accountViewModel.followRelayFeed(relayUrl)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/RelayStatusRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/RelayStatusRow.kt
@@ -40,6 +40,15 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.connection_success_rate_description
+import com.vitorpamplona.amethyst.commons.resources.errors
+import com.vitorpamplona.amethyst.commons.resources.read_from_relay
+import com.vitorpamplona.amethyst.commons.resources.read_from_relay_description
+import com.vitorpamplona.amethyst.commons.resources.spam
+import com.vitorpamplona.amethyst.commons.resources.spam_description
+import com.vitorpamplona.amethyst.commons.resources.write_to_relay
+import com.vitorpamplona.amethyst.commons.resources.write_to_relay_description
 import com.vitorpamplona.amethyst.service.countToHumanReadable
 import com.vitorpamplona.amethyst.service.countToHumanReadableBytes
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -103,8 +112,8 @@ fun RelayStatusRow(
                         },
                         onLongPress = {
                             accountViewModel.toastManager.toast(
-                                R.string.read_from_relay,
-                                R.string.read_from_relay_description,
+                                Res.string.read_from_relay,
+                                Res.string.read_from_relay_description,
                             )
                         },
                     )
@@ -135,8 +144,8 @@ fun RelayStatusRow(
                         },
                         onLongPress = {
                             accountViewModel.toastManager.toast(
-                                R.string.write_to_relay,
-                                R.string.write_to_relay_description,
+                                Res.string.write_to_relay,
+                                Res.string.write_to_relay_description,
                             )
                         },
                     )
@@ -167,8 +176,8 @@ fun RelayStatusRow(
                         },
                         onLongPress = {
                             accountViewModel.toastManager.toast(
-                                R.string.errors,
-                                R.string.connection_success_rate_description,
+                                Res.string.errors,
+                                Res.string.connection_success_rate_description,
                             )
                         },
                     )
@@ -208,8 +217,8 @@ fun RelayStatusRow(
                         },
                         onLongPress = {
                             accountViewModel.toastManager.toast(
-                                R.string.spam,
-                                R.string.spam_description,
+                                Res.string.spam,
+                                Res.string.spam_description,
                             )
                         },
                     )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/vanish/RequestToVanishScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/vanish/RequestToVanishScreen.kt
@@ -70,6 +70,9 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.request_to_vanish
+import com.vitorpamplona.amethyst.commons.resources.vanish_request_sent
 import com.vitorpamplona.amethyst.model.nip11RelayInfo.Nip11CachedRetriever
 import com.vitorpamplona.amethyst.ui.components.TitleExplainer
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
@@ -396,8 +399,8 @@ fun RequestToVanishScreen(
                     }
                 }
                 accountViewModel.toastManager.toast(
-                    R.string.request_to_vanish,
-                    R.string.vanish_request_sent,
+                    Res.string.request_to_vanish,
+                    Res.string.vanish_request_sent,
                 )
                 nav.popBack()
             },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/SecurityFiltersScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/SecurityFiltersScreen.kt
@@ -67,6 +67,10 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.login_with_a_private_key_to_be_able_to_hide_word
+import com.vitorpamplona.amethyst.commons.resources.login_with_a_private_key_to_be_able_to_show_word
+import com.vitorpamplona.amethyst.commons.resources.read_only_user
 import com.vitorpamplona.amethyst.model.WarningType
 import com.vitorpamplona.amethyst.model.parseWarningType
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.observeAccountIsHiddenWord
@@ -409,8 +413,8 @@ fun MutedWordActionOptions(
         ShowWordButton {
             if (!accountViewModel.isWriteable()) {
                 accountViewModel.toastManager.toast(
-                    R.string.read_only_user,
-                    R.string.login_with_a_private_key_to_be_able_to_show_word,
+                    Res.string.read_only_user,
+                    Res.string.login_with_a_private_key_to_be_able_to_show_word,
                 )
             } else {
                 accountViewModel.showWord(word)
@@ -420,8 +424,8 @@ fun MutedWordActionOptions(
         HideWordButton {
             if (!accountViewModel.isWriteable()) {
                 accountViewModel.toastManager.toast(
-                    R.string.read_only_user,
-                    R.string.login_with_a_private_key_to_be_able_to_hide_word,
+                    Res.string.read_only_user,
+                    Res.string.login_with_a_private_key_to_be_able_to_hide_word,
                 )
             } else {
                 accountViewModel.hideWord(word)
@@ -471,8 +475,8 @@ private fun hideIfWritable(
 ) {
     if (!accountViewModel.isWriteable()) {
         accountViewModel.toastManager.toast(
-            R.string.read_only_user,
-            R.string.login_with_a_private_key_to_be_able_to_hide_word,
+            Res.string.read_only_user,
+            Res.string.login_with_a_private_key_to_be_able_to_hide_word,
         )
     } else {
         accountViewModel.hide(currentWordToAdd.value)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/AddWalletScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/AddWalletScreen.kt
@@ -56,6 +56,9 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.couldnt_find_nwc_wallets
+import com.vitorpamplona.amethyst.commons.resources.couldnt_find_nwc_wallets_description
 import com.vitorpamplona.amethyst.ui.components.util.getText
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.painterRes
@@ -137,8 +140,8 @@ fun AddWalletScreen(
                             )
                         } catch (_: IllegalArgumentException) {
                             accountViewModel.toastManager.toast(
-                                R.string.couldnt_find_nwc_wallets,
-                                R.string.couldnt_find_nwc_wallets_description,
+                                Res.string.couldnt_find_nwc_wallets,
+                                Res.string.couldnt_find_nwc_wallets_description,
                             )
                         }
                     },

--- a/commons/src/commonMain/composeResources/values/strings.xml
+++ b/commons/src/commonMain/composeResources/values/strings.xml
@@ -54,4 +54,15 @@
     <!-- Accessibility -->
     <string name="accessibility_user_avatar">User avatar</string>
     <string name="accessibility_navigate">Navigate</string>
+
+    <!-- Toast Messages -->
+    <string name="error_dialog_zap_error">Unable to send zap</string>
+    <string name="failed_to_save_the_video">Failed to save the video</string>
+    <string name="media_added">Media added</string>
+    <string name="media_added_to_profile_gallery">Media added to your Profile Gallery</string>
+    <string name="messages_cant_upload_explainer">Insert the destination of the message first</string>
+    <string name="messages_cant_upload_title">Can\'t Upload</string>
+    <string name="torrent_failure">Failed to open file</string>
+    <string name="torrent_no_apps">No torrent apps installed to open and download the file.</string>
+    <string name="torrent_no_info">Event doesn\'t have enough information to build a magnet link</string>
 </resources>

--- a/commons/src/commonMain/composeResources/values/strings.xml
+++ b/commons/src/commonMain/composeResources/values/strings.xml
@@ -65,4 +65,81 @@
     <string name="torrent_failure">Failed to open file</string>
     <string name="torrent_no_apps">No torrent apps installed to open and download the file.</string>
     <string name="torrent_no_info">Event doesn\'t have enough information to build a magnet link</string>
+
+    <!-- Toast Messages - Draft Notes -->
+    <string name="draft_note">Draft Note</string>
+    <string name="it_s_not_possible_to_quote_to_a_draft_note">It\'s not possible to quote a draft note</string>
+    <string name="it_s_not_possible_to_react_to_a_draft_note">It\'s not possible to react a draft note</string>
+    <string name="it_s_not_possible_to_reply_to_a_draft_note">It\'s not possible to reply a draft note</string>
+    <string name="it_s_not_possible_to_zap_to_a_draft_note">It\'s not possible to zap a draft note</string>
+
+    <!-- Toast Messages - Read Only User -->
+    <string name="read_only_user">Read-only user</string>
+    <string name="login_with_a_private_key_to_be_able_to_boost_posts">You are using a public key and public keys are read-only. Login with a Private key to be able to boost posts</string>
+    <string name="login_with_a_private_key_to_be_able_to_follow">You are using a public key and public keys are read-only. Login with a Private key to be able to follow</string>
+    <string name="login_with_a_private_key_to_be_able_to_hide_word">You are using a public key and public keys are read-only. Login with a Private key to be able to hide a word or sentence</string>
+    <string name="login_with_a_private_key_to_be_able_to_reply">You are using a public key and public keys are read-only. Login with a Private key to be able to reply</string>
+    <string name="login_with_a_private_key_to_be_able_to_send_zaps">You are using a public key and public keys are read-only. Login with a Private key to be able to send zaps</string>
+    <string name="login_with_a_private_key_to_be_able_to_show_word">You are using a public key and public keys are read-only. Login with a Private key to be able to show a word or sentence</string>
+    <string name="login_with_a_private_key_to_be_able_to_sign_events">You are using a public key and public keys are read-only. Login with a Private key to be able to sign for events</string>
+    <string name="login_with_a_private_key_to_be_able_to_unfollow">You are using a public key and public keys are read-only. Login with a Private key to be able to unfollow</string>
+    <string name="login_with_a_private_key_to_like_posts">You are using a public key and public keys are read-only. Login with a Private key to like posts</string>
+
+    <!-- Toast Messages - Poll -->
+    <string name="poll_unable_to_vote">Unable to vote</string>
+    <string name="poll_is_closed_explainer">Poll is closed to new votes</string>
+    <string name="poll_author_no_vote">Poll authors can\'t vote in their own polls.</string>
+    <string name="one_vote_per_user_on_atomic_votes">Only one vote per user is allowed on this type of poll</string>
+
+    <!-- Toast Messages - Reactions -->
+    <string name="no_reactions_setup">No reactions setup</string>
+    <string name="no_reaction_type_setup_long_press_to_change">No reaction types pre-selected for this user. Long press on the heart button to change</string>
+
+    <!-- Toast Messages - Relay -->
+    <string name="read_from_relay">Read from Relay</string>
+    <string name="read_from_relay_description">The amount in bytes that was received from this relay, including filters and events</string>
+    <string name="write_to_relay">Write to Relay</string>
+    <string name="write_to_relay_description">The amount in bytes that was sent to this relay, including filters and events</string>
+    <string name="errors">Errors</string>
+    <string name="connection_success_rate_description">Percentage of successful connections to the relay</string>
+    <string name="spam">Spam</string>
+    <string name="spam_description">The number of spamming events coming from this relay</string>
+
+    <!-- Toast Messages - Signer -->
+    <string name="error_opening_external_signer">Error opening signer app</string>
+    <string name="error_opening_external_signer_description">The signer app could not be found. Check if the app hasn\'t been uninstalled</string>
+    <string name="signer_not_found_exception">Signer not found</string>
+    <string name="signer_not_found_exception_description">Was the Signer app uninstalled? Check if the signer is installed and has this account. Log off and Log in again of the signer app has changed.</string>
+    <string name="signer_illegal_state_exception_description">External signer returned a payload that is strange for the request. There might be a bug on either Amethyst or the Signer.</string>
+    <string name="unauthorized_exception">Unauthorized Decryption</string>
+    <string name="unauthorized_exception_description">The signer did not authorize a decryption that is required to make this operation. Activate NIP-44 decryptions in your signer app and try again</string>
+
+    <!-- Toast Messages - Wallet -->
+    <string name="couldnt_find_nwc_wallets">Wallet not found</string>
+    <string name="couldnt_find_nwc_wallets_description">Amethyst couldn\'t find any wallet apps that support Nostr Wallet Connect (NWC).</string>
+    <string name="invalid_nip47_uri_title">Invalid NIP-47 URI</string>
+    <string name="invalid_nip47_uri_description">The URI %1$s is not a valid NIP-47 login URI.</string>
+    <string name="error_parsing_nip47_title">Could not setup Wallet Connect</string>
+
+    <!-- Toast Messages - Navigation -->
+    <string name="invalid_nip19_uri">Invalid address</string>
+    <string name="invalid_nip19_uri_description">Amethyst received a URI to open but that uri was invalid: %1$s</string>
+
+    <!-- Toast Messages - OTS -->
+    <string name="ots_info_title">Timestamp Proof</string>
+    <string name="ots_info_description">There\'s proof this post was signed sometime before %1$s. The proof was stamped in the Bitcoin blockchain at that date and time.</string>
+
+    <!-- Toast Messages - Vanish -->
+    <string name="request_to_vanish">Request to Vanish</string>
+    <string name="vanish_request_sent">Vanish request sent</string>
+
+    <!-- Toast Messages - Error -->
+    <string name="error">Error</string>
+
+    <!-- Toast Messages - Media -->
+    <string name="failed_to_save_the_image">Failed to save the image</string>
+
+    <!-- Toast Messages - Blossom -->
+    <string name="no_blossom_apps_found_title">Can\'t open Blossom links</string>
+    <string name="no_blossom_apps_found_description">Blossom apps were not found. Please install a local Blossom app to see this file</string>
 </resources>


### PR DESCRIPTION
## Summary

Convert ~55 remaining direct `R.string` Int-based toast callers across 22 files to use `Res.string` StringResource from the commons KMP module. Add 50 new string keys to commons `composeResources/values/strings.xml`.

Also convert function-reference callers and propagated `(Int, Int) -> Unit` callback signatures to `(StringResource, StringResource) -> Unit`:
- `DisplayUrlWithLoadingSymbol`
- `ClickableUrl`
- `openBlossomUriAsIntent`
- `ZoomableContentDialog` (`failure` variable)

**Depends on:** #2264 (toast message classes converted from Int to StringResource)

## Changes

- **27 Kotlin files** updated across `amethyst/src/` and `commons/src/`
- **50 string keys** added to `commons/src/commonMain/composeResources/values/strings.xml` covering:
  - Draft note messages
  - Read-only user / login prompts
  - Poll voting messages  
  - Reaction setup messages
  - Relay status messages
  - Signer error messages
  - Wallet/NWC messages
  - Navigation error messages
  - OTS timestamp messages
  - Vanish request messages
  - Media save failure messages
  - Blossom URI error messages

## Build

```
./gradlew :amethyst:compilePlayDebugKotlin — BUILD SUCCESSFUL
./gradlew spotlessApply — clean
```