### PR TITLE
feat: move ThreadFeedViewModel, ChannelFeedViewModel to commons

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/dal/ChannelFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/dal/ChannelFeedViewModel.kt
@@ -25,12 +25,11 @@ import androidx.lifecycle.ViewModelProvider
 import com.vitorpamplona.amethyst.commons.model.Channel
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.privateDM.dal.ListChangeFeedViewModel
 
 class ChannelFeedViewModel(
-    val channel: Channel,
-    val account: Account,
-) : ListChangeFeedViewModel(ChannelFeedFilter(channel, account), LocalCache) {
+    channel: Channel,
+    account: Account,
+) : com.vitorpamplona.amethyst.commons.viewmodels.ChannelFeedViewModel(channel, account, LocalCache) {
     class Factory(
         val channel: Channel,
         val account: Account,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/dal/ThreadFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/dal/ThreadFeedViewModel.kt
@@ -22,14 +22,13 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.threadview.dal
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import com.vitorpamplona.amethyst.commons.viewmodels.thread.ThreadFeedFilter
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 
 class ThreadFeedViewModel(
     account: Account,
     noteId: String,
-) : com.vitorpamplona.amethyst.commons.viewmodels.thread.LevelFeedViewModel(ThreadFeedFilter(account, noteId, LocalCache), LocalCache) {
+) : com.vitorpamplona.amethyst.commons.viewmodels.thread.ThreadFeedViewModel(account, noteId, LocalCache) {
     class Factory(
         val account: Account,
         val noteId: String,

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/ChannelFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/ChannelFeedFilter.kt
@@ -18,7 +18,28 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.dal
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-// Re-export from commons for backwards compatibility
-typealias ChannelFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.ChannelFeedFilter
+import com.vitorpamplona.amethyst.commons.model.Channel
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.Note
+
+class ChannelFeedFilter(
+    val channel: Channel,
+    val account: IAccount,
+) : AdditiveFeedFilter<Note>(),
+    ChangesFlowFilter<Note> {
+    override fun feedKey() = channel
+
+    override fun changesFlow() = channel.changesFlow()
+
+    // returns the last Note of each user.
+    override fun feed(): List<Note> = sort(channel.notes.filterIntoSet { key, it -> account.isAcceptable(it) })
+
+    override fun applyFilter(newItems: Set<Note>): Set<Note> =
+        newItems
+            .filter { channel.notes.containsKey(it.idHex) && account.isAcceptable(it) }
+            .toSet()
+
+    override fun sort(items: Set<Note>): List<Note> = items.sortedWith(DefaultFeedOrder)
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/ChannelFeedViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/ChannelFeedViewModel.kt
@@ -18,7 +18,15 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.dal
+package com.vitorpamplona.amethyst.commons.viewmodels
 
-// Re-export from commons for backwards compatibility
-typealias ChannelFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.ChannelFeedFilter
+import com.vitorpamplona.amethyst.commons.model.Channel
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+import com.vitorpamplona.amethyst.commons.ui.feeds.ChannelFeedFilter
+
+open class ChannelFeedViewModel(
+    val channel: Channel,
+    val account: IAccount,
+    cacheProvider: ICacheProvider,
+) : ListChangeFeedViewModel(ChannelFeedFilter(channel, account), cacheProvider)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/thread/ThreadFeedViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/thread/ThreadFeedViewModel.kt
@@ -18,7 +18,13 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.dal
+package com.vitorpamplona.amethyst.commons.viewmodels.thread
 
-// Re-export from commons for backwards compatibility
-typealias ChannelFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.ChannelFeedFilter
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+
+open class ThreadFeedViewModel(
+    account: IAccount,
+    noteId: String,
+    cacheProvider: ICacheProvider,
+) : LevelFeedViewModel(ThreadFeedFilter(account, noteId, cacheProvider), cacheProvider)


### PR DESCRIPTION
Part of the KMP iOS migration (#2238).

Moves more ViewModels and FeedFilters to commons using the expanded IAccount interface.

### Moved to commons
- **ThreadFeedViewModel** — was using Account/LocalCache, now uses IAccount/ICacheProvider (ThreadFeedFilter was already in commons)
- **ChannelFeedFilter** — was using Account, now uses IAccount; all other deps (Channel, AdditiveFeedFilter, ChangesFlowFilter, DefaultFeedOrder) were already in commons
- **ChannelFeedViewModel** — wraps ChannelFeedFilter with IAccount/ICacheProvider

### Pattern
- Commons versions use IAccount/ICacheProvider interfaces
- Amethyst versions retain ViewModelProvider.Factory wrappers and pass concrete Account/LocalCache

Previous: #2247 (batch 1), #2253 (batch 2), #2274 (batch 3), #2281 (batch 4).