### PR TITLE
feat: expand IAccount interface with user visibility, follow checks, and relay management (v4)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -2136,20 +2136,20 @@ class Account(
         challenge: String,
     ): RelayAuthEvent = RelayAuthEvent.create(relay, challenge, signer)
 
-    suspend fun hideWord(word: String) {
+    override suspend fun hideWord(word: String) {
         sendMyPublicAndPrivateOutbox(muteList.hideWord(word))
     }
 
-    suspend fun showWord(word: String) {
+    override suspend fun showWord(word: String) {
         sendMyPublicAndPrivateOutbox(blockPeopleList.showWord(word))
         sendMyPublicAndPrivateOutbox(muteList.showWord(word))
     }
 
-    suspend fun hideUser(pubkeyHex: HexKey) {
+    override suspend fun hideUser(pubkeyHex: HexKey) {
         sendMyPublicAndPrivateOutbox(muteList.hideUser(pubkeyHex))
     }
 
-    suspend fun showUser(pubkeyHex: HexKey) {
+    override suspend fun showUser(pubkeyHex: HexKey) {
         sendMyPublicAndPrivateOutbox(blockPeopleList.showUser(pubkeyHex))
         sendMyPublicAndPrivateOutbox(muteList.showUser(pubkeyHex))
         hiddenUsers.showUser(pubkeyHex)
@@ -2269,9 +2269,9 @@ class Account(
             false
         }
 
-    fun isFollowing(user: User): Boolean = user.pubkeyHex in followingKeySet()
+    override fun isFollowing(user: User): Boolean = user.pubkeyHex in followingKeySet()
 
-    fun isFollowing(user: HexKey): Boolean = user in followingKeySet()
+    override fun isFollowing(user: HexKey): Boolean = user in followingKeySet()
 
     fun isKnown(user: User): Boolean = user.pubkeyHex in allFollows.flow.value.authors
 
@@ -2311,15 +2311,15 @@ class Account(
         ).toSet()
     }
 
-    suspend fun saveDMRelayList(dmRelays: List<NormalizedRelayUrl>) = sendLiterallyEverywhere(dmRelayList.saveRelayList(dmRelays))
+    override suspend fun saveDMRelayList(dmRelays: List<NormalizedRelayUrl>) = sendLiterallyEverywhere(dmRelayList.saveRelayList(dmRelays))
 
     suspend fun savePrivateOutboxRelayList(relays: List<NormalizedRelayUrl>) = sendMyPublicAndPrivateOutbox(privateStorageRelayList.saveRelayList(relays))
 
-    suspend fun saveSearchRelayList(searchRelays: List<NormalizedRelayUrl>) = sendMyPublicAndPrivateOutbox(searchRelayList.saveRelayList(searchRelays))
+    override suspend fun saveSearchRelayList(searchRelays: List<NormalizedRelayUrl>) = sendMyPublicAndPrivateOutbox(searchRelayList.saveRelayList(searchRelays))
 
     suspend fun saveIndexerRelayList(trustedRelays: List<NormalizedRelayUrl>) = sendMyPublicAndPrivateOutbox(indexerRelayList.saveRelayList(trustedRelays))
 
-    suspend fun saveBroadcastRelayList(trustedRelays: List<NormalizedRelayUrl>) = sendMyPublicAndPrivateOutbox(broadcastRelayList.saveRelayList(trustedRelays))
+    override suspend fun saveBroadcastRelayList(relays: List<NormalizedRelayUrl>) = sendMyPublicAndPrivateOutbox(broadcastRelayList.saveRelayList(relays))
 
     suspend fun saveProxyRelayList(trustedRelays: List<NormalizedRelayUrl>) = sendMyPublicAndPrivateOutbox(proxyRelayList.saveRelayList(trustedRelays))
 
@@ -2358,7 +2358,7 @@ class Account(
         client.publish(signedEvent, followPlusAllMineWithIndex.flow.value + client.availableRelaysFlow().value)
     }
 
-    suspend fun sendNip65RelayList(relays: List<AdvertisedRelayInfo>) = sendLiterallyEverywhere(nip65RelayList.saveRelayList(relays))
+    override suspend fun sendNip65RelayList(relays: List<AdvertisedRelayInfo>) = sendLiterallyEverywhere(nip65RelayList.saveRelayList(relays))
 
     suspend fun sendBlossomServersList(servers: List<String>) = sendMyPublicAndPrivateOutbox(blossomServers.saveBlossomServersList(servers))
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
@@ -22,6 +22,8 @@ package com.vitorpamplona.amethyst.commons.model
 
 import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupList
 import com.vitorpamplona.amethyst.commons.model.privateChats.ChatroomList
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import com.vitorpamplona.quartz.nip04Dm.messages.PrivateDmEvent
@@ -33,6 +35,7 @@ import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Request
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Response
 import com.vitorpamplona.quartz.nip57Zaps.IPrivateZapsDecryptionCache
 import com.vitorpamplona.quartz.nip59Giftwrap.wraps.GiftWrapEvent
+import com.vitorpamplona.quartz.nip65RelayList.tags.AdvertisedRelayInfo
 import com.vitorpamplona.quartz.utils.DualCase
 
 /**
@@ -119,4 +122,38 @@ interface IAccount {
 
     /** Broadcast pre-created gift wraps (e.g. reactions within group DMs) */
     suspend fun sendGiftWraps(wraps: List<GiftWrapEvent>)
+
+    // --- v4: User visibility & follow checks ---
+
+    /** Mute a user (add to mute list) */
+    suspend fun hideUser(pubkeyHex: HexKey)
+
+    /** Unmute a user (remove from block/mute lists) */
+    suspend fun showUser(pubkeyHex: HexKey)
+
+    /** Mute a word */
+    suspend fun hideWord(word: String)
+
+    /** Unmute a word */
+    suspend fun showWord(word: String)
+
+    /** Check if account follows the given user */
+    fun isFollowing(user: User): Boolean
+
+    /** Check if account follows the given pubkey */
+    fun isFollowing(user: HexKey): Boolean
+
+    // --- v4: Relay list management ---
+
+    /** Save NIP-65 advertised relay list */
+    suspend fun sendNip65RelayList(relays: List<AdvertisedRelayInfo>)
+
+    /** Save DM inbox relay list */
+    suspend fun saveDMRelayList(dmRelays: List<NormalizedRelayUrl>)
+
+    /** Save search relay list */
+    suspend fun saveSearchRelayList(searchRelays: List<NormalizedRelayUrl>)
+
+    /** Save broadcast relay list */
+    suspend fun saveBroadcastRelayList(relays: List<NormalizedRelayUrl>)
 }


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

Adds 10 new abstract members to `IAccount` in commons:

**User visibility & follow checks (6):**
- `hideUser(pubkeyHex)` / `showUser(pubkeyHex)` — mute/unmute users
- `hideWord(word)` / `showWord(word)` — mute/unmute words
- `isFollowing(user: User)` / `isFollowing(user: HexKey)` — follow checks

**Relay list management (4):**
- `sendNip65RelayList(relays)` — save NIP-65 advertised relay list
- `saveDMRelayList(dmRelays)` — save DM inbox relay list
- `saveSearchRelayList(searchRelays)` — save search relay list
- `saveBroadcastRelayList(relays)` — save broadcast relay list

These are needed to unblock ViewModel migration to commons (relay settings screens, user profile actions, mute management).

Follows the same incremental expansion pattern as #2237 (v1, +9), #2260 (v2, +10), #2278 (v3, +10).

All methods already implemented by `Account.kt` — this PR just promotes them to the interface and adds `override`.