### PR TITLE
feat: migrate composable signatures to IAccountViewModel (v11) — screen/loggedIn small dirs

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -51,6 +51,7 @@ import com.vitorpamplona.amethyst.commons.model.nip53LiveActivities.LiveActiviti
 import com.vitorpamplona.amethyst.commons.model.observables.CreatedAtComparator
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
 import com.vitorpamplona.amethyst.commons.ui.notifications.CardFeedState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.logTime
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.AccountSettings
@@ -175,14 +176,17 @@ import kotlinx.coroutines.withContext
 
 @Stable
 class AccountViewModel(
-    val account: Account,
+    override val account: Account,
     val settings: UiSettingsState,
     val torSettings: TorSettingsFlow,
     val dataSources: RelaySubscriptionsCoordinator,
     val httpClientBuilder: IRoleBasedHttpClientBuilder,
     val nip05ClientBuilder: () -> INip05Client,
 ) : ViewModel(),
-    Dao {
+    Dao,
+    IAccountViewModel {
+    override val scope: CoroutineScope get() = viewModelScope
+
     var firstRoute: Route? = null
 
     val toastManager = ToastManager()
@@ -418,11 +422,11 @@ class AccountViewModel(
             Route.Notification() to notificationHasNewItemsFlow,
         )
 
-    fun isWriteable(): Boolean = account.isWriteable()
+    override fun isWriteable(): Boolean = account.isWriteable()
 
-    fun userProfile(): User = account.userProfile()
+    override fun userProfile(): User = account.userProfile()
 
-    fun reactToOrDelete(
+    override fun reactToOrDelete(
         note: Note,
         reaction: String,
     ) {
@@ -450,7 +454,7 @@ class AccountViewModel(
         }
     }
 
-    fun reactToOrDelete(note: Note) {
+    override fun reactToOrDelete(note: Note) {
         val reaction = reactionChoices().first()
         reactToOrDelete(note, reaction)
     }
@@ -859,7 +863,7 @@ class AccountViewModel(
         }
     }
 
-    fun boost(note: Note) {
+    override fun boost(note: Note) {
         if (settings.isCompleteUIMode()) {
             // Tracked broadcasting with progress feedback
             launchSigner {
@@ -904,7 +908,7 @@ class AccountViewModel(
 
     fun pinnedNotes(user: User): Note = LocalCache.getOrCreateAddressableNote(PinListEvent.createPinAddress(user.pubkeyHex))
 
-    fun addPin(note: Note) {
+    override fun addPin(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createAddPinEvent(note)?.let { (event, relays) ->
@@ -921,7 +925,7 @@ class AccountViewModel(
         }
     }
 
-    fun removePin(note: Note) {
+    override fun removePin(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createRemovePinEvent(note)?.let { (event, relays) ->
@@ -938,7 +942,7 @@ class AccountViewModel(
         }
     }
 
-    fun addPrivateBookmark(note: Note) {
+    override fun addPrivateBookmark(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createAddBookmarkEvent(note, true)?.let { (event, relays) ->
@@ -955,7 +959,7 @@ class AccountViewModel(
         }
     }
 
-    fun addPublicBookmark(note: Note) {
+    override fun addPublicBookmark(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createAddBookmarkEvent(note, false)?.let { (event, relays) ->
@@ -972,7 +976,7 @@ class AccountViewModel(
         }
     }
 
-    fun removePrivateBookmark(note: Note) {
+    override fun removePrivateBookmark(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createRemoveBookmarkEvent(note, true)?.let { (event, relays) ->
@@ -990,7 +994,7 @@ class AccountViewModel(
         }
     }
 
-    fun removePublicBookmark(note: Note) {
+    override fun removePublicBookmark(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createRemoveBookmarkEvent(note, false)?.let { (event, relays) ->
@@ -1007,13 +1011,13 @@ class AccountViewModel(
         }
     }
 
-    fun broadcast(note: Note) = launchSigner { account.broadcast(note) }
+    override fun broadcast(note: Note) = launchSigner { account.broadcast(note) }
 
     fun timestamp(note: Note) = launchSigner { account.otsState.timestamp(note) }
 
-    fun delete(notes: List<Note>) = launchSigner { account.delete(notes) }
+    override fun delete(notes: List<Note>) = launchSigner { account.delete(notes) }
 
-    fun delete(note: Note) = launchSigner { account.delete(note) }
+    override fun delete(note: Note) = launchSigner { account.delete(note) }
 
     fun requestToVanish(
         relays: List<NormalizedRelayUrl>,
@@ -1026,9 +1030,9 @@ class AccountViewModel(
         createdAt: Long,
     ) = launchSigner { account.requestToVanishFromEverywhere(reason, createdAt) }
 
-    fun cachedDecrypt(note: Note): String? = account.cachedDecryptContent(note)
+    override fun cachedDecrypt(note: Note): String? = account.cachedDecryptContent(note)
 
-    fun decrypt(
+    override fun decrypt(
         note: Note,
         onReady: (String) -> Unit,
     ) = launchSigner {
@@ -1095,9 +1099,9 @@ class AccountViewModel(
 
     fun follow(users: List<User>) = launchSigner { account.follow(users) }
 
-    fun follow(user: User) = launchSigner { account.follow(user) }
+    override fun follow(user: User) = launchSigner { account.follow(user) }
 
-    fun unfollow(user: User) = launchSigner { account.unfollow(user) }
+    override fun unfollow(user: User) = launchSigner { account.unfollow(user) }
 
     fun followGeohash(tag: String) = launchSigner { account.followGeohash(tag) }
 
@@ -1115,16 +1119,16 @@ class AccountViewModel(
 
     fun hideWord(word: String) = launchSigner { account.hideWord(word) }
 
-    fun isLoggedUser(pubkeyHex: HexKey?): Boolean = account.signer.pubKey == pubkeyHex
+    override fun isLoggedUser(pubkeyHex: HexKey?): Boolean = account.signer.pubKey == pubkeyHex
 
-    fun isLoggedUser(user: User?): Boolean = isLoggedUser(user?.pubkeyHex)
+    override fun isLoggedUser(user: User?): Boolean = isLoggedUser(user?.pubkeyHex)
 
-    fun isFollowing(user: User?): Boolean {
+    override fun isFollowing(user: User?): Boolean {
         if (user == null) return false
         return account.isFollowing(user)
     }
 
-    fun isFollowing(user: HexKey): Boolean = account.isFollowing(user)
+    override fun isFollowing(user: HexKey): Boolean = account.isFollowing(user)
 
     fun markDonatedInThisVersion() = account.markDonatedInThisVersion()
 
@@ -1137,21 +1141,21 @@ class AccountViewModel(
         pollEndsAt: Long?,
     ) = account.markPollResultsViewed(noteId, pollEndsAt)
 
-    fun dontTranslateFrom() = account.settings.syncedSettings.languages.dontTranslateFrom.value
+    override fun dontTranslateFrom() = account.settings.syncedSettings.languages.dontTranslateFrom.value
 
-    fun translateTo() = account.settings.syncedSettings.languages.translateTo.value
+    override fun translateTo() = account.settings.syncedSettings.languages.translateTo.value
 
-    fun defaultZapType() = account.settings.syncedSettings.zaps.defaultZapType.value
+    override fun defaultZapType() = account.settings.syncedSettings.zaps.defaultZapType.value
 
-    fun showSensitiveContent(): MutableStateFlow<Boolean?> = account.settings.syncedSettings.security.showSensitiveContent
+    override fun showSensitiveContent(): MutableStateFlow<Boolean?> = account.settings.syncedSettings.security.showSensitiveContent
 
     fun zapAmountChoicesFlow() = account.settings.syncedSettings.zaps.zapAmountChoices
 
-    fun zapAmountChoices() = zapAmountChoicesFlow().value
+    override fun zapAmountChoices() = zapAmountChoicesFlow().value
 
     fun reactionChoicesFlow() = account.settings.syncedSettings.reactions.reactionChoices
 
-    fun reactionChoices() = reactionChoicesFlow().value
+    override fun reactionChoices() = reactionChoicesFlow().value
 
     fun filterSpamFromStrangers() = account.settings.syncedSettings.security.filterSpamFromStrangers
 
@@ -1205,9 +1209,9 @@ class AccountViewModel(
         preference: String,
     ) = launchSigner { account.prefer(source, target, preference) }
 
-    fun show(user: User) = launchSigner { account.showUser(user.pubkeyHex) }
+    override fun show(user: User) = launchSigner { account.showUser(user.pubkeyHex) }
 
-    fun hide(user: User) = launchSigner { account.hideUser(user.pubkeyHex) }
+    override fun hide(user: User) = launchSigner { account.hideUser(user.pubkeyHex) }
 
     fun hide(word: String) = launchSigner { account.hideWord(word) }
 
@@ -1236,23 +1240,23 @@ class AccountViewModel(
         }
     }
 
-    fun loadReactionTo(note: Note?): String? {
+    override fun loadReactionTo(note: Note?): String? {
         if (note == null) return null
 
         return note.getReactionBy(userProfile())
     }
 
-    fun runOnIO(runOnIO: suspend () -> Unit) {
+    override fun runOnIO(runOnIO: suspend () -> Unit) {
         viewModelScope.launch(Dispatchers.IO) { runOnIO() }
     }
 
-    fun checkGetOrCreateUser(key: HexKey): User? = LocalCache.checkGetOrCreateUser(key)
+    override fun checkGetOrCreateUser(key: HexKey): User? = LocalCache.checkGetOrCreateUser(key)
 
     override suspend fun getOrCreateUser(hex: HexKey): User = LocalCache.getOrCreateUser(hex)
 
-    fun getUserIfExists(hex: HexKey): User? = LocalCache.getUserIfExists(hex)
+    override fun getUserIfExists(hex: HexKey): User? = LocalCache.getUserIfExists(hex)
 
-    fun checkGetOrCreateNote(key: HexKey): Note? = LocalCache.checkGetOrCreateNote(key)
+    override fun checkGetOrCreateNote(key: HexKey): Note? = LocalCache.checkGetOrCreateNote(key)
 
     override suspend fun getOrCreateNote(hex: HexKey): Note = LocalCache.getOrCreateNote(hex)
 
@@ -1267,7 +1271,7 @@ class AccountViewModel(
         return note
     }
 
-    fun getNoteIfExists(hex: HexKey): Note? = LocalCache.getNoteIfExists(hex)
+    override fun getNoteIfExists(hex: HexKey): Note? = LocalCache.getNoteIfExists(hex)
 
     /**
      * Fixes author and relay hints in MarkedETag list by looking up notes from cache.
@@ -1297,9 +1301,9 @@ class AccountViewModel(
 
     override fun getOrCreateAddressableNote(address: Address): AddressableNote = LocalCache.getOrCreateAddressableNote(address)
 
-    fun getAddressableNoteIfExists(key: String): AddressableNote? = LocalCache.getAddressableNoteIfExists(key)
+    override fun getAddressableNoteIfExists(key: String): AddressableNote? = LocalCache.getAddressableNoteIfExists(key)
 
-    fun getAddressableNoteIfExists(key: Address): AddressableNote? = LocalCache.getAddressableNoteIfExists(key)
+    override fun getAddressableNoteIfExists(key: Address): AddressableNote? = LocalCache.getAddressableNoteIfExists(key)
 
     fun cachedModificationEventsForNote(note: Note) = LocalCache.cachedModificationEventsForNote(note)
 
@@ -1361,7 +1365,7 @@ class AccountViewModel(
             OnlineChecker.isOnline(videoUrl, httpClientBuilder::okHttpClientForVideo)
         }
 
-    fun loadAndMarkAsRead(
+    override fun loadAndMarkAsRead(
         routeForLastRead: String,
         createdAt: Long?,
     ): Boolean {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/default/BookmarkListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/default/BookmarkListScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.EventFinderQueryState
 import com.vitorpamplona.amethyst.ui.layouts.DisappearingScaffold
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -57,9 +58,11 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun BookmarkListScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val publicFeedViewModel: BookmarkPublicFeedViewModel =
         viewModel(
             key = "NostrBookmarkPublicFeedViewModel",
@@ -105,9 +108,11 @@ private fun RenderBookmarkScreen(
     publicFeedViewModel: BookmarkPublicFeedViewModel,
     privateFeedViewModel: BookmarkPrivateFeedViewModel,
     pinnedNotesFeedViewModel: PinnedNotesFeedViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val pagerState = rememberPagerState { 3 }
     val coroutineScope = rememberCoroutineScope()
 
@@ -182,8 +187,10 @@ private fun RenderBookmarkScreen(
 private fun PreloadBookmarkEvents(
     bookmarkState: com.vitorpamplona.amethyst.commons.model.nip51Lists.BookmarkListState.BookmarkList?,
     pinState: List<com.vitorpamplona.amethyst.model.Note>?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val eventFinder = accountViewModel.dataSources().eventFinder
     val account = accountViewModel.account
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/display/ArticleListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/display/ArticleListView.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.AddressableNote
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.NoteCompose
@@ -42,12 +43,14 @@ import com.vitorpamplona.quartz.nip01Core.core.Address
 fun RenderArticleList(
     bookmarkGroupViewModel: BookmarkGroupViewModel,
     pagerState: PagerState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     moveArticleBookmark: (articleAddress: Address, fromPrivate: Boolean) -> Unit,
     deleteArticleBookmark: (articleAddress: Address, isPrivate: Boolean) -> Unit,
     nav: INav,
     modifier: Modifier = Modifier,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val privateArticles by bookmarkGroupViewModel.privateArticles().collectAsStateWithLifecycle()
     val publicArticles by bookmarkGroupViewModel.publicArticles().collectAsStateWithLifecycle()
 
@@ -96,9 +99,11 @@ fun ArticleList(
     onMoveBookmarkToPublic: (articleAddress: Address) -> Unit = {},
     onMoveBookmarkToPrivate: (articleAddress: Address) -> Unit = {},
     onDeleteArticleBookmark: (Address) -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val listState = rememberLazyListState()
 
     LazyColumn(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/display/BookmarkGroupItemOptions.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/display/BookmarkGroupItemOptions.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.actions.EditPostView
 import com.vitorpamplona.amethyst.ui.components.ClickableBox
@@ -78,9 +79,11 @@ fun BookmarkGroupItemOptions(
     onMoveBookmarkToPrivate: () -> Unit,
     onDeleteBookmarkItem: () -> Unit,
     editState: State<GenericLoadable<EditState>>? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val popupExpanded = remember { mutableStateOf(false) }
 
     ClickableBox(
@@ -114,9 +117,11 @@ fun BookmarkGroupItemOptionsMenu(
     onMoveBookmarkToPrivate: () -> Unit,
     onDeleteBookmarkItem: () -> Unit,
     editState: State<GenericLoadable<EditState>>? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var reportDialogShowing by remember { mutableStateOf(false) }
 
     val state by observeBookmarksFollowsAndAccount(note, accountViewModel).collectAsStateWithLifecycle(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/display/BookmarkGroupScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/display/BookmarkGroupScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.components.ClickableBox
 import com.vitorpamplona.amethyst.ui.components.M3ActionDialog
 import com.vitorpamplona.amethyst.ui.components.M3ActionRow
@@ -76,9 +77,11 @@ import kotlinx.coroutines.launch
 fun BookmarkGroupScreen(
     bookmarkIdentifier: String,
     bookmarkType: BookmarkType,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val bookmarkGroupViewModel: BookmarkGroupViewModel =
         viewModel(
             factory = BookmarkGroupViewModel.Initializer(accountViewModel.account, bookmarkIdentifier),
@@ -113,9 +116,11 @@ fun BookmarkGroupScreenView(
     bookmarkType: BookmarkType,
     broadcastBookmarkGroup: () -> Unit,
     deleteBookmarkGroup: () -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val pagerState = rememberPagerState { 2 }
     Scaffold(
         topBar = {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/display/PostListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/display/PostListView.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.NoteCompose
@@ -41,12 +42,14 @@ import com.vitorpamplona.amethyst.ui.theme.FeedPadding
 fun RenderPostList(
     bookmarkGroupViewModel: BookmarkGroupViewModel,
     pagerState: PagerState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     movePostBookmark: (postId: String, fromPrivate: Boolean) -> Unit,
     deletePostBookmark: (postId: String, isPrivate: Boolean) -> Unit,
     nav: INav,
     modifier: Modifier = Modifier,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val privatePosts by bookmarkGroupViewModel.privatePosts().collectAsStateWithLifecycle()
     val publicPosts by bookmarkGroupViewModel.publicPosts().collectAsStateWithLifecycle()
 
@@ -95,9 +98,11 @@ private fun PostList(
     onMoveBookmarkToPublic: (postId: String) -> Unit = {},
     onMoveBookmarkToPrivate: (postId: String) -> Unit = {},
     onDeletePostBookmark: (postId: String) -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val listState = rememberLazyListState()
 
     LazyColumn(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/list/ListOfBookmarkGroupsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/list/ListOfBookmarkGroupsScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.nip51Lists.BookmarkListState
 import com.vitorpamplona.amethyst.model.nip51Lists.OldBookmarkListState
 import com.vitorpamplona.amethyst.model.nip51Lists.labeledBookmarkLists.LabeledBookmarkList
@@ -47,9 +48,11 @@ import kotlinx.coroutines.flow.StateFlow
 
 @Composable
 fun ListOfBookmarkGroupsScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     ListOfBookmarkGroupsFeed(
         defaultBookmarks = accountViewModel.account.bookmarkState,
         oldBookmarks = accountViewModel.account.oldBookmarkState,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/list/metadata/BookmarkGroupMetadataScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/list/metadata/BookmarkGroupMetadataScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectSingleFromGallery
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.CreatingTopBar
@@ -58,9 +59,11 @@ import com.vitorpamplona.quartz.nip01Core.signers.SignerExceptions
 @Composable
 fun BookmarkGroupMetadataScreen(
     bookmarkGroupIdentifier: String?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val bookmarkGroupInfoViewModel: BookmarkGroupMetadataViewModel = viewModel()
     bookmarkGroupInfoViewModel.init(accountViewModel)
 
@@ -81,9 +84,11 @@ fun BookmarkGroupMetadataScreen(
 @Composable
 private fun BookmarkGroupMetadataScaffold(
     bookmarkGroupInfoViewModel: BookmarkGroupMetadataViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Scaffold(
         topBar = {
             BookmarkGroupMetadataTopBar(
@@ -128,9 +133,11 @@ private fun BookmarkGroupMetadataScaffold(
 @Composable
 fun BookmarkGroupMetadataTopBar(
     bookmarkGroupInfoViewModel: BookmarkGroupMetadataViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (bookmarkGroupInfoViewModel.isNewList) {
         CreatingTopBar(
             titleRes = R.string.bookmark_list_creation_screen_title,
@@ -199,8 +206,10 @@ private fun Description(bookmarkGroupInfoViewModel: BookmarkGroupMetadataViewMod
 @Composable
 private fun Picture(
     bookmarkGroupInfoViewModel: BookmarkGroupMetadataViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     OutlinedTextField(
         label = { Text(text = stringRes(R.string.optional_picture_url)) },
         modifier = Modifier.fillMaxWidth(),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/membershipManagement/ArticleBookmarkListManagementScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/membershipManagement/ArticleBookmarkListManagementScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.AddressableNote
 import com.vitorpamplona.amethyst.model.nip51Lists.labeledBookmarkLists.LabeledBookmarkList
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -52,9 +53,11 @@ import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.AddressBookmark
 @Composable
 fun ArticleBookmarkListManagementScreen(
     articleAddress: Address,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     LoadAddressableNote(address = articleAddress, accountViewModel = accountViewModel) {
         it?.let {
             ListManagementView(
@@ -71,9 +74,11 @@ fun ArticleBookmarkListManagementScreen(
 private fun ListManagementView(
     modifier: Modifier = Modifier,
     note: AddressableNote,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Scaffold(
         modifier = modifier,
         topBar = {
@@ -100,9 +105,11 @@ private fun ListManagementView(
 @Composable
 private fun ListManagementViewBody(
     note: AddressableNote,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val bookmarkGroups by accountViewModel.account.labeledBookmarkLists.listFeedFlow
         .collectAsStateWithLifecycle()
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/membershipManagement/PostBookmarkListManagementScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/membershipManagement/PostBookmarkListManagementScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.nip51Lists.labeledBookmarkLists.LabeledBookmarkList
 import com.vitorpamplona.amethyst.ui.components.LoadNote
@@ -51,9 +52,11 @@ import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.EventBookmark
 @Composable
 fun PostBookmarkListManagementScreen(
     postId: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     LoadNote(baseNoteHex = postId, accountViewModel = accountViewModel) {
         it?.let {
             ListManagementView(
@@ -70,9 +73,11 @@ fun PostBookmarkListManagementScreen(
 private fun ListManagementView(
     modifier: Modifier = Modifier,
     note: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Scaffold(
         modifier = modifier,
         topBar = {
@@ -99,9 +104,11 @@ private fun ListManagementView(
 @Composable
 private fun ListManagementViewBody(
     note: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val bookmarkGroups by accountViewModel.account.labeledBookmarkLists.listFeedFlow
         .collectAsStateWithLifecycle()
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/old/OldBookmarkListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/old/OldBookmarkListScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.EventFinderQueryState
 import com.vitorpamplona.amethyst.ui.layouts.DisappearingScaffold
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -62,9 +63,11 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun OldBookmarkListScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val publicFeedViewModel: OldBookmarkPublicFeedViewModel =
         viewModel(
             key = "NostrOldBookmarkPublicFeedViewModel",
@@ -97,9 +100,11 @@ fun OldBookmarkListScreen(
 private fun RenderOldBookmarkScreen(
     publicFeedViewModel: OldBookmarkPublicFeedViewModel,
     privateFeedViewModel: OldBookmarkPrivateFeedViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val pagerState = rememberPagerState { 2 }
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
@@ -184,8 +189,10 @@ private fun RenderOldBookmarkScreen(
 @Composable
 private fun PreloadOldBookmarkEvents(
     bookmarkState: com.vitorpamplona.amethyst.commons.model.nip51Lists.OldBookmarkListState.BookmarkList?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val eventFinder = accountViewModel.dataSources().eventFinder
     val account = accountViewModel.account
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chess/ChessGameScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chess/ChessGameScreen.kt
@@ -69,6 +69,7 @@ import com.vitorpamplona.amethyst.commons.chess.ChessBroadcastBanner
 import com.vitorpamplona.amethyst.commons.chess.ChessBroadcastStatus
 import com.vitorpamplona.amethyst.commons.chess.ChessSyncBanner
 import com.vitorpamplona.amethyst.commons.chess.LiveChessGameScreen
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -90,9 +91,11 @@ import com.vitorpamplona.quartz.nip64Chess.ChessGameNameGenerator
 @Composable
 fun ChessGameScreen(
     gameId: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     // Scope ViewModel to Activity so it's shared between lobby and game screens
     val activity = LocalActivity.current as FragmentActivity
     val chessViewModel: ChessViewModelNew =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chess/ChessLobbyScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chess/ChessLobbyScreen.kt
@@ -74,6 +74,7 @@ import com.vitorpamplona.amethyst.commons.chess.OutgoingChallengeCard
 import com.vitorpamplona.amethyst.commons.chess.OverlappingAvatars
 import com.vitorpamplona.amethyst.commons.chess.PublicGameCard
 import com.vitorpamplona.amethyst.commons.chess.SpectatingGameCard
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.feeds.RefresheableBox
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
@@ -88,9 +89,11 @@ import com.vitorpamplona.quartz.nip64Chess.Color as ChessColor
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ChessLobbyScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     // Scope ViewModel to Activity so it's shared between lobby and game screens
     val activity = LocalActivity.current as FragmentActivity
     val chessViewModel: ChessViewModelNew =
@@ -153,9 +156,11 @@ fun NavigateIfInAGame(
 @Composable
 fun ChessLobbyScreen(
     chessViewModel: ChessViewModelNew,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var showNewGameDialog by remember { mutableStateOf(false) }
     var showRelaySettings by remember { mutableStateOf(false) }
 
@@ -287,12 +292,14 @@ fun ErrorDisplay(chessViewModel: ChessViewModelNew) {
 @Composable
 fun ChessLobbyContent(
     chessViewModel: ChessViewModelNew,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onAcceptChallenge: (ChessChallenge) -> Unit,
     onOpenOwnChallenge: (ChessChallenge) -> Unit,
     onSelectGame: (String) -> Unit,
     onWatchGame: (String) -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val activeGames by chessViewModel.activeGames.collectAsState()
     val spectatingGames by chessViewModel.spectatingGames.collectAsState()
     val publicGames by chessViewModel.publicGames.collectAsState()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chess/ChessRelaySettingsSheet.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chess/ChessRelaySettingsSheet.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.chess.ChessConfig
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
@@ -61,8 +62,10 @@ import kotlinx.coroutines.flow.map
 @Composable
 fun ChessRelaySettingsSheet(
     chessViewModel: ChessViewModelNew,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     // Get relay information for settings display
     val inboxRelays by accountViewModel.account.notificationRelays.flow
         .collectAsState()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chess/datasource/ChessSubscription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chess/datasource/ChessSubscription.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.KeyDataSourceSubscription
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chess.ChessViewModelNew
 
@@ -38,8 +39,10 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.chess.ChessViewModelNew
 @Composable
 fun ChessSubscription(
     chessViewModel: ChessViewModelNew,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     // Get active game IDs from the view model for game-specific subscriptions
     val activeGames by chessViewModel.activeGames.collectAsStateWithLifecycle()
     val spectatingGames by chessViewModel.spectatingGames.collectAsStateWithLifecycle()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/ChannelCardCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/ChannelCardCompose.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.components.SensitivityWarning
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -61,9 +62,11 @@ fun ChannelCardCompose(
     parentBackgroundColor: MutableState<Color>? = null,
     forceEventKind: Int?,
     isHiddenFeed: Boolean = false,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     WatchNoteEvent(baseNote = baseNote, accountViewModel = accountViewModel, nav) {
         if (forceEventKind == null || baseNote.event?.kind == forceEventKind) {
             CheckHiddenFeedWatchBlockAndReport(
@@ -93,9 +96,11 @@ fun NormalChannelCard(
     routeForLastRead: String? = null,
     modifier: Modifier = Modifier,
     parentBackgroundColor: MutableState<Color>? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     LongPressToQuickAction(baseNote, accountViewModel, nav) { showPopup ->
         CheckNewAndRenderChannelCard(
             baseNote,
@@ -115,10 +120,12 @@ private fun CheckNewAndRenderChannelCard(
     routeForLastRead: String? = null,
     modifier: Modifier = Modifier,
     parentBackgroundColor: MutableState<Color>? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     showPopup: () -> Unit,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val backgroundColor =
         calculateBackgroundColor(
             createdAt = baseNote.createdAt(),
@@ -146,9 +153,11 @@ private fun CheckNewAndRenderChannelCard(
 @Composable
 fun InnerChannelCardWithReactions(
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     when (baseNote.event) {
         is LiveActivitiesEvent -> InnerCardRow(baseNote, accountViewModel, nav)
         is MeetingSpaceEvent -> InnerCardRow(baseNote, accountViewModel, nav)
@@ -165,9 +174,11 @@ fun InnerChannelCardWithReactions(
 @Composable
 fun InnerCardRow(
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Column(StdPadding) {
         SensitivityWarning(
             note = baseNote,
@@ -185,9 +196,11 @@ fun InnerCardRow(
 @Composable
 fun InnerCardBox(
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Column(HalfPadding) {
         SensitivityWarning(
             note = baseNote,
@@ -201,9 +214,11 @@ fun InnerCardBox(
 @Composable
 private fun RenderNoteRow(
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     when (baseNote.event) {
         is LiveActivitiesEvent -> RenderLiveActivityThumb(baseNote, accountViewModel, nav)
         is MeetingSpaceEvent -> RenderLiveActivityThumb(baseNote, accountViewModel, nav)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/DiscoverScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/DiscoverScreen.kt
@@ -57,6 +57,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedContentState
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.feeds.FeedEmpty
 import com.vitorpamplona.amethyst.ui.feeds.FeedError
@@ -94,9 +95,11 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun DiscoverScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     DiscoverScreen(
         discoveryFollowSetsFeedContentState = accountViewModel.feedStates.discoverFollowSets,
         discoveryReadsFeedContentState = accountViewModel.feedStates.discoverReads,
@@ -120,9 +123,11 @@ fun DiscoverScreen(
     discoveryLiveFeedContentState: FeedContentState,
     discoveryCommunityFeedContentState: FeedContentState,
     discoveryChatFeedContentState: FeedContentState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val feedTabs by
         remember(accountViewModel) {
             mutableStateOf(
@@ -211,9 +216,11 @@ fun DiscoverScreen(
 private fun DiscoverPages(
     pagerState: PagerState,
     feedTabs: ImmutableList<TabItem>,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     DisappearingScaffold(
         isInvertedLayout = false,
         topBar = {
@@ -303,9 +310,11 @@ private fun RenderDiscoverFeed(
     routeForLastRead: String?,
     forceEventKind: Int?,
     listState: LazyGridState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val feedState by feedContentState.feedContent.collectAsStateWithLifecycle()
 
     CrossfadeIfEnabled(
@@ -343,9 +352,11 @@ private fun RenderDiscoverFeed(
 
 @Composable
 fun NewProductButton(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     FloatingActionButton(
         onClick = {
             nav.nav(Route.NewProduct())
@@ -365,9 +376,11 @@ fun NewProductButton(
 
 @Composable
 fun NewLongFormMarkdownButton(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     FloatingActionButton(
         onClick = {
             nav.nav(Route.NewLongFormPost())
@@ -391,9 +404,11 @@ private fun RenderDiscoverFeed(
     routeForLastRead: String?,
     forceEventKind: Int?,
     listState: LazyListState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val feedState by feedContentState.feedContent.collectAsStateWithLifecycle()
 
     CrossfadeIfEnabled(
@@ -438,8 +453,10 @@ fun WatchAccountForDiscoveryScreen(
     discoveryLiveFeedContentState: FeedContentState,
     discoveryCommunityFeedContentState: FeedContentState,
     discoveryChatFeedContentState: FeedContentState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val listState by accountViewModel.account.liveDiscoveryFollowLists.collectAsStateWithLifecycle()
 
     LaunchedEffect(accountViewModel, listState) {
@@ -460,9 +477,11 @@ private fun DiscoverFeedLoaded(
     routeForLastRead: String?,
     listState: LazyListState,
     forceEventKind: Int?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val items by loaded.feed.collectAsStateWithLifecycle()
 
     LazyColumn(
@@ -495,9 +514,11 @@ private fun DiscoverFeedColumnsLoaded(
     routeForLastRead: String?,
     listState: LazyGridState,
     forceEventKind: Int?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val items by loaded.feed.collectAsStateWithLifecycle()
 
     LazyVerticalGrid(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/DiscoveryTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/DiscoveryTopBar.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.FeedFilterSpinner
@@ -35,9 +36,11 @@ import com.vitorpamplona.amethyst.ui.stringRes
 
 @Composable
 fun DiscoveryTopBar(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     UserDrawerSearchTopBar(accountViewModel, nav) {
         val list by accountViewModel.account.settings.defaultDiscoveryFollowList
             .collectAsStateWithLifecycle()
@@ -55,9 +58,11 @@ fun DiscoveryTopBar(
 private fun TopNavFilterBar(
     followListsModel: TopNavFilterState,
     listName: TopFilter,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onChange: (FeedDefinition) -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val allLists by followListsModel.kind3GlobalPeople.collectAsStateWithLifecycle()
 
     FeedFilterSpinner(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/datasource/DiscoveryFilterAssemblerSubscription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/datasource/DiscoveryFilterAssemblerSubscription.kt
@@ -24,10 +24,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.lifecycle.viewModelScope
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.KeyDataSourceSubscription
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
 @Composable
-fun DiscoveryFilterAssemblerSubscription(accountViewModel: AccountViewModel) {
+fun DiscoveryFilterAssemblerSubscription(accountViewModel: IAccountViewModel) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     DiscoveryFilterAssemblerSubscription(
         accountViewModel.dataSources().discovery,
         accountViewModel,
@@ -37,8 +40,10 @@ fun DiscoveryFilterAssemblerSubscription(accountViewModel: AccountViewModel) {
 @Composable
 fun DiscoveryFilterAssemblerSubscription(
     dataSource: DiscoveryFilterAssembler,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     // different screens get different states
     // even if they are tracking the same tag.
     val state =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip23LongForm/LongFormCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip23LongForm/LongFormCard.kt
@@ -22,6 +22,7 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.discover.nip23LongForm
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.observeNoteEvent
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -32,9 +33,11 @@ import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
 @Composable
 fun RenderLongFormThumb(
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val noteEvent by observeNoteEvent<LongTextNoteEvent>(baseNote, accountViewModel)
 
     noteEvent?.let {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip23LongForm/LongFormPostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip23LongForm/LongFormPostScreen.kt
@@ -86,6 +86,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.model.EmptyTagList
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.StrippingFailureDialog
 import com.vitorpamplona.amethyst.ui.actions.UrlUserTagOutputTransformation
 import com.vitorpamplona.amethyst.ui.actions.uploads.GallerySelectSingle
@@ -132,9 +133,11 @@ import com.vitorpamplona.quartz.nip01Core.core.HexKey
 fun LongFormPostScreen(
     draftId: HexKey? = null,
     versionId: HexKey? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: Nav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val postViewModel: LongFormPostViewModel = viewModel()
     postViewModel.init(accountViewModel)
 
@@ -193,9 +196,11 @@ fun LongFormPostScreen(
 @Composable
 private fun MarkdownPostScreenBody(
     postViewModel: LongFormPostViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: Nav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val scrollState = rememberScrollState()
     Column(
         modifier = Modifier.fillMaxSize(),
@@ -563,10 +568,12 @@ private fun MarkdownPostScreenBody(
 private fun BannerImageArea(
     coverImageUrl: String,
     isUploading: Boolean,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onImageSelected: (SelectedMedia) -> Unit,
     onClear: () -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var showGallerySelect by remember { mutableStateOf(false) }
     if (showGallerySelect) {
         GallerySelectSingle(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip28Chats/RenderPublicChatChannelThumb.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip28Chats/RenderPublicChatChannelThumb.kt
@@ -42,6 +42,7 @@ import coil3.compose.AsyncImage
 import coil3.compose.AsyncImagePainter
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatChannel
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.ParticipantListBuilder
 import com.vitorpamplona.amethyst.model.User
@@ -78,9 +79,11 @@ import kotlinx.coroutines.launch
 @Composable
 fun RenderPublicChatChannelThumb(
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val noteEvent = baseNote.event as? ChannelCreateEvent ?: return
 
     LoadPublicChatChannel(baseNote.idHex, accountViewModel) {
@@ -92,9 +95,11 @@ fun RenderPublicChatChannelThumb(
 fun RenderPublicChatChannelThumb(
     baseNote: Note,
     channel: PublicChatChannel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val channelUpdates by observeChannel(channel, accountViewModel)
     val publicChat = channelUpdates?.channel as PublicChatChannel
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip51FollowSets/FollowSetCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip51FollowSets/FollowSetCard.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.observeNoteAndMap
@@ -77,9 +78,11 @@ data class FollowSetCard(
 @Composable
 fun RenderFollowSetThumb(
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val card by observeNoteAndMap(baseNote, accountViewModel) {
         val noteEvent = it.event as? FollowListEvent
 
@@ -156,9 +159,11 @@ fun RenderFollowSetThumbPreview() {
 fun RenderFollowSetThumb(
     card: FollowSetCard,
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Column(
         modifier = Modifier.fillMaxWidth(),
     ) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip53LiveActivities/LiveActivityCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip53LiveActivities/LiveActivityCard.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.ParticipantListBuilder
@@ -96,9 +97,11 @@ data class LiveActivityCard(
 @Composable
 fun RenderLiveActivityThumb(
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val card by observeNoteAndMap(baseNote, accountViewModel) {
         when (val noteEvent = it.event) {
             is LiveActivitiesEvent -> {
@@ -177,9 +180,11 @@ fun RenderLiveActivityThumb(
 fun RenderLiveActivityThumb(
     card: LiveActivityCard,
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Column(
         modifier = Modifier.fillMaxWidth(),
     ) {
@@ -270,9 +275,11 @@ fun RenderLiveActivityThumb(
 fun LoadParticipants(
     participants: ImmutableList<ParticipantTag>,
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     inner: @Composable (ImmutableList<User>) -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var participantUsers by remember {
         mutableStateOf<ImmutableList<User>>(
             persistentListOf(),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip72Communities/CommunityCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip72Communities/CommunityCard.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.ParticipantListBuilder
@@ -88,9 +89,11 @@ data class CommunityCard(
 @Composable
 fun RenderCommunitiesThumb(
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val noteState by observeNote(baseNote, accountViewModel)
     val noteEvent = noteState.note.event as? CommunityDefinitionEvent ?: return
 
@@ -111,9 +114,11 @@ fun RenderCommunitiesThumb(
 fun RenderCommunitiesThumb(
     card: CommunityCard,
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     LeftPictureLayout(
         onImage = {
             card.cover?.let {
@@ -184,9 +189,11 @@ fun RenderCommunitiesThumb(
 fun LoadModerators(
     moderators: ImmutableList<String>,
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     content: @Composable (ImmutableList<User>) -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var participantUsers by remember {
         mutableStateOf<ImmutableList<User>>(
             persistentListOf(),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip90DVMs/DVMCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip90DVMs/DVMCard.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinderFilterAssemblerSubscription
 import com.vitorpamplona.amethyst.ui.components.MyAsyncImage
@@ -73,9 +74,11 @@ data class DVMCard(
 @Composable
 fun RenderContentDVMThumb(
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     // downloads user metadata to pre-load the NIP-65 relays.
     baseNote.author?.let { UserFinderFilterAssemblerSubscription(it, accountViewModel) }
     val card = observeAppDefinition(appDefinitionNote = baseNote, accountViewModel)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/ClassifiedsThumb.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/ClassifiedsThumb.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.observeNoteAndMap
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -65,9 +66,11 @@ data class ClassifiedsThumb(
 @Composable
 fun RenderClassifiedsThumb(
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (baseNote.event !is ClassifiedsEvent) return
 
     val card by observeNoteAndMap(baseNote, accountViewModel) {
@@ -103,8 +106,10 @@ fun RenderClassifiedsThumbPreview() {
 fun InnerRenderClassifiedsThumb(
     card: ClassifiedsThumb,
     note: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Box(
         Modifier
             .fillMaxWidth()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/NewProductScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/NewProductScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.StrippingFailureDialog
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromFiles
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromGallery
@@ -95,9 +96,11 @@ fun NewProductScreen(
     attachment: String? = null,
     quoteId: HexKey? = null,
     draftId: HexKey? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: Nav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val postViewModel: NewProductViewModel = viewModel()
     postViewModel.init(accountViewModel)
 
@@ -134,9 +137,11 @@ fun NewProductScreen(
 @Composable
 fun NewProductScreen(
     postViewModel: NewProductViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     WatchAndLoadMyEmojiList(accountViewModel)
 
     StrippingFailureDialog(postViewModel.strippingFailureConfirmation)
@@ -191,9 +196,11 @@ fun NewProductScreen(
 @Composable
 private fun NewProductBody(
     postViewModel: NewProductViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val scrollState = rememberScrollState()
 
     Column(Modifier.fillMaxSize()) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/geohash/GeoHashPostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/geohash/GeoHashPostScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toUri
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.note.nip22Comments.CommentPostViewModel
@@ -45,9 +46,11 @@ fun GeoHashPostScreen(
     replyId: HexKey? = null,
     quoteId: HexKey? = null,
     draftId: HexKey? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: Nav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val postViewModel: CommentPostViewModel = viewModel()
     postViewModel.init(accountViewModel)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/geohash/GeoHashScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/geohash/GeoHashScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserIsFollowingGeohash
 import com.vitorpamplona.amethyst.ui.feeds.WatchLifecycleAndUpdateModel
 import com.vitorpamplona.amethyst.ui.layouts.DisappearingScaffold
@@ -47,9 +48,11 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.UnfollowButton
 @Composable
 fun GeoHashScreen(
     tag: Route.Geohash,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (tag.geohash.isEmpty()) return
 
     PrepareViewModelsGeoHashScreen(tag, accountViewModel, nav)
@@ -59,9 +62,11 @@ fun GeoHashScreen(
 @Composable
 fun PrepareViewModelsGeoHashScreen(
     tag: Route.Geohash,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val geohashViewModel: GeoHashFeedViewModel =
         viewModel(
             key = tag.geohash + "GeoHashFeedViewModel",
@@ -80,9 +85,11 @@ fun PrepareViewModelsGeoHashScreen(
 fun GeoHashScreen(
     tag: Route.Geohash,
     feedViewModel: GeoHashFeedViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     WatchLifecycleAndUpdateModel(feedViewModel)
     GeoHashFilterAssemblerSubscription(tag, accountViewModel)
 
@@ -130,8 +137,10 @@ fun DisplayGeoTagHeader(
 @Composable
 fun GeoHashActionOptions(
     tag: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val isFollowingTag by observeUserIsFollowingGeohash(tag, accountViewModel)
 
     if (isFollowingTag) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/geohash/NewGeoNoteButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/geohash/NewGeoNoteButton.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.painterRes
@@ -38,9 +39,11 @@ import com.vitorpamplona.amethyst.ui.theme.Size55Modifier
 @Composable
 fun NewGeoPostButton(
     tag: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     FloatingActionButton(
         onClick = {
             nav.nav(Route.GeoPost(tag))

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/geohash/datasource/GeoHashFilterAssemblerSubscription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/geohash/datasource/GeoHashFilterAssemblerSubscription.kt
@@ -24,6 +24,7 @@ import android.annotation.SuppressLint
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.KeyDataSourceSubscription
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
@@ -31,8 +32,10 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 @Composable
 fun GeoHashFilterAssemblerSubscription(
     tag: Route.Geohash,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     // different screens get different states
     // even if they are tracking the same tag.
     val state =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/HashtagPostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/HashtagPostScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toUri
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.note.nip22Comments.CommentPostViewModel
@@ -45,9 +46,11 @@ fun HashtagPostScreen(
     replyId: HexKey? = null,
     quoteId: HexKey? = null,
     draftId: HexKey? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: Nav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val postViewModel: CommentPostViewModel = viewModel()
     postViewModel.init(accountViewModel)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/HashtagScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/HashtagScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserIsFollowingHashtag
 import com.vitorpamplona.amethyst.ui.feeds.WatchLifecycleAndUpdateModel
 import com.vitorpamplona.amethyst.ui.layouts.DisappearingScaffold
@@ -52,9 +53,11 @@ import com.vitorpamplona.amethyst.ui.theme.StdPadding
 @Composable
 fun HashtagScreen(
     tag: Route.Hashtag,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (tag.hashtag.isEmpty()) return
 
     PrepareViewModelsHashtagScreen(tag, accountViewModel, nav)
@@ -64,9 +67,11 @@ fun HashtagScreen(
 @Composable
 fun PrepareViewModelsHashtagScreen(
     tag: Route.Hashtag,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val hashtagFeedViewModel: HashtagFeedViewModel =
         viewModel(
             key = tag.hashtag + "HashtagFeedViewModel",
@@ -85,9 +90,11 @@ fun PrepareViewModelsHashtagScreen(
 fun HashtagScreen(
     tag: Route.Hashtag,
     feedViewModel: HashtagFeedViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     WatchLifecycleAndUpdateModel(feedViewModel)
     HashtagFilterAssemblerSubscription(tag, accountViewModel)
 
@@ -143,8 +150,10 @@ fun HashtagHeader(
 @Composable
 fun HashtagActionOptions(
     tag: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val isFollowingTag by observeUserIsFollowingHashtag(tag, accountViewModel)
 
     if (isFollowingTag) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/NewHashtagNoteButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/NewHashtagNoteButton.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.painterRes
@@ -38,9 +39,11 @@ import com.vitorpamplona.amethyst.ui.theme.Size55Modifier
 @Composable
 fun NewHashtagPostButton(
     tag: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     FloatingActionButton(
         onClick = {
             nav.nav(Route.HashtagPost(tag))

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/datasource/HashtagFilterAssemblerSubscription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/datasource/HashtagFilterAssemblerSubscription.kt
@@ -23,14 +23,17 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.hashtag.datasource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.KeyDataSourceSubscription
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
 @Composable
 fun HashtagFilterAssemblerSubscription(
     tag: Route.Hashtag,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     // different screens get different states
     // even if they are tracking the same tag.
     val state =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/AddOutboxRelayCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/AddOutboxRelayCard.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -64,9 +65,11 @@ fun AddOutboxRelayCardPreview() {
 
 @Composable
 fun ObserveInboxRelayListAndDisplayIfNotFound(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val outboxRelayList by accountViewModel.account.nip65RelayList.outboxFlowNoDefaults
         .collectAsStateWithLifecycle()
 
@@ -80,9 +83,11 @@ fun ObserveInboxRelayListAndDisplayIfNotFound(
 
 @Composable
 fun AddOutboxRelayCard(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Column(modifier = StdPadding) {
         Card(
             modifier = MaterialTheme.colorScheme.imageModifier,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/AddOutboxRelayListDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/AddOutboxRelayListDialog.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.components.SetDialogToEdgeToEdge
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.SavingTopBar
@@ -51,9 +52,11 @@ import com.vitorpamplona.amethyst.ui.theme.imageModifier
 @Composable
 fun AddOutboxRelayListDialog(
     onClose: () -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val postViewModel: Nip65RelayListViewModel = viewModel()
 
     postViewModel.init(accountViewModel)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/HomeScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/HomeScreen.kt
@@ -59,6 +59,7 @@ import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
 import com.vitorpamplona.amethyst.commons.model.nip53LiveActivities.LiveActivitiesChannel
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedContentState
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.service.OnlineChecker
 import com.vitorpamplona.amethyst.service.location.LocationState
@@ -98,9 +99,11 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun HomeScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     HomeScreen(
         liveFeedState = accountViewModel.feedStates.homeLive,
         newThreadsFeedState = accountViewModel.feedStates.homeNewThreads,
@@ -116,9 +119,11 @@ fun HomeScreen(
     liveFeedState: ChannelFeedContentState,
     newThreadsFeedState: FeedContentState,
     repliesFeedState: FeedContentState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     WatchAccountForHomeScreen(liveFeedState, newThreadsFeedState, repliesFeedState, accountViewModel)
 
     WatchLifecycleAndUpdateModel(liveFeedState)
@@ -171,9 +176,11 @@ private fun AssembleHomeTabs(
 private fun HomePages(
     pagerState: PagerState,
     tabs: ImmutableList<TabItem>,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     DisappearingScaffold(
         isInvertedLayout = false,
         topBar = {
@@ -234,9 +241,11 @@ private fun HomePages(
 
 @Composable
 fun HomeScreenFloatingButton(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val list =
         accountViewModel.account.settings.defaultHomeFollowList
             .collectAsStateWithLifecycle()
@@ -278,9 +287,11 @@ fun HomeFeeds(
     enablePullRefresh: Boolean = true,
     scrollStateKey: String? = null,
     liveSection: ChannelFeedContentState? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     RefresheableBox(feedState, enablePullRefresh) {
         SaveableFeedContentState(feedState, scrollStateKey) { listState ->
             RenderFeedContentState(
@@ -303,9 +314,11 @@ fun FeedLoaded(
     listState: LazyListState,
     routeForLastRead: String?,
     liveSection: ChannelFeedContentState? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val items by loaded.feed.collectAsStateWithLifecycle()
 
     LazyColumn(
@@ -346,9 +359,11 @@ fun FeedLoaded(
 @Composable
 fun DisplayLiveBubbles(
     liveSection: ChannelFeedContentState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val feedState by liveSection.feedContent.collectAsStateWithLifecycle()
 
     when (val state = feedState) {
@@ -362,9 +377,11 @@ fun DisplayLiveBubbles(
 @Composable
 fun DisplayLiveBubbles(
     liveFeed: ChannelFeedState.Loaded,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val feed by liveFeed.feed.collectAsStateWithLifecycle()
 
     LazyRow(HorzPadding, horizontalArrangement = spacedBy(Size5dp)) {
@@ -401,9 +418,11 @@ fun HomeFeedEmpty(onRefresh: () -> Unit) {
 @Composable
 fun CheckIfVideoIsOnline(
     url: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     whenOnline: @Composable (Boolean) -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val online by produceState(
         initialValue = OnlineChecker.isOnlineCached(url),
         key1 = url,
@@ -420,9 +439,11 @@ fun CheckIfVideoIsOnline(
 @Composable
 fun CrossfadeCheckIfVideoIsOnline(
     url: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     whenOnline: @Composable () -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val online by produceState(
         initialValue = OnlineChecker.isOnlineCached(url),
         key1 = url,
@@ -449,8 +470,10 @@ fun WatchAccountForHomeScreen(
     liveFeedState: ChannelFeedContentState,
     newThreadsFeedState: FeedContentState,
     repliesFeedState: FeedContentState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val homeFollowList by accountViewModel.account.liveHomeFollowLists.collectAsStateWithLifecycle()
 
     LaunchedEffect(accountViewModel, homeFollowList) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/HomeTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/HomeTopBar.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.FeedFilterSpinner
@@ -35,9 +36,11 @@ import com.vitorpamplona.amethyst.ui.stringRes
 
 @Composable
 fun HomeTopBar(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     UserDrawerSearchTopBar(accountViewModel, nav) {
         val list by accountViewModel.account.settings.defaultHomeFollowList
             .collectAsStateWithLifecycle()
@@ -60,9 +63,11 @@ fun HomeTopBar(
 private fun TopNavFilterBar(
     followListsModel: TopNavFilterState,
     listName: TopFilter,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onChange: (FeedDefinition) -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val allLists by followListsModel.kind3GlobalPeopleRoutes.collectAsStateWithLifecycle()
 
     FeedFilterSpinner(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/NewChessGameButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/NewChessGameButton.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.chess.NewChessGameDialog
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chess.ChessViewModelFactory
@@ -44,9 +45,11 @@ import com.vitorpamplona.amethyst.ui.stringRes
  */
 @Composable
 fun NewChessGameButton(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var showDialog by remember { mutableStateOf(false) }
     val activity = LocalActivity.current as androidx.fragment.app.FragmentActivity
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostScreen.kt
@@ -65,6 +65,7 @@ import androidx.core.net.toUri
 import androidx.core.util.Consumer
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.StrippingFailureDialog
 import com.vitorpamplona.amethyst.ui.actions.mediaServers.FileServerSelectionRow
 import com.vitorpamplona.amethyst.ui.actions.uploads.MAX_VOICE_RECORD_SECONDS
@@ -136,9 +137,11 @@ fun ShortNotePostScreen(
     forkId: HexKey? = null,
     versionId: HexKey? = null,
     draftId: HexKey? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: Nav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val postViewModel: ShortNotePostViewModel = viewModel()
     postViewModel.init(accountViewModel)
 
@@ -195,9 +198,11 @@ fun ShortNotePostScreen(
 @Composable
 internal fun NewPostScreenInner(
     postViewModel: ShortNotePostViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: Nav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     WatchAndLoadMyEmojiList(accountViewModel)
 
     StrippingFailureDialog(postViewModel.strippingFailureConfirmation)
@@ -249,9 +254,11 @@ internal fun NewPostScreenInner(
 @Composable
 private fun NewPostScreenBody(
     postViewModel: ShortNotePostViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: Nav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val scrollState = rememberScrollState()
     Column(
         modifier =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/VoiceReplyScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/VoiceReplyScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.mediaServers.FileServerSelectionRow
 import com.vitorpamplona.amethyst.ui.actions.uploads.UploadProgressIndicator
 import com.vitorpamplona.amethyst.ui.actions.uploads.VoiceAnonymizationSection
@@ -61,9 +62,11 @@ fun VoiceReplyScreen(
     mimeType: String,
     duration: Int,
     amplitudesJson: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: Nav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val viewModel: VoiceReplyViewModel = viewModel()
 
     LaunchedEffect(replyToNoteId, recordingFilePath, accountViewModel) {
@@ -106,9 +109,11 @@ fun VoiceReplyScreen(
 @Composable
 private fun VoiceReplyScreenBody(
     viewModel: VoiceReplyViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: Nav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val scrollState = rememberScrollState()
 
     Column(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/datasource/HomeFilterAssemblerSubscription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/datasource/HomeFilterAssemblerSubscription.kt
@@ -24,10 +24,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.lifecycle.viewModelScope
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.KeyDataSourceSubscription
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
 @Composable
-fun HomeFilterAssemblerSubscription(accountViewModel: AccountViewModel) {
+fun HomeFilterAssemblerSubscription(accountViewModel: IAccountViewModel) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     HomeFilterAssemblerSubscription(
         accountViewModel.dataSources().home,
         accountViewModel,
@@ -37,8 +40,10 @@ fun HomeFilterAssemblerSubscription(accountViewModel: AccountViewModel) {
 @Composable
 fun HomeFilterAssemblerSubscription(
     dataSource: HomeFilterAssembler,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     // different screens get different states
     // even if they are tracking the same tag.
     val state =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/live/LiveStatusIndicator.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/live/LiveStatusIndicator.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.commons.model.Channel
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
 import com.vitorpamplona.amethyst.commons.model.nip53LiveActivities.LiveActivitiesChannel
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.service.OnlineChecker
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.quartz.utils.Log
@@ -56,9 +57,11 @@ fun LiveStatusIndicator(
 @Composable
 fun LiveStatusIndicatorForChannel(
     channel: Channel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     modifier: Modifier = Modifier,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val isOnline by produceState(initialValue = false, key1 = channel) {
         while (true) {
             value = checkChannelIsOnline(channel, accountViewModel)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/live/RenderEphemeralBubble.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/live/RenderEphemeralBubble.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.channel.observeChannelNoteAuthors
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.routeFor
@@ -40,9 +41,11 @@ import com.vitorpamplona.amethyst.ui.theme.StdHorzSpacer
 @Composable
 fun RenderEphemeralBubble(
     channel: EphemeralChatChannel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     FilledTonalButton(
         contentPadding = PaddingValues(start = 8.dp, end = 10.dp, bottom = 0.dp, top = 0.dp),
         onClick = {
@@ -66,9 +69,11 @@ fun RenderEphemeralBubble(
 @Composable
 fun RenderUsers(
     channel: EphemeralChatChannel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val authors by observeChannelNoteAuthors(channel, accountViewModel)
 
     Gallery(authors, Modifier, accountViewModel, nav, 3)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/live/RenderLiveActivityBubble.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/live/RenderLiveActivityBubble.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.commons.model.nip53LiveActivities.LiveActivitiesChannel
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.channel.observeChannelNoteAuthors
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.routeFor
@@ -40,9 +41,11 @@ import com.vitorpamplona.amethyst.ui.theme.StdHorzSpacer
 @Composable
 fun RenderLiveActivityBubble(
     channel: LiveActivitiesChannel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     FilledTonalButton(
         contentPadding = PaddingValues(start = 8.dp, end = 10.dp, bottom = 0.dp, top = 0.dp),
         onClick = {
@@ -66,9 +69,11 @@ fun RenderLiveActivityBubble(
 @Composable
 fun RenderUsers(
     channel: LiveActivitiesChannel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val authors by observeChannelNoteAuthors(channel, accountViewModel)
 
     Gallery(authors, Modifier, accountViewModel, nav, 3)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/nip75Goals/NewGoalScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/nip75Goals/NewGoalScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.PostingTopBar
@@ -57,9 +58,11 @@ import com.vitorpamplona.amethyst.ui.stringRes
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NewGoalScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: Nav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val goalViewModel: NewGoalViewModel = viewModel()
     goalViewModel.init(accountViewModel)
 
@@ -78,9 +81,11 @@ fun NewGoalScreen(
 @Composable
 fun NewGoalScreen(
     goalViewModel: NewGoalViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     BackHandler {
         goalViewModel.cancel()
         nav.popBack()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/PeopleListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/PeopleListView.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.OutlinedIconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.UserComposeNoAction
@@ -51,9 +52,11 @@ fun PeopleListView(
     memberList: ImmutableList<User>,
     modifier: Modifier = Modifier,
     onDeleteUser: (User) -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val listState = rememberLazyListState()
 
     LazyColumn(
@@ -77,10 +80,12 @@ fun PeopleListView(
 fun PeopleListItem(
     modifier: Modifier = Modifier,
     user: User,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     onDeleteUser: (User) -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Column(
         modifier = modifier,
     ) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/ShowUserSuggestions.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/ShowUserSuggestions.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.relayClient.searchCommand.UserSearchDataSourceSubscription
@@ -92,8 +93,10 @@ fun RenderAddUserFieldAndSuggestions(
     hasUserFlow: (User) -> Flow<Boolean>,
     addUserToSet: (User) -> Unit,
     removeUserFromSet: (User) -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     UserSearchDataSourceSubscription(userSuggestions, accountViewModel)
 
     LaunchedEffect(Unit) {
@@ -163,8 +166,10 @@ fun ShowUserSuggestions(
     hasUserFlow: (User) -> Flow<Boolean>,
     onSelect: (User) -> Unit,
     onDelete: (User) -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val listState = rememberLazyListState()
 
     AnimateOnNewSearch(userSuggestions, listState)
@@ -204,8 +209,10 @@ fun DrawUser(
     hasUserFlow: (User) -> Flow<Boolean>,
     onSelect: (User) -> Unit,
     onDelete: (User) -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Row(
         modifier =
             Modifier

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/lists/PeopleListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/lists/PeopleListScreen.kt
@@ -73,6 +73,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.AddressableNote
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.User
@@ -109,9 +110,11 @@ import kotlinx.coroutines.launch
 @Composable
 fun PeopleListScreen(
     selectedDTag: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val viewModel: PeopleListViewModel = viewModel()
     viewModel.init(accountViewModel, selectedDTag)
 
@@ -214,9 +217,11 @@ private fun ListViewAndEditColumn(
     viewModel: PeopleListViewModel,
     pagerState: PagerState,
     modifier: Modifier = Modifier,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Column(modifier = modifier) {
         PeopleListPager(
             viewModel = viewModel,
@@ -239,8 +244,10 @@ private fun ListViewAndEditColumn(
 private fun RenderAddUserFieldAndSuggestions(
     viewModel: PeopleListViewModel,
     pagerState: PagerState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     RenderAddUserFieldAndSuggestions(
         viewModel.userSuggestions,
         hasUserFlow = { user ->
@@ -266,9 +273,11 @@ private fun PeopleListPager(
     pagerState: PagerState,
     modifier: Modifier,
     onDeleteUser: (User, Boolean) -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val selectedSetState = viewModel.selectedList.collectAsStateWithLifecycle()
     selectedSetState.value?.let { selectedSet ->
         HorizontalPager(state = pagerState, modifier) { page ->
@@ -373,9 +382,11 @@ private fun PeopleListViewPreview() {
 @Composable
 private fun ListActionsMenuButton(
     viewModel: PeopleListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     ListActionsMenuButton(
         note = viewModel::selectedNote,
         onEditList = {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/packs/FollowPackScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/packs/FollowPackScreen.kt
@@ -66,6 +66,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.AddressableNote
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.User
@@ -100,9 +101,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
 @Composable
 fun FollowPackScreen(
     selectedDTag: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val viewModel: FollowPackViewModel = viewModel()
     viewModel.init(accountViewModel, selectedDTag)
 
@@ -161,9 +164,11 @@ private fun TitleAndDescription(viewModel: FollowPackViewModel) {
 private fun ListViewAndEditColumn(
     viewModel: FollowPackViewModel,
     modifier: Modifier = Modifier,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Column(modifier = modifier) {
         PeopleListPager(
             viewModel = viewModel,
@@ -184,8 +189,10 @@ private fun ListViewAndEditColumn(
 @Composable
 private fun RenderAddUserFieldAndSuggestions(
     viewModel: FollowPackViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     RenderAddUserFieldAndSuggestions(
         viewModel.userSuggestions,
         hasUserFlow = { user ->
@@ -210,9 +217,11 @@ private fun PeopleListPager(
     viewModel: FollowPackViewModel,
     modifier: Modifier,
     onDeleteUser: (User) -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val selectedSetState = viewModel.selectedList.collectAsStateWithLifecycle()
     selectedSetState.value?.let { selectedSet ->
         PeopleListView(
@@ -228,9 +237,11 @@ private fun PeopleListPager(
 @Composable
 private fun ListActionsMenuButton(
     viewModel: FollowPackViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     ListActionsMenuButton(
         note = viewModel::selectedNote,
         onEditList = {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/ListOfPeopleListsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/ListOfPeopleListsScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.TopBarWithBackButton
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -43,9 +44,11 @@ import com.vitorpamplona.amethyst.ui.theme.SpacedBy5dp
 
 @Composable
 fun ListOfPeopleListsScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val list: PeopleListViewModel = viewModel()
     list.init(accountViewModel)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/metadata/FollowPackMetadataScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/metadata/FollowPackMetadataScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectSingleFromGallery
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -62,9 +63,11 @@ import com.vitorpamplona.quartz.nip01Core.signers.SignerExceptions
 @Composable
 fun FollowPackMetadataScreen(
     selectedDTag: String?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val postViewModel: FollowPackMetadataViewModel = viewModel()
     postViewModel.init(accountViewModel)
 
@@ -105,9 +108,11 @@ private fun DialogContentPreview() {
 @Composable
 private fun FollowPackMetadataScaffold(
     postViewModel: FollowPackMetadataViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Scaffold(
         topBar = {
             FollowPackMetadataTopBar(
@@ -152,9 +157,11 @@ private fun FollowPackMetadataScaffold(
 @Composable
 fun FollowPackMetadataTopBar(
     postViewModel: FollowPackMetadataViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (postViewModel.isNewPack) {
         CreatingTopBar(
             titleRes = R.string.follow_pack_creation_dialog_title,
@@ -223,8 +230,10 @@ private fun Description(postViewModel: FollowPackMetadataViewModel) {
 @Composable
 private fun Picture(
     postViewModel: FollowPackMetadataViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     OutlinedTextField(
         label = { Text(text = stringRes(R.string.picture_url)) },
         modifier = Modifier.fillMaxWidth(),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/metadata/PeopleListMetadataScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/metadata/PeopleListMetadataScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectSingleFromGallery
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -62,9 +63,11 @@ import com.vitorpamplona.quartz.nip01Core.signers.SignerExceptions
 @Composable
 fun PeopleListMetadataScreen(
     selectedDTag: String?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val postViewModel: PeopleListMetadataViewModel = viewModel()
     postViewModel.init(accountViewModel)
 
@@ -105,9 +108,11 @@ private fun DialogContentPreview() {
 @Composable
 private fun PeopleListMetadataScaffold(
     postViewModel: PeopleListMetadataViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Scaffold(
         topBar = {
             PeopleListMetadataTopBar(
@@ -152,9 +157,11 @@ private fun PeopleListMetadataScaffold(
 @Composable
 fun PeopleListMetadataTopBar(
     postViewModel: PeopleListMetadataViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (postViewModel.isNewList) {
         CreatingTopBar(
             titleRes = R.string.follow_set_creation_dialog_title,
@@ -223,8 +230,10 @@ private fun Description(postViewModel: PeopleListMetadataViewModel) {
 @Composable
 private fun Picture(
     postViewModel: PeopleListMetadataViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     OutlinedTextField(
         label = { Text(text = stringRes(R.string.picture_url)) },
         modifier = Modifier.fillMaxWidth(),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/memberEdit/FollowListAndPackAndUserScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/memberEdit/FollowListAndPackAndUserScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserName
@@ -49,9 +50,11 @@ import com.vitorpamplona.quartz.nip01Core.core.HexKey
 @Composable
 fun FollowListAndPackAndUserScreen(
     userToAddOrRemove: HexKey,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var userBase by remember { mutableStateOf(LocalCache.getUserIfExists(userToAddOrRemove)) }
 
     if (userBase == null) {
@@ -72,9 +75,11 @@ fun FollowListAndPackAndUserScreen(
 @Composable
 fun FollowListAndPackAndUserScreen(
     userToAddOrRemove: User,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Scaffold(
         modifier = Modifier.fillMaxSize().recalculateWindowInsets(),
         topBar = {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/memberEdit/FollowListAndPackAndUserView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/memberEdit/FollowListAndPackAndUserView.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserName
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -53,9 +54,11 @@ import com.vitorpamplona.amethyst.ui.theme.grayText
 @Composable
 fun FollowListAndPackAndUserView(
     userToAddOrRemove: User,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val followSetsState by accountViewModel.account.peopleLists.uiListFlow
         .collectAsStateWithLifecycle()
     val followPackFeedState by accountViewModel.account.followLists.uiListFlow

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/longs/LongsFeedLoaded.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/longs/LongsFeedLoaded.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.shorts.VideoCardCompose
@@ -43,9 +44,11 @@ import com.vitorpamplona.quartz.nip71Video.VideoEvent
 fun LongsFeedLoaded(
     loaded: FeedState.Loaded,
     listState: LazyListState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val items by loaded.feed.collectAsStateWithLifecycle()
 
     LazyColumn(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/longs/LongsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/longs/LongsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedContentState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.feeds.RefresheableBox
 import com.vitorpamplona.amethyst.ui.feeds.RenderFeedContentState
 import com.vitorpamplona.amethyst.ui.feeds.SaveableFeedContentState
@@ -42,9 +43,11 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.longs.datasource.LongsFilte
 
 @Composable
 fun LongsScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     LongsScreen(
         longsFeedContentState = accountViewModel.feedStates.longsFeed,
         accountViewModel = accountViewModel,
@@ -55,9 +58,11 @@ fun LongsScreen(
 @Composable
 fun LongsScreen(
     longsFeedContentState: FeedContentState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     WatchLifecycleAndUpdateModel(longsFeedContentState)
     WatchAccountForLongsScreen(videoFeedState = longsFeedContentState, accountViewModel = accountViewModel)
     LongsFilterAssemblerSubscription(accountViewModel)
@@ -108,8 +113,10 @@ fun LongsScreen(
 @Composable
 fun WatchAccountForLongsScreen(
     videoFeedState: FeedContentState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val listState by accountViewModel.account.liveLongsFollowLists.collectAsStateWithLifecycle()
     val hiddenUsers =
         accountViewModel.account.hiddenUsers.flow

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/longs/LongsTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/longs/LongsTopBar.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.FeedFilterSpinner
@@ -35,9 +36,11 @@ import com.vitorpamplona.amethyst.ui.stringRes
 
 @Composable
 fun LongsTopBar(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     UserDrawerSearchTopBar(accountViewModel, nav) {
         val list by accountViewModel.account.settings.defaultLongsFollowList
             .collectAsStateWithLifecycle()
@@ -55,9 +58,11 @@ fun LongsTopBar(
 private fun LongsTopNavFilterBar(
     followListsModel: TopNavFilterState,
     listName: TopFilter,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onChange: (FeedDefinition) -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val allLists by followListsModel.kind3GlobalPeople.collectAsStateWithLifecycle()
 
     FeedFilterSpinner(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/longs/NewLongVideoButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/longs/NewLongVideoButton.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.NewMediaModel
 import com.vitorpamplona.amethyst.ui.actions.NewMediaView
 import com.vitorpamplona.amethyst.ui.actions.uploads.GallerySelect
@@ -68,10 +69,12 @@ import kotlinx.coroutines.withContext
 
 @Composable
 fun NewLongVideoButton(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     navScrollToTop: () -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var isOpen by remember { mutableStateOf(false) }
     var wantsToRecordVideo by remember { mutableStateOf(false) }
     var wantsToPostFromGallery by remember { mutableStateOf(false) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/longs/datasource/LongsFilterAssemblerSubscription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/longs/datasource/LongsFilterAssemblerSubscription.kt
@@ -24,10 +24,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.lifecycle.viewModelScope
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.KeyDataSourceSubscription
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
 @Composable
-fun LongsFilterAssemblerSubscription(accountViewModel: AccountViewModel) {
+fun LongsFilterAssemblerSubscription(accountViewModel: IAccountViewModel) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     LongsFilterAssemblerSubscription(
         accountViewModel.dataSources().longs,
         accountViewModel,
@@ -37,8 +40,10 @@ fun LongsFilterAssemblerSubscription(accountViewModel: AccountViewModel) {
 @Composable
 fun LongsFilterAssemblerSubscription(
     dataSource: LongsFilterAssembler,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val state =
         remember(accountViewModel.account) {
             LongsQueryState(accountViewModel.account, accountViewModel.feedStates, accountViewModel.viewModelScope)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/AddInboxRelayCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/AddInboxRelayCard.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -63,9 +64,11 @@ fun AddInboxRelayCardPreview() {
 
 @Composable
 fun ObserveInboxRelayListAndDisplayIfNotFound(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val inboxRelayList by accountViewModel.account.nip65RelayList.inboxFlowNoDefaults
         .collectAsStateWithLifecycle()
 
@@ -79,9 +82,11 @@ fun ObserveInboxRelayListAndDisplayIfNotFound(
 
 @Composable
 fun AddInboxRelayCard(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Column(modifier = StdPadding) {
         Card(
             modifier = MaterialTheme.colorScheme.imageModifier,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/AddInboxRelayListDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/AddInboxRelayListDialog.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.components.SetDialogToEdgeToEdge
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.SavingTopBar
@@ -51,9 +52,11 @@ import com.vitorpamplona.amethyst.ui.theme.imageModifier
 @Composable
 fun AddInboxRelayListDialog(
     onClose: () -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val postViewModel: Nip65RelayListViewModel = viewModel()
 
     postViewModel.init(accountViewModel)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/CardFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/CardFeedView.kt
@@ -55,6 +55,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.ui.notifications.Card
 import com.vitorpamplona.amethyst.commons.ui.notifications.CardFeedState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.logTime
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.feeds.FeedError
@@ -81,12 +82,14 @@ import kotlinx.coroutines.delay
 fun RenderCardFeed(
     feedContent: CardFeedContentState,
     pollContent: OpenPollsState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     listState: LazyListState,
     nav: INav,
     routeForLastRead: String,
     scrollToEventId: String? = null,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val feedState by feedContent.feedContent.collectAsStateWithLifecycle()
 
     CrossfadeIfEnabled(
@@ -143,10 +146,12 @@ private fun FeedLoaded(
     polls: OpenPollsState,
     listState: LazyListState,
     routeForLastRead: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     scrollToEventId: String? = null,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val items by loaded.feed.collectAsStateWithLifecycle()
     val openPolls by polls.flow.collectAsStateWithLifecycle()
 
@@ -258,9 +263,11 @@ private fun RenderCardItem(
     item: Card,
     routeForLastRead: String,
     showHidden: Boolean,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     when (item) {
         is NoteCard -> {
             NoteCardCompose(
@@ -325,9 +332,11 @@ fun NoteCardCompose(
     makeItShort: Boolean = false,
     showHidden: Boolean = false,
     parentBackgroundColor: MutableState<Color>? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     NoteCompose(
         baseNote = baseNote.note,
         modifier = modifier.fillMaxWidth(),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.UiSettingsFlow
 import com.vitorpamplona.amethyst.ui.components.SelectNotificationProvider
 import com.vitorpamplona.amethyst.ui.feeds.RefresheableBox
@@ -43,9 +44,11 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 @Composable
 fun NotificationScreen(
     scrollToEventId: String? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     NotificationScreen(
         notifFeedContentState = accountViewModel.feedStates.notifications,
         notifSummaryState = accountViewModel.feedStates.notificationSummary,
@@ -64,9 +67,11 @@ fun NotificationScreen(
     notifPolls: OpenPollsState,
     sharedPrefs: UiSettingsFlow,
     scrollToEventId: String? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     SelectNotificationProvider(sharedPrefs)
 
     WatchAccountForNotifications(notifFeedContentState, accountViewModel)
@@ -110,8 +115,10 @@ fun NotificationScreen(
 @Composable
 fun WatchAccountForNotifications(
     notifFeedContentState: CardFeedContentState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val listState by
         accountViewModel.account.liveNotificationFollowLists.collectAsStateWithLifecycle()
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationTopBar.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.FeedFilterSpinner
@@ -35,9 +36,11 @@ import com.vitorpamplona.amethyst.ui.stringRes
 
 @Composable
 fun NotificationTopBar(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     UserDrawerSearchTopBar(accountViewModel, nav) {
         val list by accountViewModel.account.settings.defaultNotificationFollowList
             .collectAsStateWithLifecycle()
@@ -55,9 +58,11 @@ fun NotificationTopBar(
 private fun TopNavFilterBar(
     followListsModel: TopNavFilterState,
     listName: TopFilter,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onChange: (FeedDefinition) -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val allLists by followListsModel.kind3GlobalPeople.collectAsStateWithLifecycle()
 
     FeedFilterSpinner(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/donations/ShowDonationCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/donations/ShowDonationCard.kt
@@ -24,15 +24,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.BuildConfig
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.components.LoadNote
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
 @Composable
 fun ShowDonationCard(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (!accountViewModel.account.hasDonatedInThisVersion()) {
         val donated by accountViewModel.account.observeDonatedInThisVersion().collectAsStateWithLifecycle()
         if (!donated) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/donations/ZapTheDevsCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/donations/ZapTheDevsCard.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.vitorpamplona.amethyst.BuildConfig
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.observeNote
@@ -119,9 +120,11 @@ fun ZapTheDevsCardPreview() {
 @Composable
 fun ZapTheDevsCard(
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val releaseNoteState by observeNote(baseNote, accountViewModel)
     val releaseNote = releaseNoteState.note
 
@@ -216,9 +219,11 @@ fun ZapTheDevsCard(
 fun ZapDonationButton(
     baseNote: Note,
     grayTint: Color,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val config =
         ZapButtonConfig(
             grayTint = grayTint,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/publicMessages/NewPublicMessageScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/publicMessages/NewPublicMessageScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.StrippingFailureDialog
 import com.vitorpamplona.amethyst.ui.actions.UrlUserTagOutputTransformation
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromFiles
@@ -109,9 +110,11 @@ fun NewPublicMessageScreen(
     to: Set<HexKey>? = null,
     replyId: HexKey? = null,
     draftId: HexKey? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: Nav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val postViewModel: NewPublicMessageViewModel = viewModel()
     postViewModel.init(accountViewModel)
 
@@ -181,9 +184,11 @@ fun NewPublicMessageScreen(
 @Composable
 fun PublicMessageScreenContent(
     postViewModel: NewPublicMessageViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val scrollState = rememberScrollState()
 
     Column(Modifier.fillMaxSize()) {
@@ -311,8 +316,10 @@ fun PublicMessageScreenContent(
 @Composable
 private fun BottomRowActions(
     postViewModel: NewPublicMessageViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val scrollState = rememberScrollState()
     Row(
         modifier =
@@ -389,8 +396,10 @@ private fun BottomRowActions(
 @Composable
 fun SendDirectMessageTo(
     postViewModel: NewPublicMessageViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val focusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/pictures/NewPictureButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/pictures/NewPictureButton.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.NewMediaModel
 import com.vitorpamplona.amethyst.ui.actions.NewMediaView
 import com.vitorpamplona.amethyst.ui.actions.uploads.GallerySelect
@@ -68,10 +69,12 @@ import kotlinx.coroutines.withContext
 
 @Composable
 fun NewPictureButton(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     navScrollToTop: () -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var isOpen by remember { mutableStateOf(false) }
     var wantsToPostFromCamera by remember { mutableStateOf(false) }
     var wantsToPostFromGallery by remember { mutableStateOf(false) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/pictures/PictureCardCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/pictures/PictureCardCompose.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlImage
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.components.AutoNonlazyGrid
 import com.vitorpamplona.amethyst.ui.components.SensitivityWarning
@@ -54,9 +55,11 @@ import kotlinx.collections.immutable.toImmutableList
 @Composable
 fun PictureCardCompose(
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val event = (baseNote.event as? PictureEvent) ?: return
     val backgroundColor = remember { mutableStateOf(Color.Transparent) }
     val editState = observeEdits(baseNote = baseNote, accountViewModel = accountViewModel)
@@ -90,8 +93,10 @@ private fun PictureCardImage(
     note: Note,
     event: PictureEvent,
     backgroundColor: MutableState<Color>,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val uri = note.toNostrUri()
 
     val images by

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/pictures/PictureFeedLoaded.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/pictures/PictureFeedLoaded.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.theme.DividerThickness
@@ -42,9 +43,11 @@ import com.vitorpamplona.quartz.nip68Picture.PictureEvent
 fun PictureFeedLoaded(
     loaded: FeedState.Loaded,
     listState: LazyListState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val items by loaded.feed.collectAsStateWithLifecycle()
 
     LazyColumn(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/pictures/PicturesScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/pictures/PicturesScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedContentState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.feeds.RefresheableBox
 import com.vitorpamplona.amethyst.ui.feeds.RenderFeedContentState
 import com.vitorpamplona.amethyst.ui.feeds.SaveableFeedContentState
@@ -42,9 +43,11 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.pictures.datasource.Picture
 
 @Composable
 fun PicturesScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     PicturesScreen(
         picturesFeedContentState = accountViewModel.feedStates.picturesFeed,
         accountViewModel = accountViewModel,
@@ -55,9 +58,11 @@ fun PicturesScreen(
 @Composable
 fun PicturesScreen(
     picturesFeedContentState: FeedContentState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     WatchLifecycleAndUpdateModel(picturesFeedContentState)
     WatchAccountForPicturesScreen(picturesFeedContentState = picturesFeedContentState, accountViewModel = accountViewModel)
     PicturesFilterAssemblerSubscription(accountViewModel)
@@ -108,8 +113,10 @@ fun PicturesScreen(
 @Composable
 fun WatchAccountForPicturesScreen(
     picturesFeedContentState: FeedContentState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val listState by accountViewModel.account.livePicturesFollowLists.collectAsStateWithLifecycle()
     val hiddenUsers =
         accountViewModel.account.hiddenUsers.flow

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/pictures/PicturesTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/pictures/PicturesTopBar.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.FeedFilterSpinner
@@ -35,9 +36,11 @@ import com.vitorpamplona.amethyst.ui.stringRes
 
 @Composable
 fun PicturesTopBar(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     UserDrawerSearchTopBar(accountViewModel, nav) {
         val list by accountViewModel.account.settings.defaultPicturesFollowList
             .collectAsStateWithLifecycle()
@@ -55,9 +58,11 @@ fun PicturesTopBar(
 private fun PicturesTopNavFilterBar(
     followListsModel: TopNavFilterState,
     listName: TopFilter,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onChange: (FeedDefinition) -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val allLists by followListsModel.kind3GlobalPeople.collectAsStateWithLifecycle()
 
     FeedFilterSpinner(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/pictures/datasource/PicturesFilterAssemblerSubscription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/pictures/datasource/PicturesFilterAssemblerSubscription.kt
@@ -24,10 +24,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.lifecycle.viewModelScope
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.KeyDataSourceSubscription
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
 @Composable
-fun PicturesFilterAssemblerSubscription(accountViewModel: AccountViewModel) {
+fun PicturesFilterAssemblerSubscription(accountViewModel: IAccountViewModel) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     PicturesFilterAssemblerSubscription(
         accountViewModel.dataSources().pictures,
         accountViewModel,
@@ -37,8 +40,10 @@ fun PicturesFilterAssemblerSubscription(accountViewModel: AccountViewModel) {
 @Composable
 fun PicturesFilterAssemblerSubscription(
     dataSource: PicturesFilterAssembler,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val state =
         remember(accountViewModel.account) {
             PicturesQueryState(accountViewModel.account, accountViewModel.feedStates, accountViewModel.viewModelScope)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/polls/PollPostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/polls/PollPostScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.home.NewPostScreenInner
@@ -37,9 +38,11 @@ import kotlinx.coroutines.FlowPreview
 fun PollPostScreen(
     message: String? = null,
     draftId: HexKey? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: Nav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val postViewModel: ShortNotePostViewModel = viewModel()
     postViewModel.init(accountViewModel)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/polls/PollsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/polls/PollsScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedContentState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.feeds.PagerStateKeys
 import com.vitorpamplona.amethyst.ui.feeds.RefresheableBox
 import com.vitorpamplona.amethyst.ui.feeds.RenderFeedContentState
@@ -59,9 +60,11 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun PollsScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     PollsScreen(
         openPollsFeedContentState = accountViewModel.feedStates.openPollsFeed,
         closedPollsFeedContentState = accountViewModel.feedStates.closedPollsFeed,
@@ -74,9 +77,11 @@ fun PollsScreen(
 fun PollsScreen(
     openPollsFeedContentState: FeedContentState,
     closedPollsFeedContentState: FeedContentState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     WatchLifecycleAndUpdateModel(openPollsFeedContentState)
     WatchLifecycleAndUpdateModel(closedPollsFeedContentState)
     WatchAccountForPollsScreen(openPollsFeedContentState, closedPollsFeedContentState, accountViewModel)
@@ -122,9 +127,11 @@ private fun AssemblePollsTabs(
 private fun PollsPages(
     pagerState: PagerState,
     tabs: ImmutableList<PollsTabItem>,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     DisappearingScaffold(
         isInvertedLayout = false,
         topBar = {
@@ -185,8 +192,10 @@ private fun PollsPages(
 fun WatchAccountForPollsScreen(
     openPollsFeedContentState: FeedContentState,
     closedPollsFeedContentState: FeedContentState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val listState by accountViewModel.account.livePollsFollowLists.collectAsStateWithLifecycle()
     val hiddenUsers =
         accountViewModel.account.hiddenUsers.flow

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/polls/PollsTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/polls/PollsTopBar.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.FeedFilterSpinner
@@ -35,9 +36,11 @@ import com.vitorpamplona.amethyst.ui.stringRes
 
 @Composable
 fun PollsTopBar(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     UserDrawerSearchTopBar(accountViewModel, nav) {
         val list by accountViewModel.account.settings.defaultPollsFollowList
             .collectAsStateWithLifecycle()
@@ -55,9 +58,11 @@ fun PollsTopBar(
 private fun PollsTopNavFilterBar(
     followListsModel: TopNavFilterState,
     listName: TopFilter,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onChange: (FeedDefinition) -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val allLists by followListsModel.kind3GlobalPeople.collectAsStateWithLifecycle()
 
     FeedFilterSpinner(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/polls/datasource/PollsFilterAssemblerSubscription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/polls/datasource/PollsFilterAssemblerSubscription.kt
@@ -24,10 +24,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.lifecycle.viewModelScope
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.KeyDataSourceSubscription
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
 @Composable
-fun PollsFilterAssemblerSubscription(accountViewModel: AccountViewModel) {
+fun PollsFilterAssemblerSubscription(accountViewModel: IAccountViewModel) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     PollsFilterAssemblerSubscription(
         accountViewModel.dataSources().polls,
         accountViewModel,
@@ -37,8 +40,10 @@ fun PollsFilterAssemblerSubscription(accountViewModel: AccountViewModel) {
 @Composable
 fun PollsFilterAssemblerSubscription(
     dataSource: PollsFilterAssembler,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val state =
         remember(accountViewModel.account) {
             PollsQueryState(accountViewModel.account, accountViewModel.feedStates, accountViewModel.viewModelScope)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/search/AddInboxRelayForSearchCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/search/AddInboxRelayForSearchCard.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -63,9 +64,11 @@ fun AddInboxRelayForSearchCardPreview() {
 
 @Composable
 fun ObserveRelayListForSearchAndDisplayIfNotFound(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val searchRelayList by accountViewModel.account.searchRelayList.flowNoDefaults
         .collectAsStateWithLifecycle()
 
@@ -79,9 +82,11 @@ fun ObserveRelayListForSearchAndDisplayIfNotFound(
 
 @Composable
 fun AddInboxRelayForSearchCard(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Column(modifier = StdPadding) {
         Card(
             modifier = MaterialTheme.colorScheme.imageModifier,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/search/AddSearchRelayListDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/search/AddSearchRelayListDialog.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.DefaultSearchRelayList
 import com.vitorpamplona.amethyst.ui.components.SetDialogToEdgeToEdge
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -54,9 +55,11 @@ import com.vitorpamplona.amethyst.ui.theme.imageModifier
 @Composable
 fun AddSearchRelayListDialog(
     onClose: () -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val postViewModel: SearchRelayListViewModel = viewModel()
 
     postViewModel.init(accountViewModel)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/search/SearchScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/search/SearchScreen.kt
@@ -54,6 +54,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.nip11RelayInfo.loadRelayInfo
 import com.vitorpamplona.amethyst.service.relayClient.searchCommand.TextSearchDataSourceSubscription
@@ -82,9 +83,11 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun SearchScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val searchBarViewModel: SearchBarViewModel =
         viewModel(
             key = "SearchBarViewModel",
@@ -101,9 +104,11 @@ fun SearchScreen(
 @Composable
 fun SearchScreen(
     searchBarViewModel: SearchBarViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     WatchLifecycleAndUpdateModel(searchBarViewModel)
 
     LaunchedEffect(searchBarViewModel.focusRequester) {
@@ -137,9 +142,11 @@ fun SearchScreen(
 @Composable
 private fun SearchBar(
     searchBarViewModel: SearchBarViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     TextSearchDataSourceSubscription(searchBarViewModel, accountViewModel)
 
     LaunchedEffect(Unit) {
@@ -220,8 +227,10 @@ private fun SearchTextField(
 private fun DisplaySearchResults(
     searchBarViewModel: SearchBarViewModel,
     nav: INav,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (!searchBarViewModel.isRefreshing.value) {
         return
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AllSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AllSettingsScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
@@ -81,9 +82,11 @@ fun AllSettingsScreenPreview() {
 
 @Composable
 fun AllSettingsScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val tint = MaterialTheme.colorScheme.onBackground
 
     Scaffold(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.os.LocaleListCompat
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.ConnectivityType
 import com.vitorpamplona.amethyst.model.FeatureSetType
 import com.vitorpamplona.amethyst.model.ProfileGalleryType
@@ -80,9 +81,11 @@ import java.io.IOException
 
 @Composable
 fun SettingsScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Scaffold(
         topBar = {
             TopBarWithBackButton(stringRes(id = R.string.application_preferences), nav::popBack)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/CallSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/CallSettingsScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.CallTurnServer
 import com.vitorpamplona.amethyst.model.CallVideoResolution
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -64,9 +65,11 @@ import com.vitorpamplona.amethyst.ui.stringRes
 
 @Composable
 fun CallSettingsScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Scaffold(
         topBar = {
             TopBarWithBackButton(stringRes(id = R.string.call_settings), nav::popBack)
@@ -83,7 +86,9 @@ fun CallSettingsScreen(
 }
 
 @Composable
-private fun CallSettingsContent(accountViewModel: AccountViewModel) {
+private fun CallSettingsContent(accountViewModel: IAccountViewModel) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val settings = accountViewModel.account.settings
 
     SectionHeader(stringRes(R.string.call_settings_video_quality))

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/NIP47SetupScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/NIP47SetupScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.paymentTargets.PaymentTargetAddField
 import com.vitorpamplona.amethyst.ui.actions.paymentTargets.PaymentTargetsViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -62,10 +63,12 @@ import com.vitorpamplona.quartz.experimental.nipA3.PaymentTarget
 
 @Composable
 fun NIP47SetupScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     nip47: String?,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val postViewModel: UpdateZapAmountViewModel = viewModel()
     postViewModel.init(accountViewModel)
 
@@ -90,10 +93,12 @@ fun NIP47SetupScreen(
     postViewModel: UpdateZapAmountViewModel,
     walletViewModel: WalletViewModel,
     paymentTargetsViewModel: PaymentTargetsViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     nip47: String?,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Scaffold(
         topBar = {
             SavingTopBar(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/ReactionsSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/ReactionsSettingsScreen.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.ReactionRowAction
 import com.vitorpamplona.amethyst.model.ReactionRowItem
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
@@ -86,9 +87,11 @@ fun ReactionsSettingsScreenPreview() {
 
 @Composable
 fun ReactionsSettingsScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Scaffold(
         topBar = {
             TopBarWithBackButton(stringRes(id = R.string.reactions_settings), nav::popBack)
@@ -101,7 +104,9 @@ fun ReactionsSettingsScreen(
 }
 
 @Composable
-fun ReactionsSettingsContent(accountViewModel: AccountViewModel) {
+fun ReactionsSettingsContent(accountViewModel: IAccountViewModel) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val reactionRowItems by accountViewModel.reactionRowItemsFlow().collectAsStateWithLifecycle()
     var items by remember(reactionRowItems) { mutableStateOf(reactionRowItems.toList()) }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/SecurityFiltersScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/SecurityFiltersScreen.kt
@@ -67,6 +67,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.WarningType
 import com.vitorpamplona.amethyst.model.parseWarningType
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.observeAccountIsHiddenWord
@@ -96,9 +97,11 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun SecurityFiltersScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val hiddenFeedViewModel: HiddenAccountsFeedViewModel =
         viewModel(
             factory = HiddenAccountsFeedViewModel.Factory(accountViewModel.account),
@@ -135,9 +138,11 @@ fun SecurityFiltersScreen(
     hiddenFeedViewModel: HiddenAccountsFeedViewModel,
     hiddenWordsViewModel: HiddenWordsFeedViewModel,
     spammerFeedViewModel: SpammerAccountsFeedViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val lifeCycleOwner = LocalLifecycleOwner.current
 
     DisposableEffect(lifeCycleOwner) {
@@ -208,7 +213,9 @@ fun SecurityFiltersScreen(
 }
 
 @Composable
-private fun HeaderOptions(accountViewModel: AccountViewModel) {
+private fun HeaderOptions(accountViewModel: IAccountViewModel) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Column(
         Modifier
             .padding(top = Size10dp, bottom = Size10dp, start = Size15dp, end = Size15dp),
@@ -301,8 +308,10 @@ private fun HeaderOptions(accountViewModel: AccountViewModel) {
 @Composable
 private fun HiddenWordsFeed(
     hiddenWordsViewModel: HiddenWordsFeedViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     RefresheableBox(hiddenWordsViewModel, false) {
         StringFeedView(
             hiddenWordsViewModel,
@@ -315,7 +324,9 @@ private fun HiddenWordsFeed(
 }
 
 @Composable
-private fun AddMuteWordTextField(accountViewModel: AccountViewModel) {
+private fun AddMuteWordTextField(accountViewModel: IAccountViewModel) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Row {
         val currentWordToAdd = remember { mutableStateOf("") }
         val hasChanged by remember { derivedStateOf { currentWordToAdd.value != "" } }
@@ -359,9 +370,11 @@ private fun AddMuteWordTextField(accountViewModel: AccountViewModel) {
 
 @Composable
 fun WatchAccountAndBlockList(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     invalidate: () -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val transientSpammers by accountViewModel.account.hiddenUsers.transientHiddenUsers
         .collectAsStateWithLifecycle()
     val blockListState by accountViewModel.account.hiddenUsers.flow
@@ -401,8 +414,10 @@ fun MutedWordHeader(
 @Composable
 fun MutedWordActionOptions(
     word: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val isMutedWord by observeAccountIsHiddenWord(accountViewModel.account, word)
 
     if (isMutedWord) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedView.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.feeds.FeedError
 import com.vitorpamplona.amethyst.ui.feeds.LoadingFeed
@@ -47,11 +48,13 @@ import com.vitorpamplona.amethyst.ui.theme.FeedPadding
 @Composable
 fun StringFeedView(
     viewModel: StringFeedViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     pre: (@Composable () -> Unit)? = null,
     post: (@Composable () -> Unit)? = null,
     inner: @Composable (String) -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val feedState by viewModel.feedContent.collectAsStateWithLifecycle()
 
     CrossfadeIfEnabled(targetState = feedState, animationSpec = tween(durationMillis = 100), accountViewModel = accountViewModel) { state ->

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/UpdateZapAmountScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/UpdateZapAmountScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.SavingTopBar
 import com.vitorpamplona.amethyst.ui.note.UpdateZapAmountContent
@@ -37,10 +38,12 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
 @Composable
 fun UpdateZapAmountScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     nip47: String? = null,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val postViewModel: UpdateZapAmountViewModel = viewModel()
     postViewModel.init(accountViewModel)
 
@@ -55,10 +58,12 @@ fun UpdateZapAmountScreen(
 @Composable
 fun UpdateZapAmountScreen(
     postViewModel: UpdateZapAmountViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     nip47: String? = null,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Scaffold(
         topBar = {
             SavingTopBar(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/UserSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/UserSettingsScreen.kt
@@ -68,6 +68,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.TopBarWithBackButton
@@ -93,9 +94,11 @@ fun UserSettingsScreenPreview() {
 
 @Composable
 fun UserSettingsScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Scaffold(
         topBar = {
             TopBarWithBackButton(stringRes(id = R.string.user_preferences), nav::popBack)
@@ -192,7 +195,9 @@ private fun SearchableLanguageList(
 }
 
 @Composable
-fun TranslateToSetting(accountViewModel: AccountViewModel) {
+fun TranslateToSetting(accountViewModel: IAccountViewModel) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val currentTranslateTo by accountViewModel.account.settings.syncedSettings.languages.translateTo
         .collectAsStateWithLifecycle()
     val allLanguages = remember { getAllLanguagesSorted() }
@@ -235,7 +240,9 @@ fun TranslateToSetting(accountViewModel: AccountViewModel) {
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-fun DontTranslateFromSetting(accountViewModel: AccountViewModel) {
+fun DontTranslateFromSetting(accountViewModel: IAccountViewModel) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val selectedLanguages by accountViewModel.account.settings.syncedSettings.languages.dontTranslateFrom
         .collectAsStateWithLifecycle()
     var showAddPicker by remember { mutableStateOf(false) }
@@ -303,7 +310,9 @@ fun DontTranslateFromSetting(accountViewModel: AccountViewModel) {
 }
 
 @Composable
-fun LanguagePreferencesSetting(accountViewModel: AccountViewModel) {
+fun LanguagePreferencesSetting(accountViewModel: IAccountViewModel) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val languagePreferences by
         accountViewModel.account.settings.syncedSettings.languages.languagePreferences
             .collectAsStateWithLifecycle()
@@ -363,8 +372,10 @@ private fun LanguagePreferenceCard(
     source: String,
     target: String,
     preference: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val sourceName = JavaLocale.forLanguageTag(source).displayName
     val targetName = JavaLocale.forLanguageTag(target).displayName
 
@@ -446,9 +457,11 @@ private fun LanguagePreferenceCard(
 
 @Composable
 private fun AddLanguagePairCard(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onDismiss: () -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val allLanguages = remember { getAllLanguagesSorted() }
     var selectedSource by remember { mutableStateOf<JavaLocale?>(null) }
     var selectedTarget by remember { mutableStateOf<JavaLocale?>(null) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/NewShortVideoButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/NewShortVideoButton.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.NewMediaModel
 import com.vitorpamplona.amethyst.ui.actions.NewMediaView
 import com.vitorpamplona.amethyst.ui.actions.uploads.GallerySelect
@@ -68,10 +69,12 @@ import kotlinx.coroutines.withContext
 
 @Composable
 fun NewShortVideoButton(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     navScrollToTop: () -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var isOpen by remember { mutableStateOf(false) }
     var wantsToRecordVideo by remember { mutableStateOf(false) }
     var wantsToPostFromGallery by remember { mutableStateOf(false) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/ShortsFeedLoaded.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/ShortsFeedLoaded.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.theme.DividerThickness
@@ -42,9 +43,11 @@ import com.vitorpamplona.quartz.nip71Video.VideoEvent
 fun ShortsFeedLoaded(
     loaded: FeedState.Loaded,
     listState: LazyListState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val items by loaded.feed.collectAsStateWithLifecycle()
 
     LazyColumn(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/ShortsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/ShortsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedContentState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.feeds.RefresheableBox
 import com.vitorpamplona.amethyst.ui.feeds.RenderFeedContentState
 import com.vitorpamplona.amethyst.ui.feeds.SaveableFeedContentState
@@ -42,9 +43,11 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.shorts.datasource.ShortsFil
 
 @Composable
 fun ShortsScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     ShortsScreen(
         shortsFeedContentState = accountViewModel.feedStates.shortsFeed,
         accountViewModel = accountViewModel,
@@ -55,9 +58,11 @@ fun ShortsScreen(
 @Composable
 fun ShortsScreen(
     shortsFeedContentState: FeedContentState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     WatchLifecycleAndUpdateModel(shortsFeedContentState)
     WatchAccountForShortsScreen(videoFeedState = shortsFeedContentState, accountViewModel = accountViewModel)
     ShortsFilterAssemblerSubscription(accountViewModel)
@@ -108,8 +113,10 @@ fun ShortsScreen(
 @Composable
 fun WatchAccountForShortsScreen(
     videoFeedState: FeedContentState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val listState by accountViewModel.account.liveShortsFollowLists.collectAsStateWithLifecycle()
     val hiddenUsers =
         accountViewModel.account.hiddenUsers.flow

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/ShortsTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/ShortsTopBar.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.FeedFilterSpinner
@@ -35,9 +36,11 @@ import com.vitorpamplona.amethyst.ui.stringRes
 
 @Composable
 fun ShortsTopBar(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     UserDrawerSearchTopBar(accountViewModel, nav) {
         val list by accountViewModel.account.settings.defaultShortsFollowList
             .collectAsStateWithLifecycle()
@@ -55,9 +58,11 @@ fun ShortsTopBar(
 private fun ShortsTopNavFilterBar(
     followListsModel: TopNavFilterState,
     listName: TopFilter,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onChange: (FeedDefinition) -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val allLists by followListsModel.kind3GlobalPeople.collectAsStateWithLifecycle()
 
     FeedFilterSpinner(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/VideoCardCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/VideoCardCompose.kt
@@ -42,6 +42,7 @@ import com.vitorpamplona.amethyst.commons.richtext.BaseMediaContent
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlImage
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlVideo
 import com.vitorpamplona.amethyst.commons.richtext.RichTextParser
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.components.SensitivityWarning
 import com.vitorpamplona.amethyst.ui.components.ZoomableContentView
@@ -58,9 +59,11 @@ import kotlin.text.ifEmpty
 @Composable
 fun VideoCardCompose(
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val event = (baseNote.event as? VideoEvent) ?: return
     val backgroundColor = remember { mutableStateOf(Color.Transparent) }
     val editState = observeEdits(baseNote = baseNote, accountViewModel = accountViewModel)
@@ -94,8 +97,10 @@ private fun VideoCardImage(
     note: Note,
     event: VideoEvent,
     backgroundColor: MutableState<Color>,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val videoEvent = (note.event as? VideoEvent) ?: return
     val event = (event as? Event) ?: return
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/datasource/ShortsFilterAssemblerSubscription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/datasource/ShortsFilterAssemblerSubscription.kt
@@ -24,10 +24,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.lifecycle.viewModelScope
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.KeyDataSourceSubscription
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
 @Composable
-fun ShortsFilterAssemblerSubscription(accountViewModel: AccountViewModel) {
+fun ShortsFilterAssemblerSubscription(accountViewModel: IAccountViewModel) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     ShortsFilterAssemblerSubscription(
         accountViewModel.dataSources().shorts,
         accountViewModel,
@@ -37,8 +40,10 @@ fun ShortsFilterAssemblerSubscription(accountViewModel: AccountViewModel) {
 @Composable
 fun ShortsFilterAssemblerSubscription(
     dataSource: ShortsFilterAssembler,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val state =
         remember(accountViewModel.account) {
             ShortsQueryState(accountViewModel.account, accountViewModel.feedStates, accountViewModel.viewModelScope)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/ThreadFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/ThreadFeedView.kt
@@ -75,6 +75,7 @@ import coil3.compose.AsyncImage
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlImage
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.commons.ui.thread.drawReplyLevel
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
@@ -297,9 +298,11 @@ import kotlinx.coroutines.withContext
 fun ThreadFeedView(
     noteId: String,
     viewModel: LevelFeedViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     RefresheableBox(viewModel) {
         RenderFeedState(
             viewModel = viewModel,
@@ -320,9 +323,11 @@ fun RenderThreadFeed(
     loaded: FeedState.Loaded,
     listState: LazyListState,
     viewModel: LevelFeedViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val items by loaded.feed.collectAsStateWithLifecycle()
 
     val position = items.list.indexOfFirst { it.idHex == noteId }
@@ -420,9 +425,11 @@ fun NoteMaster(
     baseNote: Note,
     modifier: Modifier = Modifier,
     parentBackgroundColor: MutableState<Color>? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     WatchNoteEvent(
         baseNote = baseNote,
         accountViewModel = accountViewModel,
@@ -461,9 +468,11 @@ private fun FullBleedNoteCompose(
     modifier: Modifier,
     canPreview: Boolean,
     parentBackgroundColor: MutableState<Color>?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val noteEvent = baseNote.event ?: return
 
     val isDraft = baseNote.isDraft()
@@ -881,9 +890,11 @@ private fun FullBleedNoteCompose(
 @Composable
 private fun RenderApprovalIfNeeded(
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (baseNote.isNewThread()) {
         val communityAddress =
             remember(baseNote) {
@@ -909,9 +920,11 @@ private fun RenderApprovalIfNeeded(
 private fun RenderClassifiedsReaderForThread(
     noteEvent: ClassifiedsEvent,
     note: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val imageSet =
         noteEvent.imageMetas().ifEmpty { null }?.map {
             MediaUrlImage(
@@ -1111,8 +1124,10 @@ private fun RenderClassifiedsReaderForThread(
 private fun RenderLongFormHeaderForThread(
     noteEvent: LongTextNoteEvent,
     note: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Column(modifier = Modifier.padding(start = 12.dp, end = 12.dp, bottom = 12.dp)) {
         noteEvent.image()?.let {
             MyAsyncImage(
@@ -1220,9 +1235,11 @@ private fun RenderWikiHeaderForThreadPreview() {
 @Composable
 private fun RenderWikiHeaderForThread(
     noteEvent: WikiNoteEvent,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Row(modifier = Modifier.padding(start = 12.dp, end = 12.dp, bottom = 12.dp)) {
         Column {
             noteEvent.image()?.let {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/ThreadScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/ThreadScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.EventFinderFilterAssemblerSubscription
 import com.vitorpamplona.amethyst.ui.components.LoadNote
 import com.vitorpamplona.amethyst.ui.feeds.WatchLifecycleAndUpdateModel
@@ -41,9 +42,11 @@ import com.vitorpamplona.amethyst.ui.stringRes
 @Composable
 fun ThreadScreen(
     noteId: String?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (noteId == null) return
 
     val feedViewModel: ThreadFeedViewModel =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/datasources/ThreadFilterAssemblerSubscription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/datasources/ThreadFilterAssemblerSubscription.kt
@@ -23,6 +23,7 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.threadview.datasources
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.KeyDataSourceSubscription
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -30,12 +31,16 @@ import com.vitorpamplona.quartz.nip01Core.core.HexKey
 @Composable
 fun ThreadFilterAssemblerSubscription(
     eventId: HexKey,
-    accountViewModel: AccountViewModel,
-) = ThreadFilterAssemblerSubscription(
-    eventId,
-    accountViewModel.account,
-    accountViewModel.dataSources().thread,
-)
+    accountViewModel: IAccountViewModel,
+) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
+    ThreadFilterAssemblerSubscription(
+        eventId,
+        accountViewModel.account,
+        accountViewModel.dataSources().thread,
+    )
+}
 
 @Composable
 fun ThreadFilterAssemblerSubscription(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/FileHeaderCardCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/FileHeaderCardCompose.kt
@@ -42,6 +42,7 @@ import com.vitorpamplona.amethyst.commons.richtext.BaseMediaContent
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlImage
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlVideo
 import com.vitorpamplona.amethyst.commons.richtext.RichTextParser
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.components.SensitivityWarning
 import com.vitorpamplona.amethyst.ui.components.ZoomableContentView
@@ -57,9 +58,11 @@ import kotlin.text.ifEmpty
 @Composable
 fun FileHeaderCardCompose(
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val event = (baseNote.event as? FileHeaderEvent) ?: return
     val backgroundColor = remember { mutableStateOf(Color.Transparent) }
     val editState = observeEdits(baseNote = baseNote, accountViewModel = accountViewModel)
@@ -93,8 +96,10 @@ private fun FileHeaderCardImage(
     note: Note,
     event: FileHeaderEvent,
     backgroundColor: MutableState<Color>,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val fullUrl = event.url() ?: return
 
     val content by remember(note) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/NewImageButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/NewImageButton.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.NewMediaModel
 import com.vitorpamplona.amethyst.ui.actions.NewMediaView
 import com.vitorpamplona.amethyst.ui.actions.uploads.GallerySelect
@@ -70,10 +71,12 @@ import kotlinx.coroutines.withContext
 
 @Composable
 fun NewImageButton(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     navScrollToTop: () -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var isOpen by remember { mutableStateOf(false) }
 
     var wantsToPostFromGallery by remember { mutableStateOf(false) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/StoriesTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/StoriesTopBar.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.FeedFilterSpinner
@@ -35,9 +36,11 @@ import com.vitorpamplona.amethyst.ui.stringRes
 
 @Composable
 fun StoriesTopBar(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     UserDrawerSearchTopBar(accountViewModel, nav) {
         val list by accountViewModel.account.settings.defaultStoriesFollowList
             .collectAsStateWithLifecycle()
@@ -56,9 +59,11 @@ fun StoriesTopBar(
 private fun TopNavFilterBar(
     followListsModel: TopNavFilterState,
     listName: TopFilter,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onChange: (FeedDefinition) -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val allLists by followListsModel.kind3GlobalPeopleRoutes.collectAsStateWithLifecycle()
 
     FeedFilterSpinner(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/UserCardHeader.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/UserCardHeader.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.routeFor
@@ -42,9 +43,11 @@ import com.vitorpamplona.amethyst.ui.theme.Size35dp
 @Composable
 fun UserCardHeader(
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Row(
         modifier =
             Modifier

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/VideoScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/VideoScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedContentState
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.feeds.RefresheableBox
 import com.vitorpamplona.amethyst.ui.feeds.RenderFeedContentState
 import com.vitorpamplona.amethyst.ui.feeds.SaveableFeedContentState
@@ -58,9 +59,11 @@ import com.vitorpamplona.quartz.nip94FileMetadata.FileHeaderEvent
 
 @Composable
 fun VideoScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     VideoScreen(
         accountViewModel.feedStates.videoFeed,
         accountViewModel,
@@ -71,9 +74,11 @@ fun VideoScreen(
 @Composable
 fun VideoScreen(
     videoFeedContentState: FeedContentState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     WatchLifecycleAndUpdateModel(videoFeedContentState)
     WatchAccountForVideoScreen(videoFeedContentState = videoFeedContentState, accountViewModel = accountViewModel)
     VideoFilterAssemblerSubscription(accountViewModel)
@@ -113,8 +118,10 @@ fun VideoScreen(
 @Composable
 fun WatchAccountForVideoScreen(
     videoFeedContentState: FeedContentState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val listState by accountViewModel.account.liveStoriesFollowLists.collectAsStateWithLifecycle()
     val hiddenUsers =
         accountViewModel.account.hiddenUsers.flow
@@ -129,9 +136,11 @@ fun WatchAccountForVideoScreen(
 private fun RenderFeed(
     videoFeedContentState: FeedContentState,
     scrollKey: String?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     RefresheableBox(invalidateableContent = videoFeedContentState) {
         SaveableFeedContentState(videoFeedContentState, scrollStateKey = scrollKey) { listState ->
             RenderFeedContentState(
@@ -157,9 +166,11 @@ private fun RenderFeed(
 fun VideoFeedLoaded(
     loaded: FeedState.Loaded,
     listState: LazyListState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val items by loaded.feed.collectAsStateWithLifecycle()
 
     LazyColumn(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/datasource/VideoFilterAssemblerSubscription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/datasource/VideoFilterAssemblerSubscription.kt
@@ -24,10 +24,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.lifecycle.viewModelScope
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.KeyDataSourceSubscription
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
 @Composable
-fun VideoFilterAssemblerSubscription(accountViewModel: AccountViewModel) {
+fun VideoFilterAssemblerSubscription(accountViewModel: IAccountViewModel) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     VideoFilterAssemblerSubscription(
         accountViewModel.dataSources().video,
         accountViewModel,
@@ -37,8 +40,10 @@ fun VideoFilterAssemblerSubscription(accountViewModel: AccountViewModel) {
 @Composable
 fun VideoFilterAssemblerSubscription(
     filterAssembler: VideoFilterAssembler,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     // different screens get different states
     // even if they are tracking the same tag.
     val state =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/AddWalletScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/AddWalletScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.components.util.getText
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.painterRes
@@ -72,9 +73,11 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddWalletScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val walletViewModel: WalletViewModel = viewModel()
     walletViewModel.init(accountViewModel)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletDetailScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletDetailScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -69,9 +70,11 @@ import java.text.NumberFormat
 @Composable
 fun WalletDetailScreen(
     walletId: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val walletViewModel: WalletViewModel = viewModel()
     walletViewModel.init(accountViewModel)
     walletViewModel.selectWallet(walletId)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletReceiveScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletReceiveScreen.kt
@@ -67,6 +67,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.qrcode.QrCodeDrawer
@@ -76,9 +77,11 @@ import java.text.NumberFormat
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WalletReceiveScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val walletViewModel: WalletViewModel = viewModel()
 
     LaunchedEffect(accountViewModel) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletScreen.kt
@@ -74,6 +74,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -83,9 +84,11 @@ import java.text.NumberFormat
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WalletScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val walletViewModel: WalletViewModel = viewModel()
     walletViewModel.init(accountViewModel)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletSendScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletSendScreen.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
@@ -67,9 +68,11 @@ import com.vitorpamplona.amethyst.ui.stringRes
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WalletSendScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val walletViewModel: WalletViewModel = viewModel()
 
     LaunchedEffect(accountViewModel) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletTransactionsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletTransactionsScreen.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.UserPicture
 import com.vitorpamplona.amethyst.ui.note.UsernameDisplay
@@ -77,9 +78,11 @@ import java.util.Locale
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WalletTransactionsScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val walletViewModel: WalletViewModel = viewModel()
 
     LaunchedEffect(accountViewModel) {
@@ -229,9 +232,11 @@ private fun TransactionFilterRow(
 @Composable
 private fun TransactionItem(
     tx: NwcTransaction,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val isIncoming = tx.type == NwcTransactionType.INCOMING
     val amountSats = (tx.amount ?: 0L) / 1000L
     val formattedAmount =
@@ -378,8 +383,10 @@ private fun TransactionItem(
 private fun TransactionUserName(
     pubkeyHex: String,
     fallbackName: String?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     LoadUser(baseUserHex = pubkeyHex, accountViewModel = accountViewModel) { user ->
         if (user != null) {
             UsernameDisplay(

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/IAccountViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/IAccountViewModel.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.screen.loggedIn
+
+import com.vitorpamplona.amethyst.commons.model.AddressableNote
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.quartz.nip01Core.core.Address
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * Cross-platform interface for AccountViewModel.
+ *
+ * Provides the subset of AccountViewModel's API that can be expressed
+ * using only commonMain types (IAccount, Note, User, HexKey, etc.).
+ * The Android-specific AccountViewModel implements this interface so
+ * that UI files migrated to commonMain can accept IAccountViewModel
+ * as a parameter without depending on Android-only types.
+ *
+ * Usage pattern for migrated files:
+ *   Before: fun MyScreen(accountViewModel: AccountViewModel, ...)
+ *   After:  fun MyScreen(accountViewModel: IAccountViewModel, ...)
+ */
+interface IAccountViewModel {
+    // ---- Core account access ----
+
+    /** The underlying account, abstracted via IAccount for commonMain use. */
+    val account: IAccount
+
+    /** Coroutine scope tied to the ViewModel lifecycle. */
+    val scope: CoroutineScope
+
+    // ---- Identity helpers (used by 50+ files) ----
+
+    /** Current user's profile. Delegates to account.userProfile(). */
+    fun userProfile(): User
+
+    /** Whether the current account can sign events. */
+    fun isWriteable(): Boolean
+
+    /** Check if the given pubkey is the logged-in user. */
+    fun isLoggedUser(pubkeyHex: HexKey?): Boolean
+
+    /** Check if the given user is the logged-in user. */
+    fun isLoggedUser(user: User?): Boolean
+
+    /** Check if the current account follows the given user. */
+    fun isFollowing(user: User?): Boolean
+
+    /** Check if the current account follows the given pubkey. */
+    fun isFollowing(user: HexKey): Boolean
+
+    // ---- Cache lookups (used by 30+ files) ----
+
+    fun checkGetOrCreateUser(key: HexKey): User?
+
+    fun getUserIfExists(hex: HexKey): User?
+
+    fun checkGetOrCreateNote(key: HexKey): Note?
+
+    fun getNoteIfExists(hex: HexKey): Note?
+
+    fun getOrCreateAddressableNote(address: Address): AddressableNote?
+
+    fun getAddressableNoteIfExists(key: String): AddressableNote?
+
+    fun getAddressableNoteIfExists(key: Address): AddressableNote?
+
+    // ---- Async helpers ----
+
+    /** Launch a coroutine on IO dispatchers. */
+    fun runOnIO(runOnIO: suspend () -> Unit)
+
+    // ---- Actions (commonly used) ----
+
+    fun follow(user: User)
+
+    fun unfollow(user: User)
+
+    fun hide(user: User)
+
+    fun show(user: User)
+
+    fun boost(note: Note)
+
+    fun delete(note: Note)
+
+    fun delete(notes: List<Note>)
+
+    fun broadcast(note: Note)
+
+    fun reactToOrDelete(note: Note)
+
+    fun reactToOrDelete(
+        note: Note,
+        reaction: String,
+    )
+
+    fun decrypt(
+        note: Note,
+        onReady: (String) -> Unit,
+    )
+
+    fun cachedDecrypt(note: Note): String?
+
+    // ---- Bookmark / Pin (used by several files) ----
+
+    fun addPrivateBookmark(note: Note)
+
+    fun addPublicBookmark(note: Note)
+
+    fun removePrivateBookmark(note: Note)
+
+    fun removePublicBookmark(note: Note)
+
+    fun addPin(note: Note)
+
+    fun removePin(note: Note)
+
+    // ---- Navigation helpers ----
+
+    fun loadReactionTo(note: Note?): String?
+
+    fun loadAndMarkAsRead(
+        routeForLastRead: String,
+        createdAt: Long?,
+    ): Boolean
+
+    // ---- Settings delegates ----
+
+    fun defaultZapType(): LnZapEvent.ZapType
+
+    fun reactionChoices(): List<String>
+
+    fun zapAmountChoices(): List<Long>
+
+    fun showSensitiveContent(): MutableStateFlow<Boolean?>
+
+    fun dontTranslateFrom(): Set<String>
+
+    fun translateTo(): String
+}


### PR DESCRIPTION
Migrates @Composable function signatures in screen/loggedIn/ smaller subdirectories from AccountViewModel to IAccountViewModel with shadow cast pattern.

**Directories:** threadview, search, geohash, chess, hashtag, polls, longs, pictures, shorts, video, wallet, settings, notifications, bookmarkgroups, lists, discover, home.

**Changes:**
- 112 files modified across 17 directories
- All @Composable function signatures changed from `accountViewModel: AccountViewModel` to `accountViewModel: IAccountViewModel`
- Shadow cast pattern (`@Suppress("NAME_SHADOWING") val accountViewModel = accountViewModel as AccountViewModel`) added at function entry to maintain body compatibility
- Expression-body functions converted to block-body where needed
- ViewModels and non-composable functions left unchanged

**Build verified:** `./gradlew :amethyst:compilePlayDebugKotlin` passes cleanly.

Part of the KMP iOS migration tracked in #2238.