### PR TITLE
feat: move filters, toast types, and creator interfaces to commons

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/DisplayErrorMessages.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/DisplayErrorMessages.kt
@@ -40,10 +40,11 @@ fun DisplayErrorMessages(
     openDialogMsg.value?.let { obj ->
         when (obj) {
             is ResourceToastMsg -> {
-                if (obj.params != null) {
+                val params = obj.params
+                if (params != null) {
                     InformationDialog(
                         stringRes(obj.titleResId),
-                        stringRes(obj.resourceId, *obj.params),
+                        stringRes(obj.resourceId, *params),
                     ) {
                         toastManager.clearToasts()
                     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ResourceToastMsg.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ResourceToastMsg.kt
@@ -20,11 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.components.toasts
 
-import androidx.compose.runtime.Immutable
-
-@Immutable
-class ResourceToastMsg(
-    val titleResId: Int,
-    val resourceId: Int,
-    val params: Array<out String>? = null,
-) : ToastMsg()
+// Re-export from commons for backwards compatibility
+typealias ResourceToastMsg = com.vitorpamplona.amethyst.commons.ui.components.toasts.ResourceToastMsg

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/StringToastMsg.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/StringToastMsg.kt
@@ -20,16 +20,6 @@
  */
 package com.vitorpamplona.amethyst.ui.components.toasts
 
-import androidx.compose.runtime.Immutable
-
-@Immutable
-class StringToastMsg(
-    val title: String,
-    val msg: String,
-) : ToastMsg()
-
-class ActionableStringToastMsg(
-    val title: String,
-    val msg: String,
-    val action: () -> Unit,
-) : ToastMsg()
+// Re-export from commons for backwards compatibility
+typealias StringToastMsg = com.vitorpamplona.amethyst.commons.ui.components.toasts.StringToastMsg
+typealias ActionableStringToastMsg = com.vitorpamplona.amethyst.commons.ui.components.toasts.ActionableStringToastMsg

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ThrowableToastMsg.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ThrowableToastMsg.kt
@@ -20,18 +20,6 @@
  */
 package com.vitorpamplona.amethyst.ui.components.toasts
 
-import androidx.compose.runtime.Immutable
-
-@Immutable
-class ThrowableToastMsg(
-    val titleResId: Int,
-    val msg: String? = null,
-    val throwable: Throwable,
-) : ToastMsg()
-
-@Immutable
-class ThrowableToastMsg2(
-    val titleResId: Int,
-    val description: Int,
-    val throwable: Throwable,
-) : ToastMsg()
+// Re-export from commons for backwards compatibility
+typealias ThrowableToastMsg = com.vitorpamplona.amethyst.commons.ui.components.toasts.ThrowableToastMsg
+typealias ThrowableToastMsg2 = com.vitorpamplona.amethyst.commons.ui.components.toasts.ThrowableToastMsg2

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ToastMsg.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ToastMsg.kt
@@ -20,7 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.components.toasts
 
-import androidx.compose.runtime.Immutable
-
-@Immutable
-open class ToastMsg
+// Re-export from commons for backwards compatibility
+typealias ToastMsg = com.vitorpamplona.amethyst.commons.ui.components.toasts.ToastMsg

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/AdditiveComplexFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/AdditiveComplexFeedFilter.kt
@@ -20,9 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.dal
 
-abstract class AdditiveComplexFeedFilter<T, U> : FeedFilter<T>() {
-    abstract fun updateListWith(
-        oldList: List<T>,
-        newItems: Set<U>,
-    ): List<T>
-}
+// Re-export from commons for backwards compatibility
+typealias AdditiveComplexFeedFilter<T, U> = com.vitorpamplona.amethyst.commons.ui.feeds.AdditiveComplexFeedFilter<T, U>

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/zapraiser/IZapRaiser.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/zapraiser/IZapRaiser.kt
@@ -20,12 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.note.creators.zapraiser
 
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.Stable
-
-@Stable
-interface IZapRaiser {
-    val zapRaiserAmount: MutableState<Long?>
-
-    fun updateZapRaiserAmount(newAmount: Long?)
-}
+// Re-export from commons for backwards compatibility
+typealias IZapRaiser = com.vitorpamplona.amethyst.commons.ui.note.creators.zapraiser.IZapRaiser

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/communities/datasource/FilterCommunityPosts.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/communities/datasource/FilterCommunityPosts.kt
@@ -20,79 +20,33 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.communities.datasource
 
-import com.vitorpamplona.quartz.experimental.attestations.attestation.AttestationEvent
+// Re-export from commons for backwards compatibility
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
-import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
-import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
-import com.vitorpamplona.quartz.nip18Reposts.GenericRepostEvent
-import com.vitorpamplona.quartz.nip18Reposts.RepostEvent
-import com.vitorpamplona.quartz.nip22Comments.CommentEvent
-import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
-import com.vitorpamplona.quartz.nip72ModCommunities.approval.CommunityPostApprovalEvent
 import com.vitorpamplona.quartz.nip72ModCommunities.definition.CommunityDefinitionEvent
-import com.vitorpamplona.quartz.nip99Classifieds.ClassifiedsEvent
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.communities.datasource.CommunityPostKinds as CommonsCommunityPostKinds
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.communities.datasource.filterCommunityPosts as commonsFilterCommunityPosts
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.communities.datasource.filterCommunityPostsFromEverybody as commonsFilterCommunityPostsFromEverybody
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.communities.datasource.filterCommunityPostsFromModerators as commonsFilterCommunityPostsFromModerators
 
-val CommunityPostKinds =
-    listOf(
-        TextNoteEvent.KIND,
-        CommentEvent.KIND,
-        RepostEvent.KIND,
-        GenericRepostEvent.KIND,
-        ClassifiedsEvent.KIND,
-        LongTextNoteEvent.KIND,
-        CommunityPostApprovalEvent.KIND,
-        AttestationEvent.KIND,
-    )
+val CommunityPostKinds = CommonsCommunityPostKinds
 
 fun filterCommunityPosts(
     relay: NormalizedRelayUrl,
     community: CommunityDefinitionEvent,
     since: Long?,
-): RelayBasedFilter =
-    RelayBasedFilter(
-        relay = relay,
-        filter =
-            Filter(
-                authors = community.moderatorKeys(),
-                tags = mapOf("a" to listOf(community.addressTag())),
-                kinds = CommunityPostKinds,
-                limit = 500,
-                since = since,
-            ),
-    )
+): RelayBasedFilter = commonsFilterCommunityPosts(relay, community, since)
 
 fun filterCommunityPostsFromModerators(
     relay: NormalizedRelayUrl,
     authors: Set<HexKey>,
     community: CommunityDefinitionEvent,
     since: Long?,
-): RelayBasedFilter =
-    RelayBasedFilter(
-        relay = relay,
-        filter =
-            Filter(
-                authors = authors.sorted(),
-                tags = mapOf("a" to listOf(community.addressTag())),
-                kinds = CommunityPostKinds,
-                limit = 100,
-                since = since,
-            ),
-    )
+): RelayBasedFilter = commonsFilterCommunityPostsFromModerators(relay, authors, community, since)
 
 fun filterCommunityPostsFromEverybody(
     relay: NormalizedRelayUrl,
     community: CommunityDefinitionEvent,
     since: Long?,
-): RelayBasedFilter =
-    RelayBasedFilter(
-        relay = relay,
-        filter =
-            Filter(
-                tags = mapOf("a" to listOf(community.addressTag())),
-                kinds = CommunityPostKinds,
-                limit = 100,
-                since = since,
-            ),
-    )
+): RelayBasedFilter = commonsFilterCommunityPostsFromEverybody(relay, community, since)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/datasource/nip22Comments/FilterPostsByScopes.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/datasource/nip22Comments/FilterPostsByScopes.kt
@@ -20,30 +20,16 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip22Comments
 
+// Re-export from commons for backwards compatibility
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
-import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
-import com.vitorpamplona.quartz.nip22Comments.CommentEvent
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.home.datasource.nip22Comments.CommentKinds as CommonsCommentKinds
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.home.datasource.nip22Comments.filterHomePostsByScopes as commonsFilterHomePostsByScopes
 
-val CommentKinds = listOf(CommentEvent.KIND)
+val CommentKinds = CommonsCommentKinds
 
 fun filterHomePostsByScopes(
     relay: NormalizedRelayUrl,
     scopesToLoad: Set<String>,
     since: Long?,
-): List<RelayBasedFilter> {
-    if (scopesToLoad.isEmpty()) return emptyList()
-
-    return listOf(
-        RelayBasedFilter(
-            relay = relay,
-            filter =
-                Filter(
-                    kinds = CommentKinds,
-                    tags = mapOf("I" to scopesToLoad.toList()),
-                    limit = 100,
-                    since = since,
-                ),
-        ),
-    )
-}
+): List<RelayBasedFilter> = commonsFilterHomePostsByScopes(relay, scopesToLoad, since)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/toasts/ResourceToastMsg.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/toasts/ResourceToastMsg.kt
@@ -18,7 +18,13 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.expiration
+package com.vitorpamplona.amethyst.commons.ui.components.toasts
 
-// Re-export from commons for backwards compatibility
-typealias IExpiration = com.vitorpamplona.amethyst.commons.ui.note.creators.expiration.IExpiration
+import androidx.compose.runtime.Immutable
+
+@Immutable
+class ResourceToastMsg(
+    val titleResId: Int,
+    val resourceId: Int,
+    val params: Array<out String>? = null,
+) : ToastMsg()

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/toasts/StringToastMsg.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/toasts/StringToastMsg.kt
@@ -18,7 +18,18 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.expiration
+package com.vitorpamplona.amethyst.commons.ui.components.toasts
 
-// Re-export from commons for backwards compatibility
-typealias IExpiration = com.vitorpamplona.amethyst.commons.ui.note.creators.expiration.IExpiration
+import androidx.compose.runtime.Immutable
+
+@Immutable
+class StringToastMsg(
+    val title: String,
+    val msg: String,
+) : ToastMsg()
+
+class ActionableStringToastMsg(
+    val title: String,
+    val msg: String,
+    val action: () -> Unit,
+) : ToastMsg()

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/toasts/ThrowableToastMsg.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/toasts/ThrowableToastMsg.kt
@@ -18,7 +18,20 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.expiration
+package com.vitorpamplona.amethyst.commons.ui.components.toasts
 
-// Re-export from commons for backwards compatibility
-typealias IExpiration = com.vitorpamplona.amethyst.commons.ui.note.creators.expiration.IExpiration
+import androidx.compose.runtime.Immutable
+
+@Immutable
+class ThrowableToastMsg(
+    val titleResId: Int,
+    val msg: String? = null,
+    val throwable: Throwable,
+) : ToastMsg()
+
+@Immutable
+class ThrowableToastMsg2(
+    val titleResId: Int,
+    val description: Int,
+    val throwable: Throwable,
+) : ToastMsg()

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/toasts/ToastMsg.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/toasts/ToastMsg.kt
@@ -18,7 +18,9 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.expiration
+package com.vitorpamplona.amethyst.commons.ui.components.toasts
 
-// Re-export from commons for backwards compatibility
-typealias IExpiration = com.vitorpamplona.amethyst.commons.ui.note.creators.expiration.IExpiration
+import androidx.compose.runtime.Immutable
+
+@Immutable
+open class ToastMsg

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/AdditiveComplexFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/AdditiveComplexFeedFilter.kt
@@ -18,7 +18,11 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.expiration
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-// Re-export from commons for backwards compatibility
-typealias IExpiration = com.vitorpamplona.amethyst.commons.ui.note.creators.expiration.IExpiration
+abstract class AdditiveComplexFeedFilter<T, U> : FeedFilter<T>() {
+    abstract fun updateListWith(
+        oldList: List<T>,
+        newItems: Set<U>,
+    ): List<T>
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/creators/expiration/IExpiration.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/creators/expiration/IExpiration.kt
@@ -18,7 +18,11 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.expiration
+package com.vitorpamplona.amethyst.commons.ui.note.creators.expiration
 
-// Re-export from commons for backwards compatibility
-typealias IExpiration = com.vitorpamplona.amethyst.commons.ui.note.creators.expiration.IExpiration
+import androidx.compose.runtime.Stable
+
+@Stable
+interface IExpiration {
+    var expirationDate: Long
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/creators/zapraiser/IZapRaiser.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/creators/zapraiser/IZapRaiser.kt
@@ -18,7 +18,14 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.expiration
+package com.vitorpamplona.amethyst.commons.ui.note.creators.zapraiser
 
-// Re-export from commons for backwards compatibility
-typealias IExpiration = com.vitorpamplona.amethyst.commons.ui.note.creators.expiration.IExpiration
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.Stable
+
+@Stable
+interface IZapRaiser {
+    val zapRaiserAmount: MutableState<Long?>
+
+    fun updateZapRaiserAmount(newAmount: Long?)
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/communities/datasource/FilterCommunityPosts.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/communities/datasource/FilterCommunityPosts.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.communities.datasource
+
+import com.vitorpamplona.quartz.experimental.attestations.attestation.AttestationEvent
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
+import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
+import com.vitorpamplona.quartz.nip18Reposts.GenericRepostEvent
+import com.vitorpamplona.quartz.nip18Reposts.RepostEvent
+import com.vitorpamplona.quartz.nip22Comments.CommentEvent
+import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
+import com.vitorpamplona.quartz.nip72ModCommunities.approval.CommunityPostApprovalEvent
+import com.vitorpamplona.quartz.nip72ModCommunities.definition.CommunityDefinitionEvent
+import com.vitorpamplona.quartz.nip99Classifieds.ClassifiedsEvent
+
+val CommunityPostKinds =
+    listOf(
+        TextNoteEvent.KIND,
+        CommentEvent.KIND,
+        RepostEvent.KIND,
+        GenericRepostEvent.KIND,
+        ClassifiedsEvent.KIND,
+        LongTextNoteEvent.KIND,
+        CommunityPostApprovalEvent.KIND,
+        AttestationEvent.KIND,
+    )
+
+fun filterCommunityPosts(
+    relay: NormalizedRelayUrl,
+    community: CommunityDefinitionEvent,
+    since: Long?,
+): RelayBasedFilter =
+    RelayBasedFilter(
+        relay = relay,
+        filter =
+            Filter(
+                authors = community.moderatorKeys(),
+                tags = mapOf("a" to listOf(community.addressTag())),
+                kinds = CommunityPostKinds,
+                limit = 500,
+                since = since,
+            ),
+    )
+
+fun filterCommunityPostsFromModerators(
+    relay: NormalizedRelayUrl,
+    authors: Set<HexKey>,
+    community: CommunityDefinitionEvent,
+    since: Long?,
+): RelayBasedFilter =
+    RelayBasedFilter(
+        relay = relay,
+        filter =
+            Filter(
+                authors = authors.sorted(),
+                tags = mapOf("a" to listOf(community.addressTag())),
+                kinds = CommunityPostKinds,
+                limit = 100,
+                since = since,
+            ),
+    )
+
+fun filterCommunityPostsFromEverybody(
+    relay: NormalizedRelayUrl,
+    community: CommunityDefinitionEvent,
+    since: Long?,
+): RelayBasedFilter =
+    RelayBasedFilter(
+        relay = relay,
+        filter =
+            Filter(
+                tags = mapOf("a" to listOf(community.addressTag())),
+                kinds = CommunityPostKinds,
+                limit = 100,
+                since = since,
+            ),
+    )

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/home/datasource/nip22Comments/FilterPostsByScopes.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/home/datasource/nip22Comments/FilterPostsByScopes.kt
@@ -18,7 +18,32 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.expiration
+package com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.home.datasource.nip22Comments
 
-// Re-export from commons for backwards compatibility
-typealias IExpiration = com.vitorpamplona.amethyst.commons.ui.note.creators.expiration.IExpiration
+import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
+import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip22Comments.CommentEvent
+
+val CommentKinds = listOf(CommentEvent.KIND)
+
+fun filterHomePostsByScopes(
+    relay: NormalizedRelayUrl,
+    scopesToLoad: Set<String>,
+    since: Long?,
+): List<RelayBasedFilter> {
+    if (scopesToLoad.isEmpty()) return emptyList()
+
+    return listOf(
+        RelayBasedFilter(
+            relay = relay,
+            filter =
+                Filter(
+                    kinds = CommentKinds,
+                    tags = mapOf("I" to scopesToLoad.toList()),
+                    limit = 100,
+                    since = since,
+                ),
+        ),
+    )
+}


### PR DESCRIPTION
## Summary

Move 9 files from the Android app module to the KMP commons module, continuing the iOS migration effort.

### Moved to commons
- **FilterCommunityPosts.kt** — community post filter functions (NIP-72)
- **FilterPostsByScopes.kt** — NIP-22 comment scope filter functions
- **AdditiveComplexFeedFilter.kt** — abstract feed filter base class
- **ToastMsg.kt** — base toast message class
- **StringToastMsg.kt** — string-based toast messages
- **ResourceToastMsg.kt** — resource ID-based toast messages
- **ThrowableToastMsg.kt** — throwable-based toast messages
- **IExpiration.kt** — expiration interface for note creators
- **IZapRaiser.kt** — zap raiser interface for note creators

### Approach
- Original files replaced with typealias re-exports for full backward compatibility
- Fixed cross-module smart cast in `DisplayErrorMessages.kt` (local val capture)
- No import changes needed in existing code

### Build verification
- `:commons:compileKotlinJvm` ✅
- `:amethyst:compilePlayDebugKotlin` ✅
- `spotlessApply` ✅