### PR TITLE
feat: move simple FeedFilters to commons (batch 6)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -267,6 +267,13 @@ class Account(
     override val hiddenWordsCase: List<DualCase> get() = hiddenUsers.flow.value.hiddenWordsCase
     override val hiddenUsersHashCodes: Set<Int> get() = hiddenUsers.flow.value.hiddenUsersHashCodes
     override val spammersHashCodes: Set<Int> get() = hiddenUsers.flow.value.spammersHashCodes
+    override val liveHiddenUsers get() = hiddenUsers.flow.value
+
+    override fun isKnown(user: User): Boolean = user.pubkeyHex in allFollows.flow.value.authors
+
+    override fun isKnown(user: String): Boolean = user in allFollows.flow.value.authors
+
+    override fun pinnedNotesList(): List<Note> = pinState.pinnedNotesList.value
 
     val userMetadata = UserMetadataState(signer, cache, scope, settings)
 
@@ -2272,10 +2279,6 @@ class Account(
     fun isFollowing(user: User): Boolean = user.pubkeyHex in followingKeySet()
 
     fun isFollowing(user: HexKey): Boolean = user in followingKeySet()
-
-    fun isKnown(user: User): Boolean = user.pubkeyHex in allFollows.flow.value.authors
-
-    fun isKnown(user: HexKey): Boolean = user in allFollows.flow.value.authors
 
     private fun hasExcessiveHashtags(note: Note): Boolean {
         val limit = settings.syncedSettings.security.maxHashtagLimit.value

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/default/dal/PinnedNotesFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/default/dal/PinnedNotesFeedFilter.kt
@@ -20,17 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.default.dal
 
-import com.vitorpamplona.amethyst.model.Account
-import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.ui.dal.FeedFilter
-
-class PinnedNotesFeedFilter(
-    val account: Account,
-) : FeedFilter<Note>() {
-    override fun feedKey(): String =
-        account.pinState.pinnedNotesList.value
-            .hashCode()
-            .toString()
-
-    override fun feed(): List<Note> = account.pinState.pinnedNotesList.value
-}
+// Re-export from commons for backwards compatibility
+typealias PinnedNotesFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.dal.PinnedNotesFeedFilter

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/followPacks/feed/dal/FollowPackMembersFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/followPacks/feed/dal/FollowPackMembersFeedFilter.kt
@@ -20,35 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.followPacks.feed.dal
 
-import com.vitorpamplona.amethyst.model.Account
-import com.vitorpamplona.amethyst.model.AddressableNote
-import com.vitorpamplona.amethyst.model.LocalCache.checkGetOrCreateUser
-import com.vitorpamplona.amethyst.model.User
-import com.vitorpamplona.amethyst.ui.dal.FeedFilter
-import com.vitorpamplona.quartz.nip51Lists.followList.FollowListEvent
-
-class FollowPackMembersFeedFilter(
-    val followPackNote: AddressableNote,
-    val account: Account,
-) : FeedFilter<User>() {
-    override fun feedKey(): String = account.userProfile().pubkeyHex + "-" + followPackNote.idHex
-
-    val cache: MutableMap<FollowListEvent, List<User>> = mutableMapOf()
-
-    override fun feed(): List<User> {
-        val followPackEvent = followPackNote.event as? FollowListEvent ?: return emptyList()
-
-        val previousList = cache[followPackEvent]
-        if (previousList != null) return previousList
-
-        val follows =
-            followPackEvent
-                .followIdSet()
-                .mapNotNull { hex -> checkGetOrCreateUser(hex) }
-                .filter { !account.isHidden(it) }
-                .sortedByDescending { account.isKnown(it) }
-
-        cache[followPackEvent] = follows
-        return follows
-    }
-}
+// Re-export from commons for backwards compatibility
+typealias FollowPackMembersFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.dal.FollowPackMembersFeedFilter

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/dal/HiddenAccountsFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/dal/HiddenAccountsFeedFilter.kt
@@ -20,28 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.dal
 
-import com.vitorpamplona.amethyst.model.Account
-import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.model.User
-import com.vitorpamplona.amethyst.ui.dal.FeedFilter
-import com.vitorpamplona.quartz.utils.Log
-import kotlinx.coroutines.CancellationException
-
-class HiddenAccountsFeedFilter(
-    val account: Account,
-) : FeedFilter<User>() {
-    override fun feedKey(): String = account.userProfile().pubkeyHex
-
-    override fun showHiddenKey(): Boolean = true
-
-    override fun feed(): List<User> =
-        account.hiddenUsers.flow.value.hiddenUsers.reversed().mapNotNull {
-            try {
-                LocalCache.getOrCreateUser(it)
-            } catch (e: Exception) {
-                if (e is CancellationException) throw e
-                Log.e("HiddenAccountsFeedFilter") { "Failed to parse key $it" }
-                null
-            }
-        }
-}
+// Re-export from commons for backwards compatibility
+typealias HiddenAccountsFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.dal.HiddenAccountsFeedFilter

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/dal/HiddenAccountsFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/dal/HiddenAccountsFeedViewModel.kt
@@ -27,7 +27,7 @@ import com.vitorpamplona.amethyst.ui.screen.UserFeedViewModel
 
 class HiddenAccountsFeedViewModel(
     val account: Account,
-) : UserFeedViewModel(HiddenAccountsFeedFilter(account)) {
+) : UserFeedViewModel(HiddenAccountsFeedFilter(account, account.cache)) {
     class Factory(
         val account: Account,
     ) : ViewModelProvider.Factory {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/dal/HiddenWordsFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/dal/HiddenWordsFeedFilter.kt
@@ -20,17 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.dal
 
-import com.vitorpamplona.amethyst.model.Account
-import com.vitorpamplona.amethyst.ui.dal.FeedFilter
-
-class HiddenWordsFeedFilter(
-    val account: Account,
-) : FeedFilter<String>() {
-    override fun feedKey(): String = account.userProfile().pubkeyHex
-
-    override fun showHiddenKey(): Boolean = true
-
-    override fun feed(): List<String> =
-        account.hiddenUsers.flow.value.hiddenWords
-            .toList()
-}
+// Re-export from commons for backwards compatibility
+typealias HiddenWordsFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.dal.HiddenWordsFeedFilter

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
@@ -105,6 +105,18 @@ interface IAccount {
     /** Marmot MLS group chat list */
     val marmotGroupList: MarmotGroupList
 
+    /** Current hidden users state (live, from flows) */
+    val liveHiddenUsers: LiveHiddenUsers
+
+    /** Whether the given user is known (followed) by this account */
+    fun isKnown(user: User): Boolean
+
+    /** Whether the given hex key is known (followed) by this account */
+    fun isKnown(user: String): Boolean
+
+    /** Currently pinned notes list */
+    fun pinnedNotesList(): List<Note>
+
     /** Whether a note is acceptable (not hidden, not blocked, etc.) */
     fun isAcceptable(note: Note): Boolean
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/dal/FollowPackMembersFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/dal/FollowPackMembersFeedFilter.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.feeds.dal
+
+import com.vitorpamplona.amethyst.commons.model.AddressableNote
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+import com.vitorpamplona.amethyst.commons.ui.feeds.FeedFilter
+import com.vitorpamplona.quartz.nip51Lists.followList.FollowListEvent
+
+class FollowPackMembersFeedFilter(
+    val followPackNote: AddressableNote,
+    val account: IAccount,
+    val cache: ICacheProvider,
+) : FeedFilter<User>() {
+    override fun feedKey(): String = account.userProfile().pubkeyHex + "-" + followPackNote.idHex
+
+    val localCache: MutableMap<FollowListEvent, List<User>> = mutableMapOf()
+
+    override fun feed(): List<User> {
+        val followPackEvent = followPackNote.event as? FollowListEvent ?: return emptyList()
+
+        val previousList = localCache[followPackEvent]
+        if (previousList != null) return previousList
+
+        val follows =
+            followPackEvent
+                .followIdSet()
+                .mapNotNull { hex -> cache.getOrCreateUser(hex) }
+                .filter { !account.isHidden(it) }
+                .sortedByDescending { account.isKnown(it) }
+
+        localCache[followPackEvent] = follows
+        return follows
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/dal/HiddenAccountsFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/dal/HiddenAccountsFeedFilter.kt
@@ -18,23 +18,31 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.followPacks.feed.dal
+package com.vitorpamplona.amethyst.commons.ui.feeds.dal
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import com.vitorpamplona.amethyst.model.Account
-import com.vitorpamplona.amethyst.model.AddressableNote
-import com.vitorpamplona.amethyst.ui.screen.UserFeedViewModel
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+import com.vitorpamplona.amethyst.commons.ui.feeds.FeedFilter
+import com.vitorpamplona.quartz.utils.Log
+import kotlinx.coroutines.CancellationException
 
-class FollowPackMembersUserFeedViewModel(
-    val followPackNote: AddressableNote,
-    val account: Account,
-) : UserFeedViewModel(FollowPackMembersFeedFilter(followPackNote, account, account.cache)) {
-    class Factory(
-        val followPackNote: AddressableNote,
-        val account: Account,
-    ) : ViewModelProvider.Factory {
-        @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(modelClass: Class<T>): T = FollowPackMembersUserFeedViewModel(followPackNote, account) as T
-    }
+class HiddenAccountsFeedFilter(
+    val account: IAccount,
+    val cache: ICacheProvider,
+) : FeedFilter<User>() {
+    override fun feedKey(): String = account.userProfile().pubkeyHex
+
+    override fun showHiddenKey(): Boolean = true
+
+    override fun feed(): List<User> =
+        account.liveHiddenUsers.hiddenUsers.reversed().mapNotNull {
+            try {
+                cache.getOrCreateUser(it)
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                Log.e("HiddenAccountsFeedFilter") { "Failed to parse key $it" }
+                null
+            }
+        }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/dal/HiddenWordsFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/dal/HiddenWordsFeedFilter.kt
@@ -18,23 +18,19 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.followPacks.feed.dal
+package com.vitorpamplona.amethyst.commons.ui.feeds.dal
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import com.vitorpamplona.amethyst.model.Account
-import com.vitorpamplona.amethyst.model.AddressableNote
-import com.vitorpamplona.amethyst.ui.screen.UserFeedViewModel
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.ui.feeds.FeedFilter
 
-class FollowPackMembersUserFeedViewModel(
-    val followPackNote: AddressableNote,
-    val account: Account,
-) : UserFeedViewModel(FollowPackMembersFeedFilter(followPackNote, account, account.cache)) {
-    class Factory(
-        val followPackNote: AddressableNote,
-        val account: Account,
-    ) : ViewModelProvider.Factory {
-        @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(modelClass: Class<T>): T = FollowPackMembersUserFeedViewModel(followPackNote, account) as T
-    }
+class HiddenWordsFeedFilter(
+    val account: IAccount,
+) : FeedFilter<String>() {
+    override fun feedKey(): String = account.userProfile().pubkeyHex
+
+    override fun showHiddenKey(): Boolean = true
+
+    override fun feed(): List<String> =
+        account.liveHiddenUsers.hiddenWords
+            .toList()
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/dal/PinnedNotesFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/dal/PinnedNotesFeedFilter.kt
@@ -18,23 +18,20 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.followPacks.feed.dal
+package com.vitorpamplona.amethyst.commons.ui.feeds.dal
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import com.vitorpamplona.amethyst.model.Account
-import com.vitorpamplona.amethyst.model.AddressableNote
-import com.vitorpamplona.amethyst.ui.screen.UserFeedViewModel
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.ui.feeds.FeedFilter
 
-class FollowPackMembersUserFeedViewModel(
-    val followPackNote: AddressableNote,
-    val account: Account,
-) : UserFeedViewModel(FollowPackMembersFeedFilter(followPackNote, account, account.cache)) {
-    class Factory(
-        val followPackNote: AddressableNote,
-        val account: Account,
-    ) : ViewModelProvider.Factory {
-        @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(modelClass: Class<T>): T = FollowPackMembersUserFeedViewModel(followPackNote, account) as T
-    }
+class PinnedNotesFeedFilter(
+    val account: IAccount,
+) : FeedFilter<Note>() {
+    override fun feedKey(): String =
+        account
+            .pinnedNotesList()
+            .hashCode()
+            .toString()
+
+    override fun feed(): List<Note> = account.pinnedNotesList()
 }


### PR DESCRIPTION
## Summary

Move 4 simple FeedFilters from amethyst to commons module for KMP iOS migration.

### Moved filters
- **HiddenAccountsFeedFilter** — hidden accounts list display
- **HiddenWordsFeedFilter** — hidden words list display
- **FollowPackMembersFeedFilter** — follow pack member listing
- **PinnedNotesFeedFilter** — pinned notes display

### IAccount additions
- `liveHiddenUsers: LiveHiddenUsers` — current hidden users state from flows
- `isKnown(User): Boolean` / `isKnown(String): Boolean` — follow status check
- `pinnedNotesList(): List<Note>` — current pinned notes

### Approach
- Original files replaced with typealiases for backwards compatibility
- ViewModels updated to pass `ICacheProvider` where needed
- Commons filters use `IAccount` + `ICacheProvider` interfaces instead of concrete `Account`/`LocalCache`

### Not moved (need cache collection infrastructure)
- RelayFeedFilter (needs `notes.filterIntoSet`)
- UserProfileMutualFeedFilter (needs `notes` + `addressables` collections)
- UserProfileAppRecommendationsFeedFilter (needs `mapFlattenIntoSet`)
- WebBookmarkFeedFilter (needs specialized `filterIntoSet` extension)

### Build verification
- `:commons:compileKotlinJvm` ✅
- `:amethyst:compilePlayDebugKotlin` ✅