### PR TITLE
feat: expand IAccount with domain methods for ViewModel migration (v3)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -253,8 +253,8 @@ class Account(
     val nwcFilterAssembler: () -> NWCPaymentFilterAssembler,
     val otsResolverBuilder: () -> OtsResolver,
     val cache: LocalCache,
-    val client: INostrClient,
-    val scope: CoroutineScope,
+    override val client: INostrClient,
+    override val scope: CoroutineScope,
     val mlsGroupStateStore: MlsGroupStateStore? = null,
 ) : IAccount {
     private var userProfileCache: User? = null
@@ -309,7 +309,7 @@ class Account(
     val ephemeralChatList = EphemeralChatListState(signer, cache, ephemeralChatListDecryptionCache, scope, settings)
 
     val publicChatListDecryptionCache = PublicChatListDecryptionCache(signer)
-    val publicChatList = PublicChatListState(signer, cache, publicChatListDecryptionCache, scope, settings)
+    override val publicChatList = PublicChatListState(signer, cache, publicChatListDecryptionCache, scope, settings)
 
     val communityListDecryptionCache = CommunityListDecryptionCache(signer)
     val communityList = CommunityListState(signer, cache, communityListDecryptionCache, scope, settings)
@@ -335,9 +335,9 @@ class Account(
 
     val labeledBookmarkLists = LabeledBookmarkListsState(signer, cache, scope)
     val oldBookmarkState = OldBookmarkListState(signer, cache, scope)
-    val bookmarkState = BookmarkListState(signer, cache, scope)
+    override val bookmarkState = BookmarkListState(signer, cache, scope)
     val pinState = PinListState(signer, cache, scope)
-    val emoji = EmojiPackState(signer, cache, scope)
+    override val emoji = EmojiPackState(signer, cache, scope)
 
     val vanish = VanishRequestsState(signer, cache, client, scope)
 
@@ -1321,9 +1321,9 @@ class Account(
         return event
     }
 
-    suspend fun <T : Event> signAndComputeBroadcast(
+    override suspend fun <T : Event> signAndComputeBroadcast(
         template: EventTemplate<T>,
-        broadcast: List<Event> = emptyList(),
+        broadcast: List<Event>,
     ): T {
         val event = signer.sign(template)
         cache.justConsumeMyOwnEvent(event)
@@ -1343,9 +1343,9 @@ class Account(
         return event
     }
 
-    suspend fun <T : Event> signAnonymouslyAndBroadcast(
+    override suspend fun <T : Event> signAnonymouslyAndBroadcast(
         template: EventTemplate<T>,
-        broadcast: List<Event> = emptyList(),
+        broadcast: List<Event>,
     ): T {
         val anonymousSigner = NostrSignerInternal(KeyPair())
         val event = anonymousSigner.sign(template)
@@ -1397,10 +1397,10 @@ class Account(
         extraNotesToBroadcast.forEach { client.publish(it, relays) }
     }
 
-    suspend fun createAndSendDraftIgnoreErrors(
+    override suspend fun createAndSendDraftIgnoreErrors(
         draftTag: String,
         template: EventTemplate<out Event>,
-        broadcast: Set<Event> = emptySet(),
+        broadcast: Set<Event>,
     ) {
         try {
             createAndSendDraftInner(draftTag, template, broadcast)
@@ -1433,7 +1433,7 @@ class Account(
         }
     }
 
-    suspend fun deleteDraftIgnoreErrors(draftTag: String) {
+    override suspend fun deleteDraftIgnoreErrors(draftTag: String) {
         try {
             deleteDraftInner(draftTag)
         } catch (e: Exception) {
@@ -2371,7 +2371,7 @@ class Account(
 
     fun loadLastRead(route: String): Long = settings.lastReadPerRoute.value[route]?.value ?: 0
 
-    fun loadLastReadFlow(route: String) = settings.getLastReadFlow(route)
+    override fun loadLastReadFlow(route: String) = settings.getLastReadFlow(route)
 
     fun hasDonatedInThisVersion() = settings.hasDonatedInVersion(BuildConfig.VERSION_NAME)
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
@@ -21,7 +21,12 @@
 package com.vitorpamplona.amethyst.commons.model
 
 import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupList
+import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatListState
+import com.vitorpamplona.amethyst.commons.model.nip30CustomEmojis.EmojiPackState
+import com.vitorpamplona.amethyst.commons.model.nip51Lists.BookmarkListState
 import com.vitorpamplona.amethyst.commons.model.privateChats.ChatroomList
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import com.vitorpamplona.quartz.nip04Dm.messages.PrivateDmEvent
@@ -34,6 +39,8 @@ import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Response
 import com.vitorpamplona.quartz.nip57Zaps.IPrivateZapsDecryptionCache
 import com.vitorpamplona.quartz.nip59Giftwrap.wraps.GiftWrapEvent
 import com.vitorpamplona.quartz.utils.DualCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Interface for NIP-47 wallet connect signer state.
@@ -119,4 +126,44 @@ interface IAccount {
 
     /** Broadcast pre-created gift wraps (e.g. reactions within group DMs) */
     suspend fun sendGiftWraps(wraps: List<GiftWrapEvent>)
+
+    /** Nostr relay client for publishing events */
+    val client: INostrClient
+
+    /** Coroutine scope for account-scoped operations */
+    val scope: CoroutineScope
+
+    /** Bookmark list state (NIP-51) */
+    val bookmarkState: BookmarkListState
+
+    /** Custom emoji pack state (NIP-30) */
+    val emoji: EmojiPackState
+
+    /** Public chat channel list state (NIP-28) */
+    val publicChatList: PublicChatListState
+
+    /** Get a flow of the last-read timestamp for a given route */
+    fun loadLastReadFlow(route: String): StateFlow<Long>
+
+    /** Sign an event and broadcast it with computed relay list */
+    suspend fun <T : Event> signAndComputeBroadcast(
+        template: EventTemplate<T>,
+        broadcast: List<Event> = emptyList(),
+    ): T
+
+    /** Sign an event anonymously and broadcast it */
+    suspend fun <T : Event> signAnonymouslyAndBroadcast(
+        template: EventTemplate<T>,
+        broadcast: List<Event> = emptyList(),
+    ): T
+
+    /** Create and send a draft event, ignoring errors */
+    suspend fun createAndSendDraftIgnoreErrors(
+        draftTag: String,
+        template: EventTemplate<out Event>,
+        broadcast: Set<Event> = emptySet(),
+    )
+
+    /** Delete a draft event by tag, ignoring errors */
+    suspend fun deleteDraftIgnoreErrors(draftTag: String)
 }


### PR DESCRIPTION
## Summary

Expand the `IAccount` interface in the `commons` KMP module with domain-specific methods that ViewModels need, enabling more ViewModel migration to KMP for iOS support.

## New IAccount Members

All types are KMP-compatible (quartz, commons, or kotlinx):

- **`client: INostrClient`** — relay client for publishing events
- **`scope: CoroutineScope`** — account-scoped coroutine scope
- **`bookmarkState: BookmarkListState`** — NIP-51 bookmark list state (already in commons)
- **`emoji: EmojiPackState`** — NIP-30 custom emoji pack state (already in commons)
- **`publicChatList: PublicChatListState`** — NIP-28 public chat channels (already in commons)
- **`loadLastReadFlow(route): StateFlow<Long>`** — last-read timestamps for routes
- **`signAndComputeBroadcast(template, broadcast)`** — sign and broadcast events
- **`signAnonymouslyAndBroadcast(template, broadcast)`** — anonymous sign and broadcast
- **`createAndSendDraftIgnoreErrors(draftTag, template, broadcast)`** — draft creation
- **`deleteDraftIgnoreErrors(draftTag)`** — draft deletion

## Build Verification

- `:commons:compileKotlinJvm` ✅
- `:amethyst:compilePlayDebugKotlin` ✅
- `spotlessCheck` ✅