### PR TITLE
feat: move utilities and data classes to commons (batch 13)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/AdditiveComplexFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/AdditiveComplexFeedFilter.kt
@@ -20,9 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.dal
 
-abstract class AdditiveComplexFeedFilter<T, U> : FeedFilter<T>() {
-    abstract fun updateListWith(
-        oldList: List<T>,
-        newItems: Set<U>,
-    ): List<T>
-}
+// Re-export from commons for backwards compatibility
+typealias AdditiveComplexFeedFilter<T, U> = com.vitorpamplona.amethyst.commons.ui.feeds.AdditiveComplexFeedFilter<T, U>

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapFormatterNoDecimals.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapFormatterNoDecimals.kt
@@ -21,50 +21,16 @@
 package com.vitorpamplona.amethyst.ui.note
 
 import java.math.BigDecimal
-import java.math.RoundingMode
-import java.text.DecimalFormat
 
-private val dfG =
-    object : ThreadLocal<DecimalFormat>() {
-        override fun initialValue() = DecimalFormat("#G")
-    }
+// Re-export from commons for backwards compatibility
+fun showAmountInteger(amount: BigDecimal?): String =
+    com.vitorpamplona.amethyst.commons.util
+        .showAmountInteger(amount)
 
-private val dfM =
-    object : ThreadLocal<DecimalFormat>() {
-        override fun initialValue() = DecimalFormat("#M")
-    }
+fun showAmountInteger(amount: Int?): String =
+    com.vitorpamplona.amethyst.commons.util
+        .showAmountInteger(amount)
 
-private val dfK =
-    object : ThreadLocal<DecimalFormat>() {
-        override fun initialValue() = DecimalFormat("#k")
-    }
-
-private val dfN =
-    object : ThreadLocal<DecimalFormat>() {
-        override fun initialValue() = DecimalFormat("#")
-    }
-
-fun showAmountInteger(amount: BigDecimal?): String {
-    if (amount == null) return ""
-    if (amount.abs() < BigDecimal(0.01)) return ""
-
-    return when {
-        amount >= OneGiga -> dfG.get()?.format(amount.div(OneGiga).setScale(0, RoundingMode.HALF_UP)) ?: ""
-        amount >= OneMega -> dfM.get()?.format(amount.div(OneMega).setScale(0, RoundingMode.HALF_UP)) ?: ""
-        amount >= TenKilo -> dfK.get()?.format(amount.div(OneKilo).setScale(0, RoundingMode.HALF_UP)) ?: ""
-        else -> dfN.get()?.format(amount) ?: ""
-    }
-}
-
-fun showAmountInteger(amount: Int?): String {
-    if (amount == null) return "0"
-
-    return showAmountIntegerWithZero(BigDecimal.valueOf(amount.toLong()))
-}
-
-fun showAmountIntegerWithZero(amount: BigDecimal?): String {
-    if (amount == null) return "0"
-    if (amount.abs() < BigDecimal(0.01)) return "0"
-
-    return showAmountInteger(amount)
-}
+fun showAmountIntegerWithZero(amount: BigDecimal?): String =
+    com.vitorpamplona.amethyst.commons.util
+        .showAmountIntegerWithZero(amount)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/BookmarkType.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/BookmarkType.kt
@@ -20,8 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups
 
-enum class BookmarkType {
-    PostBookmark,
-
-    ArticleBookmark,
-}
+// Re-export from commons for backwards compatibility
+typealias BookmarkType = com.vitorpamplona.amethyst.commons.ui.bookmarkgroups.BookmarkType

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedView.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.settings.StringFeedState
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.feeds.FeedError
 import com.vitorpamplona.amethyst.ui.feeds.LoadingFeed

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedViewModel.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vitorpamplona.amethyst.commons.ui.feeds.InvalidatableContent
+import com.vitorpamplona.amethyst.commons.ui.settings.StringFeedState
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.service.BundledUpdate
 import com.vitorpamplona.amethyst.service.checkNotInMainThread

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/dal/SupportedContent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/dal/SupportedContent.kt
@@ -20,27 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.video.dal
 
-class SupportedContent(
-    val blockedUrls: List<String>,
-    val mimeTypes: Set<String>,
-    val supportedFileExtensions: Set<String>,
-) {
-    private fun validExtension(fullUrl: String): Boolean {
-        val queryIndex = fullUrl.indexOf('?')
-        if (queryIndex > 0) {
-            return supportedFileExtensions.any { fullUrl.startsWith(it, queryIndex - it.length) }
-        }
-
-        val fragmentIndex = fullUrl.indexOf('#')
-        if (fragmentIndex > 0) {
-            return supportedFileExtensions.any { fullUrl.startsWith(it, fragmentIndex - it.length) }
-        }
-
-        return supportedFileExtensions.any { fullUrl.endsWith(it) }
-    }
-
-    fun acceptableUrl(
-        url: String,
-        mimeType: String?,
-    ) = blockedUrls.none { url.contains(it) } && ((mimeType != null && mimeTypes.contains(mimeType)) || validExtension(url))
-}
+// Re-export from commons for backwards compatibility
+typealias SupportedContent = com.vitorpamplona.amethyst.commons.ui.video.SupportedContent

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/actions/mediaServers/ServerName.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/actions/mediaServers/ServerName.kt
@@ -18,10 +18,32 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.actions.mediaServers
+package com.vitorpamplona.amethyst.commons.ui.actions.mediaServers
 
-// Re-export from commons for backwards compatibility
-typealias ServerName = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.ServerName
-typealias ServerType = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.ServerType
+import kotlinx.serialization.Serializable
 
-val DEFAULT_MEDIA_SERVERS = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.DEFAULT_MEDIA_SERVERS
+@Serializable
+data class ServerName(
+    val name: String,
+    val baseUrl: String,
+    val type: ServerType = ServerType.Blossom,
+)
+
+enum class ServerType {
+    Blossom,
+    NIP95,
+    NIP96,
+}
+
+val DEFAULT_MEDIA_SERVERS: List<ServerName> =
+    listOf(
+        ServerName("Nostr.Build", "https://blossom.band/", ServerType.Blossom),
+        ServerName("24242.io", "https://24242.io/", ServerType.Blossom),
+        ServerName("Azzamo", "https://blossom.azzamo.media", ServerType.Blossom),
+        ServerName("YakiHonne", "https://blossom.yakihonne.com/", ServerType.Blossom),
+        ServerName("Primal", "https://blossom.primal.net/", ServerType.Blossom),
+        ServerName("Sovbit", "https://cdn.sovbit.host", ServerType.Blossom),
+        ServerName("Nostr.Download", "https://nostr.download", ServerType.Blossom),
+        ServerName("Satellite (Paid)", "https://cdn.satellite.earth", ServerType.Blossom),
+        ServerName("NostrMedia (Paid)", "https://nostrmedia.com", ServerType.Blossom),
+    )

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/bookmarkgroups/BookmarkType.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/bookmarkgroups/BookmarkType.kt
@@ -18,10 +18,10 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.actions.mediaServers
+package com.vitorpamplona.amethyst.commons.ui.bookmarkgroups
 
-// Re-export from commons for backwards compatibility
-typealias ServerName = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.ServerName
-typealias ServerType = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.ServerType
+enum class BookmarkType {
+    PostBookmark,
 
-val DEFAULT_MEDIA_SERVERS = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.DEFAULT_MEDIA_SERVERS
+    ArticleBookmark,
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/AdditiveComplexFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/AdditiveComplexFeedFilter.kt
@@ -18,21 +18,11 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.coroutines.flow.MutableStateFlow
-
-sealed class StringFeedState {
-    object Loading : StringFeedState()
-
-    class Loaded(
-        val feed: MutableStateFlow<ImmutableList<String>>,
-    ) : StringFeedState()
-
-    object Empty : StringFeedState()
-
-    class FeedError(
-        val errorMessage: String,
-    ) : StringFeedState()
+abstract class AdditiveComplexFeedFilter<T, U> : FeedFilter<T>() {
+    abstract fun updateListWith(
+        oldList: List<T>,
+        newItems: Set<U>,
+    ): List<T>
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/settings/StringFeedState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/settings/StringFeedState.kt
@@ -18,10 +18,21 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.actions.mediaServers
+package com.vitorpamplona.amethyst.commons.ui.settings
 
-// Re-export from commons for backwards compatibility
-typealias ServerName = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.ServerName
-typealias ServerType = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.ServerType
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.coroutines.flow.MutableStateFlow
 
-val DEFAULT_MEDIA_SERVERS = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.DEFAULT_MEDIA_SERVERS
+sealed class StringFeedState {
+    object Loading : StringFeedState()
+
+    class Loaded(
+        val feed: MutableStateFlow<ImmutableList<String>>,
+    ) : StringFeedState()
+
+    object Empty : StringFeedState()
+
+    class FeedError(
+        val errorMessage: String,
+    ) : StringFeedState()
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/video/SupportedContent.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/video/SupportedContent.kt
@@ -18,10 +18,29 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.actions.mediaServers
+package com.vitorpamplona.amethyst.commons.ui.video
 
-// Re-export from commons for backwards compatibility
-typealias ServerName = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.ServerName
-typealias ServerType = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.ServerType
+class SupportedContent(
+    val blockedUrls: List<String>,
+    val mimeTypes: Set<String>,
+    val supportedFileExtensions: Set<String>,
+) {
+    private fun validExtension(fullUrl: String): Boolean {
+        val queryIndex = fullUrl.indexOf('?')
+        if (queryIndex > 0) {
+            return supportedFileExtensions.any { fullUrl.startsWith(it, queryIndex - it.length) }
+        }
 
-val DEFAULT_MEDIA_SERVERS = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.DEFAULT_MEDIA_SERVERS
+        val fragmentIndex = fullUrl.indexOf('#')
+        if (fragmentIndex > 0) {
+            return supportedFileExtensions.any { fullUrl.startsWith(it, fragmentIndex - it.length) }
+        }
+
+        return supportedFileExtensions.any { fullUrl.endsWith(it) }
+    }
+
+    fun acceptableUrl(
+        url: String,
+        mimeType: String?,
+    ) = blockedUrls.none { url.contains(it) } && ((mimeType != null && mimeTypes.contains(mimeType)) || validExtension(url))
+}

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/util/ZapFormatterNoDecimals.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/util/ZapFormatterNoDecimals.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.util
+
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.text.DecimalFormat
+
+private val dfG = ThreadLocal.withInitial { DecimalFormat("#G") }
+private val dfM = ThreadLocal.withInitial { DecimalFormat("#M") }
+private val dfK = ThreadLocal.withInitial { DecimalFormat("#k") }
+private val dfN = ThreadLocal.withInitial { DecimalFormat("#") }
+
+private val IntOneGiga = BigDecimal(1_000_000_000)
+private val IntOneMega = BigDecimal(1_000_000)
+private val IntTenKilo = BigDecimal(10_000)
+private val IntOneKilo = BigDecimal(1_000)
+
+fun showAmountInteger(amount: BigDecimal?): String {
+    if (amount == null) return ""
+    if (amount.abs() < BigDecimal(0.01)) return ""
+
+    return when {
+        amount >= IntOneGiga -> dfG.get()!!.format(amount.div(IntOneGiga).setScale(0, RoundingMode.HALF_UP))
+        amount >= IntOneMega -> dfM.get()!!.format(amount.div(IntOneMega).setScale(0, RoundingMode.HALF_UP))
+        amount >= IntTenKilo -> dfK.get()!!.format(amount.div(IntOneKilo).setScale(0, RoundingMode.HALF_UP))
+        else -> dfN.get()!!.format(amount)
+    }
+}
+
+fun showAmountInteger(amount: Int?): String {
+    if (amount == null) return "0"
+
+    return showAmountIntegerWithZero(BigDecimal.valueOf(amount.toLong()))
+}
+
+fun showAmountIntegerWithZero(amount: BigDecimal?): String {
+    if (amount == null) return "0"
+    if (amount.abs() < BigDecimal(0.01)) return "0"
+
+    return showAmountInteger(amount)
+}


### PR DESCRIPTION
## Summary

Move platform-independent utilities and data classes from `amethyst/ui/` to the `commons` module for KMP iOS reuse.

### Moved to `commonMain`:
- **ServerName**, **ServerType**, **DEFAULT_MEDIA_SERVERS** — media server configuration data classes
- **StringFeedState** — sealed class for string feed UI states
- **BookmarkType** — simple enum for bookmark categories
- **SupportedContent** — URL/MIME type filtering logic (no platform deps)
- **AdditiveComplexFeedFilter** — extends `FeedFilter` (already in commons)

### Moved to `jvmAndroid`:
- **ZapFormatterNoDecimals** — integer amount formatting (uses `java.text.DecimalFormat`)

### Backwards compatibility
Original locations retain re-exports via typealiases or delegate functions. Consumers in the same package (`StringFeedView`, `StringFeedViewModel`) updated with explicit imports.

### Verification
- `:commons:compileKotlinJvm` ✅
- `:amethyst:compilePlayDebugKotlin` ✅
- `SupportedContentTest` ✅