### PR TITLE
feat: add viewModelScope to IAccountViewModel interface in commons

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -51,6 +51,7 @@ import com.vitorpamplona.amethyst.commons.model.nip53LiveActivities.LiveActiviti
 import com.vitorpamplona.amethyst.commons.model.observables.CreatedAtComparator
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
 import com.vitorpamplona.amethyst.commons.ui.notifications.CardFeedState
+import com.vitorpamplona.amethyst.commons.viewmodels.IAccountViewModel
 import com.vitorpamplona.amethyst.logTime
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.AccountSettings
@@ -175,14 +176,18 @@ import kotlinx.coroutines.withContext
 
 @Stable
 class AccountViewModel(
-    val account: Account,
+    override val account: Account,
     val settings: UiSettingsState,
     val torSettings: TorSettingsFlow,
     val dataSources: RelaySubscriptionsCoordinator,
     val httpClientBuilder: IRoleBasedHttpClientBuilder,
     val nip05ClientBuilder: () -> INip05Client,
 ) : ViewModel(),
+    IAccountViewModel,
     Dao {
+    override val accountViewModelScope: CoroutineScope
+        get() = viewModelScope
+
     var firstRoute: Route? = null
 
     val toastManager = ToastManager()

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/IAccountViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/IAccountViewModel.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.viewmodels
+
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import kotlinx.coroutines.CoroutineScope
+
+interface IAccountViewModel {
+    val account: IAccount
+    val accountViewModelScope: CoroutineScope
+}


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

## What

Creates `IAccountViewModel` interface in `commons` with two properties:

```kotlin
interface IAccountViewModel {
    val account: IAccount
    val accountViewModelScope: CoroutineScope
}
```

`AccountViewModel` now implements this interface, bridging Android's `viewModelScope` extension property to the platform-agnostic `accountViewModelScope`.

## Why

~45 files reference `accountViewModel.viewModelScope` to launch coroutines. By exposing a `CoroutineScope` through the commons interface, composables can be progressively migrated from depending on the Android-specific `AccountViewModel` to the platform-agnostic `IAccountViewModel`.

The property is named `accountViewModelScope` (rather than `viewModelScope`) because Android's `ViewModel.viewModelScope` is an extension property that can't directly satisfy an interface contract.

## Changes

- **New:** `commons/.../viewmodels/IAccountViewModel.kt` — interface with `account: IAccount` + `accountViewModelScope: CoroutineScope`
- **Modified:** `AccountViewModel.kt` — implements `IAccountViewModel`, adds `override val accountViewModelScope` delegating to `viewModelScope`