### PR TITLE
feat: move IFeedTopNavFilter and related interfaces to commons

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/IFeedTopNavPerRelayFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/IFeedTopNavPerRelayFilter.kt
@@ -20,4 +20,4 @@
  */
 package com.vitorpamplona.amethyst.model.topNavFeeds
 
-interface IFeedTopNavPerRelayFilter
+typealias IFeedTopNavPerRelayFilter = com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavPerRelayFilter

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/IFeedTopNavPerRelayFilterSet.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/IFeedTopNavPerRelayFilterSet.kt
@@ -20,4 +20,4 @@
  */
 package com.vitorpamplona.amethyst.model.topNavFeeds
 
-interface IFeedTopNavPerRelayFilterSet
+typealias IFeedTopNavPerRelayFilterSet = com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavPerRelayFilterSet

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allFollows/AllFollowsByOutboxTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allFollows/AllFollowsByOutboxTopNavFilter.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.allFollows
 
 import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.topNavFeeds.CommunityRelayLoader
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
@@ -78,17 +79,17 @@ class AllFollowsByOutboxTopNavFilter(
                 (communities != null && noteEvent.isTaggedAddressableNotes(communities))
         }
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<AllFollowsTopNavPerRelayFilterSet> {
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<AllFollowsTopNavPerRelayFilterSet> {
         val authorsPerRelay =
             if (authors != null) {
-                OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache) { it }
+                OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache as LocalCache) { it }
             } else {
                 MutableStateFlow(emptyMap())
             }
 
         val communitiesPerRelay =
             if (communities != null) {
-                CommunityRelayLoader.toCommunitiesPerRelayFlow(communities, cache) { it }
+                CommunityRelayLoader.toCommunitiesPerRelayFlow(communities, cache as LocalCache) { it }
             } else {
                 MutableStateFlow(emptyMap())
             }
@@ -109,17 +110,17 @@ class AllFollowsByOutboxTopNavFilter(
         }
     }
 
-    override fun startValue(cache: LocalCache): AllFollowsTopNavPerRelayFilterSet {
+    override fun startValue(cache: ICacheProvider): AllFollowsTopNavPerRelayFilterSet {
         val authorsPerRelay =
             if (authors != null) {
-                OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache) { it }
+                OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache as LocalCache) { it }
             } else {
                 emptyMap()
             }
 
         val communitiesPerRelay =
             if (communities != null) {
-                CommunityRelayLoader.communitiesPerRelaySnapshot(communities, cache) { it }
+                CommunityRelayLoader.communitiesPerRelaySnapshot(communities, cache as LocalCache) { it }
             } else {
                 emptyMap()
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allFollows/AllFollowsByProxyTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allFollows/AllFollowsByProxyTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.allFollows
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -74,7 +74,7 @@ class AllFollowsByProxyTopNavFilter(
         }
 
     // forces the use of the Proxy on all connections, replacing the outbox model.
-    override fun toPerRelayFlow(cache: LocalCache): Flow<AllFollowsTopNavPerRelayFilterSet> =
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<AllFollowsTopNavPerRelayFilterSet> =
         MutableStateFlow(
             AllFollowsTopNavPerRelayFilterSet(
                 proxyRelays.associateWith {
@@ -88,7 +88,7 @@ class AllFollowsByProxyTopNavFilter(
             ),
         )
 
-    override fun startValue(cache: LocalCache): AllFollowsTopNavPerRelayFilterSet {
+    override fun startValue(cache: ICacheProvider): AllFollowsTopNavPerRelayFilterSet {
         // forces the use of the Proxy on all connections, replacing the outbox model.
         return AllFollowsTopNavPerRelayFilterSet(
             proxyRelays.associateWith {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allUserFollows/AllUserFollowsByOutboxTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allUserFollows/AllUserFollowsByOutboxTopNavFilter.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.allUserFollows
 
 import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.OutboxRelayLoader
@@ -62,8 +63,8 @@ class AllUserFollowsByOutboxTopNavFilter(
             }
         }
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<AuthorsTopNavPerRelayFilterSet> {
-        val authorsPerRelay = OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache) { it }
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<AuthorsTopNavPerRelayFilterSet> {
+        val authorsPerRelay = OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache as LocalCache) { it }
 
         return combine(authorsPerRelay, defaultRelays, blockedRelays) { perRelayAuthors, default, blockedRelays ->
             val allRelays = perRelayAuthors.keys.filter { it !in blockedRelays }.ifEmpty { default }
@@ -78,8 +79,8 @@ class AllUserFollowsByOutboxTopNavFilter(
         }
     }
 
-    override fun startValue(cache: LocalCache): AuthorsTopNavPerRelayFilterSet {
-        val authorsPerRelay = OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache) { it }
+    override fun startValue(cache: ICacheProvider): AuthorsTopNavPerRelayFilterSet {
+        val authorsPerRelay = OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache as LocalCache) { it }
 
         val allRelays = authorsPerRelay.keys.filter { it !in blockedRelays.value }.ifEmpty { defaultRelays.value }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allUserFollows/AllUserFollowsByProxyTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allUserFollows/AllUserFollowsByProxyTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.allUserFollows
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.author.AuthorsTopNavPerRelayFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.author.AuthorsTopNavPerRelayFilterSet
@@ -60,7 +60,7 @@ class AllUserFollowsByProxyTopNavFilter(
         }
 
     // forces the use of the Proxy on all connections, replacing the outbox model.
-    override fun toPerRelayFlow(cache: LocalCache): Flow<AuthorsTopNavPerRelayFilterSet> =
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<AuthorsTopNavPerRelayFilterSet> =
         MutableStateFlow(
             AuthorsTopNavPerRelayFilterSet(
                 proxyRelays.associateWith {
@@ -71,7 +71,7 @@ class AllUserFollowsByProxyTopNavFilter(
             ),
         )
 
-    override fun startValue(cache: LocalCache): AuthorsTopNavPerRelayFilterSet {
+    override fun startValue(cache: ICacheProvider): AuthorsTopNavPerRelayFilterSet {
         // forces the use of the Proxy on all connections, replacing the outbox model.
         return AuthorsTopNavPerRelayFilterSet(
             proxyRelays.associateWith {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/aroundMe/LocationTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/aroundMe/LocationTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.aroundMe
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -52,12 +52,12 @@ class LocationTopNavFilter(
         }
     }
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<LocationTopNavPerRelayFilterSet> =
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<LocationTopNavPerRelayFilterSet> =
         MutableStateFlow(
             LocationTopNavPerRelayFilterSet(relayList.associateWith { LocationTopNavPerRelayFilter(geotags) }),
         )
 
-    override fun startValue(cache: LocalCache): LocationTopNavPerRelayFilterSet =
+    override fun startValue(cache: ICacheProvider): LocationTopNavPerRelayFilterSet =
         LocationTopNavPerRelayFilterSet(
             relayList.associateWith { LocationTopNavPerRelayFilter(geotags) },
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/chess/ChessTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/chess/ChessTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.chess
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -45,7 +45,7 @@ class ChessTopNavFilter(
             noteEvent is LiveChessGameChallengeEvent ||
             noteEvent is LiveChessGameEndEvent
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<ChessTopNavPerRelayFilterSet> =
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<ChessTopNavPerRelayFilterSet> =
         combine(outboxRelays, proxyRelays) { outboxRelays, proxyRelays ->
             if (proxyRelays.isNotEmpty()) {
                 ChessTopNavPerRelayFilterSet(proxyRelays.associateWith { ChessTopNavPerRelayFilter })
@@ -54,7 +54,7 @@ class ChessTopNavFilter(
             }
         }
 
-    override fun startValue(cache: LocalCache): ChessTopNavPerRelayFilterSet =
+    override fun startValue(cache: ICacheProvider): ChessTopNavPerRelayFilterSet =
         if (proxyRelays.value.isNotEmpty()) {
             ChessTopNavPerRelayFilterSet(proxyRelays.value.associateWith { ChessTopNavPerRelayFilter })
         } else {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/global/GlobalTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/global/GlobalTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.global
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -40,7 +40,7 @@ class GlobalTopNavFilter(
 
     override fun match(noteEvent: Event) = true
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<GlobalTopNavPerRelayFilterSet> =
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<GlobalTopNavPerRelayFilterSet> =
         combine(outboxRelays, proxyRelays, relayFeeds) { outboxRelays, proxyRelays, relayFeeds ->
             if (proxyRelays.isNotEmpty()) {
                 GlobalTopNavPerRelayFilterSet(proxyRelays.associateWith { GlobalTopNavPerRelayFilter })
@@ -49,7 +49,7 @@ class GlobalTopNavFilter(
             }
         }
 
-    override fun startValue(cache: LocalCache): GlobalTopNavPerRelayFilterSet =
+    override fun startValue(cache: ICacheProvider): GlobalTopNavPerRelayFilterSet =
         if (proxyRelays.value.isNotEmpty()) {
             GlobalTopNavPerRelayFilterSet(proxyRelays.value.associateWith { GlobalTopNavPerRelayFilter })
         } else {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/hashtag/HashtagTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/hashtag/HashtagTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.hashtag
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -48,14 +48,14 @@ class HashtagTopNavFilter(
             noteEvent.isTaggedHashes(hashtags)
         }
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<HashtagTopNavPerRelayFilterSet> =
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<HashtagTopNavPerRelayFilterSet> =
         MutableStateFlow(
             HashtagTopNavPerRelayFilterSet(
                 relayList.associateWith { HashtagTopNavPerRelayFilter(hashtags) },
             ),
         )
 
-    override fun startValue(cache: LocalCache): HashtagTopNavPerRelayFilterSet =
+    override fun startValue(cache: ICacheProvider): HashtagTopNavPerRelayFilterSet =
         HashtagTopNavPerRelayFilterSet(
             relayList.associateWith { HashtagTopNavPerRelayFilter(hashtags) },
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/allcommunities/AllCommunitiesTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/allcommunities/AllCommunitiesTopNavFilter.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.allcommunities
 
 import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.topNavFeeds.CommunityRelayLoader
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
@@ -46,16 +47,16 @@ class AllCommunitiesTopNavFilter(
             map.mapValues { AllCommunitiesTopNavPerRelayFilter(it.value) },
         )
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<AllCommunitiesTopNavPerRelayFilterSet> {
-        val communitiesPerRelay = CommunityRelayLoader.toCommunitiesPerRelayFlow(communities, cache) { it }
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<AllCommunitiesTopNavPerRelayFilterSet> {
+        val communitiesPerRelay = CommunityRelayLoader.toCommunitiesPerRelayFlow(communities, cache as LocalCache) { it }
 
         return combine(communitiesPerRelay, blockedRelays) { communitiesPerRelay, blockedRelays ->
             convert(communitiesPerRelay.minus(blockedRelays))
         }
     }
 
-    override fun startValue(cache: LocalCache): AllCommunitiesTopNavPerRelayFilterSet {
-        val communitiesPerRelay = CommunityRelayLoader.communitiesPerRelaySnapshot(communities, cache) { it }
+    override fun startValue(cache: ICacheProvider): AllCommunitiesTopNavPerRelayFilterSet {
+        val communitiesPerRelay = CommunityRelayLoader.communitiesPerRelaySnapshot(communities, cache as LocalCache) { it }
 
         return convert(communitiesPerRelay.minus(blockedRelays.value))
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/author/AuthorsByOutboxTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/author/AuthorsByOutboxTopNavFilter.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.author
 
 import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.OutboxRelayLoader
@@ -51,16 +52,16 @@ class AuthorsByOutboxTopNavFilter(
             map.mapValues { AuthorsTopNavPerRelayFilter(it.value) },
         )
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<AuthorsTopNavPerRelayFilterSet> {
-        val authorsPerRelay = OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache) { it }
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<AuthorsTopNavPerRelayFilterSet> {
+        val authorsPerRelay = OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache as LocalCache) { it }
 
         return combine(authorsPerRelay, blockedRelays) { authors, blocked ->
             convert(authors.minus(blocked))
         }
     }
 
-    override fun startValue(cache: LocalCache): AuthorsTopNavPerRelayFilterSet {
-        val authorsPerRelay = OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache) { it }
+    override fun startValue(cache: ICacheProvider): AuthorsTopNavPerRelayFilterSet {
+        val authorsPerRelay = OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache as LocalCache) { it }
 
         return convert(authorsPerRelay.minus(blockedRelays.value))
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/community/SingleCommunityTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/community/SingleCommunityTopNavFilter.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.community
 
 import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.OutboxRelayLoader
@@ -53,7 +54,7 @@ class SingleCommunityTopNavFilter(
             (authors != null && noteEvent.pubKey in authors) || noteEvent.isTaggedAddressableNote(community)
         }
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<SingleCommunityTopNavPerRelayFilterSet> {
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<SingleCommunityTopNavPerRelayFilterSet> {
         // relay field takes priority
         if (relays.isNotEmpty()) {
             return blockedRelays.map { blocked ->
@@ -67,7 +68,7 @@ class SingleCommunityTopNavFilter(
 
         if (authors != null) {
             // go by authors
-            val authorsPerRelay = OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache) { it }
+            val authorsPerRelay = OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache as LocalCache) { it }
 
             return combine(authorsPerRelay, blockedRelays) { authorsPerRelay, blocked ->
                 SingleCommunityTopNavPerRelayFilterSet(
@@ -81,14 +82,14 @@ class SingleCommunityTopNavFilter(
         // go by hints
         return blockedRelays.map { blocked ->
             SingleCommunityTopNavPerRelayFilterSet(
-                cache.relayHints.hintsForAddress(community).minus(blocked).associateWith {
+                (cache as LocalCache).relayHints.hintsForAddress(community).minus(blocked).associateWith {
                     SingleCommunityTopNavPerRelayFilter(community, authors)
                 },
             )
         }
     }
 
-    override fun startValue(cache: LocalCache): SingleCommunityTopNavPerRelayFilterSet {
+    override fun startValue(cache: ICacheProvider): SingleCommunityTopNavPerRelayFilterSet {
         // relay field takes priority
         if (relays.isNotEmpty()) {
             return SingleCommunityTopNavPerRelayFilterSet(
@@ -100,7 +101,7 @@ class SingleCommunityTopNavFilter(
 
         if (authors != null) {
             // go by authors
-            val authorsPerRelay = OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache) { it }
+            val authorsPerRelay = OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache as LocalCache) { it }
 
             return SingleCommunityTopNavPerRelayFilterSet(
                 authorsPerRelay.minus(blockedRelays.value).mapValues {
@@ -111,7 +112,7 @@ class SingleCommunityTopNavFilter(
 
         // go by hints
         return SingleCommunityTopNavPerRelayFilterSet(
-            cache.relayHints.hintsForAddress(community).minus(blockedRelays.value).associateWith {
+            (cache as LocalCache).relayHints.hintsForAddress(community).minus(blockedRelays.value).associateWith {
                 SingleCommunityTopNavPerRelayFilter(community, authors)
             },
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/muted/MutedAuthorsByOutboxTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/muted/MutedAuthorsByOutboxTopNavFilter.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.muted
 
 import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.OutboxRelayLoader
@@ -51,16 +52,16 @@ class MutedAuthorsByOutboxTopNavFilter(
             map.mapValues { MutedAuthorsTopNavPerRelayFilter(it.value) },
         )
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<MutedAuthorsTopNavPerRelayFilterSet> {
-        val authorsPerRelay = OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache) { it }
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<MutedAuthorsTopNavPerRelayFilterSet> {
+        val authorsPerRelay = OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache as LocalCache) { it }
 
         return combine(authorsPerRelay, blockedRelays) { authors, blocked ->
             convert(authors.minus(blocked))
         }
     }
 
-    override fun startValue(cache: LocalCache): MutedAuthorsTopNavPerRelayFilterSet {
-        val authorsPerRelay = OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache) { it }
+    override fun startValue(cache: ICacheProvider): MutedAuthorsTopNavPerRelayFilterSet {
+        val authorsPerRelay = OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache as LocalCache) { it }
 
         return convert(authorsPerRelay.minus(blockedRelays.value))
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/muted/MutedAuthorsByProxyTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/muted/MutedAuthorsByProxyTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.muted
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -44,14 +44,14 @@ class MutedAuthorsByProxyTopNavFilter(
             noteEvent.pubKey in authors
         }
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<MutedAuthorsTopNavPerRelayFilterSet> =
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<MutedAuthorsTopNavPerRelayFilterSet> =
         MutableStateFlow(
             MutedAuthorsTopNavPerRelayFilterSet(
                 proxyRelays.associateWith { MutedAuthorsTopNavPerRelayFilter(authors) },
             ),
         )
 
-    override fun startValue(cache: LocalCache): MutedAuthorsTopNavPerRelayFilterSet =
+    override fun startValue(cache: ICacheProvider): MutedAuthorsTopNavPerRelayFilterSet =
         MutedAuthorsTopNavPerRelayFilterSet(
             proxyRelays.associateWith { MutedAuthorsTopNavPerRelayFilter(authors) },
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/relay/RelayTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/relay/RelayTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.relay
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -37,7 +37,7 @@ class RelayTopNavFilter(
 
     override fun match(noteEvent: Event) = true
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<RelayTopNavPerRelayFilterSet> = flowOf(RelayTopNavPerRelayFilterSet(relayUrl))
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<RelayTopNavPerRelayFilterSet> = flowOf(RelayTopNavPerRelayFilterSet(relayUrl))
 
-    override fun startValue(cache: LocalCache): RelayTopNavPerRelayFilterSet = RelayTopNavPerRelayFilterSet(relayUrl)
+    override fun startValue(cache: ICacheProvider): RelayTopNavPerRelayFilterSet = RelayTopNavPerRelayFilterSet(relayUrl)
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/unknown/UnknownTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/unknown/UnknownTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.unknown
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
@@ -37,7 +37,7 @@ class UnknownTopNavFilter(
 
     override fun match(noteEvent: Event) = false
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<UnknownTopNavPerRelayFilterSet> = MutableStateFlow(UnknownTopNavPerRelayFilterSet)
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<UnknownTopNavPerRelayFilterSet> = MutableStateFlow(UnknownTopNavPerRelayFilterSet)
 
-    override fun startValue(cache: LocalCache) = UnknownTopNavPerRelayFilterSet
+    override fun startValue(cache: ICacheProvider) = UnknownTopNavPerRelayFilterSet
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/IFeedTopNavFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/IFeedTopNavFilter.kt
@@ -18,41 +18,19 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.author
+package com.vitorpamplona.amethyst.commons.model.topNavFeeds
 
-import androidx.compose.runtime.Immutable
 import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
-import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
-import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
-import com.vitorpamplona.quartz.nip53LiveActivities.streaming.LiveActivitiesEvent
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 
-@Immutable
-class AuthorsByProxyTopNavFilter(
-    val authors: Set<String>,
-    val proxyRelays: Set<NormalizedRelayUrl>,
-) : IFeedTopNavFilter {
-    override fun matchAuthor(pubkey: HexKey) = pubkey in authors
+interface IFeedTopNavFilter {
+    fun matchAuthor(pubkey: HexKey): Boolean
 
-    override fun match(noteEvent: Event): Boolean =
-        if (noteEvent is LiveActivitiesEvent) {
-            noteEvent.participantsIntersect(authors)
-        } else {
-            noteEvent.pubKey in authors
-        }
+    fun match(noteEvent: Event): Boolean
 
-    override fun toPerRelayFlow(cache: ICacheProvider): Flow<AuthorsTopNavPerRelayFilterSet> =
-        MutableStateFlow(
-            AuthorsTopNavPerRelayFilterSet(
-                proxyRelays.associateWith { AuthorsTopNavPerRelayFilter(authors) },
-            ),
-        )
+    fun toPerRelayFlow(cache: ICacheProvider): Flow<IFeedTopNavPerRelayFilterSet>
 
-    override fun startValue(cache: ICacheProvider): AuthorsTopNavPerRelayFilterSet =
-        AuthorsTopNavPerRelayFilterSet(
-            proxyRelays.associateWith { AuthorsTopNavPerRelayFilter(authors) },
-        )
+    fun startValue(cache: ICacheProvider): IFeedTopNavPerRelayFilterSet
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/IFeedTopNavPerRelayFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/IFeedTopNavPerRelayFilter.kt
@@ -18,6 +18,6 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model.topNavFeeds
+package com.vitorpamplona.amethyst.commons.model.topNavFeeds
 
-typealias IFeedTopNavFilter = com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavFilter
+interface IFeedTopNavPerRelayFilter

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/IFeedTopNavPerRelayFilterSet.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/IFeedTopNavPerRelayFilterSet.kt
@@ -18,6 +18,6 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model.topNavFeeds
+package com.vitorpamplona.amethyst.commons.model.topNavFeeds
 
-typealias IFeedTopNavFilter = com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavFilter
+interface IFeedTopNavPerRelayFilterSet


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

Moves IFeedTopNavFilter, IFeedTopNavPerRelayFilter, IFeedTopNavPerRelayFilterSet to commons module.
Replaces LocalCache parameter with ICacheProvider in interface methods.

Original locations now contain typealiases for backward compatibility — all existing consumers
continue to compile without import changes. Implementations cast ICacheProvider back to LocalCache
where needed for LocalCache-specific APIs (relayHints, OutboxRelayLoader).

Prerequisite for adding reactive follow list flows to IAccount (#2238 Phase 9 expansion),
which in turn unblocks all DAL FeedFilter subclass migration.