### PR TITLE
feat: move composables to commons (batch 16) — newly portable files

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/RelayProxyClientConnector.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/RelayProxyClientConnector.kt
@@ -20,12 +20,12 @@
  */
 package com.vitorpamplona.amethyst.service.relayClient
 
+import com.vitorpamplona.amethyst.commons.ui.tor.TorServiceStatus
 import com.vitorpamplona.amethyst.model.torState.TorRelayEvaluation
 import com.vitorpamplona.amethyst.service.connectivity.ConnectivityManager
 import com.vitorpamplona.amethyst.service.connectivity.ConnectivityStatus
 import com.vitorpamplona.amethyst.service.okhttp.DualHttpClientManagerForRelays
 import com.vitorpamplona.amethyst.ui.tor.TorManager
-import com.vitorpamplona.amethyst.ui.tor.TorServiceStatus
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CoroutineScope

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/AdditiveComplexFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/AdditiveComplexFeedFilter.kt
@@ -20,9 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.dal
 
-abstract class AdditiveComplexFeedFilter<T, U> : FeedFilter<T>() {
-    abstract fun updateListWith(
-        oldList: List<T>,
-        newItems: Set<U>,
-    ): List<T>
-}
+// Re-export from commons for backwards compatibility
+typealias AdditiveComplexFeedFilter<T, U> = com.vitorpamplona.amethyst.commons.ui.feeds.AdditiveComplexFeedFilter<T, U>

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
@@ -23,7 +23,7 @@ package com.vitorpamplona.amethyst.ui.navigation.routes
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
 import androidx.navigation.toRoute
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.BookmarkType
+import com.vitorpamplona.amethyst.commons.ui.screens.bookmarkgroups.BookmarkType
 import com.vitorpamplona.quartz.nip01Core.core.Address
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip17Dm.base.ChatroomKey

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/BookmarkType.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/BookmarkType.kt
@@ -20,8 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups
 
-enum class BookmarkType {
-    PostBookmark,
-
-    ArticleBookmark,
-}
+// Re-export from commons for backwards compatibility
+typealias BookmarkType = com.vitorpamplona.amethyst.commons.ui.screens.bookmarkgroups.BookmarkType

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/display/BookmarkGroupScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/display/BookmarkGroupScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screens.bookmarkgroups.BookmarkType
 import com.vitorpamplona.amethyst.ui.components.ClickableBox
 import com.vitorpamplona.amethyst.ui.components.M3ActionDialog
 import com.vitorpamplona.amethyst.ui.components.M3ActionRow
@@ -65,7 +66,6 @@ import com.vitorpamplona.amethyst.ui.navigation.topbars.ShorterTopAppBar
 import com.vitorpamplona.amethyst.ui.note.ArrowBackIcon
 import com.vitorpamplona.amethyst.ui.note.VerticalDotsIcon
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.BookmarkType
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.ButtonBorder
 import com.vitorpamplona.amethyst.ui.theme.StdPadding

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/list/BookmarkGroupItem.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/list/BookmarkGroupItem.kt
@@ -57,13 +57,13 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screens.bookmarkgroups.BookmarkType
 import com.vitorpamplona.amethyst.model.nip51Lists.labeledBookmarkLists.LabeledBookmarkList
 import com.vitorpamplona.amethyst.ui.components.ClickableBox
 import com.vitorpamplona.amethyst.ui.components.M3ActionDialog
 import com.vitorpamplona.amethyst.ui.components.M3ActionRow
 import com.vitorpamplona.amethyst.ui.components.M3ActionSection
 import com.vitorpamplona.amethyst.ui.note.VerticalDotsIcon
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.BookmarkType
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.DoubleVertSpacer
 import com.vitorpamplona.amethyst.ui.theme.Font10SP

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/list/ListOfBookmarkGroupsFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/list/ListOfBookmarkGroupsFeedView.kt
@@ -42,10 +42,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screens.bookmarkgroups.BookmarkType
 import com.vitorpamplona.amethyst.model.nip51Lists.BookmarkListState
 import com.vitorpamplona.amethyst.model.nip51Lists.OldBookmarkListState
 import com.vitorpamplona.amethyst.model.nip51Lists.labeledBookmarkLists.LabeledBookmarkList
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.BookmarkType
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.DividerThickness
 import com.vitorpamplona.amethyst.ui.theme.FeedPadding

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/list/ListOfBookmarkGroupsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/list/ListOfBookmarkGroupsScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screens.bookmarkgroups.BookmarkType
 import com.vitorpamplona.amethyst.model.nip51Lists.BookmarkListState
 import com.vitorpamplona.amethyst.model.nip51Lists.OldBookmarkListState
 import com.vitorpamplona.amethyst.model.nip51Lists.labeledBookmarkLists.LabeledBookmarkList
@@ -41,7 +42,6 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.navigation.topbars.TopBarWithBackButton
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.BookmarkType
 import com.vitorpamplona.amethyst.ui.stringRes
 import kotlinx.coroutines.flow.StateFlow
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/membershipManagement/ArticleBookmarkListManagementScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/membershipManagement/ArticleBookmarkListManagementScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screens.bookmarkgroups.BookmarkType
 import com.vitorpamplona.amethyst.model.AddressableNote
 import com.vitorpamplona.amethyst.model.nip51Lists.labeledBookmarkLists.LabeledBookmarkList
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -43,7 +44,6 @@ import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.navigation.topbars.TopBarWithBackButton
 import com.vitorpamplona.amethyst.ui.note.LoadAddressableNote
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.BookmarkType
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.lists.list.NewListButton
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.quartz.nip01Core.core.Address

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/membershipManagement/PostBookmarkListManagementScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/membershipManagement/PostBookmarkListManagementScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screens.bookmarkgroups.BookmarkType
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.nip51Lists.labeledBookmarkLists.LabeledBookmarkList
 import com.vitorpamplona.amethyst.ui.components.LoadNote
@@ -43,7 +44,6 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.navigation.topbars.TopBarWithBackButton
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups.BookmarkType
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.lists.list.NewListButton
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.EventBookmark

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/communities/datasource/FilterCommunityPosts.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/communities/datasource/FilterCommunityPosts.kt
@@ -20,79 +20,33 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.communities.datasource
 
-import com.vitorpamplona.quartz.experimental.attestations.attestation.AttestationEvent
+// Re-export from commons for backwards compatibility
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
-import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
-import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
-import com.vitorpamplona.quartz.nip18Reposts.GenericRepostEvent
-import com.vitorpamplona.quartz.nip18Reposts.RepostEvent
-import com.vitorpamplona.quartz.nip22Comments.CommentEvent
-import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
-import com.vitorpamplona.quartz.nip72ModCommunities.approval.CommunityPostApprovalEvent
 import com.vitorpamplona.quartz.nip72ModCommunities.definition.CommunityDefinitionEvent
-import com.vitorpamplona.quartz.nip99Classifieds.ClassifiedsEvent
+import com.vitorpamplona.amethyst.commons.ui.screens.communities.datasource.CommunityPostKinds as CommonsCommunityPostKinds
+import com.vitorpamplona.amethyst.commons.ui.screens.communities.datasource.filterCommunityPosts as commonsFilterCommunityPosts
+import com.vitorpamplona.amethyst.commons.ui.screens.communities.datasource.filterCommunityPostsFromEverybody as commonsFilterCommunityPostsFromEverybody
+import com.vitorpamplona.amethyst.commons.ui.screens.communities.datasource.filterCommunityPostsFromModerators as commonsFilterCommunityPostsFromModerators
 
-val CommunityPostKinds =
-    listOf(
-        TextNoteEvent.KIND,
-        CommentEvent.KIND,
-        RepostEvent.KIND,
-        GenericRepostEvent.KIND,
-        ClassifiedsEvent.KIND,
-        LongTextNoteEvent.KIND,
-        CommunityPostApprovalEvent.KIND,
-        AttestationEvent.KIND,
-    )
+val CommunityPostKinds = CommonsCommunityPostKinds
 
 fun filterCommunityPosts(
     relay: NormalizedRelayUrl,
     community: CommunityDefinitionEvent,
     since: Long?,
-): RelayBasedFilter =
-    RelayBasedFilter(
-        relay = relay,
-        filter =
-            Filter(
-                authors = community.moderatorKeys(),
-                tags = mapOf("a" to listOf(community.addressTag())),
-                kinds = CommunityPostKinds,
-                limit = 500,
-                since = since,
-            ),
-    )
+): RelayBasedFilter = commonsFilterCommunityPosts(relay, community, since)
 
 fun filterCommunityPostsFromModerators(
     relay: NormalizedRelayUrl,
     authors: Set<HexKey>,
     community: CommunityDefinitionEvent,
     since: Long?,
-): RelayBasedFilter =
-    RelayBasedFilter(
-        relay = relay,
-        filter =
-            Filter(
-                authors = authors.sorted(),
-                tags = mapOf("a" to listOf(community.addressTag())),
-                kinds = CommunityPostKinds,
-                limit = 100,
-                since = since,
-            ),
-    )
+): RelayBasedFilter = commonsFilterCommunityPostsFromModerators(relay, authors, community, since)
 
 fun filterCommunityPostsFromEverybody(
     relay: NormalizedRelayUrl,
     community: CommunityDefinitionEvent,
     since: Long?,
-): RelayBasedFilter =
-    RelayBasedFilter(
-        relay = relay,
-        filter =
-            Filter(
-                tags = mapOf("a" to listOf(community.addressTag())),
-                kinds = CommunityPostKinds,
-                limit = 100,
-                since = since,
-            ),
-    )
+): RelayBasedFilter = commonsFilterCommunityPostsFromEverybody(relay, community, since)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedView.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.screens.settings.StringFeedState
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.feeds.FeedError
 import com.vitorpamplona.amethyst.ui.feeds.LoadingFeed

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedViewModel.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vitorpamplona.amethyst.commons.ui.feeds.InvalidatableContent
+import com.vitorpamplona.amethyst.commons.ui.screens.settings.StringFeedState
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.service.BundledUpdate
 import com.vitorpamplona.amethyst.service.checkNotInMainThread

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/dal/SupportedContent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/dal/SupportedContent.kt
@@ -20,27 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.video.dal
 
-class SupportedContent(
-    val blockedUrls: List<String>,
-    val mimeTypes: Set<String>,
-    val supportedFileExtensions: Set<String>,
-) {
-    private fun validExtension(fullUrl: String): Boolean {
-        val queryIndex = fullUrl.indexOf('?')
-        if (queryIndex > 0) {
-            return supportedFileExtensions.any { fullUrl.startsWith(it, queryIndex - it.length) }
-        }
-
-        val fragmentIndex = fullUrl.indexOf('#')
-        if (fragmentIndex > 0) {
-            return supportedFileExtensions.any { fullUrl.startsWith(it, fragmentIndex - it.length) }
-        }
-
-        return supportedFileExtensions.any { fullUrl.endsWith(it) }
-    }
-
-    fun acceptableUrl(
-        url: String,
-        mimeType: String?,
-    ) = blockedUrls.none { url.contains(it) } && ((mimeType != null && mimeTypes.contains(mimeType)) || validExtension(url))
-}
+// Re-export from commons for backwards compatibility
+typealias SupportedContent = com.vitorpamplona.amethyst.commons.ui.screens.video.dal.SupportedContent

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/datasource/FeedBasis.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/datasource/FeedBasis.kt
@@ -20,35 +20,21 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.video.datasource
 
-import com.vitorpamplona.quartz.experimental.nip95.header.FileStorageHeaderEvent
-import com.vitorpamplona.quartz.nip68Picture.PictureEvent
-import com.vitorpamplona.quartz.nip71Video.VideoHorizontalEvent
-import com.vitorpamplona.quartz.nip71Video.VideoNormalEvent
-import com.vitorpamplona.quartz.nip71Video.VideoShortEvent
-import com.vitorpamplona.quartz.nip71Video.VideoVerticalEvent
-import com.vitorpamplona.quartz.nip94FileMetadata.FileHeaderEvent
+// Re-export from commons for backwards compatibility
+import com.vitorpamplona.amethyst.commons.ui.screens.video.datasource.LegacyMimeTypeMap as CommonsLegacyMimeTypeMap
+import com.vitorpamplona.amethyst.commons.ui.screens.video.datasource.LegacyMimeTypes as CommonsLegacyMimeTypes
+import com.vitorpamplona.amethyst.commons.ui.screens.video.datasource.PictureAndVideoKTags as CommonsPictureAndVideoKTags
+import com.vitorpamplona.amethyst.commons.ui.screens.video.datasource.PictureAndVideoKinds as CommonsPictureAndVideoKinds
+import com.vitorpamplona.amethyst.commons.ui.screens.video.datasource.PictureAndVideoLegacyKTags as CommonsPictureAndVideoLegacyKTags
+import com.vitorpamplona.amethyst.commons.ui.screens.video.datasource.PictureAndVideoLegacyKinds as CommonsPictureAndVideoLegacyKinds
+import com.vitorpamplona.amethyst.commons.ui.screens.video.datasource.SUPPORTED_VIDEO_FEED_MIME_TYPES as CommonsSUPPORTED_VIDEO_FEED_MIME_TYPES
+import com.vitorpamplona.amethyst.commons.ui.screens.video.datasource.SUPPORTED_VIDEO_FEED_MIME_TYPES_SET as CommonsSUPPORTED_VIDEO_FEED_MIME_TYPES_SET
 
-val SUPPORTED_VIDEO_FEED_MIME_TYPES = listOf("image/jpeg", "image/gif", "image/png", "image/webp", "video/mp4", "video/mpeg", "video/webm", "audio/aac", "audio/mpeg", "audio/webm", "audio/wav", "image/avif")
-val SUPPORTED_VIDEO_FEED_MIME_TYPES_SET = SUPPORTED_VIDEO_FEED_MIME_TYPES.toSet()
-
-val PictureAndVideoKinds =
-    listOf(
-        PictureEvent.KIND,
-        VideoHorizontalEvent.KIND,
-        VideoVerticalEvent.KIND,
-        VideoNormalEvent.KIND,
-        VideoShortEvent.KIND,
-    )
-
-val PictureAndVideoKTags =
-    listOf(
-        PictureEvent.KIND.toString(),
-        VideoHorizontalEvent.KIND.toString(),
-        VideoVerticalEvent.KIND.toString(),
-        VideoNormalEvent.KIND.toString(),
-        VideoShortEvent.KIND.toString(),
-    )
-val PictureAndVideoLegacyKinds = listOf(FileHeaderEvent.KIND, FileStorageHeaderEvent.KIND)
-val PictureAndVideoLegacyKTags = listOf(FileHeaderEvent.KIND.toString(), FileStorageHeaderEvent.KIND.toString())
-val LegacyMimeTypes = SUPPORTED_VIDEO_FEED_MIME_TYPES
-val LegacyMimeTypeMap = mapOf("m" to LegacyMimeTypes)
+val SUPPORTED_VIDEO_FEED_MIME_TYPES = CommonsSUPPORTED_VIDEO_FEED_MIME_TYPES
+val SUPPORTED_VIDEO_FEED_MIME_TYPES_SET = CommonsSUPPORTED_VIDEO_FEED_MIME_TYPES_SET
+val PictureAndVideoKinds = CommonsPictureAndVideoKinds
+val PictureAndVideoKTags = CommonsPictureAndVideoKTags
+val PictureAndVideoLegacyKinds = CommonsPictureAndVideoLegacyKinds
+val PictureAndVideoLegacyKTags = CommonsPictureAndVideoLegacyKTags
+val LegacyMimeTypes = CommonsLegacyMimeTypes
+val LegacyMimeTypeMap = CommonsLegacyMimeTypeMap

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorManager.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.ui.tor
 
 import android.content.Context
+import com.vitorpamplona.amethyst.commons.ui.tor.TorServiceStatus
 import com.vitorpamplona.amethyst.model.preferences.TorSharedPreferences
 import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CoroutineScope

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorService.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorService.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.ui.tor
 
 import android.content.Context
+import com.vitorpamplona.amethyst.commons.ui.tor.TorServiceStatus
 import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorServiceStatus.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorServiceStatus.kt
@@ -20,12 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.tor
 
-sealed class TorServiceStatus {
-    data class Active(
-        val port: Int,
-    ) : TorServiceStatus()
-
-    object Off : TorServiceStatus()
-
-    object Connecting : TorServiceStatus()
-}
+// Re-export from commons for backwards compatibility
+typealias TorServiceStatus = com.vitorpamplona.amethyst.commons.ui.tor.TorServiceStatus

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/actions/mediaServers/ServerName.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/actions/mediaServers/ServerName.kt
@@ -18,10 +18,32 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.actions.mediaServers
+package com.vitorpamplona.amethyst.commons.ui.actions.mediaServers
 
-// Re-export from commons for backwards compatibility
-typealias ServerName = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.ServerName
-typealias ServerType = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.ServerType
+import kotlinx.serialization.Serializable
 
-val DEFAULT_MEDIA_SERVERS: List<ServerName> = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.DEFAULT_MEDIA_SERVERS
+@Serializable
+data class ServerName(
+    val name: String,
+    val baseUrl: String,
+    val type: ServerType = ServerType.Blossom,
+)
+
+enum class ServerType {
+    Blossom,
+    NIP95,
+    NIP96,
+}
+
+val DEFAULT_MEDIA_SERVERS: List<ServerName> =
+    listOf(
+        ServerName("Nostr.Build", "https://blossom.band/", ServerType.Blossom),
+        ServerName("24242.io", "https://24242.io/", ServerType.Blossom),
+        ServerName("Azzamo", "https://blossom.azzamo.media", ServerType.Blossom),
+        ServerName("YakiHonne", "https://blossom.yakihonne.com/", ServerType.Blossom),
+        ServerName("Primal", "https://blossom.primal.net/", ServerType.Blossom),
+        ServerName("Sovbit", "https://cdn.sovbit.host", ServerType.Blossom),
+        ServerName("Nostr.Download", "https://nostr.download", ServerType.Blossom),
+        ServerName("Satellite (Paid)", "https://cdn.satellite.earth", ServerType.Blossom),
+        ServerName("NostrMedia (Paid)", "https://nostrmedia.com", ServerType.Blossom),
+    )

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/AdditiveComplexFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/AdditiveComplexFeedFilter.kt
@@ -18,10 +18,11 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.actions.mediaServers
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-// Re-export from commons for backwards compatibility
-typealias ServerName = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.ServerName
-typealias ServerType = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.ServerType
-
-val DEFAULT_MEDIA_SERVERS: List<ServerName> = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.DEFAULT_MEDIA_SERVERS
+abstract class AdditiveComplexFeedFilter<T, U> : FeedFilter<T>() {
+    abstract fun updateListWith(
+        oldList: List<T>,
+        newItems: Set<U>,
+    ): List<T>
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screens/bookmarkgroups/BookmarkType.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screens/bookmarkgroups/BookmarkType.kt
@@ -18,7 +18,10 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings
+package com.vitorpamplona.amethyst.commons.ui.screens.bookmarkgroups
 
-// Re-export from commons for backwards compatibility
-typealias StringFeedState = com.vitorpamplona.amethyst.commons.ui.screens.settings.StringFeedState
+enum class BookmarkType {
+    PostBookmark,
+
+    ArticleBookmark,
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screens/communities/datasource/FilterCommunityPosts.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screens/communities/datasource/FilterCommunityPosts.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.screens.communities.datasource
+
+import com.vitorpamplona.quartz.experimental.attestations.attestation.AttestationEvent
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
+import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
+import com.vitorpamplona.quartz.nip18Reposts.GenericRepostEvent
+import com.vitorpamplona.quartz.nip18Reposts.RepostEvent
+import com.vitorpamplona.quartz.nip22Comments.CommentEvent
+import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
+import com.vitorpamplona.quartz.nip72ModCommunities.approval.CommunityPostApprovalEvent
+import com.vitorpamplona.quartz.nip72ModCommunities.definition.CommunityDefinitionEvent
+import com.vitorpamplona.quartz.nip99Classifieds.ClassifiedsEvent
+
+val CommunityPostKinds =
+    listOf(
+        TextNoteEvent.KIND,
+        CommentEvent.KIND,
+        RepostEvent.KIND,
+        GenericRepostEvent.KIND,
+        ClassifiedsEvent.KIND,
+        LongTextNoteEvent.KIND,
+        CommunityPostApprovalEvent.KIND,
+        AttestationEvent.KIND,
+    )
+
+fun filterCommunityPosts(
+    relay: NormalizedRelayUrl,
+    community: CommunityDefinitionEvent,
+    since: Long?,
+): RelayBasedFilter =
+    RelayBasedFilter(
+        relay = relay,
+        filter =
+            Filter(
+                authors = community.moderatorKeys(),
+                tags = mapOf("a" to listOf(community.addressTag())),
+                kinds = CommunityPostKinds,
+                limit = 500,
+                since = since,
+            ),
+    )
+
+fun filterCommunityPostsFromModerators(
+    relay: NormalizedRelayUrl,
+    authors: Set<HexKey>,
+    community: CommunityDefinitionEvent,
+    since: Long?,
+): RelayBasedFilter =
+    RelayBasedFilter(
+        relay = relay,
+        filter =
+            Filter(
+                authors = authors.sorted(),
+                tags = mapOf("a" to listOf(community.addressTag())),
+                kinds = CommunityPostKinds,
+                limit = 100,
+                since = since,
+            ),
+    )
+
+fun filterCommunityPostsFromEverybody(
+    relay: NormalizedRelayUrl,
+    community: CommunityDefinitionEvent,
+    since: Long?,
+): RelayBasedFilter =
+    RelayBasedFilter(
+        relay = relay,
+        filter =
+            Filter(
+                tags = mapOf("a" to listOf(community.addressTag())),
+                kinds = CommunityPostKinds,
+                limit = 100,
+                since = since,
+            ),
+    )

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screens/home/datasource/nip22Comments/FilterPostsByScopes.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screens/home/datasource/nip22Comments/FilterPostsByScopes.kt
@@ -18,18 +18,32 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip22Comments
+package com.vitorpamplona.amethyst.commons.ui.screens.home.datasource.nip22Comments
 
-// Re-export from commons for backwards compatibility
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
+import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
-import com.vitorpamplona.amethyst.commons.ui.screens.home.datasource.nip22Comments.CommentKinds as CommonsCommentKinds
-import com.vitorpamplona.amethyst.commons.ui.screens.home.datasource.nip22Comments.filterHomePostsByScopes as commonsFilterHomePostsByScopes
+import com.vitorpamplona.quartz.nip22Comments.CommentEvent
 
-val CommentKinds = CommonsCommentKinds
+val CommentKinds = listOf(CommentEvent.KIND)
 
 fun filterHomePostsByScopes(
     relay: NormalizedRelayUrl,
     scopesToLoad: Set<String>,
     since: Long?,
-): List<RelayBasedFilter> = commonsFilterHomePostsByScopes(relay, scopesToLoad, since)
+): List<RelayBasedFilter> {
+    if (scopesToLoad.isEmpty()) return emptyList()
+
+    return listOf(
+        RelayBasedFilter(
+            relay = relay,
+            filter =
+                Filter(
+                    kinds = CommentKinds,
+                    tags = mapOf("I" to scopesToLoad.toList()),
+                    limit = 100,
+                    since = since,
+                ),
+        ),
+    )
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screens/settings/StringFeedState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screens/settings/StringFeedState.kt
@@ -18,7 +18,21 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings
+package com.vitorpamplona.amethyst.commons.ui.screens.settings
 
-// Re-export from commons for backwards compatibility
-typealias StringFeedState = com.vitorpamplona.amethyst.commons.ui.screens.settings.StringFeedState
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.coroutines.flow.MutableStateFlow
+
+sealed class StringFeedState {
+    object Loading : StringFeedState()
+
+    class Loaded(
+        val feed: MutableStateFlow<ImmutableList<String>>,
+    ) : StringFeedState()
+
+    object Empty : StringFeedState()
+
+    class FeedError(
+        val errorMessage: String,
+    ) : StringFeedState()
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screens/video/dal/SupportedContent.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screens/video/dal/SupportedContent.kt
@@ -18,10 +18,29 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.actions.mediaServers
+package com.vitorpamplona.amethyst.commons.ui.screens.video.dal
 
-// Re-export from commons for backwards compatibility
-typealias ServerName = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.ServerName
-typealias ServerType = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.ServerType
+class SupportedContent(
+    val blockedUrls: List<String>,
+    val mimeTypes: Set<String>,
+    val supportedFileExtensions: Set<String>,
+) {
+    private fun validExtension(fullUrl: String): Boolean {
+        val queryIndex = fullUrl.indexOf('?')
+        if (queryIndex > 0) {
+            return supportedFileExtensions.any { fullUrl.startsWith(it, queryIndex - it.length) }
+        }
 
-val DEFAULT_MEDIA_SERVERS: List<ServerName> = com.vitorpamplona.amethyst.commons.ui.actions.mediaServers.DEFAULT_MEDIA_SERVERS
+        val fragmentIndex = fullUrl.indexOf('#')
+        if (fragmentIndex > 0) {
+            return supportedFileExtensions.any { fullUrl.startsWith(it, fragmentIndex - it.length) }
+        }
+
+        return supportedFileExtensions.any { fullUrl.endsWith(it) }
+    }
+
+    fun acceptableUrl(
+        url: String,
+        mimeType: String?,
+    ) = blockedUrls.none { url.contains(it) } && ((mimeType != null && mimeTypes.contains(mimeType)) || validExtension(url))
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screens/video/datasource/FeedBasis.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screens/video/datasource/FeedBasis.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.screens.video.datasource
+
+import com.vitorpamplona.quartz.experimental.nip95.header.FileStorageHeaderEvent
+import com.vitorpamplona.quartz.nip68Picture.PictureEvent
+import com.vitorpamplona.quartz.nip71Video.VideoHorizontalEvent
+import com.vitorpamplona.quartz.nip71Video.VideoNormalEvent
+import com.vitorpamplona.quartz.nip71Video.VideoShortEvent
+import com.vitorpamplona.quartz.nip71Video.VideoVerticalEvent
+import com.vitorpamplona.quartz.nip94FileMetadata.FileHeaderEvent
+
+val SUPPORTED_VIDEO_FEED_MIME_TYPES = listOf("image/jpeg", "image/gif", "image/png", "image/webp", "video/mp4", "video/mpeg", "video/webm", "audio/aac", "audio/mpeg", "audio/webm", "audio/wav", "image/avif")
+val SUPPORTED_VIDEO_FEED_MIME_TYPES_SET = SUPPORTED_VIDEO_FEED_MIME_TYPES.toSet()
+
+val PictureAndVideoKinds =
+    listOf(
+        PictureEvent.KIND,
+        VideoHorizontalEvent.KIND,
+        VideoVerticalEvent.KIND,
+        VideoNormalEvent.KIND,
+        VideoShortEvent.KIND,
+    )
+
+val PictureAndVideoKTags =
+    listOf(
+        PictureEvent.KIND.toString(),
+        VideoHorizontalEvent.KIND.toString(),
+        VideoVerticalEvent.KIND.toString(),
+        VideoNormalEvent.KIND.toString(),
+        VideoShortEvent.KIND.toString(),
+    )
+val PictureAndVideoLegacyKinds = listOf(FileHeaderEvent.KIND, FileStorageHeaderEvent.KIND)
+val PictureAndVideoLegacyKTags = listOf(FileHeaderEvent.KIND.toString(), FileStorageHeaderEvent.KIND.toString())
+val LegacyMimeTypes = SUPPORTED_VIDEO_FEED_MIME_TYPES
+val LegacyMimeTypeMap = mapOf("m" to LegacyMimeTypes)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/tor/TorServiceStatus.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/tor/TorServiceStatus.kt
@@ -18,7 +18,14 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings
+package com.vitorpamplona.amethyst.commons.ui.tor
 
-// Re-export from commons for backwards compatibility
-typealias StringFeedState = com.vitorpamplona.amethyst.commons.ui.screens.settings.StringFeedState
+sealed class TorServiceStatus {
+    data class Active(
+        val port: Int,
+    ) : TorServiceStatus()
+
+    object Off : TorServiceStatus()
+
+    object Connecting : TorServiceStatus()
+}


### PR DESCRIPTION
Moves platform-independent types and utility functions to the commons module for KMP iOS migration.

## What moved

### Data types & abstractions
- **AdditiveComplexFeedFilter** — abstract feed filter extending commons FeedFilter
- **ServerName + ServerType** — media server data model with serialization  
- **SupportedContent** — URL/MIME type validation for video feeds
- **FeedBasis** — video feed mime types and event kind constants

### Sealed classes & enums (with explicit import updates)
- **TorServiceStatus** — sealed class for Tor connection states
- **StringFeedState** — sealed class for string feed loading states
- **BookmarkType** — enum for bookmark categories

### Relay filter functions (quartz-only deps)
- **FilterCommunityPosts** — community post filter builders
- **FilterPostsByScopes** — NIP-22 comment scope filters

## Approach
- Types moved to `commons/src/commonMain/kotlin/` with appropriate package names
- Original files replaced with typealiases or delegating re-exports for backwards compatibility
- Consumers of sealed classes/enums updated with explicit imports from commons (Kotlin typealias limitation with nested type resolution via same-package access)

Part of the KMP iOS migration tracked in #2238.