### PR TITLE
feat: expand IAccount with chat, relay, and hidden state accessors (v7)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -253,7 +253,7 @@ class Account(
     val nwcFilterAssembler: () -> NWCPaymentFilterAssembler,
     val otsResolverBuilder: () -> OtsResolver,
     val cache: LocalCache,
-    val client: INostrClient,
+    override val client: INostrClient,
     val scope: CoroutineScope,
     val mlsGroupStateStore: MlsGroupStateStore? = null,
 ) : IAccount {
@@ -267,6 +267,9 @@ class Account(
     override val hiddenWordsCase: List<DualCase> get() = hiddenUsers.flow.value.hiddenWordsCase
     override val hiddenUsersHashCodes: Set<Int> get() = hiddenUsers.flow.value.hiddenUsersHashCodes
     override val spammersHashCodes: Set<Int> get() = hiddenUsers.flow.value.spammersHashCodes
+
+    override val hiddenUsersFlow get() = hiddenUsers.flow
+    override val transientHiddenUsers get() = hiddenUsers.transientHiddenUsers
 
     val userMetadata = UserMetadataState(signer, cache, scope, settings)
 
@@ -309,7 +312,7 @@ class Account(
     val ephemeralChatList = EphemeralChatListState(signer, cache, ephemeralChatListDecryptionCache, scope, settings)
 
     val publicChatListDecryptionCache = PublicChatListDecryptionCache(signer)
-    val publicChatList = PublicChatListState(signer, cache, publicChatListDecryptionCache, scope, settings)
+    override val publicChatList = PublicChatListState(signer, cache, publicChatListDecryptionCache, scope, settings)
 
     val communityListDecryptionCache = CommunityListDecryptionCache(signer)
     val communityList = CommunityListState(signer, cache, communityListDecryptionCache, scope, settings)
@@ -362,6 +365,7 @@ class Account(
     val followPlusAllMineWithIndex = MergedFollowPlusMineWithIndexRelayListsState(followOutboxesOrProxy, nip65RelayList, privateStorageRelayList, localRelayList, indexerRelayList, scope)
     val followPlusAllMineWithSearch = MergedFollowPlusMineWithSearchRelayListsState(followOutboxesOrProxy, nip65RelayList, privateStorageRelayList, localRelayList, searchRelayList, scope)
     val defaultGlobalRelays = MergedFollowPlusMineRelayListsState(followOutboxesOrProxy, nip65RelayList, privateStorageRelayList, localRelayList, scope)
+    override val defaultGlobalRelaysFlow get() = defaultGlobalRelays.flow
 
     // keeps a cache of the declared outbox relays for each author
     val declaredFollowsPerOutboxRelay = DeclaredFollowsPerOutboxRelay(kind3FollowList, cache, scope).flow
@@ -2215,11 +2219,13 @@ class Account(
 
     suspend fun decryptZapOrNull(event: LnZapRequestEvent): LnZapPrivateEvent? = if (event.isPrivateZap() && isWriteable()) privateZapsDecryptionCache.decryptPrivateZap(event) else null
 
-    fun isAllHidden(users: Set<HexKey>): Boolean = users.all { isHidden(it) }
-
     override fun isHidden(user: User) = isHidden(user.pubkeyHex)
 
     fun isHidden(userHex: String): Boolean = hiddenUsers.flow.value.isUserHidden(userHex)
+
+    override fun isAllHidden(users: Set<HexKey>): Boolean = users.all { isHidden(it) }
+
+    override fun isFollowing(user: HexKey): Boolean = user in followingKeySet()
 
     override fun followingKeySet(): Set<HexKey> = kind3FollowList.flow.value.authors
 
@@ -2270,8 +2276,6 @@ class Account(
         }
 
     fun isFollowing(user: User): Boolean = user.pubkeyHex in followingKeySet()
-
-    fun isFollowing(user: HexKey): Boolean = user in followingKeySet()
 
     fun isKnown(user: User): Boolean = user.pubkeyHex in allFollows.flow.value.authors
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
@@ -21,7 +21,11 @@
 package com.vitorpamplona.amethyst.commons.model
 
 import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupList
+import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatListState
 import com.vitorpamplona.amethyst.commons.model.privateChats.ChatroomList
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import com.vitorpamplona.quartz.nip04Dm.messages.PrivateDmEvent
@@ -34,6 +38,7 @@ import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Response
 import com.vitorpamplona.quartz.nip57Zaps.IPrivateZapsDecryptionCache
 import com.vitorpamplona.quartz.nip59Giftwrap.wraps.GiftWrapEvent
 import com.vitorpamplona.quartz.utils.DualCase
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Interface for NIP-47 wallet connect signer state.
@@ -119,4 +124,25 @@ interface IAccount {
 
     /** Broadcast pre-created gift wraps (e.g. reactions within group DMs) */
     suspend fun sendGiftWraps(wraps: List<GiftWrapEvent>)
+
+    /** Combined hidden users state as a reactive flow (mutes + blocks + transient) */
+    val hiddenUsersFlow: StateFlow<LiveHiddenUsers>
+
+    /** Transient (session-only) hidden users, e.g. detected spammers */
+    val transientHiddenUsers: StateFlow<Set<String>>
+
+    /** True if every user in the set is hidden (muted, blocked, or transient) */
+    fun isAllHidden(users: Set<HexKey>): Boolean
+
+    /** Whether the given pubkey is in the follow list */
+    fun isFollowing(user: HexKey): Boolean
+
+    /** NIP-28 public chat channel list state */
+    val publicChatList: PublicChatListState
+
+    /** Nostr relay client for network operations */
+    val client: INostrClient
+
+    /** Merged default global relay set (outbox + NIP-65 + private + local) */
+    val defaultGlobalRelaysFlow: StateFlow<Set<NormalizedRelayUrl>>
 }


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

Adds 7 new members to the IAccount interface:

- **hiddenUsersFlow** (`StateFlow<LiveHiddenUsers>`) — combined mute/block/transient hidden state as a reactive flow
- **transientHiddenUsers** (`StateFlow<Set<String>>`) — session-only spammer tracking
- **isAllHidden(users)** — bulk hidden check for user sets
- **isFollowing(user: HexKey)** — follow list membership check
- **publicChatList** (`PublicChatListState`) — NIP-28 public channel subscriptions
- **client** (`INostrClient`) — relay network operations
- **defaultGlobalRelaysFlow** (`StateFlow<Set<NormalizedRelayUrl>>`) — merged default global relay set

These unblock migrating DAL filters (SpammerAccountsFeedFilter, HiddenAccountsFeedFilter, HashtagFeedFilter, Home/Video/Discover feed filters) and composable relay/upload UI to commons.

Follows: #2237 (v1), #2260 (v2), #2278 (v3), #2280 (v4), #2289 (v5), #2304 (v6).