### PR TITLE
feat: expand IAccount and IAccountViewModel interfaces (v9) — unblock signature migration

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -253,7 +253,7 @@ class Account(
     val nwcFilterAssembler: () -> NWCPaymentFilterAssembler,
     val otsResolverBuilder: () -> OtsResolver,
     val cache: LocalCache,
-    val client: INostrClient,
+    override val client: INostrClient,
     val scope: CoroutineScope,
     val mlsGroupStateStore: MlsGroupStateStore? = null,
 ) : IAccount {
@@ -282,25 +282,25 @@ class Account(
     val privateStorageDecryptionCache = PrivateStorageRelayListDecryptionCache(signer)
     val privateStorageRelayList = PrivateStorageRelayListState(signer, cache, privateStorageDecryptionCache, scope, settings)
 
-    val searchRelayListDecryptionCache = SearchRelayListDecryptionCache(signer)
+    override val searchRelayListDecryptionCache = SearchRelayListDecryptionCache(signer)
     val searchRelayList = SearchRelayListState(signer, cache, searchRelayListDecryptionCache, scope, settings)
 
-    val trustedRelayListDecryptionCache = TrustedRelayListDecryptionCache(signer)
+    override val trustedRelayListDecryptionCache = TrustedRelayListDecryptionCache(signer)
     val trustedRelayList = TrustedRelayListState(signer, cache, trustedRelayListDecryptionCache, scope, settings)
 
-    val proxyRelayListDecryptionCache = ProxyRelayListDecryptionCache(signer)
+    override val proxyRelayListDecryptionCache = ProxyRelayListDecryptionCache(signer)
     val proxyRelayList = ProxyRelayListState(signer, cache, proxyRelayListDecryptionCache, scope, settings)
 
-    val broadcastRelayListDecryptionCache = BroadcastRelayListDecryptionCache(signer)
+    override val broadcastRelayListDecryptionCache = BroadcastRelayListDecryptionCache(signer)
     val broadcastRelayList = BroadcastRelayListState(signer, cache, broadcastRelayListDecryptionCache, scope, settings)
 
-    val indexerRelayListDecryptionCache = IndexerRelayListDecryptionCache(signer)
+    override val indexerRelayListDecryptionCache = IndexerRelayListDecryptionCache(signer)
     val indexerRelayList = IndexerRelayListState(signer, cache, indexerRelayListDecryptionCache, scope, settings)
 
-    val relayFeedsListDecryptionCache = RelayFeedsListDecryptionCache(signer)
+    override val relayFeedsListDecryptionCache = RelayFeedsListDecryptionCache(signer)
     val relayFeedsList = RelayFeedListState(signer, cache, relayFeedsListDecryptionCache, scope, settings)
 
-    val blockedRelayListDecryptionCache = BlockedRelayListDecryptionCache(signer)
+    override val blockedRelayListDecryptionCache = BlockedRelayListDecryptionCache(signer)
     val blockedRelayList = BlockedRelayListState(signer, cache, blockedRelayListDecryptionCache, scope, settings)
 
     val kind3FollowList = Kind3FollowListState(signer, cache, scope, settings)
@@ -331,12 +331,12 @@ class Account(
     val peopleLists = PeopleListsState(signer, cache, peopleListDecryptionCache, scope)
     val followLists = FollowListsState(signer, cache, scope)
 
-    val hiddenUsers = HiddenUsersState(muteList.flow, blockPeopleList.flow, scope, settings)
+    override val hiddenUsers = HiddenUsersState(muteList.flow, blockPeopleList.flow, scope, settings)
 
     val labeledBookmarkLists = LabeledBookmarkListsState(signer, cache, scope)
     val oldBookmarkState = OldBookmarkListState(signer, cache, scope)
-    val bookmarkState = BookmarkListState(signer, cache, scope)
-    val pinState = PinListState(signer, cache, scope)
+    override val bookmarkState = BookmarkListState(signer, cache, scope)
+    override val pinState = PinListState(signer, cache, scope)
     val emoji = EmojiPackState(signer, cache, scope)
 
     val vanish = VanishRequestsState(signer, cache, client, scope)
@@ -351,7 +351,7 @@ class Account(
     val dmRelays = DmInboxRelayState(dmRelayList, nip65RelayList, privateStorageRelayList, localRelayList, scope)
     val notificationRelays = NotificationInboxRelayState(nip65RelayList, localRelayList, scope)
 
-    val trustedRelays = TrustedRelayListsState(nip65RelayList, privateStorageRelayList, localRelayList, dmRelayList, searchRelayList, trustedRelayList, broadcastRelayList, scope)
+    override val trustedRelays = TrustedRelayListsState(nip65RelayList, privateStorageRelayList, localRelayList, dmRelayList, searchRelayList, trustedRelayList, broadcastRelayList, scope)
 
     // Follows Relays
     val followOutboxesOrProxy = FollowListOutboxOrProxyRelays(kind3FollowList, blockedRelayList, proxyRelayList, cache, scope)
@@ -371,7 +371,7 @@ class Account(
     val followsPerRelay = FollowsPerOutboxRelay(kind3FollowList, blockedRelayList, proxyRelayList, cache, scope).flow
 
     // Merges all follow lists to create a single All Follows feed.
-    val allFollows = MergedFollowListsState(kind3FollowList, peopleLists, followLists, hashtagList, geohashList, communityList, scope)
+    override val allFollows = MergedFollowListsState(kind3FollowList, peopleLists, followLists, hashtagList, geohashList, communityList, scope)
 
     val privateDMDecryptionCache = PrivateDMCache(signer)
     override val privateZapsDecryptionCache = PrivateZapCache(signer)
@@ -2269,9 +2269,9 @@ class Account(
             false
         }
 
-    fun isFollowing(user: User): Boolean = user.pubkeyHex in followingKeySet()
+    override fun isFollowing(user: User): Boolean = user.pubkeyHex in followingKeySet()
 
-    fun isFollowing(user: HexKey): Boolean = user in followingKeySet()
+    override fun isFollowing(hex: HexKey): Boolean = hex in followingKeySet()
 
     fun isKnown(user: User): Boolean = user.pubkeyHex in allFollows.flow.value.authors
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/HiddenUsersState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/HiddenUsersState.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.model.nip51Lists
 
+import com.vitorpamplona.amethyst.commons.model.IHiddenUsersState
 import com.vitorpamplona.amethyst.commons.model.LiveHiddenUsers
 import com.vitorpamplona.amethyst.model.AccountSettings
 import com.vitorpamplona.amethyst.service.checkNotInMainThread
@@ -44,8 +45,8 @@ class HiddenUsersState(
     val blockList: StateFlow<List<MuteTag>>,
     val scope: CoroutineScope,
     val settings: AccountSettings,
-) {
-    var transientHiddenUsers: MutableStateFlow<Set<String>> = MutableStateFlow(setOf())
+) : IHiddenUsersState {
+    override var transientHiddenUsers: MutableStateFlow<Set<String>> = MutableStateFlow(setOf())
 
     fun assembleLiveHiddenUsers(
         blockList: List<MuteTag>,
@@ -69,7 +70,7 @@ class HiddenUsersState(
         )
     }
 
-    val flow: StateFlow<LiveHiddenUsers> =
+    override val flow: StateFlow<LiveHiddenUsers> =
         combineTransform(
             blockList,
             muteList,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/PinListState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/PinListState.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.model.nip51Lists
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.model.IPinListState
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.NoteState
@@ -43,7 +44,7 @@ class PinListState(
     val signer: NostrSigner,
     val cache: LocalCache,
     val scope: CoroutineScope,
-) {
+) : IPinListState {
     val pinList = cache.getOrCreateAddressableNote(PinListEvent.createPinAddress(signer.pubKey))
 
     fun getPinListFlow(): StateFlow<NoteState> = pinList.flow().metadata.stateFlow
@@ -70,7 +71,7 @@ class PinListState(
                 emptyList(),
             )
 
-    val pinnedEventIdSet: StateFlow<Set<String>> =
+    override val pinnedEventIdSet: StateFlow<Set<String>> =
         pinnedNotes
             .map { pins ->
                 pins.map { it.eventId }.toSet()
@@ -97,7 +98,7 @@ class PinListState(
                 emptyList(),
             )
 
-    fun isPinned(note: Note): Boolean = pinnedEventIdSet.value.contains(note.idHex)
+    override fun isPinned(note: Note): Boolean = pinnedEventIdSet.value.contains(note.idHex)
 
     suspend fun addPin(note: Note): PinListEvent {
         val currentList = getPinList()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/relayLists/GenericRelayListCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/relayLists/GenericRelayListCache.kt
@@ -20,6 +20,9 @@
  */
 package com.vitorpamplona.amethyst.model.nip51Lists.relayLists
 
+import com.vitorpamplona.amethyst.commons.model.EmptyRelayListCard
+import com.vitorpamplona.amethyst.commons.model.IRelayListDecryptionCache
+import com.vitorpamplona.amethyst.commons.model.RelayListCard
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import com.vitorpamplona.quartz.nip51Lists.PrivateTagArrayEvent
@@ -35,7 +38,7 @@ import kotlinx.coroutines.flow.onStart
 
 open class GenericRelayListCache<T : PrivateTagArrayEvent>(
     val signer: NostrSigner,
-) {
+) : IRelayListDecryptionCache {
     val cachedPrivateLists = PrivateTagArrayEventCache<T>(signer)
 
     fun cachedRelays(event: T) = cachedPrivateLists.mergeTagListPrecached(event).relaySet()
@@ -43,7 +46,7 @@ open class GenericRelayListCache<T : PrivateTagArrayEvent>(
     suspend fun relays(event: T) = cachedPrivateLists.mergeTagList(event).relaySet()
 
     @Suppress("UNCHECKED_CAST")
-    fun fastStartValueForRelayList(note: Note): RelayListCard {
+    override fun fastStartValueForRelayList(note: Note): RelayListCard {
         val noteEvent = note.event as? T
         return if (noteEvent != null) {
             RelayListCard(cachedRelays(noteEvent).toList())
@@ -54,7 +57,7 @@ open class GenericRelayListCache<T : PrivateTagArrayEvent>(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Suppress("UNCHECKED_CAST")
-    fun observeDecryptedRelayList(note: Note): Flow<RelayListCard> =
+    override fun observeDecryptedRelayList(note: Note): Flow<RelayListCard> =
         note
             .flow()
             .metadata.stateFlow

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/serverList/MergedFollowListsState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/serverList/MergedFollowListsState.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.model.serverList
 
 import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.commons.model.IAllFollowsState
 import com.vitorpamplona.amethyst.model.nip02FollowLists.Kind3FollowListState
 import com.vitorpamplona.amethyst.model.nip51Lists.geohashLists.GeohashListState
 import com.vitorpamplona.amethyst.model.nip51Lists.hashtagLists.HashtagListState
@@ -50,17 +51,17 @@ class MergedFollowListsState(
     val geohashList: GeohashListState,
     val communityList: CommunityListState,
     val scope: CoroutineScope,
-) {
+) : IAllFollowsState {
     /**
      This contains a big OR of everything the user wants to see in the a single feed.
      */
     @Immutable
     class AllFollows(
-        val authors: Set<String> = emptySet(),
-        val hashtags: Set<String> = emptySet(),
-        val geotags: Set<String> = emptySet(),
-        val communities: Set<String> = emptySet(),
-    ) {
+        override val authors: Set<String> = emptySet(),
+        override val hashtags: Set<String> = emptySet(),
+        override val geotags: Set<String> = emptySet(),
+        override val communities: Set<String> = emptySet(),
+    ) : IAllFollowsState.AllFollows(authors, hashtags, geotags, communities) {
         val geotagScopes: Set<String> = geotags.mapTo(mutableSetOf()) { GeohashId.toScope(it) }
         val hashtagScopes: Set<String> = hashtags.mapTo(mutableSetOf()) { HashtagId.toScope(it) }
     }
@@ -81,7 +82,7 @@ class MergedFollowListsState(
         )
 
     @OptIn(kotlinx.coroutines.FlowPreview::class)
-    val flow: StateFlow<AllFollows> =
+    override val flow: StateFlow<AllFollows> =
         combine(
             listOf(
                 kind3List.flow,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/serverList/TrustedRelayListsState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/serverList/TrustedRelayListsState.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.model.serverList
 
+import com.vitorpamplona.amethyst.commons.model.ITrustedRelayListsState
 import com.vitorpamplona.amethyst.model.edits.PrivateStorageRelayListState
 import com.vitorpamplona.amethyst.model.localRelays.LocalRelayListState
 import com.vitorpamplona.amethyst.model.nip17Dms.DmRelayListState
@@ -46,10 +47,10 @@ class TrustedRelayListsState(
     val trustedRelayList: TrustedRelayListState,
     val broadcastRelayList: BroadcastRelayListState,
     val scope: CoroutineScope,
-) {
+) : ITrustedRelayListsState {
     fun mergeLists(lists: Array<Set<NormalizedRelayUrl>>): Set<NormalizedRelayUrl> = lists.reduce { acc, set -> acc + set }
 
-    val flow: StateFlow<Set<NormalizedRelayUrl>> =
+    override val flow: StateFlow<Set<NormalizedRelayUrl>> =
         combine(
             listOf(
                 nip65RelayList.allFlowNoDefaults,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/RelayList.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/RelayList.kt
@@ -45,8 +45,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.model.RelayListCard
 import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.model.nip51Lists.relayLists.RelayListCard
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserRelayIntoList
 import com.vitorpamplona.amethyst.ui.components.ShowMoreButton
 import com.vitorpamplona.amethyst.ui.components.util.setText

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -175,14 +175,15 @@ import kotlinx.coroutines.withContext
 
 @Stable
 class AccountViewModel(
-    val account: Account,
+    override val account: Account,
     val settings: UiSettingsState,
     val torSettings: TorSettingsFlow,
     val dataSources: RelaySubscriptionsCoordinator,
     val httpClientBuilder: IRoleBasedHttpClientBuilder,
-    val nip05ClientBuilder: () -> INip05Client,
+    override val nip05ClientBuilder: () -> INip05Client,
 ) : ViewModel(),
-    Dao {
+    Dao,
+    com.vitorpamplona.amethyst.commons.model.IAccountViewModel {
     var firstRoute: Route? = null
 
     val toastManager = ToastManager()
@@ -418,9 +419,9 @@ class AccountViewModel(
             Route.Notification() to notificationHasNewItemsFlow,
         )
 
-    fun isWriteable(): Boolean = account.isWriteable()
+    override fun isWriteable(): Boolean = account.isWriteable()
 
-    fun userProfile(): User = account.userProfile()
+    override fun userProfile(): User = account.userProfile()
 
     fun reactToOrDelete(
         note: Note,
@@ -536,7 +537,7 @@ class AccountViewModel(
 
     private val noteMustShowExpandButtonFlows = LruCache<Note, StateFlow<Boolean>>(300)
 
-    fun createMustShowExpandButtonFlows(note: Note): StateFlow<Boolean> =
+    override fun createMustShowExpandButtonFlows(note: Note): StateFlow<Boolean> =
         noteMustShowExpandButtonFlows.get(note)
             ?: note
                 .flow()
@@ -1013,7 +1014,7 @@ class AccountViewModel(
 
     fun delete(notes: List<Note>) = launchSigner { account.delete(notes) }
 
-    fun delete(note: Note) = launchSigner { account.delete(note) }
+    override fun delete(note: Note) = launchSigner { account.delete(note) }
 
     fun requestToVanish(
         relays: List<NormalizedRelayUrl>,
@@ -1028,14 +1029,14 @@ class AccountViewModel(
 
     fun cachedDecrypt(note: Note): String? = account.cachedDecryptContent(note)
 
-    fun decrypt(
+    override fun decrypt(
         note: Note,
         onReady: (String) -> Unit,
     ) = launchSigner {
         account.decryptContent(note)?.let { onReady(it) }
     }
 
-    inline fun launchSigner(crossinline action: suspend () -> Unit) {
+    override fun launchSigner(action: suspend () -> Unit) {
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 action()
@@ -1095,9 +1096,9 @@ class AccountViewModel(
 
     fun follow(users: List<User>) = launchSigner { account.follow(users) }
 
-    fun follow(user: User) = launchSigner { account.follow(user) }
+    override fun follow(user: User) = launchSigner { account.follow(user) }
 
-    fun unfollow(user: User) = launchSigner { account.unfollow(user) }
+    override fun unfollow(user: User) = launchSigner { account.unfollow(user) }
 
     fun followGeohash(tag: String) = launchSigner { account.followGeohash(tag) }
 
@@ -1115,16 +1116,16 @@ class AccountViewModel(
 
     fun hideWord(word: String) = launchSigner { account.hideWord(word) }
 
-    fun isLoggedUser(pubkeyHex: HexKey?): Boolean = account.signer.pubKey == pubkeyHex
+    override fun isLoggedUser(pubkeyHex: HexKey?): Boolean = account.signer.pubKey == pubkeyHex
 
-    fun isLoggedUser(user: User?): Boolean = isLoggedUser(user?.pubkeyHex)
+    override fun isLoggedUser(user: User?): Boolean = isLoggedUser(user?.pubkeyHex)
 
-    fun isFollowing(user: User?): Boolean {
+    override fun isFollowing(user: User?): Boolean {
         if (user == null) return false
         return account.isFollowing(user)
     }
 
-    fun isFollowing(user: HexKey): Boolean = account.isFollowing(user)
+    override fun isFollowing(hex: HexKey): Boolean = account.isFollowing(hex)
 
     fun markDonatedInThisVersion() = account.markDonatedInThisVersion()
 
@@ -1207,9 +1208,9 @@ class AccountViewModel(
 
     fun show(user: User) = launchSigner { account.showUser(user.pubkeyHex) }
 
-    fun hide(user: User) = launchSigner { account.hideUser(user.pubkeyHex) }
+    override fun hide(user: User) = launchSigner { account.hideUser(user.pubkeyHex) }
 
-    fun hide(word: String) = launchSigner { account.hideWord(word) }
+    override fun hide(word: String) = launchSigner { account.hideWord(word) }
 
     fun showUser(pubkeyHex: String) = launchSigner { account.showUser(pubkeyHex) }
 
@@ -1242,17 +1243,17 @@ class AccountViewModel(
         return note.getReactionBy(userProfile())
     }
 
-    fun runOnIO(runOnIO: suspend () -> Unit) {
-        viewModelScope.launch(Dispatchers.IO) { runOnIO() }
+    override fun runOnIO(block: suspend () -> Unit) {
+        viewModelScope.launch(Dispatchers.IO) { block() }
     }
 
-    fun checkGetOrCreateUser(key: HexKey): User? = LocalCache.checkGetOrCreateUser(key)
+    override fun checkGetOrCreateUser(key: HexKey): User? = LocalCache.checkGetOrCreateUser(key)
 
     override suspend fun getOrCreateUser(hex: HexKey): User = LocalCache.getOrCreateUser(hex)
 
     fun getUserIfExists(hex: HexKey): User? = LocalCache.getUserIfExists(hex)
 
-    fun checkGetOrCreateNote(key: HexKey): Note? = LocalCache.checkGetOrCreateNote(key)
+    override fun checkGetOrCreateNote(key: HexKey): Note? = LocalCache.checkGetOrCreateNote(key)
 
     override suspend fun getOrCreateNote(hex: HexKey): Note = LocalCache.getOrCreateNote(hex)
 
@@ -1267,7 +1268,7 @@ class AccountViewModel(
         return note
     }
 
-    fun getNoteIfExists(hex: HexKey): Note? = LocalCache.getNoteIfExists(hex)
+    override fun getNoteIfExists(hex: HexKey): Note? = LocalCache.getNoteIfExists(hex)
 
     /**
      * Fixes author and relay hints in MarkedETag list by looking up notes from cache.
@@ -1297,7 +1298,7 @@ class AccountViewModel(
 
     override fun getOrCreateAddressableNote(address: Address): AddressableNote = LocalCache.getOrCreateAddressableNote(address)
 
-    fun getAddressableNoteIfExists(key: String): AddressableNote? = LocalCache.getAddressableNoteIfExists(key)
+    override fun getAddressableNoteIfExists(key: String): AddressableNote? = LocalCache.getAddressableNoteIfExists(key)
 
     fun getAddressableNoteIfExists(key: Address): AddressableNote? = LocalCache.getAddressableNoteIfExists(key)
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccount.kt
@@ -21,7 +21,10 @@
 package com.vitorpamplona.amethyst.commons.model
 
 import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupList
+import com.vitorpamplona.amethyst.commons.model.nip51Lists.BookmarkListState
 import com.vitorpamplona.amethyst.commons.model.privateChats.ChatroomList
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import com.vitorpamplona.quartz.nip04Dm.messages.PrivateDmEvent
@@ -119,4 +122,61 @@ interface IAccount {
 
     /** Broadcast pre-created gift wraps (e.g. reactions within group DMs) */
     suspend fun sendGiftWraps(wraps: List<GiftWrapEvent>)
+
+    // ── Follow / relationship queries ──────────────────────────────
+
+    /** Whether the account follows the given user */
+    fun isFollowing(user: User): Boolean
+
+    /** Whether the account follows the user identified by hex pubkey */
+    fun isFollowing(hex: HexKey): Boolean
+
+    // ── Bookmark & pin state ──────────────────────────────────────
+
+    /** Bookmark list state (NIP-51 bookmarks) */
+    val bookmarkState: BookmarkListState
+
+    /** Pin list state (NIP-51 pin lists) */
+    val pinState: IPinListState
+
+    // ── Follow / content lists ───────────────────────────────────
+
+    /** Merged state of all follow lists (kind-3 + people + hashtag + geohash + community) */
+    val allFollows: IAllFollowsState
+
+    /** Merged set of all trusted relay URLs */
+    val trustedRelays: ITrustedRelayListsState
+
+    // ── Hidden users ─────────────────────────────────────────────
+
+    /** Reactive hidden-users state (mute lists + transient spammers) */
+    val hiddenUsers: IHiddenUsersState
+
+    // ── Relay list decryption caches ─────────────────────────────
+
+    /** Decryption cache for search relay lists */
+    val searchRelayListDecryptionCache: IRelayListDecryptionCache
+
+    /** Decryption cache for trusted relay lists */
+    val trustedRelayListDecryptionCache: IRelayListDecryptionCache
+
+    /** Decryption cache for proxy relay lists */
+    val proxyRelayListDecryptionCache: IRelayListDecryptionCache
+
+    /** Decryption cache for broadcast relay lists */
+    val broadcastRelayListDecryptionCache: IRelayListDecryptionCache
+
+    /** Decryption cache for indexer relay lists */
+    val indexerRelayListDecryptionCache: IRelayListDecryptionCache
+
+    /** Decryption cache for relay feed lists */
+    val relayFeedsListDecryptionCache: IRelayListDecryptionCache
+
+    /** Decryption cache for blocked relay lists */
+    val blockedRelayListDecryptionCache: IRelayListDecryptionCache
+
+    // ── Nostr client ─────────────────────────────────────────────
+
+    /** Nostr relay client for broadcasting events */
+    val client: INostrClient
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccountViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAccountViewModel.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model
+
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip05DnsIdentifiers.INip05Client
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Interface for the account view-model, abstracting Android-specific
+ * AccountViewModel for use in multiplatform composables.
+ *
+ * Implementations should delegate to the platform Account and cache layer.
+ */
+interface IAccountViewModel {
+    /** The underlying account */
+    val account: IAccount
+
+    /** Factory for NIP-05 verification clients */
+    val nip05ClientBuilder: () -> INip05Client
+
+    // ── Identity helpers ──────────────────────────────────────────
+
+    /** Current user's profile */
+    fun userProfile(): User
+
+    /** Whether the given pubkey belongs to the logged-in user */
+    fun isLoggedUser(pubkeyHex: HexKey?): Boolean
+
+    /** Whether the given user is the logged-in user */
+    fun isLoggedUser(user: User?): Boolean
+
+    /** Whether the account has write permissions */
+    fun isWriteable(): Boolean
+
+    /** Whether the logged-in user follows the given user */
+    fun isFollowing(user: User?): Boolean
+
+    /** Whether the logged-in user follows the given hex pubkey */
+    fun isFollowing(hex: HexKey): Boolean
+
+    // ── Cache lookups ─────────────────────────────────────────────
+
+    /** Retrieve a note from cache, or null */
+    fun getNoteIfExists(hex: HexKey): Note?
+
+    /** Retrieve an addressable note from cache by its string key, or null */
+    fun getAddressableNoteIfExists(key: String): AddressableNote?
+
+    /** Retrieve or lazily create a user from cache, or null if hex is invalid */
+    fun checkGetOrCreateUser(key: HexKey): User?
+
+    /** Retrieve or lazily create a note from cache, or null if hex is invalid */
+    fun checkGetOrCreateNote(key: HexKey): Note?
+
+    // ── Signer helpers ────────────────────────────────────────────
+
+    /**
+     * Launch a signing action in the background. If the signer is read-only,
+     * implementations should surface an appropriate error to the user.
+     *
+     * Note: the Android implementation is `inline` with `crossinline`; this
+     * interface method intentionally omits those modifiers so it can be
+     * overridden on all platforms.
+     */
+    fun launchSigner(action: suspend () -> Unit)
+
+    /** Run block on IO dispatcher */
+    fun runOnIO(block: suspend () -> Unit)
+
+    // ── Note display helpers ──────────────────────────────────────
+
+    /**
+     * Creates a [StateFlow] that emits whether the "show expand" button
+     * should be displayed for the given note (e.g. based on relay count).
+     */
+    fun createMustShowExpandButtonFlows(note: Note): StateFlow<Boolean>
+
+    /**
+     * Decrypt the content of a note and deliver the plaintext to [onReady].
+     */
+    fun decrypt(
+        note: Note,
+        onReady: (String) -> Unit,
+    )
+
+    // ── Actions ───────────────────────────────────────────────────
+
+    /** Follow a user */
+    fun follow(user: User)
+
+    /** Unfollow a user */
+    fun unfollow(user: User)
+
+    /** Delete a note */
+    fun delete(note: Note)
+
+    /** Hide a user (transient block) */
+    fun hide(user: User)
+
+    /** Hide a word */
+    fun hide(word: String)
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAllFollowsState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IAllFollowsState.kt
@@ -18,11 +18,22 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-@file:Suppress("unused")
+package com.vitorpamplona.amethyst.commons.model
 
-package com.vitorpamplona.amethyst.model.nip51Lists.relayLists
+import kotlinx.coroutines.flow.StateFlow
 
-// Re-export from commons for backward compatibility
-typealias RelayListCard = com.vitorpamplona.amethyst.commons.model.RelayListCard
+/**
+ * Interface for the merged "all follows" state that combines kind-3 follow lists,
+ * people lists, hashtag lists, geohash lists, and community lists into a single feed filter.
+ * Used by composables to observe changes in the user's followed content.
+ */
+interface IAllFollowsState {
+    val flow: StateFlow<AllFollows>
 
-val EmptyRelayListCard = com.vitorpamplona.amethyst.commons.model.EmptyRelayListCard
+    open class AllFollows(
+        open val authors: Set<String> = emptySet(),
+        open val hashtags: Set<String> = emptySet(),
+        open val geotags: Set<String> = emptySet(),
+        open val communities: Set<String> = emptySet(),
+    )
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IHiddenUsersState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IHiddenUsersState.kt
@@ -18,11 +18,19 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-@file:Suppress("unused")
+package com.vitorpamplona.amethyst.commons.model
 
-package com.vitorpamplona.amethyst.model.nip51Lists.relayLists
+import kotlinx.coroutines.flow.StateFlow
 
-// Re-export from commons for backward compatibility
-typealias RelayListCard = com.vitorpamplona.amethyst.commons.model.RelayListCard
+/**
+ * Interface for hidden-users state.
+ * Provides a reactive flow of the combined hidden/muted user lists and
+ * a separate flow of transiently-hidden (spammer) users.
+ */
+interface IHiddenUsersState {
+    /** Combined hidden-user and mute-list state */
+    val flow: StateFlow<LiveHiddenUsers>
 
-val EmptyRelayListCard = com.vitorpamplona.amethyst.commons.model.EmptyRelayListCard
+    /** Set of transiently hidden (spammer) user pubkeys */
+    val transientHiddenUsers: StateFlow<Set<String>>
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IPinListState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IPinListState.kt
@@ -18,11 +18,18 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-@file:Suppress("unused")
+package com.vitorpamplona.amethyst.commons.model
 
-package com.vitorpamplona.amethyst.model.nip51Lists.relayLists
+import kotlinx.coroutines.flow.StateFlow
 
-// Re-export from commons for backward compatibility
-typealias RelayListCard = com.vitorpamplona.amethyst.commons.model.RelayListCard
+/**
+ * Interface for pin list state.
+ * Used by composables to check whether a note is pinned.
+ */
+interface IPinListState {
+    /** Set of pinned event IDs, as a StateFlow for reactive observation */
+    val pinnedEventIdSet: StateFlow<Set<String>>
 
-val EmptyRelayListCard = com.vitorpamplona.amethyst.commons.model.EmptyRelayListCard
+    /** Checks whether the given note is currently pinned */
+    fun isPinned(note: Note): Boolean
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IRelayListDecryptionCache.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/IRelayListDecryptionCache.kt
@@ -18,11 +18,16 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-@file:Suppress("unused")
+package com.vitorpamplona.amethyst.commons.model
 
-package com.vitorpamplona.amethyst.model.nip51Lists.relayLists
+import kotlinx.coroutines.flow.Flow
 
-// Re-export from commons for backward compatibility
-typealias RelayListCard = com.vitorpamplona.amethyst.commons.model.RelayListCard
+/**
+ * Interface for relay-list decryption caches.
+ * Used by composables to observe decrypted relay lists from encrypted NIP-51 events.
+ */
+interface IRelayListDecryptionCache {
+    fun observeDecryptedRelayList(note: Note): Flow<RelayListCard>
 
-val EmptyRelayListCard = com.vitorpamplona.amethyst.commons.model.EmptyRelayListCard
+    fun fastStartValueForRelayList(note: Note): RelayListCard
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/ITrustedRelayListsState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/ITrustedRelayListsState.kt
@@ -18,11 +18,16 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-@file:Suppress("unused")
+package com.vitorpamplona.amethyst.commons.model
 
-package com.vitorpamplona.amethyst.model.nip51Lists.relayLists
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import kotlinx.coroutines.flow.StateFlow
 
-// Re-export from commons for backward compatibility
-typealias RelayListCard = com.vitorpamplona.amethyst.commons.model.RelayListCard
-
-val EmptyRelayListCard = com.vitorpamplona.amethyst.commons.model.EmptyRelayListCard
+/**
+ * Interface for the trusted relay lists state.
+ * Merges all relay lists the user has configured into a single set
+ * of trusted relay URLs.
+ */
+interface ITrustedRelayListsState {
+    val flow: StateFlow<Set<NormalizedRelayUrl>>
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/RelayListCard.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/RelayListCard.kt
@@ -18,11 +18,14 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-@file:Suppress("unused")
+package com.vitorpamplona.amethyst.commons.model
 
-package com.vitorpamplona.amethyst.model.nip51Lists.relayLists
+import androidx.compose.runtime.Immutable
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 
-// Re-export from commons for backward compatibility
-typealias RelayListCard = com.vitorpamplona.amethyst.commons.model.RelayListCard
+@Immutable
+data class RelayListCard(
+    val relays: List<NormalizedRelayUrl>,
+)
 
-val EmptyRelayListCard = com.vitorpamplona.amethyst.commons.model.EmptyRelayListCard
+val EmptyRelayListCard = RelayListCard(emptyList())


### PR DESCRIPTION
Adds commonly-used Account and AccountViewModel members to the IAccount and IAccountViewModel interfaces in commons, unblocking more composable signature migrations.

## IAccount additions
- `isFollowing(User)`, `isFollowing(HexKey)`
- `bookmarkState` (BookmarkListState, already in commons)
- `pinState` (new `IPinListState` interface)
- `allFollows` (new `IAllFollowsState` interface)
- `trustedRelays` (new `ITrustedRelayListsState` interface)
- `hiddenUsers` (new `IHiddenUsersState` interface)
- `client` (INostrClient)
- 7 relay list decryption caches via new `IRelayListDecryptionCache` interface

## New IAccountViewModel interface
Created `IAccountViewModel` in commons with the most commonly used members:
- `account`, `userProfile()`, `isLoggedUser()`, `isWriteable()`
- `isFollowing()`, `getNoteIfExists()`, `getAddressableNoteIfExists()`
- `checkGetOrCreateUser()`, `checkGetOrCreateNote()`
- `launchSigner()`, `runOnIO()`, `createMustShowExpandButtonFlows()`
- `decrypt()`, `follow()`, `unfollow()`, `delete()`, `hide()`
- `nip05ClientBuilder`

## Supporting types moved/created
- `RelayListCard` moved to commons (typealias kept for backward compat)
- `IAllFollowsState`, `ITrustedRelayListsState`, `IPinListState`
- `IHiddenUsersState`, `IRelayListDecryptionCache`

Part of the KMP iOS migration tracked in #2238.