### PR TITLE
feat: add expect/actual wrappers for JVM utility APIs in commons (KMP)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/previews/HtmlParser.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/previews/HtmlParser.kt
@@ -70,7 +70,7 @@ class HtmlParser {
 
             // if sniffing was failed, detect charset from content
             val charset = HtmlCharsetParser.detectCharset(bodyBytes)
-            val content = bodyBytes.toString(charset)
+            val content = bodyBytes.toString(charset.javaCharset)
             return@withContext MetaTagsParser.parse(content)
         }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/UrlPreviewCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/UrlPreviewCard.kt
@@ -101,7 +101,7 @@ fun UrlPreviewCard(
         )
 
         Text(
-            text = previewInfo.verifiedUrl?.host ?: previewInfo.url,
+            text = previewInfo.verifiedUrlHost ?: previewInfo.url,
             style = MaterialTheme.typography.bodySmall,
             modifier = MaxWidthWithHorzPadding,
             color = Color.Gray,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/previews/PreviewUrl.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/previews/PreviewUrl.kt
@@ -227,7 +227,7 @@ private fun MyLoadUrlPreviewDirect(
                         )
 
                         Text(
-                            text = state.previewInfo.verifiedUrl?.host ?: state.previewInfo.title,
+                            text = state.previewInfo.verifiedUrlHost ?: state.previewInfo.title,
                             style = MaterialTheme.typography.bodyMedium,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/webBookmarks/WebBookmarksScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/webBookmarks/WebBookmarksScreen.kt
@@ -295,7 +295,7 @@ private fun WebBookmarkCard(
                 )
 
                 Text(
-                    text = previewInfo?.verifiedUrl?.host ?: event.url(),
+                    text = previewInfo?.verifiedUrlHost ?: event.url(),
                     style = MaterialTheme.typography.bodySmall,
                     color = Color.Gray,
                     maxLines = 1,

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/ChessEventCollector.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/ChessEventCollector.kt
@@ -20,6 +20,8 @@
  */
 package com.vitorpamplona.amethyst.commons.chess
 
+import com.vitorpamplona.amethyst.commons.platformcompat.PlatformConcurrentHashMap
+import com.vitorpamplona.amethyst.commons.platformcompat.platformConcurrentKeySet
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip64Chess.jester.JesterEvent
 import com.vitorpamplona.quartz.nip64Chess.jester.JesterGameEvents
@@ -29,7 +31,6 @@ import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Collects and aggregates Jester chess events for a game from any source.
@@ -68,10 +69,10 @@ class ChessEventCollector(
     val startEvent: StateFlow<JesterEvent?> = _startEvent.asStateFlow()
 
     // Move events (deduplicated by event ID)
-    private val moves = ConcurrentHashMap<String, JesterEvent>()
+    private val moves = PlatformConcurrentHashMap<String, JesterEvent>()
 
     // Track all processed event IDs for fast deduplication
-    private val processedEventIds = ConcurrentHashMap.newKeySet<String>()
+    private val processedEventIds = platformConcurrentKeySet<String>()
 
     // Flow that emits when any event is added (for reactive updates)
     private val _eventCount = MutableStateFlow(0)
@@ -218,7 +219,7 @@ class ChessEventCollector(
  * such as in a chess lobby or when spectating multiple games.
  */
 class ChessEventCollectorManager {
-    private val collectors = ConcurrentHashMap<String, ChessEventCollector>()
+    private val collectors = PlatformConcurrentHashMap<String, ChessEventCollector>()
 
     /**
      * Get or create a collector for a game.

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/ChessLobbyLogic.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/ChessLobbyLogic.kt
@@ -20,6 +20,8 @@
  */
 package com.vitorpamplona.amethyst.commons.chess
 
+import com.vitorpamplona.amethyst.commons.platformcompat.PlatformConcurrentHashMap
+import com.vitorpamplona.amethyst.commons.platformcompat.platformSynchronizedSet
 import com.vitorpamplona.quartz.nip64Chess.ChessGameEnd
 import com.vitorpamplona.quartz.nip64Chess.ChessMoveEvent
 import com.vitorpamplona.quartz.nip64Chess.Color
@@ -130,17 +132,17 @@ class ChessLobbyLogic(
     val state = ChessLobbyState(userPubkey, scope)
 
     private val dismissedGameIds: MutableSet<String> =
-        java.util.Collections.synchronizedSet(
+        platformSynchronizedSet(
             dismissedStorage?.load(userPubkey)?.toMutableSet() ?: mutableSetOf(),
         )
 
     // Track when games were last loaded to prevent duplicate fetches
     // (e.g., discoverUserGames loads a game, then polling immediately re-fetches it)
-    private val recentlyLoadedGames = java.util.concurrent.ConcurrentHashMap<String, Long>()
+    private val recentlyLoadedGames = PlatformConcurrentHashMap<String, Long>()
 
     // Dedup incoming events (same event delivered by multiple relays)
     // Bounded LRU: evict oldest when exceeding capacity
-    private val seenEventIds = java.util.Collections.synchronizedSet(LinkedHashSet<String>())
+    private val seenEventIds = platformSynchronizedSet(LinkedHashSet<String>())
     private val seenEventIdsMax = 500
 
     private val pollingDelegate =

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/ChessLobbyState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/ChessLobbyState.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.commons.chess
 
 import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.commons.platformcompat.PlatformAtomicLong
 import com.vitorpamplona.quartz.nip64Chess.Color
 import com.vitorpamplona.quartz.nip64Chess.GameStatus
 import com.vitorpamplona.quartz.nip64Chess.LiveChessGameState
@@ -29,7 +30,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Challenge expiry: 24 hours
@@ -247,7 +247,7 @@ class ChessLobbyState(
 
     // State version counter - increments on every game state update
     // UI can observe this to force recomposition when internal state changes
-    private val stateVersionCounter = AtomicLong(0)
+    private val stateVersionCounter = PlatformAtomicLong(0)
     private val _stateVersion = MutableStateFlow(0L)
     val stateVersion: StateFlow<Long> = _stateVersion.asStateFlow()
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/ChessRelayFetchHelper.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/ChessRelayFetchHelper.kt
@@ -20,6 +20,8 @@
  */
 package com.vitorpamplona.amethyst.commons.chess
 
+import com.vitorpamplona.amethyst.commons.platformcompat.PlatformConcurrentHashMap
+import com.vitorpamplona.amethyst.commons.platformcompat.platformConcurrentKeySet
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.reqs.SubscriptionListener
@@ -28,7 +30,6 @@ import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.withTimeoutOrNull
-import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Progress callback for relay fetch operations
@@ -74,10 +75,10 @@ class ChessRelayFetchHelper(
     ): List<Event> {
         if (filters.isEmpty()) return emptyList()
 
-        val events = ConcurrentHashMap<String, Event>()
+        val events = PlatformConcurrentHashMap<String, Event>()
         val relayCount = filters.keys.size
-        val eoseReceived = ConcurrentHashMap.newKeySet<NormalizedRelayUrl>()
-        val relayEventCounts = ConcurrentHashMap<NormalizedRelayUrl, Int>()
+        val eoseReceived = platformConcurrentKeySet<NormalizedRelayUrl>()
+        val relayEventCounts = PlatformConcurrentHashMap<NormalizedRelayUrl, Int>()
         val allEose = CompletableDeferred<Unit>()
         val subId = newSubId()
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Channel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Channel.kt
@@ -21,13 +21,13 @@
 package com.vitorpamplona.amethyst.commons.model
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.platformcompat.PlatformWeakReference
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.utils.cache.LargeCache
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import java.lang.ref.WeakReference
 
 @Stable
 abstract class Channel : NotesGatherer {
@@ -41,13 +41,13 @@ abstract class Channel : NotesGatherer {
 
     private var relays = mapOf<NormalizedRelayUrl, Counter>()
 
-    private var changesFlow: WeakReference<MutableSharedFlow<ListChange<Note>>> = WeakReference(null)
+    private var changesFlow: PlatformWeakReference<MutableSharedFlow<ListChange<Note>>> = PlatformWeakReference(null)
 
     fun changesFlow(): MutableSharedFlow<ListChange<Note>> {
         val current = changesFlow.get()
         if (current != null) return current
         val new = MutableSharedFlow<ListChange<Note>>(0, 10, BufferOverflow.DROP_OLDEST)
-        changesFlow = WeakReference(new)
+        changesFlow = PlatformWeakReference(new)
         return new
     }
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Note.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Note.kt
@@ -61,6 +61,7 @@ import com.vitorpamplona.quartz.nip57Zaps.LnZapRequestEvent
 import com.vitorpamplona.quartz.nip59Giftwrap.WrappedEvent
 import com.vitorpamplona.quartz.nip72ModCommunities.approval.CommunityPostApprovalEvent
 import com.vitorpamplona.quartz.nip72ModCommunities.definition.CommunityDefinitionEvent
+import com.vitorpamplona.quartz.utils.BigDecimal
 import com.vitorpamplona.quartz.utils.TimeUtils
 import com.vitorpamplona.quartz.utils.anyAsync
 import com.vitorpamplona.quartz.utils.containsAny
@@ -71,7 +72,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
-import java.math.BigDecimal
 
 interface NotesGatherer {
     fun removeNote(note: Note)
@@ -153,7 +153,7 @@ open class Note(
     var zaps = mapOf<Note, Note?>()
         private set
 
-    var zapsAmount: BigDecimal = BigDecimal.ZERO
+    var zapsAmount: BigDecimal = BigDecimal(0)
 
     var zapPayments = mapOf<Note, Note?>()
         private set
@@ -318,7 +318,7 @@ open class Note(
         reports = mapOf()
         zaps = mapOf()
         zapPayments = mapOf()
-        zapsAmount = BigDecimal.ZERO
+        zapsAmount = BigDecimal(0)
         relays = listOf()
 
         if (repliesChanged) flowSet?.replies?.invalidateData()
@@ -618,13 +618,13 @@ open class Note(
             }.flatten()
 
     private fun updateZapTotal() {
-        var sumOfAmounts = BigDecimal.ZERO
+        var sumOfAmounts = BigDecimal(0)
 
         // Regular Zap Receipts
         zaps.forEach {
             val noteEvent = it.value?.event
             if (noteEvent is LnZapEvent) {
-                sumOfAmounts += noteEvent.amount ?: BigDecimal.ZERO
+                sumOfAmounts = sumOfAmounts.add(noteEvent.amount ?: BigDecimal(0))
             }
         }
 
@@ -701,7 +701,7 @@ open class Note(
                     val amount =
                         try {
                             LnInvoiceUtil.getAmountInSats(invoice)
-                        } catch (e: java.lang.Exception) {
+                        } catch (e: Exception) {
                             if (e is CancellationException) throw e
                             null
                         }
@@ -762,7 +762,7 @@ open class Note(
                 pledgeValue != null && it.author == user
             }
 
-    fun pledgedAmountByOthers(): BigDecimal = replies.sumOf { it.event?.addedRewardValue() ?: BigDecimal.ZERO }
+    fun pledgedAmountByOthers(): BigDecimal = replies.fold(BigDecimal(0)) { acc, note -> acc.add(note.event?.addedRewardValue() ?: BigDecimal(0)) }
 
     fun hasAnyReports(): Boolean {
         val dayAgo = TimeUtils.oneDayAgo()
@@ -846,7 +846,7 @@ open class Note(
         boosts = emptyList()
         reports = emptyMap()
         zaps = emptyMap()
-        zapsAmount = BigDecimal.ZERO
+        zapsAmount = BigDecimal(0)
     }
 
     fun isHiddenFor(accountChoices: LiveHiddenUsers): Boolean {

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/marmotGroups/MarmotGroupChatroom.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/marmotGroups/MarmotGroupChatroom.kt
@@ -25,11 +25,11 @@ import com.vitorpamplona.amethyst.commons.model.Channel.Companion.DefaultFeedOrd
 import com.vitorpamplona.amethyst.commons.model.ListChange
 import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.amethyst.commons.model.NotesGatherer
+import com.vitorpamplona.amethyst.commons.platformcompat.PlatformWeakReference
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import java.lang.ref.WeakReference
 
 /**
  * Represents a Marmot MLS group chat room.
@@ -49,13 +49,13 @@ class MarmotGroupChatroom(
     var newestMessage: Note? = null
     val unreadCount = MutableStateFlow(0)
 
-    private var changesFlow: WeakReference<MutableSharedFlow<ListChange<Note>>> = WeakReference(null)
+    private var changesFlow: PlatformWeakReference<MutableSharedFlow<ListChange<Note>>> = PlatformWeakReference(null)
 
     fun changesFlow(): MutableSharedFlow<ListChange<Note>> {
         val current = changesFlow.get()
         if (current != null) return current
         val new = MutableSharedFlow<ListChange<Note>>(0, 100, BufferOverflow.DROP_OLDEST)
-        changesFlow = WeakReference(new)
+        changesFlow = PlatformWeakReference(new)
         return new
     }
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip01Core/UserRelaysCache.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip01Core/UserRelaysCache.kt
@@ -21,10 +21,10 @@
 package com.vitorpamplona.amethyst.commons.model.nip01Core
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.platformcompat.PlatformWeakReference
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.isLocalHost
 import kotlinx.coroutines.flow.MutableStateFlow
-import java.lang.ref.WeakReference
 
 @Stable
 data class RelayInfo(
@@ -52,11 +52,11 @@ val DefaultOrder =
 @Stable
 class UserRelaysCache {
     var data: Map<NormalizedRelayUrl, RelayInfo> = mapOf()
-    private var flow: WeakReference<MutableStateFlow<Wrapper>>? = null
+    private var flow: PlatformWeakReference<MutableStateFlow<Wrapper>>? = null
 
     fun flow() =
         flow?.get() ?: synchronized(this) {
-            flow?.get() ?: MutableStateFlow(Wrapper(data)).also { flow = WeakReference(it) }
+            flow?.get() ?: MutableStateFlow(Wrapper(data)).also { flow = PlatformWeakReference(it) }
         }
 
     fun add(

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/observables/EventListMatchingFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/observables/EventListMatchingFilter.kt
@@ -22,11 +22,10 @@ package com.vitorpamplona.amethyst.commons.model.observables
 
 import com.vitorpamplona.amethyst.commons.model.AddressableNote
 import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.platformcompat.platformConcurrentSortedSet
 import com.vitorpamplona.quartz.nip01Core.core.AddressableEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
-import java.util.SortedSet
-import java.util.concurrent.ConcurrentSkipListSet
 
 /**
  * Creates a list of events (regular and addressable)
@@ -35,11 +34,11 @@ import java.util.concurrent.ConcurrentSkipListSet
  */
 class EventListMatchingFilter<T : Event>(
     private val filter: Filter,
-    private val atOnce: (filter: Filter) -> SortedSet<Note>,
+    private val atOnce: (filter: Filter) -> Set<Note>,
     private val update: (List<T>) -> Unit,
 ) : Observable {
     // Keeping this here blocks it from being cleared from memory
-    var currentResults: ConcurrentSkipListSet<Note> = ConcurrentSkipListSet(CreatedAtIdHexComparator)
+    var currentResults: MutableSet<Note> = platformConcurrentSortedSet(CreatedAtIdHexComparator)
 
     @Suppress("UNCHECKED_CAST")
     override fun new(
@@ -74,7 +73,7 @@ class EventListMatchingFilter<T : Event>(
 
     @Suppress("UNCHECKED_CAST")
     fun init() {
-        currentResults = ConcurrentSkipListSet(atOnce(filter))
+        currentResults = platformConcurrentSortedSet(atOnce(filter))
         update(currentResults.mapNotNull { it.event as? T })
     }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/observables/NoteListMatchingFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/observables/NoteListMatchingFilter.kt
@@ -22,11 +22,10 @@ package com.vitorpamplona.amethyst.commons.model.observables
 
 import com.vitorpamplona.amethyst.commons.model.AddressableNote
 import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.platformcompat.platformConcurrentSortedSet
 import com.vitorpamplona.quartz.nip01Core.core.AddressableEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
-import java.util.SortedSet
-import java.util.concurrent.ConcurrentSkipListSet
 
 /**
  * Creates a list of notes (regular and addressable)
@@ -36,10 +35,10 @@ import java.util.concurrent.ConcurrentSkipListSet
  */
 class NoteListMatchingFilter(
     private val filter: Filter,
-    private val atOnce: (filter: Filter) -> SortedSet<Note>,
+    private val atOnce: (filter: Filter) -> Set<Note>,
     private val update: (List<Note>) -> Unit,
 ) : Observable {
-    var currentResults: ConcurrentSkipListSet<Note> = ConcurrentSkipListSet(CreatedAtIdHexComparator)
+    var currentResults: MutableSet<Note> = platformConcurrentSortedSet(CreatedAtIdHexComparator)
 
     override fun new(
         event: Event,
@@ -66,7 +65,7 @@ class NoteListMatchingFilter(
     }
 
     fun init() {
-        currentResults = ConcurrentSkipListSet(atOnce(filter))
+        currentResults = platformConcurrentSortedSet(atOnce(filter))
         update(currentResults.toList())
     }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/privateChats/Chatroom.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/privateChats/Chatroom.kt
@@ -26,6 +26,7 @@ import com.vitorpamplona.amethyst.commons.model.ListChange
 import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.amethyst.commons.model.NotesGatherer
 import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.platformcompat.PlatformWeakReference
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip04Dm.messages.PrivateDmEvent
 import com.vitorpamplona.quartz.nip14Subject.subject
@@ -33,7 +34,6 @@ import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import java.lang.ref.WeakReference
 
 @Stable
 class Chatroom : NotesGatherer {
@@ -44,13 +44,13 @@ class Chatroom : NotesGatherer {
     var ownerSentMessage: Boolean = false
     var newestMessage: Note? = null
 
-    private var changesFlow: WeakReference<MutableSharedFlow<ListChange<Note>>> = WeakReference(null)
+    private var changesFlow: PlatformWeakReference<MutableSharedFlow<ListChange<Note>>> = PlatformWeakReference(null)
 
     fun changesFlow(): MutableSharedFlow<ListChange<Note>> {
         val current = changesFlow.get()
         if (current != null) return current
         val new = MutableSharedFlow<ListChange<Note>>(0, 100, BufferOverflow.DROP_OLDEST)
-        changesFlow = WeakReference(new)
+        changesFlow = PlatformWeakReference(new)
         return new
     }
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformAtomicLong.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformAtomicLong.kt
@@ -18,23 +18,12 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.richtext
+package com.vitorpamplona.amethyst.commons.platformcompat
 
-import com.vitorpamplona.amethyst.commons.platformcompat.base64Decode
+expect class PlatformAtomicLong(
+    initialValue: Long,
+) {
+    fun get(): Long
 
-object Base64Image {
-    val pattern = Patterns.BASE64_IMAGE
-
-    fun isBase64(content: String): Boolean = Patterns.BASE64_IMAGE.matches(content)
-
-    fun parse(content: String): ByteArray {
-        val matcher = pattern.find(content)
-        if (matcher != null) {
-            val base64String = matcher.groups[2]?.value
-            val byteArray = base64Decode(base64String ?: throw Exception("Unable to extract base64 from $content"))
-            return byteArray
-        }
-
-        throw Exception("Unable to convert base64 to image $content")
-    }
+    fun incrementAndGet(): Long
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformBase64.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformBase64.kt
@@ -18,23 +18,6 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.richtext
+package com.vitorpamplona.amethyst.commons.platformcompat
 
-import com.vitorpamplona.amethyst.commons.platformcompat.base64Decode
-
-object Base64Image {
-    val pattern = Patterns.BASE64_IMAGE
-
-    fun isBase64(content: String): Boolean = Patterns.BASE64_IMAGE.matches(content)
-
-    fun parse(content: String): ByteArray {
-        val matcher = pattern.find(content)
-        if (matcher != null) {
-            val base64String = matcher.groups[2]?.value
-            val byteArray = base64Decode(base64String ?: throw Exception("Unable to extract base64 from $content"))
-            return byteArray
-        }
-
-        throw Exception("Unable to convert base64 to image $content")
-    }
-}
+expect fun base64Decode(input: String): ByteArray

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformCharset.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformCharset.kt
@@ -18,23 +18,19 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.richtext
+package com.vitorpamplona.amethyst.commons.platformcompat
 
-import com.vitorpamplona.amethyst.commons.platformcompat.base64Decode
+expect class PlatformCharset {
+    fun name(): String
 
-object Base64Image {
-    val pattern = Patterns.BASE64_IMAGE
-
-    fun isBase64(content: String): Boolean = Patterns.BASE64_IMAGE.matches(content)
-
-    fun parse(content: String): ByteArray {
-        val matcher = pattern.find(content)
-        if (matcher != null) {
-            val base64String = matcher.groups[2]?.value
-            val byteArray = base64Decode(base64String ?: throw Exception("Unable to extract base64 from $content"))
-            return byteArray
-        }
-
-        throw Exception("Unable to convert base64 to image $content")
+    companion object {
+        fun forName(charsetName: String): PlatformCharset
     }
 }
+
+expect fun decodeBytes(
+    bytes: ByteArray,
+    offset: Int,
+    length: Int,
+    charset: PlatformCharset,
+): String

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformConcurrentHashMap.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformConcurrentHashMap.kt
@@ -18,23 +18,8 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.richtext
+package com.vitorpamplona.amethyst.commons.platformcompat
 
-import com.vitorpamplona.amethyst.commons.platformcompat.base64Decode
+expect class PlatformConcurrentHashMap<K, V>() : MutableMap<K, V>
 
-object Base64Image {
-    val pattern = Patterns.BASE64_IMAGE
-
-    fun isBase64(content: String): Boolean = Patterns.BASE64_IMAGE.matches(content)
-
-    fun parse(content: String): ByteArray {
-        val matcher = pattern.find(content)
-        if (matcher != null) {
-            val base64String = matcher.groups[2]?.value
-            val byteArray = base64Decode(base64String ?: throw Exception("Unable to extract base64 from $content"))
-            return byteArray
-        }
-
-        throw Exception("Unable to convert base64 to image $content")
-    }
-}
+expect fun <T> platformConcurrentKeySet(): MutableSet<T>

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformConcurrentSortedSet.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformConcurrentSortedSet.kt
@@ -18,23 +18,21 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.richtext
+package com.vitorpamplona.amethyst.commons.platformcompat
 
-import com.vitorpamplona.amethyst.commons.platformcompat.base64Decode
+/**
+ * Creates a thread-safe sorted set backed by a platform-specific implementation.
+ * On JVM/Android this uses ConcurrentSkipListSet.
+ */
+expect fun <T> platformConcurrentSortedSet(comparator: Comparator<T>): MutableSet<T>
 
-object Base64Image {
-    val pattern = Patterns.BASE64_IMAGE
+/**
+ * Creates a thread-safe sorted set from an existing sorted set.
+ */
+expect fun <T> platformConcurrentSortedSet(source: Set<T>): MutableSet<T>
 
-    fun isBase64(content: String): Boolean = Patterns.BASE64_IMAGE.matches(content)
-
-    fun parse(content: String): ByteArray {
-        val matcher = pattern.find(content)
-        if (matcher != null) {
-            val base64String = matcher.groups[2]?.value
-            val byteArray = base64Decode(base64String ?: throw Exception("Unable to extract base64 from $content"))
-            return byteArray
-        }
-
-        throw Exception("Unable to convert base64 to image $content")
-    }
-}
+/**
+ * Wraps a mutable set in a synchronized wrapper.
+ * On JVM/Android this uses Collections.synchronizedSet.
+ */
+expect fun <T> platformSynchronizedSet(set: MutableSet<T>): MutableSet<T>

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformFile.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformFile.kt
@@ -18,23 +18,13 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.richtext
+package com.vitorpamplona.amethyst.commons.platformcompat
 
-import com.vitorpamplona.amethyst.commons.platformcompat.base64Decode
+expect class PlatformFile {
+    constructor(path: String)
+    constructor(parent: PlatformFile, child: String)
 
-object Base64Image {
-    val pattern = Patterns.BASE64_IMAGE
+    fun exists(): Boolean
 
-    fun isBase64(content: String): Boolean = Patterns.BASE64_IMAGE.matches(content)
-
-    fun parse(content: String): ByteArray {
-        val matcher = pattern.find(content)
-        if (matcher != null) {
-            val base64String = matcher.groups[2]?.value
-            val byteArray = base64Decode(base64String ?: throw Exception("Unable to extract base64 from $content"))
-            return byteArray
-        }
-
-        throw Exception("Unable to convert base64 to image $content")
-    }
+    fun getPath(): String
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformUri.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformUri.kt
@@ -18,23 +18,15 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.richtext
+package com.vitorpamplona.amethyst.commons.platformcompat
 
-import com.vitorpamplona.amethyst.commons.platformcompat.base64Decode
+/**
+ * Validates a URL string by attempting to parse it.
+ * Returns true if the URL is well-formed, false otherwise.
+ */
+expect fun isValidUrl(url: String): Boolean
 
-object Base64Image {
-    val pattern = Patterns.BASE64_IMAGE
-
-    fun isBase64(content: String): Boolean = Patterns.BASE64_IMAGE.matches(content)
-
-    fun parse(content: String): ByteArray {
-        val matcher = pattern.find(content)
-        if (matcher != null) {
-            val base64String = matcher.groups[2]?.value
-            val byteArray = base64Decode(base64String ?: throw Exception("Unable to extract base64 from $content"))
-            return byteArray
-        }
-
-        throw Exception("Unable to convert base64 to image $content")
-    }
-}
+/**
+ * Returns the host from a URL string, or null if invalid.
+ */
+expect fun getUrlHost(url: String): String?

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformWeakReference.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformWeakReference.kt
@@ -18,23 +18,10 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.richtext
+package com.vitorpamplona.amethyst.commons.platformcompat
 
-import com.vitorpamplona.amethyst.commons.platformcompat.base64Decode
-
-object Base64Image {
-    val pattern = Patterns.BASE64_IMAGE
-
-    fun isBase64(content: String): Boolean = Patterns.BASE64_IMAGE.matches(content)
-
-    fun parse(content: String): ByteArray {
-        val matcher = pattern.find(content)
-        if (matcher != null) {
-            val base64String = matcher.groups[2]?.value
-            val byteArray = base64Decode(base64String ?: throw Exception("Unable to extract base64 from $content"))
-            return byteArray
-        }
-
-        throw Exception("Unable to convert base64 to image $content")
-    }
+expect class PlatformWeakReference<T : Any>(
+    referent: T?,
+) {
+    fun get(): T?
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/preview/HtmlCharsetParser.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/preview/HtmlCharsetParser.kt
@@ -20,7 +20,8 @@
  */
 package com.vitorpamplona.amethyst.commons.preview
 
-import java.nio.charset.Charset
+import com.vitorpamplona.amethyst.commons.platformcompat.PlatformCharset
+import com.vitorpamplona.amethyst.commons.platformcompat.decodeBytes
 
 object HtmlCharsetParser {
     val ATTRIBUTE_VALUE_CHARSET = "charset"
@@ -29,14 +30,14 @@ object HtmlCharsetParser {
 
     private val RE_CONTENT_TYPE_CHARSET = Regex("""charset=([^;]+)""")
 
-    fun detectCharset(bodyBytes: ByteArray): Charset {
+    fun detectCharset(bodyBytes: ByteArray): PlatformCharset {
         // try to detect charset from meta tags parsed from first 1024 bytes of body
-        val firstPart = String(bodyBytes, 0, 1024, Charset.forName("utf-8"))
+        val firstPart = decodeBytes(bodyBytes, 0, minOf(bodyBytes.size, 1024), PlatformCharset.forName("utf-8"))
         val metaTags = MetaTagsParser.parse(firstPart)
         metaTags.forEach { meta ->
             val charsetAttr = meta.attr(ATTRIBUTE_VALUE_CHARSET)
             if (charsetAttr.isNotEmpty()) {
-                runCatching { Charset.forName(charsetAttr) }.getOrNull()?.let {
+                runCatching { PlatformCharset.forName(charsetAttr) }.getOrNull()?.let {
                     return it
                 }
             }
@@ -44,13 +45,13 @@ object HtmlCharsetParser {
                 RE_CONTENT_TYPE_CHARSET
                     .find(meta.attr(CONTENT))
                     ?.let {
-                        runCatching { Charset.forName(it.groupValues[1]) }.getOrNull()
+                        runCatching { PlatformCharset.forName(it.groupValues[1]) }.getOrNull()
                     }?.let {
                         return it
                     }
             }
         }
         // defaults to UTF-8
-        return Charset.forName("utf-8")
+        return PlatformCharset.forName("utf-8")
     }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/preview/UrlInfoItem.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/preview/UrlInfoItem.kt
@@ -21,7 +21,8 @@
 package com.vitorpamplona.amethyst.commons.preview
 
 import androidx.compose.runtime.Immutable
-import java.net.URI
+import com.vitorpamplona.amethyst.commons.platformcompat.getUrlHost
+import com.vitorpamplona.amethyst.commons.platformcompat.isValidUrl
 
 @Immutable
 class UrlInfoItem(
@@ -31,16 +32,17 @@ class UrlInfoItem(
     val image: String = "",
     val mimeType: String,
 ) {
-    val verifiedUrl = runCatching { URI(url).toURL() }.getOrNull()
+    val isUrlValid = isValidUrl(url)
+    val verifiedUrlHost = getUrlHost(url)
     val imageUrlFullPath =
         if (image.startsWith("/")) {
-            runCatching {
-                verifiedUrl
-                    ?.toURI()
-                    ?.resolve(image)
-                    ?.toURL()
-                    ?.toString()
-            }.getOrNull() ?: image
+            val host = getUrlHost(url)
+            if (host != null && isUrlValid) {
+                val scheme = if (url.startsWith("https")) "https" else "http"
+                "$scheme://$host$image"
+            } else {
+                image
+            }
         } else {
             image
         }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/composeSubscriptionManagers/ComposeSubscriptionManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/composeSubscriptionManagers/ComposeSubscriptionManager.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.commons.relayClient.composeSubscriptionManagers
 
 import androidx.compose.runtime.Stable
-import java.util.concurrent.ConcurrentHashMap
+import com.vitorpamplona.amethyst.commons.platformcompat.PlatformConcurrentHashMap
 
 /**
  *  This allows composables to directly register their queries
@@ -32,7 +32,7 @@ import java.util.concurrent.ConcurrentHashMap
 abstract class ComposeSubscriptionManager<T> :
     ComposeSubscriptionManagerControls,
     Subscribable<T> {
-    private var composeSubscriptions: ConcurrentHashMap<T, T> = ConcurrentHashMap()
+    private var composeSubscriptions: PlatformConcurrentHashMap<T, T> = PlatformConcurrentHashMap()
 
     // This is called by main. Keep it really fast.
     override fun subscribe(query: T?) {

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/composeSubscriptionManagers/MutableComposeSubscriptionManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/composeSubscriptionManagers/MutableComposeSubscriptionManager.kt
@@ -21,12 +21,12 @@
 package com.vitorpamplona.amethyst.commons.relayClient.composeSubscriptionManagers
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.platformcompat.PlatformConcurrentHashMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import java.util.concurrent.ConcurrentHashMap
 
 /**
  *  This allows composables to directly register their queries
@@ -41,7 +41,7 @@ import java.util.concurrent.ConcurrentHashMap
 abstract class MutableComposeSubscriptionManager<T : MutableQueryState>(
     val scope: CoroutineScope,
 ) : ComposeSubscriptionManagerControls {
-    private var composeSubscriptions: ConcurrentHashMap<T, Job?> = ConcurrentHashMap()
+    private var composeSubscriptions: PlatformConcurrentHashMap<T, Job?> = PlatformConcurrentHashMap()
 
     // This is called by main. Keep it really fast.
     fun subscribe(query: T?) {

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/MediaContentModels.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/MediaContentModels.kt
@@ -21,8 +21,8 @@
 package com.vitorpamplona.amethyst.commons.richtext
 
 import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.commons.platformcompat.PlatformFile
 import com.vitorpamplona.quartz.nip94FileMetadata.tags.DimensionTag
-import java.io.File
 
 @Immutable
 abstract class BaseMediaContent(
@@ -101,7 +101,7 @@ class EncryptedMediaUrlVideo(
 
 @Immutable
 abstract class MediaPreloadedContent(
-    val localFile: File?,
+    val localFile: PlatformFile?,
     description: String? = null,
     val mimeType: String? = null,
     val isVerified: Boolean? = null,
@@ -115,7 +115,7 @@ abstract class MediaPreloadedContent(
 
 @Immutable
 class MediaLocalImage(
-    localFile: File?,
+    localFile: PlatformFile?,
     mimeType: String? = null,
     description: String? = null,
     dim: DimensionTag? = null,
@@ -126,7 +126,7 @@ class MediaLocalImage(
 
 @Immutable
 class MediaLocalVideo(
-    localFile: File?,
+    localFile: PlatformFile?,
     mimeType: String? = null,
     description: String? = null,
     dim: DimensionTag? = null,

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
@@ -22,6 +22,7 @@ package com.vitorpamplona.amethyst.commons.richtext
 
 import com.vitorpamplona.amethyst.commons.emojicoder.EmojiCoder
 import com.vitorpamplona.amethyst.commons.model.ImmutableListOfLists
+import com.vitorpamplona.amethyst.commons.platformcompat.isValidUrl
 import com.vitorpamplona.quartz.experimental.inlineMetadata.Nip54InlineMetadata
 import com.vitorpamplona.quartz.nip30CustomEmoji.CustomEmoji
 import com.vitorpamplona.quartz.nip31Alts.AltTag
@@ -38,9 +39,6 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.collections.immutable.toPersistentList
-import java.net.MalformedURLException
-import java.net.URI
-import java.net.URISyntaxException
 import kotlin.coroutines.cancellation.CancellationException
 
 class RichTextParser {
@@ -422,18 +420,9 @@ class RichTextParser {
         }
 
         fun isValidURL(url: String?): Boolean =
-            try {
-                if (url != null) {
-                    URI(url).toURL()
-                    true
-                } else {
-                    false
-                }
-            } catch (e: MalformedURLException) {
-                false
-            } catch (e: URISyntaxException) {
-                false
-            } catch (e: IllegalArgumentException) {
+            if (url != null) {
+                isValidUrl(url)
+            } else {
                 false
             }
 

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformAtomicLong.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformAtomicLong.kt
@@ -18,23 +18,16 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.richtext
+package com.vitorpamplona.amethyst.commons.platformcompat
 
-import com.vitorpamplona.amethyst.commons.platformcompat.base64Decode
+actual class PlatformAtomicLong actual constructor(
+    initialValue: Long,
+) {
+    private val atomic =
+        java.util.concurrent.atomic
+            .AtomicLong(initialValue)
 
-object Base64Image {
-    val pattern = Patterns.BASE64_IMAGE
+    actual fun get(): Long = atomic.get()
 
-    fun isBase64(content: String): Boolean = Patterns.BASE64_IMAGE.matches(content)
-
-    fun parse(content: String): ByteArray {
-        val matcher = pattern.find(content)
-        if (matcher != null) {
-            val base64String = matcher.groups[2]?.value
-            val byteArray = base64Decode(base64String ?: throw Exception("Unable to extract base64 from $content"))
-            return byteArray
-        }
-
-        throw Exception("Unable to convert base64 to image $content")
-    }
+    actual fun incrementAndGet(): Long = atomic.incrementAndGet()
 }

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformBase64.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformBase64.kt
@@ -18,23 +18,9 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.richtext
+package com.vitorpamplona.amethyst.commons.platformcompat
 
-import com.vitorpamplona.amethyst.commons.platformcompat.base64Decode
-
-object Base64Image {
-    val pattern = Patterns.BASE64_IMAGE
-
-    fun isBase64(content: String): Boolean = Patterns.BASE64_IMAGE.matches(content)
-
-    fun parse(content: String): ByteArray {
-        val matcher = pattern.find(content)
-        if (matcher != null) {
-            val base64String = matcher.groups[2]?.value
-            val byteArray = base64Decode(base64String ?: throw Exception("Unable to extract base64 from $content"))
-            return byteArray
-        }
-
-        throw Exception("Unable to convert base64 to image $content")
-    }
-}
+actual fun base64Decode(input: String): ByteArray =
+    java.util.Base64
+        .getDecoder()
+        .decode(input)

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformCharset.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformCharset.kt
@@ -18,23 +18,26 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.richtext
+package com.vitorpamplona.amethyst.commons.platformcompat
 
-import com.vitorpamplona.amethyst.commons.platformcompat.base64Decode
+actual class PlatformCharset(
+    val javaCharset: java.nio.charset.Charset,
+) {
+    actual fun name(): String = javaCharset.name()
 
-object Base64Image {
-    val pattern = Patterns.BASE64_IMAGE
-
-    fun isBase64(content: String): Boolean = Patterns.BASE64_IMAGE.matches(content)
-
-    fun parse(content: String): ByteArray {
-        val matcher = pattern.find(content)
-        if (matcher != null) {
-            val base64String = matcher.groups[2]?.value
-            val byteArray = base64Decode(base64String ?: throw Exception("Unable to extract base64 from $content"))
-            return byteArray
-        }
-
-        throw Exception("Unable to convert base64 to image $content")
+    actual companion object {
+        actual fun forName(charsetName: String): PlatformCharset =
+            PlatformCharset(
+                java.nio.charset.Charset
+                    .forName(charsetName),
+            )
     }
 }
+
+@Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
+actual fun decodeBytes(
+    bytes: ByteArray,
+    offset: Int,
+    length: Int,
+    charset: PlatformCharset,
+): String = java.lang.String(bytes, offset, length, charset.javaCharset) as String

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformConcurrentHashMap.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformConcurrentHashMap.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.platformcompat
+
+import java.util.concurrent.ConcurrentHashMap
+
+actual class PlatformConcurrentHashMap<K, V> actual constructor() : MutableMap<K, V> {
+    private val delegate = ConcurrentHashMap<K, V>()
+
+    override val entries: MutableSet<MutableMap.MutableEntry<K, V>> get() = delegate.entries
+    override val keys: MutableSet<K> get() = delegate.keys
+    override val size: Int get() = delegate.size
+    override val values: MutableCollection<V> get() = delegate.values
+
+    override fun clear() = delegate.clear()
+
+    override fun isEmpty(): Boolean = delegate.isEmpty()
+
+    override fun remove(key: K): V? = delegate.remove(key)
+
+    override fun putAll(from: Map<out K, V>) = delegate.putAll(from)
+
+    override fun put(
+        key: K,
+        value: V,
+    ): V? = delegate.put(key, value)
+
+    override fun get(key: K): V? = delegate.get(key)
+
+    override fun containsValue(value: V): Boolean = delegate.containsValue(value)
+
+    override fun containsKey(key: K): Boolean = delegate.containsKey(key)
+}
+
+actual fun <T> platformConcurrentKeySet(): MutableSet<T> = ConcurrentHashMap.newKeySet()

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformConcurrentSortedSet.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformConcurrentSortedSet.kt
@@ -18,23 +18,12 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.richtext
+package com.vitorpamplona.amethyst.commons.platformcompat
 
-import com.vitorpamplona.amethyst.commons.platformcompat.base64Decode
+import java.util.concurrent.ConcurrentSkipListSet
 
-object Base64Image {
-    val pattern = Patterns.BASE64_IMAGE
+actual fun <T> platformConcurrentSortedSet(comparator: Comparator<T>): MutableSet<T> = ConcurrentSkipListSet(comparator)
 
-    fun isBase64(content: String): Boolean = Patterns.BASE64_IMAGE.matches(content)
+actual fun <T> platformConcurrentSortedSet(source: Set<T>): MutableSet<T> = ConcurrentSkipListSet(source)
 
-    fun parse(content: String): ByteArray {
-        val matcher = pattern.find(content)
-        if (matcher != null) {
-            val base64String = matcher.groups[2]?.value
-            val byteArray = base64Decode(base64String ?: throw Exception("Unable to extract base64 from $content"))
-            return byteArray
-        }
-
-        throw Exception("Unable to convert base64 to image $content")
-    }
-}
+actual fun <T> platformSynchronizedSet(set: MutableSet<T>): MutableSet<T> = java.util.Collections.synchronizedSet(set)

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformFile.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformFile.kt
@@ -18,23 +18,6 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.richtext
+package com.vitorpamplona.amethyst.commons.platformcompat
 
-import com.vitorpamplona.amethyst.commons.platformcompat.base64Decode
-
-object Base64Image {
-    val pattern = Patterns.BASE64_IMAGE
-
-    fun isBase64(content: String): Boolean = Patterns.BASE64_IMAGE.matches(content)
-
-    fun parse(content: String): ByteArray {
-        val matcher = pattern.find(content)
-        if (matcher != null) {
-            val base64String = matcher.groups[2]?.value
-            val byteArray = base64Decode(base64String ?: throw Exception("Unable to extract base64 from $content"))
-            return byteArray
-        }
-
-        throw Exception("Unable to convert base64 to image $content")
-    }
-}
+actual typealias PlatformFile = java.io.File

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformUri.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformUri.kt
@@ -18,23 +18,25 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.richtext
+package com.vitorpamplona.amethyst.commons.platformcompat
 
-import com.vitorpamplona.amethyst.commons.platformcompat.base64Decode
+import java.net.MalformedURLException
+import java.net.URI
+import java.net.URISyntaxException
 
-object Base64Image {
-    val pattern = Patterns.BASE64_IMAGE
-
-    fun isBase64(content: String): Boolean = Patterns.BASE64_IMAGE.matches(content)
-
-    fun parse(content: String): ByteArray {
-        val matcher = pattern.find(content)
-        if (matcher != null) {
-            val base64String = matcher.groups[2]?.value
-            val byteArray = base64Decode(base64String ?: throw Exception("Unable to extract base64 from $content"))
-            return byteArray
-        }
-
-        throw Exception("Unable to convert base64 to image $content")
+actual fun isValidUrl(url: String): Boolean =
+    try {
+        URI(url).toURL()
+        true
+    } catch (e: MalformedURLException) {
+        false
+    } catch (e: URISyntaxException) {
+        false
     }
-}
+
+actual fun getUrlHost(url: String): String? =
+    try {
+        URI(url).host
+    } catch (e: Exception) {
+        null
+    }

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformWeakReference.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/platformcompat/PlatformWeakReference.kt
@@ -18,23 +18,12 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.richtext
+package com.vitorpamplona.amethyst.commons.platformcompat
 
-import com.vitorpamplona.amethyst.commons.platformcompat.base64Decode
+actual class PlatformWeakReference<T : Any> actual constructor(
+    referent: T?,
+) {
+    private val ref = java.lang.ref.WeakReference(referent)
 
-object Base64Image {
-    val pattern = Patterns.BASE64_IMAGE
-
-    fun isBase64(content: String): Boolean = Patterns.BASE64_IMAGE.matches(content)
-
-    fun parse(content: String): ByteArray {
-        val matcher = pattern.find(content)
-        if (matcher != null) {
-            val base64String = matcher.groups[2]?.value
-            val byteArray = base64Decode(base64String ?: throw Exception("Unable to extract base64 from $content"))
-            return byteArray
-        }
-
-        throw Exception("Unable to convert base64 to image $content")
-    }
+    actual fun get(): T? = ref.get()
 }


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

## Summary
Removes **all** `java.*` imports from `commons/src/commonMain` by introducing expect/actual wrappers in a new `platformcompat` package. This is required for iOS compilation of the commons module.

## New expect/actual wrappers (`commons/platformcompat`)

| Wrapper | JVM API replaced |
|---------|-----------------|
| `PlatformWeakReference<T>` | `java.lang.ref.WeakReference` |
| `PlatformConcurrentHashMap<K,V>` | `java.util.concurrent.ConcurrentHashMap` |
| `PlatformAtomicLong` | `java.util.concurrent.atomic.AtomicLong` |
| `PlatformCharset` | `java.nio.charset.Charset` |
| `PlatformFile` | `java.io.File` (typealias on JVM) |
| `isValidUrl` / `getUrlHost` | `java.net.URI` / `java.net.URL` |
| `base64Decode` | `java.util.Base64` |
| `platformConcurrentSortedSet` | `ConcurrentSkipListSet` |
| `platformConcurrentKeySet` | `ConcurrentHashMap.newKeySet` |
| `platformSynchronizedSet` | `Collections.synchronizedSet` |

Also migrates `BigDecimal` usage in `Note.kt` to use quartz's existing expect/actual wrapper (`com.vitorpamplona.quartz.utils.BigDecimal`).

## Files changed
- **16 new files**: 8 expect declarations (commonMain) + 8 actual implementations (jvmAndroid)
- **22 modified files**: Updated imports and usages across commons and amethyst modules

## Build verification
- ✅ `:commons:compileKotlinJvm`
- ✅ `:amethyst:compileFdroidDebugKotlin`
- ✅ `spotlessCheck`