### PR TITLE
feat: Android IMediaUploader implementation + refactor 3 metadata VMs

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/AndroidMediaUploader.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/AndroidMediaUploader.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.uploads
+
+import android.content.Context
+import android.net.Uri
+import com.vitorpamplona.amethyst.Amethyst
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.upload.IMediaUploader
+import com.vitorpamplona.amethyst.commons.upload.MediaUploadException
+import com.vitorpamplona.amethyst.commons.upload.MediaUploadResult
+import com.vitorpamplona.amethyst.model.Account
+import com.vitorpamplona.amethyst.service.uploads.blossom.BlossomUploader
+import com.vitorpamplona.amethyst.service.uploads.nip96.Nip96Uploader
+import com.vitorpamplona.amethyst.ui.actions.mediaServers.ServerType
+import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.quartz.nip01Core.signers.SignerExceptions
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Android implementation of [IMediaUploader] that wraps the existing upload pipeline:
+ * MetadataStripper → MediaCompressor → Nip96/Blossom upload.
+ *
+ * Used by metadata ViewModels (BookmarkGroupMetadata, FollowPackMetadata,
+ * PeopleListMetadata, ChannelMetadata, NewUserMetadata) to upload profile
+ * pictures and banners through a platform-abstracted interface.
+ */
+class AndroidMediaUploader(
+    private val context: Context,
+    private val account: Account,
+) : IMediaUploader {
+    override suspend fun uploadMedia(
+        mediaUri: String,
+        mimeType: String?,
+        onProgress: ((Float) -> Unit)?,
+    ): MediaUploadResult {
+        val uri = Uri.parse(mediaUri)
+
+        // Step 1: Strip location metadata if user setting enabled
+        val strippedUri =
+            if (account.settings.stripLocationOnUpload) {
+                val result = MetadataStripper.strip(uri, mimeType, context.applicationContext)
+                if (!result.stripped) {
+                    throw MediaUploadException(
+                        title = stringRes(context, R.string.metadata_strip_failed_title),
+                        message = stringRes(context, R.string.metadata_strip_failed_upload_cancelled),
+                    )
+                }
+                result.uri
+            } else {
+                uri
+            }
+
+        // Step 2: Compress media
+        val compResult =
+            MediaCompressor().compress(
+                strippedUri,
+                mimeType,
+                CompressorQuality.MEDIUM,
+                context.applicationContext,
+            )
+
+        // Step 3: Upload to the user's configured file server
+        try {
+            val server = account.settings.defaultFileServer
+            val result =
+                when (server.type) {
+                    ServerType.NIP96 -> {
+                        Nip96Uploader().upload(
+                            uri = compResult.uri,
+                            contentType = compResult.contentType,
+                            size = compResult.size,
+                            alt = null,
+                            sensitiveContent = null,
+                            serverBaseUrl = server.baseUrl,
+                            okHttpClient = Amethyst.instance.roleBasedHttpClientBuilder::okHttpClientForUploads,
+                            onProgress = { percent -> onProgress?.invoke(percent) },
+                            httpAuth = account::createHTTPAuthorization,
+                            context = context,
+                        )
+                    }
+
+                    ServerType.Blossom -> {
+                        BlossomUploader().upload(
+                            uri = compResult.uri,
+                            contentType = compResult.contentType,
+                            size = compResult.size,
+                            alt = null,
+                            sensitiveContent = null,
+                            serverBaseUrl = server.baseUrl,
+                            okHttpClient = Amethyst.instance.roleBasedHttpClientBuilder::okHttpClientForUploads,
+                            httpAuth = account::createBlossomUploadAuth,
+                            context = context,
+                        )
+                    }
+
+                    ServerType.NIP95 -> {
+                        throw MediaUploadException(
+                            title = stringRes(context, R.string.failed_to_upload_media_no_details),
+                            message = "NIP-95 uploads are not supported through IMediaUploader. Use UploadOrchestrator directly.",
+                        )
+                    }
+                }
+
+            if (result.url != null) {
+                return MediaUploadResult(
+                    url = result.url,
+                    sha256 = result.sha256,
+                    size = result.size,
+                    type = result.type,
+                )
+            } else {
+                throw MediaUploadException(
+                    title = stringRes(context, R.string.failed_to_upload_media_no_details),
+                    message = stringRes(context, R.string.server_did_not_provide_a_url_after_uploading),
+                )
+            }
+        } catch (e: MediaUploadException) {
+            throw e
+        } catch (_: SignerExceptions.ReadOnlyException) {
+            throw MediaUploadException(
+                title = stringRes(context, R.string.failed_to_upload_media_no_details),
+                message = stringRes(context, R.string.login_with_a_private_key_to_be_able_to_upload),
+            )
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            throw MediaUploadException(
+                title = stringRes(context, R.string.failed_to_upload_media_no_details),
+                message = e.message ?: e.javaClass.simpleName,
+                cause = e,
+            )
+        }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/list/metadata/BookmarkGroupMetadataScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/list/metadata/BookmarkGroupMetadataScreen.kt
@@ -62,7 +62,13 @@ fun BookmarkGroupMetadataScreen(
     nav: INav,
 ) {
     val bookmarkGroupInfoViewModel: BookmarkGroupMetadataViewModel = viewModel()
-    bookmarkGroupInfoViewModel.init(accountViewModel)
+    bookmarkGroupInfoViewModel.init(
+        accountViewModel,
+        com.vitorpamplona.amethyst.service.uploads.AndroidMediaUploader(
+            context = androidx.compose.ui.platform.LocalContext.current,
+            account = accountViewModel.account,
+        ),
+    )
 
     if (bookmarkGroupIdentifier != null) {
         LaunchedEffect(bookmarkGroupInfoViewModel) {
@@ -219,7 +225,7 @@ private fun Picture(
                 tint = MaterialTheme.colorScheme.placeholderText,
                 modifier = Modifier.padding(start = 2.dp),
             ) {
-                bookmarkGroupInfoViewModel.uploadForPicture(it, context, onError = accountViewModel.toastManager::toast)
+                bookmarkGroupInfoViewModel.uploadForPicture(it, onError = accountViewModel.toastManager::toast)
             }
         },
     )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/list/metadata/BookmarkGroupMetadataViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/list/metadata/BookmarkGroupMetadataViewModel.kt
@@ -20,7 +20,6 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.list.metadata
 
-import android.content.Context
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -29,28 +28,20 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.vitorpamplona.amethyst.Amethyst
-import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.upload.IMediaUploader
+import com.vitorpamplona.amethyst.commons.upload.MediaUploadException
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.nip51Lists.labeledBookmarkLists.LabeledBookmarkList
-import com.vitorpamplona.amethyst.service.uploads.CompressorQuality
-import com.vitorpamplona.amethyst.service.uploads.MediaCompressor
-import com.vitorpamplona.amethyst.service.uploads.MetadataStripper
-import com.vitorpamplona.amethyst.service.uploads.blossom.BlossomUploader
-import com.vitorpamplona.amethyst.service.uploads.nip96.Nip96Uploader
-import com.vitorpamplona.amethyst.ui.actions.mediaServers.ServerType
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
-import com.vitorpamplona.amethyst.ui.stringRes
-import com.vitorpamplona.quartz.nip01Core.signers.SignerExceptions
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlin.coroutines.cancellation.CancellationException
 
 @Stable
 class BookmarkGroupMetadataViewModel : ViewModel() {
     private lateinit var accountViewModel: AccountViewModel
     private lateinit var account: Account
+    private lateinit var mediaUploader: IMediaUploader
 
     var bookmarkGroup by mutableStateOf<LabeledBookmarkList?>(null)
     val isNewList by derivedStateOf { bookmarkGroup == null }
@@ -65,9 +56,13 @@ class BookmarkGroupMetadataViewModel : ViewModel() {
         name.value.text.isNotBlank()
     }
 
-    fun init(accountViewModel: AccountViewModel) {
+    fun init(
+        accountViewModel: AccountViewModel,
+        mediaUploader: IMediaUploader,
+    ) {
         this.accountViewModel = accountViewModel
         this.account = accountViewModel.account
+        this.mediaUploader = mediaUploader
     }
 
     fun new() {
@@ -116,89 +111,22 @@ class BookmarkGroupMetadataViewModel : ViewModel() {
 
     fun uploadForPicture(
         uri: SelectedMedia,
-        context: Context,
         onError: (String, String) -> Unit,
     ) {
         viewModelScope.launch(Dispatchers.IO) {
-            upload(
-                uri,
-                context,
-                onUploading = { isUploadingImageForPicture = it },
-                onUploaded = { picture.value = TextFieldValue(it) },
-                onError = onError,
-            )
-        }
-    }
-
-    private suspend fun upload(
-        galleryUri: SelectedMedia,
-        context: Context,
-        onUploading: (Boolean) -> Unit,
-        onUploaded: (String) -> Unit,
-        onError: (String, String) -> Unit,
-    ) {
-        onUploading(true)
-
-        val sourceUri =
-            if (account.settings.stripLocationOnUpload) {
-                val result = MetadataStripper.strip(galleryUri.uri, galleryUri.mimeType, context.applicationContext)
-                if (!result.stripped) {
-                    onError(
-                        stringRes(context, R.string.metadata_strip_failed_title),
-                        stringRes(context, R.string.metadata_strip_failed_upload_cancelled),
+            isUploadingImageForPicture = true
+            try {
+                val result =
+                    mediaUploader.uploadMedia(
+                        mediaUri = uri.uri.toString(),
+                        mimeType = uri.mimeType,
                     )
-                    onUploading(false)
-                    return
-                }
-                result.uri
-            } else {
-                galleryUri.uri
+                picture.value = TextFieldValue(result.url)
+            } catch (e: MediaUploadException) {
+                onError(e.title, e.message)
+            } finally {
+                isUploadingImageForPicture = false
             }
-        val compResult = MediaCompressor().compress(sourceUri, galleryUri.mimeType, CompressorQuality.MEDIUM, context.applicationContext)
-
-        try {
-            val result =
-                if (account.settings.defaultFileServer.type == ServerType.NIP96) {
-                    Nip96Uploader().upload(
-                        uri = compResult.uri,
-                        contentType = compResult.contentType,
-                        size = compResult.size,
-                        alt = null,
-                        sensitiveContent = null,
-                        serverBaseUrl = account.settings.defaultFileServer.baseUrl,
-                        okHttpClient = Amethyst.instance.roleBasedHttpClientBuilder::okHttpClientForUploads,
-                        onProgress = {},
-                        httpAuth = account::createHTTPAuthorization,
-                        context = context,
-                    )
-                } else {
-                    BlossomUploader().upload(
-                        uri = compResult.uri,
-                        contentType = compResult.contentType,
-                        size = compResult.size,
-                        alt = null,
-                        sensitiveContent = null,
-                        serverBaseUrl = account.settings.defaultFileServer.baseUrl,
-                        okHttpClient = Amethyst.instance.roleBasedHttpClientBuilder::okHttpClientForUploads,
-                        httpAuth = account::createBlossomUploadAuth,
-                        context = context,
-                    )
-                }
-
-            if (result.url != null) {
-                onUploading(false)
-                onUploaded(result.url)
-            } else {
-                onUploading(false)
-                onError(stringRes(context, R.string.failed_to_upload_media_no_details), stringRes(context, R.string.server_did_not_provide_a_url_after_uploading))
-            }
-        } catch (_: SignerExceptions.ReadOnlyException) {
-            onUploading(false)
-            onError(stringRes(context, R.string.failed_to_upload_media_no_details), stringRes(context, R.string.login_with_a_private_key_to_be_able_to_upload))
-        } catch (e: Exception) {
-            if (e is CancellationException) throw e
-            onUploading(false)
-            onError(stringRes(context, R.string.failed_to_upload_media_no_details), e.message ?: e.javaClass.simpleName)
         }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/metadata/FollowPackMetadataScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/metadata/FollowPackMetadataScreen.kt
@@ -66,7 +66,13 @@ fun FollowPackMetadataScreen(
     nav: INav,
 ) {
     val postViewModel: FollowPackMetadataViewModel = viewModel()
-    postViewModel.init(accountViewModel)
+    postViewModel.init(
+        accountViewModel,
+        com.vitorpamplona.amethyst.service.uploads.AndroidMediaUploader(
+            context = androidx.compose.ui.platform.LocalContext.current,
+            account = accountViewModel.account,
+        ),
+    )
 
     if (selectedDTag != null) {
         LaunchedEffect(postViewModel) {
@@ -90,7 +96,13 @@ fun FollowPackMetadataScreen(
 private fun DialogContentPreview() {
     val accountViewModel = mockAccountViewModel()
     val postViewModel: FollowPackMetadataViewModel = viewModel()
-    postViewModel.init(accountViewModel)
+    postViewModel.init(
+        accountViewModel,
+        com.vitorpamplona.amethyst.service.uploads.AndroidMediaUploader(
+            context = androidx.compose.ui.platform.LocalContext.current,
+            account = accountViewModel.account,
+        ),
+    )
 
     ThemeComparisonRow {
         FollowPackMetadataScaffold(
@@ -243,7 +255,7 @@ private fun Picture(
                 tint = MaterialTheme.colorScheme.placeholderText,
                 modifier = Modifier.padding(start = 2.dp),
             ) {
-                postViewModel.uploadForPicture(it, context, onError = accountViewModel.toastManager::toast)
+                postViewModel.uploadForPicture(it, onError = accountViewModel.toastManager::toast)
             }
         },
     )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/metadata/FollowPackMetadataViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/metadata/FollowPackMetadataViewModel.kt
@@ -20,7 +20,6 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.lists.list.metadata
 
-import android.content.Context
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -29,23 +28,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.vitorpamplona.amethyst.Amethyst
-import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.upload.IMediaUploader
+import com.vitorpamplona.amethyst.commons.upload.MediaUploadException
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.nip51Lists.peopleList.PeopleList
-import com.vitorpamplona.amethyst.service.uploads.CompressorQuality
-import com.vitorpamplona.amethyst.service.uploads.MediaCompressor
-import com.vitorpamplona.amethyst.service.uploads.MetadataStripper
-import com.vitorpamplona.amethyst.service.uploads.blossom.BlossomUploader
-import com.vitorpamplona.amethyst.service.uploads.nip96.Nip96Uploader
-import com.vitorpamplona.amethyst.ui.actions.mediaServers.ServerType
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
-import com.vitorpamplona.amethyst.ui.stringRes
-import com.vitorpamplona.quartz.nip01Core.signers.SignerExceptions
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlin.coroutines.cancellation.CancellationException
 
 @Stable
 class FollowPackMetadataViewModel : ViewModel() {
@@ -65,9 +55,15 @@ class FollowPackMetadataViewModel : ViewModel() {
         name.value.text.isNotBlank()
     }
 
-    fun init(accountViewModel: AccountViewModel) {
+    private lateinit var mediaUploader: IMediaUploader
+
+    fun init(
+        accountViewModel: AccountViewModel,
+        mediaUploader: IMediaUploader,
+    ) {
         this.accountViewModel = accountViewModel
         this.account = accountViewModel.account
+        this.mediaUploader = mediaUploader
     }
 
     fun new() {
@@ -115,89 +111,22 @@ class FollowPackMetadataViewModel : ViewModel() {
 
     fun uploadForPicture(
         uri: SelectedMedia,
-        context: Context,
         onError: (String, String) -> Unit,
     ) {
         viewModelScope.launch(Dispatchers.IO) {
-            upload(
-                uri,
-                context,
-                onUploading = { isUploadingImageForPicture = it },
-                onUploaded = { picture.value = TextFieldValue(it) },
-                onError = onError,
-            )
-        }
-    }
-
-    private suspend fun upload(
-        galleryUri: SelectedMedia,
-        context: Context,
-        onUploading: (Boolean) -> Unit,
-        onUploaded: (String) -> Unit,
-        onError: (String, String) -> Unit,
-    ) {
-        onUploading(true)
-
-        val sourceUri =
-            if (account.settings.stripLocationOnUpload) {
-                val result = MetadataStripper.strip(galleryUri.uri, galleryUri.mimeType, context.applicationContext)
-                if (!result.stripped) {
-                    onError(
-                        stringRes(context, R.string.metadata_strip_failed_title),
-                        stringRes(context, R.string.metadata_strip_failed_upload_cancelled),
+            isUploadingImageForPicture = true
+            try {
+                val result =
+                    mediaUploader.uploadMedia(
+                        mediaUri = uri.uri.toString(),
+                        mimeType = uri.mimeType,
                     )
-                    onUploading(false)
-                    return
-                }
-                result.uri
-            } else {
-                galleryUri.uri
+                picture.value = TextFieldValue(result.url)
+            } catch (e: MediaUploadException) {
+                onError(e.title, e.message)
+            } finally {
+                isUploadingImageForPicture = false
             }
-        val compResult = MediaCompressor().compress(sourceUri, galleryUri.mimeType, CompressorQuality.MEDIUM, context.applicationContext)
-
-        try {
-            val result =
-                if (account.settings.defaultFileServer.type == ServerType.NIP96) {
-                    Nip96Uploader().upload(
-                        uri = compResult.uri,
-                        contentType = compResult.contentType,
-                        size = compResult.size,
-                        alt = null,
-                        sensitiveContent = null,
-                        serverBaseUrl = account.settings.defaultFileServer.baseUrl,
-                        okHttpClient = Amethyst.instance.roleBasedHttpClientBuilder::okHttpClientForUploads,
-                        onProgress = {},
-                        httpAuth = account::createHTTPAuthorization,
-                        context = context,
-                    )
-                } else {
-                    BlossomUploader().upload(
-                        uri = compResult.uri,
-                        contentType = compResult.contentType,
-                        size = compResult.size,
-                        alt = null,
-                        sensitiveContent = null,
-                        serverBaseUrl = account.settings.defaultFileServer.baseUrl,
-                        okHttpClient = Amethyst.instance.roleBasedHttpClientBuilder::okHttpClientForUploads,
-                        httpAuth = account::createBlossomUploadAuth,
-                        context = context,
-                    )
-                }
-
-            if (result.url != null) {
-                onUploading(false)
-                onUploaded(result.url)
-            } else {
-                onUploading(false)
-                onError(stringRes(context, R.string.failed_to_upload_media_no_details), stringRes(context, R.string.server_did_not_provide_a_url_after_uploading))
-            }
-        } catch (_: SignerExceptions.ReadOnlyException) {
-            onUploading(false)
-            onError(stringRes(context, R.string.failed_to_upload_media_no_details), stringRes(context, R.string.login_with_a_private_key_to_be_able_to_upload))
-        } catch (e: Exception) {
-            if (e is CancellationException) throw e
-            onUploading(false)
-            onError(stringRes(context, R.string.failed_to_upload_media_no_details), e.message ?: e.javaClass.simpleName)
         }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/metadata/PeopleListMetadataScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/metadata/PeopleListMetadataScreen.kt
@@ -66,7 +66,13 @@ fun PeopleListMetadataScreen(
     nav: INav,
 ) {
     val postViewModel: PeopleListMetadataViewModel = viewModel()
-    postViewModel.init(accountViewModel)
+    postViewModel.init(
+        accountViewModel,
+        com.vitorpamplona.amethyst.service.uploads.AndroidMediaUploader(
+            context = androidx.compose.ui.platform.LocalContext.current,
+            account = accountViewModel.account,
+        ),
+    )
 
     if (selectedDTag != null) {
         LaunchedEffect(postViewModel) {
@@ -90,7 +96,13 @@ fun PeopleListMetadataScreen(
 private fun DialogContentPreview() {
     val accountViewModel = mockAccountViewModel()
     val postViewModel: PeopleListMetadataViewModel = viewModel()
-    postViewModel.init(accountViewModel)
+    postViewModel.init(
+        accountViewModel,
+        com.vitorpamplona.amethyst.service.uploads.AndroidMediaUploader(
+            context = androidx.compose.ui.platform.LocalContext.current,
+            account = accountViewModel.account,
+        ),
+    )
 
     ThemeComparisonRow {
         PeopleListMetadataScaffold(
@@ -243,7 +255,7 @@ private fun Picture(
                 tint = MaterialTheme.colorScheme.placeholderText,
                 modifier = Modifier.padding(start = 2.dp),
             ) {
-                postViewModel.uploadForPicture(it, context, onError = accountViewModel.toastManager::toast)
+                postViewModel.uploadForPicture(it, onError = accountViewModel.toastManager::toast)
             }
         },
     )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/metadata/PeopleListMetadataViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/metadata/PeopleListMetadataViewModel.kt
@@ -20,7 +20,6 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.lists.list.metadata
 
-import android.content.Context
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -29,23 +28,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.vitorpamplona.amethyst.Amethyst
-import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.upload.IMediaUploader
+import com.vitorpamplona.amethyst.commons.upload.MediaUploadException
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.nip51Lists.peopleList.PeopleList
-import com.vitorpamplona.amethyst.service.uploads.CompressorQuality
-import com.vitorpamplona.amethyst.service.uploads.MediaCompressor
-import com.vitorpamplona.amethyst.service.uploads.MetadataStripper
-import com.vitorpamplona.amethyst.service.uploads.blossom.BlossomUploader
-import com.vitorpamplona.amethyst.service.uploads.nip96.Nip96Uploader
-import com.vitorpamplona.amethyst.ui.actions.mediaServers.ServerType
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
-import com.vitorpamplona.amethyst.ui.stringRes
-import com.vitorpamplona.quartz.nip01Core.signers.SignerExceptions
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlin.coroutines.cancellation.CancellationException
 
 @Stable
 class PeopleListMetadataViewModel : ViewModel() {
@@ -65,9 +55,15 @@ class PeopleListMetadataViewModel : ViewModel() {
         name.value.text.isNotBlank()
     }
 
-    fun init(accountViewModel: AccountViewModel) {
+    private lateinit var mediaUploader: IMediaUploader
+
+    fun init(
+        accountViewModel: AccountViewModel,
+        mediaUploader: IMediaUploader,
+    ) {
         this.accountViewModel = accountViewModel
         this.account = accountViewModel.account
+        this.mediaUploader = mediaUploader
     }
 
     fun new() {
@@ -116,89 +112,22 @@ class PeopleListMetadataViewModel : ViewModel() {
 
     fun uploadForPicture(
         uri: SelectedMedia,
-        context: Context,
         onError: (String, String) -> Unit,
     ) {
         viewModelScope.launch(Dispatchers.IO) {
-            upload(
-                uri,
-                context,
-                onUploading = { isUploadingImageForPicture = it },
-                onUploaded = { picture.value = TextFieldValue(it) },
-                onError = onError,
-            )
-        }
-    }
-
-    private suspend fun upload(
-        galleryUri: SelectedMedia,
-        context: Context,
-        onUploading: (Boolean) -> Unit,
-        onUploaded: (String) -> Unit,
-        onError: (String, String) -> Unit,
-    ) {
-        onUploading(true)
-
-        val sourceUri =
-            if (account.settings.stripLocationOnUpload) {
-                val result = MetadataStripper.strip(galleryUri.uri, galleryUri.mimeType, context.applicationContext)
-                if (!result.stripped) {
-                    onError(
-                        stringRes(context, R.string.metadata_strip_failed_title),
-                        stringRes(context, R.string.metadata_strip_failed_upload_cancelled),
+            isUploadingImageForPicture = true
+            try {
+                val result =
+                    mediaUploader.uploadMedia(
+                        mediaUri = uri.uri.toString(),
+                        mimeType = uri.mimeType,
                     )
-                    onUploading(false)
-                    return
-                }
-                result.uri
-            } else {
-                galleryUri.uri
+                picture.value = TextFieldValue(result.url)
+            } catch (e: MediaUploadException) {
+                onError(e.title, e.message)
+            } finally {
+                isUploadingImageForPicture = false
             }
-        val compResult = MediaCompressor().compress(sourceUri, galleryUri.mimeType, CompressorQuality.MEDIUM, context.applicationContext)
-
-        try {
-            val result =
-                if (account.settings.defaultFileServer.type == ServerType.NIP96) {
-                    Nip96Uploader().upload(
-                        uri = compResult.uri,
-                        contentType = compResult.contentType,
-                        size = compResult.size,
-                        alt = null,
-                        sensitiveContent = null,
-                        serverBaseUrl = account.settings.defaultFileServer.baseUrl,
-                        okHttpClient = Amethyst.instance.roleBasedHttpClientBuilder::okHttpClientForUploads,
-                        onProgress = {},
-                        httpAuth = account::createHTTPAuthorization,
-                        context = context,
-                    )
-                } else {
-                    BlossomUploader().upload(
-                        uri = compResult.uri,
-                        contentType = compResult.contentType,
-                        size = compResult.size,
-                        alt = null,
-                        sensitiveContent = null,
-                        serverBaseUrl = account.settings.defaultFileServer.baseUrl,
-                        okHttpClient = Amethyst.instance.roleBasedHttpClientBuilder::okHttpClientForUploads,
-                        httpAuth = account::createBlossomUploadAuth,
-                        context = context,
-                    )
-                }
-
-            if (result.url != null) {
-                onUploading(false)
-                onUploaded(result.url)
-            } else {
-                onUploading(false)
-                onError(stringRes(context, R.string.failed_to_upload_media_no_details), stringRes(context, R.string.server_did_not_provide_a_url_after_uploading))
-            }
-        } catch (_: SignerExceptions.ReadOnlyException) {
-            onUploading(false)
-            onError(stringRes(context, R.string.failed_to_upload_media_no_details), stringRes(context, R.string.login_with_a_private_key_to_be_able_to_upload))
-        } catch (e: Exception) {
-            if (e is CancellationException) throw e
-            onUploading(false)
-            onError(stringRes(context, R.string.failed_to_upload_media_no_details), e.message ?: e.javaClass.simpleName)
         }
     }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/upload/IMediaUploader.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/upload/IMediaUploader.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.upload
+
+/**
+ * Platform-abstracted media upload interface.
+ *
+ * Encapsulates the full upload pipeline: metadata stripping, compression,
+ * and upload via the user's configured file server (NIP-96 or Blossom).
+ *
+ * Android implementation wraps MetadataStripper, MediaCompressor, and
+ * Nip96Uploader/BlossomUploader. iOS implementation will provide native equivalents.
+ *
+ * Used by metadata ViewModels (BookmarkGroupMetadata, FollowPackMetadata,
+ * PeopleListMetadata, ChannelMetadata, NewUserMetadata) to upload profile
+ * pictures and banners without depending on Android Context.
+ */
+interface IMediaUploader {
+    /**
+     * Upload media (image/video) through the full pipeline:
+     * 1. Strip location metadata (if user setting enabled)
+     * 2. Compress media
+     * 3. Upload to the user's configured file server
+     *
+     * @param mediaUri Platform-opaque URI string identifying the media to upload
+     * @param mimeType MIME type of the media (e.g. "image/jpeg"), or null if unknown
+     * @param onProgress Optional progress callback (0.0 to 1.0)
+     * @return [MediaUploadResult] with the uploaded media URL and metadata
+     * @throws MediaUploadException on failure
+     */
+    suspend fun uploadMedia(
+        mediaUri: String,
+        mimeType: String?,
+        onProgress: ((Float) -> Unit)? = null,
+    ): MediaUploadResult
+}
+
+/**
+ * Result of a successful media upload.
+ */
+data class MediaUploadResult(
+    /** Publicly accessible URL of the uploaded media. */
+    val url: String,
+    /** SHA-256 hash of the uploaded blob, if provided by the server. */
+    val sha256: String? = null,
+    /** Size of the uploaded blob in bytes. */
+    val size: Long? = null,
+    /** MIME type of the uploaded blob. */
+    val type: String? = null,
+)
+
+/**
+ * Exception thrown when media upload fails.
+ */
+class MediaUploadException(
+    /** Short error title suitable for UI display. */
+    val title: String,
+    /** Detailed error message. */
+    override val message: String,
+    override val cause: Throwable? = null,
+) : Exception(message, cause)


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

## What
- Creates `AndroidMediaUploader` implementing `IMediaUploader` from commons (#2283)
- Wraps the existing upload pipeline: MetadataStripper → MediaCompressor → Nip96/Blossom
- Refactors 3 metadata ViewModels to use `IMediaUploader` instead of direct upload deps:
  - `BookmarkGroupMetadataViewModel`
  - `FollowPackMetadataViewModel`
  - `PeopleListMetadataViewModel`

## Why
These ViewModels had duplicated upload logic (strip → compress → upload). By injecting `IMediaUploader`, the upload pipeline becomes a single method call. This:
1. Removes ~280 lines of duplicated upload code across 3 VMs
2. Makes the VMs closer to being movable to commons (still need Compose/ViewModel abstraction)
3. Unblocks iOS implementation — just provide an `IosMediaUploader`

## Remaining
- `ChannelMetadataViewModel` and `NewUserMetadataViewModel` can follow the same pattern (they have banner upload too, slightly more complex)
- VMs still depend on Compose runtime + AndroidX ViewModel — moving to commons requires further abstraction

## Build
✅ `:commons:compileKotlinJvm` — passes
✅ `:amethyst:compilePlayDebugKotlin` — passes
✅ `spotlessCheck` — passes