### PR TITLE
feat: migrate launchSigner from UI to ViewModels in lists directory

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -1913,6 +1913,46 @@ class AccountViewModel(
             }
     }
 
+    // --- People List / Follow Pack helpers for UI ---
+
+    fun removeUserFromPeopleList(
+        user: User,
+        isPrivate: Boolean,
+        identifierTag: String,
+    ) {
+        launchSigner {
+            account.peopleLists.removeUserFromSet(user, isPrivate, identifierTag, account)
+        }
+    }
+
+    fun addUserToPeopleList(
+        user: User,
+        identifierTag: String,
+        isPrivate: Boolean,
+    ) {
+        launchSigner {
+            account.peopleLists.addUserToSet(user, identifierTag, isPrivate, account)
+        }
+    }
+
+    fun removeUserFromFollowPack(
+        user: User,
+        identifierTag: String,
+    ) {
+        launchSigner {
+            account.followLists.removeUserFromSet(user, identifierTag, account)
+        }
+    }
+
+    fun addUserToFollowPack(
+        user: User,
+        identifierTag: String,
+    ) {
+        launchSigner {
+            account.followLists.addUserToSet(user, identifierTag, account)
+        }
+    }
+
     val bechLinkCache = CachedLoadedBechLink(this)
 
     class CachedLoadedBechLink(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/lists/PeopleListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/lists/PeopleListScreen.kt
@@ -223,9 +223,7 @@ private fun ListViewAndEditColumn(
             pagerState = pagerState,
             modifier = Modifier.weight(1f),
             onDeleteUser = { user, isPrivate ->
-                accountViewModel.launchSigner {
-                    viewModel.removeUserFromSet(user, isPrivate)
-                }
+                viewModel.removeUser(user, isPrivate)
             },
             accountViewModel = accountViewModel,
             nav = nav,
@@ -247,14 +245,10 @@ private fun RenderAddUserFieldAndSuggestions(
             viewModel.hasUserFlow(user, pagerState.currentPage == 1)
         },
         addUserToSet = { user ->
-            accountViewModel.launchSigner {
-                viewModel.addUserToSet(user, pagerState.currentPage == 1)
-            }
+            viewModel.addUser(user, pagerState.currentPage == 1)
         },
         removeUserFromSet = { user ->
-            accountViewModel.launchSigner {
-                viewModel.removeUserFromSet(user, pagerState.currentPage == 1)
-            }
+            viewModel.removeUser(user, pagerState.currentPage == 1)
         },
         accountViewModel = accountViewModel,
     )
@@ -382,16 +376,10 @@ private fun ListActionsMenuButton(
             nav.nav { Route.PeopleListMetadataEdit(viewModel.selectedDTag.value) }
         },
         onBroadcastList = {
-            accountViewModel.launchSigner {
-                viewModel.loadNote()?.let { updatedSetNote ->
-                    accountViewModel.broadcast(updatedSetNote)
-                }
-            }
+            viewModel.broadcastList()
         },
         onDeleteList = {
-            accountViewModel.launchSigner {
-                viewModel.deleteFollowSet()
-            }
+            viewModel.deleteList()
             nav.popBack()
         },
     )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/lists/PeopleListViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/lists/PeopleListViewModel.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.flow.transformLatest
 @Stable
 class PeopleListViewModel : ViewModel() {
     lateinit var account: Account
+    lateinit var accountViewModel: AccountViewModel
     lateinit var userSuggestions: UserSuggestionState
 
     var userSuggestionFocus by mutableStateOf<UserSuggestionState?>(null)
@@ -72,6 +73,7 @@ class PeopleListViewModel : ViewModel() {
     ) {
         if (!this::account.isInitialized || this.account != accountVM.account) {
             this.account = accountVM.account
+            this.accountViewModel = accountVM
             this.userSuggestions = UserSuggestionState(accountVM.account, accountVM.nip05ClientBuilder())
         }
 
@@ -96,6 +98,38 @@ class PeopleListViewModel : ViewModel() {
         isPrivate: Boolean,
     ) {
         account.peopleLists.addUserToSet(user, selectedDTag.value, isPrivate, account)
+    }
+
+    fun removeUser(
+        user: User,
+        isPrivate: Boolean,
+    ) {
+        accountViewModel.launchSigner {
+            removeUserFromSet(user, isPrivate)
+        }
+    }
+
+    fun addUser(
+        user: User,
+        isPrivate: Boolean,
+    ) {
+        accountViewModel.launchSigner {
+            addUserToSet(user, isPrivate)
+        }
+    }
+
+    fun deleteList() {
+        accountViewModel.launchSigner {
+            deleteFollowSet()
+        }
+    }
+
+    fun broadcastList() {
+        accountViewModel.launchSigner {
+            loadNote()?.let { updatedSetNote ->
+                accountViewModel.broadcast(updatedSetNote)
+            }
+        }
     }
 
     fun hasUserFlow(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/packs/FollowPackScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/packs/FollowPackScreen.kt
@@ -169,9 +169,7 @@ private fun ListViewAndEditColumn(
             viewModel = viewModel,
             modifier = Modifier.weight(1f),
             onDeleteUser = { user ->
-                accountViewModel.launchSigner {
-                    viewModel.removeUserFromSet(user)
-                }
+                viewModel.removeUser(user)
             },
             accountViewModel = accountViewModel,
             nav = nav,
@@ -192,14 +190,10 @@ private fun RenderAddUserFieldAndSuggestions(
             viewModel.hasUserFlow(user)
         },
         addUserToSet = { user ->
-            accountViewModel.launchSigner {
-                viewModel.addUserToSet(user)
-            }
+            viewModel.addUser(user)
         },
         removeUserFromSet = { user ->
-            accountViewModel.launchSigner {
-                viewModel.removeUserFromSet(user)
-            }
+            viewModel.removeUser(user)
         },
         accountViewModel = accountViewModel,
     )
@@ -237,16 +231,10 @@ private fun ListActionsMenuButton(
             nav.nav { Route.FollowPackMetadataEdit(viewModel.selectedDTag.value) }
         },
         onBroadcastList = {
-            accountViewModel.launchSigner {
-                viewModel.loadNote()?.let { updatedSetNote ->
-                    accountViewModel.broadcast(updatedSetNote)
-                }
-            }
+            viewModel.broadcastList()
         },
         onDeleteList = {
-            accountViewModel.launchSigner {
-                viewModel.deleteFollowSet()
-            }
+            viewModel.deleteList()
             nav.popBack()
         },
     )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/packs/FollowPackViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/packs/FollowPackViewModel.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.flow.transformLatest
 @Stable
 class FollowPackViewModel : ViewModel() {
     lateinit var account: Account
+    lateinit var accountViewModel: AccountViewModel
     lateinit var userSuggestions: UserSuggestionState
 
     var userSuggestionFocus by mutableStateOf<UserSuggestionState?>(null)
@@ -72,6 +73,7 @@ class FollowPackViewModel : ViewModel() {
     ) {
         if (!this::account.isInitialized || this.account != accountVM.account) {
             this.account = accountVM.account
+            this.accountViewModel = accountVM
             this.userSuggestions = UserSuggestionState(accountVM.account, accountVM.nip05ClientBuilder())
         }
 
@@ -90,6 +92,32 @@ class FollowPackViewModel : ViewModel() {
 
     suspend fun addUserToSet(user: User) {
         account.followLists.addUserToSet(user, selectedDTag.value, account)
+    }
+
+    fun removeUser(user: User) {
+        accountViewModel.launchSigner {
+            removeUserFromSet(user)
+        }
+    }
+
+    fun addUser(user: User) {
+        accountViewModel.launchSigner {
+            addUserToSet(user)
+        }
+    }
+
+    fun deleteList() {
+        accountViewModel.launchSigner {
+            deleteFollowSet()
+        }
+    }
+
+    fun broadcastList() {
+        accountViewModel.launchSigner {
+            loadNote()?.let { updatedSetNote ->
+                accountViewModel.broadcast(updatedSetNote)
+            }
+        }
     }
 
     fun hasUserFlow(user: User): Flow<Boolean> =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/memberEdit/FollowListAndPackAndUserView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/memberEdit/FollowListAndPackAndUserView.kt
@@ -106,14 +106,11 @@ fun FollowListAndPackAndUserView(
                     userIsPrivateMember = list.privateMembers.contains(userToAddOrRemove),
                     userIsPublicMember = list.publicMembers.contains(userToAddOrRemove),
                     onRemoveUser = {
-                        accountViewModel.launchSigner {
-                            accountViewModel.account.peopleLists.removeUserFromSet(
-                                userToAddOrRemove,
-                                isPrivate = list.privateMembers.contains(userToAddOrRemove),
-                                list.identifierTag,
-                                accountViewModel.account,
-                            )
-                        }
+                        accountViewModel.removeUserFromPeopleList(
+                            userToAddOrRemove,
+                            isPrivate = list.privateMembers.contains(userToAddOrRemove),
+                            list.identifierTag,
+                        )
                     },
                     privateMemberSize = list.privateMembers.size,
                     publicMemberSize = list.publicMembers.size,
@@ -121,14 +118,11 @@ fun FollowListAndPackAndUserView(
                         nav.nav(Route.MyPeopleListView(list.identifierTag))
                     },
                     onAddUserToList = { userShouldBePrivate ->
-                        accountViewModel.launchSigner {
-                            accountViewModel.account.peopleLists.addUserToSet(
-                                userToAddOrRemove,
-                                list.identifierTag,
-                                userShouldBePrivate,
-                                accountViewModel.account,
-                            )
-                        }
+                        accountViewModel.addUserToPeopleList(
+                            userToAddOrRemove,
+                            list.identifierTag,
+                            userShouldBePrivate,
+                        )
                     },
                 )
                 HorizontalDivider(thickness = DividerThickness)
@@ -181,23 +175,17 @@ fun FollowListAndPackAndUserView(
                         nav.nav(Route.MyFollowPackView(list.identifierTag))
                     },
                     onRemoveUser = {
-                        accountViewModel.launchSigner {
-                            accountViewModel.account.followLists.removeUserFromSet(
-                                userToAddOrRemove,
-                                list.identifierTag,
-                                accountViewModel.account,
-                            )
-                        }
+                        accountViewModel.removeUserFromFollowPack(
+                            userToAddOrRemove,
+                            list.identifierTag,
+                        )
                     },
                     memberSize = list.publicMembers.size,
                     onAddUserToList = {
-                        accountViewModel.launchSigner {
-                            accountViewModel.account.followLists.addUserToSet(
-                                userToAddOrRemove,
-                                list.identifierTag,
-                                accountViewModel.account,
-                            )
-                        }
+                        accountViewModel.addUserToFollowPack(
+                            userToAddOrRemove,
+                            list.identifierTag,
+                        )
                     },
                 )
                 HorizontalDivider(thickness = DividerThickness)


### PR DESCRIPTION
## Summary

Migrate all `launchSigner` calls from composable UI files in the lists directory into their respective ViewModels, continuing the KMP iOS migration effort.

## Changes

### Display ViewModels
- **PeopleListViewModel** (display): Added wrapper methods `removeUser`, `addUser`, `deleteList`, `broadcastList` that internally call `launchSigner`
- **FollowPackViewModel** (display): Added wrapper methods `removeUser`, `addUser`, `deleteList`, `broadcastList` that internally call `launchSigner`

### AccountViewModel
- Added helper methods `removeUserFromPeopleList`, `addUserToPeopleList`, `removeUserFromFollowPack`, `addUserToFollowPack` for use by `FollowListAndPackAndUserView`

### UI Files (launchSigner removed)
- **PeopleListScreen**: 5 `launchSigner` calls → ViewModel method calls
- **FollowPackScreen**: 5 `launchSigner` calls → ViewModel method calls
- **FollowListAndPackAndUserView**: 4 `launchSigner` calls → AccountViewModel helper methods

## Result
All `launchSigner` calls in the `lists/` directory are now exclusively in ViewModel files, not in composable UI code. This moves us closer to platform-independent UI composables for KMP.

## Verification
- `compilePlayDebugKotlin` passes with no errors