### PR TITLE
feat: move TorServiceStatus sealed class to commons

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/RelayProxyClientConnector.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/RelayProxyClientConnector.kt
@@ -20,12 +20,12 @@
  */
 package com.vitorpamplona.amethyst.service.relayClient
 
+import com.vitorpamplona.amethyst.commons.tor.TorServiceStatus
 import com.vitorpamplona.amethyst.model.torState.TorRelayEvaluation
 import com.vitorpamplona.amethyst.service.connectivity.ConnectivityManager
 import com.vitorpamplona.amethyst.service.connectivity.ConnectivityStatus
 import com.vitorpamplona.amethyst.service.okhttp.DualHttpClientManagerForRelays
 import com.vitorpamplona.amethyst.ui.tor.TorManager
-import com.vitorpamplona.amethyst.ui.tor.TorServiceStatus
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CoroutineScope

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorManager.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.ui.tor
 
 import android.content.Context
+import com.vitorpamplona.amethyst.commons.tor.TorServiceStatus
 import com.vitorpamplona.amethyst.model.preferences.TorSharedPreferences
 import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CoroutineScope

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorService.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorService.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.ui.tor
 
 import android.content.Context
+import com.vitorpamplona.amethyst.commons.tor.TorServiceStatus
 import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/tor/TorServiceStatus.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/tor/TorServiceStatus.kt
@@ -18,14 +18,14 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.tor
+package com.vitorpamplona.amethyst.commons.tor
 
 sealed class TorServiceStatus {
     data class Active(
         val port: Int,
     ) : TorServiceStatus()
 
-    object Off : TorServiceStatus()
+    data object Off : TorServiceStatus()
 
-    object Connecting : TorServiceStatus()
+    data object Connecting : TorServiceStatus()
 }


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

Moves `TorServiceStatus` sealed class from `amethyst/ui/tor` to `commons/tor` with **direct consumer imports** (not typealiases — typealiases break `is`-checks for nested sealed class members).

### Changes
- Moved `TorServiceStatus` to `commons/src/commonMain/kotlin/.../commons/tor/TorServiceStatus.kt`
- Updated package from `com.vitorpamplona.amethyst.ui.tor` → `com.vitorpamplona.amethyst.commons.tor`
- Updated 3 consumers to import directly from commons:
  - `TorManager.kt` — added explicit import
  - `TorService.kt` — added explicit import  
  - `RelayProxyClientConnector.kt` — updated import path
- Changed `object` to `data object` for `Off` and `Connecting` (KMP best practice)

Similar approach to #2284 (GenericLoadable + UrlPreviewState).