### PR TITLE
feat: move TranslationConfig to commons with smart cast fixes

### DIFF
--- a/amethyst/src/play/java/com/vitorpamplona/amethyst/ui/components/TranslatableRichTextViewer.kt
+++ b/amethyst/src/play/java/com/vitorpamplona/amethyst/ui/components/TranslatableRichTextViewer.kt
@@ -140,14 +140,17 @@ private fun RenderTextWithTranslateOptions(
     Column {
         displayText(toBeViewed)
 
+        val sourceLang = translatedTextState.sourceLang
+        val targetLang = translatedTextState.targetLang
+
         if (
-            translatedTextState.sourceLang != null &&
-            translatedTextState.targetLang != null &&
-            translatedTextState.sourceLang != translatedTextState.targetLang
+            sourceLang != null &&
+            targetLang != null &&
+            sourceLang != targetLang
         ) {
             TranslationMessage(
-                translatedTextState.sourceLang,
-                translatedTextState.targetLang,
+                sourceLang,
+                targetLang,
                 translationMessageModifier,
                 accountViewModel,
             ) {
@@ -365,18 +368,21 @@ fun TranslateAndWatchLanguageChanges(
                     accountViewModel.translateTo(),
                 ).addOnCompleteListener { task ->
                     if (task.isSuccessful && !content.equals(task.result.result, true)) {
-                        if (task.result.sourceLang != null && task.result.targetLang != null) {
+                        val resultSourceLang = task.result.sourceLang
+                        val resultTargetLang = task.result.targetLang
+
+                        if (resultSourceLang != null && resultTargetLang != null) {
                             val preference =
                                 accountViewModel.account.settings.preferenceBetween(
-                                    task.result.sourceLang!!,
-                                    task.result.targetLang!!,
+                                    resultSourceLang,
+                                    resultTargetLang,
                                 )
                             val newConfig =
                                 TranslationConfig(
                                     result = task.result.result,
-                                    sourceLang = task.result.sourceLang,
-                                    targetLang = task.result.targetLang,
-                                    showOriginal = preference == task.result.sourceLang,
+                                    sourceLang = resultSourceLang,
+                                    targetLang = resultTargetLang,
+                                    showOriginal = preference == resultSourceLang,
                                 )
 
                             onTranslated(newConfig)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/compose/TranslationConfig.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/compose/TranslationConfig.kt
@@ -18,6 +18,14 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.components
+package com.vitorpamplona.amethyst.commons.compose
 
-typealias TranslationConfig = com.vitorpamplona.amethyst.commons.compose.TranslationConfig
+import androidx.compose.runtime.Immutable
+
+@Immutable
+data class TranslationConfig(
+    val result: String?,
+    val sourceLang: String?,
+    val targetLang: String?,
+    val showOriginal: Boolean,
+)


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

Moves `TranslationConfig` data class from `amethyst` module to `commons/compose`, replacing the original with a typealias for backward compatibility.

Fixes cross-module smart cast issues in `TranslatableRichTextViewer` by introducing local vals for nullable property access (`sourceLang`, `targetLang`). This prevents "smart cast impossible, property declared in different module" compiler errors that arise when accessing nullable properties through a typealias from another module.

**Changes:**
- New: `commons/.../compose/TranslationConfig.kt` (the actual data class)
- Modified: `amethyst/.../TranslationConfig.kt` → typealias
- Modified: `TranslatableRichTextViewer.kt` → 2 smart cast fixes (local vals for nullable fields)

Pattern documented for future data class migrations.