### PR TITLE
feat: migrate remaining SubAssemblers from PerUniqueIdEoseManager to PerKeyEoseManager

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/channel/nip28PublicChats/ChannelMetadataWatcherSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/channel/nip28PublicChats/ChannelMetadataWatcherSubAssembler.kt
@@ -22,30 +22,30 @@ package com.vitorpamplona.amethyst.service.relayClient.reqCommand.channel.nip28P
 
 import com.vitorpamplona.amethyst.commons.model.Channel
 import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatChannel
-import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUniqueIdEoseManager
+import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.PerKeyEoseManager
+import com.vitorpamplona.amethyst.commons.relays.SincePerRelayMap
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.channel.ChannelFinderQueryState
-import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 
 class ChannelMetadataWatcherSubAssembler(
     client: INostrClient,
     allKeys: () -> Set<ChannelFinderQueryState>,
-) : PerUniqueIdEoseManager<ChannelFinderQueryState, Channel>(client, allKeys) {
+) : PerKeyEoseManager<ChannelFinderQueryState, Channel>(client, allKeys) {
     override fun updateFilter(
-        key: ChannelFinderQueryState,
+        queryState: ChannelFinderQueryState,
         since: SincePerRelayMap?,
     ): List<RelayBasedFilter> =
-        if (key.channel is PublicChatChannel) {
-            key.channel.relays().flatMap {
-                filterChannelMetadataUpdatesById(it, listOf(key.channel), since?.get(it)?.time)
+        if (queryState.channel is PublicChatChannel) {
+            queryState.channel.relays().flatMap {
+                filterChannelMetadataUpdatesById(it, listOf(queryState.channel), since?.get(it)?.time)
             }
         } else {
             emptyList()
         }
 
     /**
-     * Only one key per channel.
+     * Only one queryState per channel.
      */
-    override fun id(key: ChannelFinderQueryState) = key.channel
+    override fun extractKey(queryState: ChannelFinderQueryState) = queryState.channel
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/channel/nip53LiveActivities/LiveActivityWatcherSubAssembly.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/channel/nip53LiveActivities/LiveActivityWatcherSubAssembly.kt
@@ -22,9 +22,9 @@ package com.vitorpamplona.amethyst.service.relayClient.reqCommand.channel.nip53L
 
 import com.vitorpamplona.amethyst.commons.model.Channel
 import com.vitorpamplona.amethyst.commons.model.nip53LiveActivities.LiveActivitiesChannel
-import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUniqueIdEoseManager
+import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.PerKeyEoseManager
+import com.vitorpamplona.amethyst.commons.relays.SincePerRelayMap
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.channel.ChannelFinderQueryState
-import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 
@@ -35,21 +35,21 @@ import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 class LiveActivityWatcherSubAssembly(
     client: INostrClient,
     allKeys: () -> Set<ChannelFinderQueryState>,
-) : PerUniqueIdEoseManager<ChannelFinderQueryState, Channel>(client, allKeys) {
+) : PerKeyEoseManager<ChannelFinderQueryState, Channel>(client, allKeys) {
     override fun updateFilter(
-        key: ChannelFinderQueryState,
+        queryState: ChannelFinderQueryState,
         since: SincePerRelayMap?,
     ): List<RelayBasedFilter> =
-        if (key.channel is LiveActivitiesChannel) {
-            key.channel.relays().flatMap {
-                filterLiveStreamUpdatesByAddress(it, listOf(key.channel), since?.get(it)?.time)
+        if (queryState.channel is LiveActivitiesChannel) {
+            queryState.channel.relays().flatMap {
+                filterLiveStreamUpdatesByAddress(it, listOf(queryState.channel), since?.get(it)?.time)
             }
         } else {
             emptyList()
         }
 
     /**
-     * Only one key per channel.
+     * Only one queryState per channel.
      */
-    override fun id(key: ChannelFinderQueryState) = key.channel
+    override fun extractKey(queryState: ChannelFinderQueryState) = queryState.channel
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/searchCommand/subassemblies/SearchPostWatcherSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/searchCommand/subassemblies/SearchPostWatcherSubAssembler.kt
@@ -20,10 +20,10 @@
  */
 package com.vitorpamplona.amethyst.service.relayClient.searchCommand.subassemblies
 
+import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.PerKeyEoseManager
+import com.vitorpamplona.amethyst.commons.relays.SincePerRelayMap
 import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUniqueIdEoseManager
 import com.vitorpamplona.amethyst.service.relayClient.searchCommand.SearchQueryState
-import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.nip01Core.core.toHexKey
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
@@ -46,16 +46,16 @@ class SearchPostWatcherSubAssembler(
     val cache: LocalCache,
     client: INostrClient,
     allKeys: () -> Set<SearchQueryState>,
-) : PerUniqueIdEoseManager<SearchQueryState, Int>(client, allKeys) {
+) : PerKeyEoseManager<SearchQueryState, Int>(client, allKeys) {
     override fun updateFilter(
-        key: SearchQueryState,
+        queryState: SearchQueryState,
         since: SincePerRelayMap?,
     ): List<RelayBasedFilter>? {
-        val mySearchString = key.searchQuery.value
+        val mySearchString = queryState.searchQuery.value
 
         if (mySearchString.isBlank()) return null
 
-        val defaultRelaysWithSearch = key.account.followPlusAllMineWithSearch.flow.value
+        val defaultRelaysWithSearch = queryState.account.followPlusAllMineWithSearch.flow.value
 
         val directFilters =
             runCatching {
@@ -85,12 +85,12 @@ class SearchPostWatcherSubAssembler(
             }.getOrDefault(emptyList())
 
         val searchFilters =
-            key.account.searchRelayList.flow.value.flatMap {
+            queryState.account.searchRelayList.flow.value.flatMap {
                 searchPostsByText(mySearchString, it)
             }
 
         return directFilters + searchFilters
     }
 
-    override fun id(key: SearchQueryState) = key.searchQuery.hashCode()
+    override fun extractKey(queryState: SearchQueryState) = queryState.searchQuery.hashCode()
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/searchCommand/subassemblies/SearchUserWatcherSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/searchCommand/subassemblies/SearchUserWatcherSubAssembler.kt
@@ -20,11 +20,11 @@
  */
 package com.vitorpamplona.amethyst.service.relayClient.searchCommand.subassemblies
 
+import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.PerKeyEoseManager
+import com.vitorpamplona.amethyst.commons.relays.SincePerRelayMap
 import com.vitorpamplona.amethyst.model.DefaultIndexerRelayList
 import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUniqueIdEoseManager
 import com.vitorpamplona.amethyst.service.relayClient.searchCommand.SearchQueryState
-import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.nip01Core.core.toHexKey
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
@@ -47,19 +47,19 @@ class SearchUserWatcherSubAssembler(
     val cache: LocalCache,
     client: INostrClient,
     allKeys: () -> Set<SearchQueryState>,
-) : PerUniqueIdEoseManager<SearchQueryState, Int>(client, allKeys) {
+) : PerKeyEoseManager<SearchQueryState, Int>(client, allKeys) {
     override fun updateFilter(
-        key: SearchQueryState,
+        queryState: SearchQueryState,
         since: SincePerRelayMap?,
     ): List<RelayBasedFilter>? {
-        val mySearchString = key.searchQuery.value
+        val mySearchString = queryState.searchQuery.value
 
         if (mySearchString.isBlank()) return null
 
         val indexRelays =
-            key.account.indexerRelayList.flow.value
+            queryState.account.indexerRelayList.flow.value
                 .ifEmpty { DefaultIndexerRelayList }
-        val defaultRelaysWithSearch = key.account.followPlusAllMineWithSearch.flow.value
+        val defaultRelaysWithSearch = queryState.account.followPlusAllMineWithSearch.flow.value
 
         val directFilters =
             runCatching {
@@ -89,12 +89,12 @@ class SearchUserWatcherSubAssembler(
             }.getOrDefault(emptyList())
 
         val searchFilters =
-            key.account.searchRelayList.flow.value.flatMap {
+            queryState.account.searchRelayList.flow.value.flatMap {
                 searchPeopleByName(mySearchString, it)
             }
 
         return directFilters + searchFilters
     }
 
-    override fun id(key: SearchQueryState) = key.searchQuery.hashCode()
+    override fun extractKey(queryState: SearchQueryState) = queryState.searchQuery.hashCode()
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/datasource/subassemblies/ChannelPublicFilterSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/datasource/subassemblies/ChannelPublicFilterSubAssembler.kt
@@ -24,8 +24,8 @@ import com.vitorpamplona.amethyst.commons.model.Channel
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
 import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatChannel
 import com.vitorpamplona.amethyst.commons.model.nip53LiveActivities.LiveActivitiesChannel
-import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUniqueIdEoseManager
-import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
+import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.PerKeyEoseManager
+import com.vitorpamplona.amethyst.commons.relays.SincePerRelayMap
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.datasource.ChannelQueryState
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
@@ -33,17 +33,17 @@ import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 class ChannelPublicFilterSubAssembler(
     client: INostrClient,
     allKeys: () -> Set<ChannelQueryState>,
-) : PerUniqueIdEoseManager<ChannelQueryState, Channel>(client, allKeys) {
+) : PerKeyEoseManager<ChannelQueryState, Channel>(client, allKeys) {
     override fun updateFilter(
-        key: ChannelQueryState,
+        queryState: ChannelQueryState,
         since: SincePerRelayMap?,
     ): List<RelayBasedFilter>? =
-        when (val channel = key.channel) {
+        when (val channel = queryState.channel) {
             is EphemeralChatChannel -> filterMessagesToEphemeralChat(channel, since)
             is PublicChatChannel -> filterMessagesToPublicChat(channel, since)
             is LiveActivitiesChannel -> filterMessagesToLiveActivities(channel, since)
             else -> null
         }
 
-    override fun id(key: ChannelQueryState) = key.channel
+    override fun extractKey(queryState: ChannelQueryState) = queryState.channel
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chess/datasource/ChessFeedFilterSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chess/datasource/ChessFeedFilterSubAssembler.kt
@@ -20,8 +20,8 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.chess.datasource
 
-import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUniqueIdEoseManager
-import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
+import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.PerKeyEoseManager
+import com.vitorpamplona.amethyst.commons.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
@@ -50,24 +50,24 @@ data class ChessQueryState(
 class ChessFeedFilterSubAssembler(
     client: INostrClient,
     allKeys: () -> Set<ChessQueryState>,
-) : PerUniqueIdEoseManager<ChessQueryState, String>(client, allKeys) {
+) : PerKeyEoseManager<ChessQueryState, String>(client, allKeys) {
     var onChessEvent: ((Event) -> Unit)? = null
 
     override fun updateFilter(
-        key: ChessQueryState,
+        queryState: ChessQueryState,
         since: SincePerRelayMap?,
-    ): List<RelayBasedFilter> = filterChessEvents(key, since)
+    ): List<RelayBasedFilter> = filterChessEvents(queryState, since)
 
-    override fun id(key: ChessQueryState): String = key.userPubkey
+    override fun extractKey(queryState: ChessQueryState): String = queryState.userPubkey
 
-    override fun newSub(key: ChessQueryState): Subscription =
+    override fun newSub(queryState: ChessQueryState): Subscription =
         requestNewSubscription(
             object : SubscriptionListener {
                 override fun onEose(
                     relay: NormalizedRelayUrl,
                     forFilters: List<Filter>?,
                 ) {
-                    newEose(key, relay, TimeUtils.now(), forFilters)
+                    newEose(queryState, relay, TimeUtils.now(), forFilters)
                 }
 
                 override fun onEvent(
@@ -77,7 +77,7 @@ class ChessFeedFilterSubAssembler(
                     forFilters: List<Filter>?,
                 ) {
                     if (isLive) {
-                        newEose(key, relay, TimeUtils.now(), forFilters)
+                        newEose(queryState, relay, TimeUtils.now(), forFilters)
                     }
                     onChessEvent?.invoke(event)
                 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/geohash/datasource/GeoHashFeedFilterSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/geohash/datasource/GeoHashFeedFilterSubAssembler.kt
@@ -20,22 +20,22 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.geohash.datasource
 
-import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUniqueIdEoseManager
-import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
+import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.PerKeyEoseManager
+import com.vitorpamplona.amethyst.commons.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 
 class GeoHashFeedFilterSubAssembler(
     client: INostrClient,
     allKeys: () -> Set<GeohashQueryState>,
-) : PerUniqueIdEoseManager<GeohashQueryState, String>(client, allKeys) {
+) : PerKeyEoseManager<GeohashQueryState, String>(client, allKeys) {
     override fun updateFilter(
-        key: GeohashQueryState,
+        queryState: GeohashQueryState,
         since: SincePerRelayMap?,
-    ): List<RelayBasedFilter> = filterPostsByGeohash(key.geohash, key.relays, since)
+    ): List<RelayBasedFilter> = filterPostsByGeohash(queryState.geohash, queryState.relays, since)
 
     /**
-     * Only one key per hashtag.
+     * Only one queryState per hashtag.
      */
-    override fun id(key: GeohashQueryState) = key.lowercaseGeohash
+    override fun extractKey(queryState: GeohashQueryState) = queryState.lowercaseGeohash
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/datasource/HashtagFeedFilterSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/datasource/HashtagFeedFilterSubAssembler.kt
@@ -20,22 +20,22 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.hashtag.datasource
 
-import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUniqueIdEoseManager
-import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
+import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.PerKeyEoseManager
+import com.vitorpamplona.amethyst.commons.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 
 class HashtagFeedFilterSubAssembler(
     client: INostrClient,
     allKeys: () -> Set<HashtagQueryState>,
-) : PerUniqueIdEoseManager<HashtagQueryState, String>(client, allKeys) {
+) : PerKeyEoseManager<HashtagQueryState, String>(client, allKeys) {
     override fun updateFilter(
-        key: HashtagQueryState,
+        queryState: HashtagQueryState,
         since: SincePerRelayMap?,
-    ): List<RelayBasedFilter> = filterPostsByHashtags(key.hashtag, key.relays, since)
+    ): List<RelayBasedFilter> = filterPostsByHashtags(queryState.hashtag, queryState.relays, since)
 
     /**
-     * Only one key per hashtag.
+     * Only one queryState per hashtag.
      */
-    override fun id(key: HashtagQueryState) = key.lowercaseHashtag
+    override fun extractKey(queryState: HashtagQueryState) = queryState.lowercaseHashtag
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relay/datasource/RelayFeedFilterSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relay/datasource/RelayFeedFilterSubAssembler.kt
@@ -20,22 +20,22 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.relay.datasource
 
-import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUniqueIdEoseManager
-import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
+import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.PerKeyEoseManager
+import com.vitorpamplona.amethyst.commons.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 
 class RelayFeedFilterSubAssembler(
     client: INostrClient,
     allKeys: () -> Set<RelayFeedQueryState>,
-) : PerUniqueIdEoseManager<RelayFeedQueryState, String>(client, allKeys) {
+) : PerKeyEoseManager<RelayFeedQueryState, String>(client, allKeys) {
     override fun updateFilter(
-        key: RelayFeedQueryState,
+        queryState: RelayFeedQueryState,
         since: SincePerRelayMap?,
-    ): List<RelayBasedFilter> = filterPostsByRelay(key.relayUrl, since)
+    ): List<RelayBasedFilter> = filterPostsByRelay(queryState.relayUrl, since)
 
     /**
-     * One key per relay URL.
+     * One queryState per relay URL.
      */
-    override fun id(key: RelayFeedQueryState) = key.relayUrl.url
+    override fun extractKey(queryState: RelayFeedQueryState) = queryState.relayUrl.url
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/datasource/RelayInfoNip66FilterSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/datasource/RelayInfoNip66FilterSubAssembler.kt
@@ -20,8 +20,8 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.datasource
 
-import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUniqueIdEoseManager
-import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
+import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.PerKeyEoseManager
+import com.vitorpamplona.amethyst.commons.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
@@ -30,14 +30,14 @@ import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.RelayDiscoveryEvent
 class RelayInfoNip66FilterSubAssembler(
     client: INostrClient,
     allKeys: () -> Set<RelayInfoNip66QueryState>,
-) : PerUniqueIdEoseManager<RelayInfoNip66QueryState, String>(client, allKeys) {
+) : PerKeyEoseManager<RelayInfoNip66QueryState, String>(client, allKeys) {
     override fun updateFilter(
-        key: RelayInfoNip66QueryState,
+        queryState: RelayInfoNip66QueryState,
         since: SincePerRelayMap?,
     ): List<RelayBasedFilter> {
-        val relayUrl = key.relayUrl.url
+        val relayUrl = queryState.relayUrl.url
 
-        return key.relays.map { relay ->
+        return queryState.relays.map { relay ->
             RelayBasedFilter(
                 relay = relay,
                 filter =
@@ -51,5 +51,5 @@ class RelayInfoNip66FilterSubAssembler(
         }
     }
 
-    override fun id(key: RelayInfoNip66QueryState) = key.relayUrl.url
+    override fun extractKey(queryState: RelayInfoNip66QueryState) = queryState.relayUrl.url
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/datasources/subassembies/ThreadEventLoaderSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/datasources/subassembies/ThreadEventLoaderSubAssembler.kt
@@ -21,9 +21,9 @@
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.threadview.datasources.subassembies
 
 import com.vitorpamplona.amethyst.commons.model.ThreadAssembler
+import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.PerKeyEoseManager
+import com.vitorpamplona.amethyst.commons.relays.SincePerRelayMap
 import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUniqueIdEoseManager
-import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.threadview.datasources.ThreadQueryState
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
@@ -41,15 +41,15 @@ import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 class ThreadEventLoaderSubAssembler(
     client: INostrClient,
     allKeys: () -> Set<ThreadQueryState>,
-) : PerUniqueIdEoseManager<ThreadQueryState, HexKey>(client, allKeys, invalidateAfterEose = true) {
+) : PerKeyEoseManager<ThreadQueryState, HexKey>(client, allKeys, invalidateAfterEose = true) {
     override fun updateFilter(
-        key: ThreadQueryState,
+        queryState: ThreadQueryState,
         since: SincePerRelayMap?,
     ): List<RelayBasedFilter>? {
-        val branches = ThreadAssembler(LocalCache).findThreadFor(key.eventId) ?: return null
-        val defaultRelays = key.account.followPlusAllMineWithSearch.flow.value
+        val branches = ThreadAssembler(LocalCache).findThreadFor(queryState.eventId) ?: return null
+        val defaultRelays = queryState.account.followPlusAllMineWithSearch.flow.value
         return filterMissingEventsForThread(branches, defaultRelays)
     }
 
-    override fun id(key: ThreadQueryState) = key.eventId
+    override fun extractKey(queryState: ThreadQueryState) = queryState.eventId
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/datasources/subassembies/ThreadFilterSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/datasources/subassembies/ThreadFilterSubAssembler.kt
@@ -21,9 +21,9 @@
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.threadview.datasources.subassembies
 
 import com.vitorpamplona.amethyst.commons.model.ThreadAssembler
+import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.PerKeyEoseManager
+import com.vitorpamplona.amethyst.commons.relays.SincePerRelayMap
 import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUniqueIdEoseManager
-import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.threadview.datasources.ThreadQueryState
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
@@ -38,15 +38,15 @@ import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 class ThreadFilterSubAssembler(
     client: INostrClient,
     allKeys: () -> Set<ThreadQueryState>,
-) : PerUniqueIdEoseManager<ThreadQueryState, HexKey>(client, allKeys) {
+) : PerKeyEoseManager<ThreadQueryState, HexKey>(client, allKeys) {
     override fun updateFilter(
-        key: ThreadQueryState,
+        queryState: ThreadQueryState,
         since: SincePerRelayMap?,
     ): List<RelayBasedFilter>? {
-        val root = ThreadAssembler(LocalCache).findRoot(key.eventId) ?: return null
+        val root = ThreadAssembler(LocalCache).findRoot(queryState.eventId) ?: return null
 
         return filterEventsInThreadForRoot(root, since)
     }
 
-    override fun id(key: ThreadQueryState) = key.eventId
+    override fun extractKey(queryState: ThreadQueryState) = queryState.eventId
 }


### PR DESCRIPTION
## Summary

Continue the KMP migration by switching all 12 remaining SubAssemblers from the Android-only `PerUniqueIdEoseManager` to the KMP `PerKeyEoseManager` (already in commons).

## Files Changed (12)

- **HashtagFeedFilterSubAssembler**
- **GeoHashFeedFilterSubAssembler**  
- **ChessFeedFilterSubAssembler**
- **ThreadEventLoaderSubAssembler**
- **ThreadFilterSubAssembler**
- **RelayInfoNip66FilterSubAssembler**
- **ChannelPublicFilterSubAssembler**
- **RelayFeedFilterSubAssembler**
- **SearchPostWatcherSubAssembler**
- **SearchUserWatcherSubAssembler**
- **LiveActivityWatcherSubAssembly**
- **ChannelMetadataWatcherSubAssembler**

## Changes per file

- `PerUniqueIdEoseManager` → `PerKeyEoseManager` (from commons package)
- `SincePerRelayMap` import → `commons.relays`
- `id()` → `extractKey()`
- Parameter rename `key` → `queryState` for consistency with base class

## Build

```
./gradlew :commons:compileKotlinJvm :amethyst:compilePlayDebugKotlin  # ✅ BUILD SUCCESSFUL
./gradlew spotlessApply  # ✅ No formatting changes needed
```

Unblocks further filter assembler migration to KMP.