### PR TITLE
feat: move relay ViewModel infrastructure to commons (batch 9)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoModel.kt
@@ -20,157 +20,49 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.vitorpamplona.amethyst.Amethyst
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoState
 import com.vitorpamplona.amethyst.model.Account
-import com.vitorpamplona.amethyst.service.replace
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
-import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.count
+import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 
-abstract class BasicRelaySetupInfoModel : ViewModel() {
+abstract class BasicRelaySetupInfoModel : BasicRelaySetupInfoState() {
     lateinit var accountViewModel: AccountViewModel
     lateinit var account: Account
-
-    private val _relays = MutableStateFlow<List<BasicRelaySetupInfo>>(emptyList())
-    val relays = _relays.asStateFlow()
-
-    private val _countResults = MutableStateFlow<Map<NormalizedRelayUrl, RelayCountResult>>(emptyMap())
-    val countResults = _countResults.asStateFlow()
-
-    var hasModified = false
 
     fun init(accountViewModel: AccountViewModel) {
         this.accountViewModel = accountViewModel
         this.account = accountViewModel.account
     }
 
-    fun load() {
-        clear()
-        loadRelayDocuments()
-        loadCounts()
-    }
-
-    abstract fun getRelayList(): List<NormalizedRelayUrl>?
-
-    abstract suspend fun saveRelayList(urlList: List<NormalizedRelayUrl>)
-
-    open fun countFilters(relayUrl: NormalizedRelayUrl): List<CountFilter> = emptyList()
-
-    fun create() {
-        if (hasModified) {
-            accountViewModel.launchSigner {
-                saveRelayList(_relays.value.map { it.relay })
-                clear()
-            }
+    override fun launchSigner(block: suspend () -> Unit) {
+        accountViewModel.launchSigner {
+            block()
         }
     }
 
-    fun loadRelayDocuments() {
-        viewModelScope.launch(Dispatchers.IO) {
-            _relays.value.forEach { item ->
-                Amethyst.instance.nip11Cache.loadRelayInfo(
-                    relay = item.relay,
-                    onInfo = {
-                        togglePaidRelay(item, it.limitation?.payment_required ?: false)
-                    },
-                    onError = { url, errorCode, exceptionMessage -> },
-                )
-            }
-        }
-    }
-
-    private fun loadCounts() {
-        _countResults.value = emptyMap()
-
-        val client = account.client
-        val relayList = _relays.value
-        if (relayList.isEmpty()) return
-
-        relayList.forEach { item ->
-            val filters = countFilters(item.relay)
-            if (filters.isEmpty()) return@forEach
-
-            filters.forEach { countFilter ->
-                viewModelScope.launch(Dispatchers.IO) {
-                    val result = client.count(item.relay, countFilter.filter)
-                    if (result != null) {
-                        _countResults.update { currentMap ->
-                            val current = currentMap[item.relay] ?: RelayCountResult()
-                            val entries = current.counts.toMutableList()
-                            val newEntry =
-                                RelayCountResult.CountEntry(
-                                    label = countFilter.label,
-                                    count = result.count,
-                                    approximate = result.approximate,
-                                )
-                            val existing = entries.indexOfFirst { it.label == countFilter.label }
-                            if (existing >= 0) entries[existing] = newEntry else entries.add(newEntry)
-                            currentMap + (item.relay to RelayCountResult(entries))
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    open fun relayListBuilder(): List<BasicRelaySetupInfo> {
-        val relayList = getRelayList() ?: emptyList()
-
-        return relayList
-            .map {
-                relaySetupInfoBuilder(
-                    normalized = it,
-                    forcesTor =
-                        Amethyst.instance.torEvaluatorFlow.flow.value
-                            .useTor(it),
-                )
-            }.distinctBy { it.relay }
-    }
-
-    fun clear() {
-        _relays.update { relayListBuilder() }
-    }
-
-    fun addRelay(relay: BasicRelaySetupInfo) {
-        if (relays.value.any { it.relay == relay.relay }) return
-
-        _relays.update { it.plus(relay) }
-        hasModified = true
-    }
-
-    fun deleteRelay(relay: BasicRelaySetupInfo) {
-        _relays.update { it.minus(relay) }
-        hasModified = true
-    }
-
-    fun moveRelay(
-        from: Int,
-        to: Int,
+    override suspend fun loadRelayInfo(
+        relay: NormalizedRelayUrl,
+        onPaid: (Boolean) -> Unit,
     ) {
-        _relays.update { list ->
-            list.toMutableList().apply {
-                add(to, removeAt(from))
-            }
-        }
-        hasModified = true
+        Amethyst.instance.nip11Cache.loadRelayInfo(
+            relay = relay,
+            onInfo = {
+                onPaid(it.limitation?.payment_required ?: false)
+            },
+            onError = { url, errorCode, exceptionMessage -> },
+        )
     }
 
-    fun deleteAll() {
-        _relays.update { relays -> emptyList() }
-        hasModified = true
-    }
+    override fun buildRelaySetupInfo(normalized: NormalizedRelayUrl): BasicRelaySetupInfo =
+        relaySetupInfoBuilder(
+            normalized = normalized,
+            forcesTor =
+                Amethyst.instance.torEvaluatorFlow.flow.value
+                    .useTor(normalized),
+        )
 
-    fun togglePaidRelay(
-        relay: BasicRelaySetupInfo,
-        paid: Boolean,
-    ) {
-        _relays.update { it.replace(relay, relay.copy(paidRelay = paid)) }
-    }
+    override fun getClient(): INostrClient = account.client
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/RelayEventCountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/RelayEventCountViewModel.kt
@@ -20,22 +20,6 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common
 
-import androidx.compose.runtime.Immutable
-import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
+typealias RelayCountResult = com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.relays.common.RelayCountResult
 
-@Immutable
-data class RelayCountResult(
-    val counts: List<CountEntry> = emptyList(),
-) {
-    @Immutable
-    data class CountEntry(
-        val label: Int,
-        val count: Int,
-        val approximate: Boolean = false,
-    )
-}
-
-data class CountFilter(
-    val label: Int,
-    val filter: Filter,
-)
+typealias CountFilter = com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.relays.common.CountFilter

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/RelayListCollection.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/RelayListCollection.kt
@@ -22,40 +22,22 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common
 
 import com.vitorpamplona.amethyst.R
 
-data class RelayListCollection(
-    val homeRelays: List<BasicRelaySetupInfo>,
-    val notifRelays: List<BasicRelaySetupInfo>,
-    val dmRelays: List<BasicRelaySetupInfo>,
-    val privateOutboxRelays: List<BasicRelaySetupInfo>,
-    val proxyRelays: List<BasicRelaySetupInfo>,
-    val broadcastRelays: List<BasicRelaySetupInfo>,
-    val indexerRelays: List<BasicRelaySetupInfo>,
-    val searchRelays: List<BasicRelaySetupInfo>,
-    val localRelays: List<BasicRelaySetupInfo>,
-    val trustedRelays: List<BasicRelaySetupInfo>,
-    val favoriteRelays: List<BasicRelaySetupInfo>,
-    val blockedRelays: List<BasicRelaySetupInfo>,
-) {
-    fun sections(): List<RelaySection> =
-        listOf(
-            RelaySection("home", R.string.public_home_section, R.string.public_home_section_explainer, homeRelays),
-            RelaySection("notifications", R.string.public_notif_section, R.string.public_notif_section_explainer, notifRelays),
-            RelaySection("private_inbox", R.string.private_inbox_section, R.string.private_inbox_section_explainer, dmRelays),
-            RelaySection("private_outbox", R.string.private_outbox_section, R.string.private_outbox_section_explainer, privateOutboxRelays),
-            RelaySection("proxy", R.string.proxy_section, R.string.proxy_section_explainer, proxyRelays),
-            RelaySection("broadcast", R.string.broadcast_section, R.string.broadcast_section_explainer, broadcastRelays),
-            RelaySection("indexer", R.string.indexer_section, R.string.indexer_section_explainer, indexerRelays),
-            RelaySection("search", R.string.search_section, R.string.search_section_explainer, searchRelays),
-            RelaySection("local", R.string.local_section, R.string.local_section_explainer, localRelays),
-            RelaySection("trusted", R.string.trusted_section, R.string.trusted_section_explainer, trustedRelays),
-            RelaySection("favorites", R.string.favorite_section, R.string.favorite_section_explainer, favoriteRelays),
-            RelaySection("blocked", R.string.blocked_section, R.string.blocked_section_explainer, blockedRelays),
-        )
-}
+typealias RelayListCollection = com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.relays.common.RelayListCollection
 
-data class RelaySection(
-    val fileName: String,
-    val titleRes: Int,
-    val descriptionRes: Int,
-    val relays: List<BasicRelaySetupInfo>,
-)
+typealias RelaySection = com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.relays.common.RelaySection
+
+fun RelayListCollection.sections(): List<RelaySection> =
+    listOf(
+        RelaySection("home", R.string.public_home_section, R.string.public_home_section_explainer, homeRelays),
+        RelaySection("notifications", R.string.public_notif_section, R.string.public_notif_section_explainer, notifRelays),
+        RelaySection("private_inbox", R.string.private_inbox_section, R.string.private_inbox_section_explainer, dmRelays),
+        RelaySection("private_outbox", R.string.private_outbox_section, R.string.private_outbox_section_explainer, privateOutboxRelays),
+        RelaySection("proxy", R.string.proxy_section, R.string.proxy_section_explainer, proxyRelays),
+        RelaySection("broadcast", R.string.broadcast_section, R.string.broadcast_section_explainer, broadcastRelays),
+        RelaySection("indexer", R.string.indexer_section, R.string.indexer_section_explainer, indexerRelays),
+        RelaySection("search", R.string.search_section, R.string.search_section_explainer, searchRelays),
+        RelaySection("local", R.string.local_section, R.string.local_section_explainer, localRelays),
+        RelaySection("trusted", R.string.trusted_section, R.string.trusted_section_explainer, trustedRelays),
+        RelaySection("favorites", R.string.favorite_section, R.string.favorite_section_explainer, favoriteRelays),
+        RelaySection("blocked", R.string.blocked_section, R.string.blocked_section_explainer, blockedRelays),
+    )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/RelaySuggestionState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/RelaySuggestionState.kt
@@ -21,10 +21,10 @@
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.relays.common.IRelaySuggestionState
 import com.vitorpamplona.amethyst.model.LocalCache
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -60,13 +60,4 @@ class RelaySuggestionState : IRelaySuggestionState {
     override fun reset() {
         currentInput.tryEmit("")
     }
-}
-
-@Stable
-interface IRelaySuggestionState {
-    val results: Flow<List<BasicRelaySetupInfo>>
-
-    fun processInput(input: String)
-
-    fun reset()
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/RelayUrlEditField.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/RelayUrlEditField.kt
@@ -46,6 +46,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.relays.common.IRelaySuggestionState
 import com.vitorpamplona.amethyst.model.nip11RelayInfo.Nip11CachedRetriever
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/ShowRelaySuggestionList.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/ShowRelaySuggestionList.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.relays.common.IRelaySuggestionState
 import com.vitorpamplona.amethyst.model.nip11RelayInfo.Nip11CachedRetriever
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip65/Nip65RelayListViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip65/Nip65RelayListViewModel.kt
@@ -25,11 +25,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.relays.common.RelayCountResult
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.service.replace
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayCountResult
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
 import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.count
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/relays/common/BasicRelaySetupInfo.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/relays/common/BasicRelaySetupInfo.kt
@@ -18,19 +18,18 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common
+package com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.relays.common
 
-import com.vitorpamplona.amethyst.Amethyst
+import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.quartz.nip01Core.relay.client.stats.RelayStat
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 
-typealias BasicRelaySetupInfo = com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
-
-fun relaySetupInfoBuilder(
-    normalized: NormalizedRelayUrl,
-    forcesTor: Boolean = false,
-): BasicRelaySetupInfo =
-    BasicRelaySetupInfo(
-        relay = normalized,
-        relayStat = Amethyst.instance.relayStats.get(normalized),
-        forcesTor = forcesTor,
-    )
+@Immutable
+data class BasicRelaySetupInfo(
+    val relay: NormalizedRelayUrl,
+    val relayStat: RelayStat,
+    val paidRelay: Boolean = false,
+    val forcesTor: Boolean = false,
+    val users: List<User> = emptyList(),
+)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoState.kt
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.relays.common
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
+import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.count
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Platform-agnostic abstract base for relay setup ViewModels.
+ *
+ * Manages the relay list state (add/delete/move/clear) and count results.
+ * Platform-specific operations (relay info loading, signer access, tor evaluation)
+ * are provided via abstract methods that each platform implements.
+ */
+abstract class BasicRelaySetupInfoState : ViewModel() {
+    private val _relays = MutableStateFlow<List<BasicRelaySetupInfo>>(emptyList())
+    val relays = _relays.asStateFlow()
+
+    private val _countResults = MutableStateFlow<Map<NormalizedRelayUrl, RelayCountResult>>(emptyMap())
+    val countResults = _countResults.asStateFlow()
+
+    var hasModified = false
+
+    // --- Abstract: relay list source/destination ---
+
+    abstract fun getRelayList(): List<NormalizedRelayUrl>?
+
+    abstract suspend fun saveRelayList(urlList: List<NormalizedRelayUrl>)
+
+    // --- Abstract: platform-specific hooks ---
+
+    /** Launch a block that requires signer access (e.g. signing events). */
+    abstract fun launchSigner(block: suspend () -> Unit)
+
+    /** Load NIP-11 relay information and call [onPaid] with the result. */
+    abstract suspend fun loadRelayInfo(
+        relay: NormalizedRelayUrl,
+        onPaid: (Boolean) -> Unit,
+    )
+
+    /** Build a [BasicRelaySetupInfo] for the given relay URL. */
+    abstract fun buildRelaySetupInfo(normalized: NormalizedRelayUrl): BasicRelaySetupInfo
+
+    /** Provide the [INostrClient] for relay count queries. */
+    abstract fun getClient(): INostrClient
+
+    // --- Open: count filters for relay event counts ---
+
+    open fun countFilters(relayUrl: NormalizedRelayUrl): List<CountFilter> = emptyList()
+
+    // --- Core state management ---
+
+    fun create() {
+        if (hasModified) {
+            launchSigner {
+                saveRelayList(_relays.value.map { it.relay })
+                clear()
+            }
+        }
+    }
+
+    fun load() {
+        clear()
+        loadRelayDocuments()
+        loadCounts()
+    }
+
+    fun loadRelayDocuments() {
+        viewModelScope.launch(Dispatchers.IO) {
+            _relays.value.forEach { item ->
+                loadRelayInfo(item.relay) { paid ->
+                    togglePaidRelay(item, paid)
+                }
+            }
+        }
+    }
+
+    private fun loadCounts() {
+        _countResults.value = emptyMap()
+
+        val client = getClient()
+        val relayList = _relays.value
+        if (relayList.isEmpty()) return
+
+        relayList.forEach { item ->
+            val filters = countFilters(item.relay)
+            if (filters.isEmpty()) return@forEach
+
+            filters.forEach { countFilter ->
+                viewModelScope.launch(Dispatchers.IO) {
+                    val result = client.count(item.relay, countFilter.filter)
+                    if (result != null) {
+                        _countResults.update { currentMap ->
+                            val current = currentMap[item.relay] ?: RelayCountResult()
+                            val entries = current.counts.toMutableList()
+                            val newEntry =
+                                RelayCountResult.CountEntry(
+                                    label = countFilter.label,
+                                    count = result.count,
+                                    approximate = result.approximate,
+                                )
+                            val existing = entries.indexOfFirst { it.label == countFilter.label }
+                            if (existing >= 0) entries[existing] = newEntry else entries.add(newEntry)
+                            currentMap + (item.relay to RelayCountResult(entries))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    open fun relayListBuilder(): List<BasicRelaySetupInfo> {
+        val relayList = getRelayList() ?: emptyList()
+
+        return relayList
+            .map { buildRelaySetupInfo(it) }
+            .distinctBy { it.relay }
+    }
+
+    fun clear() {
+        _relays.update { relayListBuilder() }
+    }
+
+    fun addRelay(relay: BasicRelaySetupInfo) {
+        if (relays.value.any { it.relay == relay.relay }) return
+
+        _relays.update { it.plus(relay) }
+        hasModified = true
+    }
+
+    fun deleteRelay(relay: BasicRelaySetupInfo) {
+        _relays.update { it.minus(relay) }
+        hasModified = true
+    }
+
+    fun moveRelay(
+        from: Int,
+        to: Int,
+    ) {
+        _relays.update { list ->
+            list.toMutableList().apply {
+                add(to, removeAt(from))
+            }
+        }
+        hasModified = true
+    }
+
+    fun deleteAll() {
+        _relays.update { emptyList() }
+        hasModified = true
+    }
+
+    fun togglePaidRelay(
+        relay: BasicRelaySetupInfo,
+        paid: Boolean,
+    ) {
+        _relays.update { it.replace(relay, relay.copy(paidRelay = paid)) }
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/relays/common/IRelaySuggestionState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/relays/common/IRelaySuggestionState.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.relays.common
+
+import androidx.compose.runtime.Stable
+import kotlinx.coroutines.flow.Flow
+
+@Stable
+interface IRelaySuggestionState {
+    val results: Flow<List<BasicRelaySetupInfo>>
+
+    fun processInput(input: String)
+
+    fun reset()
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/relays/common/IterableExt.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/relays/common/IterableExt.kt
@@ -18,19 +18,9 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common
+package com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.relays.common
 
-import com.vitorpamplona.amethyst.Amethyst
-import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
-
-typealias BasicRelaySetupInfo = com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
-
-fun relaySetupInfoBuilder(
-    normalized: NormalizedRelayUrl,
-    forcesTor: Boolean = false,
-): BasicRelaySetupInfo =
-    BasicRelaySetupInfo(
-        relay = normalized,
-        relayStat = Amethyst.instance.relayStats.get(normalized),
-        forcesTor = forcesTor,
-    )
+fun <T> Iterable<T>.replace(
+    old: T,
+    new: T,
+): List<T> = map { if (it == old) new else it }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/relays/common/RelayCountResult.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/relays/common/RelayCountResult.kt
@@ -18,19 +18,24 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common
+package com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.relays.common
 
-import com.vitorpamplona.amethyst.Amethyst
-import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import androidx.compose.runtime.Immutable
+import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 
-typealias BasicRelaySetupInfo = com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
-
-fun relaySetupInfoBuilder(
-    normalized: NormalizedRelayUrl,
-    forcesTor: Boolean = false,
-): BasicRelaySetupInfo =
-    BasicRelaySetupInfo(
-        relay = normalized,
-        relayStat = Amethyst.instance.relayStats.get(normalized),
-        forcesTor = forcesTor,
+@Immutable
+data class RelayCountResult(
+    val counts: List<CountEntry> = emptyList(),
+) {
+    @Immutable
+    data class CountEntry(
+        val label: Int,
+        val count: Int,
+        val approximate: Boolean = false,
     )
+}
+
+data class CountFilter(
+    val label: Int,
+    val filter: Filter,
+)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/relays/common/RelayListCollection.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/relays/common/RelayListCollection.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.relays.common
+
+data class RelayListCollection(
+    val homeRelays: List<BasicRelaySetupInfo>,
+    val notifRelays: List<BasicRelaySetupInfo>,
+    val dmRelays: List<BasicRelaySetupInfo>,
+    val privateOutboxRelays: List<BasicRelaySetupInfo>,
+    val proxyRelays: List<BasicRelaySetupInfo>,
+    val broadcastRelays: List<BasicRelaySetupInfo>,
+    val indexerRelays: List<BasicRelaySetupInfo>,
+    val searchRelays: List<BasicRelaySetupInfo>,
+    val localRelays: List<BasicRelaySetupInfo>,
+    val trustedRelays: List<BasicRelaySetupInfo>,
+    val favoriteRelays: List<BasicRelaySetupInfo>,
+    val blockedRelays: List<BasicRelaySetupInfo>,
+)
+
+data class RelaySection(
+    val fileName: String,
+    val titleRes: Int,
+    val descriptionRes: Int,
+    val relays: List<BasicRelaySetupInfo>,
+)


### PR DESCRIPTION
Moves relay ViewModel data types, base state management, and interfaces to commons for KMP.

## What moved to commons

- **BasicRelaySetupInfo** data class — relay setup info with stat, tor, and paid relay flags
- **RelayCountResult** + **CountFilter** data classes — relay event count results
- **replace()** extension — Iterable utility used by relay state management
- **BasicRelaySetupInfoState** abstract ViewModel — platform-agnostic relay list state management (add/delete/move/clear, NIP-11 info loading, count queries via INostrClient)
- **IRelaySuggestionState** interface — relay suggestion search contract

## What stays in Android

- **BasicRelaySetupInfoModel** — extends BasicRelaySetupInfoState, provides Android-specific implementations (Amethyst singleton for NIP-11 cache, tor evaluation, relay stats; Account for client access; AccountViewModel for signer)
- **relaySetupInfoBuilder()** — uses Amethyst.instance.relayStats
- **RelaySuggestionState** — uses LocalCache for relay hints
- All concrete relay VM subclasses (BlockedRelayListViewModel, etc.) — depend on Account relay list methods
- All View/Composable files — remain Android-specific

## Pattern

The abstract base in commons captures the shared state management logic (flows, mutations, count loading) while abstract methods allow each platform to inject its relay info loader, signer, client, and setup info builder.

Part of the KMP iOS migration tracked in #2238.