### PR TITLE
feat: move UserExternalIdentitiesViewModel to commons (batch 4)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/ProfileScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/ProfileScreen.kt
@@ -174,7 +174,11 @@ fun PrepareViewModels(
     val externalIdentities: UserExternalIdentitiesViewModel =
         viewModel(
             key = baseUser.pubkeyHex + "UserExternalIdentitiesViewModel",
-            factory = UserExternalIdentitiesViewModel.Factory(baseUser),
+            factory =
+                com.vitorpamplona.amethyst.commons.viewmodels.UserExternalIdentitiesViewModel.Factory(
+                    baseUser,
+                    com.vitorpamplona.amethyst.model.LocalCache,
+                ),
         )
 
     val zapFeedViewModel: UserProfileZapsViewModel =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/identity/UserExternalIdentitiesViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/identity/UserExternalIdentitiesViewModel.kt
@@ -20,47 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.header.identity
 
-import androidx.compose.runtime.Stable
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewModelScope
-import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.model.User
-import com.vitorpamplona.quartz.nip39ExtIdentities.ExternalIdentitiesEvent
-import com.vitorpamplona.quartz.nip39ExtIdentities.identityClaims
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
-
-@Stable
-class UserExternalIdentitiesViewModel(
-    val user: User,
-) : ViewModel() {
-    private val note =
-        LocalCache.getOrCreateAddressableNote(
-            ExternalIdentitiesEvent.createAddress(user.pubkeyHex),
-        )
-
-    val identities =
-        note
-            .flow()
-            .metadata.stateFlow
-            .map { state ->
-                val event = state.note.event as? ExternalIdentitiesEvent
-                event?.identityClaims() ?: emptyList()
-            }.flowOn(Dispatchers.IO)
-            .stateIn(
-                scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(5000),
-                initialValue = emptyList(),
-            )
-
-    class Factory(
-        val user: User,
-    ) : ViewModelProvider.Factory {
-        @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(modelClass: Class<T>): T = UserExternalIdentitiesViewModel(user) as T
-    }
-}
+// Re-export from commons for backwards compatibility
+typealias UserExternalIdentitiesViewModel = com.vitorpamplona.amethyst.commons.viewmodels.UserExternalIdentitiesViewModel

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/UserExternalIdentitiesViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/UserExternalIdentitiesViewModel.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.viewmodels
+
+import androidx.compose.runtime.Stable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+import com.vitorpamplona.quartz.nip39ExtIdentities.ExternalIdentitiesEvent
+import com.vitorpamplona.quartz.nip39ExtIdentities.identityClaims
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlin.reflect.KClass
+
+@Stable
+class UserExternalIdentitiesViewModel(
+    val user: User,
+    cacheProvider: ICacheProvider,
+) : ViewModel() {
+    private val note =
+        cacheProvider.getOrCreateAddressableNote(
+            ExternalIdentitiesEvent.createAddress(user.pubkeyHex),
+        )
+
+    val identities =
+        note
+            .flow()
+            .metadata.stateFlow
+            .map { state ->
+                val event = state.note.event as? ExternalIdentitiesEvent
+                event?.identityClaims() ?: emptyList()
+            }.flowOn(Dispatchers.IO)
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5000),
+                initialValue = emptyList(),
+            )
+
+    class Factory(
+        val user: User,
+        val cacheProvider: ICacheProvider,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(
+            modelClass: KClass<T>,
+            extras: androidx.lifecycle.viewmodel.CreationExtras,
+        ): T = UserExternalIdentitiesViewModel(user, cacheProvider) as T
+    }
+}


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

Moves UserExternalIdentitiesViewModel to the commons module with a backward-compatible typealias.

**Pattern:** `LocalCache` → `ICacheProvider` (injected via constructor)
**Previous:** #2247 (batch 1), #2253 (batch 2), #2274 (batch 3)

### Files moved:
- **UserExternalIdentitiesViewModel** → `commons/src/commonMain/.../viewmodels/UserExternalIdentitiesViewModel.kt`

### Changes:
- VM now takes `ICacheProvider` instead of using `LocalCache` singleton directly
- Factory updated to accept `ICacheProvider` parameter
- Typealias left at original location for backward compatibility
- Call site in ProfileScreen updated to pass `LocalCache` as `ICacheProvider`

### Why only 1 VM?
Analyzed 10 candidate ViewModels — most have heavy Android dependencies (Context, R.string, media uploaders, Amethyst singleton) or depend on Account-specific methods not on IAccount:
- BookmarkGroupMetadataViewModel — Android Context, uploaders, R.string
- BookmarkGroupViewModel — Account.labeledBookmarkLists (not on IAccount)
- FollowPackMetadataViewModel — Android Context, uploaders, R.string
- PeopleListMetadataViewModel — Android Context, uploaders, R.string
- ChannelMetadataViewModel — Android Context, LocalCache direct, uploaders
- PaymentTargetsViewModel — Account.paymentTargetsState (not on IAccount)
- ZapPollNoteViewModel — Account.calculateIfNoteWasZappedByAccount (not on IAccount)
- SignUpViewModel — AccountSessionManager, TorSettingsFlow, R.string
- LoginViewModel — AccountSessionManager, TorSettingsFlow, R.string
- NewMediaModel — Android Context, uploaders, R.string