### PR TITLE
feat: move composables to commons (batch 8)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/mediaServers/ServerName.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/mediaServers/ServerName.kt
@@ -20,30 +20,9 @@
  */
 package com.vitorpamplona.amethyst.ui.actions.mediaServers
 
-import kotlinx.serialization.Serializable
+// Backward compatibility - moved to commons
+typealias ServerName = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.ServerName
+typealias ServerType = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.ServerType
 
-@Serializable
-data class ServerName(
-    val name: String,
-    val baseUrl: String,
-    val type: ServerType = ServerType.Blossom,
-)
-
-enum class ServerType {
-    Blossom,
-    NIP95,
-    NIP96,
-}
-
-val DEFAULT_MEDIA_SERVERS: List<ServerName> =
-    listOf(
-        ServerName("Nostr.Build", "https://blossom.band/", ServerType.Blossom),
-        ServerName("24242.io", "https://24242.io/", ServerType.Blossom),
-        ServerName("Azzamo", "https://blossom.azzamo.media", ServerType.Blossom),
-        ServerName("YakiHonne", "https://blossom.yakihonne.com/", ServerType.Blossom),
-        ServerName("Primal", "https://blossom.primal.net/", ServerType.Blossom),
-        ServerName("Sovbit", "https://cdn.sovbit.host", ServerType.Blossom),
-        ServerName("Nostr.Download", "https://nostr.download", ServerType.Blossom),
-        ServerName("Satellite (Paid)", "https://cdn.satellite.earth", ServerType.Blossom),
-        ServerName("NostrMedia (Paid)", "https://nostrmedia.com", ServerType.Blossom),
-    )
+val DEFAULT_MEDIA_SERVERS: List<ServerName>
+    get() = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.DEFAULT_MEDIA_SERVERS

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/uploads/MediaUploadTracker.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/uploads/MediaUploadTracker.kt
@@ -20,28 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.actions.uploads
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
-
-class MediaUploadTracker {
-    var isUploadingImage by mutableStateOf(false)
-        private set
-    var isUploadingFile by mutableStateOf(false)
-        private set
-
-    val isUploading: Boolean get() = isUploadingImage || isUploadingFile
-
-    fun startUpload(hasNonMedia: Boolean) {
-        if (hasNonMedia) {
-            isUploadingFile = true
-        } else {
-            isUploadingImage = true
-        }
-    }
-
-    fun finishUpload() {
-        isUploadingImage = false
-        isUploadingFile = false
-    }
-}
+// Backward compatibility - moved to commons
+typealias MediaUploadTracker = com.vitorpamplona.amethyst.commons.ui.actions.uploads.MediaUploadTracker

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/TranslationConfig.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/TranslationConfig.kt
@@ -20,12 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.components
 
-import androidx.compose.runtime.Immutable
-
-@Immutable
-data class TranslationConfig(
-    val result: String?,
-    val sourceLang: String?,
-    val targetLang: String?,
-    val showOriginal: Boolean,
-)
+// Backward compatibility - moved to commons
+typealias TranslationConfig = com.vitorpamplona.amethyst.commons.ui.components.TranslationConfig

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/DisplayErrorMessages.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/DisplayErrorMessages.kt
@@ -40,10 +40,11 @@ fun DisplayErrorMessages(
     openDialogMsg.value?.let { obj ->
         when (obj) {
             is ResourceToastMsg -> {
-                if (obj.params != null) {
+                val params = obj.params
+                if (params != null) {
                     InformationDialog(
                         stringRes(obj.titleResId),
-                        stringRes(obj.resourceId, *obj.params),
+                        stringRes(obj.resourceId, *params),
                     ) {
                         toastManager.clearToasts()
                     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ResourceToastMsg.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ResourceToastMsg.kt
@@ -20,11 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.components.toasts
 
-import androidx.compose.runtime.Immutable
-
-@Immutable
-class ResourceToastMsg(
-    val titleResId: Int,
-    val resourceId: Int,
-    val params: Array<out String>? = null,
-) : ToastMsg()
+// Backward compatibility - moved to commons
+typealias ResourceToastMsg = com.vitorpamplona.amethyst.commons.ui.components.toasts.ResourceToastMsg

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/StringToastMsg.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/StringToastMsg.kt
@@ -20,16 +20,6 @@
  */
 package com.vitorpamplona.amethyst.ui.components.toasts
 
-import androidx.compose.runtime.Immutable
-
-@Immutable
-class StringToastMsg(
-    val title: String,
-    val msg: String,
-) : ToastMsg()
-
-class ActionableStringToastMsg(
-    val title: String,
-    val msg: String,
-    val action: () -> Unit,
-) : ToastMsg()
+// Backward compatibility - moved to commons
+typealias StringToastMsg = com.vitorpamplona.amethyst.commons.ui.components.toasts.StringToastMsg
+typealias ActionableStringToastMsg = com.vitorpamplona.amethyst.commons.ui.components.toasts.ActionableStringToastMsg

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ThrowableToastMsg.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ThrowableToastMsg.kt
@@ -20,18 +20,6 @@
  */
 package com.vitorpamplona.amethyst.ui.components.toasts
 
-import androidx.compose.runtime.Immutable
-
-@Immutable
-class ThrowableToastMsg(
-    val titleResId: Int,
-    val msg: String? = null,
-    val throwable: Throwable,
-) : ToastMsg()
-
-@Immutable
-class ThrowableToastMsg2(
-    val titleResId: Int,
-    val description: Int,
-    val throwable: Throwable,
-) : ToastMsg()
+// Backward compatibility - moved to commons
+typealias ThrowableToastMsg = com.vitorpamplona.amethyst.commons.ui.components.toasts.ThrowableToastMsg
+typealias ThrowableToastMsg2 = com.vitorpamplona.amethyst.commons.ui.components.toasts.ThrowableToastMsg2

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ToastMsg.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ToastMsg.kt
@@ -20,7 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.components.toasts
 
-import androidx.compose.runtime.Immutable
-
-@Immutable
-open class ToastMsg
+// Backward compatibility - moved to commons
+typealias ToastMsg = com.vitorpamplona.amethyst.commons.ui.components.toasts.ToastMsg

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/AdditiveComplexFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/AdditiveComplexFeedFilter.kt
@@ -20,9 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.dal
 
-abstract class AdditiveComplexFeedFilter<T, U> : FeedFilter<T>() {
-    abstract fun updateListWith(
-        oldList: List<T>,
-        newItems: Set<U>,
-    ): List<T>
-}
+// Backward compatibility - moved to commons
+typealias AdditiveComplexFeedFilter<T, U> = com.vitorpamplona.amethyst.commons.ui.feeds.AdditiveComplexFeedFilter<T, U>

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/draftTags/DraftTagState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/draftTags/DraftTagState.kt
@@ -20,41 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.note.creators.draftTags
 
-import androidx.compose.runtime.Stable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
-import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.update
-import kotlin.uuid.ExperimentalUuidApi
-import kotlin.uuid.Uuid
-
-@Stable
-class DraftTagState {
-    var current: String by mutableStateOf(newTag())
-    var usedDraftTags by mutableStateOf(setOf(current))
-
-    private val _versions = MutableStateFlow(0)
-
-    @OptIn(FlowPreview::class)
-    val versions = _versions.debounce(1000)
-
-    @OptIn(ExperimentalUuidApi::class)
-    fun newTag() = Uuid.random().toString()
-
-    fun rotate() {
-        set(newTag())
-        _versions.update { 0 }
-    }
-
-    fun set(existingTag: String) {
-        current = existingTag
-        usedDraftTags += existingTag
-    }
-
-    fun newVersion() {
-        _versions.update { it + 1 }
-    }
-}
+// Backward compatibility - moved to commons
+typealias DraftTagState = com.vitorpamplona.amethyst.commons.ui.note.creators.draftTags.DraftTagState

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/expiration/IExpiration.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/expiration/IExpiration.kt
@@ -20,9 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.note.creators.expiration
 
-import androidx.compose.runtime.Stable
-
-@Stable
-interface IExpiration {
-    var expirationDate: Long
-}
+// Backward compatibility - moved to commons
+typealias IExpiration = com.vitorpamplona.amethyst.commons.ui.note.creators.expiration.IExpiration

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/BookmarkType.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/BookmarkType.kt
@@ -20,8 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups
 
-enum class BookmarkType {
-    PostBookmark,
-
-    ArticleBookmark,
-}
+// Backward compatibility - moved to commons
+typealias BookmarkType = com.vitorpamplona.amethyst.commons.ui.bookmarkgroups.BookmarkType

--- a/amethyst/src/play/java/com/vitorpamplona/amethyst/ui/components/TranslatableRichTextViewer.kt
+++ b/amethyst/src/play/java/com/vitorpamplona/amethyst/ui/components/TranslatableRichTextViewer.kt
@@ -140,14 +140,16 @@ private fun RenderTextWithTranslateOptions(
     Column {
         displayText(toBeViewed)
 
+        val sourceLang = translatedTextState.sourceLang
+        val targetLang = translatedTextState.targetLang
         if (
-            translatedTextState.sourceLang != null &&
-            translatedTextState.targetLang != null &&
-            translatedTextState.sourceLang != translatedTextState.targetLang
+            sourceLang != null &&
+            targetLang != null &&
+            sourceLang != targetLang
         ) {
             TranslationMessage(
-                translatedTextState.sourceLang,
-                translatedTextState.targetLang,
+                sourceLang,
+                targetLang,
                 translationMessageModifier,
                 accountViewModel,
             ) {

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/actions/mediaServers/ServerName.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/actions/mediaServers/ServerName.kt
@@ -18,7 +18,32 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.zapraiser
+package com.vitorpamplona.amethyst.commons.ui.actions.mediaServers
 
-// Backward compatibility - moved to commons
-typealias IZapRaiser = com.vitorpamplona.amethyst.commons.ui.note.creators.zapraiser.IZapRaiser
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ServerName(
+    val name: String,
+    val baseUrl: String,
+    val type: ServerType = ServerType.Blossom,
+)
+
+enum class ServerType {
+    Blossom,
+    NIP95,
+    NIP96,
+}
+
+val DEFAULT_MEDIA_SERVERS: List<ServerName> =
+    listOf(
+        ServerName("Nostr.Build", "https://blossom.band/", ServerType.Blossom),
+        ServerName("24242.io", "https://24242.io/", ServerType.Blossom),
+        ServerName("Azzamo", "https://blossom.azzamo.media", ServerType.Blossom),
+        ServerName("YakiHonne", "https://blossom.yakihonne.com/", ServerType.Blossom),
+        ServerName("Primal", "https://blossom.primal.net/", ServerType.Blossom),
+        ServerName("Sovbit", "https://cdn.sovbit.host", ServerType.Blossom),
+        ServerName("Nostr.Download", "https://nostr.download", ServerType.Blossom),
+        ServerName("Satellite (Paid)", "https://cdn.satellite.earth", ServerType.Blossom),
+        ServerName("NostrMedia (Paid)", "https://nostrmedia.com", ServerType.Blossom),
+    )

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/actions/uploads/MediaUploadTracker.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/actions/uploads/MediaUploadTracker.kt
@@ -18,7 +18,30 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.zapraiser
+package com.vitorpamplona.amethyst.commons.ui.actions.uploads
 
-// Backward compatibility - moved to commons
-typealias IZapRaiser = com.vitorpamplona.amethyst.commons.ui.note.creators.zapraiser.IZapRaiser
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+class MediaUploadTracker {
+    var isUploadingImage by mutableStateOf(false)
+        private set
+    var isUploadingFile by mutableStateOf(false)
+        private set
+
+    val isUploading: Boolean get() = isUploadingImage || isUploadingFile
+
+    fun startUpload(hasNonMedia: Boolean) {
+        if (hasNonMedia) {
+            isUploadingFile = true
+        } else {
+            isUploadingImage = true
+        }
+    }
+
+    fun finishUpload() {
+        isUploadingImage = false
+        isUploadingFile = false
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/bookmarkgroups/BookmarkType.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/bookmarkgroups/BookmarkType.kt
@@ -18,7 +18,10 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.zapraiser
+package com.vitorpamplona.amethyst.commons.ui.bookmarkgroups
 
-// Backward compatibility - moved to commons
-typealias IZapRaiser = com.vitorpamplona.amethyst.commons.ui.note.creators.zapraiser.IZapRaiser
+enum class BookmarkType {
+    PostBookmark,
+
+    ArticleBookmark,
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/TranslationConfig.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/TranslationConfig.kt
@@ -18,7 +18,14 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.zapraiser
+package com.vitorpamplona.amethyst.commons.ui.components
 
-// Backward compatibility - moved to commons
-typealias IZapRaiser = com.vitorpamplona.amethyst.commons.ui.note.creators.zapraiser.IZapRaiser
+import androidx.compose.runtime.Immutable
+
+@Immutable
+data class TranslationConfig(
+    val result: String?,
+    val sourceLang: String?,
+    val targetLang: String?,
+    val showOriginal: Boolean,
+)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/toasts/ResourceToastMsg.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/toasts/ResourceToastMsg.kt
@@ -18,7 +18,13 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.zapraiser
+package com.vitorpamplona.amethyst.commons.ui.components.toasts
 
-// Backward compatibility - moved to commons
-typealias IZapRaiser = com.vitorpamplona.amethyst.commons.ui.note.creators.zapraiser.IZapRaiser
+import androidx.compose.runtime.Immutable
+
+@Immutable
+class ResourceToastMsg(
+    val titleResId: Int,
+    val resourceId: Int,
+    val params: Array<out String>? = null,
+) : ToastMsg()

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/toasts/StringToastMsg.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/toasts/StringToastMsg.kt
@@ -18,7 +18,18 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.zapraiser
+package com.vitorpamplona.amethyst.commons.ui.components.toasts
 
-// Backward compatibility - moved to commons
-typealias IZapRaiser = com.vitorpamplona.amethyst.commons.ui.note.creators.zapraiser.IZapRaiser
+import androidx.compose.runtime.Immutable
+
+@Immutable
+class StringToastMsg(
+    val title: String,
+    val msg: String,
+) : ToastMsg()
+
+class ActionableStringToastMsg(
+    val title: String,
+    val msg: String,
+    val action: () -> Unit,
+) : ToastMsg()

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/toasts/ThrowableToastMsg.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/toasts/ThrowableToastMsg.kt
@@ -18,7 +18,20 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.zapraiser
+package com.vitorpamplona.amethyst.commons.ui.components.toasts
 
-// Backward compatibility - moved to commons
-typealias IZapRaiser = com.vitorpamplona.amethyst.commons.ui.note.creators.zapraiser.IZapRaiser
+import androidx.compose.runtime.Immutable
+
+@Immutable
+class ThrowableToastMsg(
+    val titleResId: Int,
+    val msg: String? = null,
+    val throwable: Throwable,
+) : ToastMsg()
+
+@Immutable
+class ThrowableToastMsg2(
+    val titleResId: Int,
+    val description: Int,
+    val throwable: Throwable,
+) : ToastMsg()

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/toasts/ToastMsg.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/toasts/ToastMsg.kt
@@ -18,7 +18,9 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.zapraiser
+package com.vitorpamplona.amethyst.commons.ui.components.toasts
 
-// Backward compatibility - moved to commons
-typealias IZapRaiser = com.vitorpamplona.amethyst.commons.ui.note.creators.zapraiser.IZapRaiser
+import androidx.compose.runtime.Immutable
+
+@Immutable
+open class ToastMsg

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/AdditiveComplexFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/AdditiveComplexFeedFilter.kt
@@ -18,7 +18,11 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.zapraiser
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-// Backward compatibility - moved to commons
-typealias IZapRaiser = com.vitorpamplona.amethyst.commons.ui.note.creators.zapraiser.IZapRaiser
+abstract class AdditiveComplexFeedFilter<T, U> : FeedFilter<T>() {
+    abstract fun updateListWith(
+        oldList: List<T>,
+        newItems: Set<U>,
+    ): List<T>
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/layouts/DisappearingFloatingButton.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/layouts/DisappearingFloatingButton.kt
@@ -18,18 +18,49 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.layouts
+package com.vitorpamplona.amethyst.commons.ui.layouts
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.BottomAppBarScrollBehavior
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.unit.dp
 
-// Backward compatibility - moved to commons
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DisappearingFloatingButton(
     scrollBehavior: BottomAppBarScrollBehavior,
     content: @Composable (BoxScope.() -> Unit),
-) = com.vitorpamplona.amethyst.commons.ui.layouts
-    .DisappearingFloatingButton(scrollBehavior, content)
+) {
+    // We calculate the scale/alpha based on how much the bar is expanded
+    // 1.0 = fully visible, 0.0 = fully hidden
+    val progress = (1f - scrollBehavior.state.collapsedFraction).coerceAtLeast(0.001f)
+
+    Box(
+        modifier =
+            Modifier
+                .size(75.dp)
+                .layout { measurable, constraints ->
+                    val placeable = measurable.measure(constraints)
+                    // Adjust the height of the layout so the FAB doesn't leave a "hole"
+                    val currentHeight = (placeable.height * progress).toInt()
+                    layout(placeable.width, currentHeight) {
+                        placeable.placeRelative(0, 0)
+                    }
+                }.graphicsLayer {
+                    this.translationY = this.size.height / 3.5f
+                    this.scaleX = progress
+                    this.scaleY = progress
+                    this.alpha = progress
+                    clip = true
+                },
+        contentAlignment = Alignment.TopCenter,
+        content = content,
+    )
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/navigation/topbars/ShorterTopAppBar.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/navigation/topbars/ShorterTopAppBar.kt
@@ -18,20 +18,21 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.navigation.topbars
+package com.vitorpamplona.amethyst.commons.ui.navigation.topbars
 
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarColors
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 
-// Backward compatibility - moved to commons
-val TopBarSize = com.vitorpamplona.amethyst.commons.ui.navigation.topbars.TopBarSize
+val TopBarSize = 50.dp
 
 @ExperimentalMaterial3Api
 @Composable
@@ -44,7 +45,7 @@ fun ShorterTopAppBar(
     windowInsets: WindowInsets = TopAppBarDefaults.windowInsets,
     colors: TopAppBarColors = TopAppBarDefaults.topAppBarColors(),
     scrollBehavior: TopAppBarScrollBehavior? = null,
-) = com.vitorpamplona.amethyst.commons.ui.navigation.topbars.ShorterTopAppBar(
+) = TopAppBar(
     title,
     modifier,
     navigationIcon,

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/creators/draftTags/DraftTagState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/creators/draftTags/DraftTagState.kt
@@ -18,7 +18,43 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.zapraiser
+package com.vitorpamplona.amethyst.commons.ui.note.creators.draftTags
 
-// Backward compatibility - moved to commons
-typealias IZapRaiser = com.vitorpamplona.amethyst.commons.ui.note.creators.zapraiser.IZapRaiser
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.update
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@Stable
+class DraftTagState {
+    var current: String by mutableStateOf(newTag())
+    var usedDraftTags by mutableStateOf(setOf(current))
+
+    private val _versions = MutableStateFlow(0)
+
+    @OptIn(FlowPreview::class)
+    val versions = _versions.debounce(1000)
+
+    @OptIn(ExperimentalUuidApi::class)
+    fun newTag() = Uuid.random().toString()
+
+    fun rotate() {
+        set(newTag())
+        _versions.update { 0 }
+    }
+
+    fun set(existingTag: String) {
+        current = existingTag
+        usedDraftTags += existingTag
+    }
+
+    fun newVersion() {
+        _versions.update { it + 1 }
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/creators/expiration/IExpiration.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/creators/expiration/IExpiration.kt
@@ -18,7 +18,11 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.zapraiser
+package com.vitorpamplona.amethyst.commons.ui.note.creators.expiration
 
-// Backward compatibility - moved to commons
-typealias IZapRaiser = com.vitorpamplona.amethyst.commons.ui.note.creators.zapraiser.IZapRaiser
+import androidx.compose.runtime.Stable
+
+@Stable
+interface IExpiration {
+    var expirationDate: Long
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/creators/zapraiser/IZapRaiser.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/creators/zapraiser/IZapRaiser.kt
@@ -18,7 +18,14 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.zapraiser
+package com.vitorpamplona.amethyst.commons.ui.note.creators.zapraiser
 
-// Backward compatibility - moved to commons
-typealias IZapRaiser = com.vitorpamplona.amethyst.commons.ui.note.creators.zapraiser.IZapRaiser
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.Stable
+
+@Stable
+interface IZapRaiser {
+    val zapRaiserAmount: MutableState<Long?>
+
+    fun updateZapRaiserAmount(newAmount: Long?)
+}


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

Moves 15 more UI files to commons module with backward-compatible typealiases/wrappers.
Previous batches: #2230, #2231, #2232, #2233, #2242, #2248, #2249, #2255, #2263, #2265, #2268, #2273.

**Files moved (all zero non-commons deps):**
- `ToastMsg`, `ResourceToastMsg`, `StringToastMsg`/`ActionableStringToastMsg`, `ThrowableToastMsg`/`ThrowableToastMsg2` — toast message system
- `BookmarkType` — bookmark type enum
- `IExpiration` — expiration interface
- `IZapRaiser` — zap raiser interface
- `TranslationConfig` — translation config data class
- `MediaUploadTracker` — media upload state tracker
- `ServerName`, `ServerType`, `DEFAULT_MEDIA_SERVERS` — media server config
- `DraftTagState` — draft tag state management
- `AdditiveComplexFeedFilter` — feed filter base class
- `ShorterTopAppBar` — shorter top app bar composable + `TopBarSize`
- `DisappearingFloatingButton` — disappearing FAB composable

Also fixes two smart-cast issues for cross-module property access:
- `TranslatableRichTextViewer`: local vars for nullable `sourceLang`/`targetLang`
- `DisplayErrorMessages`: local var for nullable `params`