### PR TITLE
feat: add non-inline signer wrapper methods to IAccount

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -541,7 +541,7 @@ class Account(
 
     private suspend fun sendNewAppSpecificData() = sendMyPublicAndPrivateOutbox(appSpecific.saveNewAppSpecificData())
 
-    suspend fun reactTo(
+    override suspend fun reactTo(
         note: Note,
         reaction: String,
     ) = ReactionAction.reactTo(
@@ -652,21 +652,21 @@ class Account(
         return zapRequest
     }
 
-    suspend fun report(
+    override suspend fun report(
         note: Note,
         type: ReportType,
-        content: String = "",
+        content: String,
     ) = sendMyPublicAndPrivateOutbox(ReportAction.report(note, type, content, userProfile(), signer))
 
-    suspend fun report(
+    override suspend fun report(
         user: User,
         type: ReportType,
-        content: String = "",
+        content: String,
     ) = sendMyPublicAndPrivateOutbox(ReportAction.report(user, type, content, userProfile(), signer))
 
-    suspend fun delete(note: Note) = delete(listOf(note))
+    override suspend fun delete(note: Note) = delete(listOf(note))
 
-    suspend fun delete(notes: List<Note>) {
+    override suspend fun delete(notes: List<Note>) {
         if (!isWriteable()) return
 
         val myNotes = notes.filter { it.author == userProfile() && it.event != null }
@@ -715,7 +715,7 @@ class Account(
         alt: String,
     ) = blossomServers.createBlossomDeleteAuth(hash, alt)
 
-    suspend fun boost(note: Note) {
+    override suspend fun boost(note: Note) {
         RepostAction.repost(note, signer)?.let { event ->
             client.publish(event, computeMyReactionToNote(note, event))
             cache.justConsumeMyOwnEvent(event)
@@ -949,7 +949,7 @@ class Account(
         }
     }
 
-    suspend fun broadcast(note: Note) {
+    override suspend fun broadcast(note: Note) {
         note.event?.let { noteEvent ->
             if (noteEvent is WrappedEvent && noteEvent.host != null) {
                 // download the event and send it.
@@ -979,31 +979,31 @@ class Account(
 
     fun upgradeAttestations() = otsState.upgradeAttestationsIfNeeded(::sendAutomatic)
 
-    suspend fun follow(users: List<User>) = sendMyPublicAndPrivateOutbox(kind3FollowList.follow(users))
+    override suspend fun follow(users: List<User>) = sendMyPublicAndPrivateOutbox(kind3FollowList.follow(users))
 
-    suspend fun follow(user: User) = sendMyPublicAndPrivateOutbox(kind3FollowList.follow(user))
+    override suspend fun follow(user: User) = sendMyPublicAndPrivateOutbox(kind3FollowList.follow(user))
 
-    suspend fun unfollow(user: User) = sendMyPublicAndPrivateOutbox(kind3FollowList.unfollow(user))
+    override suspend fun unfollow(user: User) = sendMyPublicAndPrivateOutbox(kind3FollowList.unfollow(user))
 
-    suspend fun follow(channel: PublicChatChannel) = sendMyPublicAndPrivateOutbox(publicChatList.follow(channel))
+    override suspend fun follow(channel: PublicChatChannel) = sendMyPublicAndPrivateOutbox(publicChatList.follow(channel))
 
-    suspend fun unfollow(channel: PublicChatChannel) = sendMyPublicAndPrivateOutbox(publicChatList.unfollow(channel))
+    override suspend fun unfollow(channel: PublicChatChannel) = sendMyPublicAndPrivateOutbox(publicChatList.unfollow(channel))
 
-    suspend fun follow(channel: EphemeralChatChannel) = sendMyPublicAndPrivateOutbox(ephemeralChatList.follow(channel))
+    override suspend fun follow(channel: EphemeralChatChannel) = sendMyPublicAndPrivateOutbox(ephemeralChatList.follow(channel))
 
-    suspend fun unfollow(channel: EphemeralChatChannel) = sendMyPublicAndPrivateOutbox(ephemeralChatList.unfollow(channel))
+    override suspend fun unfollow(channel: EphemeralChatChannel) = sendMyPublicAndPrivateOutbox(ephemeralChatList.unfollow(channel))
 
-    suspend fun follow(community: AddressableNote) = sendMyPublicAndPrivateOutbox(communityList.follow(community))
+    override suspend fun follow(community: AddressableNote) = sendMyPublicAndPrivateOutbox(communityList.follow(community))
 
-    suspend fun unfollow(community: AddressableNote) = sendMyPublicAndPrivateOutbox(communityList.unfollow(community))
+    override suspend fun unfollow(community: AddressableNote) = sendMyPublicAndPrivateOutbox(communityList.unfollow(community))
 
-    suspend fun followHashtag(tag: String) = sendMyPublicAndPrivateOutbox(hashtagList.follow(tag))
+    override suspend fun followHashtag(tag: String) = sendMyPublicAndPrivateOutbox(hashtagList.follow(tag))
 
-    suspend fun unfollowHashtag(tag: String) = sendMyPublicAndPrivateOutbox(hashtagList.unfollow(tag))
+    override suspend fun unfollowHashtag(tag: String) = sendMyPublicAndPrivateOutbox(hashtagList.unfollow(tag))
 
-    suspend fun followGeohash(geohash: String) = sendMyPublicAndPrivateOutbox(geohashList.follow(geohash))
+    override suspend fun followGeohash(geohash: String) = sendMyPublicAndPrivateOutbox(geohashList.follow(geohash))
 
-    suspend fun unfollowGeohash(geohash: String) = sendMyPublicAndPrivateOutbox(geohashList.unfollow(geohash))
+    override suspend fun unfollowGeohash(geohash: String) = sendMyPublicAndPrivateOutbox(geohashList.unfollow(geohash))
 
     suspend fun approveCommunityPost(
         post: Note,
@@ -1981,7 +1981,7 @@ class Account(
         delete(note)
     }
 
-    suspend fun addBookmark(
+    override suspend fun addBookmark(
         note: Note,
         isPrivate: Boolean,
     ) {
@@ -1990,7 +1990,7 @@ class Account(
         sendMyPublicAndPrivateOutbox(bookmarkState.addBookmark(note, isPrivate))
     }
 
-    suspend fun removeBookmark(
+    override suspend fun removeBookmark(
         note: Note,
         isPrivate: Boolean,
     ) {
@@ -2002,7 +2002,7 @@ class Account(
         }
     }
 
-    suspend fun removeBookmark(note: Note) {
+    override suspend fun removeBookmark(note: Note) {
         if (!isWriteable() || note.isDraft()) return
 
         val event = bookmarkState.removeBookmark(note)
@@ -2094,13 +2094,13 @@ class Account(
         sendMyPublicAndPrivateOutbox(newEvent)
     }
 
-    suspend fun addPin(note: Note) {
+    override suspend fun addPin(note: Note) {
         if (!isWriteable() || note.isDraft()) return
 
         sendMyPublicAndPrivateOutbox(pinState.addPin(note))
     }
 
-    suspend fun removePin(note: Note) {
+    override suspend fun removePin(note: Note) {
         if (!isWriteable() || note.isDraft()) return
 
         val event = pinState.removePin(note)
@@ -2136,20 +2136,20 @@ class Account(
         challenge: String,
     ): RelayAuthEvent = RelayAuthEvent.create(relay, challenge, signer)
 
-    suspend fun hideWord(word: String) {
+    override suspend fun hideWord(word: String) {
         sendMyPublicAndPrivateOutbox(muteList.hideWord(word))
     }
 
-    suspend fun showWord(word: String) {
+    override suspend fun showWord(word: String) {
         sendMyPublicAndPrivateOutbox(blockPeopleList.showWord(word))
         sendMyPublicAndPrivateOutbox(muteList.showWord(word))
     }
 
-    suspend fun hideUser(pubkeyHex: HexKey) {
+    override suspend fun hideUser(pubkeyHex: HexKey) {
         sendMyPublicAndPrivateOutbox(muteList.hideUser(pubkeyHex))
     }
 
-    suspend fun showUser(pubkeyHex: HexKey) {
+    override suspend fun showUser(pubkeyHex: HexKey) {
         sendMyPublicAndPrivateOutbox(blockPeopleList.showUser(pubkeyHex))
         sendMyPublicAndPrivateOutbox(muteList.showUser(pubkeyHex))
         hiddenUsers.showUser(pubkeyHex)
@@ -2327,9 +2327,9 @@ class Account(
 
     suspend fun saveRelayFeedsList(trustedRelays: List<NormalizedRelayUrl>) = sendMyPublicAndPrivateOutbox(relayFeedsList.saveRelayList(trustedRelays))
 
-    suspend fun followRelayFeed(url: NormalizedRelayUrl) = sendMyPublicAndPrivateOutbox(relayFeedsList.addRelay(url))
+    override suspend fun followRelayFeed(url: NormalizedRelayUrl) = sendMyPublicAndPrivateOutbox(relayFeedsList.addRelay(url))
 
-    suspend fun unfollowRelayFeed(url: NormalizedRelayUrl) = sendMyPublicAndPrivateOutbox(relayFeedsList.removeRelay(url))
+    override suspend fun unfollowRelayFeed(url: NormalizedRelayUrl) = sendMyPublicAndPrivateOutbox(relayFeedsList.removeRelay(url))
 
     suspend fun saveBlockedRelayList(blockedRelays: List<NormalizedRelayUrl>) = sendMyPublicAndPrivateOutbox(blockedRelayList.saveRelayList(blockedRelays))
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
@@ -20,8 +20,11 @@
  */
 package com.vitorpamplona.amethyst.commons.model
 
+import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
 import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupList
+import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatChannel
 import com.vitorpamplona.amethyst.commons.model.privateChats.ChatroomList
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import com.vitorpamplona.quartz.nip04Dm.messages.PrivateDmEvent
@@ -31,6 +34,7 @@ import com.vitorpamplona.quartz.nip47WalletConnect.events.LnZapPaymentRequestEve
 import com.vitorpamplona.quartz.nip47WalletConnect.events.LnZapPaymentResponseEvent
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Request
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Response
+import com.vitorpamplona.quartz.nip56Reports.ReportType
 import com.vitorpamplona.quartz.nip57Zaps.IPrivateZapsDecryptionCache
 import com.vitorpamplona.quartz.nip59Giftwrap.wraps.GiftWrapEvent
 import com.vitorpamplona.quartz.utils.DualCase
@@ -119,4 +123,133 @@ interface IAccount {
 
     /** Broadcast pre-created gift wraps (e.g. reactions within group DMs) */
     suspend fun sendGiftWraps(wraps: List<GiftWrapEvent>)
+
+    // =========================================================================
+    // Signer wrapper methods
+    // Non-inline suspend methods that encapsulate common launchSigner patterns.
+    // These enable gradual migration from AccountViewModel.launchSigner { ... }
+    // to direct IAccount method calls, supporting KMP/iOS usage.
+    // =========================================================================
+
+    // -- Follow / Unfollow --
+
+    /** Follow a single user */
+    suspend fun follow(user: User)
+
+    /** Follow multiple users */
+    suspend fun follow(users: List<User>)
+
+    /** Unfollow a user */
+    suspend fun unfollow(user: User)
+
+    /** Follow a community */
+    suspend fun follow(community: AddressableNote)
+
+    /** Unfollow a community */
+    suspend fun unfollow(community: AddressableNote)
+
+    /** Follow a public chat channel */
+    suspend fun follow(channel: PublicChatChannel)
+
+    /** Unfollow a public chat channel */
+    suspend fun unfollow(channel: PublicChatChannel)
+
+    /** Follow an ephemeral chat channel */
+    suspend fun follow(channel: EphemeralChatChannel)
+
+    /** Unfollow an ephemeral chat channel */
+    suspend fun unfollow(channel: EphemeralChatChannel)
+
+    /** Follow a hashtag */
+    suspend fun followHashtag(tag: String)
+
+    /** Unfollow a hashtag */
+    suspend fun unfollowHashtag(tag: String)
+
+    /** Follow a geohash */
+    suspend fun followGeohash(geohash: String)
+
+    /** Unfollow a geohash */
+    suspend fun unfollowGeohash(geohash: String)
+
+    /** Follow a relay feed */
+    suspend fun followRelayFeed(url: NormalizedRelayUrl)
+
+    /** Unfollow a relay feed */
+    suspend fun unfollowRelayFeed(url: NormalizedRelayUrl)
+
+    // -- Notes: React, Boost, Delete, Broadcast --
+
+    /** React to a note with the given reaction string */
+    suspend fun reactTo(
+        note: Note,
+        reaction: String,
+    )
+
+    /** Boost (repost) a note */
+    suspend fun boost(note: Note)
+
+    /** Delete a single note */
+    suspend fun delete(note: Note)
+
+    /** Delete multiple notes */
+    suspend fun delete(notes: List<Note>)
+
+    /** Broadcast a note to relays */
+    suspend fun broadcast(note: Note)
+
+    // -- Reporting --
+
+    /** Report a note */
+    suspend fun report(
+        note: Note,
+        type: ReportType,
+        content: String = "",
+    )
+
+    /** Report a user */
+    suspend fun report(
+        user: User,
+        type: ReportType,
+        content: String = "",
+    )
+
+    // -- Bookmarks --
+
+    /** Add a note to bookmarks */
+    suspend fun addBookmark(
+        note: Note,
+        isPrivate: Boolean,
+    )
+
+    /** Remove a note from bookmarks (specific privacy) */
+    suspend fun removeBookmark(
+        note: Note,
+        isPrivate: Boolean,
+    )
+
+    /** Remove a note from bookmarks (both public and private) */
+    suspend fun removeBookmark(note: Note)
+
+    // -- Pins --
+
+    /** Pin a note */
+    suspend fun addPin(note: Note)
+
+    /** Unpin a note */
+    suspend fun removePin(note: Note)
+
+    // -- Mute / Block --
+
+    /** Hide a word from content */
+    suspend fun hideWord(word: String)
+
+    /** Show a previously hidden word */
+    suspend fun showWord(word: String)
+
+    /** Hide a user by pubkey */
+    suspend fun hideUser(pubkeyHex: String)
+
+    /** Show a previously hidden user */
+    suspend fun showUser(pubkeyHex: String)
 }


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

`launchSigner` is an inline function on `AccountViewModel` that catches signer exceptions — it can't be on an interface. This PR adds **31 non-inline suspend methods** to `IAccount` that expose the common operations currently wrapped by `launchSigner`:

### New methods on IAccount

**Follow/Unfollow** (14 methods):
- `follow(User)`, `follow(List<User>)`, `unfollow(User)`
- `follow/unfollow(AddressableNote)` (communities)
- `follow/unfollow(PublicChatChannel)`, `follow/unfollow(EphemeralChatChannel)`
- `followHashtag`, `unfollowHashtag`, `followGeohash`, `unfollowGeohash`
- `followRelayFeed`, `unfollowRelayFeed`

**Notes** (5 methods):
- `reactTo(Note, String)`, `boost(Note)`
- `delete(Note)`, `delete(List<Note>)`, `broadcast(Note)`

**Reporting** (2 methods):
- `report(Note, ReportType, String)`, `report(User, ReportType, String)`

**Bookmarks** (3 methods):
- `addBookmark(Note, Boolean)`, `removeBookmark(Note, Boolean)`, `removeBookmark(Note)`

**Pins** (2 methods):
- `addPin(Note)`, `removePin(Note)`

**Mute/Block** (4 methods):
- `hideWord`, `showWord`, `hideUser`, `showUser`

**No callers changed** — existing `accountViewModel.launchSigner { account.xxx() }` patterns remain. Future PRs can migrate callers to use these IAccount methods directly.