### PR TITLE
feat: move feed state sealed classes to commons

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/feeds/ChannelFeedContentState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/feeds/ChannelFeedContentState.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateOf
 import com.vitorpamplona.amethyst.commons.model.Channel
+import com.vitorpamplona.amethyst.commons.ui.feeds.ChannelFeedState
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.service.BundledInsert
 import com.vitorpamplona.amethyst.service.BundledUpdate

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/feeds/ChannelFeedState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/feeds/ChannelFeedState.kt
@@ -20,21 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.feeds
 
-import androidx.compose.runtime.Stable
-import com.vitorpamplona.amethyst.commons.model.Channel
-import kotlinx.coroutines.flow.MutableStateFlow
-
-@Stable
-sealed class ChannelFeedState {
-    object Loading : ChannelFeedState()
-
-    class Loaded(
-        val feed: MutableStateFlow<LoadedFeedState<Channel>>,
-    ) : ChannelFeedState()
-
-    object Empty : ChannelFeedState()
-
-    class FeedError(
-        val errorMessage: String,
-    ) : ChannelFeedState()
-}
+// Re-export from commons for backwards compatibility
+typealias ChannelFeedState = com.vitorpamplona.amethyst.commons.ui.feeds.ChannelFeedState

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/UserFeedState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/UserFeedState.kt
@@ -20,26 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen
 
-import androidx.compose.runtime.Stable
-import com.vitorpamplona.amethyst.model.User
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.coroutines.flow.MutableStateFlow
-
-@Stable
-sealed class UserFeedState {
-    @Stable
-    object Loading : UserFeedState()
-
-    @Stable
-    class Loaded(
-        val feed: MutableStateFlow<ImmutableList<User>>,
-    ) : UserFeedState()
-
-    @Stable
-    object Empty : UserFeedState()
-
-    @Stable
-    class FeedError(
-        val errorMessage: String,
-    ) : UserFeedState()
-}
+// Re-export from commons for backwards compatibility
+typealias UserFeedState = com.vitorpamplona.amethyst.commons.ui.feeds.UserFeedState

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/UserFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/UserFeedView.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.commons.ui.feeds.UserFeedState
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.feeds.FeedEmpty
 import com.vitorpamplona.amethyst.ui.feeds.FeedError

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/UserFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/UserFeedViewModel.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vitorpamplona.amethyst.commons.ui.feeds.InvalidatableContent
+import com.vitorpamplona.amethyst.commons.ui.feeds.UserFeedState
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.BundledUpdate

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/HomeScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/HomeScreen.kt
@@ -57,6 +57,7 @@ import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
 import com.vitorpamplona.amethyst.commons.model.nip53LiveActivities.LiveActivitiesChannel
+import com.vitorpamplona.amethyst.commons.ui.feeds.ChannelFeedState
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedContentState
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
 import com.vitorpamplona.amethyst.model.TopFilter
@@ -65,7 +66,6 @@ import com.vitorpamplona.amethyst.service.location.LocationState
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.components.zonedDrawerSwipe
 import com.vitorpamplona.amethyst.ui.feeds.ChannelFeedContentState
-import com.vitorpamplona.amethyst.ui.feeds.ChannelFeedState
 import com.vitorpamplona.amethyst.ui.feeds.PagerStateKeys
 import com.vitorpamplona.amethyst.ui.feeds.RefresheableBox
 import com.vitorpamplona.amethyst.ui.feeds.RenderFeedContentState

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedView.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.feeds.StringFeedState
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.feeds.FeedError
 import com.vitorpamplona.amethyst.ui.feeds.LoadingFeed

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedViewModel.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vitorpamplona.amethyst.commons.ui.feeds.InvalidatableContent
+import com.vitorpamplona.amethyst.commons.ui.feeds.StringFeedState
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.service.BundledUpdate
 import com.vitorpamplona.amethyst.service.checkNotInMainThread

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/ChannelFeedState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/ChannelFeedState.kt
@@ -18,7 +18,23 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-// Re-export from commons for backwards compatibility
-typealias StringFeedState = com.vitorpamplona.amethyst.commons.ui.feeds.StringFeedState
+import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.model.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+
+@Stable
+sealed class ChannelFeedState {
+    object Loading : ChannelFeedState()
+
+    class Loaded(
+        val feed: MutableStateFlow<LoadedFeedState<Channel>>,
+    ) : ChannelFeedState()
+
+    object Empty : ChannelFeedState()
+
+    class FeedError(
+        val errorMessage: String,
+    ) : ChannelFeedState()
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/StringFeedState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/StringFeedState.kt
@@ -18,7 +18,21 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-// Re-export from commons for backwards compatibility
-typealias StringFeedState = com.vitorpamplona.amethyst.commons.ui.feeds.StringFeedState
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.coroutines.flow.MutableStateFlow
+
+sealed class StringFeedState {
+    object Loading : StringFeedState()
+
+    class Loaded(
+        val feed: MutableStateFlow<ImmutableList<String>>,
+    ) : StringFeedState()
+
+    object Empty : StringFeedState()
+
+    class FeedError(
+        val errorMessage: String,
+    ) : StringFeedState()
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/UserFeedState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/UserFeedState.kt
@@ -18,7 +18,28 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-// Re-export from commons for backwards compatibility
-typealias StringFeedState = com.vitorpamplona.amethyst.commons.ui.feeds.StringFeedState
+import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.model.User
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.coroutines.flow.MutableStateFlow
+
+@Stable
+sealed class UserFeedState {
+    @Stable
+    object Loading : UserFeedState()
+
+    @Stable
+    class Loaded(
+        val feed: MutableStateFlow<ImmutableList<User>>,
+    ) : UserFeedState()
+
+    @Stable
+    object Empty : UserFeedState()
+
+    @Stable
+    class FeedError(
+        val errorMessage: String,
+    ) : UserFeedState()
+}


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

Moves ChannelFeedState, StringFeedState, UserFeedState sealed classes to commons
with direct consumer imports (typealiases break is-checks for nested types).
Similar to #2284 (GenericLoadable + UrlPreviewState) and #2292 (TorServiceStatus).

### Changes
- **Moved to `commons/ui/feeds/`:** ChannelFeedState, StringFeedState, UserFeedState
- **Original files:** replaced with typealiases for backward compatibility
- **6 consumer files** updated with direct commons imports
- All dependencies (Channel, User, LoadedFeedState) already in commons