### PR TITLE
feat: move DAL FeedFilter subclasses to commons (batch 1)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
@@ -25,8 +25,8 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.compose.runtime.Immutable
 import androidx.core.content.edit
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.AccountSettings
-import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.model.UiSettings
 import com.vitorpamplona.amethyst.model.nip47WalletConnect.NwcWalletEntry
 import com.vitorpamplona.amethyst.model.nip47WalletConnect.NwcWalletEntryNorm

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.amethyst.BuildConfig
 import com.vitorpamplona.amethyst.LocalPreferences
 import com.vitorpamplona.amethyst.commons.marmot.MarmotManager
 import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.LiveHiddenUsers
 import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatListDecryptionCache
@@ -240,6 +241,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.math.BigDecimal
@@ -328,11 +330,11 @@ class Account(
     val trustProviderList = TrustProviderListState(signer, cache, trustProviderListDecryptionCache, scope, settings)
 
     val peopleListDecryptionCache = PeopleListDecryptionCache(signer)
-    val blockPeopleList = BlockPeopleListState(signer, cache, peopleListDecryptionCache, scope)
+    override val blockPeopleList = BlockPeopleListState(signer, cache, peopleListDecryptionCache, scope)
     val peopleLists = PeopleListsState(signer, cache, peopleListDecryptionCache, scope)
     val followLists = FollowListsState(signer, cache, scope)
 
-    val hiddenUsers = HiddenUsersState(muteList.flow, blockPeopleList.flow, scope, settings)
+    override val hiddenUsers = HiddenUsersState(muteList.flow, blockPeopleList.flow, scope, settings)
 
     val labeledBookmarkLists = LabeledBookmarkListsState(signer, cache, scope)
     val oldBookmarkState = OldBookmarkListState(signer, cache, scope)
@@ -416,29 +418,46 @@ class Account(
         ).flow
 
     // App-ready Feeds
-    val liveHomeFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultHomeFollowList)
+    override val liveHomeFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultHomeFollowList)
     val liveHomeFollowListsPerRelay = OutboxLoaderState(liveHomeFollowLists, cache, scope).flow
 
-    val liveStoriesFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultStoriesFollowList)
+    override val liveStoriesFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultStoriesFollowList)
     val liveStoriesFollowListsPerRelay = OutboxLoaderState(liveStoriesFollowLists, cache, scope).flow
 
-    val liveDiscoveryFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultDiscoveryFollowList)
+    override val liveDiscoveryFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultDiscoveryFollowList)
     val liveDiscoveryFollowListsPerRelay = OutboxLoaderState(liveDiscoveryFollowLists, cache, scope).flow
 
-    val liveNotificationFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultNotificationFollowList)
+    override val liveNotificationFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultNotificationFollowList)
     val liveNotificationFollowListsPerRelay = OutboxLoaderState(liveNotificationFollowLists, cache, scope).flow
 
-    val livePollsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultPollsFollowList)
+    override val livePollsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultPollsFollowList)
     val livePollsFollowListsPerRelay = OutboxLoaderState(livePollsFollowLists, cache, scope).flow
 
-    val livePicturesFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultPicturesFollowList)
+    override val livePicturesFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultPicturesFollowList)
     val livePicturesFollowListsPerRelay = OutboxLoaderState(livePicturesFollowLists, cache, scope).flow
 
-    val liveShortsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultShortsFollowList)
+    override val liveShortsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultShortsFollowList)
     val liveShortsFollowListsPerRelay = OutboxLoaderState(liveShortsFollowLists, cache, scope).flow
 
-    val liveLongsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultLongsFollowList)
+    override val liveLongsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultLongsFollowList)
     val liveLongsFollowListsPerRelay = OutboxLoaderState(liveLongsFollowLists, cache, scope).flow
+
+    // IAccount reactive state overrides
+    override val liveHiddenUsersFlow: StateFlow<LiveHiddenUsers> get() = hiddenUsers.flow
+
+    override val liveBookmarks: StateFlow<com.vitorpamplona.amethyst.commons.model.nip51Lists.BookmarkListState.BookmarkList> get() = bookmarkState.bookmarks
+
+    override val liveOldBookmarks: StateFlow<com.vitorpamplona.amethyst.commons.model.nip51Lists.OldBookmarkListState.BookmarkList> get() = oldBookmarkState.bookmarks
+
+    override val liveProxyRelayList: StateFlow<Set<NormalizedRelayUrl>> get() = proxyRelayList.flow
+
+    override val defaultHomeFollowListFlow: StateFlow<String> by lazy {
+        settings.defaultHomeFollowList
+            .map { it.code }
+            .stateIn(scope, SharingStarted.Eagerly, settings.defaultHomeFollowList.value.code)
+    }
+
+    override fun getBlockListAddress() = blockPeopleList.getBlockListAddress()
 
     override fun isWriteable(): Boolean = settings.isWriteable()
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.amethyst.BuildConfig
 import com.vitorpamplona.amethyst.LocalPreferences
 import com.vitorpamplona.amethyst.commons.marmot.MarmotManager
 import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.LiveHiddenUsers
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatListDecryptionCache
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatListState
@@ -239,6 +240,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.math.BigDecimal
@@ -415,29 +417,42 @@ class Account(
         ).flow
 
     // App-ready Feeds
-    val liveHomeFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultHomeFollowList)
+    override val liveHomeFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultHomeFollowList)
     val liveHomeFollowListsPerRelay = OutboxLoaderState(liveHomeFollowLists, cache, scope).flow
 
-    val liveStoriesFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultStoriesFollowList)
+    override val liveStoriesFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultStoriesFollowList)
     val liveStoriesFollowListsPerRelay = OutboxLoaderState(liveStoriesFollowLists, cache, scope).flow
 
-    val liveDiscoveryFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultDiscoveryFollowList)
+    override val liveDiscoveryFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultDiscoveryFollowList)
     val liveDiscoveryFollowListsPerRelay = OutboxLoaderState(liveDiscoveryFollowLists, cache, scope).flow
 
-    val liveNotificationFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultNotificationFollowList)
+    override val liveNotificationFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultNotificationFollowList)
     val liveNotificationFollowListsPerRelay = OutboxLoaderState(liveNotificationFollowLists, cache, scope).flow
 
-    val livePollsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultPollsFollowList)
+    override val livePollsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultPollsFollowList)
     val livePollsFollowListsPerRelay = OutboxLoaderState(livePollsFollowLists, cache, scope).flow
 
-    val livePicturesFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultPicturesFollowList)
+    override val livePicturesFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultPicturesFollowList)
     val livePicturesFollowListsPerRelay = OutboxLoaderState(livePicturesFollowLists, cache, scope).flow
 
-    val liveShortsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultShortsFollowList)
+    override val liveShortsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultShortsFollowList)
     val liveShortsFollowListsPerRelay = OutboxLoaderState(liveShortsFollowLists, cache, scope).flow
 
-    val liveLongsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultLongsFollowList)
+    override val liveLongsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultLongsFollowList)
     val liveLongsFollowListsPerRelay = OutboxLoaderState(liveLongsFollowLists, cache, scope).flow
+
+    // IAccount reactive state flow overrides for DAL filter migration
+    override val liveHiddenUsersFlow: StateFlow<LiveHiddenUsers> get() = hiddenUsers.flow
+
+    override fun getBlockListAddress() = blockPeopleList.getBlockListAddress()
+
+    override val liveBookmarks get() = bookmarkState.bookmarks
+    override val liveOldBookmarks get() = oldBookmarkState.bookmarks
+    override val liveProxyRelayList get() = proxyRelayList.flow
+    override val defaultHomeFollowListFlow: StateFlow<String> =
+        settings.defaultHomeFollowList
+            .map { it.code }
+            .stateIn(scope, SharingStarted.Eagerly, settings.defaultHomeFollowList.value.code)
 
     override fun isWriteable(): Boolean = settings.isWriteable()
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -25,7 +25,7 @@ import com.vitorpamplona.amethyst.BuildConfig
 import com.vitorpamplona.amethyst.LocalPreferences
 import com.vitorpamplona.amethyst.commons.marmot.MarmotManager
 import com.vitorpamplona.amethyst.commons.model.IAccount
-import com.vitorpamplona.amethyst.commons.model.LiveHiddenUsers
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatListDecryptionCache
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatListState
@@ -240,7 +240,6 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.math.BigDecimal
@@ -249,7 +248,7 @@ import kotlin.coroutines.cancellation.CancellationException
 @OptIn(DelicateCoroutinesApi::class)
 @Stable
 class Account(
-    val settings: AccountSettings = AccountSettings(KeyPair()),
+    override val settings: AccountSettings = AccountSettings(KeyPair()),
     override val signer: NostrSigner,
     val geolocationFlow: () -> StateFlow<LocationState.LocationResult>,
     val nwcFilterAssembler: () -> NWCPaymentFilterAssembler,
@@ -417,42 +416,29 @@ class Account(
         ).flow
 
     // App-ready Feeds
-    override val liveHomeFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultHomeFollowList)
+    val liveHomeFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultHomeFollowList)
     val liveHomeFollowListsPerRelay = OutboxLoaderState(liveHomeFollowLists, cache, scope).flow
 
-    override val liveStoriesFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultStoriesFollowList)
+    val liveStoriesFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultStoriesFollowList)
     val liveStoriesFollowListsPerRelay = OutboxLoaderState(liveStoriesFollowLists, cache, scope).flow
 
-    override val liveDiscoveryFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultDiscoveryFollowList)
+    val liveDiscoveryFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultDiscoveryFollowList)
     val liveDiscoveryFollowListsPerRelay = OutboxLoaderState(liveDiscoveryFollowLists, cache, scope).flow
 
-    override val liveNotificationFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultNotificationFollowList)
+    val liveNotificationFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultNotificationFollowList)
     val liveNotificationFollowListsPerRelay = OutboxLoaderState(liveNotificationFollowLists, cache, scope).flow
 
-    override val livePollsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultPollsFollowList)
+    val livePollsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultPollsFollowList)
     val livePollsFollowListsPerRelay = OutboxLoaderState(livePollsFollowLists, cache, scope).flow
 
-    override val livePicturesFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultPicturesFollowList)
+    val livePicturesFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultPicturesFollowList)
     val livePicturesFollowListsPerRelay = OutboxLoaderState(livePicturesFollowLists, cache, scope).flow
 
-    override val liveShortsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultShortsFollowList)
+    val liveShortsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultShortsFollowList)
     val liveShortsFollowListsPerRelay = OutboxLoaderState(liveShortsFollowLists, cache, scope).flow
 
-    override val liveLongsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultLongsFollowList)
+    val liveLongsFollowLists: StateFlow<IFeedTopNavFilter> = topNavFilterFlow(settings.defaultLongsFollowList)
     val liveLongsFollowListsPerRelay = OutboxLoaderState(liveLongsFollowLists, cache, scope).flow
-
-    // IAccount reactive state flow overrides for DAL filter migration
-    override val liveHiddenUsersFlow: StateFlow<LiveHiddenUsers> get() = hiddenUsers.flow
-
-    override fun getBlockListAddress() = blockPeopleList.getBlockListAddress()
-
-    override val liveBookmarks get() = bookmarkState.bookmarks
-    override val liveOldBookmarks get() = oldBookmarkState.bookmarks
-    override val liveProxyRelayList get() = proxyRelayList.flow
-    override val defaultHomeFollowListFlow: StateFlow<String> =
-        settings.defaultHomeFollowList
-            .map { it.code }
-            .stateIn(scope, SharingStarted.Eagerly, settings.defaultHomeFollowList.value.code)
 
     override fun isWriteable(): Boolean = settings.isWriteable()
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -21,6 +21,8 @@
 package com.vitorpamplona.amethyst.model
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.model.IAccountSettings
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatRepository
 import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatListRepository
 import com.vitorpamplona.amethyst.model.nip47WalletConnect.NwcWalletEntryNorm
@@ -29,7 +31,6 @@ import com.vitorpamplona.amethyst.ui.actions.mediaServers.ServerName
 import com.vitorpamplona.amethyst.ui.screen.FeedDefinition
 import com.vitorpamplona.quartz.experimental.ephemChat.list.EphemeralChatListEvent
 import com.vitorpamplona.quartz.experimental.nipA3.PaymentTargetsEvent
-import com.vitorpamplona.quartz.nip01Core.core.Address
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.crypto.KeyPair
 import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
@@ -102,59 +103,6 @@ val DefaultSignerPermissions =
         Permission(CommandType.DECRYPT_ZAP_EVENT),
     )
 
-@Serializable
-sealed class TopFilter(
-    val code: String,
-) {
-    @Serializable
-    object Global : TopFilter(" Global ")
-
-    @Serializable
-    object AllFollows : TopFilter(" All Follows ")
-
-    @Serializable
-    object AllUserFollows : TopFilter(" All User Follows ")
-
-    @Serializable
-    object DefaultFollows : TopFilter(" Main User Follows ")
-
-    @Serializable
-    object AroundMe : TopFilter(" Around Me ")
-
-    @Serializable
-    object Chess : TopFilter(" Chess ")
-
-    @Serializable
-    class PeopleList(
-        val address: Address,
-    ) : TopFilter(address.toValue())
-
-    @Serializable
-    class MuteList(
-        val address: Address,
-    ) : TopFilter(address.toValue())
-
-    @Serializable
-    class Community(
-        val address: Address,
-    ) : TopFilter("Community/${address.toValue()}")
-
-    @Serializable
-    class Hashtag(
-        val tag: String,
-    ) : TopFilter("Hashtag/$tag")
-
-    @Serializable
-    class Geohash(
-        val tag: String,
-    ) : TopFilter("Geohash/$tag")
-
-    @Serializable
-    class Relay(
-        val url: String,
-    ) : TopFilter("Relay/$url")
-}
-
 @Stable
 class AccountSettings(
     val keyPair: KeyPair,
@@ -163,14 +111,14 @@ class AccountSettings(
     var localRelayServers: MutableStateFlow<Set<String>> = MutableStateFlow(setOf()),
     var defaultFileServer: ServerName = DEFAULT_MEDIA_SERVERS[0],
     var stripLocationOnUpload: Boolean = true,
-    val defaultHomeFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.AllFollows),
-    val defaultStoriesFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.Global),
-    val defaultNotificationFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.Global),
+    override val defaultHomeFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.AllFollows),
+    override val defaultStoriesFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.Global),
+    override val defaultNotificationFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.Global),
     val defaultDiscoveryFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.Global),
-    val defaultPollsFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.Global),
-    val defaultPicturesFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.Global),
-    val defaultShortsFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.Global),
-    val defaultLongsFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.Global),
+    override val defaultPollsFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.Global),
+    override val defaultPicturesFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.Global),
+    override val defaultShortsFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.Global),
+    override val defaultLongsFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.Global),
     val nwcWallets: MutableStateFlow<List<NwcWalletEntryNorm>> = MutableStateFlow(emptyList()),
     val defaultNwcWalletId: MutableStateFlow<String?> = MutableStateFlow(null),
     var hideDeleteRequestDialog: Boolean = false,
@@ -203,7 +151,8 @@ class AccountSettings(
     var callTurnServers: List<CallTurnServer> = emptyList(),
     var callVideoResolution: CallVideoResolution = CallVideoResolution.HD_720,
     var callMaxBitrateBps: Int = 1_500_000,
-) : EphemeralChatRepository,
+) : IAccountSettings,
+    EphemeralChatRepository,
     PublicChatListRepository {
     val saveable = MutableStateFlow(AccountSettingsUpdater(null))
     val syncedSettings: AccountSyncedSettings = AccountSyncedSettings(AccountSyncedSettingsInternal())

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/HiddenUsersState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/HiddenUsersState.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.model.nip51Lists
 
+import com.vitorpamplona.amethyst.commons.model.IHiddenUsersState
 import com.vitorpamplona.amethyst.commons.model.LiveHiddenUsers
 import com.vitorpamplona.amethyst.model.AccountSettings
 import com.vitorpamplona.amethyst.service.checkNotInMainThread
@@ -44,7 +45,7 @@ class HiddenUsersState(
     val blockList: StateFlow<List<MuteTag>>,
     val scope: CoroutineScope,
     val settings: AccountSettings,
-) {
+) : IHiddenUsersState {
     var transientHiddenUsers: MutableStateFlow<Set<String>> = MutableStateFlow(setOf())
 
     fun assembleLiveHiddenUsers(
@@ -69,7 +70,7 @@ class HiddenUsersState(
         )
     }
 
-    val flow: StateFlow<LiveHiddenUsers> =
+    override val flow: StateFlow<LiveHiddenUsers> =
         combineTransform(
             blockList,
             muteList,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/blockPeopleList/BlockPeopleListState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/blockPeopleList/BlockPeopleListState.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.model.nip51Lists.blockPeopleList
 
+import com.vitorpamplona.amethyst.commons.model.IBlockPeopleListState
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.NoteState
@@ -43,11 +44,11 @@ class BlockPeopleListState(
     val cache: LocalCache,
     val decryptionCache: PeopleListDecryptionCache,
     val scope: CoroutineScope,
-) {
+) : IBlockPeopleListState {
     // Creates a long-term reference for this note so that the GC doesn't collect the note it self
     val blockListNote = cache.getOrCreateAddressableNote(getBlockListAddress())
 
-    fun getBlockListAddress() = PeopleListEvent.createBlockAddress(signer.pubKey)
+    override fun getBlockListAddress() = PeopleListEvent.createBlockAddress(signer.pubKey)
 
     fun getBlockListFlow(): StateFlow<NoteState> = blockListNote.flow().metadata.stateFlow
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/FeedTopNavFilterState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/FeedTopNavFilterState.kt
@@ -20,8 +20,8 @@
  */
 package com.vitorpamplona.amethyst.model.topNavFeeds
 
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.model.nip02FollowLists.Kind3FollowListState
 import com.vitorpamplona.amethyst.model.serverList.MergedFollowListsState
 import com.vitorpamplona.amethyst.model.topNavFeeds.allFollows.AllFollowsFeedFlow

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/IFeedTopNavPerRelayFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/IFeedTopNavPerRelayFilter.kt
@@ -20,4 +20,4 @@
  */
 package com.vitorpamplona.amethyst.model.topNavFeeds
 
-interface IFeedTopNavPerRelayFilter
+typealias IFeedTopNavPerRelayFilter = com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavPerRelayFilter

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/IFeedTopNavPerRelayFilterSet.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/IFeedTopNavPerRelayFilterSet.kt
@@ -20,4 +20,4 @@
  */
 package com.vitorpamplona.amethyst.model.topNavFeeds
 
-interface IFeedTopNavPerRelayFilterSet
+typealias IFeedTopNavPerRelayFilterSet = com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavPerRelayFilterSet

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allFollows/AllFollowsByOutboxTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allFollows/AllFollowsByOutboxTopNavFilter.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.allFollows
 
 import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.topNavFeeds.CommunityRelayLoader
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
@@ -78,17 +79,17 @@ class AllFollowsByOutboxTopNavFilter(
                 (communities != null && noteEvent.isTaggedAddressableNotes(communities))
         }
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<AllFollowsTopNavPerRelayFilterSet> {
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<AllFollowsTopNavPerRelayFilterSet> {
         val authorsPerRelay =
             if (authors != null) {
-                OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache) { it }
+                OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache as LocalCache) { it }
             } else {
                 MutableStateFlow(emptyMap())
             }
 
         val communitiesPerRelay =
             if (communities != null) {
-                CommunityRelayLoader.toCommunitiesPerRelayFlow(communities, cache) { it }
+                CommunityRelayLoader.toCommunitiesPerRelayFlow(communities, cache as LocalCache) { it }
             } else {
                 MutableStateFlow(emptyMap())
             }
@@ -109,17 +110,17 @@ class AllFollowsByOutboxTopNavFilter(
         }
     }
 
-    override fun startValue(cache: LocalCache): AllFollowsTopNavPerRelayFilterSet {
+    override fun startValue(cache: ICacheProvider): AllFollowsTopNavPerRelayFilterSet {
         val authorsPerRelay =
             if (authors != null) {
-                OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache) { it }
+                OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache as LocalCache) { it }
             } else {
                 emptyMap()
             }
 
         val communitiesPerRelay =
             if (communities != null) {
-                CommunityRelayLoader.communitiesPerRelaySnapshot(communities, cache) { it }
+                CommunityRelayLoader.communitiesPerRelaySnapshot(communities, cache as LocalCache) { it }
             } else {
                 emptyMap()
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allFollows/AllFollowsByProxyTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allFollows/AllFollowsByProxyTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.allFollows
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -74,7 +74,7 @@ class AllFollowsByProxyTopNavFilter(
         }
 
     // forces the use of the Proxy on all connections, replacing the outbox model.
-    override fun toPerRelayFlow(cache: LocalCache): Flow<AllFollowsTopNavPerRelayFilterSet> =
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<AllFollowsTopNavPerRelayFilterSet> =
         MutableStateFlow(
             AllFollowsTopNavPerRelayFilterSet(
                 proxyRelays.associateWith {
@@ -88,7 +88,7 @@ class AllFollowsByProxyTopNavFilter(
             ),
         )
 
-    override fun startValue(cache: LocalCache): AllFollowsTopNavPerRelayFilterSet {
+    override fun startValue(cache: ICacheProvider): AllFollowsTopNavPerRelayFilterSet {
         // forces the use of the Proxy on all connections, replacing the outbox model.
         return AllFollowsTopNavPerRelayFilterSet(
             proxyRelays.associateWith {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allUserFollows/AllUserFollowsByOutboxTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allUserFollows/AllUserFollowsByOutboxTopNavFilter.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.allUserFollows
 
 import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.OutboxRelayLoader
@@ -62,8 +63,8 @@ class AllUserFollowsByOutboxTopNavFilter(
             }
         }
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<AuthorsTopNavPerRelayFilterSet> {
-        val authorsPerRelay = OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache) { it }
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<AuthorsTopNavPerRelayFilterSet> {
+        val authorsPerRelay = OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache as LocalCache) { it }
 
         return combine(authorsPerRelay, defaultRelays, blockedRelays) { perRelayAuthors, default, blockedRelays ->
             val allRelays = perRelayAuthors.keys.filter { it !in blockedRelays }.ifEmpty { default }
@@ -78,8 +79,8 @@ class AllUserFollowsByOutboxTopNavFilter(
         }
     }
 
-    override fun startValue(cache: LocalCache): AuthorsTopNavPerRelayFilterSet {
-        val authorsPerRelay = OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache) { it }
+    override fun startValue(cache: ICacheProvider): AuthorsTopNavPerRelayFilterSet {
+        val authorsPerRelay = OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache as LocalCache) { it }
 
         val allRelays = authorsPerRelay.keys.filter { it !in blockedRelays.value }.ifEmpty { defaultRelays.value }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allUserFollows/AllUserFollowsByProxyTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allUserFollows/AllUserFollowsByProxyTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.allUserFollows
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.author.AuthorsTopNavPerRelayFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.author.AuthorsTopNavPerRelayFilterSet
@@ -60,7 +60,7 @@ class AllUserFollowsByProxyTopNavFilter(
         }
 
     // forces the use of the Proxy on all connections, replacing the outbox model.
-    override fun toPerRelayFlow(cache: LocalCache): Flow<AuthorsTopNavPerRelayFilterSet> =
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<AuthorsTopNavPerRelayFilterSet> =
         MutableStateFlow(
             AuthorsTopNavPerRelayFilterSet(
                 proxyRelays.associateWith {
@@ -71,7 +71,7 @@ class AllUserFollowsByProxyTopNavFilter(
             ),
         )
 
-    override fun startValue(cache: LocalCache): AuthorsTopNavPerRelayFilterSet {
+    override fun startValue(cache: ICacheProvider): AuthorsTopNavPerRelayFilterSet {
         // forces the use of the Proxy on all connections, replacing the outbox model.
         return AuthorsTopNavPerRelayFilterSet(
             proxyRelays.associateWith {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/aroundMe/LocationTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/aroundMe/LocationTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.aroundMe
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -52,12 +52,12 @@ class LocationTopNavFilter(
         }
     }
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<LocationTopNavPerRelayFilterSet> =
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<LocationTopNavPerRelayFilterSet> =
         MutableStateFlow(
             LocationTopNavPerRelayFilterSet(relayList.associateWith { LocationTopNavPerRelayFilter(geotags) }),
         )
 
-    override fun startValue(cache: LocalCache): LocationTopNavPerRelayFilterSet =
+    override fun startValue(cache: ICacheProvider): LocationTopNavPerRelayFilterSet =
         LocationTopNavPerRelayFilterSet(
             relayList.associateWith { LocationTopNavPerRelayFilter(geotags) },
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/chess/ChessTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/chess/ChessTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.chess
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -45,7 +45,7 @@ class ChessTopNavFilter(
             noteEvent is LiveChessGameChallengeEvent ||
             noteEvent is LiveChessGameEndEvent
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<ChessTopNavPerRelayFilterSet> =
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<ChessTopNavPerRelayFilterSet> =
         combine(outboxRelays, proxyRelays) { outboxRelays, proxyRelays ->
             if (proxyRelays.isNotEmpty()) {
                 ChessTopNavPerRelayFilterSet(proxyRelays.associateWith { ChessTopNavPerRelayFilter })
@@ -54,7 +54,7 @@ class ChessTopNavFilter(
             }
         }
 
-    override fun startValue(cache: LocalCache): ChessTopNavPerRelayFilterSet =
+    override fun startValue(cache: ICacheProvider): ChessTopNavPerRelayFilterSet =
         if (proxyRelays.value.isNotEmpty()) {
             ChessTopNavPerRelayFilterSet(proxyRelays.value.associateWith { ChessTopNavPerRelayFilter })
         } else {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/global/GlobalTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/global/GlobalTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.global
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -40,7 +40,7 @@ class GlobalTopNavFilter(
 
     override fun match(noteEvent: Event) = true
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<GlobalTopNavPerRelayFilterSet> =
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<GlobalTopNavPerRelayFilterSet> =
         combine(outboxRelays, proxyRelays, relayFeeds) { outboxRelays, proxyRelays, relayFeeds ->
             if (proxyRelays.isNotEmpty()) {
                 GlobalTopNavPerRelayFilterSet(proxyRelays.associateWith { GlobalTopNavPerRelayFilter })
@@ -49,7 +49,7 @@ class GlobalTopNavFilter(
             }
         }
 
-    override fun startValue(cache: LocalCache): GlobalTopNavPerRelayFilterSet =
+    override fun startValue(cache: ICacheProvider): GlobalTopNavPerRelayFilterSet =
         if (proxyRelays.value.isNotEmpty()) {
             GlobalTopNavPerRelayFilterSet(proxyRelays.value.associateWith { GlobalTopNavPerRelayFilter })
         } else {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/hashtag/HashtagTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/hashtag/HashtagTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.hashtag
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -48,14 +48,14 @@ class HashtagTopNavFilter(
             noteEvent.isTaggedHashes(hashtags)
         }
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<HashtagTopNavPerRelayFilterSet> =
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<HashtagTopNavPerRelayFilterSet> =
         MutableStateFlow(
             HashtagTopNavPerRelayFilterSet(
                 relayList.associateWith { HashtagTopNavPerRelayFilter(hashtags) },
             ),
         )
 
-    override fun startValue(cache: LocalCache): HashtagTopNavPerRelayFilterSet =
+    override fun startValue(cache: ICacheProvider): HashtagTopNavPerRelayFilterSet =
         HashtagTopNavPerRelayFilterSet(
             relayList.associateWith { HashtagTopNavPerRelayFilter(hashtags) },
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/allcommunities/AllCommunitiesTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/allcommunities/AllCommunitiesTopNavFilter.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.allcommunities
 
 import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.topNavFeeds.CommunityRelayLoader
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
@@ -46,16 +47,16 @@ class AllCommunitiesTopNavFilter(
             map.mapValues { AllCommunitiesTopNavPerRelayFilter(it.value) },
         )
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<AllCommunitiesTopNavPerRelayFilterSet> {
-        val communitiesPerRelay = CommunityRelayLoader.toCommunitiesPerRelayFlow(communities, cache) { it }
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<AllCommunitiesTopNavPerRelayFilterSet> {
+        val communitiesPerRelay = CommunityRelayLoader.toCommunitiesPerRelayFlow(communities, cache as LocalCache) { it }
 
         return combine(communitiesPerRelay, blockedRelays) { communitiesPerRelay, blockedRelays ->
             convert(communitiesPerRelay.minus(blockedRelays))
         }
     }
 
-    override fun startValue(cache: LocalCache): AllCommunitiesTopNavPerRelayFilterSet {
-        val communitiesPerRelay = CommunityRelayLoader.communitiesPerRelaySnapshot(communities, cache) { it }
+    override fun startValue(cache: ICacheProvider): AllCommunitiesTopNavPerRelayFilterSet {
+        val communitiesPerRelay = CommunityRelayLoader.communitiesPerRelaySnapshot(communities, cache as LocalCache) { it }
 
         return convert(communitiesPerRelay.minus(blockedRelays.value))
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/author/AuthorsByOutboxTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/author/AuthorsByOutboxTopNavFilter.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.author
 
 import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.OutboxRelayLoader
@@ -51,16 +52,16 @@ class AuthorsByOutboxTopNavFilter(
             map.mapValues { AuthorsTopNavPerRelayFilter(it.value) },
         )
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<AuthorsTopNavPerRelayFilterSet> {
-        val authorsPerRelay = OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache) { it }
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<AuthorsTopNavPerRelayFilterSet> {
+        val authorsPerRelay = OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache as LocalCache) { it }
 
         return combine(authorsPerRelay, blockedRelays) { authors, blocked ->
             convert(authors.minus(blocked))
         }
     }
 
-    override fun startValue(cache: LocalCache): AuthorsTopNavPerRelayFilterSet {
-        val authorsPerRelay = OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache) { it }
+    override fun startValue(cache: ICacheProvider): AuthorsTopNavPerRelayFilterSet {
+        val authorsPerRelay = OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache as LocalCache) { it }
 
         return convert(authorsPerRelay.minus(blockedRelays.value))
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/community/SingleCommunityTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/community/SingleCommunityTopNavFilter.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.community
 
 import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.OutboxRelayLoader
@@ -53,7 +54,7 @@ class SingleCommunityTopNavFilter(
             (authors != null && noteEvent.pubKey in authors) || noteEvent.isTaggedAddressableNote(community)
         }
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<SingleCommunityTopNavPerRelayFilterSet> {
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<SingleCommunityTopNavPerRelayFilterSet> {
         // relay field takes priority
         if (relays.isNotEmpty()) {
             return blockedRelays.map { blocked ->
@@ -67,7 +68,7 @@ class SingleCommunityTopNavFilter(
 
         if (authors != null) {
             // go by authors
-            val authorsPerRelay = OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache) { it }
+            val authorsPerRelay = OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache as LocalCache) { it }
 
             return combine(authorsPerRelay, blockedRelays) { authorsPerRelay, blocked ->
                 SingleCommunityTopNavPerRelayFilterSet(
@@ -81,14 +82,14 @@ class SingleCommunityTopNavFilter(
         // go by hints
         return blockedRelays.map { blocked ->
             SingleCommunityTopNavPerRelayFilterSet(
-                cache.relayHints.hintsForAddress(community).minus(blocked).associateWith {
+                (cache as LocalCache).relayHints.hintsForAddress(community).minus(blocked).associateWith {
                     SingleCommunityTopNavPerRelayFilter(community, authors)
                 },
             )
         }
     }
 
-    override fun startValue(cache: LocalCache): SingleCommunityTopNavPerRelayFilterSet {
+    override fun startValue(cache: ICacheProvider): SingleCommunityTopNavPerRelayFilterSet {
         // relay field takes priority
         if (relays.isNotEmpty()) {
             return SingleCommunityTopNavPerRelayFilterSet(
@@ -100,7 +101,7 @@ class SingleCommunityTopNavFilter(
 
         if (authors != null) {
             // go by authors
-            val authorsPerRelay = OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache) { it }
+            val authorsPerRelay = OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache as LocalCache) { it }
 
             return SingleCommunityTopNavPerRelayFilterSet(
                 authorsPerRelay.minus(blockedRelays.value).mapValues {
@@ -111,7 +112,7 @@ class SingleCommunityTopNavFilter(
 
         // go by hints
         return SingleCommunityTopNavPerRelayFilterSet(
-            cache.relayHints.hintsForAddress(community).minus(blockedRelays.value).associateWith {
+            (cache as LocalCache).relayHints.hintsForAddress(community).minus(blockedRelays.value).associateWith {
                 SingleCommunityTopNavPerRelayFilter(community, authors)
             },
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/muted/MutedAuthorsByOutboxTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/muted/MutedAuthorsByOutboxTopNavFilter.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.muted
 
 import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.OutboxRelayLoader
@@ -51,16 +52,16 @@ class MutedAuthorsByOutboxTopNavFilter(
             map.mapValues { MutedAuthorsTopNavPerRelayFilter(it.value) },
         )
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<MutedAuthorsTopNavPerRelayFilterSet> {
-        val authorsPerRelay = OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache) { it }
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<MutedAuthorsTopNavPerRelayFilterSet> {
+        val authorsPerRelay = OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache as LocalCache) { it }
 
         return combine(authorsPerRelay, blockedRelays) { authors, blocked ->
             convert(authors.minus(blocked))
         }
     }
 
-    override fun startValue(cache: LocalCache): MutedAuthorsTopNavPerRelayFilterSet {
-        val authorsPerRelay = OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache) { it }
+    override fun startValue(cache: ICacheProvider): MutedAuthorsTopNavPerRelayFilterSet {
+        val authorsPerRelay = OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache as LocalCache) { it }
 
         return convert(authorsPerRelay.minus(blockedRelays.value))
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/muted/MutedAuthorsByProxyTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/muted/MutedAuthorsByProxyTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.muted
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -44,14 +44,14 @@ class MutedAuthorsByProxyTopNavFilter(
             noteEvent.pubKey in authors
         }
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<MutedAuthorsTopNavPerRelayFilterSet> =
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<MutedAuthorsTopNavPerRelayFilterSet> =
         MutableStateFlow(
             MutedAuthorsTopNavPerRelayFilterSet(
                 proxyRelays.associateWith { MutedAuthorsTopNavPerRelayFilter(authors) },
             ),
         )
 
-    override fun startValue(cache: LocalCache): MutedAuthorsTopNavPerRelayFilterSet =
+    override fun startValue(cache: ICacheProvider): MutedAuthorsTopNavPerRelayFilterSet =
         MutedAuthorsTopNavPerRelayFilterSet(
             proxyRelays.associateWith { MutedAuthorsTopNavPerRelayFilter(authors) },
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/relay/RelayTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/relay/RelayTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.relay
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -37,7 +37,7 @@ class RelayTopNavFilter(
 
     override fun match(noteEvent: Event) = true
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<RelayTopNavPerRelayFilterSet> = flowOf(RelayTopNavPerRelayFilterSet(relayUrl))
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<RelayTopNavPerRelayFilterSet> = flowOf(RelayTopNavPerRelayFilterSet(relayUrl))
 
-    override fun startValue(cache: LocalCache): RelayTopNavPerRelayFilterSet = RelayTopNavPerRelayFilterSet(relayUrl)
+    override fun startValue(cache: ICacheProvider): RelayTopNavPerRelayFilterSet = RelayTopNavPerRelayFilterSet(relayUrl)
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/unknown/UnknownFeedFlow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/unknown/UnknownFeedFlow.kt
@@ -20,7 +20,7 @@
  */
 package com.vitorpamplona.amethyst.model.topNavFeeds.unknown
 
-import com.vitorpamplona.amethyst.model.TopFilter
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedFlowsType
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import kotlinx.coroutines.flow.FlowCollector

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/unknown/UnknownTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/unknown/UnknownTopNavFilter.kt
@@ -21,8 +21,8 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.unknown
 
 import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/unknown/UnknownTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/unknown/UnknownTopNavFilter.kt
@@ -22,7 +22,7 @@ package com.vitorpamplona.amethyst.model.topNavFeeds.unknown
 
 import androidx.compose.runtime.Immutable
 import com.vitorpamplona.amethyst.commons.model.TopFilter
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -37,7 +37,7 @@ class UnknownTopNavFilter(
 
     override fun match(noteEvent: Event) = false
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<UnknownTopNavPerRelayFilterSet> = MutableStateFlow(UnknownTopNavPerRelayFilterSet)
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<UnknownTopNavPerRelayFilterSet> = MutableStateFlow(UnknownTopNavPerRelayFilterSet)
 
-    override fun startValue(cache: LocalCache) = UnknownTopNavPerRelayFilterSet
+    override fun startValue(cache: ICacheProvider) = UnknownTopNavPerRelayFilterSet
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/AdditiveComplexFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/AdditiveComplexFeedFilter.kt
@@ -20,9 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.dal
 
-abstract class AdditiveComplexFeedFilter<T, U> : FeedFilter<T>() {
-    abstract fun updateListWith(
-        oldList: List<T>,
-        newItems: Set<U>,
-    ): List<T>
-}
+// Re-export from commons for backwards compatibility
+typealias AdditiveComplexFeedFilter<T, U> = com.vitorpamplona.amethyst.commons.ui.feeds.AdditiveComplexFeedFilter<T, U>

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/FeedFilterSpinner.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/FeedFilterSpinner.kt
@@ -76,8 +76,8 @@ import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.AddressableNote
-import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.service.call.CallSessionBridge.accountViewModel
 import com.vitorpamplona.amethyst.service.location.LocationState
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.observeNote

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/TopNavFilterState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/TopNavFilterState.kt
@@ -24,9 +24,9 @@ import android.content.Context
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.AddressableNote
-import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.service.checkNotInMainThread
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.stringRes

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/default/dal/BookmarkPrivateFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/default/dal/BookmarkPrivateFeedFilter.kt
@@ -20,17 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.default.dal
 
-import com.vitorpamplona.amethyst.model.Account
-import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.ui.dal.FeedFilter
-
-class BookmarkPrivateFeedFilter(
-    val account: Account,
-) : FeedFilter<Note>() {
-    override fun feedKey(): String =
-        account.bookmarkState.bookmarks.value
-            .hashCode()
-            .toString()
-
-    override fun feed(): List<Note> = account.bookmarkState.bookmarks.value.private
-}
+// Re-export from commons for backwards compatibility
+typealias BookmarkPrivateFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.BookmarkPrivateFeedFilter

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/default/dal/BookmarkPublicFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/default/dal/BookmarkPublicFeedFilter.kt
@@ -20,17 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.default.dal
 
-import com.vitorpamplona.amethyst.model.Account
-import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.ui.dal.FeedFilter
-
-class BookmarkPublicFeedFilter(
-    val account: Account,
-) : FeedFilter<Note>() {
-    override fun feedKey(): String =
-        account.bookmarkState.bookmarks.value
-            .hashCode()
-            .toString()
-
-    override fun feed(): List<Note> = account.bookmarkState.bookmarks.value.public
-}
+// Re-export from commons for backwards compatibility
+typealias BookmarkPublicFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.BookmarkPublicFeedFilter

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/old/dal/OldBookmarkPublicFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/old/dal/OldBookmarkPublicFeedFilter.kt
@@ -20,17 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.old.dal
 
-import com.vitorpamplona.amethyst.model.Account
-import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.ui.dal.FeedFilter
-
-class OldBookmarkPublicFeedFilter(
-    val account: Account,
-) : FeedFilter<Note>() {
-    override fun feedKey(): String =
-        account.oldBookmarkState.bookmarks.value
-            .hashCode()
-            .toString()
-
-    override fun feed(): List<Note> = account.oldBookmarkState.bookmarks.value.public
-}
+// Re-export from commons for backwards compatibility
+typealias OldBookmarkPublicFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.OldBookmarkPublicFeedFilter

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/DiscoveryTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/DiscoveryTopBar.kt
@@ -24,7 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.model.TopFilter
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.FeedFilterSpinner
 import com.vitorpamplona.amethyst.ui.navigation.topbars.UserDrawerSearchTopBar

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/datasource/DiscoveryFollowsSetsAndLiveStreamsSubAssembler2.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/datasource/DiscoveryFollowsSetsAndLiveStreamsSubAssembler2.kt
@@ -20,7 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.discover.datasource
 
-import com.vitorpamplona.amethyst.model.TopFilter
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUserAndFollowListEoseManager
 import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/datasource/DiscoveryLongFormClassifiedsAndDVMSubAssembler1.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/datasource/DiscoveryLongFormClassifiedsAndDVMSubAssembler1.kt
@@ -20,7 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.discover.datasource
 
-import com.vitorpamplona.amethyst.model.TopFilter
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUserAndFollowListEoseManager
 import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/datasource/DiscoveryPublicChatsAndCommunitiesSubAssembler3.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/datasource/DiscoveryPublicChatsAndCommunitiesSubAssembler3.kt
@@ -20,7 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.discover.datasource
 
-import com.vitorpamplona.amethyst.model.TopFilter
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUserAndFollowListEoseManager
 import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip23LongForm/DiscoverLongFormFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip23LongForm/DiscoverLongFormFeedFilter.kt
@@ -20,10 +20,10 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.discover.nip23LongForm
 
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.model.filterIntoSet
 import com.vitorpamplona.amethyst.ui.dal.AdditiveFeedFilter
 import com.vitorpamplona.amethyst.ui.dal.DefaultFeedOrder

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip28Chats/DiscoverChatFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip28Chats/DiscoverChatFeedFilter.kt
@@ -20,10 +20,10 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.discover.nip28Chats
 
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.ui.dal.AdditiveFeedFilter
 import com.vitorpamplona.amethyst.ui.dal.FilterByListParams
 import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelCreateEvent

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip51FollowSets/DiscoverFollowSetsFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip51FollowSets/DiscoverFollowSetsFeedFilter.kt
@@ -20,10 +20,10 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.discover.nip51FollowSets
 
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.model.filterIntoSet
 import com.vitorpamplona.amethyst.ui.dal.AdditiveFeedFilter
 import com.vitorpamplona.amethyst.ui.dal.DefaultFeedOrder

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip53LiveActivities/DiscoverLiveFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip53LiveActivities/DiscoverLiveFeedFilter.kt
@@ -20,11 +20,11 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.discover.nip53LiveActivities
 
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.ParticipantListBuilder
-import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.allFollows.AllFollowsByOutboxTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.allFollows.AllFollowsByProxyTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.author.AuthorsByOutboxTopNavFilter

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip72Communities/DiscoverCommunityFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip72Communities/DiscoverCommunityFeedFilter.kt
@@ -20,10 +20,10 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.discover.nip72Communities
 
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.model.mapNotNullIntoSet
 import com.vitorpamplona.amethyst.ui.dal.AdditiveFeedFilter
 import com.vitorpamplona.amethyst.ui.dal.FilterByListParams

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip90DVMs/DiscoverNIP89FeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip90DVMs/DiscoverNIP89FeedFilter.kt
@@ -20,11 +20,11 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.discover.nip90DVMs
 
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.ParticipantListBuilder
-import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.model.filterIntoSet
 import com.vitorpamplona.amethyst.model.topNavFeeds.allFollows.AllFollowsByOutboxTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.allFollows.AllFollowsByProxyTopNavFilter

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/DiscoverMarketplaceFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/DiscoverMarketplaceFeedFilter.kt
@@ -20,10 +20,10 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.discover.nip99Classifieds
 
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.model.filterIntoSet
 import com.vitorpamplona.amethyst.ui.dal.AdditiveFeedFilter
 import com.vitorpamplona.amethyst.ui.dal.FilterByListParams

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/HomeScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/HomeScreen.kt
@@ -55,11 +55,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
 import com.vitorpamplona.amethyst.commons.model.nip53LiveActivities.LiveActivitiesChannel
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedContentState
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
-import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.service.OnlineChecker
 import com.vitorpamplona.amethyst.service.location.LocationState
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/HomeTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/HomeTopBar.kt
@@ -24,7 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.model.TopFilter
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.FeedFilterSpinner
 import com.vitorpamplona.amethyst.ui.navigation.topbars.UserDrawerSearchTopBar

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/datasource/nip65Follows/HomeOutboxEventsEoseManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/datasource/nip65Follows/HomeOutboxEventsEoseManager.kt
@@ -20,7 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip65Follows
 
-import com.vitorpamplona.amethyst.model.TopFilter
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.model.topNavFeeds.allFollows.AllFollowsTopNavPerRelayFilterSet
 import com.vitorpamplona.amethyst.model.topNavFeeds.aroundMe.LocationTopNavPerRelayFilterSet

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/longs/LongsTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/longs/LongsTopBar.kt
@@ -24,7 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.model.TopFilter
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.FeedFilterSpinner
 import com.vitorpamplona.amethyst.ui.navigation.topbars.UserDrawerSearchTopBar

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/longs/dal/LongsFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/longs/dal/LongsFeedFilter.kt
@@ -20,12 +20,12 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.longs.dal
 
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.commons.richtext.RichTextParser
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.AddressableNote
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.model.filterIntoSet
 import com.vitorpamplona.amethyst.ui.dal.AdditiveFeedFilter
 import com.vitorpamplona.amethyst.ui.dal.DefaultFeedOrder

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/longs/datasource/LongsSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/longs/datasource/LongsSubAssembler.kt
@@ -20,7 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.longs.datasource
 
-import com.vitorpamplona.amethyst.model.TopFilter
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUserAndFollowListEoseManager
 import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationTopBar.kt
@@ -24,7 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.model.TopFilter
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.FeedFilterSpinner
 import com.vitorpamplona.amethyst.ui.navigation.topbars.UserDrawerSearchTopBar

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationFeedFilter.kt
@@ -20,11 +20,11 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications.dal
 
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.AddressableNote
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.model.filterIntoSet
 import com.vitorpamplona.amethyst.ui.dal.AdditiveFeedFilter
 import com.vitorpamplona.amethyst.ui.dal.DefaultFeedOrder

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/pictures/PicturesTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/pictures/PicturesTopBar.kt
@@ -24,7 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.model.TopFilter
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.FeedFilterSpinner
 import com.vitorpamplona.amethyst.ui.navigation.topbars.UserDrawerSearchTopBar

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/pictures/dal/PictureFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/pictures/dal/PictureFeedFilter.kt
@@ -20,10 +20,10 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.pictures.dal
 
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.ui.dal.AdditiveFeedFilter
 import com.vitorpamplona.amethyst.ui.dal.DefaultFeedOrder
 import com.vitorpamplona.amethyst.ui.dal.FilterByListParams

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/pictures/datasource/PicturesSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/pictures/datasource/PicturesSubAssembler.kt
@@ -20,7 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.pictures.datasource
 
-import com.vitorpamplona.amethyst.model.TopFilter
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUserAndFollowListEoseManager
 import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/polls/PollsTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/polls/PollsTopBar.kt
@@ -24,7 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.model.TopFilter
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.FeedFilterSpinner
 import com.vitorpamplona.amethyst.ui.navigation.topbars.UserDrawerSearchTopBar

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/polls/dal/ClosedPollsFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/polls/dal/ClosedPollsFeedFilter.kt
@@ -20,10 +20,10 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.polls.dal
 
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.ui.dal.AdditiveFeedFilter
 import com.vitorpamplona.amethyst.ui.dal.DefaultFeedOrder
 import com.vitorpamplona.amethyst.ui.dal.FilterByListParams

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/polls/dal/OpenPollsFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/polls/dal/OpenPollsFeedFilter.kt
@@ -20,10 +20,10 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.polls.dal
 
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.ui.dal.AdditiveFeedFilter
 import com.vitorpamplona.amethyst.ui.dal.DefaultFeedOrder
 import com.vitorpamplona.amethyst.ui.dal.FilterByListParams

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/polls/dal/PollsFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/polls/dal/PollsFeedFilter.kt
@@ -20,10 +20,10 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.polls.dal
 
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.ui.dal.AdditiveFeedFilter
 import com.vitorpamplona.amethyst.ui.dal.DefaultFeedOrder
 import com.vitorpamplona.amethyst.ui.dal.FilterByListParams

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/polls/datasource/PollsSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/polls/datasource/PollsSubAssembler.kt
@@ -20,7 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.polls.datasource
 
-import com.vitorpamplona.amethyst.model.TopFilter
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUserAndFollowListEoseManager
 import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/dal/HiddenAccountsFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/dal/HiddenAccountsFeedFilter.kt
@@ -20,28 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.dal
 
-import com.vitorpamplona.amethyst.model.Account
-import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.model.User
-import com.vitorpamplona.amethyst.ui.dal.FeedFilter
-import com.vitorpamplona.quartz.utils.Log
-import kotlinx.coroutines.CancellationException
-
-class HiddenAccountsFeedFilter(
-    val account: Account,
-) : FeedFilter<User>() {
-    override fun feedKey(): String = account.userProfile().pubkeyHex
-
-    override fun showHiddenKey(): Boolean = true
-
-    override fun feed(): List<User> =
-        account.hiddenUsers.flow.value.hiddenUsers.reversed().mapNotNull {
-            try {
-                LocalCache.getOrCreateUser(it)
-            } catch (e: Exception) {
-                if (e is CancellationException) throw e
-                Log.e("HiddenAccountsFeedFilter") { "Failed to parse key $it" }
-                null
-            }
-        }
-}
+// Re-export from commons for backwards compatibility
+typealias HiddenAccountsFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.HiddenAccountsFeedFilter

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/dal/HiddenAccountsFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/dal/HiddenAccountsFeedViewModel.kt
@@ -23,11 +23,12 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.dal
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.vitorpamplona.amethyst.model.Account
+import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.ui.screen.UserFeedViewModel
 
 class HiddenAccountsFeedViewModel(
     val account: Account,
-) : UserFeedViewModel(HiddenAccountsFeedFilter(account)) {
+) : UserFeedViewModel(HiddenAccountsFeedFilter(account, LocalCache)) {
     class Factory(
         val account: Account,
     ) : ViewModelProvider.Factory {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/dal/HiddenWordsFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/dal/HiddenWordsFeedFilter.kt
@@ -20,17 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.dal
 
-import com.vitorpamplona.amethyst.model.Account
-import com.vitorpamplona.amethyst.ui.dal.FeedFilter
-
-class HiddenWordsFeedFilter(
-    val account: Account,
-) : FeedFilter<String>() {
-    override fun feedKey(): String = account.userProfile().pubkeyHex
-
-    override fun showHiddenKey(): Boolean = true
-
-    override fun feed(): List<String> =
-        account.hiddenUsers.flow.value.hiddenWords
-            .toList()
-}
+// Re-export from commons for backwards compatibility
+typealias HiddenWordsFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.HiddenWordsFeedFilter

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/ShortsTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/ShortsTopBar.kt
@@ -24,7 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.model.TopFilter
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.FeedFilterSpinner
 import com.vitorpamplona.amethyst.ui.navigation.topbars.UserDrawerSearchTopBar

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/dal/ShortsFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/dal/ShortsFeedFilter.kt
@@ -20,12 +20,12 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.shorts.dal
 
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.commons.richtext.RichTextParser
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.AddressableNote
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.model.filterIntoSet
 import com.vitorpamplona.amethyst.ui.dal.AdditiveFeedFilter
 import com.vitorpamplona.amethyst.ui.dal.DefaultFeedOrder

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/datasource/ShortsSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/datasource/ShortsSubAssembler.kt
@@ -20,7 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.shorts.datasource
 
-import com.vitorpamplona.amethyst.model.TopFilter
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUserAndFollowListEoseManager
 import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/StoriesTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/StoriesTopBar.kt
@@ -24,7 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.model.TopFilter
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.FeedFilterSpinner
 import com.vitorpamplona.amethyst.ui.navigation.topbars.UserDrawerSearchTopBar

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/dal/SupportedContent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/dal/SupportedContent.kt
@@ -20,27 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.video.dal
 
-class SupportedContent(
-    val blockedUrls: List<String>,
-    val mimeTypes: Set<String>,
-    val supportedFileExtensions: Set<String>,
-) {
-    private fun validExtension(fullUrl: String): Boolean {
-        val queryIndex = fullUrl.indexOf('?')
-        if (queryIndex > 0) {
-            return supportedFileExtensions.any { fullUrl.startsWith(it, queryIndex - it.length) }
-        }
-
-        val fragmentIndex = fullUrl.indexOf('#')
-        if (fragmentIndex > 0) {
-            return supportedFileExtensions.any { fullUrl.startsWith(it, fragmentIndex - it.length) }
-        }
-
-        return supportedFileExtensions.any { fullUrl.endsWith(it) }
-    }
-
-    fun acceptableUrl(
-        url: String,
-        mimeType: String?,
-    ) = blockedUrls.none { url.contains(it) } && ((mimeType != null && mimeTypes.contains(mimeType)) || validExtension(url))
-}
+// Re-export from commons for backwards compatibility
+typealias SupportedContent = com.vitorpamplona.amethyst.commons.ui.feeds.SupportedContent

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/dal/VideoFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/dal/VideoFeedFilter.kt
@@ -20,12 +20,12 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.video.dal
 
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.commons.richtext.RichTextParser
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.AddressableNote
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.model.filterIntoSet
 import com.vitorpamplona.amethyst.ui.dal.AdditiveFeedFilter
 import com.vitorpamplona.amethyst.ui.dal.DefaultFeedOrder

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/datasource/subassemblies/VideoOutboxEventsFilterSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/datasource/subassemblies/VideoOutboxEventsFilterSubAssembler.kt
@@ -20,7 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.video.datasource.subassemblies
 
-import com.vitorpamplona.amethyst.model.TopFilter
+import com.vitorpamplona.amethyst.commons.model.TopFilter
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.model.topNavFeeds.allFollows.AllFollowsTopNavPerRelayFilterSet
 import com.vitorpamplona.amethyst.model.topNavFeeds.aroundMe.LocationTopNavPerRelayFilterSet

--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.androidKotlinMultiplatformLibrary)
     alias(libs.plugins.jetbrainsComposeCompiler)
     alias(libs.plugins.composeMultiplatform)
+    alias(libs.plugins.serialization)
 }
 
 kotlin {
@@ -69,6 +70,9 @@ kotlin {
 
                 // Immutable collections
                 api(libs.kotlinx.collections.immutable)
+
+                // Kotlin serialization
+                implementation(libs.kotlinx.serialization.json)
 
                 // Compose Multiplatform Resources
                 implementation(libs.jetbrains.compose.components.resources)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
@@ -75,6 +75,9 @@ data class LiveHiddenUsers(
  * Abstracts Android-specific Account class for use in commons.
  */
 interface IAccount {
+    /** Account settings (follow list defaults, etc.) */
+    val settings: IAccountSettings
+
     /** NIP-47 wallet connect state for payment verification */
     val nip47SignerState: INwcSignerState
 
@@ -98,6 +101,12 @@ interface IAccount {
     val hiddenWordsCase: List<DualCase>
     val hiddenUsersHashCodes: Set<Int>
     val spammersHashCodes: Set<Int>
+
+    /** Hidden users state for DAL content filtering */
+    val hiddenUsers: IHiddenUsersState
+
+    /** Block people list state for DAL filter comparisons */
+    val blockPeopleList: IBlockPeopleListState
 
     /** Set of followed user pubkeys (for feed ordering/highlighting) */
     fun followingKeySet(): Set<String>

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
@@ -21,7 +21,11 @@
 package com.vitorpamplona.amethyst.commons.model
 
 import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupList
+import com.vitorpamplona.amethyst.commons.model.nip51Lists.BookmarkListState
+import com.vitorpamplona.amethyst.commons.model.nip51Lists.OldBookmarkListState
 import com.vitorpamplona.amethyst.commons.model.privateChats.ChatroomList
+import com.vitorpamplona.quartz.nip01Core.core.Address
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import com.vitorpamplona.quartz.nip04Dm.messages.PrivateDmEvent
@@ -34,6 +38,7 @@ import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Response
 import com.vitorpamplona.quartz.nip57Zaps.IPrivateZapsDecryptionCache
 import com.vitorpamplona.quartz.nip59Giftwrap.wraps.GiftWrapEvent
 import com.vitorpamplona.quartz.utils.DualCase
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Interface for NIP-47 wallet connect signer state.
@@ -107,6 +112,36 @@ interface IAccount {
 
     /** Whether a note is acceptable (not hidden, not blocked, etc.) */
     fun isAcceptable(note: Note): Boolean
+
+    // ---- Reactive state flows for DAL filter migration ----
+
+    /** Live hidden users state (from HiddenUsersState.flow) */
+    val liveHiddenUsersFlow: StateFlow<LiveHiddenUsers>
+
+    /** Top navigation follow list filters per feed type (from topNavFilterFlow) */
+    val liveHomeFollowLists: StateFlow<ITopNavFilter>
+    val liveStoriesFollowLists: StateFlow<ITopNavFilter>
+    val liveDiscoveryFollowLists: StateFlow<ITopNavFilter>
+    val liveNotificationFollowLists: StateFlow<ITopNavFilter>
+    val livePollsFollowLists: StateFlow<ITopNavFilter>
+    val livePicturesFollowLists: StateFlow<ITopNavFilter>
+    val liveShortsFollowLists: StateFlow<ITopNavFilter>
+    val liveLongsFollowLists: StateFlow<ITopNavFilter>
+
+    /** Block list address for the current user */
+    fun getBlockListAddress(): Address
+
+    /** Bookmark list flow (from BookmarkListState.bookmarks) */
+    val liveBookmarks: StateFlow<BookmarkListState.BookmarkList>
+
+    /** Old bookmark list flow (from OldBookmarkListState.bookmarks) */
+    val liveOldBookmarks: StateFlow<OldBookmarkListState.BookmarkList>
+
+    /** Proxy relay list flow (from ProxyRelayListState.flow) */
+    val liveProxyRelayList: StateFlow<Set<NormalizedRelayUrl>>
+
+    /** Default home follow list name for feed key generation */
+    val defaultHomeFollowListFlow: StateFlow<String>
 
     /** Send a NIP-04 encrypted direct message */
     suspend fun sendNip04PrivateMessage(eventTemplate: EventTemplate<PrivateDmEvent>)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
@@ -24,6 +24,7 @@ import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupList
 import com.vitorpamplona.amethyst.commons.model.nip51Lists.BookmarkListState
 import com.vitorpamplona.amethyst.commons.model.nip51Lists.OldBookmarkListState
 import com.vitorpamplona.amethyst.commons.model.privateChats.ChatroomList
+import com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Address
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
@@ -128,14 +129,14 @@ interface IAccount {
     val liveHiddenUsersFlow: StateFlow<LiveHiddenUsers>
 
     /** Top navigation follow list filters per feed type (from topNavFilterFlow) */
-    val liveHomeFollowLists: StateFlow<ITopNavFilter>
-    val liveStoriesFollowLists: StateFlow<ITopNavFilter>
-    val liveDiscoveryFollowLists: StateFlow<ITopNavFilter>
-    val liveNotificationFollowLists: StateFlow<ITopNavFilter>
-    val livePollsFollowLists: StateFlow<ITopNavFilter>
-    val livePicturesFollowLists: StateFlow<ITopNavFilter>
-    val liveShortsFollowLists: StateFlow<ITopNavFilter>
-    val liveLongsFollowLists: StateFlow<ITopNavFilter>
+    val liveHomeFollowLists: StateFlow<IFeedTopNavFilter>
+    val liveStoriesFollowLists: StateFlow<IFeedTopNavFilter>
+    val liveDiscoveryFollowLists: StateFlow<IFeedTopNavFilter>
+    val liveNotificationFollowLists: StateFlow<IFeedTopNavFilter>
+    val livePollsFollowLists: StateFlow<IFeedTopNavFilter>
+    val livePicturesFollowLists: StateFlow<IFeedTopNavFilter>
+    val liveShortsFollowLists: StateFlow<IFeedTopNavFilter>
+    val liveLongsFollowLists: StateFlow<IFeedTopNavFilter>
 
     /** Block list address for the current user */
     fun getBlockListAddress(): Address

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccountSettings.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccountSettings.kt
@@ -18,6 +18,23 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model.topNavFeeds
+package com.vitorpamplona.amethyst.commons.model
 
-typealias IFeedTopNavFilter = com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavFilter
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Interface for account settings needed by DAL feed filters in commons.
+ * Abstracts Android-specific AccountSettings for use in KMP modules.
+ *
+ * DAL filters access settings.defaultXxxFollowList.value to determine
+ * which follow list to use for each feed type.
+ */
+interface IAccountSettings {
+    val defaultHomeFollowList: StateFlow<TopFilter>
+    val defaultStoriesFollowList: StateFlow<TopFilter>
+    val defaultNotificationFollowList: StateFlow<TopFilter>
+    val defaultPollsFollowList: StateFlow<TopFilter>
+    val defaultPicturesFollowList: StateFlow<TopFilter>
+    val defaultShortsFollowList: StateFlow<TopFilter>
+    val defaultLongsFollowList: StateFlow<TopFilter>
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IBlockPeopleListState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IBlockPeopleListState.kt
@@ -18,6 +18,16 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model.topNavFeeds
+package com.vitorpamplona.amethyst.commons.model
 
-typealias IFeedTopNavFilter = com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavFilter
+import com.vitorpamplona.quartz.nip01Core.core.Address
+
+/**
+ * Interface for block people list state, abstracting Android-specific BlockPeopleListState
+ * for use in commons DAL filters.
+ *
+ * DAL filters use [getBlockListAddress] to compare against TopFilter selections.
+ */
+interface IBlockPeopleListState {
+    fun getBlockListAddress(): Address
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IHiddenUsersState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IHiddenUsersState.kt
@@ -18,6 +18,16 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model.topNavFeeds
+package com.vitorpamplona.amethyst.commons.model
 
-typealias IFeedTopNavFilter = com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavFilter
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Interface for hidden users state, abstracting Android-specific HiddenUsersState
+ * for use in commons DAL filters.
+ *
+ * DAL filters access [flow] to get the current [LiveHiddenUsers] for content filtering.
+ */
+interface IHiddenUsersState {
+    val flow: StateFlow<LiveHiddenUsers>
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/ITopNavFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/ITopNavFilter.kt
@@ -18,14 +18,20 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model.topNavFeeds
+package com.vitorpamplona.amethyst.commons.model
 
-import com.vitorpamplona.amethyst.commons.model.ITopNavFilter
-import com.vitorpamplona.amethyst.model.LocalCache
-import kotlinx.coroutines.flow.Flow
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
 
-interface IFeedTopNavFilter : ITopNavFilter {
-    fun toPerRelayFlow(cache: LocalCache): Flow<IFeedTopNavPerRelayFilterSet>
+/**
+ * Commons-level interface for top navigation feed filters.
+ * Provides the core filtering methods needed by DAL filter classes.
+ *
+ * The amethyst module's IFeedTopNavFilter extends this with additional
+ * relay-specific methods that depend on LocalCache.
+ */
+interface ITopNavFilter {
+    fun matchAuthor(pubkey: HexKey): Boolean
 
-    fun startValue(cache: LocalCache): IFeedTopNavPerRelayFilterSet
+    fun match(noteEvent: Event): Boolean
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/TopFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/TopFilter.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model
+
+import com.vitorpamplona.quartz.nip01Core.core.Address
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed class TopFilter(
+    val code: String,
+) {
+    @Serializable
+    object Global : TopFilter(" Global ")
+
+    @Serializable
+    object AllFollows : TopFilter(" All Follows ")
+
+    @Serializable
+    object AllUserFollows : TopFilter(" All User Follows ")
+
+    @Serializable
+    object DefaultFollows : TopFilter(" Main User Follows ")
+
+    @Serializable
+    object AroundMe : TopFilter(" Around Me ")
+
+    @Serializable
+    object Chess : TopFilter(" Chess ")
+
+    @Serializable
+    class PeopleList(
+        val address: Address,
+    ) : TopFilter(address.toValue())
+
+    @Serializable
+    class MuteList(
+        val address: Address,
+    ) : TopFilter(address.toValue())
+
+    @Serializable
+    class Community(
+        val address: Address,
+    ) : TopFilter("Community/${address.toValue()}")
+
+    @Serializable
+    class Hashtag(
+        val tag: String,
+    ) : TopFilter("Hashtag/$tag")
+
+    @Serializable
+    class Geohash(
+        val tag: String,
+    ) : TopFilter("Geohash/$tag")
+
+    @Serializable
+    class Relay(
+        val url: String,
+    ) : TopFilter("Relay/$url")
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/IFeedTopNavFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/IFeedTopNavFilter.kt
@@ -20,15 +20,16 @@
  */
 package com.vitorpamplona.amethyst.commons.model.topNavFeeds
 
+import com.vitorpamplona.amethyst.commons.model.ITopNavFilter
 import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import kotlinx.coroutines.flow.Flow
 
-interface IFeedTopNavFilter {
-    fun matchAuthor(pubkey: HexKey): Boolean
+interface IFeedTopNavFilter : ITopNavFilter {
+    override fun matchAuthor(pubkey: HexKey): Boolean
 
-    fun match(noteEvent: Event): Boolean
+    override fun match(noteEvent: Event): Boolean
 
     fun toPerRelayFlow(cache: ICacheProvider): Flow<IFeedTopNavPerRelayFilterSet>
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/IFeedTopNavFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/IFeedTopNavFilter.kt
@@ -18,41 +18,19 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.author
+package com.vitorpamplona.amethyst.commons.model.topNavFeeds
 
-import androidx.compose.runtime.Immutable
 import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
-import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
-import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
-import com.vitorpamplona.quartz.nip53LiveActivities.streaming.LiveActivitiesEvent
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 
-@Immutable
-class AuthorsByProxyTopNavFilter(
-    val authors: Set<String>,
-    val proxyRelays: Set<NormalizedRelayUrl>,
-) : IFeedTopNavFilter {
-    override fun matchAuthor(pubkey: HexKey) = pubkey in authors
+interface IFeedTopNavFilter {
+    fun matchAuthor(pubkey: HexKey): Boolean
 
-    override fun match(noteEvent: Event): Boolean =
-        if (noteEvent is LiveActivitiesEvent) {
-            noteEvent.participantsIntersect(authors)
-        } else {
-            noteEvent.pubKey in authors
-        }
+    fun match(noteEvent: Event): Boolean
 
-    override fun toPerRelayFlow(cache: ICacheProvider): Flow<AuthorsTopNavPerRelayFilterSet> =
-        MutableStateFlow(
-            AuthorsTopNavPerRelayFilterSet(
-                proxyRelays.associateWith { AuthorsTopNavPerRelayFilter(authors) },
-            ),
-        )
+    fun toPerRelayFlow(cache: ICacheProvider): Flow<IFeedTopNavPerRelayFilterSet>
 
-    override fun startValue(cache: ICacheProvider): AuthorsTopNavPerRelayFilterSet =
-        AuthorsTopNavPerRelayFilterSet(
-            proxyRelays.associateWith { AuthorsTopNavPerRelayFilter(authors) },
-        )
+    fun startValue(cache: ICacheProvider): IFeedTopNavPerRelayFilterSet
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/IFeedTopNavPerRelayFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/IFeedTopNavPerRelayFilter.kt
@@ -18,6 +18,6 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model.topNavFeeds
+package com.vitorpamplona.amethyst.commons.model.topNavFeeds
 
-typealias IFeedTopNavFilter = com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavFilter
+interface IFeedTopNavPerRelayFilter

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/IFeedTopNavPerRelayFilterSet.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/IFeedTopNavPerRelayFilterSet.kt
@@ -18,6 +18,6 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model.topNavFeeds
+package com.vitorpamplona.amethyst.commons.model.topNavFeeds
 
-typealias IFeedTopNavFilter = com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavFilter
+interface IFeedTopNavPerRelayFilterSet

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/AdditiveComplexFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/AdditiveComplexFeedFilter.kt
@@ -18,7 +18,11 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.old.dal
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-// Re-export from commons for backwards compatibility
-typealias OldBookmarkPrivateFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.OldBookmarkPrivateFeedFilter
+abstract class AdditiveComplexFeedFilter<T, U> : FeedFilter<T>() {
+    abstract fun updateListWith(
+        oldList: List<T>,
+        newItems: Set<U>,
+    ): List<T>
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/BookmarkPrivateFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/BookmarkPrivateFeedFilter.kt
@@ -18,7 +18,18 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.old.dal
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-// Re-export from commons for backwards compatibility
-typealias OldBookmarkPrivateFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.OldBookmarkPrivateFeedFilter
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.Note
+
+class BookmarkPrivateFeedFilter(
+    val account: IAccount,
+) : FeedFilter<Note>() {
+    override fun feedKey(): String =
+        account.liveBookmarks.value
+            .hashCode()
+            .toString()
+
+    override fun feed(): List<Note> = account.liveBookmarks.value.private
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/BookmarkPublicFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/BookmarkPublicFeedFilter.kt
@@ -18,7 +18,18 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.old.dal
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-// Re-export from commons for backwards compatibility
-typealias OldBookmarkPrivateFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.OldBookmarkPrivateFeedFilter
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.Note
+
+class BookmarkPublicFeedFilter(
+    val account: IAccount,
+) : FeedFilter<Note>() {
+    override fun feedKey(): String =
+        account.liveBookmarks.value
+            .hashCode()
+            .toString()
+
+    override fun feed(): List<Note> = account.liveBookmarks.value.public
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/HiddenAccountsFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/HiddenAccountsFeedFilter.kt
@@ -18,7 +18,30 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.old.dal
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-// Re-export from commons for backwards compatibility
-typealias OldBookmarkPrivateFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.OldBookmarkPrivateFeedFilter
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+import com.vitorpamplona.quartz.utils.Log
+import kotlinx.coroutines.CancellationException
+
+class HiddenAccountsFeedFilter(
+    val account: IAccount,
+    val cache: ICacheProvider,
+) : FeedFilter<User>() {
+    override fun feedKey(): String = account.userProfile().pubkeyHex
+
+    override fun showHiddenKey(): Boolean = true
+
+    override fun feed(): List<User> =
+        account.hiddenUsers.flow.value.hiddenUsers.reversed().mapNotNull {
+            try {
+                cache.getOrCreateUser(it)
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                Log.e("HiddenAccountsFeedFilter") { "Failed to parse key $it" }
+                null
+            }
+        }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/HiddenWordsFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/HiddenWordsFeedFilter.kt
@@ -18,7 +18,18 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.old.dal
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-// Re-export from commons for backwards compatibility
-typealias OldBookmarkPrivateFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.OldBookmarkPrivateFeedFilter
+import com.vitorpamplona.amethyst.commons.model.IAccount
+
+class HiddenWordsFeedFilter(
+    val account: IAccount,
+) : FeedFilter<String>() {
+    override fun feedKey(): String = account.userProfile().pubkeyHex
+
+    override fun showHiddenKey(): Boolean = true
+
+    override fun feed(): List<String> =
+        account.hiddenUsers.flow.value.hiddenWords
+            .toList()
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/OldBookmarkPrivateFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/OldBookmarkPrivateFeedFilter.kt
@@ -18,7 +18,18 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.old.dal
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-// Re-export from commons for backwards compatibility
-typealias OldBookmarkPrivateFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.OldBookmarkPrivateFeedFilter
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.Note
+
+class OldBookmarkPrivateFeedFilter(
+    val account: IAccount,
+) : FeedFilter<Note>() {
+    override fun feedKey(): String =
+        account.liveOldBookmarks.value
+            .hashCode()
+            .toString()
+
+    override fun feed(): List<Note> = account.liveOldBookmarks.value.private
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/OldBookmarkPublicFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/OldBookmarkPublicFeedFilter.kt
@@ -18,7 +18,18 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.old.dal
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-// Re-export from commons for backwards compatibility
-typealias OldBookmarkPrivateFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.OldBookmarkPrivateFeedFilter
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.Note
+
+class OldBookmarkPublicFeedFilter(
+    val account: IAccount,
+) : FeedFilter<Note>() {
+    override fun feedKey(): String =
+        account.liveOldBookmarks.value
+            .hashCode()
+            .toString()
+
+    override fun feed(): List<Note> = account.liveOldBookmarks.value.public
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/SupportedContent.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/SupportedContent.kt
@@ -18,7 +18,29 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.old.dal
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-// Re-export from commons for backwards compatibility
-typealias OldBookmarkPrivateFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.OldBookmarkPrivateFeedFilter
+class SupportedContent(
+    val blockedUrls: List<String>,
+    val mimeTypes: Set<String>,
+    val supportedFileExtensions: Set<String>,
+) {
+    private fun validExtension(fullUrl: String): Boolean {
+        val queryIndex = fullUrl.indexOf('?')
+        if (queryIndex > 0) {
+            return supportedFileExtensions.any { fullUrl.startsWith(it, queryIndex - it.length) }
+        }
+
+        val fragmentIndex = fullUrl.indexOf('#')
+        if (fragmentIndex > 0) {
+            return supportedFileExtensions.any { fullUrl.startsWith(it, fragmentIndex - it.length) }
+        }
+
+        return supportedFileExtensions.any { fullUrl.endsWith(it) }
+    }
+
+    fun acceptableUrl(
+        url: String,
+        mimeType: String?,
+    ) = blockedUrls.none { url.contains(it) } && ((mimeType != null && mimeTypes.contains(mimeType)) || validExtension(url))
+}


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

Moves 8 FeedFilter-related classes from `amethyst/dal/` to `commons`, using the infrastructure from:
- #2303 (IHiddenUsersState/IBlockPeopleListState)
- #2304 (IAccount reactive flows)
- #2305 (IFeedTopNavFilter in commons)
- #2306 (IAccountSettings + TopFilter)

### Moved to commons
| Class | Key Changes |
|-------|-------------|
| `AdditiveComplexFeedFilter` | Pure abstract, no deps |
| `HiddenWordsFeedFilter` | `Account` → `IAccount` |
| `HiddenAccountsFeedFilter` | `Account` → `IAccount`, `LocalCache` → `ICacheProvider` |
| `BookmarkPublicFeedFilter` | `bookmarkState.bookmarks` → `liveBookmarks` |
| `BookmarkPrivateFeedFilter` | `bookmarkState.bookmarks` → `liveBookmarks` |
| `OldBookmarkPublicFeedFilter` | `oldBookmarkState.bookmarks` → `liveOldBookmarks` |
| `OldBookmarkPrivateFeedFilter` | `oldBookmarkState.bookmarks` → `liveOldBookmarks` |
| `SupportedContent` | Zero dependencies |

### Infrastructure changes
- `IFeedTopNavFilter` now extends `ITopNavFilter` (removes redundant method declarations)
- `IAccount` uses `IFeedTopNavFilter` for live follow list flows (matches Account's actual types)
- `Account` implements new `IAccount` members (`liveBookmarks`, `liveOldBookmarks`, `liveHiddenUsersFlow`, etc.)
- Typealiases at original locations for backwards compatibility

### Still blocked (batch 2+)
- `SpammerAccountsFeedFilter` — needs `transientHiddenUsers` on `IHiddenUsersState`
- `PinnedNotesFeedFilter` — needs `pinState` on `IAccount`
- `FilterByListParams` — depends on concrete TopNavFilter subclasses
- Most additive filters — depend on `LocalCache.notes.filterIntoSet` / `filterIntoSet` extension
- Home/Notification/Video filters — heavy deps on TopNavFilter subclasses and LocalCache