### PR TITLE
feat: add IRelayListState interface for proxy and blocked relay lists

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -289,7 +289,7 @@ class Account(
     val trustedRelayList = TrustedRelayListState(signer, cache, trustedRelayListDecryptionCache, scope, settings)
 
     val proxyRelayListDecryptionCache = ProxyRelayListDecryptionCache(signer)
-    val proxyRelayList = ProxyRelayListState(signer, cache, proxyRelayListDecryptionCache, scope, settings)
+    override val proxyRelayList = ProxyRelayListState(signer, cache, proxyRelayListDecryptionCache, scope, settings)
 
     val broadcastRelayListDecryptionCache = BroadcastRelayListDecryptionCache(signer)
     val broadcastRelayList = BroadcastRelayListState(signer, cache, broadcastRelayListDecryptionCache, scope, settings)
@@ -301,7 +301,7 @@ class Account(
     val relayFeedsList = RelayFeedListState(signer, cache, relayFeedsListDecryptionCache, scope, settings)
 
     val blockedRelayListDecryptionCache = BlockedRelayListDecryptionCache(signer)
-    val blockedRelayList = BlockedRelayListState(signer, cache, blockedRelayListDecryptionCache, scope, settings)
+    override val blockedRelayList = BlockedRelayListState(signer, cache, blockedRelayListDecryptionCache, scope, settings)
 
     val kind3FollowList = Kind3FollowListState(signer, cache, scope, settings)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/blockedRelays/BlockedRelayListState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/blockedRelays/BlockedRelayListState.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.model.nip51Lists.blockedRelays
 
+import com.vitorpamplona.amethyst.commons.model.IRelayListState
 import com.vitorpamplona.amethyst.model.AccountSettings
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
@@ -46,7 +47,7 @@ class BlockedRelayListState(
     val decryptionCache: BlockedRelayListDecryptionCache,
     val scope: CoroutineScope,
     val settings: AccountSettings,
-) {
+) : IRelayListState {
     // Creates a long-term reference for this note so that the GC doesn't collect the note it self
     val blockedListNote = cache.getOrCreateAddressableNote(getBlockedRelayListAddress())
 
@@ -61,7 +62,7 @@ class BlockedRelayListState(
         return event?.let { decryptionCache.relays(it) } ?: emptySet()
     }
 
-    val flow =
+    override val flow =
         getBlockedRelayListFlow()
             .map {
                 normalizeBlockedRelayListWithBackup(it.note)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/proxyRelays/ProxyRelayListState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/proxyRelays/ProxyRelayListState.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.model.nip51Lists.proxyRelays
 
+import com.vitorpamplona.amethyst.commons.model.IRelayListState
 import com.vitorpamplona.amethyst.model.AccountSettings
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
@@ -42,7 +43,7 @@ class ProxyRelayListState(
     val decryptionCache: ProxyRelayListDecryptionCache,
     val scope: CoroutineScope,
     val settings: AccountSettings,
-) {
+) : IRelayListState {
     // Creates a long-term reference for this note so that the GC doesn't collect the note it self
     val proxyListNote = cache.getOrCreateAddressableNote(getProxyRelayListAddress())
 
@@ -57,7 +58,7 @@ class ProxyRelayListState(
         return event?.let { decryptionCache.relays(it) } ?: emptySet()
     }
 
-    val flow =
+    override val flow =
         getProxyRelayListFlow()
             .map { normalizeProxyRelayListWithBackup(it.note) }
             .onStart { emit(normalizeProxyRelayListWithBackup(proxyListNote)) }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
@@ -119,4 +119,10 @@ interface IAccount {
 
     /** Broadcast pre-created gift wraps (e.g. reactions within group DMs) */
     suspend fun sendGiftWraps(wraps: List<GiftWrapEvent>)
+
+    /** Proxy relay list state for relay routing */
+    val proxyRelayList: IRelayListState
+
+    /** Blocked relay list state for relay filtering */
+    val blockedRelayList: IRelayListState
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IRelayListState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IRelayListState.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model
+
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Interface for relay list state (proxy relays, blocked relays, etc.).
+ * Exposes a reactive flow of normalized relay URLs.
+ * Used by DAL filters to access account.proxyRelayList.flow and account.blockedRelayList.flow.
+ */
+interface IRelayListState {
+    val flow: StateFlow<Set<NormalizedRelayUrl>>
+}


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

Creates `IRelayListState` interface in commons for `ProxyRelayListState` and `BlockedRelayListState`.

**Changes:**
- New `IRelayListState` interface in `commons/model/` with `flow: StateFlow<Set<NormalizedRelayUrl>>`
- `ProxyRelayListState` and `BlockedRelayListState` now implement `IRelayListState`
- `IAccount` now exposes `proxyRelayList` and `blockedRelayList` as `IRelayListState`
- `Account` properties marked `override` accordingly

DAL filters access `account.proxyRelayList.flow` and `account.blockedRelayList.flow` — this enables those patterns to work against the commons interface.