### PR TITLE
feat: move BookmarkType, IExpiration, IZapRaiser, AdditiveComplexFeedFilter to commons

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/AdditiveComplexFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/AdditiveComplexFeedFilter.kt
@@ -20,9 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.dal
 
-abstract class AdditiveComplexFeedFilter<T, U> : FeedFilter<T>() {
-    abstract fun updateListWith(
-        oldList: List<T>,
-        newItems: Set<U>,
-    ): List<T>
-}
+// Re-export from commons for backwards compatibility
+typealias AdditiveComplexFeedFilter<T, U> = com.vitorpamplona.amethyst.commons.ui.feeds.AdditiveComplexFeedFilter<T, U>

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/zapraiser/IZapRaiser.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/zapraiser/IZapRaiser.kt
@@ -20,12 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.note.creators.zapraiser
 
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.Stable
-
-@Stable
-interface IZapRaiser {
-    val zapRaiserAmount: MutableState<Long?>
-
-    fun updateZapRaiserAmount(newAmount: Long?)
-}
+// Re-export from commons for backwards compatibility
+typealias IZapRaiser = com.vitorpamplona.amethyst.commons.ui.note.creators.zapraiser.IZapRaiser

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/BookmarkType.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/BookmarkType.kt
@@ -20,8 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups
 
-enum class BookmarkType {
-    PostBookmark,
-
-    ArticleBookmark,
-}
+// Re-export from commons for backwards compatibility
+typealias BookmarkType = com.vitorpamplona.amethyst.commons.ui.bookmarks.BookmarkType

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/bookmarks/BookmarkType.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/bookmarks/BookmarkType.kt
@@ -18,7 +18,10 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.expiration
+package com.vitorpamplona.amethyst.commons.ui.bookmarks
 
-// Re-export from commons for backwards compatibility
-typealias IExpiration = com.vitorpamplona.amethyst.commons.ui.note.creators.expiration.IExpiration
+enum class BookmarkType {
+    PostBookmark,
+
+    ArticleBookmark,
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/AdditiveComplexFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/AdditiveComplexFeedFilter.kt
@@ -18,7 +18,11 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.expiration
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-// Re-export from commons for backwards compatibility
-typealias IExpiration = com.vitorpamplona.amethyst.commons.ui.note.creators.expiration.IExpiration
+abstract class AdditiveComplexFeedFilter<T, U> : FeedFilter<T>() {
+    abstract fun updateListWith(
+        oldList: List<T>,
+        newItems: Set<U>,
+    ): List<T>
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/creators/expiration/IExpiration.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/creators/expiration/IExpiration.kt
@@ -18,7 +18,11 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.expiration
+package com.vitorpamplona.amethyst.commons.ui.note.creators.expiration
 
-// Re-export from commons for backwards compatibility
-typealias IExpiration = com.vitorpamplona.amethyst.commons.ui.note.creators.expiration.IExpiration
+import androidx.compose.runtime.Stable
+
+@Stable
+interface IExpiration {
+    var expirationDate: Long
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/creators/zapraiser/IZapRaiser.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/creators/zapraiser/IZapRaiser.kt
@@ -18,7 +18,14 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.expiration
+package com.vitorpamplona.amethyst.commons.ui.note.creators.zapraiser
 
-// Re-export from commons for backwards compatibility
-typealias IExpiration = com.vitorpamplona.amethyst.commons.ui.note.creators.expiration.IExpiration
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.Stable
+
+@Stable
+interface IZapRaiser {
+    val zapRaiserAmount: MutableState<Long?>
+
+    fun updateZapRaiserAmount(newAmount: Long?)
+}


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

Moves thin types/interfaces from the amethyst module to commons:
- **BookmarkType** enum — cross-platform bookmark categorization
- **IExpiration** interface — post expiration date for creators
- **IZapRaiser** interface — zap raiser UI state
- **AdditiveComplexFeedFilter** abstract class — extends FeedFilter (already in commons)

Backward-compatible typealiases left at original locations. All existing callers continue to work unchanged.

### What was blocked
The original target (FilterAssemblerSubscription composables) couldn't move because they reference FilterAssembler classes that depend on `LocalCache`, `SincePerRelayMap`, and other amethyst-only types. TorServiceStatus (sealed class) and TranslationConfig (data class with nullable props) were also blocked due to typealias limitations with sealed class members and cross-module smart casts respectively.