### PR TITLE
feat: expand IAccount with relay, list, and cache members (v8)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -247,12 +247,12 @@ import kotlin.coroutines.cancellation.CancellationException
 @OptIn(DelicateCoroutinesApi::class)
 @Stable
 class Account(
-    val settings: AccountSettings = AccountSettings(KeyPair()),
+    override val settings: AccountSettings = AccountSettings(KeyPair()),
     override val signer: NostrSigner,
     val geolocationFlow: () -> StateFlow<LocationState.LocationResult>,
     val nwcFilterAssembler: () -> NWCPaymentFilterAssembler,
     val otsResolverBuilder: () -> OtsResolver,
-    val cache: LocalCache,
+    override val cache: LocalCache,
     val client: INostrClient,
     val scope: CoroutineScope,
     val mlsGroupStateStore: MlsGroupStateStore? = null,
@@ -272,8 +272,8 @@ class Account(
 
     override val nip47SignerState = NwcSignerState(signer, nwcFilterAssembler, cache, scope, settings)
 
-    val nip65RelayList = Nip65RelayListState(signer, cache, scope, settings)
-    val localRelayList = LocalRelayListState(signer, cache, scope, settings)
+    override val nip65RelayList = Nip65RelayListState(signer, cache, scope, settings)
+    override val localRelayList = LocalRelayListState(signer, cache, scope, settings)
 
     val forwardKind0ToLocalRelay = ForwardKind0ToLocalRelayState(client, localRelayList, settings)
 
@@ -283,7 +283,7 @@ class Account(
     val privateStorageRelayList = PrivateStorageRelayListState(signer, cache, privateStorageDecryptionCache, scope, settings)
 
     val searchRelayListDecryptionCache = SearchRelayListDecryptionCache(signer)
-    val searchRelayList = SearchRelayListState(signer, cache, searchRelayListDecryptionCache, scope, settings)
+    override val searchRelayList = SearchRelayListState(signer, cache, searchRelayListDecryptionCache, scope, settings)
 
     val trustedRelayListDecryptionCache = TrustedRelayListDecryptionCache(signer)
     val trustedRelayList = TrustedRelayListState(signer, cache, trustedRelayListDecryptionCache, scope, settings)
@@ -328,12 +328,12 @@ class Account(
 
     val peopleListDecryptionCache = PeopleListDecryptionCache(signer)
     val blockPeopleList = BlockPeopleListState(signer, cache, peopleListDecryptionCache, scope)
-    val peopleLists = PeopleListsState(signer, cache, peopleListDecryptionCache, scope)
-    val followLists = FollowListsState(signer, cache, scope)
+    override val peopleLists = PeopleListsState(signer, cache, peopleListDecryptionCache, scope)
+    override val followLists = FollowListsState(signer, cache, scope)
 
-    val hiddenUsers = HiddenUsersState(muteList.flow, blockPeopleList.flow, scope, settings)
+    override val hiddenUsers = HiddenUsersState(muteList.flow, blockPeopleList.flow, scope, settings)
 
-    val labeledBookmarkLists = LabeledBookmarkListsState(signer, cache, scope)
+    override val labeledBookmarkLists = LabeledBookmarkListsState(signer, cache, scope)
     val oldBookmarkState = OldBookmarkListState(signer, cache, scope)
     val bookmarkState = BookmarkListState(signer, cache, scope)
     val pinState = PinListState(signer, cache, scope)
@@ -343,7 +343,7 @@ class Account(
 
     val appSpecific = AppSpecificState(signer, cache, scope, settings)
 
-    val blossomServers = BlossomServerListState(signer, cache, scope, settings)
+    override val blossomServers = BlossomServerListState(signer, cache, scope, settings)
 
     // Relay settings
     val homeRelays = AccountHomeRelayState(nip65RelayList, privateStorageRelayList, localRelayList, scope)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.model
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.model.IAccountSettings
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatRepository
 import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatListRepository
 import com.vitorpamplona.amethyst.model.nip47WalletConnect.NwcWalletEntryNorm
@@ -162,7 +163,7 @@ class AccountSettings(
     var externalSignerPackageName: String? = null,
     var localRelayServers: MutableStateFlow<Set<String>> = MutableStateFlow(setOf()),
     var defaultFileServer: ServerName = DEFAULT_MEDIA_SERVERS[0],
-    var stripLocationOnUpload: Boolean = true,
+    override var stripLocationOnUpload: Boolean = true,
     val defaultHomeFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.AllFollows),
     val defaultStoriesFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.Global),
     val defaultNotificationFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.Global),
@@ -203,7 +204,8 @@ class AccountSettings(
     var callTurnServers: List<CallTurnServer> = emptyList(),
     var callVideoResolution: CallVideoResolution = CallVideoResolution.HD_720,
     var callMaxBitrateBps: Int = 1_500_000,
-) : EphemeralChatRepository,
+) : IAccountSettings,
+    EphemeralChatRepository,
     PublicChatListRepository {
     val saveable = MutableStateFlow(AccountSettingsUpdater(null))
     val syncedSettings: AccountSyncedSettings = AccountSyncedSettings(AccountSyncedSettingsInternal())
@@ -216,7 +218,7 @@ class AccountSettings(
         saveable.update { AccountSettingsUpdater(this) }
     }
 
-    fun isWriteable(): Boolean = keyPair.privKey != null || externalSignerPackageName != null
+    override fun isWriteable(): Boolean = keyPair.privKey != null || externalSignerPackageName != null
 
     // ---
     // Zaps and Reactions

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/localRelays/LocalRelayListState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/localRelays/LocalRelayListState.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.model.localRelays
 
+import com.vitorpamplona.amethyst.commons.model.ILocalRelayListState
 import com.vitorpamplona.amethyst.model.AccountSettings
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
@@ -37,10 +38,10 @@ class LocalRelayListState(
     val cache: LocalCache,
     val scope: CoroutineScope,
     val settings: AccountSettings,
-) {
+) : ILocalRelayListState {
     fun normalizeLocalRelayListWithBackup(relayList: Set<String>): Set<NormalizedRelayUrl> = relayList.mapNotNull { RelayUrlNormalizer.normalizeOrNull(it) }.toSet()
 
-    val flow =
+    override val flow =
         settings.localRelayServers
             .map { normalizeLocalRelayListWithBackup(it) }
             .flowOn(Dispatchers.IO)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/HiddenUsersState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/HiddenUsersState.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.model.nip51Lists
 
+import com.vitorpamplona.amethyst.commons.model.IHiddenUsersFlow
 import com.vitorpamplona.amethyst.commons.model.LiveHiddenUsers
 import com.vitorpamplona.amethyst.model.AccountSettings
 import com.vitorpamplona.amethyst.service.checkNotInMainThread
@@ -44,8 +45,8 @@ class HiddenUsersState(
     val blockList: StateFlow<List<MuteTag>>,
     val scope: CoroutineScope,
     val settings: AccountSettings,
-) {
-    var transientHiddenUsers: MutableStateFlow<Set<String>> = MutableStateFlow(setOf())
+) : IHiddenUsersFlow {
+    override var transientHiddenUsers: MutableStateFlow<Set<String>> = MutableStateFlow(setOf())
 
     fun assembleLiveHiddenUsers(
         blockList: List<MuteTag>,
@@ -69,7 +70,7 @@ class HiddenUsersState(
         )
     }
 
-    val flow: StateFlow<LiveHiddenUsers> =
+    override val flow: StateFlow<LiveHiddenUsers> =
         combineTransform(
             blockList,
             muteList,
@@ -110,13 +111,13 @@ class HiddenUsersState(
         }
     }
 
-    fun showUser(pubkeyHex: HexKey) {
+    override fun showUser(pubkeyHex: HexKey) {
         transientHiddenUsers.update { it - pubkeyHex }
     }
 
-    fun hideUser(pubkeyHex: HexKey) {
+    override fun hideUser(pubkeyHex: HexKey) {
         transientHiddenUsers.update { it + pubkeyHex }
     }
 
-    fun isHidden(pubkeyHex: HexKey) = pubkeyHex in transientHiddenUsers.value
+    override fun isHidden(pubkeyHex: HexKey) = pubkeyHex in transientHiddenUsers.value
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/labeledBookmarkLists/LabeledBookmarkListsState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/labeledBookmarkLists/LabeledBookmarkListsState.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.model.nip51Lists.labeledBookmarkLists
 
+import com.vitorpamplona.amethyst.commons.model.ILabeledBookmarkListsState
 import com.vitorpamplona.amethyst.commons.model.anyNotNullEvent
 import com.vitorpamplona.amethyst.commons.model.eventIdSet
 import com.vitorpamplona.amethyst.commons.model.events
@@ -55,14 +56,14 @@ class LabeledBookmarkListsState(
     val signer: NostrSigner,
     val cache: LocalCache,
     val scope: CoroutineScope,
-) {
+) : ILabeledBookmarkListsState {
     val user = cache.getOrCreateUser(signer.pubKey)
 
     fun existingLabeledBookmarkNotes() = cache.addressables.filter(LabeledBookmarkListEvent.KIND, user.pubkeyHex)
 
     val labeledBookmarkListVersions = MutableStateFlow(0)
 
-    val labeledBookmarkListNotes =
+    override val labeledBookmarkListNotes =
         labeledBookmarkListVersions
             .map { existingLabeledBookmarkNotes() }
             .onStart { emit(existingLabeledBookmarkNotes()) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/peopleList/FollowListsState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/peopleList/FollowListsState.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.model.nip51Lists.peopleList
 
+import com.vitorpamplona.amethyst.commons.model.IFollowListsState
 import com.vitorpamplona.amethyst.commons.model.anyNotNullEvent
 import com.vitorpamplona.amethyst.commons.model.eventIdSet
 import com.vitorpamplona.amethyst.commons.model.events
@@ -68,14 +69,14 @@ class FollowListsState(
     val signer: NostrSigner,
     val cache: LocalCache,
     val scope: CoroutineScope,
-) {
+) : IFollowListsState {
     val user = cache.getOrCreateUser(signer.pubKey)
 
     fun existingPeopleListNotes() = cache.addressables.filter(FollowListEvent.KIND, user.pubkeyHex)
 
     val followListVersions = MutableStateFlow(0)
 
-    val followListNotes =
+    override val followListNotes =
         followListVersions
             .map { existingPeopleListNotes() }
             .onStart { emit(existingPeopleListNotes()) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/peopleList/PeopleListsState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/peopleList/PeopleListsState.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.model.nip51Lists.peopleList
 
+import com.vitorpamplona.amethyst.commons.model.IPeopleListsState
 import com.vitorpamplona.amethyst.commons.model.anyNotNullEvent
 import com.vitorpamplona.amethyst.commons.model.eventIdSet
 import com.vitorpamplona.amethyst.commons.model.events
@@ -65,7 +66,7 @@ class PeopleListsState(
     val cache: LocalCache,
     val decryptionCache: PeopleListDecryptionCache,
     val scope: CoroutineScope,
-) {
+) : IPeopleListsState {
     val user = cache.getOrCreateUser(signer.pubKey)
 
     fun existingPeopleListNotes() =
@@ -75,7 +76,7 @@ class PeopleListsState(
 
     val peopleListVersions = MutableStateFlow(0)
 
-    val peopleListNotes =
+    override val peopleListNotes =
         peopleListVersions
             .map { existingPeopleListNotes() }
             .onStart { emit(existingPeopleListNotes()) }
@@ -111,7 +112,7 @@ class PeopleListsState(
                 }
             }.flattenToSet()
 
-    val allGoodPeopleListProfiles: StateFlow<Set<HexKey>> =
+    override val allGoodPeopleListProfiles: StateFlow<Set<HexKey>> =
         latestLists
             .map { it.mapGoodUsersToIdSet() }
             .onStart { emit(latestLists.value.mapGoodUsersToIdSet()) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/searchRelays/SearchRelayListState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/searchRelays/SearchRelayListState.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.model.nip51Lists.searchRelays
 
+import com.vitorpamplona.amethyst.commons.model.ISearchRelayListState
 import com.vitorpamplona.amethyst.model.AccountSettings
 import com.vitorpamplona.amethyst.model.DefaultSearchRelayList
 import com.vitorpamplona.amethyst.model.LocalCache
@@ -46,7 +47,7 @@ class SearchRelayListState(
     val decryptionCache: SearchRelayListDecryptionCache,
     val scope: CoroutineScope,
     val settings: AccountSettings,
-) {
+) : ISearchRelayListState {
     // Creates a long-term reference for this note so that the GC doesn't collect the note it self
     val searchListNote = cache.getOrCreateAddressableNote(getSearchRelayListAddress())
 
@@ -62,7 +63,7 @@ class SearchRelayListState(
 
     suspend fun normalizeSearchRelayListWithBackupNoDefaults(note: Note): Set<NormalizedRelayUrl> = searchListEvent(note)?.let { decryptionCache.relays(it) } ?: emptySet()
 
-    val flow =
+    override val flow =
         getSearchRelayListFlow()
             .map { normalizeSearchRelayListWithBackup(it.note) }
             .onStart { emit(normalizeSearchRelayListWithBackup(searchListNote)) }
@@ -73,7 +74,7 @@ class SearchRelayListState(
                 emptySet(),
             )
 
-    val flowNoDefaults =
+    override val flowNoDefaults =
         getSearchRelayListFlow()
             .map { normalizeSearchRelayListWithBackupNoDefaults(it.note) }
             .onStart { emit(normalizeSearchRelayListWithBackupNoDefaults(searchListNote)) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip65RelayList/Nip65RelayListState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip65RelayList/Nip65RelayListState.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.model.nip65RelayList
 
+import com.vitorpamplona.amethyst.commons.model.INip65RelayListState
 import com.vitorpamplona.amethyst.model.AccountSettings
 import com.vitorpamplona.amethyst.model.Constants
 import com.vitorpamplona.amethyst.model.LocalCache
@@ -46,7 +47,7 @@ class Nip65RelayListState(
     val cache: LocalCache,
     val scope: CoroutineScope,
     val settings: AccountSettings,
-) {
+) : INip65RelayListState {
     // Creates a long-term reference for this note so that the GC doesn't collect the note it self
     val nip65ListNote = cache.getOrCreateAddressableNote(getNIP65RelayListAddress())
 
@@ -70,7 +71,7 @@ class Nip65RelayListState(
 
     fun normalizeNIP65AllRelayListWithBackupNoDefaults(note: Note): Set<NormalizedRelayUrl> = nip65Event(note)?.relays()?.map { it.relayUrl }?.toSet() ?: emptySet()
 
-    val outboxFlow =
+    override val outboxFlow =
         getNIP65RelayListFlow()
             .map { normalizeNIP65WriteRelayListWithBackup(it.note) }
             .onStart { emit(normalizeNIP65WriteRelayListWithBackup(nip65ListNote)) }
@@ -81,7 +82,7 @@ class Nip65RelayListState(
                 emptySet(),
             )
 
-    val inboxFlow =
+    override val inboxFlow =
         getNIP65RelayListFlow()
             .map { normalizeNIP65ReadRelayListWithBackup(it.note) }
             .onStart { emit(normalizeNIP65ReadRelayListWithBackup(nip65ListNote)) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nipB7Blossom/BlossomServerListState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nipB7Blossom/BlossomServerListState.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.model.nipB7Blossom
 
+import com.vitorpamplona.amethyst.commons.model.IBlossomServerListState
 import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.model.AccountSettings
 import com.vitorpamplona.amethyst.model.Note
@@ -47,7 +48,7 @@ class BlossomServerListState(
     val cache: ICacheProvider,
     val scope: CoroutineScope,
     val settings: AccountSettings,
-) {
+) : IBlossomServerListState {
     // Creates a long-term reference for this note so that the GC doesn't collect the note it self
     val blossomListNote = cache.getOrCreateAddressableNote(getBlossomServersAddress())
 
@@ -69,7 +70,7 @@ class BlossomServerListState(
             url.removePrefix("cdn.").removePrefix("blossom.")
         }
 
-    val flow =
+    override val flow =
         getBlossomServersListFlow()
             .map {
                 normalizeServers(it.note)
@@ -116,13 +117,13 @@ class BlossomServerListState(
         }
     }
 
-    suspend fun createBlossomUploadAuth(
+    override suspend fun createBlossomUploadAuth(
         hash: HexKey,
         size: Long,
         alt: String,
     ): BlossomAuthorizationEvent = BlossomAuthorizationEvent.createUploadAuth(hash, size, alt, signer)
 
-    suspend fun createBlossomDeleteAuth(
+    override suspend fun createBlossomDeleteAuth(
         hash: HexKey,
         alt: String,
     ): BlossomAuthorizationEvent = BlossomAuthorizationEvent.createDeleteAuth(hash, alt, signer)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.commons.model
 
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupList
 import com.vitorpamplona.amethyst.commons.model.privateChats.ChatroomList
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
@@ -119,4 +120,34 @@ interface IAccount {
 
     /** Broadcast pre-created gift wraps (e.g. reactions within group DMs) */
     suspend fun sendGiftWraps(wraps: List<GiftWrapEvent>)
+
+    /** Reference to the cache provider */
+    val cache: ICacheProvider
+
+    /** Hidden users state (muted, blocked, transient) */
+    val hiddenUsers: IHiddenUsersFlow
+
+    /** Account settings */
+    val settings: IAccountSettings
+
+    /** Blossom media server list state */
+    val blossomServers: IBlossomServerListState
+
+    /** NIP-65 relay list state (inbox/outbox) */
+    val nip65RelayList: INip65RelayListState
+
+    /** Search relay list state */
+    val searchRelayList: ISearchRelayListState
+
+    /** People lists state */
+    val peopleLists: IPeopleListsState
+
+    /** Follow lists state */
+    val followLists: IFollowListsState
+
+    /** Labeled bookmark lists state */
+    val labeledBookmarkLists: ILabeledBookmarkListsState
+
+    /** Local relay list state */
+    val localRelayList: ILocalRelayListState
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccountSettings.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccountSettings.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model
+
+/**
+ * Interface for account settings needed by composables and VMs.
+ * Abstracts Android-specific AccountSettings for use in commons.
+ */
+interface IAccountSettings {
+    /** Whether the account has write permissions */
+    fun isWriteable(): Boolean
+
+    /** Whether to strip location metadata on upload */
+    val stripLocationOnUpload: Boolean
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IBlossomServerListState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IBlossomServerListState.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model
+
+import com.vitorpamplona.quartz.nipB7Blossom.BlossomAuthorizationEvent
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Interface for Blossom server list state.
+ * Used by upload/download composables to get server list and create auth events.
+ */
+interface IBlossomServerListState {
+    /** Flow of Blossom server URLs */
+    val flow: StateFlow<List<String>>
+
+    /** Create an upload authorization event for Blossom */
+    suspend fun createBlossomUploadAuth(
+        hash: String,
+        size: Long,
+        alt: String,
+    ): BlossomAuthorizationEvent
+
+    /** Create a delete authorization event for Blossom */
+    suspend fun createBlossomDeleteAuth(
+        hash: String,
+        alt: String,
+    ): BlossomAuthorizationEvent
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IFollowListsState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IFollowListsState.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Interface for follow lists state.
+ * Used by composables/VMs for follow list management.
+ */
+interface IFollowListsState {
+    /** List of follow list notes */
+    val followListNotes: StateFlow<List<AddressableNote>>
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IHiddenUsersFlow.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IHiddenUsersFlow.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Interface for hidden users state.
+ * Used by composables and VMs to observe hidden/muted user changes.
+ */
+interface IHiddenUsersFlow {
+    /** Combined flow of all hidden users (muted + blocked + transient) */
+    val flow: StateFlow<LiveHiddenUsers>
+
+    /** Transient hidden users (e.g. auto-hidden spammers, not persisted) */
+    val transientHiddenUsers: StateFlow<Set<String>>
+
+    /** Show a previously hidden user */
+    fun showUser(pubkeyHex: String)
+
+    /** Temporarily hide a user */
+    fun hideUser(pubkeyHex: String)
+
+    /** Check if a user is transiently hidden */
+    fun isHidden(pubkeyHex: String): Boolean
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/ILabeledBookmarkListsState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/ILabeledBookmarkListsState.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Interface for labeled bookmark lists state.
+ * Used by composables/VMs for bookmark list management.
+ */
+interface ILabeledBookmarkListsState {
+    /** List of labeled bookmark list notes */
+    val labeledBookmarkListNotes: StateFlow<List<AddressableNote>>
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/ILocalRelayListState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/ILocalRelayListState.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model
+
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Interface for local relay list state.
+ * Used by composables to observe the user's local relay configuration.
+ */
+interface ILocalRelayListState {
+    /** Flow of local relay URLs */
+    val flow: StateFlow<Set<NormalizedRelayUrl>>
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/INip65RelayListState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/INip65RelayListState.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model
+
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Interface for NIP-65 relay list state.
+ * Used by composables to observe the user's advertised relay list.
+ */
+interface INip65RelayListState {
+    /** Flow of inbox (read) relay URLs */
+    val inboxFlow: StateFlow<Set<NormalizedRelayUrl>>
+
+    /** Flow of outbox (write) relay URLs */
+    val outboxFlow: StateFlow<Set<NormalizedRelayUrl>>
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IPeopleListsState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IPeopleListsState.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model
+
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Interface for people lists state.
+ * Used by composables/VMs for follow set management.
+ */
+interface IPeopleListsState {
+    /** Flow of all good (non-block) people list profiles */
+    val allGoodPeopleListProfiles: StateFlow<Set<HexKey>>
+
+    /** List of people list notes */
+    val peopleListNotes: StateFlow<List<AddressableNote>>
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/ISearchRelayListState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/ISearchRelayListState.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model
+
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Interface for search relay list state.
+ * Used by search-related composables/VMs to observe the user's search relays.
+ */
+interface ISearchRelayListState {
+    /** Flow of search relay URLs (with defaults as fallback) */
+    val flow: StateFlow<Set<NormalizedRelayUrl>>
+
+    /** Flow of search relay URLs (without defaults) */
+    val flowNoDefaults: StateFlow<Set<NormalizedRelayUrl>>
+}


### PR DESCRIPTION
## Summary

Adds 10 new interface abstractions to `IAccount` in the commons module, enabling more composables, ViewModels, and DAL filters to migrate to KMP commons.

## New interfaces in commons

| Interface | IAccount member | Purpose |
|-----------|----------------|---------|
| `ICacheProvider` (existing) | `cache` | Cache access for notes/users |
| `IHiddenUsersFlow` | `hiddenUsers` | Hidden/muted user state flows |
| `IAccountSettings` | `settings` | Account settings abstraction |
| `IBlossomServerListState` | `blossomServers` | Blossom media server list & auth |
| `INip65RelayListState` | `nip65RelayList` | NIP-65 inbox/outbox relay lists |
| `ISearchRelayListState` | `searchRelayList` | Search relay list |
| `IPeopleListsState` | `peopleLists` | People lists management |
| `IFollowListsState` | `followLists` | Follow lists management |
| `ILabeledBookmarkListsState` | `labeledBookmarkLists` | Labeled bookmark lists |
| `ILocalRelayListState` | `localRelayList` | Local relay configuration |

## Changes

- **9 new interface files** in `commons/src/commonMain/.../commons/model/`
- **Updated IAccount.kt** with 10 new abstract members
- **Each Android concrete class** now implements its corresponding interface
- **Account.kt** overrides all new IAccount members
- Interfaces are minimal — only exposing StateFlows and methods actually used by UI consumers

## Build verification

Both `:commons:compileKotlinJvm` and `:amethyst:compilePlayDebugKotlin` pass successfully.