### PR TITLE
feat: expand IAccount interface with bookmark, payment, zap, and action methods (v5)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -334,8 +334,8 @@ class Account(
     val hiddenUsers = HiddenUsersState(muteList.flow, blockPeopleList.flow, scope, settings)
 
     val labeledBookmarkLists = LabeledBookmarkListsState(signer, cache, scope)
-    val oldBookmarkState = OldBookmarkListState(signer, cache, scope)
-    val bookmarkState = BookmarkListState(signer, cache, scope)
+    override val oldBookmarkState = OldBookmarkListState(signer, cache, scope)
+    override val bookmarkState = BookmarkListState(signer, cache, scope)
     val pinState = PinListState(signer, cache, scope)
     val emoji = EmojiPackState(signer, cache, scope)
 
@@ -541,7 +541,7 @@ class Account(
 
     private suspend fun sendNewAppSpecificData() = sendMyPublicAndPrivateOutbox(appSpecific.saveNewAppSpecificData())
 
-    suspend fun reactTo(
+    override suspend fun reactTo(
         note: Note,
         reaction: String,
     ) = ReactionAction.reactTo(
@@ -601,12 +601,12 @@ class Account(
         toUserPubHex = toUser?.pubkeyHex,
     )
 
-    suspend fun calculateIfNoteWasZappedByAccount(
+    override suspend fun calculateIfNoteWasZappedByAccount(
         zappedNote: Note?,
         afterTimeInSeconds: Long,
     ): Boolean = zappedNote?.isZappedBy(userProfile(), afterTimeInSeconds, this) == true
 
-    suspend fun calculateZappedAmount(zappedNote: Note): BigDecimal = zappedNote.zappedAmountWithNWCPayments(nip47SignerState)
+    override suspend fun calculateZappedAmount(zappedNote: Note): BigDecimal = zappedNote.zappedAmountWithNWCPayments(nip47SignerState)
 
     suspend fun sendNwcRequest(
         request: Request,
@@ -652,21 +652,21 @@ class Account(
         return zapRequest
     }
 
-    suspend fun report(
+    override suspend fun report(
         note: Note,
         type: ReportType,
-        content: String = "",
+        content: String,
     ) = sendMyPublicAndPrivateOutbox(ReportAction.report(note, type, content, userProfile(), signer))
 
-    suspend fun report(
+    override suspend fun report(
         user: User,
         type: ReportType,
-        content: String = "",
+        content: String,
     ) = sendMyPublicAndPrivateOutbox(ReportAction.report(user, type, content, userProfile(), signer))
 
-    suspend fun delete(note: Note) = delete(listOf(note))
+    override suspend fun delete(note: Note) = delete(listOf(note))
 
-    suspend fun delete(notes: List<Note>) {
+    override suspend fun delete(notes: List<Note>) {
         if (!isWriteable()) return
 
         val myNotes = notes.filter { it.author == userProfile() && it.event != null }
@@ -715,7 +715,7 @@ class Account(
         alt: String,
     ) = blossomServers.createBlossomDeleteAuth(hash, alt)
 
-    suspend fun boost(note: Note) {
+    override suspend fun boost(note: Note) {
         RepostAction.repost(note, signer)?.let { event ->
             client.publish(event, computeMyReactionToNote(note, event))
             cache.justConsumeMyOwnEvent(event)
@@ -1981,7 +1981,7 @@ class Account(
         delete(note)
     }
 
-    suspend fun addBookmark(
+    override suspend fun addBookmark(
         note: Note,
         isPrivate: Boolean,
     ) {
@@ -1990,7 +1990,7 @@ class Account(
         sendMyPublicAndPrivateOutbox(bookmarkState.addBookmark(note, isPrivate))
     }
 
-    suspend fun removeBookmark(
+    override suspend fun removeBookmark(
         note: Note,
         isPrivate: Boolean,
     ) {
@@ -2002,7 +2002,7 @@ class Account(
         }
     }
 
-    suspend fun removeBookmark(note: Note) {
+    override suspend fun removeBookmark(note: Note) {
         if (!isWriteable() || note.isDraft()) return
 
         val event = bookmarkState.removeBookmark(note)
@@ -2015,7 +2015,7 @@ class Account(
      * Creates a bookmark event without sending it.
      * Returns the event and target relays for tracked broadcasting.
      */
-    suspend fun createAddBookmarkEvent(
+    override suspend fun createAddBookmarkEvent(
         note: Note,
         isPrivate: Boolean,
     ): Pair<Event, Set<NormalizedRelayUrl>>? {
@@ -2031,7 +2031,7 @@ class Account(
      * Creates a remove bookmark event without sending it.
      * Returns the event and target relays for tracked broadcasting.
      */
-    suspend fun createRemoveBookmarkEvent(
+    override suspend fun createRemoveBookmarkEvent(
         note: Note,
         isPrivate: Boolean,
     ): Pair<Event, Set<NormalizedRelayUrl>>? {
@@ -2362,7 +2362,7 @@ class Account(
 
     suspend fun sendBlossomServersList(servers: List<String>) = sendMyPublicAndPrivateOutbox(blossomServers.saveBlossomServersList(servers))
 
-    suspend fun savePaymentTargets(targets: List<PaymentTarget>) = sendMyPublicAndPrivateOutbox(paymentTargetsState.savePaymentTargets(targets))
+    override suspend fun savePaymentTargets(targets: List<PaymentTarget>) = sendMyPublicAndPrivateOutbox(paymentTargetsState.savePaymentTargets(targets))
 
     fun markAsRead(
         route: String,

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
@@ -21,7 +21,12 @@
 package com.vitorpamplona.amethyst.commons.model
 
 import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupList
+import com.vitorpamplona.amethyst.commons.model.nip51Lists.BookmarkListState
+import com.vitorpamplona.amethyst.commons.model.nip51Lists.OldBookmarkListState
 import com.vitorpamplona.amethyst.commons.model.privateChats.ChatroomList
+import com.vitorpamplona.quartz.experimental.nipA3.PaymentTarget
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import com.vitorpamplona.quartz.nip04Dm.messages.PrivateDmEvent
@@ -31,9 +36,11 @@ import com.vitorpamplona.quartz.nip47WalletConnect.events.LnZapPaymentRequestEve
 import com.vitorpamplona.quartz.nip47WalletConnect.events.LnZapPaymentResponseEvent
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Request
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Response
+import com.vitorpamplona.quartz.nip56Reports.ReportType
 import com.vitorpamplona.quartz.nip57Zaps.IPrivateZapsDecryptionCache
 import com.vitorpamplona.quartz.nip59Giftwrap.wraps.GiftWrapEvent
 import com.vitorpamplona.quartz.utils.DualCase
+import java.math.BigDecimal
 
 /**
  * Interface for NIP-47 wallet connect signer state.
@@ -119,4 +126,86 @@ interface IAccount {
 
     /** Broadcast pre-created gift wraps (e.g. reactions within group DMs) */
     suspend fun sendGiftWraps(wraps: List<GiftWrapEvent>)
+
+    // --- Bookmark domain (v5) ---
+
+    /** Current bookmark list state (NIP-51 kind 10003) */
+    val bookmarkState: BookmarkListState
+
+    /** Old/legacy bookmark list state (NIP-51 kind 30001) */
+    val oldBookmarkState: OldBookmarkListState
+
+    /** Add a note to bookmarks (public or private) */
+    suspend fun addBookmark(
+        note: Note,
+        isPrivate: Boolean,
+    )
+
+    /** Remove a note from bookmarks (public or private) */
+    suspend fun removeBookmark(
+        note: Note,
+        isPrivate: Boolean,
+    )
+
+    /** Remove a note from all bookmarks (public and private) */
+    suspend fun removeBookmark(note: Note)
+
+    /** Create bookmark add event without sending (for tracked broadcasting) */
+    suspend fun createAddBookmarkEvent(
+        note: Note,
+        isPrivate: Boolean,
+    ): Pair<Event, Set<NormalizedRelayUrl>>?
+
+    /** Create bookmark remove event without sending (for tracked broadcasting) */
+    suspend fun createRemoveBookmarkEvent(
+        note: Note,
+        isPrivate: Boolean,
+    ): Pair<Event, Set<NormalizedRelayUrl>>?
+
+    // --- Payment targets domain (v5) ---
+
+    /** Save payment targets (NIP-A3) */
+    suspend fun savePaymentTargets(targets: List<PaymentTarget>)
+
+    // --- Zap domain (v5) ---
+
+    /** Check if a note was zapped by this account */
+    suspend fun calculateIfNoteWasZappedByAccount(
+        zappedNote: Note?,
+        afterTimeInSeconds: Long,
+    ): Boolean
+
+    /** Calculate total zapped amount for a note */
+    suspend fun calculateZappedAmount(zappedNote: Note): BigDecimal
+
+    // --- Core actions (v5) ---
+
+    /** React to a note with the given reaction string */
+    suspend fun reactTo(
+        note: Note,
+        reaction: String,
+    )
+
+    /** Boost/repost a note */
+    suspend fun boost(note: Note)
+
+    /** Delete a single note */
+    suspend fun delete(note: Note)
+
+    /** Delete multiple notes */
+    suspend fun delete(notes: List<Note>)
+
+    /** Report a note */
+    suspend fun report(
+        note: Note,
+        type: ReportType,
+        content: String = "",
+    )
+
+    /** Report a user */
+    suspend fun report(
+        user: User,
+        type: ReportType,
+        content: String = "",
+    )
 }


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

Adds **15 new abstract members** to the `IAccount` interface in commons, with corresponding `override` modifiers on `Account`:

### Bookmark domain
- `bookmarkState: BookmarkListState` — current bookmark list (already in commons)
- `oldBookmarkState: OldBookmarkListState` — legacy bookmarks (already in commons)
- `addBookmark(note, isPrivate)`
- `removeBookmark(note, isPrivate)` / `removeBookmark(note)`
- `createAddBookmarkEvent(note, isPrivate)` — for tracked broadcasting
- `createRemoveBookmarkEvent(note, isPrivate)` — for tracked broadcasting

### Payment targets
- `savePaymentTargets(targets: List<PaymentTarget>)`

### Zap domain
- `calculateIfNoteWasZappedByAccount(zappedNote, afterTimeInSeconds)`
- `calculateZappedAmount(zappedNote)`

### Core actions
- `reactTo(note, reaction)`
- `boost(note)`
- `delete(note)` / `delete(notes)`
- `report(note, type, content)` / `report(user, type, content)`

These unblock migration of BookmarkGroupVM (partially — still needs `labeledBookmarkLists`), PaymentTargetsVM (partially — still needs `paymentTargetsState.flow`), ZapPollNoteVM, and several other VMs that use core actions.

Follows the same pattern as #2237 (v1), #2260 (v2), #2278 (v3), #2280 (v4).