### PR TITLE
feat: migrate composable signatures to IAccountViewModel (v14) — relays/

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -51,6 +51,7 @@ import com.vitorpamplona.amethyst.commons.model.nip53LiveActivities.LiveActiviti
 import com.vitorpamplona.amethyst.commons.model.observables.CreatedAtComparator
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
 import com.vitorpamplona.amethyst.commons.ui.notifications.CardFeedState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.logTime
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.AccountSettings
@@ -175,14 +176,17 @@ import kotlinx.coroutines.withContext
 
 @Stable
 class AccountViewModel(
-    val account: Account,
+    override val account: Account,
     val settings: UiSettingsState,
     val torSettings: TorSettingsFlow,
     val dataSources: RelaySubscriptionsCoordinator,
     val httpClientBuilder: IRoleBasedHttpClientBuilder,
     val nip05ClientBuilder: () -> INip05Client,
 ) : ViewModel(),
-    Dao {
+    Dao,
+    IAccountViewModel {
+    override val scope: CoroutineScope get() = viewModelScope
+
     var firstRoute: Route? = null
 
     val toastManager = ToastManager()
@@ -418,11 +422,11 @@ class AccountViewModel(
             Route.Notification() to notificationHasNewItemsFlow,
         )
 
-    fun isWriteable(): Boolean = account.isWriteable()
+    override fun isWriteable(): Boolean = account.isWriteable()
 
-    fun userProfile(): User = account.userProfile()
+    override fun userProfile(): User = account.userProfile()
 
-    fun reactToOrDelete(
+    override fun reactToOrDelete(
         note: Note,
         reaction: String,
     ) {
@@ -450,7 +454,7 @@ class AccountViewModel(
         }
     }
 
-    fun reactToOrDelete(note: Note) {
+    override fun reactToOrDelete(note: Note) {
         val reaction = reactionChoices().first()
         reactToOrDelete(note, reaction)
     }
@@ -859,7 +863,7 @@ class AccountViewModel(
         }
     }
 
-    fun boost(note: Note) {
+    override fun boost(note: Note) {
         if (settings.isCompleteUIMode()) {
             // Tracked broadcasting with progress feedback
             launchSigner {
@@ -904,7 +908,7 @@ class AccountViewModel(
 
     fun pinnedNotes(user: User): Note = LocalCache.getOrCreateAddressableNote(PinListEvent.createPinAddress(user.pubkeyHex))
 
-    fun addPin(note: Note) {
+    override fun addPin(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createAddPinEvent(note)?.let { (event, relays) ->
@@ -921,7 +925,7 @@ class AccountViewModel(
         }
     }
 
-    fun removePin(note: Note) {
+    override fun removePin(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createRemovePinEvent(note)?.let { (event, relays) ->
@@ -938,7 +942,7 @@ class AccountViewModel(
         }
     }
 
-    fun addPrivateBookmark(note: Note) {
+    override fun addPrivateBookmark(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createAddBookmarkEvent(note, true)?.let { (event, relays) ->
@@ -955,7 +959,7 @@ class AccountViewModel(
         }
     }
 
-    fun addPublicBookmark(note: Note) {
+    override fun addPublicBookmark(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createAddBookmarkEvent(note, false)?.let { (event, relays) ->
@@ -972,7 +976,7 @@ class AccountViewModel(
         }
     }
 
-    fun removePrivateBookmark(note: Note) {
+    override fun removePrivateBookmark(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createRemoveBookmarkEvent(note, true)?.let { (event, relays) ->
@@ -990,7 +994,7 @@ class AccountViewModel(
         }
     }
 
-    fun removePublicBookmark(note: Note) {
+    override fun removePublicBookmark(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createRemoveBookmarkEvent(note, false)?.let { (event, relays) ->
@@ -1007,13 +1011,13 @@ class AccountViewModel(
         }
     }
 
-    fun broadcast(note: Note) = launchSigner { account.broadcast(note) }
+    override fun broadcast(note: Note) = launchSigner { account.broadcast(note) }
 
     fun timestamp(note: Note) = launchSigner { account.otsState.timestamp(note) }
 
-    fun delete(notes: List<Note>) = launchSigner { account.delete(notes) }
+    override fun delete(notes: List<Note>) = launchSigner { account.delete(notes) }
 
-    fun delete(note: Note) = launchSigner { account.delete(note) }
+    override fun delete(note: Note) = launchSigner { account.delete(note) }
 
     fun requestToVanish(
         relays: List<NormalizedRelayUrl>,
@@ -1026,9 +1030,9 @@ class AccountViewModel(
         createdAt: Long,
     ) = launchSigner { account.requestToVanishFromEverywhere(reason, createdAt) }
 
-    fun cachedDecrypt(note: Note): String? = account.cachedDecryptContent(note)
+    override fun cachedDecrypt(note: Note): String? = account.cachedDecryptContent(note)
 
-    fun decrypt(
+    override fun decrypt(
         note: Note,
         onReady: (String) -> Unit,
     ) = launchSigner {
@@ -1095,9 +1099,9 @@ class AccountViewModel(
 
     fun follow(users: List<User>) = launchSigner { account.follow(users) }
 
-    fun follow(user: User) = launchSigner { account.follow(user) }
+    override fun follow(user: User) = launchSigner { account.follow(user) }
 
-    fun unfollow(user: User) = launchSigner { account.unfollow(user) }
+    override fun unfollow(user: User) = launchSigner { account.unfollow(user) }
 
     fun followGeohash(tag: String) = launchSigner { account.followGeohash(tag) }
 
@@ -1115,16 +1119,16 @@ class AccountViewModel(
 
     fun hideWord(word: String) = launchSigner { account.hideWord(word) }
 
-    fun isLoggedUser(pubkeyHex: HexKey?): Boolean = account.signer.pubKey == pubkeyHex
+    override fun isLoggedUser(pubkeyHex: HexKey?): Boolean = account.signer.pubKey == pubkeyHex
 
-    fun isLoggedUser(user: User?): Boolean = isLoggedUser(user?.pubkeyHex)
+    override fun isLoggedUser(user: User?): Boolean = isLoggedUser(user?.pubkeyHex)
 
-    fun isFollowing(user: User?): Boolean {
+    override fun isFollowing(user: User?): Boolean {
         if (user == null) return false
         return account.isFollowing(user)
     }
 
-    fun isFollowing(user: HexKey): Boolean = account.isFollowing(user)
+    override fun isFollowing(user: HexKey): Boolean = account.isFollowing(user)
 
     fun markDonatedInThisVersion() = account.markDonatedInThisVersion()
 
@@ -1137,21 +1141,21 @@ class AccountViewModel(
         pollEndsAt: Long?,
     ) = account.markPollResultsViewed(noteId, pollEndsAt)
 
-    fun dontTranslateFrom() = account.settings.syncedSettings.languages.dontTranslateFrom.value
+    override fun dontTranslateFrom() = account.settings.syncedSettings.languages.dontTranslateFrom.value
 
-    fun translateTo() = account.settings.syncedSettings.languages.translateTo.value
+    override fun translateTo() = account.settings.syncedSettings.languages.translateTo.value
 
-    fun defaultZapType() = account.settings.syncedSettings.zaps.defaultZapType.value
+    override fun defaultZapType() = account.settings.syncedSettings.zaps.defaultZapType.value
 
-    fun showSensitiveContent(): MutableStateFlow<Boolean?> = account.settings.syncedSettings.security.showSensitiveContent
+    override fun showSensitiveContent(): MutableStateFlow<Boolean?> = account.settings.syncedSettings.security.showSensitiveContent
 
     fun zapAmountChoicesFlow() = account.settings.syncedSettings.zaps.zapAmountChoices
 
-    fun zapAmountChoices() = zapAmountChoicesFlow().value
+    override fun zapAmountChoices() = zapAmountChoicesFlow().value
 
     fun reactionChoicesFlow() = account.settings.syncedSettings.reactions.reactionChoices
 
-    fun reactionChoices() = reactionChoicesFlow().value
+    override fun reactionChoices() = reactionChoicesFlow().value
 
     fun filterSpamFromStrangers() = account.settings.syncedSettings.security.filterSpamFromStrangers
 
@@ -1205,9 +1209,9 @@ class AccountViewModel(
         preference: String,
     ) = launchSigner { account.prefer(source, target, preference) }
 
-    fun show(user: User) = launchSigner { account.showUser(user.pubkeyHex) }
+    override fun show(user: User) = launchSigner { account.showUser(user.pubkeyHex) }
 
-    fun hide(user: User) = launchSigner { account.hideUser(user.pubkeyHex) }
+    override fun hide(user: User) = launchSigner { account.hideUser(user.pubkeyHex) }
 
     fun hide(word: String) = launchSigner { account.hideWord(word) }
 
@@ -1236,23 +1240,23 @@ class AccountViewModel(
         }
     }
 
-    fun loadReactionTo(note: Note?): String? {
+    override fun loadReactionTo(note: Note?): String? {
         if (note == null) return null
 
         return note.getReactionBy(userProfile())
     }
 
-    fun runOnIO(runOnIO: suspend () -> Unit) {
+    override fun runOnIO(runOnIO: suspend () -> Unit) {
         viewModelScope.launch(Dispatchers.IO) { runOnIO() }
     }
 
-    fun checkGetOrCreateUser(key: HexKey): User? = LocalCache.checkGetOrCreateUser(key)
+    override fun checkGetOrCreateUser(key: HexKey): User? = LocalCache.checkGetOrCreateUser(key)
 
     override suspend fun getOrCreateUser(hex: HexKey): User = LocalCache.getOrCreateUser(hex)
 
-    fun getUserIfExists(hex: HexKey): User? = LocalCache.getUserIfExists(hex)
+    override fun getUserIfExists(hex: HexKey): User? = LocalCache.getUserIfExists(hex)
 
-    fun checkGetOrCreateNote(key: HexKey): Note? = LocalCache.checkGetOrCreateNote(key)
+    override fun checkGetOrCreateNote(key: HexKey): Note? = LocalCache.checkGetOrCreateNote(key)
 
     override suspend fun getOrCreateNote(hex: HexKey): Note = LocalCache.getOrCreateNote(hex)
 
@@ -1267,7 +1271,7 @@ class AccountViewModel(
         return note
     }
 
-    fun getNoteIfExists(hex: HexKey): Note? = LocalCache.getNoteIfExists(hex)
+    override fun getNoteIfExists(hex: HexKey): Note? = LocalCache.getNoteIfExists(hex)
 
     /**
      * Fixes author and relay hints in MarkedETag list by looking up notes from cache.
@@ -1297,9 +1301,9 @@ class AccountViewModel(
 
     override fun getOrCreateAddressableNote(address: Address): AddressableNote = LocalCache.getOrCreateAddressableNote(address)
 
-    fun getAddressableNoteIfExists(key: String): AddressableNote? = LocalCache.getAddressableNoteIfExists(key)
+    override fun getAddressableNoteIfExists(key: String): AddressableNote? = LocalCache.getAddressableNoteIfExists(key)
 
-    fun getAddressableNoteIfExists(key: Address): AddressableNote? = LocalCache.getAddressableNoteIfExists(key)
+    override fun getAddressableNoteIfExists(key: Address): AddressableNote? = LocalCache.getAddressableNoteIfExists(key)
 
     fun cachedModificationEventsForNote(note: Note) = LocalCache.cachedModificationEventsForNote(note)
 
@@ -1361,7 +1365,7 @@ class AccountViewModel(
             OnlineChecker.isOnline(videoUrl, httpClientBuilder::okHttpClientForVideo)
         }
 
-    fun loadAndMarkAsRead(
+    override fun loadAndMarkAsRead(
         routeForLastRead: String,
         createdAt: Long?,
     ): Boolean {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/AllRelayListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/AllRelayListScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.DefaultDMRelayList
 import com.vitorpamplona.amethyst.model.DefaultIndexerRelayList
 import com.vitorpamplona.amethyst.model.DefaultSearchRelayList
@@ -97,9 +98,11 @@ import com.vitorpamplona.amethyst.ui.theme.grayText
 
 @Composable
 fun AllRelayListScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val dmViewModel: DMRelayListViewModel = viewModel()
     val nip65ViewModel: Nip65RelayListViewModel = viewModel()
     val privateOutboxViewModel: PrivateOutboxRelayListViewModel = viewModel()
@@ -174,9 +177,11 @@ fun MappedAllRelayListView(
     indexerViewModel: IndexerRelayListViewModel,
     proxyViewModel: ProxyRelayListViewModel,
     relayFeedsViewModel: RelayFeedsListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val dmFeedState by dmViewModel.relays.collectAsStateWithLifecycle()
     val homeFeedState by nip65ViewModel.homeRelays.collectAsStateWithLifecycle()
     val notifFeedState by nip65ViewModel.notificationRelays.collectAsStateWithLifecycle()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/RelayInformationScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/RelayInformationScreen.kt
@@ -105,6 +105,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.commons.util.timeDiffAgoShortish
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.nip11RelayInfo.loadRelayInfo
@@ -298,9 +299,11 @@ private const val HTTPS_PREFIX = "https://"
 @Composable
 fun RelayInformationScreen(
     relayUrl: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     RelayUrlNormalizer.normalizeOrNull(relayUrl)?.let {
         RelayInformationScreen(
             relay = it,
@@ -314,9 +317,11 @@ fun RelayInformationScreen(
 @Composable
 fun RelayInformationScreen(
     relay: NormalizedRelayUrl,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         topBar = {
@@ -369,9 +374,11 @@ fun RelayInformationBody(
     relayStats: RelayStat,
     messages: ImmutableList<IRelayDebugMessage>,
     pad: PaddingValues,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val activeReqs = remember(relay) { accountViewModel.account.client.activeRequests(relay) }
     val activeCounts = remember(relay) { accountViewModel.account.client.activeCounts(relay) }
     val activeOutbox = remember(relay) { accountViewModel.account.client.activeOutboxCache(relay) }
@@ -1083,9 +1090,11 @@ private fun RenderDebugMessage(msg: IRelayDebugMessage) {
 @Composable
 private fun DisplayOwnerInformation(
     userHex: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     LoadUser(baseUserHex = userHex, accountViewModel) { loadedUser ->
         CrossfadeIfEnabled(loadedUser, accountViewModel = accountViewModel) {
             if (it != null) {
@@ -1106,9 +1115,11 @@ private fun RelayHeader(
     relay: NormalizedRelayUrl,
     relayStats: RelayStat,
     relayInfo: Nip11RelayInformation,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = SpacedBy10dp,
@@ -1620,9 +1631,11 @@ fun loadRelayDiscoveryEvents(relay: NormalizedRelayUrl): State<ImmutableList<Rel
 @Composable
 private fun RelayMonitorReportCard(
     event: RelayDiscoveryEvent,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val context = LocalContext.current
 
     OutlinedCard(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/blocked/BlockedRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/blocked/BlockedRelayListView.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.Amethyst
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -47,10 +48,12 @@ import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
 @Composable
 fun BlockedRelayList(
     postViewModel: BlockedRelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onClose: () -> Unit,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val feedState by postViewModel.relays.collectAsStateWithLifecycle()
     val newNav = rememberExtendedNav(nav, onClose)
     val dragState =
@@ -72,10 +75,12 @@ fun BlockedRelayList(
 fun LazyListScope.renderBlockedItems(
     feedState: List<BasicRelaySetupInfo>,
     postViewModel: BlockedRelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     dragState: RelayDragState? = null,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     itemsIndexed(feedState, key = { _, item -> "Blocked" + item.relay.url }) { index, item ->
         BasicRelaySetupInfoDialog(
             item,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/broadcast/BroadcastRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/broadcast/BroadcastRelayListView.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.Amethyst
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -47,10 +48,12 @@ import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
 @Composable
 fun BroadcastRelayList(
     postViewModel: BroadcastRelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onClose: () -> Unit,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val feedState by postViewModel.relays.collectAsStateWithLifecycle()
     val newNav = rememberExtendedNav(nav, onClose)
     val dragState =
@@ -72,10 +75,12 @@ fun BroadcastRelayList(
 fun LazyListScope.renderBroadcastItems(
     feedState: List<BasicRelaySetupInfo>,
     postViewModel: BroadcastRelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     dragState: RelayDragState? = null,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     itemsIndexed(feedState, key = { _, item -> "Broadcast" + item.relay.url }) { index, item ->
         BasicRelaySetupInfoDialog(
             item,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoClickableRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoClickableRow.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.nip11RelayInfo.Nip11CachedRetriever
 import com.vitorpamplona.amethyst.model.nip11RelayInfo.loadRelayInfo
 import com.vitorpamplona.amethyst.ui.components.util.setText
@@ -75,9 +76,11 @@ fun BasicRelaySetupInfoClickableRow(
     index: Int = -1,
     dragState: RelayDragState? = null,
     countResult: RelayCountResult? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val clipboardManager = LocalClipboard.current
     val scope = rememberCoroutineScope()
 
@@ -167,9 +170,11 @@ fun BasicRelaySetupInfoClickableRow(
 @Composable
 fun UsedBy(
     item: BasicRelaySetupInfo,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     if (item.users.isNotEmpty()) {
         Row(modifier = HalfHalfVertPadding, verticalAlignment = Alignment.CenterVertically) {
             item.users.getOrNull(0)?.let {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoDialog.kt
@@ -22,6 +22,7 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.nip11RelayInfo.Nip11CachedRetriever
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
@@ -36,9 +37,11 @@ fun BasicRelaySetupInfoDialog(
     countResult: RelayCountResult? = null,
     index: Int = -1,
     dragState: RelayDragState? = null,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     BasicRelaySetupInfoClickableRow(
         item = item,
         loadProfilePicture = accountViewModel.settings.showProfilePictures(),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoModel.kt
@@ -23,6 +23,7 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vitorpamplona.amethyst.Amethyst
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.service.replace
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -46,7 +47,9 @@ abstract class BasicRelaySetupInfoModel : ViewModel() {
 
     var hasModified = false
 
-    fun init(accountViewModel: AccountViewModel) {
+    fun init(accountViewModel: IAccountViewModel) {
+        @Suppress("NAME_SHADOWING")
+        val accountViewModel = accountViewModel as AccountViewModel
         this.accountViewModel = accountViewModel
         this.account = accountViewModel.account
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/RelayStatusRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/RelayStatusRow.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.service.countToHumanReadable
 import com.vitorpamplona.amethyst.service.countToHumanReadableBytes
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -87,8 +88,10 @@ fun RelayStatusRow(
     item: BasicRelaySetupInfo,
     onClick: () -> Unit,
     modifier: Modifier,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceEvenly,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/RelayUrlEditField.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/RelayUrlEditField.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.nip11RelayInfo.Nip11CachedRetriever
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -122,9 +123,11 @@ fun RelayUrlEditFieldPreview() {
 fun RelayUrlEditField(
     onNewRelay: (NormalizedRelayUrl) -> Unit,
     modifier: Modifier,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     RelayUrlEditField(
         onNewRelay = onNewRelay,
         nip11CachedRetriever = Amethyst.instance.nip11Cache,
@@ -139,9 +142,11 @@ fun RelayUrlEditField(
     onNewRelay: (NormalizedRelayUrl) -> Unit,
     nip11CachedRetriever: Nip11CachedRetriever,
     modifier: Modifier,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val relaySuggestions = remember { RelaySuggestionState() }
     RelayUrlEditField(
         onNewRelay = onNewRelay,
@@ -159,9 +164,11 @@ fun RelayUrlEditField(
     relaySuggestions: IRelaySuggestionState,
     nip11CachedRetriever: Nip11CachedRetriever,
     modifier: Modifier,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     var url by remember { mutableStateOf("") }
 
     fun submitRelay() {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/ShowRelaySuggestionList.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/ShowRelaySuggestionList.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.nip11RelayInfo.Nip11CachedRetriever
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -39,9 +40,11 @@ fun ShowRelaySuggestionList(
     onSelect: (NormalizedRelayUrl) -> Unit,
     modifier: Modifier = Modifier,
     nip11CachedRetriever: Nip11CachedRetriever,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val suggestions by relaySuggestions.results.collectAsStateWithLifecycle(emptyList())
 
     if (suggestions.isNotEmpty()) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/connected/ConnectedRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/connected/ConnectedRelayListView.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.Amethyst
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -40,10 +41,12 @@ import com.vitorpamplona.amethyst.ui.theme.HorzHalfVertPadding
 @Composable
 fun ConnectedRelayList(
     postViewModel: ConnectedRelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onClose: () -> Unit,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val newNav = rememberExtendedNav(nav, onClose)
     val feedState by postViewModel.relays.collectAsStateWithLifecycle()
 
@@ -59,9 +62,11 @@ fun ConnectedRelayList(
 fun LazyListScope.renderConnectedItems(
     feedState: List<BasicRelaySetupInfo>,
     postViewModel: ConnectedRelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     itemsIndexed(feedState, key = { _, item -> "Connected" + item.relay.url }) { index, item ->
         BasicRelaySetupInfoDialog(
             item,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/datasource/RelayInfoNip66FilterAssemblerSubscription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/datasource/RelayInfoNip66FilterAssemblerSubscription.kt
@@ -23,14 +23,17 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.datasource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.KeyDataSourceSubscription
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 
 @Composable
 fun RelayInfoNip66FilterAssemblerSubscription(
     relayUrl: NormalizedRelayUrl,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val state =
         remember(relayUrl) {
             RelayInfoNip66QueryState(relayUrl, accountViewModel.account.followOutboxesOrProxy.flow.value)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/dm/AddDMRelayListDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/dm/AddDMRelayListDialog.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.DefaultDMRelayList
 import com.vitorpamplona.amethyst.ui.components.SetDialogToEdgeToEdge
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -52,9 +53,11 @@ import com.vitorpamplona.amethyst.ui.theme.imageModifier
 @Composable
 fun AddDMRelayListDialog(
     onClose: () -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val postViewModel: DMRelayListViewModel = viewModel()
 
     postViewModel.init(accountViewModel)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/dm/DMRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/dm/DMRelayListView.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.Amethyst
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -49,10 +50,12 @@ import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 @Composable
 fun DMRelayList(
     postViewModel: DMRelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onClose: () -> Unit,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val newNav = rememberExtendedNav(nav, onClose)
     val feedState by postViewModel.relays.collectAsStateWithLifecycle()
     val dragState =
@@ -74,11 +77,13 @@ fun DMRelayList(
 fun LazyListScope.renderDMItems(
     feedState: List<BasicRelaySetupInfo>,
     postViewModel: DMRelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     countResults: Map<NormalizedRelayUrl, RelayCountResult> = emptyMap(),
     dragState: RelayDragState? = null,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     itemsIndexed(feedState, key = { _, item -> "DM" + item.relay.url }) { index, item ->
         BasicRelaySetupInfoDialog(
             item,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/eventsync/EventSyncScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/eventsync/EventSyncScreen.kt
@@ -67,6 +67,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.TopBarWithBackButton
 import com.vitorpamplona.amethyst.ui.note.timeAgoNoDotNoDay
@@ -81,9 +82,11 @@ import java.util.Locale
 
 @Composable
 fun EventSyncScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val syncViewModel = accountViewModel.eventSync
     val isMobileOrMetered by accountViewModel.settings.isMobileOrMeteredConnection.collectAsStateWithLifecycle()
     val syncState by syncViewModel.syncState.collectAsStateWithLifecycle()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/feeds/RelayFeedsListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/feeds/RelayFeedsListView.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.Amethyst
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -47,10 +48,12 @@ import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
 @Composable
 fun RelayFeedsList(
     postViewModel: RelayFeedsListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onClose: () -> Unit,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val feedState by postViewModel.relays.collectAsStateWithLifecycle()
     val newNav = rememberExtendedNav(nav, onClose)
     val dragState =
@@ -72,10 +75,12 @@ fun RelayFeedsList(
 fun LazyListScope.renderRelayFeedsItems(
     feedState: List<BasicRelaySetupInfo>,
     postViewModel: RelayFeedsListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     dragState: RelayDragState? = null,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     itemsIndexed(feedState, key = { _, item -> "RelayFeeds" + item.relay.url }) { index, item ->
         BasicRelaySetupInfoDialog(
             item,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/indexer/IndexerRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/indexer/IndexerRelayListView.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.Amethyst
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -49,10 +50,12 @@ import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 @Composable
 fun IndexerRelayList(
     postViewModel: IndexerRelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onClose: () -> Unit,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val feedState by postViewModel.relays.collectAsStateWithLifecycle()
     val newNav = rememberExtendedNav(nav, onClose)
     val dragState =
@@ -74,11 +77,13 @@ fun IndexerRelayList(
 fun LazyListScope.renderIndexerItems(
     feedState: List<BasicRelaySetupInfo>,
     postViewModel: IndexerRelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     countResults: Map<NormalizedRelayUrl, RelayCountResult> = emptyMap(),
     dragState: RelayDragState? = null,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     itemsIndexed(feedState, key = { _, item -> "Indexer" + item.relay.url }) { index, item ->
         BasicRelaySetupInfoDialog(
             item,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/local/LocalRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/local/LocalRelayListView.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Alignment
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -51,10 +52,12 @@ import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
 @Composable
 fun LocalRelayList(
     postViewModel: LocalRelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onClose: () -> Unit,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val newNav = rememberExtendedNav(nav, onClose)
     val feedState by postViewModel.relays.collectAsStateWithLifecycle()
     val dragState =
@@ -76,10 +79,12 @@ fun LocalRelayList(
 fun LazyListScope.renderLocalItems(
     feedState: List<BasicRelaySetupInfo>,
     postViewModel: LocalRelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     dragState: RelayDragState? = null,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     itemsIndexed(feedState, key = { _, item -> "Local" + item.relay.url }) { index, item ->
         BasicRelaySetupInfoDialog(
             item,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip37/PrivateOutboxRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip37/PrivateOutboxRelayListView.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.Amethyst
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -49,10 +50,12 @@ import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 @Composable
 fun PrivateOutboxRelayList(
     postViewModel: PrivateOutboxRelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onClose: () -> Unit,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val newNav = rememberExtendedNav(nav, onClose)
     val feedState by postViewModel.relays.collectAsStateWithLifecycle()
     val dragState =
@@ -74,11 +77,13 @@ fun PrivateOutboxRelayList(
 fun LazyListScope.renderPrivateOutboxItems(
     feedState: List<BasicRelaySetupInfo>,
     postViewModel: PrivateOutboxRelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     countResults: Map<NormalizedRelayUrl, RelayCountResult> = emptyMap(),
     dragState: RelayDragState? = null,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     itemsIndexed(feedState, key = { _, item -> "Outbox" + item.relay.url }) { index, item ->
         BasicRelaySetupInfoDialog(
             item,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip43/RelayMembersScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip43/RelayMembersScreen.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.UserCompose
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -87,9 +88,11 @@ import kotlinx.coroutines.launch
 @Composable
 fun RelayMembersScreen(
     relayUrl: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val normalizedRelayUrl = remember(relayUrl) { RelayUrlNormalizer.normalizeOrNull(relayUrl) }
     if (normalizedRelayUrl == null) return
 
@@ -365,8 +368,10 @@ private fun MembershipActionsLeaveSentPreview() {
 
 suspend fun sendJoinRequest(
     relay: NormalizedRelayUrl,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val template = RelayJoinRequestEvent.build()
     val signedEvent = accountViewModel.account.signer.sign(template)
     accountViewModel.account.cache.justConsumeMyOwnEvent(signedEvent)
@@ -375,8 +380,10 @@ suspend fun sendJoinRequest(
 
 suspend fun sendLeaveRequest(
     relay: NormalizedRelayUrl,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val template = RelayLeaveRequestEvent.build()
     val signedEvent = accountViewModel.account.signer.sign(template)
     accountViewModel.account.cache.justConsumeMyOwnEvent(signedEvent)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip65/Nip65RelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip65/Nip65RelayListView.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.Amethyst
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -49,10 +50,12 @@ import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 @Composable
 fun Nip65RelayList(
     postViewModel: Nip65RelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onClose: () -> Unit,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val newNav = rememberExtendedNav(nav, onClose)
 
     val homeFeedState by postViewModel.homeRelays.collectAsStateWithLifecycle()
@@ -83,10 +86,12 @@ fun Nip65RelayList(
 @Composable
 fun Nip65InboxRelayList(
     postViewModel: Nip65RelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onClose: () -> Unit,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val newNav = rememberExtendedNav(nav, onClose)
     val notifFeedState by postViewModel.notificationRelays.collectAsStateWithLifecycle()
     val dragState =
@@ -108,10 +113,12 @@ fun Nip65InboxRelayList(
 @Composable
 fun Nip65OutboxRelayList(
     postViewModel: Nip65RelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onClose: () -> Unit,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val newNav = rememberExtendedNav(nav, onClose)
     val homeFeedState by postViewModel.homeRelays.collectAsStateWithLifecycle()
     val dragState =
@@ -133,11 +140,13 @@ fun Nip65OutboxRelayList(
 fun LazyListScope.renderNip65HomeItems(
     feedState: List<BasicRelaySetupInfo>,
     postViewModel: Nip65RelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     countResults: Map<NormalizedRelayUrl, RelayCountResult> = emptyMap(),
     dragState: RelayDragState? = null,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     itemsIndexed(feedState, key = { _, item -> "Nip65Home" + item.relay.url }) { index, item ->
         BasicRelaySetupInfoDialog(
             item,
@@ -166,11 +175,13 @@ fun LazyListScope.renderNip65HomeItems(
 fun LazyListScope.renderNip65NotifItems(
     feedState: List<BasicRelaySetupInfo>,
     postViewModel: Nip65RelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     countResults: Map<NormalizedRelayUrl, RelayCountResult> = emptyMap(),
     dragState: RelayDragState? = null,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     itemsIndexed(feedState, key = { _, item -> "Nip65Notif" + item.relay.url }) { index, item ->
         BasicRelaySetupInfoDialog(
             item,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip65/Nip65RelayListViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip65/Nip65RelayListViewModel.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.service.replace
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -61,7 +62,9 @@ class Nip65RelayListViewModel : ViewModel() {
 
     var hasModified = false
 
-    fun init(accountViewModel: AccountViewModel) {
+    fun init(accountViewModel: IAccountViewModel) {
+        @Suppress("NAME_SHADOWING")
+        val accountViewModel = accountViewModel as AccountViewModel
         this.accountViewModel = accountViewModel
         this.account = accountViewModel.account
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip86/RelayManagementScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip86/RelayManagementScreen.kt
@@ -83,6 +83,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.model.nip05DnsIdentifiers.Nip05State
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.model.nip86RelayManagement.Nip86Retriever
@@ -118,9 +119,11 @@ import kotlinx.coroutines.launch
 @Composable
 fun RelayManagementScreen(
     relayUrl: String,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     RelayUrlNormalizer.normalizeOrNull(relayUrl)?.let {
         RelayManagementScreen(
             relay = it,
@@ -134,9 +137,11 @@ fun RelayManagementScreen(
 @Composable
 fun RelayManagementScreen(
     relay: NormalizedRelayUrl,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val retriever =
         remember {
             Nip86Retriever(Amethyst.instance.torEvaluatorFlow::okHttpClientForRelay)
@@ -241,8 +246,10 @@ private fun RelayManagementContent(
     viewModel: RelayManagementViewModel,
     supportedMethods: ImmutableList<String>,
     error: String?,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val tabs =
         remember(supportedMethods) {
             buildList {
@@ -356,8 +363,10 @@ private enum class ManagementTab(
 private fun PubkeysTab(
     viewModel: RelayManagementViewModel,
     supportedMethods: List<String>,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val bannedPubkeyUsers by viewModel.bannedPubkeyUsers.collectAsStateWithLifecycle(emptyList())
     val allowedPubkeyUsers by viewModel.allowedPubkeyUsers.collectAsStateWithLifecycle(emptyList())
     var showBanDialog by remember { mutableStateOf(false) }
@@ -445,8 +454,10 @@ private fun PubkeyUserCard(
     entry: PubkeyUser,
     showRemove: Boolean,
     onRemove: () -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     SlimListItem(
         modifier = Modifier.fillMaxWidth(),
         leadingContent = {
@@ -489,8 +500,10 @@ private fun PubkeyUserCard(
 @Composable
 private fun PubkeyNip05Row(
     user: User,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val nip05StateMetadata by user.nip05State().flow.collectAsStateWithLifecycle()
 
     when (val nip05State = nip05StateMetadata) {
@@ -996,8 +1009,10 @@ private fun UserSearchDialog(
     title: String,
     onConfirm: (User, String) -> Unit,
     onDismiss: () -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val userSuggestions =
         remember {
             UserSuggestionState(accountViewModel.account, accountViewModel.nip05ClientBuilder())
@@ -1096,9 +1111,11 @@ private fun UserSearchDialog(
 @Composable
 private fun SelectedUserRow(
     user: User,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onClear: () -> Unit,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Row(
         modifier =
             Modifier
@@ -1131,8 +1148,10 @@ private fun SelectedUserRow(
 private fun ShowUserSuggestions(
     userSuggestions: UserSuggestionState,
     onSelect: (User) -> Unit,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val listState = rememberLazyListState()
 
     AnimateOnNewSearch(userSuggestions, listState)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/proxy/ProxyRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/proxy/ProxyRelayListView.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.Amethyst
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -49,10 +50,12 @@ import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 @Composable
 fun ProxyRelayList(
     postViewModel: ProxyRelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onClose: () -> Unit,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val feedState by postViewModel.relays.collectAsStateWithLifecycle()
     val newNav = rememberExtendedNav(nav, onClose)
     val dragState =
@@ -74,11 +77,13 @@ fun ProxyRelayList(
 fun LazyListScope.renderProxyItems(
     feedState: List<BasicRelaySetupInfo>,
     postViewModel: ProxyRelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     countResults: Map<NormalizedRelayUrl, RelayCountResult> = emptyMap(),
     dragState: RelayDragState? = null,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     itemsIndexed(feedState, key = { _, item -> "Proxy" + item.relay.url }) { index, item ->
         BasicRelaySetupInfoDialog(
             item,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/search/SearchRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/search/SearchRelayListView.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.Amethyst
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -49,10 +50,12 @@ import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 @Composable
 fun SearchRelayList(
     postViewModel: SearchRelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onClose: () -> Unit,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val feedState by postViewModel.relays.collectAsStateWithLifecycle()
     val newNav = rememberExtendedNav(nav, onClose)
     val dragState =
@@ -74,11 +77,13 @@ fun SearchRelayList(
 fun LazyListScope.renderSearchItems(
     feedState: List<BasicRelaySetupInfo>,
     postViewModel: SearchRelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     countResults: Map<NormalizedRelayUrl, RelayCountResult> = emptyMap(),
     dragState: RelayDragState? = null,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     itemsIndexed(feedState, key = { _, item -> "Search" + item.relay.url }) { index, item ->
         BasicRelaySetupInfoDialog(
             item,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/trusted/TrustedRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/trusted/TrustedRelayListView.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.Amethyst
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -47,10 +48,12 @@ import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
 @Composable
 fun TrustedRelayList(
     postViewModel: TrustedRelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     onClose: () -> Unit,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val feedState by postViewModel.relays.collectAsStateWithLifecycle()
     val newNav = rememberExtendedNav(nav, onClose)
     val dragState =
@@ -72,10 +75,12 @@ fun TrustedRelayList(
 fun LazyListScope.renderTrustedItems(
     feedState: List<BasicRelaySetupInfo>,
     postViewModel: TrustedRelayListViewModel,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
     dragState: RelayDragState? = null,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     itemsIndexed(feedState, key = { _, item -> "Trusted" + item.relay.url }) { index, item ->
         BasicRelaySetupInfoDialog(
             item,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/vanish/RequestToVanishScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/vanish/RequestToVanishScreen.kt
@@ -70,6 +70,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.nip11RelayInfo.Nip11CachedRetriever
 import com.vitorpamplona.amethyst.ui.components.TitleExplainer
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
@@ -98,9 +99,11 @@ import java.util.Locale
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RequestToVanishScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     RequestToVanishScreen(
         nip11CachedRetriever = Amethyst.instance.nip11Cache,
         accountViewModel = accountViewModel,
@@ -112,9 +115,11 @@ fun RequestToVanishScreen(
 @Composable
 fun RequestToVanishScreen(
     nip11CachedRetriever: Nip11CachedRetriever,
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val connectedRelays by accountViewModel.account.client
         .connectedRelaysFlow()
         .collectAsStateWithLifecycle()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/vanish/VanishEventsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/vanish/VanishEventsScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.model.nip62Vanish.ComplianceStatus
 import com.vitorpamplona.amethyst.model.nip62Vanish.VanishEventItem
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -75,9 +76,11 @@ import java.util.Locale
 
 @Composable
 fun VanishEventsScreen(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     Scaffold(
         topBar = {
             TopBarWithBackButton(
@@ -100,9 +103,11 @@ fun VanishEventsScreen(
 
 @Composable
 fun VanishEventsBody(
-    accountViewModel: AccountViewModel,
+    accountViewModel: IAccountViewModel,
     nav: INav,
 ) {
+    @Suppress("NAME_SHADOWING")
+    val accountViewModel = accountViewModel as AccountViewModel
     val vanishEvents by accountViewModel.account.vanish.testableFlow
         .collectAsStateWithLifecycle()
     val scope = rememberCoroutineScope()

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/IAccountViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/IAccountViewModel.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.screen.loggedIn
+
+import com.vitorpamplona.amethyst.commons.model.AddressableNote
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.quartz.nip01Core.core.Address
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * Cross-platform interface for AccountViewModel.
+ *
+ * Provides the subset of AccountViewModel's API that can be expressed
+ * using only commonMain types (IAccount, Note, User, HexKey, etc.).
+ * The Android-specific AccountViewModel implements this interface so
+ * that UI files migrated to commonMain can accept IAccountViewModel
+ * as a parameter without depending on Android-only types.
+ *
+ * Usage pattern for migrated files:
+ *   Before: fun MyScreen(accountViewModel: AccountViewModel, ...)
+ *   After:  fun MyScreen(accountViewModel: IAccountViewModel, ...)
+ */
+interface IAccountViewModel {
+    // ---- Core account access ----
+
+    /** The underlying account, abstracted via IAccount for commonMain use. */
+    val account: IAccount
+
+    /** Coroutine scope tied to the ViewModel lifecycle. */
+    val scope: CoroutineScope
+
+    // ---- Identity helpers (used by 50+ files) ----
+
+    /** Current user's profile. Delegates to account.userProfile(). */
+    fun userProfile(): User
+
+    /** Whether the current account can sign events. */
+    fun isWriteable(): Boolean
+
+    /** Check if the given pubkey is the logged-in user. */
+    fun isLoggedUser(pubkeyHex: HexKey?): Boolean
+
+    /** Check if the given user is the logged-in user. */
+    fun isLoggedUser(user: User?): Boolean
+
+    /** Check if the current account follows the given user. */
+    fun isFollowing(user: User?): Boolean
+
+    /** Check if the current account follows the given pubkey. */
+    fun isFollowing(user: HexKey): Boolean
+
+    // ---- Cache lookups (used by 30+ files) ----
+
+    fun checkGetOrCreateUser(key: HexKey): User?
+
+    fun getUserIfExists(hex: HexKey): User?
+
+    fun checkGetOrCreateNote(key: HexKey): Note?
+
+    fun getNoteIfExists(hex: HexKey): Note?
+
+    fun getOrCreateAddressableNote(address: Address): AddressableNote?
+
+    fun getAddressableNoteIfExists(key: String): AddressableNote?
+
+    fun getAddressableNoteIfExists(key: Address): AddressableNote?
+
+    // ---- Async helpers ----
+
+    /** Launch a coroutine on IO dispatchers. */
+    fun runOnIO(runOnIO: suspend () -> Unit)
+
+    // ---- Actions (commonly used) ----
+
+    fun follow(user: User)
+
+    fun unfollow(user: User)
+
+    fun hide(user: User)
+
+    fun show(user: User)
+
+    fun boost(note: Note)
+
+    fun delete(note: Note)
+
+    fun delete(notes: List<Note>)
+
+    fun broadcast(note: Note)
+
+    fun reactToOrDelete(note: Note)
+
+    fun reactToOrDelete(
+        note: Note,
+        reaction: String,
+    )
+
+    fun decrypt(
+        note: Note,
+        onReady: (String) -> Unit,
+    )
+
+    fun cachedDecrypt(note: Note): String?
+
+    // ---- Bookmark / Pin (used by several files) ----
+
+    fun addPrivateBookmark(note: Note)
+
+    fun addPublicBookmark(note: Note)
+
+    fun removePrivateBookmark(note: Note)
+
+    fun removePublicBookmark(note: Note)
+
+    fun addPin(note: Note)
+
+    fun removePin(note: Note)
+
+    // ---- Navigation helpers ----
+
+    fun loadReactionTo(note: Note?): String?
+
+    fun loadAndMarkAsRead(
+        routeForLastRead: String,
+        createdAt: Long?,
+    ): Boolean
+
+    // ---- Settings delegates ----
+
+    fun defaultZapType(): LnZapEvent.ZapType
+
+    fun reactionChoices(): List<String>
+
+    fun zapAmountChoices(): List<Long>
+
+    fun showSensitiveContent(): MutableStateFlow<Boolean?>
+
+    fun dontTranslateFrom(): Set<String>
+
+    fun translateTo(): String
+}


### PR DESCRIPTION
Migrates composable function signatures in `screen/loggedIn/relays/` (28 files) from `AccountViewModel` to `IAccountViewModel`.

Each function parameter is changed to accept `IAccountViewModel`, with a `@Suppress("NAME_SHADOWING")` cast to `AccountViewModel` at the top of each function body for backwards compatibility.

Class fields (e.g. in `BasicRelaySetupInfoModel`, `Nip65RelayListViewModel`) remain typed as `AccountViewModel` since they call methods not yet on the interface.

Part of the KMP iOS migration tracked in #2238.