### PR TITLE
feat: move TopNavFilter interfaces and implementations to commons

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -277,7 +277,7 @@ object LocalCache : ILocalCache, ICacheProvider {
 
     val paymentTracker = NwcPaymentTracker()
 
-    val relayHints = HintIndexer()
+    override val relayHints = HintIndexer()
 
     val deletionIndex = DeletionIndex()
 
@@ -530,7 +530,7 @@ object LocalCache : ILocalCache, ICacheProvider {
         return Hex.isHex64(key)
     }
 
-    fun checkGetOrCreateAddressableNote(key: String): AddressableNote? =
+    override fun checkGetOrCreateAddressableNote(key: String): AddressableNote? =
         try {
             val addr = Address.parse(key)
             if (addr != null) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/CommunityRelayLoader.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/CommunityRelayLoader.kt
@@ -20,8 +20,8 @@
  */
 package com.vitorpamplona.amethyst.model.topNavFeeds
 
-import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.model.NoteState
+import com.vitorpamplona.amethyst.commons.model.NoteState
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip72ModCommunities.definition.CommunityDefinitionEvent
@@ -34,7 +34,7 @@ class CommunityRelayLoader {
     companion object {
         fun communitiesPerRelay(
             communityNotes: Array<NoteState>,
-            cache: LocalCache,
+            cache: ICacheProvider,
         ): Map<NormalizedRelayUrl, Set<HexKey>> =
             mapOfSet {
                 communityNotes.forEach { communityNote ->
@@ -52,7 +52,7 @@ class CommunityRelayLoader {
 
         fun <T> communitiesPerRelaySnapshot(
             communities: Set<HexKey>,
-            cache: LocalCache,
+            cache: ICacheProvider,
             transformation: (Map<NormalizedRelayUrl, Set<HexKey>>) -> T,
         ): T {
             val noteMetadata =
@@ -70,7 +70,7 @@ class CommunityRelayLoader {
 
         fun <T> toCommunitiesPerRelayFlow(
             communities: Set<HexKey>,
-            cache: LocalCache,
+            cache: ICacheProvider,
             transformation: (Map<NormalizedRelayUrl, Set<HexKey>>) -> T,
         ): Flow<T> {
             val noteMetadataFlows =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/IFeedTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/IFeedTopNavFilter.kt
@@ -20,17 +20,5 @@
  */
 package com.vitorpamplona.amethyst.model.topNavFeeds
 
-import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.quartz.nip01Core.core.Event
-import com.vitorpamplona.quartz.nip01Core.core.HexKey
-import kotlinx.coroutines.flow.Flow
-
-interface IFeedTopNavFilter {
-    fun matchAuthor(pubkey: HexKey): Boolean
-
-    fun match(noteEvent: Event): Boolean
-
-    fun toPerRelayFlow(cache: LocalCache): Flow<IFeedTopNavPerRelayFilterSet>
-
-    fun startValue(cache: LocalCache): IFeedTopNavPerRelayFilterSet
-}
+// Re-export from commons for backward compatibility
+typealias IFeedTopNavFilter = com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavFilter

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/IFeedTopNavPerRelayFilterSet.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/IFeedTopNavPerRelayFilterSet.kt
@@ -20,4 +20,5 @@
  */
 package com.vitorpamplona.amethyst.model.topNavFeeds
 
-interface IFeedTopNavPerRelayFilterSet
+// Re-export from commons for backward compatibility
+typealias IFeedTopNavPerRelayFilterSet = com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavPerRelayFilterSet

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/OutboxRelayLoader.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/OutboxRelayLoader.kt
@@ -20,10 +20,10 @@
  */
 package com.vitorpamplona.amethyst.model.topNavFeeds
 
-import com.vitorpamplona.amethyst.model.AddressableNote
+import com.vitorpamplona.amethyst.commons.model.AddressableNote
+import com.vitorpamplona.amethyst.commons.model.NoteState
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.Constants
-import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.model.NoteState
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip65RelayList.AdvertisedRelayListEvent
@@ -37,7 +37,7 @@ class OutboxRelayLoader(
 ) {
     fun authorsPerRelay(
         outboxRelayNotes: Array<NoteState>,
-        cache: LocalCache,
+        cache: ICacheProvider,
     ): Map<NormalizedRelayUrl, Set<HexKey>> =
         mapOfSet {
             outboxRelayNotes.forEach { outboxNote ->
@@ -75,7 +75,7 @@ class OutboxRelayLoader(
 
     fun <T> authorsPerRelaySnapshot(
         authors: Set<HexKey>,
-        cache: LocalCache,
+        cache: ICacheProvider,
         transformation: (Map<NormalizedRelayUrl, Set<HexKey>>) -> T,
     ): T {
         val noteMetadata =
@@ -91,7 +91,7 @@ class OutboxRelayLoader(
 
     fun <T> toAuthorsPerRelayFlow(
         authors: Set<HexKey>,
-        cache: LocalCache,
+        cache: ICacheProvider,
         transformation: (Map<NormalizedRelayUrl, Set<HexKey>>) -> T,
     ): Flow<T> {
         val noteMetadataFlows =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allFollows/AllFollowsByOutboxTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allFollows/AllFollowsByOutboxTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.allFollows
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.CommunityRelayLoader
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.OutboxRelayLoader
@@ -78,7 +78,7 @@ class AllFollowsByOutboxTopNavFilter(
                 (communities != null && noteEvent.isTaggedAddressableNotes(communities))
         }
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<AllFollowsTopNavPerRelayFilterSet> {
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<AllFollowsTopNavPerRelayFilterSet> {
         val authorsPerRelay =
             if (authors != null) {
                 OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache) { it }
@@ -109,7 +109,7 @@ class AllFollowsByOutboxTopNavFilter(
         }
     }
 
-    override fun startValue(cache: LocalCache): AllFollowsTopNavPerRelayFilterSet {
+    override fun startValue(cache: ICacheProvider): AllFollowsTopNavPerRelayFilterSet {
         val authorsPerRelay =
             if (authors != null) {
                 OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache) { it }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allFollows/AllFollowsByProxyTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allFollows/AllFollowsByProxyTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.allFollows
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -74,7 +74,7 @@ class AllFollowsByProxyTopNavFilter(
         }
 
     // forces the use of the Proxy on all connections, replacing the outbox model.
-    override fun toPerRelayFlow(cache: LocalCache): Flow<AllFollowsTopNavPerRelayFilterSet> =
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<AllFollowsTopNavPerRelayFilterSet> =
         MutableStateFlow(
             AllFollowsTopNavPerRelayFilterSet(
                 proxyRelays.associateWith {
@@ -88,7 +88,7 @@ class AllFollowsByProxyTopNavFilter(
             ),
         )
 
-    override fun startValue(cache: LocalCache): AllFollowsTopNavPerRelayFilterSet {
+    override fun startValue(cache: ICacheProvider): AllFollowsTopNavPerRelayFilterSet {
         // forces the use of the Proxy on all connections, replacing the outbox model.
         return AllFollowsTopNavPerRelayFilterSet(
             proxyRelays.associateWith {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allUserFollows/AllUserFollowsByOutboxTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allUserFollows/AllUserFollowsByOutboxTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.allUserFollows
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.OutboxRelayLoader
 import com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.author.AuthorsTopNavPerRelayFilter
@@ -62,7 +62,7 @@ class AllUserFollowsByOutboxTopNavFilter(
             }
         }
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<AuthorsTopNavPerRelayFilterSet> {
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<AuthorsTopNavPerRelayFilterSet> {
         val authorsPerRelay = OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache) { it }
 
         return combine(authorsPerRelay, defaultRelays, blockedRelays) { perRelayAuthors, default, blockedRelays ->
@@ -78,7 +78,7 @@ class AllUserFollowsByOutboxTopNavFilter(
         }
     }
 
-    override fun startValue(cache: LocalCache): AuthorsTopNavPerRelayFilterSet {
+    override fun startValue(cache: ICacheProvider): AuthorsTopNavPerRelayFilterSet {
         val authorsPerRelay = OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache) { it }
 
         val allRelays = authorsPerRelay.keys.filter { it !in blockedRelays.value }.ifEmpty { defaultRelays.value }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allUserFollows/AllUserFollowsByProxyTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/allUserFollows/AllUserFollowsByProxyTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.allUserFollows
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.author.AuthorsTopNavPerRelayFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.author.AuthorsTopNavPerRelayFilterSet
@@ -60,7 +60,7 @@ class AllUserFollowsByProxyTopNavFilter(
         }
 
     // forces the use of the Proxy on all connections, replacing the outbox model.
-    override fun toPerRelayFlow(cache: LocalCache): Flow<AuthorsTopNavPerRelayFilterSet> =
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<AuthorsTopNavPerRelayFilterSet> =
         MutableStateFlow(
             AuthorsTopNavPerRelayFilterSet(
                 proxyRelays.associateWith {
@@ -71,7 +71,7 @@ class AllUserFollowsByProxyTopNavFilter(
             ),
         )
 
-    override fun startValue(cache: LocalCache): AuthorsTopNavPerRelayFilterSet {
+    override fun startValue(cache: ICacheProvider): AuthorsTopNavPerRelayFilterSet {
         // forces the use of the Proxy on all connections, replacing the outbox model.
         return AuthorsTopNavPerRelayFilterSet(
             proxyRelays.associateWith {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/aroundMe/LocationTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/aroundMe/LocationTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.aroundMe
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -52,12 +52,12 @@ class LocationTopNavFilter(
         }
     }
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<LocationTopNavPerRelayFilterSet> =
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<LocationTopNavPerRelayFilterSet> =
         MutableStateFlow(
             LocationTopNavPerRelayFilterSet(relayList.associateWith { LocationTopNavPerRelayFilter(geotags) }),
         )
 
-    override fun startValue(cache: LocalCache): LocationTopNavPerRelayFilterSet =
+    override fun startValue(cache: ICacheProvider): LocationTopNavPerRelayFilterSet =
         LocationTopNavPerRelayFilterSet(
             relayList.associateWith { LocationTopNavPerRelayFilter(geotags) },
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/chess/ChessTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/chess/ChessTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.chess
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -45,7 +45,7 @@ class ChessTopNavFilter(
             noteEvent is LiveChessGameChallengeEvent ||
             noteEvent is LiveChessGameEndEvent
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<ChessTopNavPerRelayFilterSet> =
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<ChessTopNavPerRelayFilterSet> =
         combine(outboxRelays, proxyRelays) { outboxRelays, proxyRelays ->
             if (proxyRelays.isNotEmpty()) {
                 ChessTopNavPerRelayFilterSet(proxyRelays.associateWith { ChessTopNavPerRelayFilter })
@@ -54,7 +54,7 @@ class ChessTopNavFilter(
             }
         }
 
-    override fun startValue(cache: LocalCache): ChessTopNavPerRelayFilterSet =
+    override fun startValue(cache: ICacheProvider): ChessTopNavPerRelayFilterSet =
         if (proxyRelays.value.isNotEmpty()) {
             ChessTopNavPerRelayFilterSet(proxyRelays.value.associateWith { ChessTopNavPerRelayFilter })
         } else {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/global/GlobalTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/global/GlobalTopNavFilter.kt
@@ -20,39 +20,7 @@
  */
 package com.vitorpamplona.amethyst.model.topNavFeeds.global
 
-import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
-import com.vitorpamplona.quartz.nip01Core.core.Event
-import com.vitorpamplona.quartz.nip01Core.core.HexKey
-import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
-
-@Immutable
-class GlobalTopNavFilter(
-    val outboxRelays: StateFlow<Set<NormalizedRelayUrl>>,
-    val proxyRelays: StateFlow<Set<NormalizedRelayUrl>>,
-    val relayFeeds: StateFlow<Set<NormalizedRelayUrl>>,
-) : IFeedTopNavFilter {
-    override fun matchAuthor(pubkey: HexKey): Boolean = true
-
-    override fun match(noteEvent: Event) = true
-
-    override fun toPerRelayFlow(cache: LocalCache): Flow<GlobalTopNavPerRelayFilterSet> =
-        combine(outboxRelays, proxyRelays, relayFeeds) { outboxRelays, proxyRelays, relayFeeds ->
-            if (proxyRelays.isNotEmpty()) {
-                GlobalTopNavPerRelayFilterSet(proxyRelays.associateWith { GlobalTopNavPerRelayFilter })
-            } else {
-                GlobalTopNavPerRelayFilterSet((relayFeeds + outboxRelays).associateWith { GlobalTopNavPerRelayFilter })
-            }
-        }
-
-    override fun startValue(cache: LocalCache): GlobalTopNavPerRelayFilterSet =
-        if (proxyRelays.value.isNotEmpty()) {
-            GlobalTopNavPerRelayFilterSet(proxyRelays.value.associateWith { GlobalTopNavPerRelayFilter })
-        } else {
-            GlobalTopNavPerRelayFilterSet((relayFeeds.value + outboxRelays.value).associateWith { GlobalTopNavPerRelayFilter })
-        }
-}
+// Re-export from commons for backward compatibility
+typealias GlobalTopNavFilter = com.vitorpamplona.amethyst.commons.model.topNavFeeds.global.GlobalTopNavFilter
+typealias GlobalTopNavPerRelayFilter = com.vitorpamplona.amethyst.commons.model.topNavFeeds.global.GlobalTopNavPerRelayFilter
+typealias GlobalTopNavPerRelayFilterSet = com.vitorpamplona.amethyst.commons.model.topNavFeeds.global.GlobalTopNavPerRelayFilterSet

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/hashtag/HashtagTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/hashtag/HashtagTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.hashtag
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -48,14 +48,14 @@ class HashtagTopNavFilter(
             noteEvent.isTaggedHashes(hashtags)
         }
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<HashtagTopNavPerRelayFilterSet> =
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<HashtagTopNavPerRelayFilterSet> =
         MutableStateFlow(
             HashtagTopNavPerRelayFilterSet(
                 relayList.associateWith { HashtagTopNavPerRelayFilter(hashtags) },
             ),
         )
 
-    override fun startValue(cache: LocalCache): HashtagTopNavPerRelayFilterSet =
+    override fun startValue(cache: ICacheProvider): HashtagTopNavPerRelayFilterSet =
         HashtagTopNavPerRelayFilterSet(
             relayList.associateWith { HashtagTopNavPerRelayFilter(hashtags) },
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/allcommunities/AllCommunitiesTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/allcommunities/AllCommunitiesTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.allcommunities
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.CommunityRelayLoader
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
@@ -46,7 +46,7 @@ class AllCommunitiesTopNavFilter(
             map.mapValues { AllCommunitiesTopNavPerRelayFilter(it.value) },
         )
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<AllCommunitiesTopNavPerRelayFilterSet> {
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<AllCommunitiesTopNavPerRelayFilterSet> {
         val communitiesPerRelay = CommunityRelayLoader.toCommunitiesPerRelayFlow(communities, cache) { it }
 
         return combine(communitiesPerRelay, blockedRelays) { communitiesPerRelay, blockedRelays ->
@@ -54,7 +54,7 @@ class AllCommunitiesTopNavFilter(
         }
     }
 
-    override fun startValue(cache: LocalCache): AllCommunitiesTopNavPerRelayFilterSet {
+    override fun startValue(cache: ICacheProvider): AllCommunitiesTopNavPerRelayFilterSet {
         val communitiesPerRelay = CommunityRelayLoader.communitiesPerRelaySnapshot(communities, cache) { it }
 
         return convert(communitiesPerRelay.minus(blockedRelays.value))

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/author/AuthorsByOutboxTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/author/AuthorsByOutboxTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.author
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.OutboxRelayLoader
 import com.vitorpamplona.quartz.nip01Core.core.Event
@@ -51,7 +51,7 @@ class AuthorsByOutboxTopNavFilter(
             map.mapValues { AuthorsTopNavPerRelayFilter(it.value) },
         )
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<AuthorsTopNavPerRelayFilterSet> {
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<AuthorsTopNavPerRelayFilterSet> {
         val authorsPerRelay = OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache) { it }
 
         return combine(authorsPerRelay, blockedRelays) { authors, blocked ->
@@ -59,7 +59,7 @@ class AuthorsByOutboxTopNavFilter(
         }
     }
 
-    override fun startValue(cache: LocalCache): AuthorsTopNavPerRelayFilterSet {
+    override fun startValue(cache: ICacheProvider): AuthorsTopNavPerRelayFilterSet {
         val authorsPerRelay = OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache) { it }
 
         return convert(authorsPerRelay.minus(blockedRelays.value))

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/author/AuthorsByProxyTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/author/AuthorsByProxyTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.author
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -44,14 +44,14 @@ class AuthorsByProxyTopNavFilter(
             noteEvent.pubKey in authors
         }
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<AuthorsTopNavPerRelayFilterSet> =
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<AuthorsTopNavPerRelayFilterSet> =
         MutableStateFlow(
             AuthorsTopNavPerRelayFilterSet(
                 proxyRelays.associateWith { AuthorsTopNavPerRelayFilter(authors) },
             ),
         )
 
-    override fun startValue(cache: LocalCache): AuthorsTopNavPerRelayFilterSet =
+    override fun startValue(cache: ICacheProvider): AuthorsTopNavPerRelayFilterSet =
         AuthorsTopNavPerRelayFilterSet(
             proxyRelays.associateWith { AuthorsTopNavPerRelayFilter(authors) },
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/community/SingleCommunityTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/community/SingleCommunityTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.community
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.OutboxRelayLoader
 import com.vitorpamplona.quartz.nip01Core.core.Event
@@ -53,7 +53,7 @@ class SingleCommunityTopNavFilter(
             (authors != null && noteEvent.pubKey in authors) || noteEvent.isTaggedAddressableNote(community)
         }
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<SingleCommunityTopNavPerRelayFilterSet> {
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<SingleCommunityTopNavPerRelayFilterSet> {
         // relay field takes priority
         if (relays.isNotEmpty()) {
             return blockedRelays.map { blocked ->
@@ -88,7 +88,7 @@ class SingleCommunityTopNavFilter(
         }
     }
 
-    override fun startValue(cache: LocalCache): SingleCommunityTopNavPerRelayFilterSet {
+    override fun startValue(cache: ICacheProvider): SingleCommunityTopNavPerRelayFilterSet {
         // relay field takes priority
         if (relays.isNotEmpty()) {
             return SingleCommunityTopNavPerRelayFilterSet(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/muted/MutedAuthorsByProxyTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/noteBased/muted/MutedAuthorsByProxyTopNavFilter.kt
@@ -20,39 +20,7 @@
  */
 package com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.muted
 
-import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
-import com.vitorpamplona.quartz.nip01Core.core.Event
-import com.vitorpamplona.quartz.nip01Core.core.HexKey
-import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
-import com.vitorpamplona.quartz.nip53LiveActivities.streaming.LiveActivitiesEvent
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-
-@Immutable
-class MutedAuthorsByProxyTopNavFilter(
-    val authors: Set<String>,
-    val proxyRelays: Set<NormalizedRelayUrl>,
-) : IFeedTopNavFilter {
-    override fun matchAuthor(pubkey: HexKey) = pubkey in authors
-
-    override fun match(noteEvent: Event): Boolean =
-        if (noteEvent is LiveActivitiesEvent) {
-            noteEvent.participantsIntersect(authors)
-        } else {
-            noteEvent.pubKey in authors
-        }
-
-    override fun toPerRelayFlow(cache: LocalCache): Flow<MutedAuthorsTopNavPerRelayFilterSet> =
-        MutableStateFlow(
-            MutedAuthorsTopNavPerRelayFilterSet(
-                proxyRelays.associateWith { MutedAuthorsTopNavPerRelayFilter(authors) },
-            ),
-        )
-
-    override fun startValue(cache: LocalCache): MutedAuthorsTopNavPerRelayFilterSet =
-        MutedAuthorsTopNavPerRelayFilterSet(
-            proxyRelays.associateWith { MutedAuthorsTopNavPerRelayFilter(authors) },
-        )
-}
+// Re-export from commons for backward compatibility
+typealias MutedAuthorsByProxyTopNavFilter = com.vitorpamplona.amethyst.commons.model.topNavFeeds.noteBased.muted.MutedAuthorsByProxyTopNavFilter
+typealias MutedAuthorsTopNavPerRelayFilter = com.vitorpamplona.amethyst.commons.model.topNavFeeds.noteBased.muted.MutedAuthorsTopNavPerRelayFilter
+typealias MutedAuthorsTopNavPerRelayFilterSet = com.vitorpamplona.amethyst.commons.model.topNavFeeds.noteBased.muted.MutedAuthorsTopNavPerRelayFilterSet

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/relay/RelayTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/relay/RelayTopNavFilter.kt
@@ -20,24 +20,7 @@
  */
 package com.vitorpamplona.amethyst.model.topNavFeeds.relay
 
-import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
-import com.vitorpamplona.quartz.nip01Core.core.Event
-import com.vitorpamplona.quartz.nip01Core.core.HexKey
-import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
-
-@Immutable
-class RelayTopNavFilter(
-    val relayUrl: NormalizedRelayUrl,
-) : IFeedTopNavFilter {
-    override fun matchAuthor(pubkey: HexKey): Boolean = true
-
-    override fun match(noteEvent: Event) = true
-
-    override fun toPerRelayFlow(cache: LocalCache): Flow<RelayTopNavPerRelayFilterSet> = flowOf(RelayTopNavPerRelayFilterSet(relayUrl))
-
-    override fun startValue(cache: LocalCache): RelayTopNavPerRelayFilterSet = RelayTopNavPerRelayFilterSet(relayUrl)
-}
+// Re-export from commons for backward compatibility
+typealias RelayTopNavFilter = com.vitorpamplona.amethyst.commons.model.topNavFeeds.relay.RelayTopNavFilter
+typealias RelayTopNavPerRelayFilter = com.vitorpamplona.amethyst.commons.model.topNavFeeds.relay.RelayTopNavPerRelayFilter
+typealias RelayTopNavPerRelayFilterSet = com.vitorpamplona.amethyst.commons.model.topNavFeeds.relay.RelayTopNavPerRelayFilterSet

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/unknown/UnknownTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/unknown/UnknownTopNavFilter.kt
@@ -21,7 +21,7 @@
 package com.vitorpamplona.amethyst.model.topNavFeeds.unknown
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
@@ -37,7 +37,7 @@ class UnknownTopNavFilter(
 
     override fun match(noteEvent: Event) = false
 
-    override fun toPerRelayFlow(cache: LocalCache): Flow<UnknownTopNavPerRelayFilterSet> = MutableStateFlow(UnknownTopNavPerRelayFilterSet)
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<UnknownTopNavPerRelayFilterSet> = MutableStateFlow(UnknownTopNavPerRelayFilterSet)
 
-    override fun startValue(cache: LocalCache) = UnknownTopNavPerRelayFilterSet
+    override fun startValue(cache: ICacheProvider) = UnknownTopNavPerRelayFilterSet
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/cache/ICacheProvider.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/cache/ICacheProvider.kt
@@ -27,6 +27,7 @@ import com.vitorpamplona.amethyst.commons.model.User
 import com.vitorpamplona.quartz.nip01Core.core.Address
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.hints.HintIndexer
 
 /**
  * Cache provider interface for accessing cached Notes, Users, and Channels.
@@ -135,4 +136,22 @@ interface ICacheProvider {
     fun getOrCreateUser(pubkey: HexKey): User?
 
     fun justConsumeMyOwnEvent(event: Event): Boolean
+
+    /**
+     * Gets or creates an AddressableNote from a string address key.
+     * Parses the string to Address, returns null if invalid.
+     *
+     * @param key The address string to parse and look up
+     * @return The AddressableNote if valid, null otherwise
+     */
+    fun checkGetOrCreateAddressableNote(key: String): AddressableNote? {
+        val addr = Address.parse(key) ?: return null
+        return getOrCreateAddressableNote(addr)
+    }
+
+    /**
+     * Gets the relay hint indexer for looking up relay hints by pubkey or address.
+     * Used by OutboxRelayLoader and CommunityRelayLoader to find relay hints.
+     */
+    val relayHints: HintIndexer
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/IFeedTopNavFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/IFeedTopNavFilter.kt
@@ -18,7 +18,19 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model.topNavFeeds
+package com.vitorpamplona.amethyst.commons.model.topNavFeeds
 
-// Re-export from commons for backward compatibility
-typealias IFeedTopNavPerRelayFilter = com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavPerRelayFilter
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import kotlinx.coroutines.flow.Flow
+
+interface IFeedTopNavFilter {
+    fun matchAuthor(pubkey: HexKey): Boolean
+
+    fun match(noteEvent: Event): Boolean
+
+    fun toPerRelayFlow(cache: ICacheProvider): Flow<IFeedTopNavPerRelayFilterSet>
+
+    fun startValue(cache: ICacheProvider): IFeedTopNavPerRelayFilterSet
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/IFeedTopNavPerRelayFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/IFeedTopNavPerRelayFilter.kt
@@ -18,10 +18,6 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model.topNavFeeds.relay
+package com.vitorpamplona.amethyst.commons.model.topNavFeeds
 
-import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavPerRelayFilter
-
-@Immutable
-object RelayTopNavPerRelayFilter : IFeedTopNavPerRelayFilter
+interface IFeedTopNavPerRelayFilter

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/IFeedTopNavPerRelayFilterSet.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/IFeedTopNavPerRelayFilterSet.kt
@@ -18,7 +18,6 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model.topNavFeeds
+package com.vitorpamplona.amethyst.commons.model.topNavFeeds
 
-// Re-export from commons for backward compatibility
-typealias IFeedTopNavPerRelayFilter = com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavPerRelayFilter
+interface IFeedTopNavPerRelayFilterSet

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/global/GlobalTopNavFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/global/GlobalTopNavFilter.kt
@@ -18,50 +18,41 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.muted
+package com.vitorpamplona.amethyst.commons.model.topNavFeeds.global
 
 import androidx.compose.runtime.Immutable
 import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
-import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
-import com.vitorpamplona.amethyst.model.topNavFeeds.OutboxRelayLoader
+import com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
-import com.vitorpamplona.quartz.nip53LiveActivities.streaming.LiveActivitiesEvent
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 
 @Immutable
-class MutedAuthorsByOutboxTopNavFilter(
-    val authors: Set<String>,
-    val blockedRelays: StateFlow<Set<NormalizedRelayUrl>>,
+class GlobalTopNavFilter(
+    val outboxRelays: StateFlow<Set<NormalizedRelayUrl>>,
+    val proxyRelays: StateFlow<Set<NormalizedRelayUrl>>,
+    val relayFeeds: StateFlow<Set<NormalizedRelayUrl>>,
 ) : IFeedTopNavFilter {
-    override fun matchAuthor(pubkey: HexKey) = pubkey in authors
+    override fun matchAuthor(pubkey: HexKey): Boolean = true
 
-    override fun match(noteEvent: Event): Boolean =
-        if (noteEvent is LiveActivitiesEvent) {
-            noteEvent.participantsIntersect(authors)
+    override fun match(noteEvent: Event) = true
+
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<GlobalTopNavPerRelayFilterSet> =
+        combine(outboxRelays, proxyRelays, relayFeeds) { outboxRelays, proxyRelays, relayFeeds ->
+            if (proxyRelays.isNotEmpty()) {
+                GlobalTopNavPerRelayFilterSet(proxyRelays.associateWith { GlobalTopNavPerRelayFilter })
+            } else {
+                GlobalTopNavPerRelayFilterSet((relayFeeds + outboxRelays).associateWith { GlobalTopNavPerRelayFilter })
+            }
+        }
+
+    override fun startValue(cache: ICacheProvider): GlobalTopNavPerRelayFilterSet =
+        if (proxyRelays.value.isNotEmpty()) {
+            GlobalTopNavPerRelayFilterSet(proxyRelays.value.associateWith { GlobalTopNavPerRelayFilter })
         } else {
-            noteEvent.pubKey in authors
+            GlobalTopNavPerRelayFilterSet((relayFeeds.value + outboxRelays.value).associateWith { GlobalTopNavPerRelayFilter })
         }
-
-    fun convert(map: Map<NormalizedRelayUrl, Set<HexKey>>) =
-        MutedAuthorsTopNavPerRelayFilterSet(
-            map.mapValues { MutedAuthorsTopNavPerRelayFilter(it.value) },
-        )
-
-    override fun toPerRelayFlow(cache: ICacheProvider): Flow<MutedAuthorsTopNavPerRelayFilterSet> {
-        val authorsPerRelay = OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache) { it }
-
-        return combine(authorsPerRelay, blockedRelays) { authors, blocked ->
-            convert(authors.minus(blocked))
-        }
-    }
-
-    override fun startValue(cache: ICacheProvider): MutedAuthorsTopNavPerRelayFilterSet {
-        val authorsPerRelay = OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache) { it }
-
-        return convert(authorsPerRelay.minus(blockedRelays.value))
-    }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/global/GlobalTopNavPerRelayFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/global/GlobalTopNavPerRelayFilter.kt
@@ -18,7 +18,10 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model.topNavFeeds
+package com.vitorpamplona.amethyst.commons.model.topNavFeeds.global
 
-// Re-export from commons for backward compatibility
-typealias IFeedTopNavPerRelayFilter = com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavPerRelayFilter
+import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavPerRelayFilter
+
+@Immutable
+object GlobalTopNavPerRelayFilter : IFeedTopNavPerRelayFilter

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/global/GlobalTopNavPerRelayFilterSet.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/global/GlobalTopNavPerRelayFilterSet.kt
@@ -18,10 +18,11 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model.topNavFeeds.global
+package com.vitorpamplona.amethyst.commons.model.topNavFeeds.global
 
-import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavPerRelayFilter
+import com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavPerRelayFilterSet
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 
-@Immutable
-object GlobalTopNavPerRelayFilter : IFeedTopNavPerRelayFilter
+class GlobalTopNavPerRelayFilterSet(
+    val set: Map<NormalizedRelayUrl, GlobalTopNavPerRelayFilter>,
+) : IFeedTopNavPerRelayFilterSet

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/noteBased/muted/MutedAuthorsByProxyTopNavFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/noteBased/muted/MutedAuthorsByProxyTopNavFilter.kt
@@ -18,24 +18,22 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.muted
+package com.vitorpamplona.amethyst.commons.model.topNavFeeds.noteBased.muted
 
 import androidx.compose.runtime.Immutable
 import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
-import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
-import com.vitorpamplona.amethyst.model.topNavFeeds.OutboxRelayLoader
+import com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip53LiveActivities.streaming.LiveActivitiesEvent
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.MutableStateFlow
 
 @Immutable
-class MutedAuthorsByOutboxTopNavFilter(
+class MutedAuthorsByProxyTopNavFilter(
     val authors: Set<String>,
-    val blockedRelays: StateFlow<Set<NormalizedRelayUrl>>,
+    val proxyRelays: Set<NormalizedRelayUrl>,
 ) : IFeedTopNavFilter {
     override fun matchAuthor(pubkey: HexKey) = pubkey in authors
 
@@ -46,22 +44,15 @@ class MutedAuthorsByOutboxTopNavFilter(
             noteEvent.pubKey in authors
         }
 
-    fun convert(map: Map<NormalizedRelayUrl, Set<HexKey>>) =
-        MutedAuthorsTopNavPerRelayFilterSet(
-            map.mapValues { MutedAuthorsTopNavPerRelayFilter(it.value) },
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<MutedAuthorsTopNavPerRelayFilterSet> =
+        MutableStateFlow(
+            MutedAuthorsTopNavPerRelayFilterSet(
+                proxyRelays.associateWith { MutedAuthorsTopNavPerRelayFilter(authors) },
+            ),
         )
 
-    override fun toPerRelayFlow(cache: ICacheProvider): Flow<MutedAuthorsTopNavPerRelayFilterSet> {
-        val authorsPerRelay = OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache) { it }
-
-        return combine(authorsPerRelay, blockedRelays) { authors, blocked ->
-            convert(authors.minus(blocked))
-        }
-    }
-
-    override fun startValue(cache: ICacheProvider): MutedAuthorsTopNavPerRelayFilterSet {
-        val authorsPerRelay = OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache) { it }
-
-        return convert(authorsPerRelay.minus(blockedRelays.value))
-    }
+    override fun startValue(cache: ICacheProvider): MutedAuthorsTopNavPerRelayFilterSet =
+        MutedAuthorsTopNavPerRelayFilterSet(
+            proxyRelays.associateWith { MutedAuthorsTopNavPerRelayFilter(authors) },
+        )
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/noteBased/muted/MutedAuthorsTopNavPerRelayFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/noteBased/muted/MutedAuthorsTopNavPerRelayFilter.kt
@@ -18,11 +18,12 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model.topNavFeeds.global
+package com.vitorpamplona.amethyst.commons.model.topNavFeeds.noteBased.muted
 
-import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavPerRelayFilterSet
-import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavPerRelayFilter
 
-class GlobalTopNavPerRelayFilterSet(
-    val set: Map<NormalizedRelayUrl, GlobalTopNavPerRelayFilter>,
-) : IFeedTopNavPerRelayFilterSet
+@Immutable
+class MutedAuthorsTopNavPerRelayFilter(
+    val authors: Set<String>,
+) : IFeedTopNavPerRelayFilter

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/noteBased/muted/MutedAuthorsTopNavPerRelayFilterSet.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/noteBased/muted/MutedAuthorsTopNavPerRelayFilterSet.kt
@@ -18,11 +18,11 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model.topNavFeeds.relay
+package com.vitorpamplona.amethyst.commons.model.topNavFeeds.noteBased.muted
 
-import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavPerRelayFilterSet
+import com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavPerRelayFilterSet
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 
-class RelayTopNavPerRelayFilterSet(
-    val relayUrl: NormalizedRelayUrl,
+class MutedAuthorsTopNavPerRelayFilterSet(
+    val set: Map<NormalizedRelayUrl, MutedAuthorsTopNavPerRelayFilter>,
 ) : IFeedTopNavPerRelayFilterSet

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/relay/RelayTopNavFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/relay/RelayTopNavFilter.kt
@@ -18,11 +18,26 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.muted
+package com.vitorpamplona.amethyst.commons.model.topNavFeeds.relay
 
-import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavPerRelayFilterSet
+import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+import com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavFilter
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 
-class MutedAuthorsTopNavPerRelayFilterSet(
-    val set: Map<NormalizedRelayUrl, MutedAuthorsTopNavPerRelayFilter>,
-) : IFeedTopNavPerRelayFilterSet
+@Immutable
+class RelayTopNavFilter(
+    val relayUrl: NormalizedRelayUrl,
+) : IFeedTopNavFilter {
+    override fun matchAuthor(pubkey: HexKey): Boolean = true
+
+    override fun match(noteEvent: Event) = true
+
+    override fun toPerRelayFlow(cache: ICacheProvider): Flow<RelayTopNavPerRelayFilterSet> = flowOf(RelayTopNavPerRelayFilterSet(relayUrl))
+
+    override fun startValue(cache: ICacheProvider): RelayTopNavPerRelayFilterSet = RelayTopNavPerRelayFilterSet(relayUrl)
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/relay/RelayTopNavPerRelayFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/relay/RelayTopNavPerRelayFilter.kt
@@ -18,12 +18,10 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.muted
+package com.vitorpamplona.amethyst.commons.model.topNavFeeds.relay
 
 import androidx.compose.runtime.Immutable
-import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavPerRelayFilter
+import com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavPerRelayFilter
 
 @Immutable
-class MutedAuthorsTopNavPerRelayFilter(
-    val authors: Set<String>,
-) : IFeedTopNavPerRelayFilter
+object RelayTopNavPerRelayFilter : IFeedTopNavPerRelayFilter

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/relay/RelayTopNavPerRelayFilterSet.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/topNavFeeds/relay/RelayTopNavPerRelayFilterSet.kt
@@ -18,7 +18,11 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model.topNavFeeds
+package com.vitorpamplona.amethyst.commons.model.topNavFeeds.relay
 
-// Re-export from commons for backward compatibility
-typealias IFeedTopNavPerRelayFilter = com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavPerRelayFilter
+import com.vitorpamplona.amethyst.commons.model.topNavFeeds.IFeedTopNavPerRelayFilterSet
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+
+class RelayTopNavPerRelayFilterSet(
+    val relayUrl: NormalizedRelayUrl,
+) : IFeedTopNavPerRelayFilterSet


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

## What
Moves TopNavFilter interfaces and key concrete implementations from `amethyst` to `commons` module, unblocking FilterByListParams and additive DAL filter migration.

### Moved to commons
- **Interfaces:** `IFeedTopNavFilter`, `IFeedTopNavPerRelayFilter`, `IFeedTopNavPerRelayFilterSet`
- **Concrete:** `GlobalTopNavFilter`, `RelayTopNavFilter`, `MutedAuthorsByProxyTopNavFilter` (+ their PerRelay variants)

### Updated in amethyst (signatures only)
All remaining TopNavFilter implementations (`AllFollowsByOutbox/Proxy`, `AuthorsByOutbox/Proxy`, `MutedAuthorsByOutbox`, `HashtagTopNav`, `LocationTopNav`, `ChessTopNav`, `UnknownTopNav`, etc.) — override signatures changed from `LocalCache` → `ICacheProvider`.

### ICacheProvider extensions
- Added `relayHints: HintIndexer` (used by OutboxRelayLoader, CommunityRelayLoader)
- Added `checkGetOrCreateAddressableNote()` (used by CommunityRelayLoader)

### Backward compatibility
Original packages retain typealiases so existing imports continue to work.

### What remains
- `MutedAuthorsByOutboxTopNavFilter` stays in amethyst (depends on OutboxRelayLoader which uses Constants)
- `FilterByListParams` can now be moved to commons in a follow-up PR (all its concrete type dependencies are in commons)
- OutboxRelayLoader/CommunityRelayLoader now use ICacheProvider but remain in amethyst