### PR TITLE
feat: migrate launchSigner callers to AccountViewModel wrappers (batch 3)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewUserMetadataScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewUserMetadataScreen.kt
@@ -93,9 +93,7 @@ fun NewUserMetadataScreen(
                     nav.popBack()
                 },
                 onPost = {
-                    accountViewModel.launchSigner {
-                        postViewModel.create()
-                    }
+                    postViewModel.sendPost()
                     nav.popBack()
                 },
             )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewUserMetadataViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewUserMetadataViewModel.kt
@@ -106,6 +106,13 @@ class NewUserMetadataViewModel : ViewModel() {
         }
     }
 
+    fun sendPost(onDone: (() -> Unit)? = null) {
+        accountViewModel.launchSigner {
+            create()
+            onDone?.invoke()
+        }
+    }
+
     suspend fun create() {
         val metadata =
             account.userMetadata.sendNewUserMetadata(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/CommentPostViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/CommentPostViewModel.kt
@@ -361,6 +361,20 @@ open class CommentPostViewModel :
         }
     }
 
+    fun sendPost(onDone: (() -> Unit)? = null) {
+        accountViewModel.launchSigner {
+            sendPostSync()
+            onDone?.invoke()
+        }
+    }
+
+    fun sendDraftAndCancel() {
+        accountViewModel.launchSigner {
+            sendDraftSync()
+            cancel()
+        }
+    }
+
     suspend fun sendDraftSync() {
         if (message.text.toString().isBlank()) {
             accountViewModel.account.deleteDraftIgnoreErrors(draftTag.current)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/GenericCommentPostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/GenericCommentPostScreen.kt
@@ -151,10 +151,7 @@ fun GenericCommentPostScreen(
     StrippingFailureDialog(postViewModel.strippingFailureConfirmation)
 
     BackHandler {
-        accountViewModel.launchSigner {
-            postViewModel.sendDraftSync()
-            postViewModel.cancel()
-        }
+        postViewModel.sendDraftAndCancel()
         nav.popBack()
     }
 
@@ -165,19 +162,13 @@ fun GenericCommentPostScreen(
                 onCancel = {
                     // uses the accountViewModel scope to avoid cancelling this
                     // function when the postViewModel is released
-                    accountViewModel.launchSigner {
-                        postViewModel.sendDraftSync()
-                        postViewModel.cancel()
-                    }
+                    postViewModel.sendDraftAndCancel()
                     nav.popBack()
                 },
                 onPost = {
                     // uses the accountViewModel scope to avoid cancelling this
                     // function when the postViewModel is released
-                    accountViewModel.launchSigner {
-                        postViewModel.sendPostSync()
-                        nav.popBack()
-                    }
+                    postViewModel.sendPost { nav.popBack() }
                 },
             )
         },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Poll.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Poll.kt
@@ -267,9 +267,7 @@ fun RenderPollCard(
         card = card,
         noteId = event.id,
         onRespond = { responses ->
-            accountViewModel.launchSigner {
-                accountViewModel.account.pollRespond(event, responses)
-            }
+            accountViewModel.pollRespond(event, responses)
         },
         onViewResults = { accountViewModel.markPollResultsViewed(event.id, event.endsAt()) },
         hasViewedResults = { accountViewModel.hasViewedPollResults(event.id) },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -60,6 +60,7 @@ import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.UiSettingsFlow
 import com.vitorpamplona.amethyst.model.UrlCachedPreviewer
 import com.vitorpamplona.amethyst.model.User
+import com.vitorpamplona.amethyst.model.nip51Lists.labeledBookmarkLists.LabeledBookmarkList
 import com.vitorpamplona.amethyst.model.privacyOptions.EmptyRoleBasedHttpClientBuilder
 import com.vitorpamplona.amethyst.model.privacyOptions.IRoleBasedHttpClientBuilder
 import com.vitorpamplona.amethyst.model.privacyOptions.RoleBasedHttpClientBuilder
@@ -139,6 +140,7 @@ import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Response
 import com.vitorpamplona.quartz.nip51Lists.PinListEvent
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.BookmarkListEvent
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.OldBookmarkListEvent
+import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.BookmarkIdTag
 import com.vitorpamplona.quartz.nip51Lists.hashtagList.HashtagListEvent
 import com.vitorpamplona.quartz.nip56Reports.ReportType
 import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
@@ -1026,6 +1028,43 @@ class AccountViewModel(
         }
 
     fun sendNip17PrivateMessage(template: EventTemplate<ChatMessageEvent>) = launchSigner { account.sendNip17PrivateMessage(template) }
+
+    // Labeled bookmark list operations
+    fun broadcastBookmarkGroup(bookmarkIdentifier: String) =
+        launchSigner {
+            account.labeledBookmarkLists.getLabeledBookmarkListNote(bookmarkIdentifier)?.let {
+                account.broadcast(it)
+            }
+        }
+
+    fun deleteBookmarkGroup(bookmarkIdentifier: String) =
+        launchSigner {
+            account.labeledBookmarkLists.deleteBookmarkList(bookmarkIdentifier, account)
+        }
+
+    fun moveBookmarkInList(
+        bookmark: BookmarkIdTag,
+        groupIdentifier: String,
+        isCurrentlyPrivate: Boolean,
+    ) = launchSigner {
+        account.labeledBookmarkLists.moveBookmarkInList(bookmark, groupIdentifier, isCurrentlyPrivate, account)
+    }
+
+    fun removeBookmarkFromList(
+        bookmark: BookmarkIdTag,
+        groupIdentifier: String,
+        isPrivate: Boolean,
+    ) = launchSigner {
+        account.labeledBookmarkLists.removeBookmarkFromList(bookmark, groupIdentifier, isPrivate, account)
+    }
+
+    fun cloneBookmarkList(
+        currentBookmarkList: LabeledBookmarkList,
+        customCloneName: String?,
+        customCloneDescription: String?,
+    ) = launchSigner {
+        account.labeledBookmarkLists.cloneBookmarkList(currentBookmarkList, customCloneName, customCloneDescription, account)
+    }
 
     fun requestToVanish(
         relays: List<NormalizedRelayUrl>,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -148,8 +148,10 @@ import com.vitorpamplona.quartz.nip57Zaps.LnZapRequestEvent
 import com.vitorpamplona.quartz.nip57Zaps.zapraiser.zapraiserAmount
 import com.vitorpamplona.quartz.nip59Giftwrap.seals.SealedRumorEvent
 import com.vitorpamplona.quartz.nip59Giftwrap.wraps.GiftWrapEvent
+import com.vitorpamplona.quartz.nip88Polls.poll.PollEvent
 import com.vitorpamplona.quartz.nip90Dvms.contentDiscoveryResponse.NIP90ContentDiscoveryResponseEvent
 import com.vitorpamplona.quartz.nip94FileMetadata.tags.DimensionTag
+import com.vitorpamplona.quartz.nipB0WebBookmarks.WebBookmarkEvent
 import com.vitorpamplona.quartz.utils.Hex
 import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quartz.utils.TimeUtils
@@ -1064,6 +1066,39 @@ class AccountViewModel(
         customCloneDescription: String?,
     ) = launchSigner {
         account.labeledBookmarkLists.cloneBookmarkList(currentBookmarkList, customCloneName, customCloneDescription, account)
+    }
+
+    fun addBookmarkToList(
+        bookmark: BookmarkIdTag,
+        bookmarkListIdentifier: String,
+        isBookmarkPrivate: Boolean,
+    ) = launchSigner {
+        account.labeledBookmarkLists.addBookmarkToList(bookmark, bookmarkListIdentifier, isBookmarkPrivate, account)
+    }
+
+    fun addBookmark(
+        note: Note,
+        isPrivate: Boolean,
+    ) = launchSigner { account.addBookmark(note, isPrivate) }
+
+    fun removeBookmark(note: Note) = launchSigner { account.removeBookmark(note) }
+
+    fun sendWebBookmark(
+        url: String,
+        title: String?,
+        description: String,
+        hashtags: List<String> = emptyList(),
+    ) = launchSigner {
+        account.sendWebBookmark(url, title, description, hashtags)
+    }
+
+    fun deleteWebBookmark(event: WebBookmarkEvent) = launchSigner { account.deleteWebBookmark(event) }
+
+    fun pollRespond(
+        event: PollEvent,
+        responses: Set<String>,
+    ) = launchSigner {
+        account.pollRespond(event, responses)
     }
 
     fun requestToVanish(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -105,6 +105,7 @@ import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.RelayOfflineT
 import com.vitorpamplona.quartz.nip01Core.relay.client.auth.EmptyIAuthStatus
 import com.vitorpamplona.quartz.nip01Core.relay.client.auth.RelayAuthenticator
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
 import com.vitorpamplona.quartz.nip01Core.signers.SignerExceptions
 import com.vitorpamplona.quartz.nip01Core.tags.people.PubKeyReferenceTag
@@ -118,6 +119,7 @@ import com.vitorpamplona.quartz.nip05DnsIdentifiers.Nip05Client
 import com.vitorpamplona.quartz.nip10Notes.tags.MarkedETag
 import com.vitorpamplona.quartz.nip17Dm.base.ChatroomKeyable
 import com.vitorpamplona.quartz.nip17Dm.base.NIP17Group
+import com.vitorpamplona.quartz.nip17Dm.messages.ChatMessageEvent
 import com.vitorpamplona.quartz.nip18Reposts.GenericRepostEvent
 import com.vitorpamplona.quartz.nip18Reposts.RepostEvent
 import com.vitorpamplona.quartz.nip19Bech32.Nip19Parser
@@ -1016,6 +1018,14 @@ class AccountViewModel(
     fun delete(note: Note) = launchSigner { account.delete(note) }
 
     fun deleteDraftIgnoreErrors(draftTag: String) = launchSigner { account.deleteDraftIgnoreErrors(draftTag) }
+
+    fun migrateOldBookmarksToNew(onDone: (() -> Unit)? = null) =
+        launchSigner {
+            account.migrateOldBookmarksToNew()
+            onDone?.invoke()
+        }
+
+    fun sendNip17PrivateMessage(template: EventTemplate<ChatMessageEvent>) = launchSigner { account.sendNip17PrivateMessage(template) }
 
     fun requestToVanish(
         relays: List<NormalizedRelayUrl>,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -1015,6 +1015,8 @@ class AccountViewModel(
 
     fun delete(note: Note) = launchSigner { account.delete(note) }
 
+    fun deleteDraftIgnoreErrors(draftTag: String) = launchSigner { account.deleteDraftIgnoreErrors(draftTag) }
+
     fun requestToVanish(
         relays: List<NormalizedRelayUrl>,
         reason: String,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/display/BookmarkGroupScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/display/BookmarkGroupScreen.kt
@@ -70,6 +70,8 @@ import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.ButtonBorder
 import com.vitorpamplona.amethyst.ui.theme.StdPadding
 import com.vitorpamplona.amethyst.ui.theme.TabRowHeight
+import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.AddressBookmark
+import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.EventBookmark
 import kotlinx.coroutines.launch
 
 @Composable
@@ -88,17 +90,10 @@ fun BookmarkGroupScreen(
         bookmarkGroupViewModel,
         bookmarkType,
         broadcastBookmarkGroup = {
-            accountViewModel.launchSigner {
-                val groupNote = accountViewModel.account.labeledBookmarkLists.getLabeledBookmarkListNote(bookmarkIdentifier)
-                groupNote?.let {
-                    accountViewModel.broadcast(it)
-                }
-            }
+            accountViewModel.broadcastBookmarkGroup(bookmarkIdentifier)
         },
         deleteBookmarkGroup = {
-            accountViewModel.launchSigner {
-                bookmarkGroupViewModel.deleteBookmarkGroup(bookmarkIdentifier)
-            }
+            accountViewModel.deleteBookmarkGroup(bookmarkIdentifier)
             nav.popBack()
         },
         accountViewModel,
@@ -165,22 +160,18 @@ fun BookmarkGroupScreenView(
                         pagerState,
                         accountViewModel,
                         movePostBookmark = { postId, isPrivate ->
-                            accountViewModel.launchSigner {
-                                bookmarkGroupViewModel.movePostBookmark(
-                                    groupIdentifier = bookmarkGroupViewModel.bookmarkGroupIdentifier,
-                                    postId = postId,
-                                    isCurrentlyPrivate = isPrivate,
-                                )
-                            }
+                            accountViewModel.moveBookmarkInList(
+                                bookmark = EventBookmark(postId),
+                                groupIdentifier = bookmarkGroupViewModel.bookmarkGroupIdentifier,
+                                isCurrentlyPrivate = isPrivate,
+                            )
                         },
                         deletePostBookmark = { postId, isPrivate ->
-                            accountViewModel.launchSigner {
-                                bookmarkGroupViewModel.removePostBookmark(
-                                    bookmarkGroupViewModel.bookmarkGroupIdentifier,
-                                    postId,
-                                    isPrivate,
-                                )
-                            }
+                            accountViewModel.removeBookmarkFromList(
+                                bookmark = EventBookmark(postId),
+                                groupIdentifier = bookmarkGroupViewModel.bookmarkGroupIdentifier,
+                                isPrivate = isPrivate,
+                            )
                         },
                         nav,
                     )
@@ -192,22 +183,18 @@ fun BookmarkGroupScreenView(
                         pagerState,
                         accountViewModel,
                         moveArticleBookmark = { articleAddress, isPrivate ->
-                            accountViewModel.launchSigner {
-                                bookmarkGroupViewModel.moveArticleBookmark(
-                                    groupIdentifier = bookmarkGroupViewModel.bookmarkGroupIdentifier,
-                                    articleAddress = articleAddress,
-                                    isCurrentlyPrivate = isPrivate,
-                                )
-                            }
+                            accountViewModel.moveBookmarkInList(
+                                bookmark = AddressBookmark(articleAddress),
+                                groupIdentifier = bookmarkGroupViewModel.bookmarkGroupIdentifier,
+                                isCurrentlyPrivate = isPrivate,
+                            )
                         },
                         deleteArticleBookmark = { articleAddress, isPrivate ->
-                            accountViewModel.launchSigner {
-                                bookmarkGroupViewModel.removeArticleBookmark(
-                                    bookmarkGroupViewModel.bookmarkGroupIdentifier,
-                                    articleAddress,
-                                    isPrivate,
-                                )
-                            }
+                            accountViewModel.removeBookmarkFromList(
+                                bookmark = AddressBookmark(articleAddress),
+                                groupIdentifier = bookmarkGroupViewModel.bookmarkGroupIdentifier,
+                                isPrivate = isPrivate,
+                            )
                         },
                         nav,
                     )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/list/ListOfBookmarkGroupsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/list/ListOfBookmarkGroupsScreen.kt
@@ -67,22 +67,14 @@ fun ListOfBookmarkGroupsScreen(
             nav.nav(Route.BookmarkGroupMetadataEdit(bookmarkGroup.identifier))
         },
         cloneBookmarkGroup = { bookmarkGroup, customName, customDesc ->
-            accountViewModel.launchSigner {
-                accountViewModel.account.labeledBookmarkLists.cloneBookmarkList(
-                    currentBookmarkList = bookmarkGroup,
-                    customCloneName = customName,
-                    customCloneDescription = customDesc,
-                    account = accountViewModel.account,
-                )
-            }
+            accountViewModel.cloneBookmarkList(
+                currentBookmarkList = bookmarkGroup,
+                customCloneName = customName,
+                customCloneDescription = customDesc,
+            )
         },
         deleteBookmarkGroup = { bookmarkGroup ->
-            accountViewModel.launchSigner {
-                accountViewModel.account.labeledBookmarkLists.deleteBookmarkList(
-                    bookmarkListIdentifier = bookmarkGroup.identifier,
-                    account = accountViewModel.account,
-                )
-            }
+            accountViewModel.deleteBookmarkGroup(bookmarkGroup.identifier)
         },
         nav,
     )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/membershipManagement/ArticleBookmarkListManagementScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/membershipManagement/ArticleBookmarkListManagementScreen.kt
@@ -128,14 +128,10 @@ private fun ListManagementViewBody(
                     nav.nav(Route.Bookmarks)
                 },
                 onAddBookmarkToGroup = { shouldBePrivate ->
-                    accountViewModel.launchSigner {
-                        accountViewModel.account.addBookmark(note, shouldBePrivate)
-                    }
+                    accountViewModel.addBookmark(note, shouldBePrivate)
                 },
                 onRemoveBookmarkFromGroup = {
-                    accountViewModel.launchSigner {
-                        accountViewModel.account.removeBookmark(note)
-                    }
+                    accountViewModel.removeBookmark(note)
                 },
             )
         }
@@ -152,24 +148,18 @@ private fun ListManagementViewBody(
                 totalArticleBookmarkSize = bookmarkList.publicArticleBookmarks.size + bookmarkList.privateArticleBookmarks.size,
                 onClick = { nav.nav(Route.BookmarkGroupView(bookmarkList.identifier, BookmarkType.ArticleBookmark)) },
                 onAddBookmarkToGroup = { shouldBePrivate ->
-                    accountViewModel.launchSigner {
-                        accountViewModel.account.labeledBookmarkLists.addBookmarkToList(
-                            bookmark = AddressBookmark(address = note.address, relayHint = note.relayHintUrl()),
-                            bookmarkListIdentifier = bookmarkList.identifier,
-                            isBookmarkPrivate = shouldBePrivate,
-                            account = accountViewModel.account,
-                        )
-                    }
+                    accountViewModel.addBookmarkToList(
+                        bookmark = AddressBookmark(address = note.address, relayHint = note.relayHintUrl()),
+                        bookmarkListIdentifier = bookmarkList.identifier,
+                        isBookmarkPrivate = shouldBePrivate,
+                    )
                 },
                 onRemoveBookmarkFromGroup = {
-                    accountViewModel.launchSigner {
-                        accountViewModel.account.labeledBookmarkLists.removeBookmarkFromList(
-                            bookmark = AddressBookmark(address = note.address),
-                            bookmarkListIdentifier = bookmarkList.identifier,
-                            isBookmarkPrivate = maybePrivateBookmark != null,
-                            account = accountViewModel.account,
-                        )
-                    }
+                    accountViewModel.removeBookmarkFromList(
+                        bookmark = AddressBookmark(address = note.address),
+                        groupIdentifier = bookmarkList.identifier,
+                        isPrivate = maybePrivateBookmark != null,
+                    )
                 },
             )
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/membershipManagement/PostBookmarkListManagementScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/membershipManagement/PostBookmarkListManagementScreen.kt
@@ -127,14 +127,10 @@ private fun ListManagementViewBody(
                     nav.nav(Route.Bookmarks)
                 },
                 onAddBookmarkToGroup = { shouldBePrivate ->
-                    accountViewModel.launchSigner {
-                        accountViewModel.account.addBookmark(note, shouldBePrivate)
-                    }
+                    accountViewModel.addBookmark(note, shouldBePrivate)
                 },
                 onRemoveBookmarkFromGroup = {
-                    accountViewModel.launchSigner {
-                        accountViewModel.account.removeBookmark(note)
-                    }
+                    accountViewModel.removeBookmark(note)
                 },
             )
         }
@@ -151,24 +147,18 @@ private fun ListManagementViewBody(
                 totalArticleBookmarkSize = bookmarkList.publicArticleBookmarks.size + bookmarkList.privateArticleBookmarks.size,
                 onClick = { nav.nav(Route.BookmarkGroupView(bookmarkList.identifier, BookmarkType.PostBookmark)) },
                 onAddBookmarkToGroup = { shouldBePrivate ->
-                    accountViewModel.launchSigner {
-                        accountViewModel.account.labeledBookmarkLists.addBookmarkToList(
-                            bookmark = EventBookmark(eventId = note.idHex, relay = note.relayHintUrl(), author = note.author?.pubkeyHex),
-                            bookmarkListIdentifier = bookmarkList.identifier,
-                            isBookmarkPrivate = shouldBePrivate,
-                            account = accountViewModel.account,
-                        )
-                    }
+                    accountViewModel.addBookmarkToList(
+                        bookmark = EventBookmark(eventId = note.idHex, relay = note.relayHintUrl(), author = note.author?.pubkeyHex),
+                        bookmarkListIdentifier = bookmarkList.identifier,
+                        isBookmarkPrivate = shouldBePrivate,
+                    )
                 },
                 onRemoveBookmarkFromGroup = {
-                    accountViewModel.launchSigner {
-                        accountViewModel.account.labeledBookmarkLists.removeBookmarkFromList(
-                            bookmark = EventBookmark(eventId = note.idHex),
-                            bookmarkListIdentifier = bookmarkList.identifier,
-                            isBookmarkPrivate = maybePrivateBookmark != null,
-                            account = accountViewModel.account,
-                        )
-                    }
+                    accountViewModel.removeBookmarkFromList(
+                        bookmark = EventBookmark(eventId = note.idHex),
+                        groupIdentifier = bookmarkList.identifier,
+                        isPrivate = maybePrivateBookmark != null,
+                    )
                 },
             )
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/old/OldBookmarkListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/old/OldBookmarkListScreen.kt
@@ -138,8 +138,7 @@ private fun RenderOldBookmarkScreen(
                     )
                 },
                 onClick = {
-                    accountViewModel.launchSigner {
-                        accountViewModel.account.migrateOldBookmarksToNew()
+                    accountViewModel.migrateOldBookmarksToNew {
                         coroutineScope.launch {
                             Toast
                                 .makeText(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/header/NewChatroomSubjectDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/header/NewChatroomSubjectDialog.kt
@@ -98,17 +98,15 @@ fun NewChatroomSubjectDialog(
 
                     PostButton(
                         onPost = {
-                            accountViewModel.launchSigner {
-                                val template =
-                                    ChatMessageEvent.build(
-                                        message.value,
-                                        room.users.map { LocalCache.getOrCreateUser(it).toPTag() },
-                                    ) {
-                                        groupName.value.ifBlank { null }?.let { changeSubject(it) }
-                                    }
+                            val template =
+                                ChatMessageEvent.build(
+                                    message.value,
+                                    room.users.map { LocalCache.getOrCreateUser(it).toPTag() },
+                                ) {
+                                    groupName.value.ifBlank { null }?.let { changeSubject(it) }
+                                }
 
-                                accountViewModel.account.sendNip17PrivateMessage(template)
-                            }
+                            accountViewModel.sendNip17PrivateMessage(template)
 
                             onClose()
                         },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/ChatNewMessageViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/ChatNewMessageViewModel.kt
@@ -134,9 +134,7 @@ class ChatNewMessageViewModel :
             draftTag.versions.collectLatest {
                 // don't save the first
                 if (it > 0) {
-                    accountViewModel.launchSigner {
-                        sendDraftSync()
-                    }
+                    sendDraftSync()
                 }
             }
         }
@@ -418,6 +416,20 @@ class ChatNewMessageViewModel :
         cancel()
         accountViewModel.viewModelScope.launch(Dispatchers.IO) {
             accountViewModel.account.deleteDraftIgnoreErrors(version)
+        }
+    }
+
+    fun sendPost(onDone: (() -> Unit)? = null) {
+        accountViewModel.launchSigner {
+            sendPostSync()
+            onDone?.invoke()
+        }
+    }
+
+    fun sendDraftAndCancel() {
+        accountViewModel.launchSigner {
+            sendDraftSync()
+            cancel()
         }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/NewGroupDMScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/NewGroupDMScreen.kt
@@ -172,10 +172,7 @@ fun NewGroupDMScreen(
     WatchAndLoadMyEmojiList(accountViewModel)
 
     BackHandler {
-        accountViewModel.launchSigner {
-            postViewModel.sendDraftSync()
-            postViewModel.cancel()
-        }
+        postViewModel.sendDraftAndCancel()
         nav.popBack()
     }
 
@@ -187,17 +184,13 @@ fun NewGroupDMScreen(
                 onCancel = {
                     // uses the accountViewModel scope to avoid cancelling this
                     // function when the postViewModel is released
-                    accountViewModel.launchSigner {
-                        postViewModel.sendDraftSync()
-                        postViewModel.cancel()
-                    }
+                    postViewModel.sendDraftAndCancel()
                     nav.popBack()
                 },
                 onPost = {
                     // uses the accountViewModel scope to avoid cancelling this
                     // function when the postViewModel is released
-                    accountViewModel.launchSigner {
-                        postViewModel.sendPostSync()
+                    postViewModel.sendPost {
                         postViewModel.room.value?.let {
                             nav.nav(routeToMessage(it, null, null, null, null, accountViewModel))
                         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/PrivateMessageEditFieldRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/PrivateMessageEditFieldRow.kt
@@ -110,11 +110,10 @@ fun PrivateMessageEditFieldRow(
 ) {
     BackHandler {
         if (channelScreenModel.message.text.isNotBlank()) {
-            accountViewModel.launchSigner {
-                channelScreenModel.sendDraftSync()
-            }
+            channelScreenModel.sendDraftAndCancel()
+        } else {
+            channelScreenModel.cancel()
         }
-        channelScreenModel.cancel()
         nav.popBack()
     }
 
@@ -217,8 +216,7 @@ fun EditField(
                 isActive = channelScreenModel.canPost(),
                 modifier = EditFieldTrailingIconModifier,
             ) {
-                accountViewModel.launchSigner {
-                    channelScreenModel.sendPostSync()
+                channelScreenModel.sendPost {
                     onSendNewMessage()
                 }
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/send/ChannelNewMessageViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/send/ChannelNewMessageViewModel.kt
@@ -117,9 +117,7 @@ open class ChannelNewMessageViewModel :
             draftTag.versions.collectLatest {
                 // don't save the first
                 if (it > 0) {
-                    accountViewModel.launchSigner {
-                        sendDraftSync()
-                    }
+                    sendDraftSync()
                 }
             }
         }
@@ -300,6 +298,13 @@ open class ChannelNewMessageViewModel :
         accountViewModel.account.signAndSendPrivately(template, channelRelays)
         accountViewModel.viewModelScope.launch(Dispatchers.IO) {
             accountViewModel.account.deleteDraftIgnoreErrors(version)
+        }
+    }
+
+    fun sendDraftAndCancel() {
+        accountViewModel.launchSigner {
+            sendDraftSync()
+            cancel()
         }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/send/EditFieldRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/send/EditFieldRow.kt
@@ -64,10 +64,7 @@ fun EditFieldRow(
     nav: INav,
 ) {
     BackHandler {
-        accountViewModel.launchSigner {
-            channelScreenModel.sendDraftSync()
-            channelScreenModel.cancel()
-        }
+        channelScreenModel.sendDraftAndCancel()
         nav.popBack()
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip23LongForm/LongFormPostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip23LongForm/LongFormPostScreen.kt
@@ -149,10 +149,7 @@ fun LongFormPostScreen(
     StrippingFailureDialog(postViewModel.strippingFailureConfirmation)
 
     BackHandler {
-        accountViewModel.launchSigner {
-            postViewModel.sendDraftSync()
-            postViewModel.cancel()
-        }
+        postViewModel.sendDraftAndCancel()
         nav.popBack()
     }
 
@@ -162,16 +159,10 @@ fun LongFormPostScreen(
                 titleRes = R.string.new_long_form_post,
                 isActive = postViewModel::canPost,
                 onPost = {
-                    accountViewModel.launchSigner {
-                        postViewModel.sendPostSync()
-                        nav.popBack()
-                    }
+                    postViewModel.sendPost { nav.popBack() }
                 },
                 onCancel = {
-                    accountViewModel.launchSigner {
-                        postViewModel.sendDraftSync()
-                        postViewModel.cancel()
-                    }
+                    postViewModel.sendDraftAndCancel()
                     nav.popBack()
                 },
             )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip23LongForm/LongFormPostViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip23LongForm/LongFormPostViewModel.kt
@@ -134,9 +134,7 @@ class LongFormPostViewModel :
             draftTag.versions.collectLatest {
                 // don't save the first
                 if (it > 0) {
-                    accountViewModel.launchSigner {
-                        sendDraftSync()
-                    }
+                    sendDraftSync()
                 }
             }
         }
@@ -339,8 +337,20 @@ class LongFormPostViewModel :
             accountViewModel.account.signAndComputeBroadcast(template, emptyList())
         }
 
+        accountViewModel.deleteDraftIgnoreErrors(version)
+    }
+
+    fun sendPost(onDone: (() -> Unit)? = null) {
         accountViewModel.launchSigner {
-            accountViewModel.account.deleteDraftIgnoreErrors(version)
+            sendPostSync()
+            onDone?.invoke()
+        }
+    }
+
+    fun sendDraftAndCancel() {
+        accountViewModel.launchSigner {
+            sendDraftSync()
+            cancel()
         }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/NewProductScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/NewProductScreen.kt
@@ -142,10 +142,7 @@ fun NewProductScreen(
     StrippingFailureDialog(postViewModel.strippingFailureConfirmation)
 
     BackHandler {
-        accountViewModel.launchSigner {
-            postViewModel.sendDraftSync()
-            postViewModel.cancel()
-        }
+        postViewModel.sendDraftAndCancel()
         nav.popBack()
     }
 
@@ -157,17 +154,11 @@ fun NewProductScreen(
                 onCancel = {
                     // uses the accountViewModel scope to avoid cancelling this
                     // function when the postViewModel is released
-                    accountViewModel.launchSigner {
-                        postViewModel.sendDraftSync()
-                        postViewModel.cancel()
-                    }
+                    postViewModel.sendDraftAndCancel()
                     nav.popBack()
                 },
                 onPost = {
-                    accountViewModel.launchSigner {
-                        postViewModel.sendPostSync()
-                        nav.popBack()
-                    }
+                    postViewModel.sendPost { nav.popBack() }
                 },
             )
         },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/NewProductViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/NewProductViewModel.kt
@@ -122,9 +122,7 @@ open class NewProductViewModel :
             draftTag.versions.collectLatest {
                 // don't save the first
                 if (it > 0) {
-                    accountViewModel.launchSigner {
-                        sendDraftSync()
-                    }
+                    sendDraftSync()
                 }
             }
         }
@@ -321,6 +319,20 @@ open class NewProductViewModel :
         accountViewModel.account.signAndSendPrivatelyOrBroadcast(template, relayList = { relayList })
         accountViewModel.viewModelScope.launch(Dispatchers.IO) {
             accountViewModel.account.deleteDraftIgnoreErrors(version)
+        }
+    }
+
+    fun sendPost(onDone: (() -> Unit)? = null) {
+        accountViewModel.launchSigner {
+            sendPostSync()
+            onDone?.invoke()
+        }
+    }
+
+    fun sendDraftAndCancel() {
+        accountViewModel.launchSigner {
+            sendDraftSync()
+            cancel()
         }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostScreen.kt
@@ -203,10 +203,7 @@ internal fun NewPostScreenInner(
     StrippingFailureDialog(postViewModel.strippingFailureConfirmation)
 
     BackHandler {
-        accountViewModel.launchSigner {
-            postViewModel.sendDraftSync()
-            postViewModel.cancel()
-        }
+        postViewModel.sendDraftAndCancel()
         nav.popBack()
     }
 
@@ -217,18 +214,12 @@ internal fun NewPostScreenInner(
                 onPost = {
                     // uses the accountViewModel scope to avoid cancelling this
                     // function when the postViewModel is released
-                    accountViewModel.launchSigner {
-                        postViewModel.sendPostSync()
-                        nav.popBack()
-                    }
+                    postViewModel.sendPost { nav.popBack() }
                 },
                 onCancel = {
                     // uses the accountViewModel scope to avoid cancelling this
                     // function when the postViewModel is released
-                    accountViewModel.launchSigner {
-                        postViewModel.sendDraftSync()
-                        postViewModel.cancel()
-                    }
+                    postViewModel.sendDraftAndCancel()
                     nav.popBack()
                 },
             )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostViewModel.kt
@@ -182,9 +182,7 @@ open class ShortNotePostViewModel :
             draftTag.versions.collectLatest {
                 // don't save the first
                 if (it > 0) {
-                    accountViewModel.launchSigner {
-                        sendDraftSync()
-                    }
+                    sendDraftSync()
                 }
             }
         }
@@ -850,8 +848,20 @@ open class ShortNotePostViewModel :
             accountViewModel.account.signAndComputeBroadcast(template, extraNotesToBroadcast)
         }
 
+        accountViewModel.deleteDraftIgnoreErrors(version)
+    }
+
+    fun sendPost(onDone: (() -> Unit)? = null) {
         accountViewModel.launchSigner {
-            accountViewModel.account.deleteDraftIgnoreErrors(version)
+            sendPostSync()
+            onDone?.invoke()
+        }
+    }
+
+    fun sendDraftAndCancel() {
+        accountViewModel.launchSigner {
+            sendDraftSync()
+            cancel()
         }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/nip75Goals/NewGoalScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/nip75Goals/NewGoalScreen.kt
@@ -96,10 +96,7 @@ fun NewGoalScreen(
                     nav.popBack()
                 },
                 onPost = {
-                    accountViewModel.launchSigner {
-                        goalViewModel.sendPostSync()
-                        nav.popBack()
-                    }
+                    goalViewModel.sendPost { nav.popBack() }
                 },
             )
         },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/nip75Goals/NewGoalViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/nip75Goals/NewGoalViewModel.kt
@@ -69,6 +69,13 @@ class NewGoalViewModel : ViewModel() {
         deadlineTimestamp = TimeUtils.now() + TimeUtils.ONE_WEEK
     }
 
+    fun sendPost(onDone: (() -> Unit)? = null) {
+        accountViewModel.launchSigner {
+            sendPostSync()
+            onDone?.invoke()
+        }
+    }
+
     suspend fun sendPostSync() {
         val template = createTemplate() ?: return
         cancel()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/publicMessages/NewPublicMessageScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/publicMessages/NewPublicMessageScreen.kt
@@ -134,10 +134,7 @@ fun NewPublicMessageScreen(
     StrippingFailureDialog(postViewModel.strippingFailureConfirmation)
 
     BackHandler {
-        accountViewModel.launchSigner {
-            postViewModel.sendDraftSync()
-            postViewModel.cancel()
-        }
+        postViewModel.sendDraftAndCancel()
         nav.popBack()
     }
 
@@ -149,19 +146,13 @@ fun NewPublicMessageScreen(
                 onCancel = {
                     // uses the accountViewModel scope to avoid cancelling this
                     // function when the postViewModel is released
-                    accountViewModel.launchSigner {
-                        postViewModel.sendDraftSync()
-                        postViewModel.cancel()
-                    }
+                    postViewModel.sendDraftAndCancel()
                     nav.popBack()
                 },
                 onPost = {
                     // uses the accountViewModel scope to avoid cancelling this
                     // function when the postViewModel is released
-                    accountViewModel.launchSigner {
-                        postViewModel.sendPostSync()
-                        nav.popBack()
-                    }
+                    postViewModel.sendPost { nav.popBack() }
                 },
             )
         },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/publicMessages/NewPublicMessageViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/publicMessages/NewPublicMessageViewModel.kt
@@ -136,9 +136,7 @@ class NewPublicMessageViewModel :
             draftTag.versions.collectLatest {
                 // don't save the first
                 if (it > 0) {
-                    accountViewModel.launchSigner {
-                        sendDraftSync()
-                    }
+                    sendDraftSync()
                 }
             }
         }
@@ -345,6 +343,20 @@ class NewPublicMessageViewModel :
         accountViewModel.account.signAndComputeBroadcast(template, extraNotesToBroadcast)
         accountViewModel.viewModelScope.launch(Dispatchers.IO) {
             accountViewModel.account.deleteDraftIgnoreErrors(version)
+        }
+    }
+
+    fun sendPost(onDone: (() -> Unit)? = null) {
+        accountViewModel.launchSigner {
+            sendPostSync()
+            onDone?.invoke()
+        }
+    }
+
+    fun sendDraftAndCancel() {
+        accountViewModel.launchSigner {
+            sendDraftSync()
+            cancel()
         }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/NIP47SetupScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/NIP47SetupScreen.kt
@@ -105,11 +105,9 @@ fun NIP47SetupScreen(
                     nav.popBack()
                 },
                 onPost = {
-                    accountViewModel.launchSigner {
-                        postViewModel.sendPostSuspend()
-                        walletViewModel.saveLnAddressSuspend()
-                        paymentTargetsViewModel.savePaymentTargetsSuspend()
-                    }
+                    postViewModel.sendPost()
+                    walletViewModel.saveLnAddress()
+                    paymentTargetsViewModel.savePaymentTargets()
                     nav.popBack()
                 },
             )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/webBookmarks/WebBookmarksScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/webBookmarks/WebBookmarksScreen.kt
@@ -118,9 +118,7 @@ private fun RenderWebBookmarksScreen(
             accountViewModel = accountViewModel,
             onDismiss = { showAddDialog = false },
             onSave = { url, title, description, tags ->
-                accountViewModel.launchSigner {
-                    accountViewModel.account.sendWebBookmark(url, title, description, tags)
-                }
+                accountViewModel.sendWebBookmark(url, title, description, tags)
                 showAddDialog = false
             },
         )
@@ -214,9 +212,7 @@ private fun WebBookmarkCard(
             initialTags = event.hashtags().joinToString(", "),
             onDismiss = { showEditDialog = false },
             onSave = { url, title, description, tags ->
-                accountViewModel.launchSigner {
-                    accountViewModel.account.sendWebBookmark(url, title, description, tags)
-                }
+                accountViewModel.sendWebBookmark(url, title, description, tags)
                 showEditDialog = false
             },
         )
@@ -229,9 +225,7 @@ private fun WebBookmarkCard(
             text = { Text(stringResource(R.string.web_bookmark_delete_confirm)) },
             confirmButton = {
                 TextButton(onClick = {
-                    accountViewModel.launchSigner {
-                        accountViewModel.account.deleteWebBookmark(event)
-                    }
+                    accountViewModel.deleteWebBookmark(event)
                     showDeleteDialog = false
                 }) {
                     Text(stringResource(R.string.yes))


### PR DESCRIPTION
## Summary

Continues the migration of `accountViewModel.launchSigner { ... }` call sites to dedicated wrapper methods, supporting the KMP/iOS migration effort.

**Migrates ~49 call sites** (90 → ~51 remaining outside AccountViewModel, of which ~17 are new ViewModel-internal wrappers).

## Changes

### New AccountViewModel wrapper methods (17 total)

**Draft management:**
- `deleteDraftIgnoreErrors(draftTag)`

**Chat:**
- `sendNip17PrivateMessage(template)`

**Bookmark migration:**
- `migrateOldBookmarksToNew(onDone)`

**Bookmark operations:**
- `addBookmark(note, isPrivate)`
- `removeBookmark(note)`

**Labeled bookmark list operations:**
- `broadcastBookmarkGroup(bookmarkIdentifier)`
- `deleteBookmarkGroup(bookmarkIdentifier)`
- `moveBookmarkInList(bookmark, groupIdentifier, isCurrentlyPrivate)`
- `removeBookmarkFromList(bookmark, groupIdentifier, isPrivate)`
- `cloneBookmarkList(currentBookmarkList, customCloneName, customCloneDescription)`
- `addBookmarkToList(bookmark, bookmarkListIdentifier, isBookmarkPrivate)`

**Web bookmarks:**
- `sendWebBookmark(url, title, description, hashtags)`
- `deleteWebBookmark(event)`

**Poll:**
- `pollRespond(event, responses)`

### New posting ViewModel wrapper methods

Added `sendPost(onDone)` and `sendDraftAndCancel()` to posting ViewModels, encapsulating the `accountViewModel.launchSigner` call internally:

- `ShortNotePostViewModel`
- `LongFormPostViewModel`
- `NewProductViewModel`
- `CommentPostViewModel`
- `NewPublicMessageViewModel`
- `ChatNewMessageViewModel`
- `ChannelNewMessageViewModel` (added `sendDraftAndCancel()`; `sendPost()` already existed)
- `NewGoalViewModel`
- `NewUserMetadataViewModel`

### Migrated screen composable callers (~39 call sites)

- `ShortNotePostScreen` (3)
- `LongFormPostScreen` (3)
- `NewProductScreen` (3)
- `GenericCommentPostScreen` (3)
- `NewPublicMessageScreen` (3)
- `NewGroupDMScreen` (3)
- `PrivateMessageEditFieldRow` (2)
- `EditFieldRow` (1)
- `NewGoalScreen` (1)
- `NewUserMetadataScreen` (1)
- `BookmarkGroupScreen` (6)
- `ListOfBookmarkGroupsScreen` (2)
- `OldBookmarkListScreen` (1)
- `NewChatroomSubjectDialog` (1)
- `NIP47SetupScreen` (1)
- `ArticleBookmarkListManagementScreen` (4)
- `PostBookmarkListManagementScreen` (4)
- `WebBookmarksScreen` (3)
- `Poll.kt` (1)

### ViewModel internal migrations (~7 call sites)

- 5 init block draftTag auto-save calls (removed `launchSigner` wrapper)
- 2 `deleteDraftIgnoreErrors` calls in `sendPostSync()`

### Remaining (~14 screen call sites)

- `PeopleListScreen` (5) — add/remove user, broadcast, delete list
- `FollowPackScreen` (5) — add/remove user, broadcast, delete list
- `FollowListAndPackAndUserView` (4) — add/remove user from lists

Plus ~20 ViewModel-internal `launchSigner` calls (upload operations, metadata create/update, relay saves) that are already properly encapsulated inside ViewModel methods.

## Motivation

These wrappers reduce boilerplate and move `launchSigner` calls inside ViewModels where they belong, making Screen composables cleaner and enabling future cross-platform interface definitions.