### PR TITLE
feat: move DiscoverChat and DiscoverLive FeedFilters to commons (batch 10)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -271,8 +271,8 @@ object LocalCache : ILocalCache, ICacheProvider {
     val addressables = LargeSoftCache<Address, AddressableNote>()
 
     val chatroomList = LargeCache<HexKey, ChatroomList>()
-    val publicChatChannels = LargeCache<HexKey, PublicChatChannel>()
-    val liveChatChannels = LargeCache<Address, LiveActivitiesChannel>()
+    override val publicChatChannels = LargeCache<HexKey, PublicChatChannel>()
+    override val liveChatChannels = LargeCache<Address, LiveActivitiesChannel>()
     val ephemeralChannels = LargeCache<RoomId, EphemeralChatChannel>()
 
     val paymentTracker = NwcPaymentTracker()
@@ -420,13 +420,13 @@ object LocalCache : ILocalCache, ICacheProvider {
 
     fun getAddressableNoteIfExists(key: String): AddressableNote? = Address.parse(key)?.let { addressables.get(it) }
 
-    fun getAddressableNoteIfExists(address: Address): AddressableNote? = addressables.get(address)
+    override fun getAddressableNoteIfExists(address: Address): AddressableNote? = addressables.get(address)
 
     override fun getNoteIfExists(hexKey: String): Note? = if (hexKey.length == 64) notes.get(hexKey) else Address.parse(hexKey)?.let { addressables.get(it) }
 
     fun getNoteIfExists(key: ETag): Note? = notes.get(key.eventId)
 
-    fun getPublicChatChannelIfExists(key: String): PublicChatChannel? = publicChatChannels.get(key)
+    override fun getPublicChatChannelIfExists(key: String): PublicChatChannel? = publicChatChannels.get(key)
 
     fun getEphemeralChatChannelIfExists(key: RoomId): EphemeralChatChannel? = ephemeralChannels.get(key)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/FilterByListParams.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/FilterByListParams.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.ui.dal
 
 import com.vitorpamplona.amethyst.commons.model.LiveHiddenUsers
+import com.vitorpamplona.amethyst.commons.ui.feeds.IFilterByListParams
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.global.GlobalTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.muted.MutedAuthorsByOutboxTopNavFilter
@@ -36,11 +37,11 @@ import com.vitorpamplona.quartz.nip51Lists.peopleList.PeopleListEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 class FilterByListParams(
-    val isHiddenList: Boolean,
+    override val isHiddenList: Boolean,
     val followLists: IFeedTopNavFilter?,
     val hiddenLists: LiveHiddenUsers,
     val now: Long = TimeUtils.oneMinuteFromNow(),
-) {
+) : IFilterByListParams {
     fun isNotHidden(userHex: String) = !(hiddenLists.hiddenUsers.contains(userHex) || hiddenLists.spammers.contains(userHex))
 
     fun isNotInTheFuture(noteEvent: Event) = noteEvent.createdAt <= now
@@ -79,7 +80,7 @@ class FilterByListParams(
         }
     }
 
-    fun match(
+    override fun match(
         noteEvent: Event,
         comingFrom: List<NormalizedRelayUrl>,
     ) = (applyTopFilter(comingFrom, noteEvent)) &&

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip28Chats/DiscoverChatFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip28Chats/DiscoverChatFeedFilter.kt
@@ -22,110 +22,28 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.discover.nip28Chats
 
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.TopFilter
-import com.vitorpamplona.amethyst.ui.dal.AdditiveFeedFilter
 import com.vitorpamplona.amethyst.ui.dal.FilterByListParams
-import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelCreateEvent
-import com.vitorpamplona.quartz.nip28PublicChat.base.IsInPublicChatChannel
 
-open class DiscoverChatFeedFilter(
-    val account: Account,
-) : AdditiveFeedFilter<Note>() {
-    override fun feedKey(): String = account.userProfile().pubkeyHex + "-" + followList().code
-
-    override fun limit() = 100
-
-    open fun followList(): TopFilter = account.settings.defaultDiscoveryFollowList.value
-
-    fun TopFilter.isMuteList() = this is TopFilter.MuteList
-
-    fun TopFilter.isBlockList() = this is TopFilter.PeopleList && this.address == account.blockPeopleList.getBlockListAddress()
-
-    fun TopFilter.wantsToSeeNegativeStuff() = isMuteList() || isBlockList()
-
-    override fun showHiddenKey(): Boolean = followList().wantsToSeeNegativeStuff()
-
-    override fun feed(): List<Note> {
-        val params = buildFilterParams(account)
-
-        val allChannelNotes =
-            LocalCache.publicChatChannels.mapNotNullIntoSet { _, channel ->
-                val note = LocalCache.getNoteIfExists(channel.idHex)
-                val noteEvent = note?.event
-
-                if (noteEvent == null || params.match(noteEvent, note.relays)) {
-                    note
-                } else {
-                    null
-                }
-            }
-
-        return sort(allChannelNotes)
-    }
-
-    override fun applyFilter(newItems: Set<Note>): Set<Note> = innerApplyFilter(newItems)
-
-    fun buildFilterParams(account: Account): FilterByListParams =
-        FilterByListParams.create(
-            followLists = account.liveDiscoveryFollowLists.value,
-            hiddenUsers = account.hiddenUsers.flow.value,
-        )
-
-    protected open fun innerApplyFilter(collection: Collection<Note>): Set<Note> {
-        val params = buildFilterParams(account)
-
-        return collection.mapNotNullTo(HashSet()) { note ->
-            // note event here will never be null
-            val noteEvent = note.event
-            if (noteEvent is ChannelCreateEvent && params.match(noteEvent, note.relays)) {
-                if ((LocalCache.getPublicChatChannelIfExists(noteEvent.id)?.notes?.size() ?: 0) > 0) {
-                    note
-                } else {
-                    null
-                }
-            } else if (noteEvent is IsInPublicChatChannel) {
-                val channel = noteEvent.channelId()?.let { LocalCache.checkGetOrCreateNote(it) }
-                val channelEvent = channel?.event
-
-                if (channel != null &&
-                    (channelEvent == null || (channelEvent is ChannelCreateEvent && params.match(channelEvent, note.relays)))
-                ) {
-                    if ((LocalCache.getPublicChatChannelIfExists(channel.idHex)?.notes?.size() ?: 0) > 0) {
-                        channel
-                    } else {
-                        null
-                    }
-                } else {
-                    null
-                }
-            } else {
-                null
-            }
-        }
-    }
-
-    override fun sort(items: Set<Note>): List<Note> {
-        // precache to avoid breaking the contract
-        val lastNote =
-            items.associateWith { note ->
-                LocalCache.getPublicChatChannelIfExists(note.idHex)?.lastNote?.createdAt() ?: 0L
-            }
-
-        val createdNote =
-            items.associateWith { note ->
-                note.createdAt() ?: 0L
-            }
-
-        val comparator: Comparator<Note> =
-            compareByDescending<Note> {
-                lastNote[it]
-            }.thenByDescending {
-                createdNote[it]
-            }.thenBy {
-                it.idHex
-            }
-
-        return items.sortedWith(comparator)
-    }
-}
+/**
+ * App-specific wrapper that creates a [DiscoverChatFeedFilter][com.vitorpamplona.amethyst.commons.ui.feeds.DiscoverChatFeedFilter]
+ * with Account-specific configuration.
+ */
+@Suppress("ktlint:standard:function-naming")
+fun DiscoverChatFeedFilter(account: Account) =
+    com.vitorpamplona.amethyst.commons.ui.feeds.DiscoverChatFeedFilter(
+        userPubkeyHex = account.userProfile().pubkeyHex,
+        followListCode = { account.settings.defaultDiscoveryFollowList.value.code },
+        showHidden = {
+            val fl = account.settings.defaultDiscoveryFollowList.value
+            fl is TopFilter.MuteList ||
+                (fl is TopFilter.PeopleList && fl.address == account.blockPeopleList.getBlockListAddress())
+        },
+        filterParamsFactory = {
+            FilterByListParams.create(
+                followLists = account.liveDiscoveryFollowLists.value,
+                hiddenUsers = account.hiddenUsers.flow.value,
+            )
+        },
+        cacheProvider = LocalCache,
+    )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip53LiveActivities/DiscoverLiveFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip53LiveActivities/DiscoverLiveFeedFilter.kt
@@ -20,10 +20,9 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.discover.nip53LiveActivities
 
+import com.vitorpamplona.amethyst.commons.ui.feeds.IOnlineChecker
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.model.ParticipantListBuilder
 import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.allFollows.AllFollowsByOutboxTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.allFollows.AllFollowsByProxyTopNavFilter
@@ -33,142 +32,54 @@ import com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.community.SingleCo
 import com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.muted.MutedAuthorsByOutboxTopNavFilter
 import com.vitorpamplona.amethyst.model.topNavFeeds.noteBased.muted.MutedAuthorsByProxyTopNavFilter
 import com.vitorpamplona.amethyst.service.OnlineChecker
-import com.vitorpamplona.amethyst.ui.dal.AdditiveFeedFilter
 import com.vitorpamplona.amethyst.ui.dal.FilterByListParams
-import com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.MeetingRoomEvent
-import com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.MeetingSpaceEvent
-import com.vitorpamplona.quartz.nip53LiveActivities.streaming.LiveActivitiesEvent
-import com.vitorpamplona.quartz.nip53LiveActivities.streaming.tags.StatusTag
 
-open class DiscoverLiveFeedFilter(
-    val account: Account,
-) : AdditiveFeedFilter<Note>() {
-    override fun feedKey(): String = account.userProfile().pubkeyHex + "-" + followList().code
+/**
+ * Adapter that makes [OnlineChecker] available as [IOnlineChecker] for commons.
+ */
+private object OnlineCheckerAdapter : IOnlineChecker {
+    override fun isCachedAndOffline(url: String?): Boolean = OnlineChecker.isCachedAndOffline(url)
+}
 
-    override fun limit() = 50
-
-    open fun followList(): TopFilter = account.settings.defaultDiscoveryFollowList.value
-
-    fun TopFilter.isMuteList() = this is TopFilter.MuteList
-
-    fun TopFilter.isBlockList() = this is TopFilter.PeopleList && this.address == account.blockPeopleList.getBlockListAddress()
-
-    fun TopFilter.wantsToSeeNegativeStuff() = isMuteList() || isBlockList()
-
-    override fun showHiddenKey(): Boolean = followList().wantsToSeeNegativeStuff()
-
-    override fun feed(): List<Note> {
-        val allChannelNotes = LocalCache.liveChatChannels.mapNotNull { _, channel -> LocalCache.getAddressableNoteIfExists(channel.address) }
-        val allMessageNotes = LocalCache.liveChatChannels.map { _, channel -> channel.notes.filter { key, it -> it.event is LiveActivitiesEvent } }.flatten()
-
-        val notes = innerApplyFilter(allChannelNotes + allMessageNotes)
-
-        return sort(notes)
+/**
+ * Extracts the authors set from the discovery top filter, if available.
+ */
+private fun extractDiscoveryAuthors(account: Account): Set<String>? {
+    val topFilter = account.liveDiscoveryFollowLists.value
+    return when (topFilter) {
+        is AuthorsByOutboxTopNavFilter -> topFilter.authors
+        is MutedAuthorsByOutboxTopNavFilter -> topFilter.authors
+        is AllFollowsByOutboxTopNavFilter -> topFilter.authors
+        is SingleCommunityTopNavFilter -> topFilter.authors
+        is AuthorsByProxyTopNavFilter -> topFilter.authors
+        is MutedAuthorsByProxyTopNavFilter -> topFilter.authors
+        is AllFollowsByProxyTopNavFilter -> topFilter.authors
+        else -> null
     }
+}
 
-    override fun applyFilter(newItems: Set<Note>): Set<Note> = innerApplyFilter(newItems)
-
-    protected open fun innerApplyFilter(collection: Collection<Note>): Set<Note> {
-        val filterParams =
+/**
+ * App-specific wrapper that creates a [DiscoverLiveFeedFilter][com.vitorpamplona.amethyst.commons.ui.feeds.DiscoverLiveFeedFilter]
+ * with Account-specific configuration.
+ */
+@Suppress("ktlint:standard:function-naming")
+fun DiscoverLiveFeedFilter(account: Account) =
+    com.vitorpamplona.amethyst.commons.ui.feeds.DiscoverLiveFeedFilter(
+        userPubkeyHex = account.userProfile().pubkeyHex,
+        followListCode = { account.settings.defaultDiscoveryFollowList.value.code },
+        showHidden = {
+            val fl = account.settings.defaultDiscoveryFollowList.value
+            fl is TopFilter.MuteList ||
+                (fl is TopFilter.PeopleList && fl.address == account.blockPeopleList.getBlockListAddress())
+        },
+        filterParamsFactory = {
             FilterByListParams.create(
                 followLists = account.liveDiscoveryFollowLists.value,
                 hiddenUsers = account.hiddenUsers.flow.value,
             )
-
-        return collection.filterTo(HashSet()) {
-            val noteEvent = it.event
-            (noteEvent is LiveActivitiesEvent || noteEvent is MeetingSpaceEvent || noteEvent is MeetingRoomEvent) &&
-                filterParams.match(noteEvent, it.relays)
-        }
-    }
-
-    override fun sort(items: Set<Note>): List<Note> {
-        val topFilter = account.liveDiscoveryFollowLists.value
-        val discoveryTopFilterAuthors =
-            when (topFilter) {
-                is AuthorsByOutboxTopNavFilter -> topFilter.authors
-                is MutedAuthorsByOutboxTopNavFilter -> topFilter.authors
-                is AllFollowsByOutboxTopNavFilter -> topFilter.authors
-                is SingleCommunityTopNavFilter -> topFilter.authors
-                is AuthorsByProxyTopNavFilter -> topFilter.authors
-                is MutedAuthorsByProxyTopNavFilter -> topFilter.authors
-                is AllFollowsByProxyTopNavFilter -> topFilter.authors
-                else -> null
-            }
-
-        val followingKeySet =
-            discoveryTopFilterAuthors ?: account.kind3FollowList.flow.value.authors
-
-        val counter = ParticipantListBuilder()
-        val participantCounts =
-            items.associate { it to counter.countFollowsThatParticipateOn(it, followingKeySet) }
-
-        val allParticipants =
-            items.associate { it to counter.countFollowsThatParticipateOn(it, null) }
-
-        return items
-            .sortedWith(
-                compareBy(
-                    { convertStatusToOrder(it.event) },
-                    { participantCounts[it] },
-                    { allParticipants[it] },
-                    {
-                        when (val e = it.event) {
-                            is LiveActivitiesEvent -> e.starts() ?: it.createdAt()
-                            is MeetingRoomEvent -> e.starts() ?: it.createdAt()
-                            else -> it.createdAt()
-                        }
-                    },
-                    { it.idHex },
-                ),
-            ).reversed()
-    }
-
-    fun convertStatusToOrder(event: com.vitorpamplona.quartz.nip01Core.core.Event?): Int {
-        if (event == null) return 0
-        return when (event) {
-            is LiveActivitiesEvent -> {
-                val url = event.streaming() ?: return 0
-                when (event.status()) {
-                    StatusTag.STATUS.LIVE -> {
-                        if (OnlineChecker.isCachedAndOffline(url)) 0 else 2
-                    }
-
-                    StatusTag.STATUS.PLANNED -> {
-                        1
-                    }
-
-                    StatusTag.STATUS.ENDED -> {
-                        0
-                    }
-
-                    else -> {
-                        0
-                    }
-                }
-            }
-
-            is MeetingRoomEvent -> {
-                when (event.status()) {
-                    StatusTag.STATUS.LIVE -> 2
-                    StatusTag.STATUS.PLANNED -> 1
-                    StatusTag.STATUS.ENDED -> 0
-                    else -> 0
-                }
-            }
-
-            is MeetingSpaceEvent -> {
-                when (event.status()) {
-                    com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.tags.StatusTag.STATUS.OPEN -> 2
-                    com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.tags.StatusTag.STATUS.PRIVATE -> 1
-                    com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.tags.StatusTag.STATUS.CLOSED -> 0
-                    else -> 0
-                }
-            }
-
-            else -> {
-                0
-            }
-        }
-    }
-}
+        },
+        followingKeySet = { account.kind3FollowList.flow.value.authors },
+        discoveryAuthors = { extractDiscoveryAuthors(account) },
+        onlineChecker = OnlineCheckerAdapter,
+        cacheProvider = LocalCache,
+    )

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/cache/ICacheProvider.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/cache/ICacheProvider.kt
@@ -24,9 +24,12 @@ import com.vitorpamplona.amethyst.commons.model.AddressableNote
 import com.vitorpamplona.amethyst.commons.model.Channel
 import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatChannel
+import com.vitorpamplona.amethyst.commons.model.nip53LiveActivities.LiveActivitiesChannel
 import com.vitorpamplona.quartz.nip01Core.core.Address
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.utils.cache.ICacheOperations
 
 /**
  * Cache provider interface for accessing cached Notes, Users, and Channels.
@@ -135,4 +138,32 @@ interface ICacheProvider {
     fun getOrCreateUser(pubkey: HexKey): User?
 
     fun justConsumeMyOwnEvent(event: Event): Boolean
+
+    /**
+     * Public chat channels cache.
+     * Used by discover feed filters to iterate over channels.
+     */
+    val publicChatChannels: ICacheOperations<HexKey, PublicChatChannel>
+
+    /**
+     * Live activity channels cache.
+     * Used by discover feed filters to iterate over channels.
+     */
+    val liveChatChannels: ICacheOperations<Address, LiveActivitiesChannel>
+
+    /**
+     * Gets a PublicChatChannel if it exists in cache.
+     *
+     * @param key The channel's ID in hex format
+     * @return The PublicChatChannel if exists, null otherwise
+     */
+    fun getPublicChatChannelIfExists(key: String): PublicChatChannel?
+
+    /**
+     * Gets an AddressableNote if it exists in cache.
+     *
+     * @param address The addressable note's address
+     * @return The AddressableNote if exists, null otherwise
+     */
+    fun getAddressableNoteIfExists(address: Address): AddressableNote?
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/DiscoverChatFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/DiscoverChatFeedFilter.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.feeds
+
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelCreateEvent
+import com.vitorpamplona.quartz.nip28PublicChat.base.IsInPublicChatChannel
+
+/**
+ * Feed filter for discovering public chat channels (NIP-28).
+ *
+ * Lists public chat channels filtered by the user's selected discovery follow list.
+ * Channels are sorted by last activity (most recent first).
+ *
+ * @param userPubkeyHex The current user's public key hex
+ * @param followListCode Provider for the current follow list code (for feed key)
+ * @param showHidden Provider for whether to show hidden content
+ * @param filterParamsFactory Factory to create filter parameters from the current account state
+ * @param cacheProvider The cache provider for accessing channels and notes
+ */
+open class DiscoverChatFeedFilter(
+    val userPubkeyHex: String,
+    val followListCode: () -> String,
+    val showHidden: () -> Boolean,
+    val filterParamsFactory: () -> IFilterByListParams,
+    val cacheProvider: ICacheProvider,
+) : AdditiveFeedFilter<Note>() {
+    override fun feedKey(): String = userPubkeyHex + "-" + followListCode()
+
+    override fun limit() = 100
+
+    override fun showHiddenKey(): Boolean = showHidden()
+
+    override fun feed(): List<Note> {
+        val params = filterParamsFactory()
+
+        val allChannelNotes =
+            cacheProvider.publicChatChannels.mapNotNullIntoSet { _, channel ->
+                val note = cacheProvider.getNoteIfExists(channel.idHex)
+                val noteEvent = note?.event
+
+                if (noteEvent == null || params.match(noteEvent, note.relays)) {
+                    note
+                } else {
+                    null
+                }
+            }
+
+        return sort(allChannelNotes)
+    }
+
+    override fun applyFilter(newItems: Set<Note>): Set<Note> = innerApplyFilter(newItems)
+
+    protected open fun innerApplyFilter(collection: Collection<Note>): Set<Note> {
+        val params = filterParamsFactory()
+
+        return collection.mapNotNullTo(HashSet()) { note ->
+            // note event here will never be null
+            val noteEvent = note.event
+            if (noteEvent is ChannelCreateEvent && params.match(noteEvent, note.relays)) {
+                if ((cacheProvider.getPublicChatChannelIfExists(noteEvent.id)?.notes?.size() ?: 0) > 0) {
+                    note
+                } else {
+                    null
+                }
+            } else if (noteEvent is IsInPublicChatChannel) {
+                val channel = noteEvent.channelId()?.let { cacheProvider.checkGetOrCreateNote(it) }
+                val channelEvent = channel?.event
+
+                if (channel != null &&
+                    (channelEvent == null || (channelEvent is ChannelCreateEvent && params.match(channelEvent, note.relays)))
+                ) {
+                    if ((cacheProvider.getPublicChatChannelIfExists(channel.idHex)?.notes?.size() ?: 0) > 0) {
+                        channel
+                    } else {
+                        null
+                    }
+                } else {
+                    null
+                }
+            } else {
+                null
+            }
+        }
+    }
+
+    override fun sort(items: Set<Note>): List<Note> {
+        // precache to avoid breaking the contract
+        val lastNote =
+            items.associateWith { note ->
+                cacheProvider.getPublicChatChannelIfExists(note.idHex)?.lastNote?.createdAt() ?: 0L
+            }
+
+        val createdNote =
+            items.associateWith { note ->
+                note.createdAt() ?: 0L
+            }
+
+        val comparator: Comparator<Note> =
+            compareByDescending<Note> {
+                lastNote[it]
+            }.thenByDescending {
+                createdNote[it]
+            }.thenBy {
+                it.idHex
+            }
+
+        return items.sortedWith(comparator)
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/DiscoverLiveFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/DiscoverLiveFeedFilter.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.feeds
+
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.MeetingRoomEvent
+import com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.MeetingSpaceEvent
+import com.vitorpamplona.quartz.nip53LiveActivities.streaming.LiveActivitiesEvent
+import com.vitorpamplona.quartz.nip53LiveActivities.streaming.tags.StatusTag
+
+/**
+ * Feed filter for discovering live activities (NIP-53).
+ *
+ * Lists live streaming activities and meeting spaces, sorted by status
+ * (live > planned > ended) and participant count.
+ *
+ * @param userPubkeyHex The current user's public key hex
+ * @param followListCode Provider for the current follow list code (for feed key)
+ * @param showHidden Provider for whether to show hidden content
+ * @param filterParamsFactory Factory to create filter parameters from the current account state
+ * @param followingKeySet Provider for the set of followed user pubkeys
+ * @param discoveryAuthors Provider for the set of authors from the discovery filter (may be null for default)
+ * @param onlineChecker Checker for whether streaming URLs are online
+ * @param cacheProvider The cache provider for accessing channels and notes
+ */
+open class DiscoverLiveFeedFilter(
+    val userPubkeyHex: String,
+    val followListCode: () -> String,
+    val showHidden: () -> Boolean,
+    val filterParamsFactory: () -> IFilterByListParams,
+    val followingKeySet: () -> Set<HexKey>,
+    val discoveryAuthors: () -> Set<HexKey>?,
+    val onlineChecker: IOnlineChecker,
+    val cacheProvider: ICacheProvider,
+) : AdditiveFeedFilter<Note>() {
+    override fun feedKey(): String = userPubkeyHex + "-" + followListCode()
+
+    override fun limit() = 50
+
+    override fun showHiddenKey(): Boolean = showHidden()
+
+    override fun feed(): List<Note> {
+        val allChannelNotes = cacheProvider.liveChatChannels.mapNotNull { _, channel -> cacheProvider.getAddressableNoteIfExists(channel.address) }
+        val allMessageNotes = cacheProvider.liveChatChannels.map { _, channel -> channel.notes.filter { key, it -> it.event is LiveActivitiesEvent } }.flatten()
+
+        val notes = innerApplyFilter(allChannelNotes + allMessageNotes)
+
+        return sort(notes)
+    }
+
+    override fun applyFilter(newItems: Set<Note>): Set<Note> = innerApplyFilter(newItems)
+
+    protected open fun innerApplyFilter(collection: Collection<Note>): Set<Note> {
+        val filterParams = filterParamsFactory()
+
+        return collection.filterTo(HashSet()) {
+            val noteEvent = it.event
+            (noteEvent is LiveActivitiesEvent || noteEvent is MeetingSpaceEvent || noteEvent is MeetingRoomEvent) &&
+                filterParams.match(noteEvent, it.relays)
+        }
+    }
+
+    override fun sort(items: Set<Note>): List<Note> {
+        val followingKeySetValue =
+            discoveryAuthors() ?: followingKeySet()
+
+        val counter = ParticipantListBuilder(cacheProvider)
+        val participantCounts =
+            items.associate { it to counter.countFollowsThatParticipateOn(it, followingKeySetValue) }
+
+        val allParticipants =
+            items.associate { it to counter.countFollowsThatParticipateOn(it, null) }
+
+        return items
+            .sortedWith(
+                compareBy(
+                    { convertStatusToOrder(it.event) },
+                    { participantCounts[it] },
+                    { allParticipants[it] },
+                    {
+                        when (val e = it.event) {
+                            is LiveActivitiesEvent -> e.starts() ?: it.createdAt()
+                            is MeetingRoomEvent -> e.starts() ?: it.createdAt()
+                            else -> it.createdAt()
+                        }
+                    },
+                    { it.idHex },
+                ),
+            ).reversed()
+    }
+
+    fun convertStatusToOrder(event: com.vitorpamplona.quartz.nip01Core.core.Event?): Int {
+        if (event == null) return 0
+        return when (event) {
+            is LiveActivitiesEvent -> {
+                val url = event.streaming() ?: return 0
+                when (event.status()) {
+                    StatusTag.STATUS.LIVE -> {
+                        if (onlineChecker.isCachedAndOffline(url)) 0 else 2
+                    }
+
+                    StatusTag.STATUS.PLANNED -> {
+                        1
+                    }
+
+                    StatusTag.STATUS.ENDED -> {
+                        0
+                    }
+
+                    else -> {
+                        0
+                    }
+                }
+            }
+
+            is MeetingRoomEvent -> {
+                when (event.status()) {
+                    StatusTag.STATUS.LIVE -> 2
+                    StatusTag.STATUS.PLANNED -> 1
+                    StatusTag.STATUS.ENDED -> 0
+                    else -> 0
+                }
+            }
+
+            is MeetingSpaceEvent -> {
+                when (event.status()) {
+                    com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.tags.StatusTag.STATUS.OPEN -> 2
+                    com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.tags.StatusTag.STATUS.PRIVATE -> 1
+                    com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.tags.StatusTag.STATUS.CLOSED -> 0
+                    else -> 0
+                }
+            }
+
+            else -> {
+                0
+            }
+        }
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/IFilterByListParams.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/IFilterByListParams.kt
@@ -18,13 +18,29 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model
+package com.vitorpamplona.amethyst.commons.ui.feeds
+
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 
 /**
- * Convenience constructor that creates a ParticipantListBuilder
- * backed by [LocalCache] for backward compatibility.
+ * Interface for filter parameters used by feed filters.
+ * Abstracts the filtering logic so feed filters in commons
+ * don't depend on app-specific TopNavFilter implementations.
  */
-@Suppress("ktlint:standard:function-naming")
-fun ParticipantListBuilder() =
-    com.vitorpamplona.amethyst.commons.ui.feeds
-        .ParticipantListBuilder(LocalCache)
+interface IFilterByListParams {
+    /** Whether this is a hidden/mute list (affects visibility logic) */
+    val isHiddenList: Boolean
+
+    /**
+     * Matches an event against the filter criteria.
+     *
+     * @param noteEvent The event to match
+     * @param comingFrom The relay URLs the event came from
+     * @return true if the event matches the filter
+     */
+    fun match(
+        noteEvent: Event,
+        comingFrom: List<NormalizedRelayUrl>,
+    ): Boolean
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/IOnlineChecker.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/IOnlineChecker.kt
@@ -18,13 +18,17 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.model
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
 /**
- * Convenience constructor that creates a ParticipantListBuilder
- * backed by [LocalCache] for backward compatibility.
+ * Interface for checking whether a streaming URL is online.
+ * Used by DiscoverLiveFeedFilter for sorting live activities.
+ * Platform-specific implementations handle the actual HTTP checks.
  */
-@Suppress("ktlint:standard:function-naming")
-fun ParticipantListBuilder() =
-    com.vitorpamplona.amethyst.commons.ui.feeds
-        .ParticipantListBuilder(LocalCache)
+interface IOnlineChecker {
+    /**
+     * Returns true if the URL has been checked and found offline.
+     * Returns false if the URL is online, unchecked, or null.
+     */
+    fun isCachedAndOffline(url: String?): Boolean
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/ParticipantListBuilder.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/ParticipantListBuilder.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.feeds
+
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+
+class ParticipantListBuilder(
+    val cacheProvider: ICacheProvider,
+) {
+    private fun addFollowsThatDirectlyParticipateOnToSet(
+        baseNote: Note,
+        followingSet: Set<HexKey>?,
+        set: MutableSet<User>,
+    ) {
+        baseNote.author?.let { author ->
+            if (author !in set && (followingSet == null || author.pubkeyHex in followingSet)) {
+                set.add(author)
+            }
+        }
+
+        // Breaks these searchers down to avoid the memory use of creating multiple lists
+        baseNote.replies.forEach { reply ->
+            reply.author?.let { author ->
+                if (author !in set && (followingSet == null || author.pubkeyHex in followingSet)) {
+                    set.add(author)
+                }
+            }
+        }
+
+        baseNote.boosts.forEach { boost ->
+            boost.author?.let { author ->
+                if (author !in set && (followingSet == null || author.pubkeyHex in followingSet)) {
+                    set.add(author)
+                }
+            }
+        }
+
+        baseNote.zaps.forEach { zapPair ->
+            zapPair.key.author?.let { author ->
+                if (author !in set && (followingSet == null || author.pubkeyHex in followingSet)) {
+                    set.add(author)
+                }
+            }
+        }
+
+        baseNote.reactions.forEach { reactionSet ->
+            reactionSet.value.forEach { reaction ->
+                reaction.author?.let { author ->
+                    if (author !in set && (followingSet == null || author.pubkeyHex in followingSet)) {
+                        set.add(author)
+                    }
+                }
+            }
+        }
+    }
+
+    fun followsThatParticipateOnDirect(
+        baseNote: Note?,
+        followingSet: Set<HexKey>?,
+    ): Set<User> {
+        if (baseNote == null) return mutableSetOf()
+
+        val set = mutableSetOf<User>()
+        addFollowsThatDirectlyParticipateOnToSet(baseNote, followingSet, set)
+        return set
+    }
+
+    fun followsThatParticipateOn(
+        baseNote: Note?,
+        followingSet: Set<HexKey>?,
+    ): Set<User> {
+        if (baseNote == null) return mutableSetOf()
+
+        val mySet = mutableSetOf<User>()
+        addFollowsThatDirectlyParticipateOnToSet(baseNote, followingSet, mySet)
+
+        baseNote.replies.forEach { addFollowsThatDirectlyParticipateOnToSet(it, followingSet, mySet) }
+
+        baseNote.boosts.forEach {
+            it.replyTo?.forEach { addFollowsThatDirectlyParticipateOnToSet(it, followingSet, mySet) }
+        }
+
+        cacheProvider.getPublicChatChannelIfExists(baseNote.idHex)?.notes?.forEach { key, it ->
+            addFollowsThatDirectlyParticipateOnToSet(it, followingSet, mySet)
+        }
+
+        return mySet
+    }
+
+    fun countFollowsThatParticipateOn(
+        baseNote: Note?,
+        followingSet: Set<HexKey>?,
+    ): Int {
+        if (baseNote == null) return 0
+
+        val list = followsThatParticipateOn(baseNote, followingSet)
+
+        return list.size
+    }
+}


### PR DESCRIPTION
## Summary

Move **DiscoverChatFeedFilter** and **DiscoverLiveFeedFilter** from the app module to commons, decoupling them from Android-specific singletons (LocalCache, OnlineChecker).

## What changed

### New interfaces in commons
- **`IFilterByListParams`** — abstracts filter-matching logic so commons filters don't depend on app-specific TopNavFilter hierarchy
- **`IOnlineChecker`** — abstracts stream online-status checking (Android uses OkHttp + LruCache)

### Moved to commons
- **`DiscoverChatFeedFilter`** — discovers NIP-28 public chat channels, now takes functional parameters for account-specific config
- **`DiscoverLiveFeedFilter`** — discovers NIP-53 live activities, now takes functional parameters plus IOnlineChecker
- **`ParticipantListBuilder`** — counts follows participating on notes, now takes ICacheProvider instead of using LocalCache directly

### ICacheProvider extensions
Added 4 new members:
- `publicChatChannels: ICacheOperations<HexKey, PublicChatChannel>`
- `liveChatChannels: ICacheOperations<Address, LiveActivitiesChannel>`
- `getPublicChatChannelIfExists(key: String): PublicChatChannel?`
- `getAddressableNoteIfExists(address: Address): AddressableNote?`

### App-side changes
- **FilterByListParams** now implements `IFilterByListParams`
- **LocalCache** properties/methods marked `override` for new interface members
- Original filter files become thin factory functions that wire Account state to commons constructors
- **ParticipantListBuilder** in app becomes a factory function defaulting to LocalCache

## Build verification
- `:commons:compileKotlinJvm` ✅
- `:amethyst:compilePlayDebugKotlin` ✅