### PR TITLE
feat: convert R.string and move VoicePreset + TorSettings to commons (batch 9)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/uploads/VoicePresetSelector.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/uploads/VoicePresetSelector.kt
@@ -32,9 +32,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import com.vitorpamplona.amethyst.ui.stringRes
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun VoicePresetSelector(
@@ -43,7 +42,6 @@ fun VoicePresetSelector(
     onPresetSelected: (VoicePreset) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val context = LocalContext.current
     val isProcessing = processingPreset != null
 
     Row(
@@ -67,7 +65,7 @@ fun VoicePresetSelector(
                             color = MaterialTheme.colorScheme.onPrimary,
                         )
                     } else {
-                        Text(stringRes(context, preset.labelRes))
+                        Text(stringResource(preset.labelRes))
                     }
                 },
                 colors =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorSettings.kt
@@ -20,139 +20,34 @@
  */
 package com.vitorpamplona.amethyst.ui.tor
 
-import com.vitorpamplona.amethyst.R
+typealias TorSettings = com.vitorpamplona.amethyst.commons.ui.tor.TorSettings
 
-data class TorSettings(
-    val torType: TorType = TorType.INTERNAL,
-    val externalSocksPort: Int = 9050,
-    val onionRelaysViaTor: Boolean = true,
-    val dmRelaysViaTor: Boolean = true,
-    val newRelaysViaTor: Boolean = true,
-    val trustedRelaysViaTor: Boolean = false,
-    val urlPreviewsViaTor: Boolean = false,
-    val profilePicsViaTor: Boolean = false,
-    val imagesViaTor: Boolean = false,
-    val videosViaTor: Boolean = false,
-    val moneyOperationsViaTor: Boolean = false,
-    val nip05VerificationsViaTor: Boolean = false,
-    val mediaUploadsViaTor: Boolean = false,
-)
+typealias TorType = com.vitorpamplona.amethyst.commons.ui.tor.TorType
 
-enum class TorType(
-    val screenCode: Int,
-    val resourceId: Int,
-) {
-    OFF(0, R.string.tor_off),
-    INTERNAL(1, R.string.tor_internal),
-    EXTERNAL(2, R.string.tor_external),
-}
+typealias TorPresetType = com.vitorpamplona.amethyst.commons.ui.tor.TorPresetType
 
-fun parseTorType(code: Int?): TorType =
-    when (code) {
-        TorType.OFF.screenCode -> TorType.OFF
-        TorType.INTERNAL.screenCode -> TorType.INTERNAL
-        TorType.EXTERNAL.screenCode -> TorType.EXTERNAL
-        else -> TorType.INTERNAL
-    }
+fun parseTorType(code: Int?) =
+    com.vitorpamplona.amethyst.commons.ui.tor
+        .parseTorType(code)
 
-enum class TorPresetType(
-    val screenCode: Int,
-    val resourceId: Int,
-    val explainerId: Int,
-) {
-    ONLY_WHEN_NEEDED(0, R.string.tor_when_needed, R.string.tor_when_needed_explainer),
-    DEFAULT(1, R.string.tor_default, R.string.tor_default_explainer),
-    SMALL_PAYLOADS(2, R.string.tor_small_payloads, R.string.tor_small_payloads_explainer),
-    FULL_PRIVACY(3, R.string.tor_full_privacy, R.string.tor_full_privacy_explainer),
-    CUSTOM(4, R.string.tor_custom, R.string.tor_custom_explainer),
-}
-
-fun parseTorPresetType(code: Int?): TorPresetType =
-    when (code) {
-        TorPresetType.ONLY_WHEN_NEEDED.screenCode -> TorPresetType.ONLY_WHEN_NEEDED
-        TorPresetType.DEFAULT.screenCode -> TorPresetType.DEFAULT
-        TorPresetType.SMALL_PAYLOADS.screenCode -> TorPresetType.SMALL_PAYLOADS
-        TorPresetType.FULL_PRIVACY.screenCode -> TorPresetType.FULL_PRIVACY
-        else -> TorPresetType.CUSTOM
-    }
+fun parseTorPresetType(code: Int?) =
+    com.vitorpamplona.amethyst.commons.ui.tor
+        .parseTorPresetType(code)
 
 fun isPreset(
     torSettings: TorSettings,
     preset: TorSettings,
-): Boolean =
-    torSettings.onionRelaysViaTor == preset.onionRelaysViaTor &&
-        torSettings.dmRelaysViaTor == preset.dmRelaysViaTor &&
-        torSettings.newRelaysViaTor == preset.newRelaysViaTor &&
-        torSettings.trustedRelaysViaTor == preset.trustedRelaysViaTor &&
-        torSettings.urlPreviewsViaTor == preset.urlPreviewsViaTor &&
-        // torSettings.profilePicsViaTor == preset.profilePicsViaTor &&
-        torSettings.imagesViaTor == preset.imagesViaTor &&
-        torSettings.videosViaTor == preset.videosViaTor &&
-        torSettings.moneyOperationsViaTor == preset.moneyOperationsViaTor &&
-        torSettings.nip05VerificationsViaTor == preset.nip05VerificationsViaTor &&
-        torSettings.mediaUploadsViaTor == preset.mediaUploadsViaTor
+) = com.vitorpamplona.amethyst.commons.ui.tor
+    .isPreset(torSettings, preset)
 
-fun whichPreset(torSettings: TorSettings): TorPresetType {
-    if (isPreset(torSettings, torOnlyWhenNeededPreset)) return TorPresetType.ONLY_WHEN_NEEDED
-    if (isPreset(torSettings, torDefaultPreset)) return TorPresetType.DEFAULT
-    if (isPreset(torSettings, torSmallPayloadsPreset)) return TorPresetType.SMALL_PAYLOADS
-    if (isPreset(torSettings, torFullyPrivate)) return TorPresetType.FULL_PRIVACY
-    return TorPresetType.CUSTOM
-}
+fun whichPreset(torSettings: TorSettings) =
+    com.vitorpamplona.amethyst.commons.ui.tor
+        .whichPreset(torSettings)
 
-val torOnlyWhenNeededPreset =
-    TorSettings(
-        onionRelaysViaTor = true,
-        dmRelaysViaTor = false,
-        newRelaysViaTor = false,
-        trustedRelaysViaTor = false,
-        urlPreviewsViaTor = false,
-        profilePicsViaTor = false,
-        imagesViaTor = false,
-        videosViaTor = false,
-        moneyOperationsViaTor = false,
-        nip05VerificationsViaTor = false,
-        mediaUploadsViaTor = false,
-    )
-val torDefaultPreset =
-    TorSettings(
-        onionRelaysViaTor = true,
-        dmRelaysViaTor = true,
-        newRelaysViaTor = true,
-        trustedRelaysViaTor = false,
-        urlPreviewsViaTor = false,
-        profilePicsViaTor = false,
-        imagesViaTor = false,
-        videosViaTor = false,
-        moneyOperationsViaTor = false,
-        nip05VerificationsViaTor = false,
-        mediaUploadsViaTor = false,
-    )
-val torSmallPayloadsPreset =
-    TorSettings(
-        onionRelaysViaTor = true,
-        dmRelaysViaTor = true,
-        newRelaysViaTor = true,
-        trustedRelaysViaTor = true,
-        urlPreviewsViaTor = true,
-        profilePicsViaTor = true,
-        imagesViaTor = false,
-        videosViaTor = false,
-        moneyOperationsViaTor = true,
-        nip05VerificationsViaTor = true,
-        mediaUploadsViaTor = false,
-    )
-val torFullyPrivate =
-    TorSettings(
-        onionRelaysViaTor = true,
-        dmRelaysViaTor = true,
-        newRelaysViaTor = true,
-        trustedRelaysViaTor = true,
-        urlPreviewsViaTor = true,
-        profilePicsViaTor = true,
-        imagesViaTor = true,
-        videosViaTor = true,
-        moneyOperationsViaTor = true,
-        nip05VerificationsViaTor = true,
-        mediaUploadsViaTor = true,
-    )
+val torOnlyWhenNeededPreset = com.vitorpamplona.amethyst.commons.ui.tor.torOnlyWhenNeededPreset
+
+val torDefaultPreset = com.vitorpamplona.amethyst.commons.ui.tor.torDefaultPreset
+
+val torSmallPayloadsPreset = com.vitorpamplona.amethyst.commons.ui.tor.torSmallPayloadsPreset
+
+val torFullyPrivate = com.vitorpamplona.amethyst.commons.ui.tor.torFullyPrivate

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorSettingsDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorSettingsDialog.kt
@@ -59,6 +59,7 @@ import com.vitorpamplona.amethyst.ui.theme.ThemeComparisonColumn
 import com.vitorpamplona.amethyst.ui.theme.placeholderText
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.CancellationException
+import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun ConnectTorDialog(
@@ -166,9 +167,9 @@ fun PrivacySettingsBody(dialogViewModel: TorDialogViewModel) {
             R.string.use_internal_tor,
             R.string.use_internal_tor_explainer,
             persistentListOf(
-                TitleExplainer(stringRes(TorType.OFF.resourceId)),
-                TitleExplainer(stringRes(TorType.INTERNAL.resourceId)),
-                TitleExplainer(stringRes(TorType.EXTERNAL.resourceId)),
+                TitleExplainer(stringResource(TorType.OFF.resourceId)),
+                TitleExplainer(stringResource(TorType.INTERNAL.resourceId)),
+                TitleExplainer(stringResource(TorType.EXTERNAL.resourceId)),
             ),
             dialogViewModel.torType.value.screenCode,
         ) {
@@ -216,11 +217,11 @@ fun PrivacySettingsBody(dialogViewModel: TorDialogViewModel) {
                 R.string.tor_preset,
                 R.string.tor_preset_explainer,
                 persistentListOf(
-                    TitleExplainer(stringRes(TorPresetType.ONLY_WHEN_NEEDED.resourceId), stringRes(TorPresetType.ONLY_WHEN_NEEDED.explainerId)),
-                    TitleExplainer(stringRes(TorPresetType.DEFAULT.resourceId), stringRes(TorPresetType.DEFAULT.explainerId)),
-                    TitleExplainer(stringRes(TorPresetType.SMALL_PAYLOADS.resourceId), stringRes(TorPresetType.SMALL_PAYLOADS.explainerId)),
-                    TitleExplainer(stringRes(TorPresetType.FULL_PRIVACY.resourceId), stringRes(TorPresetType.FULL_PRIVACY.explainerId)),
-                    TitleExplainer(stringRes(TorPresetType.CUSTOM.resourceId), stringRes(TorPresetType.CUSTOM.explainerId)),
+                    TitleExplainer(stringResource(TorPresetType.ONLY_WHEN_NEEDED.resourceId), stringResource(TorPresetType.ONLY_WHEN_NEEDED.explainerId)),
+                    TitleExplainer(stringResource(TorPresetType.DEFAULT.resourceId), stringResource(TorPresetType.DEFAULT.explainerId)),
+                    TitleExplainer(stringResource(TorPresetType.SMALL_PAYLOADS.resourceId), stringResource(TorPresetType.SMALL_PAYLOADS.explainerId)),
+                    TitleExplainer(stringResource(TorPresetType.FULL_PRIVACY.resourceId), stringResource(TorPresetType.FULL_PRIVACY.explainerId)),
+                    TitleExplainer(stringResource(TorPresetType.CUSTOM.resourceId), stringResource(TorPresetType.CUSTOM.explainerId)),
                 ),
                 dialogViewModel.preset.value.screenCode,
             ) {

--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -71,7 +71,7 @@ kotlin {
                 api(libs.kotlinx.collections.immutable)
 
                 // Compose Multiplatform Resources
-                implementation(libs.jetbrains.compose.components.resources)
+                api(libs.jetbrains.compose.components.resources)
 
                 // Markdown rendering (richtext-commonmark)
                 implementation(libs.markdown.commonmark)

--- a/commons/src/commonMain/composeResources/values/strings.xml
+++ b/commons/src/commonMain/composeResources/values/strings.xml
@@ -54,4 +54,25 @@
     <!-- Accessibility -->
     <string name="accessibility_user_avatar">User avatar</string>
     <string name="accessibility_navigate">Navigate</string>
+
+    <!-- Voice Presets -->
+    <string name="voice_preset_none">None</string>
+    <string name="voice_preset_deep">Deep</string>
+    <string name="voice_preset_high">High</string>
+    <string name="voice_preset_neutral">Neutral</string>
+
+    <!-- Tor Settings -->
+    <string name="tor_off">Off</string>
+    <string name="tor_internal">Internal</string>
+    <string name="tor_external">Orbot</string>
+    <string name="tor_when_needed">Basic</string>
+    <string name="tor_when_needed_explainer">Use Tor when it\'s required by the server</string>
+    <string name="tor_default">Default</string>
+    <string name="tor_default_explainer">Hide your IP from random relays</string>
+    <string name="tor_small_payloads">All but Media</string>
+    <string name="tor_small_payloads_explainer">Hide your IP from everything, but images and videos</string>
+    <string name="tor_full_privacy">Full Privacy</string>
+    <string name="tor_full_privacy_explainer">Hide your IP in all connections</string>
+    <string name="tor_custom">Custom</string>
+    <string name="tor_custom_explainer">Make your own</string>
 </resources>

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/actions/uploads/VoicePreset.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/actions/uploads/VoicePreset.kt
@@ -18,6 +18,21 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.actions.uploads
+package com.vitorpamplona.amethyst.commons.ui.actions.uploads
 
-typealias VoicePreset = com.vitorpamplona.amethyst.commons.ui.actions.uploads.VoicePreset
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.voice_preset_deep
+import com.vitorpamplona.amethyst.commons.resources.voice_preset_high
+import com.vitorpamplona.amethyst.commons.resources.voice_preset_neutral
+import com.vitorpamplona.amethyst.commons.resources.voice_preset_none
+import org.jetbrains.compose.resources.StringResource
+
+enum class VoicePreset(
+    val pitchFactor: Double,
+    val labelRes: StringResource,
+) {
+    NONE(1.0, Res.string.voice_preset_none),
+    DEEP(1.4, Res.string.voice_preset_deep),
+    HIGH(0.75, Res.string.voice_preset_high),
+    NEUTRAL(1.1, Res.string.voice_preset_neutral),
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/tor/TorSettings.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/tor/TorSettings.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.tor
+
+import com.vitorpamplona.amethyst.commons.resources.Res
+import com.vitorpamplona.amethyst.commons.resources.tor_custom
+import com.vitorpamplona.amethyst.commons.resources.tor_custom_explainer
+import com.vitorpamplona.amethyst.commons.resources.tor_default
+import com.vitorpamplona.amethyst.commons.resources.tor_default_explainer
+import com.vitorpamplona.amethyst.commons.resources.tor_external
+import com.vitorpamplona.amethyst.commons.resources.tor_full_privacy
+import com.vitorpamplona.amethyst.commons.resources.tor_full_privacy_explainer
+import com.vitorpamplona.amethyst.commons.resources.tor_internal
+import com.vitorpamplona.amethyst.commons.resources.tor_off
+import com.vitorpamplona.amethyst.commons.resources.tor_small_payloads
+import com.vitorpamplona.amethyst.commons.resources.tor_small_payloads_explainer
+import com.vitorpamplona.amethyst.commons.resources.tor_when_needed
+import com.vitorpamplona.amethyst.commons.resources.tor_when_needed_explainer
+import org.jetbrains.compose.resources.StringResource
+
+data class TorSettings(
+    val torType: TorType = TorType.INTERNAL,
+    val externalSocksPort: Int = 9050,
+    val onionRelaysViaTor: Boolean = true,
+    val dmRelaysViaTor: Boolean = true,
+    val newRelaysViaTor: Boolean = true,
+    val trustedRelaysViaTor: Boolean = false,
+    val urlPreviewsViaTor: Boolean = false,
+    val profilePicsViaTor: Boolean = false,
+    val imagesViaTor: Boolean = false,
+    val videosViaTor: Boolean = false,
+    val moneyOperationsViaTor: Boolean = false,
+    val nip05VerificationsViaTor: Boolean = false,
+    val mediaUploadsViaTor: Boolean = false,
+)
+
+enum class TorType(
+    val screenCode: Int,
+    val resourceId: StringResource,
+) {
+    OFF(0, Res.string.tor_off),
+    INTERNAL(1, Res.string.tor_internal),
+    EXTERNAL(2, Res.string.tor_external),
+}
+
+fun parseTorType(code: Int?): TorType =
+    when (code) {
+        TorType.OFF.screenCode -> TorType.OFF
+        TorType.INTERNAL.screenCode -> TorType.INTERNAL
+        TorType.EXTERNAL.screenCode -> TorType.EXTERNAL
+        else -> TorType.INTERNAL
+    }
+
+enum class TorPresetType(
+    val screenCode: Int,
+    val resourceId: StringResource,
+    val explainerId: StringResource,
+) {
+    ONLY_WHEN_NEEDED(0, Res.string.tor_when_needed, Res.string.tor_when_needed_explainer),
+    DEFAULT(1, Res.string.tor_default, Res.string.tor_default_explainer),
+    SMALL_PAYLOADS(2, Res.string.tor_small_payloads, Res.string.tor_small_payloads_explainer),
+    FULL_PRIVACY(3, Res.string.tor_full_privacy, Res.string.tor_full_privacy_explainer),
+    CUSTOM(4, Res.string.tor_custom, Res.string.tor_custom_explainer),
+}
+
+fun parseTorPresetType(code: Int?): TorPresetType =
+    when (code) {
+        TorPresetType.ONLY_WHEN_NEEDED.screenCode -> TorPresetType.ONLY_WHEN_NEEDED
+        TorPresetType.DEFAULT.screenCode -> TorPresetType.DEFAULT
+        TorPresetType.SMALL_PAYLOADS.screenCode -> TorPresetType.SMALL_PAYLOADS
+        TorPresetType.FULL_PRIVACY.screenCode -> TorPresetType.FULL_PRIVACY
+        else -> TorPresetType.CUSTOM
+    }
+
+fun isPreset(
+    torSettings: TorSettings,
+    preset: TorSettings,
+): Boolean =
+    torSettings.onionRelaysViaTor == preset.onionRelaysViaTor &&
+        torSettings.dmRelaysViaTor == preset.dmRelaysViaTor &&
+        torSettings.newRelaysViaTor == preset.newRelaysViaTor &&
+        torSettings.trustedRelaysViaTor == preset.trustedRelaysViaTor &&
+        torSettings.urlPreviewsViaTor == preset.urlPreviewsViaTor &&
+        // torSettings.profilePicsViaTor == preset.profilePicsViaTor &&
+        torSettings.imagesViaTor == preset.imagesViaTor &&
+        torSettings.videosViaTor == preset.videosViaTor &&
+        torSettings.moneyOperationsViaTor == preset.moneyOperationsViaTor &&
+        torSettings.nip05VerificationsViaTor == preset.nip05VerificationsViaTor &&
+        torSettings.mediaUploadsViaTor == preset.mediaUploadsViaTor
+
+fun whichPreset(torSettings: TorSettings): TorPresetType {
+    if (isPreset(torSettings, torOnlyWhenNeededPreset)) return TorPresetType.ONLY_WHEN_NEEDED
+    if (isPreset(torSettings, torDefaultPreset)) return TorPresetType.DEFAULT
+    if (isPreset(torSettings, torSmallPayloadsPreset)) return TorPresetType.SMALL_PAYLOADS
+    if (isPreset(torSettings, torFullyPrivate)) return TorPresetType.FULL_PRIVACY
+    return TorPresetType.CUSTOM
+}
+
+val torOnlyWhenNeededPreset =
+    TorSettings(
+        onionRelaysViaTor = true,
+        dmRelaysViaTor = false,
+        newRelaysViaTor = false,
+        trustedRelaysViaTor = false,
+        urlPreviewsViaTor = false,
+        profilePicsViaTor = false,
+        imagesViaTor = false,
+        videosViaTor = false,
+        moneyOperationsViaTor = false,
+        nip05VerificationsViaTor = false,
+        mediaUploadsViaTor = false,
+    )
+val torDefaultPreset =
+    TorSettings(
+        onionRelaysViaTor = true,
+        dmRelaysViaTor = true,
+        newRelaysViaTor = true,
+        trustedRelaysViaTor = false,
+        urlPreviewsViaTor = false,
+        profilePicsViaTor = false,
+        imagesViaTor = false,
+        videosViaTor = false,
+        moneyOperationsViaTor = false,
+        nip05VerificationsViaTor = false,
+        mediaUploadsViaTor = false,
+    )
+val torSmallPayloadsPreset =
+    TorSettings(
+        onionRelaysViaTor = true,
+        dmRelaysViaTor = true,
+        newRelaysViaTor = true,
+        trustedRelaysViaTor = true,
+        urlPreviewsViaTor = true,
+        profilePicsViaTor = true,
+        imagesViaTor = false,
+        videosViaTor = false,
+        moneyOperationsViaTor = true,
+        nip05VerificationsViaTor = true,
+        mediaUploadsViaTor = false,
+    )
+val torFullyPrivate =
+    TorSettings(
+        onionRelaysViaTor = true,
+        dmRelaysViaTor = true,
+        newRelaysViaTor = true,
+        trustedRelaysViaTor = true,
+        urlPreviewsViaTor = true,
+        profilePicsViaTor = true,
+        imagesViaTor = true,
+        videosViaTor = true,
+        moneyOperationsViaTor = true,
+        nip05VerificationsViaTor = true,
+        mediaUploadsViaTor = true,
+    )


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

Converts `R.string` integer resource IDs → `Res.string` (`StringResource`) in data/enum classes whose only non-commons dependency was `amethyst.R`, then moves them to the commons module.

Previous batches: #2230-#2273, #2282.

### Changes
- **compose-resources**: changed from `implementation` to `api` in commons so consumers can work with `StringResource` types
- Added 17 string resources to commons `strings.xml` (voice presets + tor settings)

### Files moved to commons:
- `VoicePreset.kt` — `labelRes: Int` → `labelRes: StringResource`
- `TorSettings.kt` (includes `TorSettings`, `TorType`, `TorPresetType`, preset vals, helper functions) — `resourceId: Int` / `explainerId: Int` → `StringResource`

### Callers updated:
- `VoicePresetSelector.kt` — `stringRes(context, preset.labelRes)` → `stringResource(preset.labelRes)`
- `TorSettingsDialog.kt` — `stringRes(TorType.X.resourceId)` → `stringResource(TorType.X.resourceId)`

### Skipped:
- `RelayListCollection.kt` — uses `context.getString(section.titleRes)` in non-composable `RelayExporter`, which requires `Int` resource IDs. Needs a different migration approach.