### PR TITLE
feat: add IHiddenUsersState and IBlockPeopleListState interfaces to commons

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -327,11 +327,11 @@ class Account(
     val trustProviderList = TrustProviderListState(signer, cache, trustProviderListDecryptionCache, scope, settings)
 
     val peopleListDecryptionCache = PeopleListDecryptionCache(signer)
-    val blockPeopleList = BlockPeopleListState(signer, cache, peopleListDecryptionCache, scope)
+    override val blockPeopleList = BlockPeopleListState(signer, cache, peopleListDecryptionCache, scope)
     val peopleLists = PeopleListsState(signer, cache, peopleListDecryptionCache, scope)
     val followLists = FollowListsState(signer, cache, scope)
 
-    val hiddenUsers = HiddenUsersState(muteList.flow, blockPeopleList.flow, scope, settings)
+    override val hiddenUsers = HiddenUsersState(muteList.flow, blockPeopleList.flow, scope, settings)
 
     val labeledBookmarkLists = LabeledBookmarkListsState(signer, cache, scope)
     val oldBookmarkState = OldBookmarkListState(signer, cache, scope)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/HiddenUsersState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/HiddenUsersState.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.model.nip51Lists
 
+import com.vitorpamplona.amethyst.commons.model.IHiddenUsersState
 import com.vitorpamplona.amethyst.commons.model.LiveHiddenUsers
 import com.vitorpamplona.amethyst.model.AccountSettings
 import com.vitorpamplona.amethyst.service.checkNotInMainThread
@@ -44,7 +45,7 @@ class HiddenUsersState(
     val blockList: StateFlow<List<MuteTag>>,
     val scope: CoroutineScope,
     val settings: AccountSettings,
-) {
+) : IHiddenUsersState {
     var transientHiddenUsers: MutableStateFlow<Set<String>> = MutableStateFlow(setOf())
 
     fun assembleLiveHiddenUsers(
@@ -69,7 +70,7 @@ class HiddenUsersState(
         )
     }
 
-    val flow: StateFlow<LiveHiddenUsers> =
+    override val flow: StateFlow<LiveHiddenUsers> =
         combineTransform(
             blockList,
             muteList,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/blockPeopleList/BlockPeopleListState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/blockPeopleList/BlockPeopleListState.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.model.nip51Lists.blockPeopleList
 
+import com.vitorpamplona.amethyst.commons.model.IBlockPeopleListState
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.NoteState
@@ -43,11 +44,11 @@ class BlockPeopleListState(
     val cache: LocalCache,
     val decryptionCache: PeopleListDecryptionCache,
     val scope: CoroutineScope,
-) {
+) : IBlockPeopleListState {
     // Creates a long-term reference for this note so that the GC doesn't collect the note it self
     val blockListNote = cache.getOrCreateAddressableNote(getBlockListAddress())
 
-    fun getBlockListAddress() = PeopleListEvent.createBlockAddress(signer.pubKey)
+    override fun getBlockListAddress() = PeopleListEvent.createBlockAddress(signer.pubKey)
 
     fun getBlockListFlow(): StateFlow<NoteState> = blockListNote.flow().metadata.stateFlow
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
@@ -94,6 +94,12 @@ interface IAccount {
     val hiddenUsersHashCodes: Set<Int>
     val spammersHashCodes: Set<Int>
 
+    /** Hidden users state for DAL content filtering */
+    val hiddenUsers: IHiddenUsersState
+
+    /** Block people list state for DAL filter comparisons */
+    val blockPeopleList: IBlockPeopleListState
+
     /** Set of followed user pubkeys (for feed ordering/highlighting) */
     fun followingKeySet(): Set<String>
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IBlockPeopleListState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IBlockPeopleListState.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model
+
+import com.vitorpamplona.quartz.nip01Core.core.Address
+
+/**
+ * Interface for block people list state, abstracting Android-specific BlockPeopleListState
+ * for use in commons DAL filters.
+ *
+ * DAL filters use [getBlockListAddress] to compare against TopFilter selections.
+ */
+interface IBlockPeopleListState {
+    fun getBlockListAddress(): Address
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IHiddenUsersState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IHiddenUsersState.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Interface for hidden users state, abstracting Android-specific HiddenUsersState
+ * for use in commons DAL filters.
+ *
+ * DAL filters access [flow] to get the current [LiveHiddenUsers] for content filtering.
+ */
+interface IHiddenUsersState {
+    val flow: StateFlow<LiveHiddenUsers>
+}


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

Adds two interfaces to commons that abstract the Android-specific state classes:

- **`IHiddenUsersState`** — exposes `flow: StateFlow<LiveHiddenUsers>` for DAL content filtering
- **`IBlockPeopleListState`** — exposes `getBlockListAddress(): Address` for DAL filter comparisons

The Android `HiddenUsersState` and `BlockPeopleListState` now implement these interfaces. `IAccount` declares both as properties so DAL filters in commons can access `account.hiddenUsers.flow.value` and `account.blockPeopleList.getBlockListAddress()` without Android dependencies.