### PR TITLE
feat: move composables to commons (batch 15)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/uploads/TimeFormatUtils.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/uploads/TimeFormatUtils.kt
@@ -20,20 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.actions.uploads
 
-import java.util.Locale
-
-/**
- * Formats seconds into a human-readable time string (M:SS or MM:SS format).
- *
- * @param seconds The number of seconds to format
- * @return Formatted time string (e.g., "0:05", "1:23", "12:45")
- */
-fun formatSecondsToTime(seconds: Int): String {
-    val minutes = seconds / 60
-    val secs = seconds % 60
-    return if (minutes > 0) {
-        String.format(Locale.getDefault(), "%d:%02d", minutes, secs)
-    } else {
-        String.format(Locale.getDefault(), "0:%02d", secs)
-    }
-}
+// Re-export from commons for backwards compatibility
+fun formatSecondsToTime(seconds: Int): String =
+    com.vitorpamplona.amethyst.commons.ui.actions.uploads
+        .formatSecondsToTime(seconds)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ForwardingPainter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ForwardingPainter.kt
@@ -21,59 +21,21 @@
 package com.vitorpamplona.amethyst.ui.components
 
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.DefaultAlpha
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.painter.Painter
 
-/**
- * Create and return a new [Painter] that wraps [painter] with its [alpha], [colorFilter], or [onDraw] overwritten.
- */
+// Re-export from commons for backwards compatibility
+typealias ForwardingDrawInfo = com.vitorpamplona.amethyst.commons.ui.components.ForwardingDrawInfo
+
 fun forwardingPainter(
     painter: Painter,
-    alpha: Float = DefaultAlpha,
+    alpha: Float = androidx.compose.ui.graphics.DefaultAlpha,
     colorFilter: ColorFilter? = null,
-    onDraw: DrawScope.(ForwardingDrawInfo) -> Unit = DefaultOnDraw,
-): Painter = ForwardingPainter(painter, alpha, colorFilter, onDraw)
-
-data class ForwardingDrawInfo(
-    val painter: Painter,
-    val alpha: Float,
-    val colorFilter: ColorFilter?,
-)
-
-private class ForwardingPainter(
-    private val painter: Painter,
-    private var alpha: Float,
-    private var colorFilter: ColorFilter?,
-    private val onDraw: DrawScope.(ForwardingDrawInfo) -> Unit,
-) : Painter() {
-    private var info = newInfo()
-
-    override val intrinsicSize get() = painter.intrinsicSize
-
-    override fun applyAlpha(alpha: Float): Boolean {
-        if (alpha != DefaultAlpha) {
-            this.alpha = alpha
-            this.info = newInfo()
+    onDraw: DrawScope.(ForwardingDrawInfo) -> Unit = { info ->
+        with(info.painter) {
+            draw(size, info.alpha, info.colorFilter)
         }
-        return true
-    }
-
-    override fun applyColorFilter(colorFilter: ColorFilter?): Boolean {
-        if (colorFilter == null) {
-            this.colorFilter = colorFilter
-            this.info = newInfo()
-        }
-        return true
-    }
-
-    override fun DrawScope.onDraw() = onDraw(info)
-
-    private fun newInfo() = ForwardingDrawInfo(painter, alpha, colorFilter)
-}
-
-private val DefaultOnDraw: DrawScope.(ForwardingDrawInfo) -> Unit = { info ->
-    with(info.painter) {
-        draw(size, info.alpha, info.colorFilter)
-    }
-}
+    },
+): Painter =
+    com.vitorpamplona.amethyst.commons.ui.components
+        .forwardingPainter(painter, alpha, colorFilter, onDraw)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/GlowingCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/GlowingCard.kt
@@ -20,30 +20,14 @@
  */
 package com.vitorpamplona.amethyst.ui.components
 
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.PathEffect
-import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.StrokeJoin
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.TextUnit
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
+// Re-export from commons for backwards compatibility
 @Composable
 fun AnimatedBorderTextCornerRadius(
     text: String,
@@ -51,54 +35,10 @@ fun AnimatedBorderTextCornerRadius(
     color: Color = Color.Unspecified,
     textAlign: TextAlign? = null,
     fontSize: TextUnit = 12.sp,
-) {
-    val infiniteTransition = rememberInfiniteTransition()
-    val animatedFloatRestart =
-        infiniteTransition.animateFloat(
-            initialValue = 0f,
-            targetValue = 100f,
-            animationSpec =
-                infiniteRepeatable(
-                    animation = tween(5000, easing = LinearEasing),
-                    repeatMode = RepeatMode.Restart,
-                ),
-        )
-
-    Text(
-        text = text,
-        fontSize = fontSize,
-        modifier =
-            modifier
-                .drawBehind {
-                    val brush =
-                        Brush.sweepGradient(
-                            colors = listOf(Color.Cyan, Color.Magenta, Color.Yellow),
-                        )
-
-                    drawRoundRect(
-                        brush = brush,
-                        style =
-                            Stroke(
-                                width = 2.dp.toPx(),
-                                cap = StrokeCap.Round,
-                                join = StrokeJoin.Round,
-                                pathEffect = PathEffect.dashPathEffect(floatArrayOf(10f, 10f), animatedFloatRestart.value),
-                            ),
-                        cornerRadius =
-                            androidx.compose.ui.geometry
-                                .CornerRadius(6.dp.toPx()),
-                    )
-                }.padding(3.dp),
-        color = color,
-        textAlign = textAlign,
-    )
-}
-
-// Example usage in a composable function:
-@Composable
-@Preview
-fun ExampleAnimatedBorder() {
-    Column {
-        AnimatedBorderTextCornerRadius(text = "Rounded Corners", Modifier)
-    }
-}
+) = com.vitorpamplona.amethyst.commons.ui.components.AnimatedBorderTextCornerRadius(
+    text = text,
+    modifier = modifier,
+    color = color,
+    textAlign = textAlign,
+    fontSize = fontSize,
+)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/LoadingAnimation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/LoadingAnimation.kt
@@ -20,41 +20,14 @@
  */
 package com.vitorpamplona.amethyst.ui.components
 
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ProgressIndicatorDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.toImmutableList
 
-val DefaultAnimationColors =
-    listOf(
-        Color(0xFF5851D8),
-        Color(0xFF833AB4),
-        Color(0xFFC13584),
-        Color(0xFFE1306C),
-        Color(0xFFFD1D1D),
-        Color(0xFFF56040),
-        Color(0xFFF77737),
-        Color(0xFFFCAF45),
-        Color(0xFFFFDC80),
-        Color(0xFF5851D8),
-    ).toImmutableList()
+// Re-export from commons for backwards compatibility
+val DefaultAnimationColors = com.vitorpamplona.amethyst.commons.ui.components.DefaultAnimationColors
 
 @Composable
 fun LoadingAnimation(
@@ -62,37 +35,9 @@ fun LoadingAnimation(
     circleWidth: Dp = 4.dp,
     circleColors: ImmutableList<Color> = DefaultAnimationColors,
     animationDuration: Int = 1000,
-) {
-    val infiniteTransition = rememberInfiniteTransition()
-
-    val rotateAnimation by
-        infiniteTransition.animateFloat(
-            initialValue = 0f,
-            targetValue = 360f,
-            animationSpec =
-                infiniteRepeatable(
-                    animation =
-                        tween(
-                            durationMillis = animationDuration,
-                            easing = LinearEasing,
-                        ),
-                ),
-            label = "UploadGalleryUploadingAnimation",
-        )
-
-    CircularProgressIndicator(
-        progress = { 1f },
-        modifier =
-            Modifier
-                .size(size = indicatorSize)
-                .rotate(degrees = rotateAnimation)
-                .border(
-                    width = circleWidth,
-                    brush = Brush.sweepGradient(circleColors),
-                    shape = CircleShape,
-                ),
-        color = MaterialTheme.colorScheme.background,
-        strokeWidth = 1.dp,
-        trackColor = ProgressIndicatorDefaults.circularDeterminateTrackColor,
-    )
-}
+) = com.vitorpamplona.amethyst.commons.ui.components.LoadingAnimation(
+    indicatorSize = indicatorSize,
+    circleWidth = circleWidth,
+    circleColors = circleColors,
+    animationDuration = animationDuration,
+)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/PubKeyFormatter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/PubKeyFormatter.kt
@@ -21,13 +21,13 @@
 package com.vitorpamplona.amethyst.ui.note
 
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
-import com.vitorpamplona.quartz.nip01Core.core.toHexKey
+import com.vitorpamplona.amethyst.commons.ui.note.toDisplayHexKey as commonsToDisplayHexKey
+import com.vitorpamplona.amethyst.commons.ui.note.toHexShortDisplay as commonsToHexShortDisplay
+import com.vitorpamplona.amethyst.commons.ui.note.toShortDisplay as commonsToShortDisplay
 
-fun ByteArray.toHexShortDisplay(): String = toHexKey().toShortDisplay()
+// Re-export from commons for backwards compatibility
+fun ByteArray.toHexShortDisplay(): String = commonsToHexShortDisplay()
 
-fun String.toShortDisplay(): String {
-    if (length <= 16) return this
-    return replaceRange(8, length - 8, "…")
-}
+fun String.toShortDisplay(): String = commonsToShortDisplay()
 
-fun HexKey.toDisplayHexKey(): String = this.toShortDisplay()
+fun HexKey.toDisplayHexKey(): String = commonsToDisplayHexKey()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapFormatter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapFormatter.kt
@@ -21,63 +21,19 @@
 package com.vitorpamplona.amethyst.ui.note
 
 import java.math.BigDecimal
-import java.math.RoundingMode
-import java.text.DecimalFormat
 
-val TenGiga = BigDecimal(10000000000)
-val OneGiga = BigDecimal(1000000000)
-val TenMega = BigDecimal(10000000)
-val OneMega = BigDecimal(1000000)
-val TenKilo = BigDecimal(10000)
-val OneKilo = BigDecimal(1000)
+// Re-export from commons for backwards compatibility
+val TenGiga: BigDecimal get() = com.vitorpamplona.amethyst.commons.ui.note.TenGiga
+val OneGiga: BigDecimal get() = com.vitorpamplona.amethyst.commons.ui.note.OneGiga
+val TenMega: BigDecimal get() = com.vitorpamplona.amethyst.commons.ui.note.TenMega
+val OneMega: BigDecimal get() = com.vitorpamplona.amethyst.commons.ui.note.OneMega
+val TenKilo: BigDecimal get() = com.vitorpamplona.amethyst.commons.ui.note.TenKilo
+val OneKilo: BigDecimal get() = com.vitorpamplona.amethyst.commons.ui.note.OneKilo
 
-private val dfGBig =
-    object : ThreadLocal<DecimalFormat>() {
-        override fun initialValue() = DecimalFormat("#.#G")
-    }
+fun showAmount(amount: BigDecimal?): String =
+    com.vitorpamplona.amethyst.commons.ui.note
+        .showAmount(amount)
 
-private val dfGSmall =
-    object : ThreadLocal<DecimalFormat>() {
-        override fun initialValue() = DecimalFormat("#.0G")
-    }
-
-private val dfMBig =
-    object : ThreadLocal<DecimalFormat>() {
-        override fun initialValue() = DecimalFormat("#.#M")
-    }
-
-private val dfMSmall =
-    object : ThreadLocal<DecimalFormat>() {
-        override fun initialValue() = DecimalFormat("#.0M")
-    }
-
-private val dfK =
-    object : ThreadLocal<DecimalFormat>() {
-        override fun initialValue() = DecimalFormat("#.#k")
-    }
-
-private val dfN =
-    object : ThreadLocal<DecimalFormat>() {
-        override fun initialValue() = DecimalFormat("#")
-    }
-
-fun showAmount(amount: BigDecimal?): String {
-    if (amount == null) return ""
-    if (amount.abs() < BigDecimal(0.01)) return ""
-
-    return when {
-        amount >= TenGiga -> dfGBig.get()!!.format(amount.div(OneGiga).setScale(0, RoundingMode.HALF_UP))
-        amount >= OneGiga -> dfGSmall.get()!!.format(amount.div(OneGiga).setScale(0, RoundingMode.HALF_UP))
-        amount >= TenMega -> dfMBig.get()!!.format(amount.div(OneMega).setScale(0, RoundingMode.HALF_UP))
-        amount >= OneMega -> dfMSmall.get()!!.format(amount.div(OneMega).setScale(0, RoundingMode.HALF_UP))
-        amount >= TenKilo -> dfK.get()!!.format(amount.div(OneKilo).setScale(0, RoundingMode.HALF_UP))
-        else -> dfN.get()!!.format(amount)
-    }
-}
-
-fun showAmountWithZero(amount: BigDecimal?): String {
-    if (amount == null) return "0"
-    if (amount.abs() < BigDecimal(0.01)) return "0"
-
-    return showAmount(amount)
-}
+fun showAmountWithZero(amount: BigDecimal?): String =
+    com.vitorpamplona.amethyst.commons.ui.note
+        .showAmountWithZero(amount)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapFormatterNoDecimals.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapFormatterNoDecimals.kt
@@ -21,50 +21,16 @@
 package com.vitorpamplona.amethyst.ui.note
 
 import java.math.BigDecimal
-import java.math.RoundingMode
-import java.text.DecimalFormat
 
-private val dfG =
-    object : ThreadLocal<DecimalFormat>() {
-        override fun initialValue() = DecimalFormat("#G")
-    }
+// Re-export from commons for backwards compatibility
+fun showAmountInteger(amount: BigDecimal?): String =
+    com.vitorpamplona.amethyst.commons.ui.note
+        .showAmountInteger(amount)
 
-private val dfM =
-    object : ThreadLocal<DecimalFormat>() {
-        override fun initialValue() = DecimalFormat("#M")
-    }
+fun showAmountInteger(amount: Int?): String =
+    com.vitorpamplona.amethyst.commons.ui.note
+        .showAmountInteger(amount)
 
-private val dfK =
-    object : ThreadLocal<DecimalFormat>() {
-        override fun initialValue() = DecimalFormat("#k")
-    }
-
-private val dfN =
-    object : ThreadLocal<DecimalFormat>() {
-        override fun initialValue() = DecimalFormat("#")
-    }
-
-fun showAmountInteger(amount: BigDecimal?): String {
-    if (amount == null) return ""
-    if (amount.abs() < BigDecimal(0.01)) return ""
-
-    return when {
-        amount >= OneGiga -> dfG.get()?.format(amount.div(OneGiga).setScale(0, RoundingMode.HALF_UP)) ?: ""
-        amount >= OneMega -> dfM.get()?.format(amount.div(OneMega).setScale(0, RoundingMode.HALF_UP)) ?: ""
-        amount >= TenKilo -> dfK.get()?.format(amount.div(OneKilo).setScale(0, RoundingMode.HALF_UP)) ?: ""
-        else -> dfN.get()?.format(amount) ?: ""
-    }
-}
-
-fun showAmountInteger(amount: Int?): String {
-    if (amount == null) return "0"
-
-    return showAmountIntegerWithZero(BigDecimal.valueOf(amount.toLong()))
-}
-
-fun showAmountIntegerWithZero(amount: BigDecimal?): String {
-    if (amount == null) return "0"
-    if (amount.abs() < BigDecimal(0.01)) return "0"
-
-    return showAmountInteger(amount)
-}
+fun showAmountIntegerWithZero(amount: BigDecimal?): String =
+    com.vitorpamplona.amethyst.commons.ui.note
+        .showAmountIntegerWithZero(amount)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/messagefield/IMessageField.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/messagefield/IMessageField.kt
@@ -20,10 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.note.creators.messagefield
 
-import androidx.compose.foundation.text.input.TextFieldState
-
-interface IMessageField {
-    val message: TextFieldState
-
-    fun onMessageChanged()
-}
+// Re-export from commons for backwards compatibility
+typealias IMessageField = com.vitorpamplona.amethyst.commons.ui.note.creators.messagefield.IMessageField

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/zapraiser/IZapRaiser.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/zapraiser/IZapRaiser.kt
@@ -20,12 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.note.creators.zapraiser
 
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.Stable
-
-@Stable
-interface IZapRaiser {
-    val zapRaiserAmount: MutableState<Long?>
-
-    fun updateZapRaiserAmount(newAmount: Long?)
-}
+// Re-export from commons for backwards compatibility
+typealias IZapRaiser = com.vitorpamplona.amethyst.commons.ui.note.creators.zapraiser.IZapRaiser

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/BookmarkType.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/BookmarkType.kt
@@ -20,8 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups
 
-enum class BookmarkType {
-    PostBookmark,
-
-    ArticleBookmark,
-}
+// Re-export from commons for backwards compatibility
+typealias BookmarkType = com.vitorpamplona.amethyst.commons.ui.bookmarkgroups.BookmarkType

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/actions/uploads/TimeFormatUtils.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/actions/uploads/TimeFormatUtils.kt
@@ -18,7 +18,22 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.expiration
+package com.vitorpamplona.amethyst.commons.ui.actions.uploads
 
-// Re-export from commons for backwards compatibility
-typealias IExpiration = com.vitorpamplona.amethyst.commons.ui.note.creators.expiration.IExpiration
+import java.util.Locale
+
+/**
+ * Formats seconds into a human-readable time string (M:SS or MM:SS format).
+ *
+ * @param seconds The number of seconds to format
+ * @return Formatted time string (e.g., "0:05", "1:23", "12:45")
+ */
+fun formatSecondsToTime(seconds: Int): String {
+    val minutes = seconds / 60
+    val secs = seconds % 60
+    return if (minutes > 0) {
+        String.format(Locale.getDefault(), "%d:%02d", minutes, secs)
+    } else {
+        String.format(Locale.getDefault(), "0:%02d", secs)
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/bookmarkgroups/BookmarkType.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/bookmarkgroups/BookmarkType.kt
@@ -18,7 +18,10 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.expiration
+package com.vitorpamplona.amethyst.commons.ui.bookmarkgroups
 
-// Re-export from commons for backwards compatibility
-typealias IExpiration = com.vitorpamplona.amethyst.commons.ui.note.creators.expiration.IExpiration
+enum class BookmarkType {
+    PostBookmark,
+
+    ArticleBookmark,
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/ForwardingPainter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/ForwardingPainter.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.components
+
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.DefaultAlpha
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.painter.Painter
+
+/**
+ * Create and return a new [Painter] that wraps [painter] with its [alpha], [colorFilter], or [onDraw] overwritten.
+ */
+fun forwardingPainter(
+    painter: Painter,
+    alpha: Float = DefaultAlpha,
+    colorFilter: ColorFilter? = null,
+    onDraw: DrawScope.(ForwardingDrawInfo) -> Unit = DefaultOnDraw,
+): Painter = ForwardingPainter(painter, alpha, colorFilter, onDraw)
+
+data class ForwardingDrawInfo(
+    val painter: Painter,
+    val alpha: Float,
+    val colorFilter: ColorFilter?,
+)
+
+private class ForwardingPainter(
+    private val painter: Painter,
+    private var alpha: Float,
+    private var colorFilter: ColorFilter?,
+    private val onDraw: DrawScope.(ForwardingDrawInfo) -> Unit,
+) : Painter() {
+    private var info = newInfo()
+
+    override val intrinsicSize get() = painter.intrinsicSize
+
+    override fun applyAlpha(alpha: Float): Boolean {
+        if (alpha != DefaultAlpha) {
+            this.alpha = alpha
+            this.info = newInfo()
+        }
+        return true
+    }
+
+    override fun applyColorFilter(colorFilter: ColorFilter?): Boolean {
+        if (colorFilter == null) {
+            this.colorFilter = colorFilter
+            this.info = newInfo()
+        }
+        return true
+    }
+
+    override fun DrawScope.onDraw() = onDraw(info)
+
+    private fun newInfo() = ForwardingDrawInfo(painter, alpha, colorFilter)
+}
+
+private val DefaultOnDraw: DrawScope.(ForwardingDrawInfo) -> Unit = { info ->
+    with(info.painter) {
+        draw(size, info.alpha, info.colorFilter)
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/GlowingCard.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/GlowingCard.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.components
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun AnimatedBorderTextCornerRadius(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
+    fontSize: TextUnit = 12.sp,
+) {
+    val infiniteTransition = rememberInfiniteTransition()
+    val animatedFloatRestart =
+        infiniteTransition.animateFloat(
+            initialValue = 0f,
+            targetValue = 100f,
+            animationSpec =
+                infiniteRepeatable(
+                    animation = tween(5000, easing = LinearEasing),
+                    repeatMode = RepeatMode.Restart,
+                ),
+        )
+
+    Text(
+        text = text,
+        fontSize = fontSize,
+        modifier =
+            modifier
+                .drawBehind {
+                    val brush =
+                        Brush.sweepGradient(
+                            colors = listOf(Color.Cyan, Color.Magenta, Color.Yellow),
+                        )
+
+                    drawRoundRect(
+                        brush = brush,
+                        style =
+                            Stroke(
+                                width = 2.dp.toPx(),
+                                cap = StrokeCap.Round,
+                                join = StrokeJoin.Round,
+                                pathEffect = PathEffect.dashPathEffect(floatArrayOf(10f, 10f), animatedFloatRestart.value),
+                            ),
+                        cornerRadius =
+                            androidx.compose.ui.geometry
+                                .CornerRadius(6.dp.toPx()),
+                    )
+                }.padding(3.dp),
+        color = color,
+        textAlign = textAlign,
+    )
+}
+
+// Example usage in a composable function:
+@Composable
+@Preview
+fun ExampleAnimatedBorder() {
+    Column {
+        AnimatedBorderTextCornerRadius(text = "Rounded Corners", Modifier)
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/LoadingAnimation.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/LoadingAnimation.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.components
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProgressIndicatorDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+
+val DefaultAnimationColors =
+    listOf(
+        Color(0xFF5851D8),
+        Color(0xFF833AB4),
+        Color(0xFFC13584),
+        Color(0xFFE1306C),
+        Color(0xFFFD1D1D),
+        Color(0xFFF56040),
+        Color(0xFFF77737),
+        Color(0xFFFCAF45),
+        Color(0xFFFFDC80),
+        Color(0xFF5851D8),
+    ).toImmutableList()
+
+@Composable
+fun LoadingAnimation(
+    indicatorSize: Dp = 20.dp,
+    circleWidth: Dp = 4.dp,
+    circleColors: ImmutableList<Color> = DefaultAnimationColors,
+    animationDuration: Int = 1000,
+) {
+    val infiniteTransition = rememberInfiniteTransition()
+
+    val rotateAnimation by
+        infiniteTransition.animateFloat(
+            initialValue = 0f,
+            targetValue = 360f,
+            animationSpec =
+                infiniteRepeatable(
+                    animation =
+                        tween(
+                            durationMillis = animationDuration,
+                            easing = LinearEasing,
+                        ),
+                ),
+            label = "UploadGalleryUploadingAnimation",
+        )
+
+    CircularProgressIndicator(
+        progress = { 1f },
+        modifier =
+            Modifier
+                .size(size = indicatorSize)
+                .rotate(degrees = rotateAnimation)
+                .border(
+                    width = circleWidth,
+                    brush = Brush.sweepGradient(circleColors),
+                    shape = CircleShape,
+                ),
+        color = MaterialTheme.colorScheme.background,
+        strokeWidth = 1.dp,
+        trackColor = ProgressIndicatorDefaults.circularDeterminateTrackColor,
+    )
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/PubKeyFormatter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/PubKeyFormatter.kt
@@ -18,7 +18,16 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.expiration
+package com.vitorpamplona.amethyst.commons.ui.note
 
-// Re-export from commons for backwards compatibility
-typealias IExpiration = com.vitorpamplona.amethyst.commons.ui.note.creators.expiration.IExpiration
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.core.toHexKey
+
+fun ByteArray.toHexShortDisplay(): String = toHexKey().toShortDisplay()
+
+fun String.toShortDisplay(): String {
+    if (length <= 16) return this
+    return replaceRange(8, length - 8, "…")
+}
+
+fun HexKey.toDisplayHexKey(): String = this.toShortDisplay()

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/ZapFormatter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/ZapFormatter.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.note
+
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.text.DecimalFormat
+
+val TenGiga = BigDecimal(10000000000)
+val OneGiga = BigDecimal(1000000000)
+val TenMega = BigDecimal(10000000)
+val OneMega = BigDecimal(1000000)
+val TenKilo = BigDecimal(10000)
+val OneKilo = BigDecimal(1000)
+
+private val dfGBig =
+    object : ThreadLocal<DecimalFormat>() {
+        override fun initialValue() = DecimalFormat("#.#G")
+    }
+
+private val dfGSmall =
+    object : ThreadLocal<DecimalFormat>() {
+        override fun initialValue() = DecimalFormat("#.0G")
+    }
+
+private val dfMBig =
+    object : ThreadLocal<DecimalFormat>() {
+        override fun initialValue() = DecimalFormat("#.#M")
+    }
+
+private val dfMSmall =
+    object : ThreadLocal<DecimalFormat>() {
+        override fun initialValue() = DecimalFormat("#.0M")
+    }
+
+private val dfK =
+    object : ThreadLocal<DecimalFormat>() {
+        override fun initialValue() = DecimalFormat("#.#k")
+    }
+
+private val dfN =
+    object : ThreadLocal<DecimalFormat>() {
+        override fun initialValue() = DecimalFormat("#")
+    }
+
+fun showAmount(amount: BigDecimal?): String {
+    if (amount == null) return ""
+    if (amount.abs() < BigDecimal(0.01)) return ""
+
+    return when {
+        amount >= TenGiga -> dfGBig.get()!!.format(amount.div(OneGiga).setScale(0, RoundingMode.HALF_UP))
+        amount >= OneGiga -> dfGSmall.get()!!.format(amount.div(OneGiga).setScale(0, RoundingMode.HALF_UP))
+        amount >= TenMega -> dfMBig.get()!!.format(amount.div(OneMega).setScale(0, RoundingMode.HALF_UP))
+        amount >= OneMega -> dfMSmall.get()!!.format(amount.div(OneMega).setScale(0, RoundingMode.HALF_UP))
+        amount >= TenKilo -> dfK.get()!!.format(amount.div(OneKilo).setScale(0, RoundingMode.HALF_UP))
+        else -> dfN.get()!!.format(amount)
+    }
+}
+
+fun showAmountWithZero(amount: BigDecimal?): String {
+    if (amount == null) return "0"
+    if (amount.abs() < BigDecimal(0.01)) return "0"
+
+    return showAmount(amount)
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/ZapFormatterNoDecimals.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/ZapFormatterNoDecimals.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.note
+
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.text.DecimalFormat
+
+private val dfG =
+    object : ThreadLocal<DecimalFormat>() {
+        override fun initialValue() = DecimalFormat("#G")
+    }
+
+private val dfM =
+    object : ThreadLocal<DecimalFormat>() {
+        override fun initialValue() = DecimalFormat("#M")
+    }
+
+private val dfK =
+    object : ThreadLocal<DecimalFormat>() {
+        override fun initialValue() = DecimalFormat("#k")
+    }
+
+private val dfN =
+    object : ThreadLocal<DecimalFormat>() {
+        override fun initialValue() = DecimalFormat("#")
+    }
+
+fun showAmountInteger(amount: BigDecimal?): String {
+    if (amount == null) return ""
+    if (amount.abs() < BigDecimal(0.01)) return ""
+
+    return when {
+        amount >= OneGiga -> dfG.get()?.format(amount.div(OneGiga).setScale(0, RoundingMode.HALF_UP)) ?: ""
+        amount >= OneMega -> dfM.get()?.format(amount.div(OneMega).setScale(0, RoundingMode.HALF_UP)) ?: ""
+        amount >= TenKilo -> dfK.get()?.format(amount.div(OneKilo).setScale(0, RoundingMode.HALF_UP)) ?: ""
+        else -> dfN.get()?.format(amount) ?: ""
+    }
+}
+
+fun showAmountInteger(amount: Int?): String {
+    if (amount == null) return "0"
+
+    return showAmountIntegerWithZero(BigDecimal.valueOf(amount.toLong()))
+}
+
+fun showAmountIntegerWithZero(amount: BigDecimal?): String {
+    if (amount == null) return "0"
+    if (amount.abs() < BigDecimal(0.01)) return "0"
+
+    return showAmountInteger(amount)
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/creators/expiration/IExpiration.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/creators/expiration/IExpiration.kt
@@ -18,7 +18,11 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.expiration
+package com.vitorpamplona.amethyst.commons.ui.note.creators.expiration
 
-// Re-export from commons for backwards compatibility
-typealias IExpiration = com.vitorpamplona.amethyst.commons.ui.note.creators.expiration.IExpiration
+import androidx.compose.runtime.Stable
+
+@Stable
+interface IExpiration {
+    var expirationDate: Long
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/creators/messagefield/IMessageField.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/creators/messagefield/IMessageField.kt
@@ -18,7 +18,12 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.expiration
+package com.vitorpamplona.amethyst.commons.ui.note.creators.messagefield
 
-// Re-export from commons for backwards compatibility
-typealias IExpiration = com.vitorpamplona.amethyst.commons.ui.note.creators.expiration.IExpiration
+import androidx.compose.foundation.text.input.TextFieldState
+
+interface IMessageField {
+    val message: TextFieldState
+
+    fun onMessageChanged()
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/creators/zapraiser/IZapRaiser.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/creators/zapraiser/IZapRaiser.kt
@@ -18,7 +18,14 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.creators.expiration
+package com.vitorpamplona.amethyst.commons.ui.note.creators.zapraiser
 
-// Re-export from commons for backwards compatibility
-typealias IExpiration = com.vitorpamplona.amethyst.commons.ui.note.creators.expiration.IExpiration
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.Stable
+
+@Stable
+interface IZapRaiser {
+    val zapRaiserAmount: MutableState<Long?>
+
+    fun updateZapRaiserAmount(newAmount: Long?)
+}


### PR DESCRIPTION
Move 12 files from amethyst/ui/ to commons KMP module with backwards-compatible re-exports (typealiases for interfaces/enums, delegate functions for top-level functions/composables).

## Moved to commons

**Formatters:**
- `ZapFormatter` — `showAmount`, `showAmountWithZero`, numeric constants
- `ZapFormatterNoDecimals` — `showAmountInteger`, `showAmountIntegerWithZero`
- `PubKeyFormatter` — `toShortDisplay`, `toDisplayHexKey`, `toHexShortDisplay`
- `TimeFormatUtils` — `formatSecondsToTime`

**Composables:**
- `GlowingCard` — `AnimatedBorderTextCornerRadius`
- `LoadingAnimation` — `LoadingAnimation`, `DefaultAnimationColors`
- `ForwardingPainter` — `forwardingPainter`, `ForwardingDrawInfo`

**Interfaces & enums:**
- `IMessageField` interface
- `IZapRaiser` interface
- `IExpiration` interface
- `BookmarkType` enum

All original files replaced with thin re-export wrappers so existing imports continue to work. Both `:commons:compileKotlinJvm` and `:amethyst:compilePlayDebugKotlin` pass.