### PR TITLE
feat: add IHttpClientBuilder interface to commons for KMP

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/privacyOptions/IRoleBasedHttpClientBuilder.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/privacyOptions/IRoleBasedHttpClientBuilder.kt
@@ -20,11 +20,18 @@
  */
 package com.vitorpamplona.amethyst.model.privacyOptions
 
+import com.vitorpamplona.amethyst.commons.network.IHttpClientBuilder
 import okhttp3.OkHttpClient
 
-interface IRoleBasedHttpClientBuilder {
-    fun proxyPortForVideo(url: String): Int?
-
+/**
+ * Android/JVM-specific extension of [IHttpClientBuilder] that exposes
+ * [OkHttpClient] return types for backward compatibility.
+ *
+ * The [IHttpClientBuilder] methods are implemented by delegating to the
+ * `okHttpClientFor*` methods, since [PlatformHttpClient] is a typealias
+ * for [OkHttpClient] on JVM/Android.
+ */
+interface IRoleBasedHttpClientBuilder : IHttpClientBuilder {
     fun okHttpClientForNip05(url: String): OkHttpClient
 
     fun okHttpClientForUploads(url: String): OkHttpClient
@@ -38,4 +45,19 @@ interface IRoleBasedHttpClientBuilder {
     fun okHttpClientForPreview(url: String): OkHttpClient
 
     fun okHttpClientForPushRegistration(url: String): OkHttpClient
+
+    // Default implementations bridge IHttpClientBuilder to the okHttp-specific methods
+    override fun httpClientForNip05(url: String): OkHttpClient = okHttpClientForNip05(url)
+
+    override fun httpClientForUploads(url: String): OkHttpClient = okHttpClientForUploads(url)
+
+    override fun httpClientForImage(url: String): OkHttpClient = okHttpClientForImage(url)
+
+    override fun httpClientForVideo(url: String): OkHttpClient = okHttpClientForVideo(url)
+
+    override fun httpClientForMoney(url: String): OkHttpClient = okHttpClientForMoney(url)
+
+    override fun httpClientForPreview(url: String): OkHttpClient = okHttpClientForPreview(url)
+
+    override fun httpClientForPushRegistration(url: String): OkHttpClient = okHttpClientForPushRegistration(url)
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/network/IHttpClientBuilder.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/network/IHttpClientBuilder.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.network
+
+/**
+ * Platform-agnostic interface for role-based HTTP client construction.
+ *
+ * Different network operations (images, video, money, NIP-05, etc.) may
+ * require different proxy/Tor settings. This interface abstracts the
+ * role-based routing so that composables migrated to common code can
+ * accept it via [IAccountViewModel] without depending on OkHttp directly.
+ *
+ * On JVM/Android, [PlatformHttpClient] resolves to [okhttp3.OkHttpClient].
+ * On iOS, it will resolve to the appropriate native HTTP client.
+ */
+interface IHttpClientBuilder {
+    fun proxyPortForVideo(url: String): Int?
+
+    fun httpClientForNip05(url: String): PlatformHttpClient
+
+    fun httpClientForUploads(url: String): PlatformHttpClient
+
+    fun httpClientForImage(url: String): PlatformHttpClient
+
+    fun httpClientForVideo(url: String): PlatformHttpClient
+
+    fun httpClientForMoney(url: String): PlatformHttpClient
+
+    fun httpClientForPreview(url: String): PlatformHttpClient
+
+    fun httpClientForPushRegistration(url: String): PlatformHttpClient
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/network/PlatformHttpClient.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/network/PlatformHttpClient.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.network
+
+/**
+ * Platform-specific HTTP client type.
+ *
+ * On JVM/Android this maps to [okhttp3.OkHttpClient].
+ * On iOS this will map to the appropriate native HTTP client.
+ */
+expect class PlatformHttpClient

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/network/PlatformHttpClient.jvmAndroid.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/network/PlatformHttpClient.jvmAndroid.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.network
+
+import okhttp3.OkHttpClient
+
+actual typealias PlatformHttpClient = OkHttpClient


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

## What

Adds a platform-agnostic `IHttpClientBuilder` interface to commons, abstracting role-based HTTP client construction for different network operations (images, video, money, NIP-05, uploads, previews, push registration).

## New files

- **`IHttpClientBuilder`** (commonMain) — interface with `httpClientFor*` methods returning `PlatformHttpClient`
- **`PlatformHttpClient`** (expect/actual) — maps to `OkHttpClient` on JVM/Android, ready for iOS actual when targets are added

## Backward compatibility

`IRoleBasedHttpClientBuilder` now extends `IHttpClientBuilder`, bridging `okHttpClientFor*` → `httpClientFor*` via default implementations. **No existing call sites need to change.**

## What this unblocks

Composables that reference `accountViewModel.httpClientBuilder` can migrate to `IAccountViewModel` with a property typed as `IHttpClientBuilder` (from commons), removing the Android-module dependency.