### PR TITLE
feat: move DAL FeedFilter subclasses to commons (batch 4)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -333,9 +333,13 @@ class Account(
 
     val hiddenUsers = HiddenUsersState(muteList.flow, blockPeopleList.flow, scope, settings)
 
+    override val transientHiddenUsers: Set<String> get() = hiddenUsers.transientHiddenUsers.value
+
+    override val cacheProvider: com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider get() = cache
+
     val labeledBookmarkLists = LabeledBookmarkListsState(signer, cache, scope)
-    val oldBookmarkState = OldBookmarkListState(signer, cache, scope)
-    val bookmarkState = BookmarkListState(signer, cache, scope)
+    override val oldBookmarkState = OldBookmarkListState(signer, cache, scope)
+    override val bookmarkState = BookmarkListState(signer, cache, scope)
     val pinState = PinListState(signer, cache, scope)
     val emoji = EmojiPackState(signer, cache, scope)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/default/dal/BookmarkPrivateFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/default/dal/BookmarkPrivateFeedFilter.kt
@@ -20,17 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.default.dal
 
-import com.vitorpamplona.amethyst.model.Account
-import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.ui.dal.FeedFilter
-
-class BookmarkPrivateFeedFilter(
-    val account: Account,
-) : FeedFilter<Note>() {
-    override fun feedKey(): String =
-        account.bookmarkState.bookmarks.value
-            .hashCode()
-            .toString()
-
-    override fun feed(): List<Note> = account.bookmarkState.bookmarks.value.private
-}
+// Re-export from commons for backwards compatibility
+typealias BookmarkPrivateFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.BookmarkPrivateFeedFilter

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/default/dal/BookmarkPublicFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/default/dal/BookmarkPublicFeedFilter.kt
@@ -20,17 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.default.dal
 
-import com.vitorpamplona.amethyst.model.Account
-import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.ui.dal.FeedFilter
-
-class BookmarkPublicFeedFilter(
-    val account: Account,
-) : FeedFilter<Note>() {
-    override fun feedKey(): String =
-        account.bookmarkState.bookmarks.value
-            .hashCode()
-            .toString()
-
-    override fun feed(): List<Note> = account.bookmarkState.bookmarks.value.public
-}
+// Re-export from commons for backwards compatibility
+typealias BookmarkPublicFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.BookmarkPublicFeedFilter

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/old/dal/OldBookmarkPublicFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/old/dal/OldBookmarkPublicFeedFilter.kt
@@ -20,17 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.old.dal
 
-import com.vitorpamplona.amethyst.model.Account
-import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.ui.dal.FeedFilter
-
-class OldBookmarkPublicFeedFilter(
-    val account: Account,
-) : FeedFilter<Note>() {
-    override fun feedKey(): String =
-        account.oldBookmarkState.bookmarks.value
-            .hashCode()
-            .toString()
-
-    override fun feed(): List<Note> = account.oldBookmarkState.bookmarks.value.public
-}
+// Re-export from commons for backwards compatibility
+typealias OldBookmarkPublicFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.OldBookmarkPublicFeedFilter

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/dal/SpammerAccountsFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/dal/SpammerAccountsFeedFilter.kt
@@ -20,19 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.dal
 
-import com.vitorpamplona.amethyst.model.Account
-import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.model.User
-import com.vitorpamplona.amethyst.ui.dal.FeedFilter
-
-class SpammerAccountsFeedFilter(
-    val account: Account,
-) : FeedFilter<User>() {
-    override fun feedKey(): String = account.userProfile().pubkeyHex
-
-    override fun showHiddenKey(): Boolean = true
-
-    override fun feed(): List<User> =
-        account.hiddenUsers.transientHiddenUsers.value
-            .map { LocalCache.getOrCreateUser(it) }
-}
+// Re-export from commons for backwards compatibility
+typealias SpammerAccountsFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.SpammerAccountsFeedFilter

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
@@ -20,7 +20,10 @@
  */
 package com.vitorpamplona.amethyst.commons.model
 
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupList
+import com.vitorpamplona.amethyst.commons.model.nip51Lists.BookmarkListState
+import com.vitorpamplona.amethyst.commons.model.nip51Lists.OldBookmarkListState
 import com.vitorpamplona.amethyst.commons.model.privateChats.ChatroomList
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
@@ -107,6 +110,18 @@ interface IAccount {
 
     /** Whether a note is acceptable (not hidden, not blocked, etc.) */
     fun isAcceptable(note: Note): Boolean
+
+    /** Bookmark list state (NIP-51 bookmark lists) */
+    val bookmarkState: BookmarkListState
+
+    /** Old bookmark list state (legacy NIP-51 bookmarks) */
+    val oldBookmarkState: OldBookmarkListState
+
+    /** Set of transiently-hidden (spammer) user pubkeys */
+    val transientHiddenUsers: Set<String>
+
+    /** Cache provider for resolving notes/users */
+    val cacheProvider: ICacheProvider
 
     /** Send a NIP-04 encrypted direct message */
     suspend fun sendNip04PrivateMessage(eventTemplate: EventTemplate<PrivateDmEvent>)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/BookmarkPrivateFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/BookmarkPrivateFeedFilter.kt
@@ -18,7 +18,18 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.old.dal
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-// Re-export from commons for backwards compatibility
-typealias OldBookmarkPrivateFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.OldBookmarkPrivateFeedFilter
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.Note
+
+class BookmarkPrivateFeedFilter(
+    val account: IAccount,
+) : FeedFilter<Note>() {
+    override fun feedKey(): String =
+        account.bookmarkState.bookmarks.value
+            .hashCode()
+            .toString()
+
+    override fun feed(): List<Note> = account.bookmarkState.bookmarks.value.private
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/BookmarkPublicFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/BookmarkPublicFeedFilter.kt
@@ -18,7 +18,18 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.old.dal
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-// Re-export from commons for backwards compatibility
-typealias OldBookmarkPrivateFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.OldBookmarkPrivateFeedFilter
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.Note
+
+class BookmarkPublicFeedFilter(
+    val account: IAccount,
+) : FeedFilter<Note>() {
+    override fun feedKey(): String =
+        account.bookmarkState.bookmarks.value
+            .hashCode()
+            .toString()
+
+    override fun feed(): List<Note> = account.bookmarkState.bookmarks.value.public
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/OldBookmarkPrivateFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/OldBookmarkPrivateFeedFilter.kt
@@ -18,7 +18,18 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.old.dal
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-// Re-export from commons for backwards compatibility
-typealias OldBookmarkPrivateFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.OldBookmarkPrivateFeedFilter
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.Note
+
+class OldBookmarkPrivateFeedFilter(
+    val account: IAccount,
+) : FeedFilter<Note>() {
+    override fun feedKey(): String =
+        account.oldBookmarkState.bookmarks.value
+            .hashCode()
+            .toString()
+
+    override fun feed(): List<Note> = account.oldBookmarkState.bookmarks.value.private
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/OldBookmarkPublicFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/OldBookmarkPublicFeedFilter.kt
@@ -18,7 +18,18 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.old.dal
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-// Re-export from commons for backwards compatibility
-typealias OldBookmarkPrivateFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.OldBookmarkPrivateFeedFilter
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.Note
+
+class OldBookmarkPublicFeedFilter(
+    val account: IAccount,
+) : FeedFilter<Note>() {
+    override fun feedKey(): String =
+        account.oldBookmarkState.bookmarks.value
+            .hashCode()
+            .toString()
+
+    override fun feed(): List<Note> = account.oldBookmarkState.bookmarks.value.public
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/SpammerAccountsFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/SpammerAccountsFeedFilter.kt
@@ -18,7 +18,19 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.old.dal
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-// Re-export from commons for backwards compatibility
-typealias OldBookmarkPrivateFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.OldBookmarkPrivateFeedFilter
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.User
+
+class SpammerAccountsFeedFilter(
+    val account: IAccount,
+) : FeedFilter<User>() {
+    override fun feedKey(): String = account.userProfile().pubkeyHex
+
+    override fun showHiddenKey(): Boolean = true
+
+    override fun feed(): List<User> =
+        account.transientHiddenUsers
+            .mapNotNull { account.cacheProvider.getOrCreateUser(it) }
+}


### PR DESCRIPTION
## Summary

Move 5 more FeedFilter subclasses from the Android `amethyst` module to the KMP `commons` module, continuing the iOS migration effort.

### Filters moved
- **BookmarkPrivateFeedFilter** — private bookmarks feed
- **BookmarkPublicFeedFilter** — public bookmarks feed
- **OldBookmarkPrivateFeedFilter** — legacy private bookmarks feed
- **OldBookmarkPublicFeedFilter** — legacy public bookmarks feed
- **SpammerAccountsFeedFilter** — transient spammer accounts feed (`FeedFilter<User>`)

### IAccount interface additions
- `bookmarkState: BookmarkListState` — NIP-51 bookmark list state (type already in commons)
- `oldBookmarkState: OldBookmarkListState` — legacy bookmark list state (type already in commons)
- `transientHiddenUsers: Set<String>` — transiently-hidden (spammer) user pubkeys
- `cacheProvider: ICacheProvider` — cache provider for resolving notes/users

### Approach
- Each filter now uses `IAccount` instead of `Account`
- SpammerAccountsFeedFilter uses `account.cacheProvider` instead of `LocalCache` directly
- Original locations retain `typealias` re-exports for backwards compatibility
- Both `:commons:compileKotlinJvm` and `:amethyst:compilePlayDebugKotlin` pass

### Previous batches
Batches 1-3 moved 12 filters total + infrastructure (AdditiveFeedFilter, FeedFilter, DefaultFeedOrder, IAccount, ICacheProvider, LiveHiddenUsers, etc.).