### PR TITLE
feat: migrate composable signatures to IAccountViewModel (v15) — navigation/feeds/components

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/CrossfadeIfEnabled.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/CrossfadeIfEnabled.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.util.fastForEach
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
 @Composable
@@ -46,9 +47,11 @@ fun <T> CrossfadeIfEnabled(
     contentAlignment: Alignment = Alignment.TopStart,
     animationSpec: FiniteAnimationSpec<Float> = tween(),
     label: String = "Crossfade",
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     content: @Composable (T) -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (accountViewModel.settings.isPerformanceMode()) {
         Box(modifier, contentAlignment) {
             content(targetState)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/EditPostView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/EditPostView.kt
@@ -75,6 +75,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.richtext.RichTextParser
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.service.playback.composable.VideoView
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserInfo
@@ -110,9 +111,11 @@ fun EditPostView(
     onClose: () -> Unit,
     edit: Note,
     versionLookingAt: Note?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val postViewModel: EditPostViewModel = viewModel()
     postViewModel.init(accountViewModel)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/EditPostViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/EditPostViewModel.kt
@@ -32,6 +32,7 @@ import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.compose.currentWord
 import com.vitorpamplona.amethyst.commons.compose.insertUrlAtCursor
 import com.vitorpamplona.amethyst.commons.richtext.RichTextParser
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
@@ -101,7 +102,9 @@ open class EditPostViewModel : ViewModel() {
     var canAddInvoice by mutableStateOf(false)
     var wantsInvoice by mutableStateOf(false)
 
-    open fun init(accountViewModel: AccountViewModel) {
+    open fun init(accountViewModel: IAccountViewModel) {
+        @Suppress("NAME_SHADOWING")
+        val accountViewModel = accountViewModel as AccountViewModel
         this.accountViewModel = accountViewModel
         this.account = accountViewModel.account
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewMediaView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewMediaView.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.mediaServers.DEFAULT_MEDIA_SERVERS
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.actions.uploads.ShowImageUploadGallery
@@ -77,9 +78,11 @@ fun NewMediaView(
     uris: ImmutableList<SelectedMedia>,
     onClose: () -> Unit,
     postViewModel: NewMediaModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val account = accountViewModel.account
     val context = LocalContext.current
 
@@ -147,8 +150,10 @@ fun NewMediaView(
 @Composable
 fun ImageVideoPost(
     postViewModel: NewMediaModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val fileServers by accountViewModel.account.blossomServers.hostNameFlow
         .collectAsState()
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewUserMetadataScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewUserMetadataScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectSingleFromGallery
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.SavingTopBar
@@ -68,8 +69,10 @@ import com.vitorpamplona.amethyst.ui.theme.placeholderText
 @Composable
 fun NewUserMetadataScreen(
     nav: INav,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val postViewModel: NewUserMetadataViewModel = viewModel()
     postViewModel.init(accountViewModel)
     val context = LocalContext.current

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewUserMetadataViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewUserMetadataViewModel.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.service.uploads.CompressorQuality
 import com.vitorpamplona.amethyst.service.uploads.MediaCompressor
@@ -65,7 +66,9 @@ class NewUserMetadataViewModel : ViewModel() {
     var isUploadingImageForPicture by mutableStateOf(false)
     var isUploadingImageForBanner by mutableStateOf(false)
 
-    fun init(accountViewModel: AccountViewModel) {
+    fun init(accountViewModel: IAccountViewModel) {
+        @Suppress("NAME_SHADOWING")
+        val accountViewModel = accountViewModel as AccountViewModel
         this.accountViewModel = accountViewModel
         this.account = accountViewModel.account
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/mediaServers/AllMediaServersScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/mediaServers/AllMediaServersScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.SavingTopBar
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -46,9 +47,11 @@ import com.vitorpamplona.amethyst.ui.theme.grayText
 
 @Composable
 fun AllMediaServersScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val blossomServersViewModel: BlossomServersViewModel = viewModel()
 
     blossomServersViewModel.init(accountViewModel)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/mediaServers/BlossomServersViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/mediaServers/BlossomServersViewModel.kt
@@ -23,6 +23,7 @@ package com.vitorpamplona.amethyst.ui.actions.mediaServers
 import androidx.compose.runtime.Stable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.quartz.utils.Log
@@ -41,7 +42,9 @@ class BlossomServersViewModel : ViewModel() {
     val fileServers = _fileServers.asStateFlow()
     private var isModified = false
 
-    fun init(accountViewModel: AccountViewModel) {
+    fun init(accountViewModel: IAccountViewModel) {
+        @Suppress("NAME_SHADOWING")
+        val accountViewModel = accountViewModel as AccountViewModel
         this.accountViewModel = accountViewModel
         this.account = accountViewModel.account
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/paymentTargets/PaymentTargetsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/paymentTargets/PaymentTargetsScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.SavingTopBar
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -71,9 +72,11 @@ import com.vitorpamplona.quartz.experimental.nipA3.PaymentTarget
 
 @Composable
 fun PaymentTargetsScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val viewModel: PaymentTargetsViewModel = viewModel()
     viewModel.init(accountViewModel)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/paymentTargets/PaymentTargetsViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/paymentTargets/PaymentTargetsViewModel.kt
@@ -23,6 +23,7 @@ package com.vitorpamplona.amethyst.ui.actions.paymentTargets
 import androidx.compose.runtime.Stable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.quartz.experimental.nipA3.PaymentTarget
@@ -40,7 +41,9 @@ class PaymentTargetsViewModel : ViewModel() {
     val paymentTargets = _paymentTargets.asStateFlow()
     private var isModified = false
 
-    fun init(accountViewModel: AccountViewModel) {
+    fun init(accountViewModel: IAccountViewModel) {
+        @Suppress("NAME_SHADOWING")
+        val accountViewModel = accountViewModel as AccountViewModel
         this.accountViewModel = accountViewModel
         this.account = accountViewModel.account
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/uploads/ShowImageUploadItem.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/uploads/ShowImageUploadItem.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.service.playback.composable.VideoView
 import com.vitorpamplona.amethyst.service.uploads.MultiOrchestrator
 import com.vitorpamplona.amethyst.service.uploads.UploadOrchestrator
@@ -85,8 +86,10 @@ import kotlinx.coroutines.launch
 fun ShowImageUploadGallery(
     list: MultiOrchestrator,
     onDelete: (SelectedMediaProcessing) -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     AutoNonlazyGrid(list.size()) {
         ShowImageUploadItem(list.get(it), onDelete, accountViewModel)
     }
@@ -112,8 +115,10 @@ fun createVideoThumb(
 @Composable
 fun ShowImageGallery(
     media: SelectedMedia,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (media.isImage() == true) {
         AsyncImage(
             model = media.uri.toString(),
@@ -182,8 +187,10 @@ fun ShowImageGallery(
 fun ShowImageUploadItem(
     item: SelectedMediaProcessing,
     onDelete: (SelectedMediaProcessing) -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     ShowImageGallery(item.media, accountViewModel)
 
     OrchestratorOverlay(item.orchestrator) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/broadcast/DisplayBroadcastProgress.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/broadcast/DisplayBroadcastProgress.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.service.broadcast.BroadcastEvent
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
@@ -52,7 +53,9 @@ import kotlinx.coroutines.delay
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun DisplayBroadcastProgress(accountViewModel: AccountViewModel) {
+fun DisplayBroadcastProgress(accountViewModel: IAccountViewModel) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     // Only show in COMPLETE UI mode
     if (!accountViewModel.settings.isCompleteUIMode()) return
 
@@ -109,8 +112,10 @@ fun DisplayBroadcastProgress(accountViewModel: AccountViewModel) {
 fun DisplaySnack(
     activeBroadcasts: ImmutableList<BroadcastEvent>,
     onTap: () -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Box(modifier = Modifier.fillMaxSize()) {
         BroadcastBanner(
             broadcasts = activeBroadcasts,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.unit.sp
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.call.CallManager
 import com.vitorpamplona.amethyst.commons.call.CallState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.service.call.CallController
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
@@ -69,10 +70,12 @@ import kotlinx.coroutines.launch
 fun CallScreen(
     callManager: CallManager,
     callController: CallController?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onCallEnded: () -> Unit,
     isInPipMode: Boolean = false,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val callState by callManager.state.collectAsState()
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
@@ -216,9 +219,11 @@ fun CallScreen(
 private fun CallInProgressUI(
     peerPubKeys: Set<String>,
     statusText: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onHangup: () -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Box(
         modifier =
             Modifier
@@ -270,10 +275,12 @@ private fun CallInProgressUI(
 private fun IncomingCallUI(
     groupMembers: Set<String>,
     callType: com.vitorpamplona.quartz.nipACWebRtcCalls.tags.CallType,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onAccept: () -> Unit,
     onReject: () -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Box(
         modifier =
             Modifier

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallWidgets.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallWidgets.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.note.BaseUserPicture
 import com.vitorpamplona.amethyst.ui.note.ClickableUserPicture
 import com.vitorpamplona.amethyst.ui.note.UsernameDisplay
@@ -104,9 +105,11 @@ fun PeerVideoGrid(
     remoteVideoTracks: Map<String, VideoTrack>,
     activePeerVideos: Set<String>,
     eglBase: org.webrtc.EglBase?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     modifier: Modifier = Modifier,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val peers = remember(peerPubKeys) { peerPubKeys.toList() }
 
     if (peers.size == 1) {
@@ -167,9 +170,11 @@ fun PeerVideoGrid(
 @Composable
 fun PeerAvatarCell(
     peerPubKey: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     modifier: Modifier = Modifier,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Box(
         modifier = modifier.background(Color.DarkGray),
         contentAlignment = Alignment.Center,
@@ -202,8 +207,10 @@ fun PeerAvatarCell(
 fun GroupCallPictures(
     peerPubKeys: Set<String>,
     size: Dp,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val userList = remember(peerPubKeys) { peerPubKeys.toList() }
     val displayCount = minOf(userList.size, 4)
     val remaining = userList.size - displayCount
@@ -318,9 +325,11 @@ fun GroupCallPictures(
 @Composable
 fun GroupCallNames(
     peerPubKeys: Set<String>,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     textColor: Color = MaterialTheme.colorScheme.onSurface,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val userList = remember(peerPubKeys) { peerPubKeys.toList() }
 
     when (userList.size) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/ConnectedCallUI.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/ConnectedCallUI.kt
@@ -70,6 +70,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.call.CallState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.service.call.AudioRoute
 import com.vitorpamplona.amethyst.service.call.CallController
 import com.vitorpamplona.amethyst.ui.note.creators.userSuggestions.ShowUserSuggestionList
@@ -84,13 +85,15 @@ import org.webrtc.VideoTrack
 fun ConnectedCallUI(
     state: CallState.Connected,
     callController: CallController?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onHangup: () -> Unit,
     onToggleMute: () -> Unit,
     onToggleVideo: () -> Unit,
     onCycleAudioRoute: () -> Unit,
     onInvitePeer: (String) -> Unit = {},
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var elapsed by remember { mutableLongStateOf(0L) }
 
     LaunchedEffect(state.startedAtEpoch) {
@@ -352,11 +355,13 @@ private fun CallControls(
 
 @Composable
 private fun AddParticipantDialog(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     existingPeers: Set<String>,
     onInvite: (String) -> Unit,
     onDismiss: () -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val userSuggestions =
         remember {
             UserSuggestionState(accountViewModel.account, accountViewModel.nip05ClientBuilder())

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/PipCallUI.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/PipCallUI.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.vitorpamplona.amethyst.commons.call.CallState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.service.call.CallController
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.quartz.utils.TimeUtils
@@ -53,8 +54,10 @@ import org.webrtc.VideoTrack
 fun PipCallUI(
     peerPubKeys: Set<String>,
     statusText: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Box(
         modifier =
             Modifier
@@ -85,8 +88,10 @@ fun PipCallUI(
 fun PipConnectedCallUI(
     state: CallState.Connected,
     callController: CallController?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var elapsed by remember { mutableLongStateOf(0L) }
 
     LaunchedEffect(state.startedAtEpoch) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/CashuRedeem.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/CashuRedeem.kt
@@ -55,6 +55,7 @@ import androidx.core.net.toUri
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.hashtags.Cashu
 import com.vitorpamplona.amethyst.commons.hashtags.CustomHashTagIcons
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.service.cashu.CachedCashuParser
 import com.vitorpamplona.amethyst.service.cashu.CashuToken
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
@@ -79,8 +80,11 @@ import kotlinx.coroutines.withContext
 @Composable
 fun CashuPreview(
     cashutoken: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
+
     @Suppress("ProduceStateDoesNotAssignValue")
     val cashuData by produceState(
         initialValue = CachedCashuParser.cached(cashutoken),
@@ -113,8 +117,10 @@ fun CashuPreview(
 @Composable
 fun CashuPreview(
     tokens: ImmutableList<CashuToken>,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     tokens.forEach {
         CashuPreviewNew(
             it,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ClickableRoute.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ClickableRoute.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
 import com.vitorpamplona.amethyst.commons.model.EmptyTagList
 import com.vitorpamplona.amethyst.commons.model.ImmutableListOfLists
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.observeNote
@@ -85,9 +86,11 @@ import kotlinx.collections.immutable.ImmutableMap
 fun ClickableRoute(
     word: String,
     nip19: Nip19Parser.ParseReturn,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     when (val entity = nip19.entity) {
         is NPub -> DisplayUser(entity.hex, nip19.nip19raw, nip19.additionalChars, accountViewModel, nav)
         is NProfile -> DisplayUser(entity.hex, nip19.nip19raw, nip19.additionalChars, accountViewModel, nav)
@@ -104,9 +107,11 @@ fun ClickableRoute(
 @Composable
 fun LoadOrCreateNote(
     event: Event,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     content: @Composable (Note?) -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var note by
         remember(event.id) { mutableStateOf(accountViewModel.getNoteIfExists(event.id)) }
 
@@ -123,9 +128,11 @@ fun LoadOrCreateNote(
 private fun LoadAndDisplayEvent(
     event: Event,
     additionalChars: String?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     LoadOrCreateNote(event, accountViewModel) {
         if (it != null) {
             DisplayNoteLink(it, event.id, additionalChars, accountViewModel, nav)
@@ -150,9 +157,11 @@ fun DisplayEvent(
     hex: HexKey,
     nip19: String,
     additionalChars: String?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     LoadNote(hex, accountViewModel) {
         if (it != null) {
             DisplayNoteLink(it, hex, additionalChars, accountViewModel, nav)
@@ -177,9 +186,11 @@ private fun DisplayNoteLink(
     it: Note,
     hex: HexKey,
     addedCharts: String?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val noteState by observeNote(it, accountViewModel)
     val noteIdDisplayNote = remember(noteState) { "@${noteState.note.idDisplayNote()}" }
 
@@ -198,9 +209,11 @@ private fun DisplayAddress(
     nip19: NAddress,
     originalNip19: String,
     additionalChars: String?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var noteBase by remember(nip19) { mutableStateOf(accountViewModel.getNoteIfExists(nip19.aTag())) }
 
     if (noteBase == null) {
@@ -242,9 +255,11 @@ fun DisplayUser(
     userHex: HexKey,
     originalNip19: String,
     additionalChars: String?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var userBase by
         remember(userHex) {
             mutableStateOf(
@@ -278,9 +293,11 @@ fun DisplayUser(
 fun RenderUserAsClickableText(
     baseUser: User,
     additionalChars: String?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val userState by observeUserInfo(baseUser, accountViewModel)
 
     CreateClickableTextWithEmoji(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ClickableWithdrawal.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ClickableWithdrawal.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextDirection
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.note.ErrorMessageDialog
 import com.vitorpamplona.amethyst.ui.note.payViaIntent
@@ -43,8 +44,10 @@ import kotlinx.coroutines.launch
 @Composable
 fun MayBeWithdrawal(
     lnurlWord: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var lnWithdrawal by remember { mutableStateOf<String?>(null) }
 
     LaunchedEffect(key1 = lnurlWord) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ExpandableRichTextViewer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ExpandableRichTextViewer.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.graphics.Color
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.model.ImmutableListOfLists
 import com.vitorpamplona.amethyst.commons.richtext.ExpandableTextCutOffCalculator
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.getGradient
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -64,9 +65,11 @@ fun ExpandableRichTextViewer(
     backgroundColor: MutableState<Color>,
     id: String,
     callbackUri: String? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var showFullText by
         rememberSaveable {
             val cached = ShowFullTextCache.cache[id]

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ImageGallery.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ImageGallery.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.commons.richtext.ImageGalleryParagraph
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlImage
 import com.vitorpamplona.amethyst.commons.richtext.RichTextViewerState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.MediaAspectRatioCache
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.theme.Size10dp
@@ -117,8 +118,10 @@ private fun GalleryImage(
     modifier: Modifier = Modifier,
     roundedCorner: Boolean,
     contentScale: ContentScale,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Box(modifier = modifier) {
         ZoomableContentView(
             content = image,
@@ -134,10 +137,12 @@ private fun GalleryImage(
 fun ImageGallery(
     images: ImageGalleryParagraph,
     state: RichTextViewerState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     modifier: Modifier = Modifier,
     roundedCorner: Boolean = true,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (images.words.isEmpty()) return
 
     val resolvedImages =
@@ -161,9 +166,11 @@ fun ImageGallery(
 @Composable
 private fun SingleImageGallery(
     images: ImmutableList<MediaUrlImage>,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     roundedCorner: Boolean,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     GalleryImage(
         image = images.first(),
         allImages = images,
@@ -177,9 +184,11 @@ private fun SingleImageGallery(
 @Composable
 private fun TwoImageGallery(
     images: ImmutableList<MediaUrlImage>,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     roundedCorner: Boolean,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val orientation = rememberFirstImageOrientation(images.firstOrNull())
 
     if (orientation.isLandscape) {
@@ -220,9 +229,11 @@ private fun TwoImageGallery(
 @Composable
 private fun ThreeImageGallery(
     images: ImmutableList<MediaUrlImage>,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     roundedCorner: Boolean,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val firstImage = images.first()
     val orientation = rememberFirstImageOrientation(firstImage)
     val remainingImages = images.drop(1)
@@ -299,9 +310,11 @@ private fun ThreeImageGallery(
 @Composable
 private fun FourImageGallery(
     images: ImmutableList<MediaUrlImage>,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     roundedCorner: Boolean,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Column(
         modifier = Modifier.aspectRatio(ASPECT_RATIO),
         verticalArrangement = Arrangement.spacedBy(IMAGE_SPACING),
@@ -329,9 +342,11 @@ private fun FourImageGallery(
 @Composable
 private fun ManyImageGallery(
     images: ImmutableList<MediaUrlImage>,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     roundedCorner: Boolean,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val columns =
         when {
             images.size <= 9 -> 3

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/LoadUrlPreview.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/LoadUrlPreview.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.produceState
 import androidx.compose.ui.layout.ContentScale
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlImage
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlVideo
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.UrlCachedPreviewer
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -37,8 +38,10 @@ fun LoadUrlPreview(
     url: String,
     urlText: String,
     callbackUri: String? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (!accountViewModel.settings.showUrlPreview()) {
         ClickableUrl(urlText, url)
     } else {
@@ -51,8 +54,11 @@ fun LoadUrlPreviewDirect(
     url: String,
     urlText: String,
     callbackUri: String? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
+
     @Suppress("ProduceStateDoesNotAssignValue")
     val urlPreviewState by
         produceState(
@@ -92,8 +98,10 @@ fun RenderLoaded(
     state: UrlPreviewState.Loaded,
     url: String,
     callbackUri: String? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (state.previewInfo.mimeType.startsWith("image")) {
         Box(modifier = HalfVertPadding) {
             ZoomableContentView(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/MyAsyncImage.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/MyAsyncImage.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.layout.ContentScale
 import coil3.compose.AsyncImagePainter
 import coil3.compose.SubcomposeAsyncImage
 import coil3.compose.SubcomposeAsyncImageContent
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.MediaAspectRatioCache
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.note.DownloadForOfflineIcon
@@ -52,10 +53,12 @@ fun MyAsyncImage(
     contentScale: ContentScale,
     mainImageModifier: Modifier,
     loadedImageModifier: Modifier,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onLoadingBackground: (@Composable () -> Unit)?,
     onError: (@Composable () -> Unit)?,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val ratio = MediaAspectRatioCache.get(imageUrl)
     val showImage = remember { mutableStateOf(accountViewModel.settings.showImages()) }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ReusableZapButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ReusableZapButton.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.ZapPaymentHandler
@@ -98,11 +99,13 @@ data class ZapButtonCallbacks(
 @Composable
 fun ReusableZapButton(
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     config: ZapButtonConfig = ZapButtonConfig(),
     callbacks: ZapButtonCallbacks = ZapButtonCallbacks(),
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var wantsToZap by remember { mutableStateOf<ImmutableList<Long>?>(null) }
 
     // Makes sure the user is loaded to get his ln address ahead of time (for DVM buttons)
@@ -274,7 +277,7 @@ fun ReusableZapButton(
 
 private fun handleZapClick(
     baseNote: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     context: Context,
     zapAmountChoices: List<Long>?,
     onZapStarts: () -> Unit,
@@ -283,6 +286,8 @@ private fun handleZapClick(
     onError: (String, String, User?) -> Unit,
     onPayViaIntent: (ImmutableList<ZapPaymentHandler.Payable>) -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (baseNote.isDraft()) {
         accountViewModel.toastManager.toast(
             R.string.draft_note,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/RichTextViewer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/RichTextViewer.kt
@@ -90,6 +90,7 @@ import com.vitorpamplona.amethyst.commons.richtext.SecretEmoji
 import com.vitorpamplona.amethyst.commons.richtext.Segment
 import com.vitorpamplona.amethyst.commons.richtext.VideoSegment
 import com.vitorpamplona.amethyst.commons.richtext.WithdrawSegment
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.HashtagIcon
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
@@ -139,9 +140,11 @@ fun RichTextViewer(
     tags: ImmutableListOfLists<String>,
     backgroundColor: MutableState<Color>,
     callbackUri: String? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Column(modifier = modifier) {
         if (remember(content) { isMarkdown(content) }) {
             RenderContentAsMarkdown(content, tags, canPreview, quotesLeft, backgroundColor, callbackUri, accountViewModel, nav)
@@ -346,9 +349,11 @@ private fun RenderRegular(
     quotesLeft: Int,
     backgroundColor: MutableState<Color>,
     callbackUri: String? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (canPreview) {
         RenderRegular(content, tags, callbackUri) { paragraph, state, spaceWidth, modifier ->
             if (paragraph is ImageGalleryParagraph) {
@@ -470,9 +475,11 @@ private fun RenderWordWithoutPreview(
     word: Segment,
     state: RichTextViewerState,
     backgroundColor: MutableState<Color>,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     when (word) {
         // Don't preview Images
         is ImageSegment -> ClickableUrl(word.segmentText, word.segmentText)
@@ -523,9 +530,11 @@ private fun RenderWordWithPreview(
     backgroundColor: MutableState<Color>,
     quotesLeft: Int,
     callbackUri: String? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     when (word) {
         is ImageSegment -> ZoomableContentView(word.segmentText, state, accountViewModel)
         is VideoSegment -> ZoomableContentView(word.segmentText, state, accountViewModel)
@@ -554,8 +563,10 @@ fun BlossomUriRenderer(
     word: String,
     state: RichTextViewerState,
     callbackUri: String? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val isMedia = state.mediaForPager.contains(word)
 
     if (isMedia) {
@@ -584,8 +595,10 @@ fun BlossomUriRenderer(
 @Composable
 fun ClickableBlossomUri(
     blossomUri: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val context = LocalContext.current
 
     ClickableTextPrimary(
@@ -599,8 +612,10 @@ fun ClickableBlossomUri(
 @Composable
 fun BlossomUriRendererNoPreview(
     word: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val serverResultState =
         remember(word) {
             mutableStateOf(Amethyst.instance.blossomResolver.cachedFindServer(word))
@@ -624,8 +639,10 @@ fun BlossomUriRendererNoPreview(
 private fun ZoomableContentView(
     word: String,
     state: RichTextViewerState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     state.mediaForPager[word]?.let {
         Box(modifier = HalfVertPadding) {
             ZoomableContentView(it, state.mediaList, roundedCorner = true, contentScale = ContentScale.FillWidth, accountViewModel)
@@ -655,9 +672,11 @@ fun BechLink(
     canPreview: Boolean,
     quotesLeft: Int,
     backgroundColor: MutableState<Color>,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val loadedLink by produceCachedState(cache = accountViewModel.bechLinkCache, key = word)
 
     val baseNote = loadedLink?.baseNote
@@ -695,9 +714,11 @@ fun DisplayFullNote(
     extraChars: String?,
     quotesLeft: Int,
     backgroundColor: MutableState<Color>,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     NoteCompose(
         baseNote = note,
         modifier = MaterialTheme.colorScheme.innerPostModifier,
@@ -724,9 +745,11 @@ fun DisplaySecretEmoji(
     canPreview: Boolean,
     quotesLeft: Int,
     backgroundColor: MutableState<Color>,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (canPreview && quotesLeft > 0) {
         var secretContent by remember {
             mutableStateOf(CachedRichTextParser.cachedText(EmojiCoder.decode(segment.segmentText), state.tags))
@@ -772,9 +795,11 @@ fun CoreSecretMessage(
     callbackUri: String?,
     quotesLeft: Int,
     backgroundColor: MutableState<Color>,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (localSecretContent.paragraphs.size == 1) {
         localSecretContent.paragraphs[0].words.forEach { word ->
             RenderWordWithPreview(
@@ -871,9 +896,11 @@ private fun inlineIcon(hashtagIcon: HashtagIcon) =
 @Composable
 fun TagLink(
     word: HashIndexUserSegment,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     LoadUser(baseUserHex = word.hex, accountViewModel) {
         if (it == null) {
             Text(text = word.segmentText)
@@ -891,9 +918,11 @@ fun TagLink(
 @Composable
 fun LoadNote(
     baseNoteHex: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     content: @Composable (Note?) -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var note by
         remember(baseNoteHex) { mutableStateOf(accountViewModel.getNoteIfExists(baseNoteHex)) }
 
@@ -912,9 +941,11 @@ fun TagLink(
     canPreview: Boolean,
     quotesLeft: Int,
     backgroundColor: MutableState<Color>,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     LoadNote(baseNoteHex = word.hex, accountViewModel) {
         if (it == null) {
             Text(text = remember { word.segmentText.toShortDisplay() })
@@ -966,10 +997,12 @@ private fun DisplayNoteFromTag(
     addedChars: String?,
     canPreview: Boolean,
     quotesLeft: Int,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     backgroundColor: MutableState<Color>,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (canPreview && quotesLeft > 0) {
         NoteCompose(
             baseNote = baseNote,
@@ -994,9 +1027,11 @@ private fun DisplayNoteFromTag(
 @Composable
 private fun DisplayUserFromTag(
     baseUser: User,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val meta by observeUserInfo(baseUser, accountViewModel)
 
     CrossfadeIfEnabled(targetState = meta, label = "DisplayUserFromTag", accountViewModel = accountViewModel) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/SensitivityWarning.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/SensitivityWarning.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -66,18 +67,22 @@ import com.vitorpamplona.quartz.nip36SensitiveContent.isSensitiveOrNSFW
 @Composable
 fun SensitivityWarning(
     note: Note,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     content: @Composable () -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     note.event?.let { SensitivityWarning(it, accountViewModel, content) }
 }
 
 @Composable
 fun SensitivityWarning(
     event: Event,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     content: @Composable () -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val hasSensitiveContent = remember(event) { event.isSensitiveOrNSFW() }
 
     if (hasSensitiveContent) {
@@ -91,9 +96,11 @@ fun SensitivityWarning(
 @Composable
 fun SensitivityWarning(
     reason: String?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     content: @Composable () -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (reason != null) {
         ObserveSensitivityWarning(reason, accountViewModel, content)
     } else {
@@ -104,9 +111,11 @@ fun SensitivityWarning(
 @Composable
 fun ObserveSensitivityWarning(
     reason: String?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     content: @Composable () -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val accountState = accountViewModel.showSensitiveContent().collectAsStateWithLifecycle()
 
     var showContentWarningNote by remember(accountState) { mutableStateOf(accountState.value != true) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
@@ -79,6 +79,7 @@ import com.vitorpamplona.amethyst.commons.richtext.MediaPreloadedContent
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlContent
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlImage
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlVideo
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.MediaAspectRatioCache
 import com.vitorpamplona.amethyst.service.playback.composable.VideoViewInner
 import com.vitorpamplona.amethyst.service.playback.diskCache.isLiveStreaming
@@ -103,8 +104,10 @@ fun ZoomableImageDialog(
     imageUrl: BaseMediaContent,
     allImages: ImmutableList<BaseMediaContent> = listOf(imageUrl).toImmutableList(),
     onDismiss: () -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Dialog(
         onDismissRequest = onDismiss,
         properties =
@@ -138,8 +141,10 @@ private fun DialogContent(
     allImages: ImmutableList<BaseMediaContent>,
     imageUrl: BaseMediaContent,
     onDismiss: () -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val pagerState: PagerState = rememberPagerState { allImages.size }
     val controllerVisible = remember { mutableStateOf(true) }
     val sharePopupExpanded = remember { mutableStateOf(false) }
@@ -323,8 +328,10 @@ private fun showToastOnMain(
 private suspend fun saveMediaToGallery(
     content: BaseMediaContent,
     localContext: Context,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val isImage = content is MediaUrlImage || content is MediaLocalImage
 
     val success = if (isImage) R.string.image_saved_to_the_gallery else R.string.video_saved_to_the_gallery
@@ -372,8 +379,10 @@ private fun RenderImageOrVideo(
     roundedCorner: Boolean,
     isFiniteHeight: Boolean,
     controllerVisible: MutableState<Boolean>,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val contentScale =
         if (isFiniteHeight) {
             ContentScale.Fit

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
@@ -84,6 +84,7 @@ import com.vitorpamplona.amethyst.commons.richtext.MediaPreloadedContent
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlContent
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlImage
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlVideo
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.MediaAspectRatioCache
 import com.vitorpamplona.amethyst.service.images.BlurhashWrapper
 import com.vitorpamplona.amethyst.service.playback.composable.VideoView
@@ -136,8 +137,10 @@ fun ZoomableContentView(
     images: ImmutableList<BaseMediaContent> = remember(content) { persistentListOf(content) },
     roundedCorner: Boolean,
     contentScale: ContentScale,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var dialogOpen by remember(content) { mutableStateOf(false) }
 
     when (content) {
@@ -236,9 +239,11 @@ fun LocalImageView(
     mainImageModifier: Modifier,
     loadedImageModifier: Modifier,
     controllerVisible: MutableState<Boolean>,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     alwayShowImage: Boolean = false,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (content.localFileExists()) {
         val showImage =
             remember {
@@ -351,9 +356,11 @@ fun UrlImageView(
     mainImageModifier: Modifier,
     loadedImageModifier: Modifier,
     controllerVisible: MutableState<Boolean>,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     alwayShowImage: Boolean = false,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val ratio = content.dim?.aspectRatio() ?: MediaAspectRatioCache.get(content.url)
 
     val showImage =
@@ -714,11 +721,13 @@ fun DisplayBlurHash(
 
 @Composable
 fun ShareMediaAction(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     popupExpanded: MutableState<Boolean>,
     content: BaseMediaContent,
     onDismiss: () -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (content is MediaUrlContent) {
         ShareMediaAction(
             popupExpanded = popupExpanded,
@@ -760,8 +769,10 @@ fun ShareMediaAction(
     mimeType: String?,
     onDismiss: () -> Unit,
     content: BaseMediaContent? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     // Track if video is downloading - hoisted here to block menu dismiss during download
     val isDownloadingVideo = remember { mutableStateOf(false) }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/markdown/RenderContentAsMarkdown.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/markdown/RenderContentAsMarkdown.kt
@@ -42,6 +42,7 @@ import com.halilibo.richtext.ui.material3.RichText
 import com.vitorpamplona.amethyst.commons.model.EmptyTagList
 import com.vitorpamplona.amethyst.commons.model.ImmutableListOfLists
 import com.vitorpamplona.amethyst.commons.preview.UrlInfoItem
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.UrlCachedPreviewer
 import com.vitorpamplona.amethyst.ui.components.UrlPreviewState
@@ -68,9 +69,11 @@ fun RenderContentAsMarkdown(
     quotesLeft: Int,
     backgroundColor: MutableState<Color>,
     callbackUri: String? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val uriHandler = LocalUriHandler.current
     val onClick =
         remember(uriHandler) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/DisplayErrorMessages.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/DisplayErrorMessages.kt
@@ -22,6 +22,7 @@ package com.vitorpamplona.amethyst.ui.components.toasts
 
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.InformationDialog
 import com.vitorpamplona.amethyst.ui.components.toasts.multiline.MultiErrorToastMsg
 import com.vitorpamplona.amethyst.ui.components.toasts.multiline.MultiUserErrorMessageDialog
@@ -32,9 +33,11 @@ import com.vitorpamplona.amethyst.ui.stringRes
 @Composable
 fun DisplayErrorMessages(
     toastManager: ToastManager,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val openDialogMsg = toastManager.toasts.collectAsStateWithLifecycle(null)
 
     openDialogMsg.value?.let { obj ->

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/multiline/ErrorList.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/multiline/ErrorList.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
@@ -98,9 +99,11 @@ fun ErrorListPreview() {
 @Composable
 fun ErrorList(
     model: MultiErrorToastMsg,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val errorState by model.errors.collectAsStateWithLifecycle()
     LazyColumn {
         itemsIndexed(errorState) { index, it ->
@@ -115,9 +118,11 @@ fun ErrorList(
 @Composable
 fun ErrorRow(
     errorState: UserBasedErrorMessage,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Row(
         modifier = Modifier.fillMaxWidth().padding(vertical = Size5dp),
         horizontalArrangement = Arrangement.SpaceBetween,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/multiline/MultiUserErrorMessageDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/toasts/multiline/MultiUserErrorMessageDialog.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
@@ -80,9 +81,11 @@ fun MultiUserErrorMessageContentPreview() {
 @Composable
 fun MultiUserErrorMessageDialog(
     model: MultiErrorToastMsg,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     AlertDialog(
         onDismissRequest = accountViewModel.toastManager::clearToasts,
         title = { Text(stringRes(model.titleResId)) },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/feeds/FeedContentStateView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/feeds/FeedContentStateView.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -39,9 +40,11 @@ fun RefresheableFeedContentStateView(
     routeForLastRead: String?,
     enablePullRefresh: Boolean = true,
     scrollStateKey: String? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     RefresheableBox(feedContentState, enablePullRefresh) {
         SaveableFeedContentState(feedContentState, scrollStateKey) { listState ->
             RenderFeedContentState(feedContentState, accountViewModel, listState, nav, routeForLastRead)
@@ -88,7 +91,7 @@ fun SaveableGridFeedContentState(
 @Composable
 fun RenderFeedContentState(
     feedContentState: FeedContentState,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     listState: LazyListState,
     nav: INav,
     routeForLastRead: String?,
@@ -97,6 +100,8 @@ fun RenderFeedContentState(
     onError: @Composable (String) -> Unit = { FeedError(it, feedContentState::invalidateData) },
     onLoading: @Composable () -> Unit = { LoadingFeed() },
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val feedState by feedContentState.feedContent.collectAsStateWithLifecycle()
 
     CrossfadeIfEnabled(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/feeds/FeedLoaded.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/feeds/FeedLoaded.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.NoteCompose
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -44,9 +45,11 @@ fun FeedLoaded(
     loaded: FeedState.Loaded,
     listState: LazyListState,
     routeForLastRead: String?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val items by loaded.feed.collectAsStateWithLifecycle()
 
     LazyColumn(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/DisappearingScaffold.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/DisappearingScaffold.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.theme.DividerThickness
 
@@ -40,10 +41,12 @@ fun DisappearingScaffold(
     topBar: (@Composable () -> Unit)? = null,
     bottomBar: (@Composable () -> Unit)? = null,
     floatingButton: (@Composable () -> Unit)? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     isActive: () -> Boolean = { true },
     mainContent: @Composable (padding: PaddingValues) -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val topBehavior =
         enterAlwaysScrollBehavior(
             canScroll = {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -41,6 +41,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.call.CallState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.service.call.CallSessionBridge
 import com.vitorpamplona.amethyst.service.crashreports.DisplayCrashMessages
 import com.vitorpamplona.amethyst.service.relayClient.notifyCommand.compose.DisplayNotifyMessages
@@ -162,9 +163,11 @@ import java.net.URI
 
 @Composable
 fun AppNavigation(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     accountSessionManager: AccountSessionManager,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val nav = rememberNav()
 
     AccountSwitcherAndLeftDrawerLayout(accountViewModel, accountSessionManager, nav) {
@@ -182,7 +185,9 @@ fun AppNavigation(
 }
 
 @Composable
-private fun ObserveIncomingCalls(accountViewModel: AccountViewModel) {
+private fun ObserveIncomingCalls(accountViewModel: IAccountViewModel) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val context = LocalContext.current
     val callState by accountViewModel.callManager.state.collectAsState()
 
@@ -197,9 +202,11 @@ private fun ObserveIncomingCalls(accountViewModel: AccountViewModel) {
 
 @Composable
 fun BuildNavigation(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: Nav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val context = androidx.compose.ui.platform.LocalContext.current
     androidx.compose.runtime.LaunchedEffect(Unit) {
         accountViewModel.initCallController(context)
@@ -450,9 +457,11 @@ fun BuildNavigation(
 @Composable
 private fun NavigateIfIntentRequested(
     nav: Nav,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     accountSessionManager: AccountSessionManager,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     accountViewModel.firstRoute?.let { newRoute ->
         accountViewModel.firstRoute = null
         val currentRoute = getRouteWithArguments(newRoute::class, nav.controller)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/AppBottomBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/AppBottomBar.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.painterRes
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -52,9 +53,11 @@ import com.vitorpamplona.amethyst.ui.theme.Size10Modifier
 @Composable
 fun AppBottomBar(
     selectedRoute: Route?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: (Route) -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val isKeyboardState by keyboardAsState()
     if (isKeyboardState == KeyboardState.Closed) {
         RenderBottomMenu(selectedRoute, accountViewModel, nav)
@@ -64,9 +67,11 @@ fun AppBottomBar(
 @Composable
 private fun RenderBottomMenu(
     selectedRoute: Route?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: (Route) -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Column(
         modifier =
             Modifier
@@ -93,9 +98,11 @@ private fun RenderBottomMenu(
 private fun RowScope.HasNewItemsIcon(
     selected: Boolean,
     bottomNav: BottomBarRoute,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: (Route) -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     NavigationBarItem(
         alwaysShowLabel = false,
         icon = {
@@ -114,8 +121,10 @@ private fun RowScope.HasNewItemsIcon(
 private fun NotifiableIcon(
     selected: Boolean,
     route: BottomBarRoute,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Box(route.notifSize) {
         Icon(
             painter = painterRes(resourceId = route.icon, 0),
@@ -131,9 +140,11 @@ private fun NotifiableIcon(
 @Composable
 fun AddNotifIconIfNeeded(
     route: Route,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     modifier: Modifier = Modifier,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val flow = accountViewModel.hasNewItems[route] ?: return
     val hasNewItems by flow.collectAsStateWithLifecycle()
     if (hasNewItems) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/AccountSwitchBottomSheet.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/AccountSwitchBottomSheet.kt
@@ -57,6 +57,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.AccountInfo
 import com.vitorpamplona.amethyst.LocalPreferences
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserInfo
@@ -77,9 +78,11 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AccountSwitchBottomSheet(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     accountSessionManager: AccountSessionManager,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var popupExpanded by remember { mutableStateOf(false) }
     val scrollState = rememberScrollState()
 
@@ -116,9 +119,11 @@ fun AccountSwitchBottomSheet(
 
 @Composable
 private fun DisplayAllAccounts(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     accountSessionManager: AccountSessionManager,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val accounts by LocalPreferences.accountsFlow().collectAsStateWithLifecycle()
 
     // Trigger lazy load from encrypted storage if the flow hasn't been populated yet.
@@ -135,9 +140,11 @@ private fun DisplayAllAccounts(
 @Composable
 fun DisplayAccount(
     acc: AccountInfo,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     accountSessionManager: AccountSessionManager,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var baseUser by remember(acc) {
         mutableStateOf(
             decodePublicKeyAsHexOrNull(acc.npub)?.let {
@@ -196,8 +203,10 @@ fun DisplayAccount(
 @Composable
 private fun ActiveMarker(
     acc: AccountInfo,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val isCurrentUser by
         remember(accountViewModel) {
             derivedStateOf { accountViewModel.account.userProfile().pubkeyNpub() == acc.npub }
@@ -215,8 +224,10 @@ private fun ActiveMarker(
 @Composable
 private fun AccountPicture(
     user: User,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val userInfo by observeUserInfo(user, accountViewModel)
 
     RobohashFallbackAsyncImage(
@@ -233,8 +244,10 @@ private fun AccountPicture(
 private fun AccountName(
     acc: AccountInfo,
     user: User,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val info by observeUserInfo(user, accountViewModel)
 
     info?.let {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerContent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerContent.kt
@@ -100,6 +100,7 @@ import coil3.compose.AsyncImage
 import com.vitorpamplona.amethyst.BuildConfig
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.model.ImmutableListOfLists
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.isDebug
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.User
@@ -141,8 +142,10 @@ import kotlinx.coroutines.flow.combine
 fun DrawerContent(
     nav: INav,
     openSheet: () -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val onClickUser = {
         nav.nav(routeFor(accountViewModel.userProfile()))
         nav.closeDrawer()
@@ -200,9 +203,11 @@ fun DrawerContent(
 fun ProfileContent(
     baseAccountUser: User,
     modifier: Modifier = Modifier,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onClickUser: () -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val userInfo by observeUserInfo(baseAccountUser, accountViewModel)
 
     ProfileContentTemplate(
@@ -225,9 +230,11 @@ fun ProfileContentTemplate(
     bestDisplayName: String?,
     tags: ImmutableListOfLists<String>?,
     modifier: Modifier,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onClick: () -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Box {
         if (profileBanner != null) {
             AsyncImage(
@@ -282,9 +289,11 @@ fun ProfileContentTemplate(
 @Composable
 private fun EditStatusBoxes(
     baseAccountUser: User,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val statuses by observeUserStatuses(baseAccountUser, accountViewModel)
 
     if (statuses.isEmpty()) {
@@ -302,9 +311,11 @@ private fun EditStatusBoxes(
 fun PreviewStatusEditBar(
     savedStatus: String? = null,
     address: Address? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var isEditing by remember { mutableStateOf(false) }
 
     if (isEditing) {
@@ -376,9 +387,11 @@ fun StatusEditBar(
     savedStatus: String? = null,
     address: Address? = null,
     onDone: () -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val focusManager = LocalFocusManager.current
     val focusRequester = remember { FocusRequester() }
 
@@ -483,9 +496,11 @@ fun UserStatusDeleteButton(onClick: () -> Unit) {
 @Composable
 private fun FollowingAndFollowerCounts(
     baseAccountUser: Account,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onClick: () -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Row(
         modifier = drawerSpacing.clickable(onClick = onClick),
     ) {
@@ -514,8 +529,10 @@ fun DisplayFollowingCount(baseAccountUser: Account) {
 @Composable
 fun DisplayFollowerCount(
     baseAccountUser: Account,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val followerCount by observeUserContactCardsFollowerCount(baseAccountUser.userProfile(), accountViewModel)
 
     Text(
@@ -528,9 +545,11 @@ fun DisplayFollowerCount(
 fun ListContent(
     modifier: Modifier,
     openSheet: () -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Column(modifier) {
         NavigationRow(
             title = R.string.profile,
@@ -777,9 +796,11 @@ fun IconRow(
 
 @Composable
 fun IconRowRelays(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onClick: () -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Row(
         modifier =
             Modifier
@@ -813,7 +834,9 @@ class PoolStatus(
 )
 
 @Composable
-private fun RelayStatus(accountViewModel: AccountViewModel) {
+private fun RelayStatus(accountViewModel: IAccountViewModel) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val statusCounterFlow: Flow<PoolStatus> =
         remember(accountViewModel) {
             combine(
@@ -836,9 +859,11 @@ private fun RelayStatus(accountViewModel: AccountViewModel) {
 @Composable
 fun BottomContent(
     user: User,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Column(modifier = Modifier) {
         HorizontalDivider(
             modifier = Modifier.padding(top = 15.dp),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/RouteMaker.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/RouteMaker.kt
@@ -23,6 +23,7 @@ package com.vitorpamplona.amethyst.ui.navigation.routes
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
 import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatChannel
 import com.vitorpamplona.amethyst.commons.model.nip53LiveActivities.LiveActivitiesChannel
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
@@ -164,7 +165,7 @@ fun routeToMessage(
     replyId: HexKey? = null,
     draftId: HexKey? = null,
     expiresDays: Int? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ): Route =
     routeToMessage(
         setOf(user),
@@ -181,7 +182,7 @@ fun routeToMessage(
     replyId: HexKey? = null,
     draftId: HexKey? = null,
     expiresDays: Int? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) = routeToMessage(
     ChatroomKey(users),
     draftMessage,
@@ -197,8 +198,8 @@ fun routeToMessage(
     replyId: HexKey? = null,
     draftId: HexKey? = null,
     expiresDays: Int? = null,
-    accountViewModel: AccountViewModel,
-): Route = routeToMessage(room, draftMessage, replyId, draftId, expiresDays, accountViewModel.account)
+    accountViewModel: IAccountViewModel,
+): Route = routeToMessage(room, draftMessage, replyId, draftId, expiresDays, (accountViewModel as AccountViewModel).account)
 
 fun routeToMessage(
     room: ChatroomKey,
@@ -219,7 +220,7 @@ fun routeToMessage(
     replyId: HexKey? = null,
     draftId: HexKey? = null,
     expiresDays: Int? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ): Route = routeToMessage(user.pubkeyHex, draftMessage, replyId, draftId, expiresDays, accountViewModel)
 
 fun routeFor(note: EphemeralChatChannel): Route = Route.EphemeralChat(note.roomId.id, note.roomId.relayUrl.url)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/FeedFilterSpinner.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/FeedFilterSpinner.kt
@@ -76,6 +76,7 @@ import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.AddressableNote
 import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.service.call.CallSessionBridge.accountViewModel
@@ -110,8 +111,10 @@ fun FeedFilterSpinner(
     options: ImmutableList<FeedDefinition>,
     onSelect: (Int) -> Unit,
     modifier: Modifier = Modifier,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var optionsShowing by remember { mutableStateOf(false) }
 
     val context = LocalContext.current
@@ -273,8 +276,10 @@ fun FeedFilterSpinner(
 @Composable
 fun RenderOption(
     option: Name,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     when (option) {
         is GeoHashName -> {
             LoadCityName(option.geoHashTag) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/UserDrawerSearchTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/UserDrawerSearchTopBar.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserPicture
 import com.vitorpamplona.amethyst.ui.components.RobohashFallbackAsyncImage
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -46,10 +47,12 @@ import com.vitorpamplona.amethyst.ui.theme.placeholderText
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun UserDrawerSearchTopBar(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     content: @Composable () -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     ShorterTopAppBar(
         title = {
             Column(
@@ -73,9 +76,11 @@ fun UserDrawerSearchTopBar(
 
 @Composable
 private fun LoggedInUserPictureDrawer(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onClick: () -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     IconButton(onClick = onClick) {
         val profilePicture by observeUserPicture(accountViewModel.userProfile(), accountViewModel)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/FeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/FeedView.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedContentState
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.feeds.FeedEmpty
 import com.vitorpamplona.amethyst.ui.feeds.FeedError
@@ -48,9 +49,11 @@ fun RefresheableFeedView(
     routeForLastRead: String?,
     enablePullRefresh: Boolean = true,
     scrollStateKey: String? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     RefresheableBox(viewModel, enablePullRefresh) {
         SaveableFeedState(viewModel.feedState, scrollStateKey) { listState ->
             RenderFeedState(viewModel, accountViewModel, listState, nav, routeForLastRead)
@@ -97,7 +100,7 @@ fun SaveableGridFeedState(
 @Composable
 fun RenderFeedState(
     viewModel: FeedViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     listState: LazyListState,
     nav: INav,
     routeForLastRead: String?,
@@ -108,6 +111,8 @@ fun RenderFeedState(
     onError: @Composable (String) -> Unit = { FeedError(it) { viewModel.invalidateData() } },
     onLoading: @Composable () -> Unit = { LoadingFeed() },
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val feedState by viewModel.feedState.feedContent.collectAsStateWithLifecycle()
 
     CrossfadeIfEnabled(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/UserFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/UserFeedView.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.feeds.FeedEmpty
 import com.vitorpamplona.amethyst.ui.feeds.FeedError
@@ -44,19 +45,23 @@ import com.vitorpamplona.amethyst.ui.theme.FeedPadding
 @Composable
 fun RefreshingFeedUserFeedView(
     viewModel: UserFeedViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     enablePullRefresh: Boolean = true,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     RefresheableBox(viewModel, enablePullRefresh) { UserFeedView(viewModel, accountViewModel, nav) }
 }
 
 @Composable
 fun UserFeedView(
     viewModel: UserFeedViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val feedState by viewModel.feedContent.collectAsStateWithLifecycle()
 
     CrossfadeIfEnabled(targetState = feedState, animationSpec = tween(durationMillis = 100), accountViewModel = accountViewModel) { state ->
@@ -83,9 +88,11 @@ fun UserFeedView(
 @Composable
 private fun FeedLoaded(
     state: UserFeedState.Loaded,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val items by state.feed.collectAsStateWithLifecycle()
     val listState = rememberLazyListState()
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -51,6 +51,7 @@ import com.vitorpamplona.amethyst.commons.model.nip53LiveActivities.LiveActiviti
 import com.vitorpamplona.amethyst.commons.model.observables.CreatedAtComparator
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
 import com.vitorpamplona.amethyst.commons.ui.notifications.CardFeedState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.logTime
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.AccountSettings
@@ -175,14 +176,17 @@ import kotlinx.coroutines.withContext
 
 @Stable
 class AccountViewModel(
-    val account: Account,
+    override val account: Account,
     val settings: UiSettingsState,
     val torSettings: TorSettingsFlow,
     val dataSources: RelaySubscriptionsCoordinator,
     val httpClientBuilder: IRoleBasedHttpClientBuilder,
     val nip05ClientBuilder: () -> INip05Client,
 ) : ViewModel(),
-    Dao {
+    Dao,
+    IAccountViewModel {
+    override val scope: CoroutineScope get() = viewModelScope
+
     var firstRoute: Route? = null
 
     val toastManager = ToastManager()
@@ -418,11 +422,11 @@ class AccountViewModel(
             Route.Notification() to notificationHasNewItemsFlow,
         )
 
-    fun isWriteable(): Boolean = account.isWriteable()
+    override fun isWriteable(): Boolean = account.isWriteable()
 
-    fun userProfile(): User = account.userProfile()
+    override fun userProfile(): User = account.userProfile()
 
-    fun reactToOrDelete(
+    override fun reactToOrDelete(
         note: Note,
         reaction: String,
     ) {
@@ -450,7 +454,7 @@ class AccountViewModel(
         }
     }
 
-    fun reactToOrDelete(note: Note) {
+    override fun reactToOrDelete(note: Note) {
         val reaction = reactionChoices().first()
         reactToOrDelete(note, reaction)
     }
@@ -859,7 +863,7 @@ class AccountViewModel(
         }
     }
 
-    fun boost(note: Note) {
+    override fun boost(note: Note) {
         if (settings.isCompleteUIMode()) {
             // Tracked broadcasting with progress feedback
             launchSigner {
@@ -904,7 +908,7 @@ class AccountViewModel(
 
     fun pinnedNotes(user: User): Note = LocalCache.getOrCreateAddressableNote(PinListEvent.createPinAddress(user.pubkeyHex))
 
-    fun addPin(note: Note) {
+    override fun addPin(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createAddPinEvent(note)?.let { (event, relays) ->
@@ -921,7 +925,7 @@ class AccountViewModel(
         }
     }
 
-    fun removePin(note: Note) {
+    override fun removePin(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createRemovePinEvent(note)?.let { (event, relays) ->
@@ -938,7 +942,7 @@ class AccountViewModel(
         }
     }
 
-    fun addPrivateBookmark(note: Note) {
+    override fun addPrivateBookmark(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createAddBookmarkEvent(note, true)?.let { (event, relays) ->
@@ -955,7 +959,7 @@ class AccountViewModel(
         }
     }
 
-    fun addPublicBookmark(note: Note) {
+    override fun addPublicBookmark(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createAddBookmarkEvent(note, false)?.let { (event, relays) ->
@@ -972,7 +976,7 @@ class AccountViewModel(
         }
     }
 
-    fun removePrivateBookmark(note: Note) {
+    override fun removePrivateBookmark(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createRemoveBookmarkEvent(note, true)?.let { (event, relays) ->
@@ -990,7 +994,7 @@ class AccountViewModel(
         }
     }
 
-    fun removePublicBookmark(note: Note) {
+    override fun removePublicBookmark(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createRemoveBookmarkEvent(note, false)?.let { (event, relays) ->
@@ -1007,13 +1011,13 @@ class AccountViewModel(
         }
     }
 
-    fun broadcast(note: Note) = launchSigner { account.broadcast(note) }
+    override fun broadcast(note: Note) = launchSigner { account.broadcast(note) }
 
     fun timestamp(note: Note) = launchSigner { account.otsState.timestamp(note) }
 
-    fun delete(notes: List<Note>) = launchSigner { account.delete(notes) }
+    override fun delete(notes: List<Note>) = launchSigner { account.delete(notes) }
 
-    fun delete(note: Note) = launchSigner { account.delete(note) }
+    override fun delete(note: Note) = launchSigner { account.delete(note) }
 
     fun requestToVanish(
         relays: List<NormalizedRelayUrl>,
@@ -1026,9 +1030,9 @@ class AccountViewModel(
         createdAt: Long,
     ) = launchSigner { account.requestToVanishFromEverywhere(reason, createdAt) }
 
-    fun cachedDecrypt(note: Note): String? = account.cachedDecryptContent(note)
+    override fun cachedDecrypt(note: Note): String? = account.cachedDecryptContent(note)
 
-    fun decrypt(
+    override fun decrypt(
         note: Note,
         onReady: (String) -> Unit,
     ) = launchSigner {
@@ -1095,9 +1099,9 @@ class AccountViewModel(
 
     fun follow(users: List<User>) = launchSigner { account.follow(users) }
 
-    fun follow(user: User) = launchSigner { account.follow(user) }
+    override fun follow(user: User) = launchSigner { account.follow(user) }
 
-    fun unfollow(user: User) = launchSigner { account.unfollow(user) }
+    override fun unfollow(user: User) = launchSigner { account.unfollow(user) }
 
     fun followGeohash(tag: String) = launchSigner { account.followGeohash(tag) }
 
@@ -1115,16 +1119,16 @@ class AccountViewModel(
 
     fun hideWord(word: String) = launchSigner { account.hideWord(word) }
 
-    fun isLoggedUser(pubkeyHex: HexKey?): Boolean = account.signer.pubKey == pubkeyHex
+    override fun isLoggedUser(pubkeyHex: HexKey?): Boolean = account.signer.pubKey == pubkeyHex
 
-    fun isLoggedUser(user: User?): Boolean = isLoggedUser(user?.pubkeyHex)
+    override fun isLoggedUser(user: User?): Boolean = isLoggedUser(user?.pubkeyHex)
 
-    fun isFollowing(user: User?): Boolean {
+    override fun isFollowing(user: User?): Boolean {
         if (user == null) return false
         return account.isFollowing(user)
     }
 
-    fun isFollowing(user: HexKey): Boolean = account.isFollowing(user)
+    override fun isFollowing(user: HexKey): Boolean = account.isFollowing(user)
 
     fun markDonatedInThisVersion() = account.markDonatedInThisVersion()
 
@@ -1137,21 +1141,21 @@ class AccountViewModel(
         pollEndsAt: Long?,
     ) = account.markPollResultsViewed(noteId, pollEndsAt)
 
-    fun dontTranslateFrom() = account.settings.syncedSettings.languages.dontTranslateFrom.value
+    override fun dontTranslateFrom() = account.settings.syncedSettings.languages.dontTranslateFrom.value
 
-    fun translateTo() = account.settings.syncedSettings.languages.translateTo.value
+    override fun translateTo() = account.settings.syncedSettings.languages.translateTo.value
 
-    fun defaultZapType() = account.settings.syncedSettings.zaps.defaultZapType.value
+    override fun defaultZapType() = account.settings.syncedSettings.zaps.defaultZapType.value
 
-    fun showSensitiveContent(): MutableStateFlow<Boolean?> = account.settings.syncedSettings.security.showSensitiveContent
+    override fun showSensitiveContent(): MutableStateFlow<Boolean?> = account.settings.syncedSettings.security.showSensitiveContent
 
     fun zapAmountChoicesFlow() = account.settings.syncedSettings.zaps.zapAmountChoices
 
-    fun zapAmountChoices() = zapAmountChoicesFlow().value
+    override fun zapAmountChoices() = zapAmountChoicesFlow().value
 
     fun reactionChoicesFlow() = account.settings.syncedSettings.reactions.reactionChoices
 
-    fun reactionChoices() = reactionChoicesFlow().value
+    override fun reactionChoices() = reactionChoicesFlow().value
 
     fun filterSpamFromStrangers() = account.settings.syncedSettings.security.filterSpamFromStrangers
 
@@ -1205,9 +1209,9 @@ class AccountViewModel(
         preference: String,
     ) = launchSigner { account.prefer(source, target, preference) }
 
-    fun show(user: User) = launchSigner { account.showUser(user.pubkeyHex) }
+    override fun show(user: User) = launchSigner { account.showUser(user.pubkeyHex) }
 
-    fun hide(user: User) = launchSigner { account.hideUser(user.pubkeyHex) }
+    override fun hide(user: User) = launchSigner { account.hideUser(user.pubkeyHex) }
 
     fun hide(word: String) = launchSigner { account.hideWord(word) }
 
@@ -1236,23 +1240,23 @@ class AccountViewModel(
         }
     }
 
-    fun loadReactionTo(note: Note?): String? {
+    override fun loadReactionTo(note: Note?): String? {
         if (note == null) return null
 
         return note.getReactionBy(userProfile())
     }
 
-    fun runOnIO(runOnIO: suspend () -> Unit) {
+    override fun runOnIO(runOnIO: suspend () -> Unit) {
         viewModelScope.launch(Dispatchers.IO) { runOnIO() }
     }
 
-    fun checkGetOrCreateUser(key: HexKey): User? = LocalCache.checkGetOrCreateUser(key)
+    override fun checkGetOrCreateUser(key: HexKey): User? = LocalCache.checkGetOrCreateUser(key)
 
     override suspend fun getOrCreateUser(hex: HexKey): User = LocalCache.getOrCreateUser(hex)
 
-    fun getUserIfExists(hex: HexKey): User? = LocalCache.getUserIfExists(hex)
+    override fun getUserIfExists(hex: HexKey): User? = LocalCache.getUserIfExists(hex)
 
-    fun checkGetOrCreateNote(key: HexKey): Note? = LocalCache.checkGetOrCreateNote(key)
+    override fun checkGetOrCreateNote(key: HexKey): Note? = LocalCache.checkGetOrCreateNote(key)
 
     override suspend fun getOrCreateNote(hex: HexKey): Note = LocalCache.getOrCreateNote(hex)
 
@@ -1267,7 +1271,7 @@ class AccountViewModel(
         return note
     }
 
-    fun getNoteIfExists(hex: HexKey): Note? = LocalCache.getNoteIfExists(hex)
+    override fun getNoteIfExists(hex: HexKey): Note? = LocalCache.getNoteIfExists(hex)
 
     /**
      * Fixes author and relay hints in MarkedETag list by looking up notes from cache.
@@ -1297,9 +1301,9 @@ class AccountViewModel(
 
     override fun getOrCreateAddressableNote(address: Address): AddressableNote = LocalCache.getOrCreateAddressableNote(address)
 
-    fun getAddressableNoteIfExists(key: String): AddressableNote? = LocalCache.getAddressableNoteIfExists(key)
+    override fun getAddressableNoteIfExists(key: String): AddressableNote? = LocalCache.getAddressableNoteIfExists(key)
 
-    fun getAddressableNoteIfExists(key: Address): AddressableNote? = LocalCache.getAddressableNoteIfExists(key)
+    override fun getAddressableNoteIfExists(key: Address): AddressableNote? = LocalCache.getAddressableNoteIfExists(key)
 
     fun cachedModificationEventsForNote(note: Note) = LocalCache.cachedModificationEventsForNote(note)
 
@@ -1361,7 +1365,7 @@ class AccountViewModel(
             OnlineChecker.isOnline(videoUrl, httpClientBuilder::okHttpClientForVideo)
         }
 
-    fun loadAndMarkAsRead(
+    override fun loadAndMarkAsRead(
         routeForLastRead: String,
         createdAt: Long?,
     ): Boolean {

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/IAccountViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/IAccountViewModel.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.screen.loggedIn
+
+import com.vitorpamplona.amethyst.commons.model.AddressableNote
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.quartz.nip01Core.core.Address
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * Cross-platform interface for AccountViewModel.
+ *
+ * Provides the subset of AccountViewModel's API that can be expressed
+ * using only commonMain types (IAccount, Note, User, HexKey, etc.).
+ * The Android-specific AccountViewModel implements this interface so
+ * that UI files migrated to commonMain can accept IAccountViewModel
+ * as a parameter without depending on Android-only types.
+ *
+ * Usage pattern for migrated files:
+ *   Before: fun MyScreen(accountViewModel: AccountViewModel, ...)
+ *   After:  fun MyScreen(accountViewModel: IAccountViewModel, ...)
+ */
+interface IAccountViewModel {
+    // ---- Core account access ----
+
+    /** The underlying account, abstracted via IAccount for commonMain use. */
+    val account: IAccount
+
+    /** Coroutine scope tied to the ViewModel lifecycle. */
+    val scope: CoroutineScope
+
+    // ---- Identity helpers (used by 50+ files) ----
+
+    /** Current user's profile. Delegates to account.userProfile(). */
+    fun userProfile(): User
+
+    /** Whether the current account can sign events. */
+    fun isWriteable(): Boolean
+
+    /** Check if the given pubkey is the logged-in user. */
+    fun isLoggedUser(pubkeyHex: HexKey?): Boolean
+
+    /** Check if the given user is the logged-in user. */
+    fun isLoggedUser(user: User?): Boolean
+
+    /** Check if the current account follows the given user. */
+    fun isFollowing(user: User?): Boolean
+
+    /** Check if the current account follows the given pubkey. */
+    fun isFollowing(user: HexKey): Boolean
+
+    // ---- Cache lookups (used by 30+ files) ----
+
+    fun checkGetOrCreateUser(key: HexKey): User?
+
+    fun getUserIfExists(hex: HexKey): User?
+
+    fun checkGetOrCreateNote(key: HexKey): Note?
+
+    fun getNoteIfExists(hex: HexKey): Note?
+
+    fun getOrCreateAddressableNote(address: Address): AddressableNote?
+
+    fun getAddressableNoteIfExists(key: String): AddressableNote?
+
+    fun getAddressableNoteIfExists(key: Address): AddressableNote?
+
+    // ---- Async helpers ----
+
+    /** Launch a coroutine on IO dispatchers. */
+    fun runOnIO(runOnIO: suspend () -> Unit)
+
+    // ---- Actions (commonly used) ----
+
+    fun follow(user: User)
+
+    fun unfollow(user: User)
+
+    fun hide(user: User)
+
+    fun show(user: User)
+
+    fun boost(note: Note)
+
+    fun delete(note: Note)
+
+    fun delete(notes: List<Note>)
+
+    fun broadcast(note: Note)
+
+    fun reactToOrDelete(note: Note)
+
+    fun reactToOrDelete(
+        note: Note,
+        reaction: String,
+    )
+
+    fun decrypt(
+        note: Note,
+        onReady: (String) -> Unit,
+    )
+
+    fun cachedDecrypt(note: Note): String?
+
+    // ---- Bookmark / Pin (used by several files) ----
+
+    fun addPrivateBookmark(note: Note)
+
+    fun addPublicBookmark(note: Note)
+
+    fun removePrivateBookmark(note: Note)
+
+    fun removePublicBookmark(note: Note)
+
+    fun addPin(note: Note)
+
+    fun removePin(note: Note)
+
+    // ---- Navigation helpers ----
+
+    fun loadReactionTo(note: Note?): String?
+
+    fun loadAndMarkAsRead(
+        routeForLastRead: String,
+        createdAt: Long?,
+    ): Boolean
+
+    // ---- Settings delegates ----
+
+    fun defaultZapType(): LnZapEvent.ZapType
+
+    fun reactionChoices(): List<String>
+
+    fun zapAmountChoices(): List<Long>
+
+    fun showSensitiveContent(): MutableStateFlow<Boolean?>
+
+    fun dontTranslateFrom(): Set<String>
+
+    fun translateTo(): String
+}


### PR DESCRIPTION
Migrates composable signatures in navigation/, feeds/, components/, actions/, call/, broadcast/, layouts/, and screen/ (non-loggedIn) from `AccountViewModel` to `IAccountViewModel`.

**45 files modified** across these directories (excluding note/ and screen/loggedIn/).

Each function signature changes:
```kotlin
// Before
fun MyComposable(accountViewModel: AccountViewModel, ...) {

// After  
fun MyComposable(accountViewModel: IAccountViewModel, ...) {
    @Suppress("NAME_SHADOWING") val accountViewModel = accountViewModel as AccountViewModel
```

The shadow cast ensures zero runtime behavior change while allowing these signatures to eventually accept the interface type from commonMain.

Also cherry-picks the IAccountViewModel interface commit from the architecture-unblocks branch.

Part of the KMP iOS migration tracked in #2238.