### PR TITLE
feat: move AdditiveComplexFeedFilter and DefaultFeedOrder comparators to commons

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/AdditiveComplexFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/AdditiveComplexFeedFilter.kt
@@ -20,9 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.dal
 
-abstract class AdditiveComplexFeedFilter<T, U> : FeedFilter<T>() {
-    abstract fun updateListWith(
-        oldList: List<T>,
-        newItems: Set<U>,
-    ): List<T>
-}
+// Re-export from commons for backwards compatibility
+typealias AdditiveComplexFeedFilter<T, U> = com.vitorpamplona.amethyst.commons.ui.feeds.AdditiveComplexFeedFilter<T, U>

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/AdditiveComplexFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/AdditiveComplexFeedFilter.kt
@@ -18,9 +18,11 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.dal
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-// Re-export from commons for backwards compatibility
-val DefaultFeedOrder = com.vitorpamplona.amethyst.commons.ui.feeds.DefaultFeedOrder
-val DefaultFeedOrderEvent = com.vitorpamplona.amethyst.commons.ui.feeds.DefaultFeedOrderEvent
-val DefaultFeedOrderCard = com.vitorpamplona.amethyst.commons.ui.feeds.DefaultFeedOrderCard
+abstract class AdditiveComplexFeedFilter<T, U> : FeedFilter<T>() {
+    abstract fun updateListWith(
+        oldList: List<T>,
+        newItems: Set<U>,
+    ): List<T>
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/DefaultFeedOrder.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/DefaultFeedOrder.kt
@@ -21,6 +21,14 @@
 package com.vitorpamplona.amethyst.commons.ui.feeds
 
 import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.ui.notifications.Card
+import com.vitorpamplona.quartz.nip01Core.core.Event
 
 val DefaultFeedOrder: Comparator<Note> =
     compareByDescending<Note> { it.createdAt() }.thenBy { it.idHex }
+
+val DefaultFeedOrderEvent: Comparator<Event> =
+    compareByDescending<Event> { it.createdAt }.thenBy { it.id }
+
+val DefaultFeedOrderCard: Comparator<Card> =
+    compareByDescending<Card> { it.createdAt() }.thenBy { it.id() }


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

Moves DAL infrastructure files to the commons module:

- **AdditiveComplexFeedFilter<T, U>**: abstract class moved to `commons/ui/feeds/`, typealias left at original location for backward compatibility
- **DefaultFeedOrderEvent** & **DefaultFeedOrderCard**: comparators moved to commons alongside the existing `DefaultFeedOrder` (Note comparator), with re-exports at original location

Pattern: implementation → commons, typealias at original `amethyst.ui.dal` package.