### PR TITLE
feat: expand IAccountViewModel with settings, toastManager, httpClientBuilder

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/privacyOptions/IRoleBasedHttpClientBuilder.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/privacyOptions/IRoleBasedHttpClientBuilder.kt
@@ -20,11 +20,10 @@
  */
 package com.vitorpamplona.amethyst.model.privacyOptions
 
+import com.vitorpamplona.amethyst.commons.network.IHttpClientBuilder
 import okhttp3.OkHttpClient
 
-interface IRoleBasedHttpClientBuilder {
-    fun proxyPortForVideo(url: String): Int?
-
+interface IRoleBasedHttpClientBuilder : IHttpClientBuilder {
     fun okHttpClientForNip05(url: String): OkHttpClient
 
     fun okHttpClientForUploads(url: String): OkHttpClient
@@ -38,4 +37,19 @@ interface IRoleBasedHttpClientBuilder {
     fun okHttpClientForPreview(url: String): OkHttpClient
 
     fun okHttpClientForPushRegistration(url: String): OkHttpClient
+
+    // Bridge to IHttpClientBuilder (PlatformHttpClient = OkHttpClient on JVM)
+    override fun httpClientForNip05(url: String) = okHttpClientForNip05(url)
+
+    override fun httpClientForUploads(url: String) = okHttpClientForUploads(url)
+
+    override fun httpClientForImage(url: String) = okHttpClientForImage(url)
+
+    override fun httpClientForVideo(url: String) = okHttpClientForVideo(url)
+
+    override fun httpClientForMoney(url: String) = okHttpClientForMoney(url)
+
+    override fun httpClientForPreview(url: String) = okHttpClientForPreview(url)
+
+    override fun httpClientForPushRegistration(url: String) = okHttpClientForPushRegistration(url)
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ToastManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/ToastManager.kt
@@ -21,27 +21,28 @@
 package com.vitorpamplona.amethyst.ui.components.toasts
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.ui.components.toasts.IToastManager
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.ui.components.toasts.multiline.MultiErrorToastMsg
 import com.vitorpamplona.amethyst.ui.components.toasts.multiline.UserBasedErrorMessage
 import kotlinx.coroutines.flow.MutableStateFlow
 
 @Stable
-class ToastManager {
+class ToastManager : IToastManager {
     val toasts = MutableStateFlow<ToastMsg?>(null)
 
-    fun clearToasts() {
+    override fun clearToasts() {
         toasts.tryEmit(null)
     }
 
-    fun toast(
+    override fun toast(
         title: String,
         message: String,
     ) {
         toasts.tryEmit(StringToastMsg(title, message))
     }
 
-    fun toast(
+    override fun toast(
         title: String,
         message: String,
         action: () -> Unit,
@@ -49,14 +50,14 @@ class ToastManager {
         toasts.tryEmit(ActionableStringToastMsg(title, message, action))
     }
 
-    fun toast(
+    override fun toast(
         titleResId: Int,
         resourceId: Int,
     ) {
         toasts.tryEmit(ResourceToastMsg(titleResId, resourceId))
     }
 
-    fun toast(
+    override fun toast(
         titleResId: Int,
         message: String?,
         throwable: Throwable,
@@ -64,7 +65,7 @@ class ToastManager {
         toasts.tryEmit(ThrowableToastMsg(titleResId, message, throwable))
     }
 
-    fun toast(
+    override fun toast(
         titleResId: Int,
         description: Int,
         throwable: Throwable,
@@ -72,7 +73,7 @@ class ToastManager {
         toasts.tryEmit(ThrowableToastMsg2(titleResId, description, throwable))
     }
 
-    fun toast(
+    override fun toast(
         titleResId: Int,
         resourceId: Int,
         vararg params: String,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/UiSettingsState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/UiSettingsState.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.ui.screen
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.ui.screen.IUiSettingsState
 import com.vitorpamplona.amethyst.model.BooleanType
 import com.vitorpamplona.amethyst.model.ConnectivityType
 import com.vitorpamplona.amethyst.model.FeatureSetType
@@ -35,10 +36,10 @@ import kotlinx.coroutines.flow.stateIn
 @Stable
 class UiSettingsState(
     val uiSettingsFlow: UiSettingsFlow,
-    val isMobileOrMeteredConnection: StateFlow<Boolean>,
+    override val isMobileOrMeteredConnection: StateFlow<Boolean>,
     val scope: CoroutineScope,
-) {
-    val showProfilePictures =
+) : IUiSettingsState {
+    override val showProfilePictures =
         combine(
             uiSettingsFlow.automaticallyShowProfilePictures,
             isMobileOrMeteredConnection,
@@ -58,7 +59,7 @@ class UiSettingsState(
             },
         )
 
-    val showUrlPreview =
+    override val showUrlPreview =
         combine(
             uiSettingsFlow.automaticallyShowUrlPreview,
             isMobileOrMeteredConnection,
@@ -78,7 +79,7 @@ class UiSettingsState(
             },
         )
 
-    val startVideoPlayback =
+    override val startVideoPlayback =
         combine(
             uiSettingsFlow.automaticallyStartPlayback,
             isMobileOrMeteredConnection,
@@ -98,7 +99,7 @@ class UiSettingsState(
             },
         )
 
-    val showImages =
+    override val showImages =
         combine(
             uiSettingsFlow.automaticallyShowImages,
             isMobileOrMeteredConnection,
@@ -118,25 +119,25 @@ class UiSettingsState(
             },
         )
 
-    fun modernGalleryStyle() =
+    override fun modernGalleryStyle() =
         when (uiSettingsFlow.gallerySet.value) {
             ProfileGalleryType.CLASSIC -> false
             ProfileGalleryType.MODERN -> true
         }
 
-    fun isPerformanceMode() = uiSettingsFlow.featureSet.value == FeatureSetType.PERFORMANCE
+    override fun isPerformanceMode() = uiSettingsFlow.featureSet.value == FeatureSetType.PERFORMANCE
 
-    fun isNotPerformanceMode() = uiSettingsFlow.featureSet.value != FeatureSetType.PERFORMANCE
+    override fun isNotPerformanceMode() = uiSettingsFlow.featureSet.value != FeatureSetType.PERFORMANCE
 
-    fun isCompleteUIMode() = uiSettingsFlow.featureSet.value == FeatureSetType.COMPLETE
+    override fun isCompleteUIMode() = uiSettingsFlow.featureSet.value == FeatureSetType.COMPLETE
 
-    fun isImmersiveScrollingActive() = uiSettingsFlow.automaticallyHideNavigationBars.value == BooleanType.ALWAYS
+    override fun isImmersiveScrollingActive() = uiSettingsFlow.automaticallyHideNavigationBars.value == BooleanType.ALWAYS
 
-    fun showProfilePictures() = showProfilePictures.value
+    override fun showProfilePictures() = showProfilePictures.value
 
-    fun showUrlPreview() = showUrlPreview.value
+    override fun showUrlPreview() = showUrlPreview.value
 
-    fun startVideoPlayback() = startVideoPlayback.value
+    override fun startVideoPlayback() = startVideoPlayback.value
 
-    fun showImages() = showImages.value
+    override fun showImages() = showImages.value
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -51,6 +51,7 @@ import com.vitorpamplona.amethyst.commons.model.nip53LiveActivities.LiveActiviti
 import com.vitorpamplona.amethyst.commons.model.observables.CreatedAtComparator
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
 import com.vitorpamplona.amethyst.commons.ui.notifications.CardFeedState
+import com.vitorpamplona.amethyst.commons.viewmodels.IAccountViewModel
 import com.vitorpamplona.amethyst.logTime
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.AccountSettings
@@ -175,17 +176,21 @@ import kotlinx.coroutines.withContext
 
 @Stable
 class AccountViewModel(
-    val account: Account,
-    val settings: UiSettingsState,
+    override val account: Account,
+    override val settings: UiSettingsState,
     val torSettings: TorSettingsFlow,
     val dataSources: RelaySubscriptionsCoordinator,
-    val httpClientBuilder: IRoleBasedHttpClientBuilder,
+    override val httpClientBuilder: IRoleBasedHttpClientBuilder,
     val nip05ClientBuilder: () -> INip05Client,
 ) : ViewModel(),
-    Dao {
+    Dao,
+    IAccountViewModel {
     var firstRoute: Route? = null
 
-    val toastManager = ToastManager()
+    override val toastManager = ToastManager()
+
+    override val accountViewModelScope: CoroutineScope
+        get() = viewModelScope
     val broadcastTracker = BroadcastTracker()
     val feedStates = AccountFeedContentStates(account, viewModelScope)
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/network/IHttpClientBuilder.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/network/IHttpClientBuilder.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.network
+
+/**
+ * Platform-agnostic interface for role-based HTTP client construction.
+ *
+ * Different network operations (images, video, money, NIP-05, etc.) may
+ * require different proxy/Tor settings. This interface abstracts the
+ * role-based routing so that composables migrated to common code can
+ * accept it via [IAccountViewModel] without depending on OkHttp directly.
+ *
+ * On JVM/Android, [PlatformHttpClient] resolves to [okhttp3.OkHttpClient].
+ * On iOS, it will resolve to the appropriate native HTTP client.
+ */
+interface IHttpClientBuilder {
+    fun proxyPortForVideo(url: String): Int?
+
+    fun httpClientForNip05(url: String): PlatformHttpClient
+
+    fun httpClientForUploads(url: String): PlatformHttpClient
+
+    fun httpClientForImage(url: String): PlatformHttpClient
+
+    fun httpClientForVideo(url: String): PlatformHttpClient
+
+    fun httpClientForMoney(url: String): PlatformHttpClient
+
+    fun httpClientForPreview(url: String): PlatformHttpClient
+
+    fun httpClientForPushRegistration(url: String): PlatformHttpClient
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/network/PlatformHttpClient.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/network/PlatformHttpClient.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.network
+
+/**
+ * Platform-specific HTTP client type.
+ *
+ * On JVM/Android this maps to [okhttp3.OkHttpClient].
+ * On iOS this will map to the appropriate native HTTP client.
+ */
+expect class PlatformHttpClient

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/toasts/IToastManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/toasts/IToastManager.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.components.toasts
+
+/**
+ * Platform-agnostic toast manager interface for KMP.
+ *
+ * Android implementation uses resource IDs and Android-specific toast types.
+ * Other platforms can provide their own notification mechanisms.
+ */
+interface IToastManager {
+    fun clearToasts()
+
+    fun toast(
+        title: String,
+        message: String,
+    )
+
+    fun toast(
+        title: String,
+        message: String,
+        action: () -> Unit,
+    )
+
+    fun toast(
+        titleResId: Int,
+        resourceId: Int,
+    )
+
+    fun toast(
+        titleResId: Int,
+        message: String?,
+        throwable: Throwable,
+    )
+
+    fun toast(
+        titleResId: Int,
+        description: Int,
+        throwable: Throwable,
+    )
+
+    fun toast(
+        titleResId: Int,
+        resourceId: Int,
+        vararg params: String,
+    )
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/IUiSettingsState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/IUiSettingsState.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.screen
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Platform-agnostic interface for UI settings state.
+ *
+ * Exposes connectivity-aware display settings and feature-set mode queries.
+ * Composables in the commons module can depend on this interface instead of
+ * the concrete Android UiSettingsState class.
+ */
+interface IUiSettingsState {
+    // ── connectivity-aware display settings (StateFlow<Boolean>) ─────
+
+    /** Whether to show profile pictures (respects connectivity/user preference). */
+    val showProfilePictures: StateFlow<Boolean>
+
+    /** Whether to show URL previews (respects connectivity/user preference). */
+    val showUrlPreview: StateFlow<Boolean>
+
+    /** Whether to auto-start video playback (respects connectivity/user preference). */
+    val startVideoPlayback: StateFlow<Boolean>
+
+    /** Whether to show images inline (respects connectivity/user preference). */
+    val showImages: StateFlow<Boolean>
+
+    /** Whether the device is on a mobile/metered connection. */
+    val isMobileOrMeteredConnection: StateFlow<Boolean>
+
+    // ── feature-set mode queries ─────────────────────────────────────
+
+    /** True when the UI is in performance (minimal) mode. */
+    fun isPerformanceMode(): Boolean
+
+    /** True when the UI is NOT in performance mode. */
+    fun isNotPerformanceMode(): Boolean
+
+    /** True when the UI is in complete (all features) mode. */
+    fun isCompleteUIMode(): Boolean
+
+    /** True when immersive scrolling (auto-hide nav bars) is active. */
+    fun isImmersiveScrollingActive(): Boolean
+
+    /** True when the modern gallery style is selected. */
+    fun modernGalleryStyle(): Boolean
+
+    // ── convenience snapshot accessors ───────────────────────────────
+
+    /** Snapshot of [showProfilePictures]. */
+    fun showProfilePictures(): Boolean
+
+    /** Snapshot of [showUrlPreview]. */
+    fun showUrlPreview(): Boolean
+
+    /** Snapshot of [startVideoPlayback]. */
+    fun startVideoPlayback(): Boolean
+
+    /** Snapshot of [showImages]. */
+    fun showImages(): Boolean
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/IAccountViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/IAccountViewModel.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.viewmodels
+
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.network.IHttpClientBuilder
+import com.vitorpamplona.amethyst.commons.ui.components.toasts.IToastManager
+import com.vitorpamplona.amethyst.commons.ui.screen.IUiSettingsState
+import kotlinx.coroutines.CoroutineScope
+
+/**
+ * Platform-agnostic interface for AccountViewModel.
+ *
+ * Exposes the most commonly used members of AccountViewModel using only
+ * commons-compatible types. Composables in the commons module can depend
+ * on this interface instead of the concrete Android AccountViewModel,
+ * enabling incremental migration to KMP.
+ *
+ * Builds on #2285 (viewModelScope) and #2287 (account).
+ */
+interface IAccountViewModel {
+    /** The underlying account abstraction. */
+    val account: IAccount
+
+    /** CoroutineScope tied to the ViewModel lifecycle. */
+    val accountViewModelScope: CoroutineScope
+
+    /** UI settings (connectivity-aware display preferences). 78 usages / 38 files. */
+    val settings: IUiSettingsState
+
+    /** Toast/snackbar manager. 119 usages / 48 files. */
+    val toastManager: IToastManager
+
+    /** Role-based HTTP client builder (proxy/Tor routing). 20 usages / 6 files. */
+    val httpClientBuilder: IHttpClientBuilder
+}

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/network/PlatformHttpClient.jvmAndroid.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/network/PlatformHttpClient.jvmAndroid.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.network
+
+import okhttp3.OkHttpClient
+
+actual typealias PlatformHttpClient = OkHttpClient


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

## What

Adds platform-agnostic interfaces to the `commons` module and expands `IAccountViewModel` with the three most-used members after `account`:

| New Interface | Package | Used in |
|---|---|---|
| `IToastManager` | `commons.ui.components.toasts` | 48 files |
| `IUiSettingsState` | `commons.ui.screen` | 38 files |
| `IHttpClientBuilder` + `PlatformHttpClient` | `commons.network` | 6 files |

### IAccountViewModel now exposes:
- `account: IAccount` (from #2287)
- `accountViewModelScope: CoroutineScope` (from #2285)
- `settings: IUiSettingsState` ← **new**
- `toastManager: IToastManager` ← **new**
- `httpClientBuilder: IHttpClientBuilder` ← **new**

### Concrete classes updated:
- `ToastManager : IToastManager`
- `UiSettingsState : IUiSettingsState`
- `IRoleBasedHttpClientBuilder : IHttpClientBuilder` (bridge default methods)
- `AccountViewModel : IAccountViewModel`

## Why

These 5 members cover the vast majority of `accountViewModel.` usage across composables. With this interface in commons, ~100+ composable signatures can migrate from `AccountViewModel` → `IAccountViewModel`, unblocking their move to the commons module.

Builds on #2285 (viewModelScope) and #2287 (account + 27 signatures).