### PR TITLE
feat: expand ICacheProvider with collection-scanning methods (v2)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -266,13 +266,13 @@ interface ILocalCache {
 object LocalCache : ILocalCache, ICacheProvider {
     val antiSpam = AntiSpamFilter()
 
-    val users = LargeSoftCache<HexKey, User>()
-    val notes = LargeSoftCache<HexKey, Note>()
-    val addressables = LargeSoftCache<Address, AddressableNote>()
+    override val users = LargeSoftCache<HexKey, User>()
+    override val notes = LargeSoftCache<HexKey, Note>()
+    override val addressables = LargeSoftCache<Address, AddressableNote>()
 
     val chatroomList = LargeCache<HexKey, ChatroomList>()
-    val publicChatChannels = LargeCache<HexKey, PublicChatChannel>()
-    val liveChatChannels = LargeCache<Address, LiveActivitiesChannel>()
+    override val publicChatChannels = LargeCache<HexKey, PublicChatChannel>()
+    override val liveChatChannels = LargeCache<Address, LiveActivitiesChannel>()
     val ephemeralChannels = LargeCache<RoomId, EphemeralChatChannel>()
 
     val paymentTracker = NwcPaymentTracker()
@@ -380,7 +380,7 @@ object LocalCache : ILocalCache, ICacheProvider {
 
     fun observeLatestNote(filter: Filter) = observeNotes(filter).map { it.firstOrNull() }
 
-    fun checkGetOrCreateUser(key: String): User? = runCatching { getOrCreateUser(key) }.getOrNull()
+    override fun checkGetOrCreateUser(key: String): User? = runCatching { getOrCreateUser(key) }.getOrNull()
 
     fun load(keys: List<String>): List<User> = keys.mapNotNull(::checkGetOrCreateUser)
 
@@ -418,19 +418,19 @@ object LocalCache : ILocalCache, ICacheProvider {
         return count
     }
 
-    fun getAddressableNoteIfExists(key: String): AddressableNote? = Address.parse(key)?.let { addressables.get(it) }
+    override fun getAddressableNoteIfExists(key: String): AddressableNote? = Address.parse(key)?.let { addressables.get(it) }
 
-    fun getAddressableNoteIfExists(address: Address): AddressableNote? = addressables.get(address)
+    override fun getAddressableNoteIfExists(address: Address): AddressableNote? = addressables.get(address)
 
     override fun getNoteIfExists(hexKey: String): Note? = if (hexKey.length == 64) notes.get(hexKey) else Address.parse(hexKey)?.let { addressables.get(it) }
 
     fun getNoteIfExists(key: ETag): Note? = notes.get(key.eventId)
 
-    fun getPublicChatChannelIfExists(key: String): PublicChatChannel? = publicChatChannels.get(key)
+    override fun getPublicChatChannelIfExists(key: String): PublicChatChannel? = publicChatChannels.get(key)
 
     fun getEphemeralChatChannelIfExists(key: RoomId): EphemeralChatChannel? = ephemeralChannels.get(key)
 
-    fun getLiveActivityChannelIfExists(key: Address): LiveActivitiesChannel? = liveChatChannels.get(key)
+    override fun getLiveActivityChannelIfExists(key: Address): LiveActivitiesChannel? = liveChatChannels.get(key)
 
     fun getNoteIfExists(event: Event): Note? =
         if (event is AddressableEvent) {
@@ -512,9 +512,9 @@ object LocalCache : ILocalCache, ICacheProvider {
 
     fun getOrCreateChatroomList(key: HexKey): ChatroomList = chatroomList.getOrCreate(key) { ChatroomList(key) }
 
-    fun getOrCreatePublicChatChannel(key: HexKey): PublicChatChannel = publicChatChannels.getOrCreate(key) { PublicChatChannel(key) }
+    override fun getOrCreatePublicChatChannel(key: HexKey): PublicChatChannel = publicChatChannels.getOrCreate(key) { PublicChatChannel(key) }
 
-    fun getOrCreateLiveChannel(key: Address): LiveActivitiesChannel = liveChatChannels.getOrCreate(key) { LiveActivitiesChannel(key) }
+    override fun getOrCreateLiveChannel(key: Address): LiveActivitiesChannel = liveChatChannels.getOrCreate(key) { LiveActivitiesChannel(key) }
 
     fun getOrCreateEphemeralChannel(key: RoomId): EphemeralChatChannel = ephemeralChannels.getOrCreate(key) { EphemeralChatChannel(key) }
 
@@ -1906,7 +1906,7 @@ object LocalCache : ILocalCache, ICacheProvider {
             }
     }
 
-    fun findPublicChatChannelsStartingWith(text: String): List<PublicChatChannel> {
+    override fun findPublicChatChannelsStartingWith(text: String): List<PublicChatChannel> {
         if (text.isBlank()) return emptyList()
 
         val key = decodeEventIdAsHexOrNull(text)
@@ -1921,7 +1921,7 @@ object LocalCache : ILocalCache, ICacheProvider {
         }
     }
 
-    fun findEphemeralChatChannelsStartingWith(text: String): List<EphemeralChatChannel> {
+    override fun findEphemeralChatChannelsStartingWith(text: String): List<EphemeralChatChannel> {
         if (text.isBlank()) return emptyList()
 
         return ephemeralChannels.filter { _, channel ->
@@ -1929,7 +1929,7 @@ object LocalCache : ILocalCache, ICacheProvider {
         }
     }
 
-    fun findLiveActivityChannelsStartingWith(text: String): List<LiveActivitiesChannel> {
+    override fun findLiveActivityChannelsStartingWith(text: String): List<LiveActivitiesChannel> {
         if (text.isBlank()) return emptyList()
 
         try {

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/cache/ICacheProvider.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/cache/ICacheProvider.kt
@@ -24,9 +24,13 @@ import com.vitorpamplona.amethyst.commons.model.AddressableNote
 import com.vitorpamplona.amethyst.commons.model.Channel
 import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
+import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatChannel
+import com.vitorpamplona.amethyst.commons.model.nip53LiveActivities.LiveActivitiesChannel
 import com.vitorpamplona.quartz.nip01Core.core.Address
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.utils.cache.ICacheOperations
 
 /**
  * Cache provider interface for accessing cached Notes, Users, and Channels.
@@ -41,6 +45,44 @@ import com.vitorpamplona.quartz.nip01Core.core.HexKey
  * - Platform-agnostic model layer
  */
 interface ICacheProvider {
+    // ---------------------------------------------------------------
+    // Collection-level access (for filterIntoSet, mapFlattenIntoSet, etc.)
+    // ---------------------------------------------------------------
+
+    /**
+     * The notes cache, keyed by hex ID.
+     * Exposes collection-scanning operations (filterIntoSet, mapFlattenIntoSet, etc.)
+     * used extensively by feed filters.
+     */
+    val notes: ICacheOperations<HexKey, Note>
+
+    /**
+     * The addressable notes cache, keyed by Address.
+     * Exposes collection-scanning operations with optional kind-based sub-map filtering
+     * used by discovery, drafts, bookmarks, and other feed filters.
+     */
+    val addressables: ICacheOperations<Address, AddressableNote>
+
+    /**
+     * The users cache, keyed by public key hex.
+     * Exposes collection-scanning operations for user enumeration.
+     */
+    val users: ICacheOperations<HexKey, User>
+
+    /**
+     * The public chat channels cache, keyed by hex ID.
+     */
+    val publicChatChannels: ICacheOperations<HexKey, PublicChatChannel>
+
+    /**
+     * The live activity channels cache, keyed by Address.
+     */
+    val liveChatChannels: ICacheOperations<Address, LiveActivitiesChannel>
+
+    // ---------------------------------------------------------------
+    // Single-item lookups
+    // ---------------------------------------------------------------
+
     /**
      * Gets a channel by Note reference.
      * Used for resolving relay hints for channel messages.
@@ -133,6 +175,91 @@ interface ICacheProvider {
      * @return The User (existing or newly created)
      */
     fun getOrCreateUser(pubkey: HexKey): User?
+
+    /**
+     * Gets or creates a User by public key hex, catching exceptions.
+     * Returns null if the key is invalid.
+     *
+     * @param pubkey The user's public key in hex format
+     * @return The User if valid, null otherwise
+     */
+    fun checkGetOrCreateUser(pubkey: HexKey): User? = runCatching { getOrCreateUser(pubkey) }.getOrNull()
+
+    /**
+     * Gets an AddressableNote if it exists in cache, by string key.
+     *
+     * @param key The addressable note key as a string (parsed into Address)
+     * @return The AddressableNote if found, null otherwise
+     */
+    fun getAddressableNoteIfExists(key: String): AddressableNote? = Address.parse(key)?.let { getAddressableNoteIfExists(it) }
+
+    /**
+     * Gets an AddressableNote if it exists in cache, by Address.
+     *
+     * @param address The note's Address
+     * @return The AddressableNote if found, null otherwise
+     */
+    fun getAddressableNoteIfExists(address: Address): AddressableNote?
+
+    /**
+     * Gets a PublicChatChannel if it exists in cache.
+     *
+     * @param key The channel's hex key
+     * @return The PublicChatChannel if found, null otherwise
+     */
+    fun getPublicChatChannelIfExists(key: HexKey): PublicChatChannel?
+
+    /**
+     * Gets a LiveActivitiesChannel if it exists in cache.
+     *
+     * @param key The channel's Address
+     * @return The LiveActivitiesChannel if found, null otherwise
+     */
+    fun getLiveActivityChannelIfExists(key: Address): LiveActivitiesChannel?
+
+    /**
+     * Gets or creates a PublicChatChannel.
+     *
+     * @param key The channel's hex key
+     * @return The PublicChatChannel (existing or newly created)
+     */
+    fun getOrCreatePublicChatChannel(key: HexKey): PublicChatChannel
+
+    /**
+     * Gets or creates a LiveActivitiesChannel.
+     *
+     * @param key The channel's Address
+     * @return The LiveActivitiesChannel (existing or newly created)
+     */
+    fun getOrCreateLiveChannel(key: Address): LiveActivitiesChannel
+
+    // ---------------------------------------------------------------
+    // Search methods
+    // ---------------------------------------------------------------
+
+    /**
+     * Finds public chat channels whose name starts with the given prefix.
+     *
+     * @param text The search prefix
+     * @return List of matching PublicChatChannels
+     */
+    fun findPublicChatChannelsStartingWith(text: String): List<PublicChatChannel> = emptyList()
+
+    /**
+     * Finds live activity channels whose name starts with the given prefix.
+     *
+     * @param text The search prefix
+     * @return List of matching LiveActivitiesChannels
+     */
+    fun findLiveActivityChannelsStartingWith(text: String): List<LiveActivitiesChannel> = emptyList()
+
+    /**
+     * Finds ephemeral chat channels whose name starts with the given prefix.
+     *
+     * @param text The search prefix
+     * @return List of matching EphemeralChatChannels
+     */
+    fun findEphemeralChatChannelsStartingWith(text: String): List<EphemeralChatChannel> = emptyList()
 
     fun justConsumeMyOwnEvent(event: Event): Boolean
 }


### PR DESCRIPTION
## Summary

Expands `ICacheProvider` with collection-level access and additional lookup/search methods needed to unblock ViewModel and FeedFilter migration to KMP commons.

## Changes

### ICacheProvider — new members

**Collection-level access** (typed as `ICacheOperations<K, V>`):
- `notes` — notes cache with `filterIntoSet`, `mapFlattenIntoSet`, `maxOrNullOf`, etc.
- `addressables` — addressable notes cache with kind-based sub-map filtering
- `users` — user cache
- `publicChatChannels` — public chat channels cache
- `liveChatChannels` — live activity channels cache

**Single-item lookups:**
- `getAddressableNoteIfExists(String)` / `getAddressableNoteIfExists(Address)`
- `checkGetOrCreateUser(HexKey)`
- `getPublicChatChannelIfExists(HexKey)`
- `getLiveActivityChannelIfExists(Address)`
- `getOrCreatePublicChatChannel(HexKey)`
- `getOrCreateLiveChannel(Address)`

**Search methods:**
- `findPublicChatChannelsStartingWith(String)`
- `findLiveActivityChannelsStartingWith(String)`
- `findEphemeralChatChannelsStartingWith(String)`

### LocalCache

Added `override` modifiers to properties (`notes`, `addressables`, `users`, `publicChatChannels`, `liveChatChannels`) and methods to satisfy the expanded interface.

## Why

Feed filters (`HomeNewThreadFeedFilter`, `VideoFeedFilter`, `DiscoverFollowSetsFeedFilter`, etc.) extensively use `LocalCache.notes.filterIntoSet`, `LocalCache.addressables.filterIntoSet(kind)`, and similar collection-scanning operations. Exposing these through the interface allows the filters to depend on `ICacheProvider` instead of the `LocalCache` singleton, which is essential for KMP/iOS portability.

## Verification

- `:commons:compileKotlinJvm` ✅
- `:amethyst:compilePlayDebugKotlin` ✅