### PR TITLE
feat: migrate launchSigner callers to AccountViewModel wrappers (batch 2)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -60,6 +60,7 @@ import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.UiSettingsFlow
 import com.vitorpamplona.amethyst.model.UrlCachedPreviewer
 import com.vitorpamplona.amethyst.model.User
+import com.vitorpamplona.amethyst.model.nip51Lists.labeledBookmarkLists.LabeledBookmarkList
 import com.vitorpamplona.amethyst.model.privacyOptions.EmptyRoleBasedHttpClientBuilder
 import com.vitorpamplona.amethyst.model.privacyOptions.IRoleBasedHttpClientBuilder
 import com.vitorpamplona.amethyst.model.privacyOptions.RoleBasedHttpClientBuilder
@@ -137,6 +138,7 @@ import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Response
 import com.vitorpamplona.quartz.nip51Lists.PinListEvent
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.BookmarkListEvent
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.OldBookmarkListEvent
+import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.BookmarkIdTag
 import com.vitorpamplona.quartz.nip51Lists.hashtagList.HashtagListEvent
 import com.vitorpamplona.quartz.nip56Reports.ReportType
 import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
@@ -1006,6 +1008,55 @@ class AccountViewModel(
             launchSigner { account.removeBookmark(note, false) }
         }
     }
+
+    // -- Labeled Bookmark Lists --
+
+    fun addBookmarkToList(
+        bookmark: BookmarkIdTag,
+        bookmarkListIdentifier: String,
+        isBookmarkPrivate: Boolean,
+    ) = launchSigner {
+        account.labeledBookmarkLists.addBookmarkToList(
+            bookmark = bookmark,
+            bookmarkListIdentifier = bookmarkListIdentifier,
+            isBookmarkPrivate = isBookmarkPrivate,
+            account = account,
+        )
+    }
+
+    fun removeBookmarkFromList(
+        bookmark: BookmarkIdTag,
+        bookmarkListIdentifier: String,
+        isBookmarkPrivate: Boolean,
+    ) = launchSigner {
+        account.labeledBookmarkLists.removeBookmarkFromList(
+            bookmark = bookmark,
+            bookmarkListIdentifier = bookmarkListIdentifier,
+            isBookmarkPrivate = isBookmarkPrivate,
+            account = account,
+        )
+    }
+
+    fun cloneBookmarkList(
+        currentBookmarkList: LabeledBookmarkList,
+        customCloneName: String?,
+        customCloneDescription: String?,
+    ) = launchSigner {
+        account.labeledBookmarkLists.cloneBookmarkList(
+            currentBookmarkList = currentBookmarkList,
+            customCloneName = customCloneName,
+            customCloneDescription = customCloneDescription,
+            account = account,
+        )
+    }
+
+    fun deleteBookmarkList(bookmarkListIdentifier: String) =
+        launchSigner {
+            account.labeledBookmarkLists.deleteBookmarkList(
+                bookmarkListIdentifier = bookmarkListIdentifier,
+                account = account,
+            )
+        }
 
     fun broadcast(note: Note) = launchSigner { account.broadcast(note) }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -61,6 +61,7 @@ import com.vitorpamplona.amethyst.model.UiSettingsFlow
 import com.vitorpamplona.amethyst.model.UrlCachedPreviewer
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.model.nip51Lists.labeledBookmarkLists.LabeledBookmarkList
+import com.vitorpamplona.amethyst.model.nip51Lists.peopleList.PeopleList
 import com.vitorpamplona.amethyst.model.privacyOptions.EmptyRoleBasedHttpClientBuilder
 import com.vitorpamplona.amethyst.model.privacyOptions.IRoleBasedHttpClientBuilder
 import com.vitorpamplona.amethyst.model.privacyOptions.RoleBasedHttpClientBuilder
@@ -1057,6 +1058,100 @@ class AccountViewModel(
                 account = account,
             )
         }
+
+    // -- People Lists --
+
+    fun clonePeopleList(
+        currentPeopleList: PeopleList,
+        customCloneName: String?,
+        customCloneDescription: String?,
+    ) = launchSigner {
+        account.peopleLists.cloneFollowSet(
+            currentPeopleList = currentPeopleList,
+            customCloneName = customCloneName,
+            customCloneDescription = customCloneDescription,
+            account = account,
+        )
+    }
+
+    fun deletePeopleList(identifierTag: String) =
+        launchSigner {
+            account.peopleLists.deleteFollowSet(
+                identifierTag = identifierTag,
+                account = account,
+            )
+        }
+
+    fun addUserToPeopleList(
+        user: User,
+        identifierTag: String,
+        shouldBePrivateMember: Boolean,
+    ) = launchSigner {
+        account.peopleLists.addUserToSet(
+            user = user,
+            identifierTag = identifierTag,
+            shouldBePrivateMember = shouldBePrivateMember,
+            account = account,
+        )
+    }
+
+    fun removeUserFromPeopleList(
+        user: User,
+        isPrivate: Boolean,
+        identifierTag: String,
+    ) = launchSigner {
+        account.peopleLists.removeUserFromSet(
+            user = user,
+            isPrivate = isPrivate,
+            identifierTag = identifierTag,
+            account = account,
+        )
+    }
+
+    // -- Follow Packs --
+
+    fun cloneFollowPack(
+        currentFollowPack: PeopleList,
+        customCloneName: String?,
+        customCloneDescription: String?,
+    ) = launchSigner {
+        account.followLists.cloneFollowSet(
+            currentFollowPack = currentFollowPack,
+            customCloneName = customCloneName,
+            customCloneDescription = customCloneDescription,
+            account = account,
+        )
+    }
+
+    fun deleteFollowPack(identifierTag: String) =
+        launchSigner {
+            account.followLists.deleteFollowSet(
+                identifierTag = identifierTag,
+                account = account,
+            )
+        }
+
+    fun addUserToFollowPack(
+        user: User,
+        identifierTag: String,
+    ) = launchSigner {
+        account.followLists.addUserToSet(
+            user = user,
+            identifierTag = identifierTag,
+            account = account,
+        )
+    }
+
+    fun removeUserFromFollowPack(
+        user: User,
+        identifierTag: String,
+    ) = launchSigner {
+        account.followLists.removeUserFromSet(
+            user = user,
+            identifierTag = identifierTag,
+            account = account,
+        )
+    }
 
     fun broadcast(note: Note) = launchSigner { account.broadcast(note) }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/list/ListOfBookmarkGroupsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/list/ListOfBookmarkGroupsScreen.kt
@@ -67,22 +67,14 @@ fun ListOfBookmarkGroupsScreen(
             nav.nav(Route.BookmarkGroupMetadataEdit(bookmarkGroup.identifier))
         },
         cloneBookmarkGroup = { bookmarkGroup, customName, customDesc ->
-            accountViewModel.launchSigner {
-                accountViewModel.account.labeledBookmarkLists.cloneBookmarkList(
-                    currentBookmarkList = bookmarkGroup,
-                    customCloneName = customName,
-                    customCloneDescription = customDesc,
-                    account = accountViewModel.account,
-                )
-            }
+            accountViewModel.cloneBookmarkList(
+                currentBookmarkList = bookmarkGroup,
+                customCloneName = customName,
+                customCloneDescription = customDesc,
+            )
         },
         deleteBookmarkGroup = { bookmarkGroup ->
-            accountViewModel.launchSigner {
-                accountViewModel.account.labeledBookmarkLists.deleteBookmarkList(
-                    bookmarkListIdentifier = bookmarkGroup.identifier,
-                    account = accountViewModel.account,
-                )
-            }
+            accountViewModel.deleteBookmarkList(bookmarkGroup.identifier)
         },
         nav,
     )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/membershipManagement/ArticleBookmarkListManagementScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/membershipManagement/ArticleBookmarkListManagementScreen.kt
@@ -152,24 +152,18 @@ private fun ListManagementViewBody(
                 totalArticleBookmarkSize = bookmarkList.publicArticleBookmarks.size + bookmarkList.privateArticleBookmarks.size,
                 onClick = { nav.nav(Route.BookmarkGroupView(bookmarkList.identifier, BookmarkType.ArticleBookmark)) },
                 onAddBookmarkToGroup = { shouldBePrivate ->
-                    accountViewModel.launchSigner {
-                        accountViewModel.account.labeledBookmarkLists.addBookmarkToList(
-                            bookmark = AddressBookmark(address = note.address, relayHint = note.relayHintUrl()),
-                            bookmarkListIdentifier = bookmarkList.identifier,
-                            isBookmarkPrivate = shouldBePrivate,
-                            account = accountViewModel.account,
-                        )
-                    }
+                    accountViewModel.addBookmarkToList(
+                        bookmark = AddressBookmark(address = note.address, relayHint = note.relayHintUrl()),
+                        bookmarkListIdentifier = bookmarkList.identifier,
+                        isBookmarkPrivate = shouldBePrivate,
+                    )
                 },
                 onRemoveBookmarkFromGroup = {
-                    accountViewModel.launchSigner {
-                        accountViewModel.account.labeledBookmarkLists.removeBookmarkFromList(
-                            bookmark = AddressBookmark(address = note.address),
-                            bookmarkListIdentifier = bookmarkList.identifier,
-                            isBookmarkPrivate = maybePrivateBookmark != null,
-                            account = accountViewModel.account,
-                        )
-                    }
+                    accountViewModel.removeBookmarkFromList(
+                        bookmark = AddressBookmark(address = note.address),
+                        bookmarkListIdentifier = bookmarkList.identifier,
+                        isBookmarkPrivate = maybePrivateBookmark != null,
+                    )
                 },
             )
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/membershipManagement/PostBookmarkListManagementScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/membershipManagement/PostBookmarkListManagementScreen.kt
@@ -151,24 +151,18 @@ private fun ListManagementViewBody(
                 totalArticleBookmarkSize = bookmarkList.publicArticleBookmarks.size + bookmarkList.privateArticleBookmarks.size,
                 onClick = { nav.nav(Route.BookmarkGroupView(bookmarkList.identifier, BookmarkType.PostBookmark)) },
                 onAddBookmarkToGroup = { shouldBePrivate ->
-                    accountViewModel.launchSigner {
-                        accountViewModel.account.labeledBookmarkLists.addBookmarkToList(
-                            bookmark = EventBookmark(eventId = note.idHex, relay = note.relayHintUrl(), author = note.author?.pubkeyHex),
-                            bookmarkListIdentifier = bookmarkList.identifier,
-                            isBookmarkPrivate = shouldBePrivate,
-                            account = accountViewModel.account,
-                        )
-                    }
+                    accountViewModel.addBookmarkToList(
+                        bookmark = EventBookmark(eventId = note.idHex, relay = note.relayHintUrl(), author = note.author?.pubkeyHex),
+                        bookmarkListIdentifier = bookmarkList.identifier,
+                        isBookmarkPrivate = shouldBePrivate,
+                    )
                 },
                 onRemoveBookmarkFromGroup = {
-                    accountViewModel.launchSigner {
-                        accountViewModel.account.labeledBookmarkLists.removeBookmarkFromList(
-                            bookmark = EventBookmark(eventId = note.idHex),
-                            bookmarkListIdentifier = bookmarkList.identifier,
-                            isBookmarkPrivate = maybePrivateBookmark != null,
-                            account = accountViewModel.account,
-                        )
-                    }
+                    accountViewModel.removeBookmarkFromList(
+                        bookmark = EventBookmark(eventId = note.idHex),
+                        bookmarkListIdentifier = bookmarkList.identifier,
+                        isBookmarkPrivate = maybePrivateBookmark != null,
+                    )
                 },
             )
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/FollowPackViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/FollowPackViewModel.kt
@@ -40,22 +40,14 @@ class FollowPackViewModel : ViewModel() {
         customName: String?,
         customDescription: String?,
     ) {
-        accountViewModel.launchSigner {
-            accountViewModel.account.followLists.cloneFollowSet(
-                currentFollowPack = followSet,
-                customCloneName = customName,
-                customCloneDescription = customDescription,
-                account = accountViewModel.account,
-            )
-        }
+        accountViewModel.cloneFollowPack(
+            currentFollowPack = followSet,
+            customCloneName = customName,
+            customCloneDescription = customDescription,
+        )
     }
 
     fun deleteItem(followSet: PeopleList) {
-        accountViewModel.launchSigner {
-            accountViewModel.account.followLists.deleteFollowSet(
-                identifierTag = followSet.identifierTag,
-                account = accountViewModel.account,
-            )
-        }
+        accountViewModel.deleteFollowPack(followSet.identifierTag)
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/PeopleListViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/PeopleListViewModel.kt
@@ -40,22 +40,14 @@ class PeopleListViewModel : ViewModel() {
         customName: String?,
         customDescription: String?,
     ) {
-        accountViewModel.launchSigner {
-            accountViewModel.account.peopleLists.cloneFollowSet(
-                currentPeopleList = followSet,
-                customCloneName = customName,
-                customCloneDescription = customDescription,
-                account = accountViewModel.account,
-            )
-        }
+        accountViewModel.clonePeopleList(
+            currentPeopleList = followSet,
+            customCloneName = customName,
+            customCloneDescription = customDescription,
+        )
     }
 
     fun deleteItem(followSet: PeopleList) {
-        accountViewModel.launchSigner {
-            accountViewModel.account.peopleLists.deleteFollowSet(
-                identifierTag = followSet.identifierTag,
-                account = accountViewModel.account,
-            )
-        }
+        accountViewModel.deletePeopleList(followSet.identifierTag)
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/memberEdit/FollowListAndPackAndUserView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/memberEdit/FollowListAndPackAndUserView.kt
@@ -106,14 +106,11 @@ fun FollowListAndPackAndUserView(
                     userIsPrivateMember = list.privateMembers.contains(userToAddOrRemove),
                     userIsPublicMember = list.publicMembers.contains(userToAddOrRemove),
                     onRemoveUser = {
-                        accountViewModel.launchSigner {
-                            accountViewModel.account.peopleLists.removeUserFromSet(
-                                userToAddOrRemove,
-                                isPrivate = list.privateMembers.contains(userToAddOrRemove),
-                                list.identifierTag,
-                                accountViewModel.account,
-                            )
-                        }
+                        accountViewModel.removeUserFromPeopleList(
+                            user = userToAddOrRemove,
+                            isPrivate = list.privateMembers.contains(userToAddOrRemove),
+                            identifierTag = list.identifierTag,
+                        )
                     },
                     privateMemberSize = list.privateMembers.size,
                     publicMemberSize = list.publicMembers.size,
@@ -121,14 +118,11 @@ fun FollowListAndPackAndUserView(
                         nav.nav(Route.MyPeopleListView(list.identifierTag))
                     },
                     onAddUserToList = { userShouldBePrivate ->
-                        accountViewModel.launchSigner {
-                            accountViewModel.account.peopleLists.addUserToSet(
-                                userToAddOrRemove,
-                                list.identifierTag,
-                                userShouldBePrivate,
-                                accountViewModel.account,
-                            )
-                        }
+                        accountViewModel.addUserToPeopleList(
+                            user = userToAddOrRemove,
+                            identifierTag = list.identifierTag,
+                            shouldBePrivateMember = userShouldBePrivate,
+                        )
                     },
                 )
                 HorizontalDivider(thickness = DividerThickness)
@@ -181,23 +175,17 @@ fun FollowListAndPackAndUserView(
                         nav.nav(Route.MyFollowPackView(list.identifierTag))
                     },
                     onRemoveUser = {
-                        accountViewModel.launchSigner {
-                            accountViewModel.account.followLists.removeUserFromSet(
-                                userToAddOrRemove,
-                                list.identifierTag,
-                                accountViewModel.account,
-                            )
-                        }
+                        accountViewModel.removeUserFromFollowPack(
+                            user = userToAddOrRemove,
+                            identifierTag = list.identifierTag,
+                        )
                     },
                     memberSize = list.publicMembers.size,
                     onAddUserToList = {
-                        accountViewModel.launchSigner {
-                            accountViewModel.account.followLists.addUserToSet(
-                                userToAddOrRemove,
-                                list.identifierTag,
-                                accountViewModel.account,
-                            )
-                        }
+                        accountViewModel.addUserToFollowPack(
+                            user = userToAddOrRemove,
+                            identifierTag = list.identifierTag,
+                        )
                     },
                 )
                 HorizontalDivider(thickness = DividerThickness)


### PR DESCRIPTION
## Summary

Continues the migration of `accountViewModel.launchSigner { ... }` call sites to dedicated AccountViewModel wrapper methods, supporting the KMP/iOS migration effort.

## Changes

### New AccountViewModel wrapper methods

**Labeled Bookmark Lists:**
- `addBookmarkToList(bookmark, bookmarkListIdentifier, isBookmarkPrivate)`
- `removeBookmarkFromList(bookmark, bookmarkListIdentifier, isBookmarkPrivate)`
- `cloneBookmarkList(currentBookmarkList, customCloneName, customCloneDescription)`
- `deleteBookmarkList(bookmarkListIdentifier)`

**People Lists:**
- `clonePeopleList(currentPeopleList, customCloneName, customCloneDescription)`
- `deletePeopleList(identifierTag)`
- `addUserToPeopleList(user, identifierTag, shouldBePrivateMember)`
- `removeUserFromPeopleList(user, isPrivate, identifierTag)`

**Follow Packs:**
- `cloneFollowPack(currentFollowPack, customCloneName, customCloneDescription)`
- `deleteFollowPack(identifierTag)`
- `addUserToFollowPack(user, identifierTag)`
- `removeUserFromFollowPack(user, identifierTag)`

### Migrated callers (14 call sites)
- `ArticleBookmarkListManagementScreen` (2 calls)
- `PostBookmarkListManagementScreen` (2 calls)
- `ListOfBookmarkGroupsScreen` (2 calls)
- `PeopleListViewModel` (2 calls)
- `FollowPackViewModel` (2 calls)
- `FollowListAndPackAndUserView` (4 calls)

## Motivation

These wrappers encapsulate the `launchSigner { account.subObject.method(..., account) }` pattern, reducing boilerplate and making call sites cleaner. This is part of the gradual migration away from inline `launchSigner` blocks toward typed method calls that can be defined on cross-platform interfaces.