### PR TITLE
feat: expand IAccount with reactive state flows (v6) — unblocks DAL filters

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.amethyst.BuildConfig
 import com.vitorpamplona.amethyst.LocalPreferences
 import com.vitorpamplona.amethyst.commons.marmot.MarmotManager
 import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.LiveHiddenUsers
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatListDecryptionCache
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatListState
@@ -239,6 +240,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.math.BigDecimal
@@ -415,29 +417,42 @@ class Account(
         ).flow
 
     // App-ready Feeds
-    val liveHomeFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultHomeFollowList)
+    override val liveHomeFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultHomeFollowList)
     val liveHomeFollowListsPerRelay = OutboxLoaderState(liveHomeFollowLists, cache, scope).flow
 
-    val liveStoriesFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultStoriesFollowList)
+    override val liveStoriesFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultStoriesFollowList)
     val liveStoriesFollowListsPerRelay = OutboxLoaderState(liveStoriesFollowLists, cache, scope).flow
 
-    val liveDiscoveryFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultDiscoveryFollowList)
+    override val liveDiscoveryFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultDiscoveryFollowList)
     val liveDiscoveryFollowListsPerRelay = OutboxLoaderState(liveDiscoveryFollowLists, cache, scope).flow
 
-    val liveNotificationFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultNotificationFollowList)
+    override val liveNotificationFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultNotificationFollowList)
     val liveNotificationFollowListsPerRelay = OutboxLoaderState(liveNotificationFollowLists, cache, scope).flow
 
-    val livePollsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultPollsFollowList)
+    override val livePollsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultPollsFollowList)
     val livePollsFollowListsPerRelay = OutboxLoaderState(livePollsFollowLists, cache, scope).flow
 
-    val livePicturesFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultPicturesFollowList)
+    override val livePicturesFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultPicturesFollowList)
     val livePicturesFollowListsPerRelay = OutboxLoaderState(livePicturesFollowLists, cache, scope).flow
 
-    val liveShortsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultShortsFollowList)
+    override val liveShortsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultShortsFollowList)
     val liveShortsFollowListsPerRelay = OutboxLoaderState(liveShortsFollowLists, cache, scope).flow
 
-    val liveLongsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultLongsFollowList)
+    override val liveLongsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultLongsFollowList)
     val liveLongsFollowListsPerRelay = OutboxLoaderState(liveLongsFollowLists, cache, scope).flow
+
+    // IAccount reactive state flow overrides for DAL filter migration
+    override val liveHiddenUsersFlow: StateFlow<LiveHiddenUsers> get() = hiddenUsers.flow
+
+    override fun getBlockListAddress() = blockPeopleList.getBlockListAddress()
+
+    override val liveBookmarks get() = bookmarkState.bookmarks
+    override val liveOldBookmarks get() = oldBookmarkState.bookmarks
+    override val liveProxyRelayList get() = proxyRelayList.flow
+    override val defaultHomeFollowListFlow: StateFlow<String> =
+        settings.defaultHomeFollowList
+            .map { it.code }
+            .stateIn(scope, SharingStarted.Eagerly, settings.defaultHomeFollowList.value.code)
 
     override fun isWriteable(): Boolean = settings.isWriteable()
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
@@ -21,7 +21,11 @@
 package com.vitorpamplona.amethyst.commons.model
 
 import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupList
+import com.vitorpamplona.amethyst.commons.model.nip51Lists.BookmarkListState
+import com.vitorpamplona.amethyst.commons.model.nip51Lists.OldBookmarkListState
 import com.vitorpamplona.amethyst.commons.model.privateChats.ChatroomList
+import com.vitorpamplona.quartz.nip01Core.core.Address
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import com.vitorpamplona.quartz.nip04Dm.messages.PrivateDmEvent
@@ -34,6 +38,7 @@ import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Response
 import com.vitorpamplona.quartz.nip57Zaps.IPrivateZapsDecryptionCache
 import com.vitorpamplona.quartz.nip59Giftwrap.wraps.GiftWrapEvent
 import com.vitorpamplona.quartz.utils.DualCase
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Interface for NIP-47 wallet connect signer state.
@@ -107,6 +112,36 @@ interface IAccount {
 
     /** Whether a note is acceptable (not hidden, not blocked, etc.) */
     fun isAcceptable(note: Note): Boolean
+
+    // ---- Reactive state flows for DAL filter migration ----
+
+    /** Live hidden users state (from HiddenUsersState.flow) */
+    val liveHiddenUsersFlow: StateFlow<LiveHiddenUsers>
+
+    /** Top navigation follow list filters per feed type (from topNavFilterFlow) */
+    val liveHomeFollowLists: StateFlow<ITopNavFilter>
+    val liveStoriesFollowLists: StateFlow<ITopNavFilter>
+    val liveDiscoveryFollowLists: StateFlow<ITopNavFilter>
+    val liveNotificationFollowLists: StateFlow<ITopNavFilter>
+    val livePollsFollowLists: StateFlow<ITopNavFilter>
+    val livePicturesFollowLists: StateFlow<ITopNavFilter>
+    val liveShortsFollowLists: StateFlow<ITopNavFilter>
+    val liveLongsFollowLists: StateFlow<ITopNavFilter>
+
+    /** Block list address for the current user */
+    fun getBlockListAddress(): Address
+
+    /** Bookmark list flow (from BookmarkListState.bookmarks) */
+    val liveBookmarks: StateFlow<BookmarkListState.BookmarkList>
+
+    /** Old bookmark list flow (from OldBookmarkListState.bookmarks) */
+    val liveOldBookmarks: StateFlow<OldBookmarkListState.BookmarkList>
+
+    /** Proxy relay list flow (from ProxyRelayListState.flow) */
+    val liveProxyRelayList: StateFlow<Set<NormalizedRelayUrl>>
+
+    /** Default home follow list name for feed key generation */
+    val defaultHomeFollowListFlow: StateFlow<String>
 
     /** Send a NIP-04 encrypted direct message */
     suspend fun sendNip04PrivateMessage(eventTemplate: EventTemplate<PrivateDmEvent>)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/ITopNavFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/ITopNavFilter.kt
@@ -18,14 +18,20 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model.topNavFeeds
+package com.vitorpamplona.amethyst.commons.model
 
-import com.vitorpamplona.amethyst.commons.model.ITopNavFilter
-import com.vitorpamplona.amethyst.model.LocalCache
-import kotlinx.coroutines.flow.Flow
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
 
-interface IFeedTopNavFilter : ITopNavFilter {
-    fun toPerRelayFlow(cache: LocalCache): Flow<IFeedTopNavPerRelayFilterSet>
+/**
+ * Commons-level interface for top navigation feed filters.
+ * Provides the core filtering methods needed by DAL filter classes.
+ *
+ * The amethyst module's IFeedTopNavFilter extends this with additional
+ * relay-specific methods that depend on LocalCache.
+ */
+interface ITopNavFilter {
+    fun matchAuthor(pubkey: HexKey): Boolean
 
-    fun startValue(cache: LocalCache): IFeedTopNavPerRelayFilterSet
+    fun match(noteEvent: Event): Boolean
 }


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

Adds reactive StateFlow properties to IAccount for hidden users, follow lists, bookmarks, block list address, proxy relays, and settings. These are needed by FeedFilter subclasses in the DAL layer.

**New in commons:**
- `ITopNavFilter` interface — commons-level base for `IFeedTopNavFilter` with `matchAuthor()` and `match()` methods

**New on IAccount (15 properties/methods):**
- `liveHiddenUsersFlow: StateFlow<LiveHiddenUsers>`
- 8× follow list flows: `liveHomeFollowLists`, `liveStoriesFollowLists`, `liveDiscoveryFollowLists`, `liveNotificationFollowLists`, `livePollsFollowLists`, `livePicturesFollowLists`, `liveShortsFollowLists`, `liveLongsFollowLists` — all `StateFlow<ITopNavFilter>`
- `getBlockListAddress(): Address`
- `liveBookmarks: StateFlow<BookmarkListState.BookmarkList>`
- `liveOldBookmarks: StateFlow<OldBookmarkListState.BookmarkList>`
- `liveProxyRelayList: StateFlow<Set<NormalizedRelayUrl>>`
- `defaultHomeFollowListFlow: StateFlow<String>`

Follows the pattern of prior expansions: #2237 (v1), #2260 (v2), #2278 (v3), #2280 (v4), #2289 (v5).
Exposes flows directly rather than full state objects to keep the interface minimal.