### PR TITLE
feat: move utility extensions and small helpers to commons

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/CountFormatter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/CountFormatter.kt
@@ -20,24 +20,15 @@
  */
 package com.vitorpamplona.amethyst.service
 
-import kotlin.math.roundToInt
-
+// Re-export from commons for backwards compatibility
 fun countToHumanReadable(
     counter: Int,
     str: String,
-) = when {
-    counter >= 1000000000 -> "${(counter / 1000000000f).roundToInt()}G $str"
-    counter >= 1000000 -> "${(counter / 1000000f).roundToInt()}M $str"
-    counter >= 1000 -> "${(counter / 1000f).roundToInt()}K $str"
-    else -> "$counter $str"
-}
+) = com.vitorpamplona.amethyst.commons.util
+    .countToHumanReadable(counter, str)
 
 fun countToHumanReadable(
     counter: Long,
     str: String,
-) = when {
-    counter >= 1000000000 -> "${(counter / 1000000000f).roundToInt()}G $str"
-    counter >= 1000000 -> "${(counter / 1000000f).roundToInt()}M $str"
-    counter >= 1000 -> "${(counter / 1000f).roundToInt()}K $str"
-    else -> "$counter $str"
-}
+) = com.vitorpamplona.amethyst.commons.util
+    .countToHumanReadable(counter, str)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/IterableExt.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/IterableExt.kt
@@ -20,7 +20,10 @@
  */
 package com.vitorpamplona.amethyst.service
 
+import com.vitorpamplona.amethyst.commons.util.replace as commonsReplace
+
+// Re-export from commons for backwards compatibility
 fun <T> Iterable<T>.replace(
     old: T,
     new: T,
-): List<T> = map { if (it == old) new else it }
+): List<T> = commonsReplace(old, new)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/SetExt.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/SetExt.kt
@@ -20,4 +20,7 @@
  */
 package com.vitorpamplona.amethyst.service
 
-fun <T> Set<T>.togglePresenceInSet(item: T): Set<T> = if (contains(item)) minus(item) else plus(item)
+import com.vitorpamplona.amethyst.commons.util.togglePresenceInSet as commonsTogglePresenceInSet
+
+// Re-export from commons for backwards compatibility
+fun <T> Set<T>.togglePresenceInSet(item: T): Set<T> = commonsTogglePresenceInSet(item)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/diskCache/IsLiveStreaming.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/diskCache/IsLiveStreaming.kt
@@ -20,4 +20,7 @@
  */
 package com.vitorpamplona.amethyst.service.playback.diskCache
 
-fun isLiveStreaming(url: String) = url.contains(".m3u8", true)
+// Re-export from commons for backwards compatibility
+fun isLiveStreaming(url: String) =
+    com.vitorpamplona.amethyst.commons.util
+        .isLiveStreaming(url)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/util/IsLiveStreaming.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/util/IsLiveStreaming.kt
@@ -18,13 +18,6 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.service
+package com.vitorpamplona.amethyst.commons.util
 
-// Re-export from commons for backwards compatibility
-fun countToHumanReadableBytes(counter: Int) =
-    com.vitorpamplona.amethyst.commons.util
-        .countToHumanReadableBytes(counter)
-
-fun countToHumanReadableBytes(counter: Long) =
-    com.vitorpamplona.amethyst.commons.util
-        .countToHumanReadableBytes(counter)
+fun isLiveStreaming(url: String) = url.contains(".m3u8", true)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/util/SetUtils.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/util/SetUtils.kt
@@ -18,13 +18,10 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.service
+package com.vitorpamplona.amethyst.commons.util
 
-// Re-export from commons for backwards compatibility
-fun countToHumanReadableBytes(counter: Int) =
-    com.vitorpamplona.amethyst.commons.util
-        .countToHumanReadableBytes(counter)
-
-fun countToHumanReadableBytes(counter: Long) =
-    com.vitorpamplona.amethyst.commons.util
-        .countToHumanReadableBytes(counter)
+/**
+ * Toggles the presence of an item in a Set.
+ * If the item is present, it is removed; if absent, it is added.
+ */
+fun <T> Set<T>.togglePresenceInSet(item: T): Set<T> = if (contains(item)) minus(item) else plus(item)


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

Moves small utility files, extension functions, and helpers to commons module:

**New in commons:**
- `togglePresenceInSet` (Set extension) → `commons/util/SetUtils.kt`
- `isLiveStreaming` (URL checker) → `commons/util/IsLiveStreaming.kt`

**Converted to backward-compat wrappers** (already existed in commons):
- `IterableExt.kt` → re-exports `replace` from `commons/util/IterableUtils.kt`
- `ByteFormatter.kt` → re-exports `countToHumanReadableBytes` from `commons/util/NumberFormatters.kt`
- `CountFormatter.kt` → re-exports `countToHumanReadable` from `commons/util/NumberFormatters.kt`

Pattern: backward-compatible wrappers at original locations, implementations in commons.