### PR TITLE
feat: move note/types composables to commons (batch 17)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/CodeSnippet.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/CodeSnippet.kt
@@ -18,225 +18,23 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+@file:Suppress("unused")
+
 package com.vitorpamplona.amethyst.ui.note.types
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+// Re-export from commons for backwards compatibility
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.ui.theme.QuoteBorder
-import com.vitorpamplona.amethyst.ui.theme.StdHorzSpacer
-import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
-import com.vitorpamplona.amethyst.ui.theme.replyModifier
 import com.vitorpamplona.quartz.nipC0CodeSnippets.CodeSnippetEvent
+import com.vitorpamplona.amethyst.commons.ui.note.types.RenderCodeSnippetEvent as CommonsRenderCodeSnippetEvent
+import com.vitorpamplona.amethyst.commons.ui.note.types.RenderCodeSnippetHeaderForThread as CommonsRenderCodeSnippetHeaderForThread
 
 @Composable
 fun RenderCodeSnippetEvent(baseNote: Note) {
-    val noteEvent = baseNote.event as? CodeSnippetEvent ?: return
-
-    val name =
-        remember(noteEvent) {
-            noteEvent.snippetName()
-                ?: noteEvent.language()?.let { "$it snippet" }
-                ?: "Code Snippet"
-        }
-    val language = remember(noteEvent) { noteEvent.language() ?: noteEvent.extension() }
-    val description = remember(noteEvent) { noteEvent.snippetDescription() }
-    val codePreview =
-        remember(noteEvent) {
-            noteEvent.content
-                .lines()
-                .take(5)
-                .joinToString("\n")
-        }
-
-    Column(MaterialTheme.colorScheme.replyModifier) {
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 10.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = name,
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.weight(1f),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-            language?.let {
-                Spacer(modifier = StdHorzSpacer)
-                Box(
-                    modifier =
-                        Modifier
-                            .clip(QuoteBorder)
-                            .background(MaterialTheme.colorScheme.surfaceVariant)
-                            .padding(horizontal = 6.dp, vertical = 2.dp),
-                ) {
-                    Text(
-                        text = it,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-        }
-
-        description?.ifBlank { null }?.let {
-            Text(
-                text = it,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 10.dp),
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-            )
-            Spacer(modifier = StdVertSpacer)
-        }
-
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(10.dp)
-                    .clip(QuoteBorder)
-                    .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.05f))
-                    .border(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.3f), QuoteBorder)
-                    .padding(10.dp),
-        ) {
-            Text(
-                text = codePreview,
-                style =
-                    TextStyle(
-                        fontFamily = FontFamily.Monospace,
-                        fontSize = 12.sp,
-                    ),
-                maxLines = 5,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
-    }
+    CommonsRenderCodeSnippetEvent(baseNote)
 }
 
 @Composable
 fun RenderCodeSnippetHeaderForThread(noteEvent: CodeSnippetEvent) {
-    val name =
-        remember(noteEvent) {
-            noteEvent.snippetName()
-                ?: noteEvent.language()?.let { "$it snippet" }
-                ?: "Code Snippet"
-        }
-    val language = remember(noteEvent) { noteEvent.language() ?: noteEvent.extension() }
-    val description = remember(noteEvent) { noteEvent.snippetDescription() }
-    val license = remember(noteEvent) { noteEvent.license() }
-    val runtime = remember(noteEvent) { noteEvent.runtime() }
-    val deps = remember(noteEvent) { noteEvent.deps() }
-
-    Column(modifier = Modifier.padding(start = 12.dp, end = 12.dp, bottom = 12.dp)) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = name,
-                style = MaterialTheme.typography.headlineSmall,
-                modifier = Modifier.weight(1f),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-            language?.let {
-                Spacer(modifier = StdHorzSpacer)
-                Box(
-                    modifier =
-                        Modifier
-                            .clip(QuoteBorder)
-                            .background(MaterialTheme.colorScheme.surfaceVariant)
-                            .padding(horizontal = 8.dp, vertical = 3.dp),
-                ) {
-                    Text(
-                        text = it,
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-        }
-
-        description?.ifBlank { null }?.let {
-            Spacer(modifier = StdVertSpacer)
-            Text(
-                text = it,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
-
-        Spacer(modifier = StdVertSpacer)
-
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .clip(QuoteBorder)
-                    .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.05f))
-                    .border(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.3f), QuoteBorder)
-                    .padding(12.dp),
-        ) {
-            Text(
-                text = noteEvent.content,
-                style =
-                    TextStyle(
-                        fontFamily = FontFamily.Monospace,
-                        fontSize = 13.sp,
-                    ),
-            )
-        }
-
-        license?.let {
-            Spacer(modifier = StdVertSpacer)
-            Text(
-                text = "License: $it",
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-
-        runtime?.let {
-            Text(
-                text = "Runtime: $it",
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-
-        if (deps.isNotEmpty()) {
-            Text(
-                text = "Deps: ${deps.joinToString(", ")}",
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-    }
+    CommonsRenderCodeSnippetHeaderForThread(noteEvent)
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/EcashMint.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/EcashMint.kt
@@ -18,188 +18,30 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+@file:Suppress("unused")
+
 package com.vitorpamplona.amethyst.ui.note.types
 
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+// Re-export from commons for backwards compatibility
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
-import com.vitorpamplona.amethyst.ui.theme.QuoteBorder
-import com.vitorpamplona.amethyst.ui.theme.SmallBorder
-import com.vitorpamplona.amethyst.ui.theme.subtleBorder
 import com.vitorpamplona.quartz.nip87Ecash.cashu.CashuMintEvent
 import com.vitorpamplona.quartz.nip87Ecash.fedimint.FedimintEvent
 import com.vitorpamplona.quartz.nip87Ecash.recommendation.MintRecommendationEvent
+import com.vitorpamplona.amethyst.commons.ui.note.types.RenderCashuMint as CommonsRenderCashuMint
+import com.vitorpamplona.amethyst.commons.ui.note.types.RenderFedimint as CommonsRenderFedimint
+import com.vitorpamplona.amethyst.commons.ui.note.types.RenderMintRecommendation as CommonsRenderMintRecommendation
 
 @Composable
 fun RenderCashuMint(noteEvent: CashuMintEvent) {
-    val mintUrl = remember(noteEvent) { noteEvent.mintUrl() }
-    val nuts = remember(noteEvent) { noteEvent.nuts() }
-    val network = remember(noteEvent) { noteEvent.network() }
-
-    MintAnnouncementCard(
-        title = "Cashu Mint",
-        url = mintUrl,
-        network = network.code,
-        capabilities = nuts,
-        capabilitiesLabel = "NUTs",
-        metadata = noteEvent.content.ifBlank { null },
-    )
+    CommonsRenderCashuMint(noteEvent)
 }
 
 @Composable
 fun RenderFedimint(noteEvent: FedimintEvent) {
-    val inviteCodes = remember(noteEvent) { noteEvent.inviteCodes() }
-    val modules = remember(noteEvent) { noteEvent.modules() }
-    val network = remember(noteEvent) { noteEvent.network() }
-
-    MintAnnouncementCard(
-        title = "Fedimint",
-        url = inviteCodes.firstOrNull(),
-        network = network.code,
-        capabilities = modules,
-        capabilitiesLabel = "Modules",
-        metadata = noteEvent.content.ifBlank { null },
-    )
+    CommonsRenderFedimint(noteEvent)
 }
 
 @Composable
 fun RenderMintRecommendation(noteEvent: MintRecommendationEvent) {
-    val mintUrls = remember(noteEvent) { noteEvent.mintUrls() }
-    val mintType =
-        remember(noteEvent) {
-            when {
-                noteEvent.isCashuRecommendation() -> "Cashu Mint"
-                noteEvent.isFedimintRecommendation() -> "Fedimint"
-                else -> "Ecash Mint"
-            }
-        }
-
-    MintAnnouncementCard(
-        title = "$mintType Recommendation",
-        url = mintUrls.firstOrNull(),
-        network = null,
-        capabilities = emptyList(),
-        capabilitiesLabel = null,
-        metadata = noteEvent.content.ifBlank { null },
-    )
-}
-
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-private fun MintAnnouncementCard(
-    title: String,
-    url: String?,
-    network: String?,
-    capabilities: List<String>,
-    capabilitiesLabel: String?,
-    metadata: String?,
-) {
-    Row(
-        modifier =
-            Modifier
-                .clip(shape = QuoteBorder)
-                .border(
-                    1.dp,
-                    MaterialTheme.colorScheme.subtleBorder,
-                    QuoteBorder,
-                ).fillMaxWidth(),
-    ) {
-        Column(
-            modifier = Modifier.padding(10.dp),
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Bold,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f),
-                )
-
-                if (network != null) {
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(
-                        text = network,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.primary,
-                        fontWeight = FontWeight.Bold,
-                        modifier =
-                            Modifier
-                                .clip(SmallBorder)
-                                .border(1.dp, MaterialTheme.colorScheme.primary, SmallBorder)
-                                .padding(horizontal = 6.dp, vertical = 2.dp),
-                    )
-                }
-            }
-
-            url?.let {
-                Text(
-                    text = it,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.padding(top = 4.dp),
-                )
-            }
-
-            if (capabilities.isNotEmpty() && capabilitiesLabel != null) {
-                FlowRow(
-                    modifier = Modifier.padding(top = 6.dp),
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                    verticalArrangement = Arrangement.spacedBy(4.dp),
-                ) {
-                    Text(
-                        text = "$capabilitiesLabel: ",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = Color.Gray,
-                    )
-                    capabilities.forEach { capability ->
-                        Text(
-                            text = capability,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = Color.Gray,
-                            modifier =
-                                Modifier
-                                    .clip(SmallBorder)
-                                    .border(1.dp, Color.Gray.copy(alpha = 0.3f), SmallBorder)
-                                    .padding(horizontal = 4.dp, vertical = 1.dp),
-                        )
-                    }
-                }
-            }
-
-            metadata?.let {
-                Text(
-                    text = it,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = Color.Gray,
-                    maxLines = 3,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.padding(top = 6.dp),
-                )
-            }
-        }
-    }
+    CommonsRenderMintRecommendation(noteEvent)
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -51,6 +51,7 @@ import com.vitorpamplona.amethyst.commons.model.nip53LiveActivities.LiveActiviti
 import com.vitorpamplona.amethyst.commons.model.observables.CreatedAtComparator
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
 import com.vitorpamplona.amethyst.commons.ui.notifications.CardFeedState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
 import com.vitorpamplona.amethyst.logTime
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.AccountSettings
@@ -175,14 +176,17 @@ import kotlinx.coroutines.withContext
 
 @Stable
 class AccountViewModel(
-    val account: Account,
+    override val account: Account,
     val settings: UiSettingsState,
     val torSettings: TorSettingsFlow,
     val dataSources: RelaySubscriptionsCoordinator,
     val httpClientBuilder: IRoleBasedHttpClientBuilder,
     val nip05ClientBuilder: () -> INip05Client,
 ) : ViewModel(),
-    Dao {
+    Dao,
+    IAccountViewModel {
+    override val scope: CoroutineScope get() = viewModelScope
+
     var firstRoute: Route? = null
 
     val toastManager = ToastManager()
@@ -418,11 +422,11 @@ class AccountViewModel(
             Route.Notification() to notificationHasNewItemsFlow,
         )
 
-    fun isWriteable(): Boolean = account.isWriteable()
+    override fun isWriteable(): Boolean = account.isWriteable()
 
-    fun userProfile(): User = account.userProfile()
+    override fun userProfile(): User = account.userProfile()
 
-    fun reactToOrDelete(
+    override fun reactToOrDelete(
         note: Note,
         reaction: String,
     ) {
@@ -450,7 +454,7 @@ class AccountViewModel(
         }
     }
 
-    fun reactToOrDelete(note: Note) {
+    override fun reactToOrDelete(note: Note) {
         val reaction = reactionChoices().first()
         reactToOrDelete(note, reaction)
     }
@@ -859,7 +863,7 @@ class AccountViewModel(
         }
     }
 
-    fun boost(note: Note) {
+    override fun boost(note: Note) {
         if (settings.isCompleteUIMode()) {
             // Tracked broadcasting with progress feedback
             launchSigner {
@@ -904,7 +908,7 @@ class AccountViewModel(
 
     fun pinnedNotes(user: User): Note = LocalCache.getOrCreateAddressableNote(PinListEvent.createPinAddress(user.pubkeyHex))
 
-    fun addPin(note: Note) {
+    override fun addPin(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createAddPinEvent(note)?.let { (event, relays) ->
@@ -921,7 +925,7 @@ class AccountViewModel(
         }
     }
 
-    fun removePin(note: Note) {
+    override fun removePin(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createRemovePinEvent(note)?.let { (event, relays) ->
@@ -938,7 +942,7 @@ class AccountViewModel(
         }
     }
 
-    fun addPrivateBookmark(note: Note) {
+    override fun addPrivateBookmark(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createAddBookmarkEvent(note, true)?.let { (event, relays) ->
@@ -955,7 +959,7 @@ class AccountViewModel(
         }
     }
 
-    fun addPublicBookmark(note: Note) {
+    override fun addPublicBookmark(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createAddBookmarkEvent(note, false)?.let { (event, relays) ->
@@ -972,7 +976,7 @@ class AccountViewModel(
         }
     }
 
-    fun removePrivateBookmark(note: Note) {
+    override fun removePrivateBookmark(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createRemoveBookmarkEvent(note, true)?.let { (event, relays) ->
@@ -990,7 +994,7 @@ class AccountViewModel(
         }
     }
 
-    fun removePublicBookmark(note: Note) {
+    override fun removePublicBookmark(note: Note) {
         if (settings.isCompleteUIMode()) {
             launchSigner {
                 account.createRemoveBookmarkEvent(note, false)?.let { (event, relays) ->
@@ -1007,13 +1011,13 @@ class AccountViewModel(
         }
     }
 
-    fun broadcast(note: Note) = launchSigner { account.broadcast(note) }
+    override fun broadcast(note: Note) = launchSigner { account.broadcast(note) }
 
     fun timestamp(note: Note) = launchSigner { account.otsState.timestamp(note) }
 
-    fun delete(notes: List<Note>) = launchSigner { account.delete(notes) }
+    override fun delete(notes: List<Note>) = launchSigner { account.delete(notes) }
 
-    fun delete(note: Note) = launchSigner { account.delete(note) }
+    override fun delete(note: Note) = launchSigner { account.delete(note) }
 
     fun requestToVanish(
         relays: List<NormalizedRelayUrl>,
@@ -1026,9 +1030,9 @@ class AccountViewModel(
         createdAt: Long,
     ) = launchSigner { account.requestToVanishFromEverywhere(reason, createdAt) }
 
-    fun cachedDecrypt(note: Note): String? = account.cachedDecryptContent(note)
+    override fun cachedDecrypt(note: Note): String? = account.cachedDecryptContent(note)
 
-    fun decrypt(
+    override fun decrypt(
         note: Note,
         onReady: (String) -> Unit,
     ) = launchSigner {
@@ -1095,9 +1099,9 @@ class AccountViewModel(
 
     fun follow(users: List<User>) = launchSigner { account.follow(users) }
 
-    fun follow(user: User) = launchSigner { account.follow(user) }
+    override fun follow(user: User) = launchSigner { account.follow(user) }
 
-    fun unfollow(user: User) = launchSigner { account.unfollow(user) }
+    override fun unfollow(user: User) = launchSigner { account.unfollow(user) }
 
     fun followGeohash(tag: String) = launchSigner { account.followGeohash(tag) }
 
@@ -1115,16 +1119,16 @@ class AccountViewModel(
 
     fun hideWord(word: String) = launchSigner { account.hideWord(word) }
 
-    fun isLoggedUser(pubkeyHex: HexKey?): Boolean = account.signer.pubKey == pubkeyHex
+    override fun isLoggedUser(pubkeyHex: HexKey?): Boolean = account.signer.pubKey == pubkeyHex
 
-    fun isLoggedUser(user: User?): Boolean = isLoggedUser(user?.pubkeyHex)
+    override fun isLoggedUser(user: User?): Boolean = isLoggedUser(user?.pubkeyHex)
 
-    fun isFollowing(user: User?): Boolean {
+    override fun isFollowing(user: User?): Boolean {
         if (user == null) return false
         return account.isFollowing(user)
     }
 
-    fun isFollowing(user: HexKey): Boolean = account.isFollowing(user)
+    override fun isFollowing(user: HexKey): Boolean = account.isFollowing(user)
 
     fun markDonatedInThisVersion() = account.markDonatedInThisVersion()
 
@@ -1137,21 +1141,21 @@ class AccountViewModel(
         pollEndsAt: Long?,
     ) = account.markPollResultsViewed(noteId, pollEndsAt)
 
-    fun dontTranslateFrom() = account.settings.syncedSettings.languages.dontTranslateFrom.value
+    override fun dontTranslateFrom() = account.settings.syncedSettings.languages.dontTranslateFrom.value
 
-    fun translateTo() = account.settings.syncedSettings.languages.translateTo.value
+    override fun translateTo() = account.settings.syncedSettings.languages.translateTo.value
 
-    fun defaultZapType() = account.settings.syncedSettings.zaps.defaultZapType.value
+    override fun defaultZapType() = account.settings.syncedSettings.zaps.defaultZapType.value
 
-    fun showSensitiveContent(): MutableStateFlow<Boolean?> = account.settings.syncedSettings.security.showSensitiveContent
+    override fun showSensitiveContent(): MutableStateFlow<Boolean?> = account.settings.syncedSettings.security.showSensitiveContent
 
     fun zapAmountChoicesFlow() = account.settings.syncedSettings.zaps.zapAmountChoices
 
-    fun zapAmountChoices() = zapAmountChoicesFlow().value
+    override fun zapAmountChoices() = zapAmountChoicesFlow().value
 
     fun reactionChoicesFlow() = account.settings.syncedSettings.reactions.reactionChoices
 
-    fun reactionChoices() = reactionChoicesFlow().value
+    override fun reactionChoices() = reactionChoicesFlow().value
 
     fun filterSpamFromStrangers() = account.settings.syncedSettings.security.filterSpamFromStrangers
 
@@ -1205,9 +1209,9 @@ class AccountViewModel(
         preference: String,
     ) = launchSigner { account.prefer(source, target, preference) }
 
-    fun show(user: User) = launchSigner { account.showUser(user.pubkeyHex) }
+    override fun show(user: User) = launchSigner { account.showUser(user.pubkeyHex) }
 
-    fun hide(user: User) = launchSigner { account.hideUser(user.pubkeyHex) }
+    override fun hide(user: User) = launchSigner { account.hideUser(user.pubkeyHex) }
 
     fun hide(word: String) = launchSigner { account.hideWord(word) }
 
@@ -1236,23 +1240,23 @@ class AccountViewModel(
         }
     }
 
-    fun loadReactionTo(note: Note?): String? {
+    override fun loadReactionTo(note: Note?): String? {
         if (note == null) return null
 
         return note.getReactionBy(userProfile())
     }
 
-    fun runOnIO(runOnIO: suspend () -> Unit) {
+    override fun runOnIO(runOnIO: suspend () -> Unit) {
         viewModelScope.launch(Dispatchers.IO) { runOnIO() }
     }
 
-    fun checkGetOrCreateUser(key: HexKey): User? = LocalCache.checkGetOrCreateUser(key)
+    override fun checkGetOrCreateUser(key: HexKey): User? = LocalCache.checkGetOrCreateUser(key)
 
     override suspend fun getOrCreateUser(hex: HexKey): User = LocalCache.getOrCreateUser(hex)
 
-    fun getUserIfExists(hex: HexKey): User? = LocalCache.getUserIfExists(hex)
+    override fun getUserIfExists(hex: HexKey): User? = LocalCache.getUserIfExists(hex)
 
-    fun checkGetOrCreateNote(key: HexKey): Note? = LocalCache.checkGetOrCreateNote(key)
+    override fun checkGetOrCreateNote(key: HexKey): Note? = LocalCache.checkGetOrCreateNote(key)
 
     override suspend fun getOrCreateNote(hex: HexKey): Note = LocalCache.getOrCreateNote(hex)
 
@@ -1267,7 +1271,7 @@ class AccountViewModel(
         return note
     }
 
-    fun getNoteIfExists(hex: HexKey): Note? = LocalCache.getNoteIfExists(hex)
+    override fun getNoteIfExists(hex: HexKey): Note? = LocalCache.getNoteIfExists(hex)
 
     /**
      * Fixes author and relay hints in MarkedETag list by looking up notes from cache.
@@ -1297,9 +1301,9 @@ class AccountViewModel(
 
     override fun getOrCreateAddressableNote(address: Address): AddressableNote = LocalCache.getOrCreateAddressableNote(address)
 
-    fun getAddressableNoteIfExists(key: String): AddressableNote? = LocalCache.getAddressableNoteIfExists(key)
+    override fun getAddressableNoteIfExists(key: String): AddressableNote? = LocalCache.getAddressableNoteIfExists(key)
 
-    fun getAddressableNoteIfExists(key: Address): AddressableNote? = LocalCache.getAddressableNoteIfExists(key)
+    override fun getAddressableNoteIfExists(key: Address): AddressableNote? = LocalCache.getAddressableNoteIfExists(key)
 
     fun cachedModificationEventsForNote(note: Note) = LocalCache.cachedModificationEventsForNote(note)
 
@@ -1361,7 +1365,7 @@ class AccountViewModel(
             OnlineChecker.isOnline(videoUrl, httpClientBuilder::okHttpClientForVideo)
         }
 
-    fun loadAndMarkAsRead(
+    override fun loadAndMarkAsRead(
         routeForLastRead: String,
         createdAt: Long?,
     ): Boolean {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/BookmarkType.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/BookmarkType.kt
@@ -20,8 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.bookmarkgroups
 
-enum class BookmarkType {
-    PostBookmark,
-
-    ArticleBookmark,
-}
+// Re-export from commons for backwards compatibility
+typealias BookmarkType = com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.bookmarkgroups.BookmarkType

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/theme/Shape.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/theme/Shape.kt
@@ -20,391 +20,492 @@
  */
 package com.vitorpamplona.amethyst.ui.theme
 
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.defaultMinSize
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.CornerSize
-import androidx.compose.foundation.shape.CutCornerShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.Shapes
-import androidx.compose.material3.ripple
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.Placeholder
-import androidx.compose.ui.text.PlaceholderVerticalAlign
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.TextLinkStyles
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.KeyboardCapitalization
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import com.vitorpamplona.amethyst.ui.navigation.topbars.TopBarSize
-
-val Shapes =
-    Shapes(
-        small = RoundedCornerShape(4.dp),
-        medium = RoundedCornerShape(4.dp),
-        large = RoundedCornerShape(0.dp),
-    )
-
-val RippleRadius45dp = 45.dp // Ripple should be +10.dp over the component size
-
-val BottomTopHeight = Modifier.height(50.dp)
-val TabRowHeight = Modifier
-
-val SmallestBorder = RoundedCornerShape(5.dp)
-val SmallBorder = RoundedCornerShape(7.dp)
-val SmallishBorder = RoundedCornerShape(9.dp)
-val QuoteBorder = RoundedCornerShape(15.dp)
-
-val ButtonBorder = RoundedCornerShape(20.dp)
-val LeftHalfCircleButtonBorder = ButtonBorder.copy(topEnd = CornerSize(0f), bottomEnd = CornerSize(0f))
-val EditFieldBorder = RoundedCornerShape(25.dp)
-
-val ChatBubbleShapeMe = RoundedCornerShape(15.dp, 15.dp, 3.dp, 15.dp)
-val ChatBubbleShapeThem = RoundedCornerShape(3.dp, 15.dp, 15.dp, 15.dp)
-
-val StdButtonSizeModifier = Modifier.size(19.dp)
-
-val HalfVertSpacer = Modifier.height(2.dp)
-
-val MinHorzSpacer = Modifier.width(1.dp)
-
-val HalfHorzSpacer = Modifier.width(3.dp)
-
-val StdHorzSpacer = Modifier.width(5.dp)
-val StdVertSpacer = Modifier.height(5.dp)
-
-val DoubleHorzSpacer = Modifier.width(10.dp)
-val DoubleVertSpacer = Modifier.height(10.dp)
-
-val Height100Modifier = Modifier.height(100.dp)
-
-val HalfDoubleVertSpacer = Modifier.height(7.dp)
-
-val Size0dp = 0.dp
-val Size2dp = 2.dp
-val Size3dp = 3.dp
-val Size5dp = 5.dp
-val Size6dp = 6.dp
-val Size8dp = 8.dp
-val Size10dp = 10.dp
-val Size12dp = 12.dp
-val Size13dp = 13.dp
-val Size14dp = 14.dp
-val Size15dp = 15.dp
-val Size16dp = 16.dp
-val Size17dp = 17.dp
-val Size18dp = 18.dp
-val Size19dp = 19.dp
-val Size20dp = 20.dp
-val Size22dp = 22.dp
-val Size23dp = 23.dp
-val Size24dp = 24.dp
-val Size25dp = 25.dp
-val Size30dp = 30.dp
-val Size34dp = 34.dp
-val Size35dp = 35.dp
-val Size40dp = 40.dp
-val Size50dp = 50.dp
-val Size55dp = 55.dp
-val Size75dp = 75.dp
-val Size100dp = 100.dp
-val Size110dp = 110.dp
-val Size165dp = 165.dp
-
-val StdEndPadding = Modifier.padding(end = 10.dp)
-val HalfEndPadding = Modifier.padding(end = 5.dp)
-val HalfStartPadding = Modifier.padding(start = 5.dp)
-val StdStartPadding = Modifier.padding(start = 10.dp)
-val StdTopPadding = Modifier.padding(top = 10.dp)
-val HalfTopPadding = Modifier.padding(top = 5.dp)
-val HalfHalfTopPadding = Modifier.padding(top = 3.dp)
-
-val HalfHalfVertPadding = Modifier.padding(vertical = 3.dp)
-val HalfHalfHorzModifier = Modifier.padding(horizontal = 3.dp)
-
-val HalfPadding = Modifier.padding(5.dp)
-val StdPadding = Modifier.padding(10.dp)
-val BigPadding = Modifier.padding(15.dp)
-
-val RowColSpacing = Arrangement.spacedBy(3.dp)
-val RowColSpacing5dp = Arrangement.spacedBy(5.dp)
-val RowColSpacing10dp = Arrangement.spacedBy(10.dp)
-
-val HalfHorzPadding = Modifier.padding(horizontal = 5.dp)
-val HalfVertPadding = Modifier.padding(vertical = 5.dp)
-
-val HorzPadding = Modifier.padding(horizontal = 10.dp)
-val VertPadding = Modifier.padding(vertical = 10.dp)
-
-val HorzHalfVertPadding = Modifier.padding(horizontal = 10.dp, vertical = 5.dp)
-
-val DoubleHorzPadding = Modifier.padding(horizontal = 20.dp)
-val DoubleVertPadding = Modifier.padding(vertical = 20.dp)
-
-val MaxWidthWithHorzPadding = Modifier.fillMaxWidth().padding(horizontal = 10.dp)
-
-val Size5Modifier = Modifier.size(5.dp)
-val Size10Modifier = Modifier.size(10.dp)
-val Size14Modifier = Modifier.size(14.dp)
-val Size15Modifier = Modifier.size(15.dp)
-val Size16Modifier = Modifier.size(16.dp)
-val Size17Modifier = Modifier.size(17.dp)
-val Size18Modifier = Modifier.size(18.dp)
-val Size19Modifier = Modifier.size(19.dp)
-val Size20Modifier = Modifier.size(20.dp)
-val Size22Modifier = Modifier.size(22.dp)
-val Size24Modifier = Modifier.size(24.dp)
-val Size25Modifier = Modifier.size(25.dp)
-val Size26Modifier = Modifier.size(26.dp)
-val Size28Modifier = Modifier.size(28.dp)
-val Size30Modifier = Modifier.size(30.dp)
-val Size35Modifier = Modifier.size(35.dp)
-val Size39Modifier = Modifier.size(39.dp)
-val Size40Modifier = Modifier.size(40.dp)
-val Size50Modifier = Modifier.size(50.dp)
-val Size55Modifier = Modifier.size(55.dp)
-val Size75Modifier = Modifier.size(75.dp)
-
-val TinyBorders = Modifier.padding(2.dp)
-val NoSoTinyBorders = Modifier.padding(start = 5.dp, end = 5.dp, top = 2.dp, bottom = 2.dp)
-val ReactionRowZapraiserWithPadding = Modifier.defaultMinSize(minHeight = 4.dp).padding(start = Size75dp).fillMaxWidth()
-val ReactionRowZapraiser = Modifier.defaultMinSize(minHeight = 4.dp).fillMaxWidth()
-
-val ReactionRowExpandButton = Modifier.width(65.dp).padding(start = 31.dp)
-
-val WidthAuthorPictureModifier = Modifier.width(55.dp)
-val WidthAuthorPictureModifierWithPadding = Modifier.width(65.dp)
-
-val VideoReactionColumnPadding = Modifier.padding(bottom = 75.dp)
-
-val DividerThickness = 0.25.dp
-
-val ReactionRowHeight = Modifier.padding(vertical = 7.dp).heightIn(min = 24.dp)
-val ReactionRowHeightWithPadding = Modifier.padding(vertical = 6.dp).heightIn(min = 24.dp).padding(horizontal = 10.dp)
-val ReactionRowHeightChat = Modifier.height(20.dp)
-val ReactionRowHeightChatMaxWidth = Modifier.height(25.dp).fillMaxWidth()
-val UserNameRowHeight = Modifier.fillMaxWidth()
-val UserNameMaxRowHeight = Modifier.fillMaxWidth()
-
-val Height24dpModifier = Modifier.height(24.dp)
-val Height4dpModifier = Modifier.height(4.dp)
-val Height25Modifier = Modifier.height(Size25dp)
-
-val Height24dpFilledModifier = Modifier.fillMaxWidth().height(24.dp)
-val Height4dpFilledModifier = Modifier.fillMaxWidth().height(4.dp)
-
-val AccountPictureModifier = Modifier.size(55.dp).clip(shape = CircleShape)
-val HeaderPictureModifier = Modifier.size(34.dp).clip(shape = CircleShape)
-
-val ShowMoreRelaysButtonIconButtonModifier = Modifier.size(15.dp)
-val ShowMoreRelaysButtonIconModifier = Modifier.size(20.dp)
-val ShowMoreRelaysButtonBoxModifer = Modifier.width(55.dp).height(17.dp)
-
-val ChatBubbleMaxSizeModifier = Modifier.fillMaxWidth(0.85f)
-
-val ModifierWidth3dp = Modifier.width(3.dp)
-
-val NotificationIconModifier = Modifier.width(55.dp).padding(end = 5.dp)
-val NotificationIconModifierSmaller = Modifier.width(55.dp).padding(end = 4.dp)
-
-val ZapPictureCommentModifier = Modifier.height(35.dp).widthIn(min = 35.dp)
-val ChatHeadlineBorders = StdPadding
-
-val VolumeBottomIconSize = Modifier.size(60.dp).padding(5.dp)
-val PinBottomIconSize = Modifier.size(60.dp).padding(5.dp)
-val PlayIconSize = Modifier.size(110.dp).padding(10.dp)
-val NIP05IconSize = Modifier.size(13.dp).padding(top = 1.dp, start = 1.dp, end = 1.dp)
-
-val CashuCardBorders = Modifier.fillMaxWidth().padding(10.dp).clip(shape = QuoteBorder)
-
-val EditFieldModifier =
-    Modifier.padding(start = 10.dp, end = 10.dp, bottom = 10.dp, top = 5.dp).fillMaxWidth()
-val EditFieldTrailingIconModifier = Modifier.padding(start = 5.dp, end = 0.dp)
-
-val ZeroPadding = PaddingValues(0.dp)
-val HalfFeedPadding = PaddingValues(5.dp)
-val FeedPadding = PaddingValues(top = 10.dp, bottom = 10.dp)
-val ButtonPadding = PaddingValues(vertical = 6.dp, horizontal = 16.dp)
-
-val ChatPaddingInnerQuoteModifier = Modifier
-val ChatPaddingModifier =
-    Modifier
-        .fillMaxWidth(1f)
-        .padding(
-            start = 12.dp,
-            end = 12.dp,
-            top = 3.dp,
-            bottom = 3.dp,
-        )
-
-val profileContentHeaderModifier =
-    Modifier.fillMaxWidth().padding(top = 70.dp, start = Size25dp, end = Size25dp)
-val bannerModifier = Modifier.fillMaxWidth().height(120.dp)
-val drawerSpacing = Modifier.padding(top = Size10dp, start = Size25dp, end = Size25dp)
-
-val IconRowTextModifier = Modifier.padding(start = 16.dp)
-val IconRowModifier = Modifier.fillMaxWidth().padding(vertical = 15.dp, horizontal = 25.dp)
-
-val Width16Space = Modifier.width(Size16dp)
-
-val emptyLineItemModifier = Modifier.height(Size75dp).fillMaxWidth()
-
-val imageHeaderBannerSize = Modifier.fillMaxWidth().height(150.dp)
-
-val authorNotePictureForImageHeader = Modifier.size(75.dp).padding(10.dp)
-
-val normalWithTopMarginNoteModifier =
-    Modifier
-        .fillMaxWidth()
-        .padding(
-            start = 12.dp,
-            end = 12.dp,
-            top = 10.dp,
-        )
-
-val boostedNoteModifier =
-    Modifier
-        .fillMaxWidth()
-        .padding(
-            start = 0.dp,
-            end = 0.dp,
-            top = 0.dp,
-        )
-
-val liveStreamTag =
-    Modifier
-        .clip(SmallBorder)
-        .background(Color.Black)
-        .padding(horizontal = Size5dp)
-
-val chatAuthorBox = Modifier.size(20.dp)
-val chatAuthorImage = Modifier.size(20.dp).clip(shape = CircleShape)
-val AuthorInfoVideoFeed = Modifier.width(75.dp).padding(end = 15.dp)
-
-val messageDetailsModifier = Modifier.height(Size25dp)
-val messageBubbleLimits = Modifier.padding(start = 10.dp, end = 10.dp, top = 7.dp, bottom = 6.dp)
-
-val inlinePlaceholder =
-    Placeholder(
-        width = Font17SP,
-        height = Font17SP,
-        placeholderVerticalAlign = PlaceholderVerticalAlign.Center,
-    )
-
-val IncognitoIconModifier = Modifier.padding(top = 1.dp).size(14.dp)
-val IncognitoIconButtonModifier = Modifier.padding(top = 2.dp).size(20.dp)
-
-val hashVerifierMark = Modifier.width(40.dp).height(40.dp).padding(10.dp)
-
-val noteComposeRelayBox = Modifier.width(55.dp).heightIn(min = 17.dp).padding(start = 2.dp, end = 1.dp)
-
-val previewCardImageModifier = Modifier.fillMaxWidth().heightIn(max = 200.dp).padding(bottom = 5.dp)
-
-val reactionBox =
-    Modifier
-        .padding(horizontal = 6.dp, vertical = 6.dp)
-        .size(Size40dp)
-        .padding(5.dp)
-
-val ripple24dp = ripple(bounded = false, radius = Size24dp)
-
-val defaultTweenDuration = 100
-val defaultTweenFloatSpec = tween<Float>(durationMillis = defaultTweenDuration)
-val defaultTweenIntOffsetSpec = tween<IntOffset>(durationMillis = defaultTweenDuration)
-
-val StreamingHeaderModifier =
-    Modifier
-        .fillMaxWidth()
-        .heightIn(min = 50.dp, max = 300.dp)
-
-val PostKeyboard =
-    KeyboardOptions.Default.copy(
-        autoCorrectEnabled = true,
-        capitalization = KeyboardCapitalization.Sentences,
-    )
-
-val SettingsCategoryFirstModifier = Modifier.padding(bottom = 8.dp)
-val SettingsCategorySpacingModifier = Modifier.padding(top = 24.dp, bottom = 8.dp)
-
-val SettingsCategoryFirstWithHorzBorderModifier = Modifier.padding(bottom = 8.dp, start = 10.dp, end = 10.dp)
-val SettingsCategorySpacingWithHorzBorderModifier = Modifier.padding(top = 24.dp, bottom = 8.dp, start = 10.dp, end = 10.dp)
-
-val SquaredQuoteBorderModifier = Modifier.aspectRatio(1f).clip(shape = QuoteBorder)
-val FillWidthQuoteBorderModifier = Modifier.fillMaxWidth().clip(shape = QuoteBorder)
-
-val MediumRelayIconModifier =
-    Modifier
-        .size(Size35dp)
-        .clip(shape = CircleShape)
-
-val LargeRelayIconModifier =
-    Modifier
-        .size(Size55dp)
-        .clip(shape = CircleShape)
-
-val FollowSetImageModifier =
-    Modifier
-        .fillMaxWidth()
-        .clip(QuoteBorder)
-        .aspectRatio(ratio = 21f / 9f)
-
-val SimpleImage75Modifier = Modifier.size(Size75dp).clip(QuoteBorder)
-val SimpleImage35Modifier = Modifier.size(Size34dp).clip(shape = CircleShape)
-
-val SimpleImageBorder = Modifier.fillMaxSize().clip(QuoteBorder)
-
-val SimpleHeaderImage = Modifier.fillMaxWidth().heightIn(max = 200.dp)
-
-val BadgePictureModifier = Modifier.size(35.dp).clip(shape = CutCornerShape(20))
-
-val MaxWidthPaddingTop5dp = Modifier.fillMaxWidth().padding(top = 5.dp)
-
-val VoiceHeightModifier = Modifier.fillMaxWidth().height(100.dp)
-
-val PaddingHorizontal12Modifier = Modifier.padding(horizontal = 12.dp)
-
-val QuickActionPopupShadow = Modifier.shadow(elevation = Size6dp, shape = SmallestBorder)
-
-val SpacedBy2dp = Arrangement.spacedBy(Size2dp)
-val SpacedBy3dp = Arrangement.spacedBy(Size3dp)
-val SpacedBy5dp = Arrangement.spacedBy(Size5dp)
-val SpacedBy10dp = Arrangement.spacedBy(Size10dp)
-val SpacedBy55dp = Arrangement.spacedBy(Size55dp)
-
-val PopupUpEffect = RoundedCornerShape(0.dp, 0.dp, 15.dp, 15.dp)
-
-val Size50ModifierOffset10 = Modifier.size(50.dp).offset(y = (-10).dp)
-
-val SuggestionListDefaultHeightChat = Modifier.heightIn(0.dp, 200.dp)
-val SuggestionListDefaultHeightPage = Modifier.heightIn(0.dp, 300.dp)
-
-val FollowPackHeaderModifier = Modifier.fillMaxWidth().height(TopBarSize)
-
-val Size22ModifierWith4Padding = Modifier.size(22.dp).padding(end = 4.dp)
-
-val TextStyleBottomNavBar =
-    TextLinkStyles(
-        SpanStyle(
-            fontSize = 12.sp,
-            fontWeight = FontWeight.Bold,
-        ),
-    )
+// Backward-compatible re-exports — all shape/layout definitions live in commons
+import com.vitorpamplona.amethyst.commons.ui.theme.AccountPictureModifier as CommonsAccountPictureModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.AuthorInfoVideoFeed as CommonsAuthorInfoVideoFeed
+import com.vitorpamplona.amethyst.commons.ui.theme.BadgePictureModifier as CommonsBadgePictureModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.BigPadding as CommonsBigPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.BottomTopHeight as CommonsBottomTopHeight
+import com.vitorpamplona.amethyst.commons.ui.theme.ButtonBorder as CommonsButtonBorder
+import com.vitorpamplona.amethyst.commons.ui.theme.ButtonPadding as CommonsButtonPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.CashuCardBorders as CommonsCashuCardBorders
+import com.vitorpamplona.amethyst.commons.ui.theme.ChatBubbleMaxSizeModifier as CommonsChatBubbleMaxSizeModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.ChatBubbleShapeMe as CommonsChatBubbleShapeMe
+import com.vitorpamplona.amethyst.commons.ui.theme.ChatBubbleShapeThem as CommonsChatBubbleShapeThem
+import com.vitorpamplona.amethyst.commons.ui.theme.ChatHeadlineBorders as CommonsChatHeadlineBorders
+import com.vitorpamplona.amethyst.commons.ui.theme.ChatPaddingInnerQuoteModifier as CommonsChatPaddingInnerQuoteModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.ChatPaddingModifier as CommonsChatPaddingModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.DividerThickness as CommonsDividerThickness
+import com.vitorpamplona.amethyst.commons.ui.theme.DoubleHorzPadding as CommonsDoubleHorzPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.DoubleHorzSpacer as CommonsDoubleHorzSpacer
+import com.vitorpamplona.amethyst.commons.ui.theme.DoubleVertPadding as CommonsDoubleVertPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.DoubleVertSpacer as CommonsDoubleVertSpacer
+import com.vitorpamplona.amethyst.commons.ui.theme.EditFieldBorder as CommonsEditFieldBorder
+import com.vitorpamplona.amethyst.commons.ui.theme.EditFieldModifier as CommonsEditFieldModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.EditFieldTrailingIconModifier as CommonsEditFieldTrailingIconModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.FeedPadding as CommonsFeedPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.FillWidthQuoteBorderModifier as CommonsFillWidthQuoteBorderModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.FollowPackHeaderModifier as CommonsFollowPackHeaderModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.FollowSetImageModifier as CommonsFollowSetImageModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.HalfDoubleVertSpacer as CommonsHalfDoubleVertSpacer
+import com.vitorpamplona.amethyst.commons.ui.theme.HalfEndPadding as CommonsHalfEndPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.HalfFeedPadding as CommonsHalfFeedPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.HalfHalfHorzModifier as CommonsHalfHalfHorzModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.HalfHalfTopPadding as CommonsHalfHalfTopPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.HalfHalfVertPadding as CommonsHalfHalfVertPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.HalfHorzPadding as CommonsHalfHorzPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.HalfHorzSpacer as CommonsHalfHorzSpacer
+import com.vitorpamplona.amethyst.commons.ui.theme.HalfPadding as CommonsHalfPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.HalfStartPadding as CommonsHalfStartPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.HalfTopPadding as CommonsHalfTopPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.HalfVertPadding as CommonsHalfVertPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.HalfVertSpacer as CommonsHalfVertSpacer
+import com.vitorpamplona.amethyst.commons.ui.theme.HeaderPictureModifier as CommonsHeaderPictureModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Height100Modifier as CommonsHeight100Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Height24dpFilledModifier as CommonsHeight24dpFilledModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Height24dpModifier as CommonsHeight24dpModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Height25Modifier as CommonsHeight25Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Height4dpFilledModifier as CommonsHeight4dpFilledModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Height4dpModifier as CommonsHeight4dpModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.HorzHalfVertPadding as CommonsHorzHalfVertPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.HorzPadding as CommonsHorzPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.IconRowModifier as CommonsIconRowModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.IconRowTextModifier as CommonsIconRowTextModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.IncognitoIconButtonModifier as CommonsIncognitoIconButtonModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.IncognitoIconModifier as CommonsIncognitoIconModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.LargeRelayIconModifier as CommonsLargeRelayIconModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.LeftHalfCircleButtonBorder as CommonsLeftHalfCircleButtonBorder
+import com.vitorpamplona.amethyst.commons.ui.theme.MaxWidthPaddingTop5dp as CommonsMaxWidthPaddingTop5dp
+import com.vitorpamplona.amethyst.commons.ui.theme.MaxWidthWithHorzPadding as CommonsMaxWidthWithHorzPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.MediumRelayIconModifier as CommonsMediumRelayIconModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.MinHorzSpacer as CommonsMinHorzSpacer
+import com.vitorpamplona.amethyst.commons.ui.theme.ModifierWidth3dp as CommonsModifierWidth3dp
+import com.vitorpamplona.amethyst.commons.ui.theme.NIP05IconSize as CommonsNIP05IconSize
+import com.vitorpamplona.amethyst.commons.ui.theme.NoSoTinyBorders as CommonsNoSoTinyBorders
+import com.vitorpamplona.amethyst.commons.ui.theme.NotificationIconModifier as CommonsNotificationIconModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.NotificationIconModifierSmaller as CommonsNotificationIconModifierSmaller
+import com.vitorpamplona.amethyst.commons.ui.theme.PaddingHorizontal12Modifier as CommonsPaddingHorizontal12Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.PinBottomIconSize as CommonsPinBottomIconSize
+import com.vitorpamplona.amethyst.commons.ui.theme.PlayIconSize as CommonsPlayIconSize
+import com.vitorpamplona.amethyst.commons.ui.theme.PopupUpEffect as CommonsPopupUpEffect
+import com.vitorpamplona.amethyst.commons.ui.theme.PostKeyboard as CommonsPostKeyboard
+import com.vitorpamplona.amethyst.commons.ui.theme.QuickActionPopupShadow as CommonsQuickActionPopupShadow
+import com.vitorpamplona.amethyst.commons.ui.theme.QuoteBorder as CommonsQuoteBorder
+import com.vitorpamplona.amethyst.commons.ui.theme.ReactionRowExpandButton as CommonsReactionRowExpandButton
+import com.vitorpamplona.amethyst.commons.ui.theme.ReactionRowHeight as CommonsReactionRowHeight
+import com.vitorpamplona.amethyst.commons.ui.theme.ReactionRowHeightChat as CommonsReactionRowHeightChat
+import com.vitorpamplona.amethyst.commons.ui.theme.ReactionRowHeightChatMaxWidth as CommonsReactionRowHeightChatMaxWidth
+import com.vitorpamplona.amethyst.commons.ui.theme.ReactionRowHeightWithPadding as CommonsReactionRowHeightWithPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.ReactionRowZapraiser as CommonsReactionRowZapraiser
+import com.vitorpamplona.amethyst.commons.ui.theme.ReactionRowZapraiserWithPadding as CommonsReactionRowZapraiserWithPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.RippleRadius45dp as CommonsRippleRadius45dp
+import com.vitorpamplona.amethyst.commons.ui.theme.RowColSpacing as CommonsRowColSpacing
+import com.vitorpamplona.amethyst.commons.ui.theme.RowColSpacing10dp as CommonsRowColSpacing10dp
+import com.vitorpamplona.amethyst.commons.ui.theme.RowColSpacing5dp as CommonsRowColSpacing5dp
+import com.vitorpamplona.amethyst.commons.ui.theme.SettingsCategoryFirstModifier as CommonsSettingsCategoryFirstModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.SettingsCategoryFirstWithHorzBorderModifier as CommonsSettingsCategoryFirstWithHorzBorderModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.SettingsCategorySpacingModifier as CommonsSettingsCategorySpacingModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.SettingsCategorySpacingWithHorzBorderModifier as CommonsSettingsCategorySpacingWithHorzBorderModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Shapes as CommonsShapes
+import com.vitorpamplona.amethyst.commons.ui.theme.ShowMoreRelaysButtonBoxModifer as CommonsShowMoreRelaysButtonBoxModifer
+import com.vitorpamplona.amethyst.commons.ui.theme.ShowMoreRelaysButtonIconButtonModifier as CommonsShowMoreRelaysButtonIconButtonModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.ShowMoreRelaysButtonIconModifier as CommonsShowMoreRelaysButtonIconModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.SimpleHeaderImage as CommonsSimpleHeaderImage
+import com.vitorpamplona.amethyst.commons.ui.theme.SimpleImage35Modifier as CommonsSimpleImage35Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.SimpleImage75Modifier as CommonsSimpleImage75Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.SimpleImageBorder as CommonsSimpleImageBorder
+import com.vitorpamplona.amethyst.commons.ui.theme.Size0dp as CommonsSize0dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size100dp as CommonsSize100dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size10Modifier as CommonsSize10Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Size10dp as CommonsSize10dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size110dp as CommonsSize110dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size12dp as CommonsSize12dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size13dp as CommonsSize13dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size14Modifier as CommonsSize14Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Size14dp as CommonsSize14dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size15Modifier as CommonsSize15Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Size15dp as CommonsSize15dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size165dp as CommonsSize165dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size16Modifier as CommonsSize16Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Size16dp as CommonsSize16dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size17Modifier as CommonsSize17Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Size17dp as CommonsSize17dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size18Modifier as CommonsSize18Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Size18dp as CommonsSize18dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size19Modifier as CommonsSize19Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Size19dp as CommonsSize19dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size20Modifier as CommonsSize20Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Size20dp as CommonsSize20dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size22Modifier as CommonsSize22Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Size22ModifierWith4Padding as CommonsSize22ModifierWith4Padding
+import com.vitorpamplona.amethyst.commons.ui.theme.Size22dp as CommonsSize22dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size23dp as CommonsSize23dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size24Modifier as CommonsSize24Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Size24dp as CommonsSize24dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size25Modifier as CommonsSize25Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Size25dp as CommonsSize25dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size26Modifier as CommonsSize26Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Size28Modifier as CommonsSize28Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Size2dp as CommonsSize2dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size30Modifier as CommonsSize30Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Size30dp as CommonsSize30dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size34dp as CommonsSize34dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size35Modifier as CommonsSize35Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Size35dp as CommonsSize35dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size39Modifier as CommonsSize39Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Size3dp as CommonsSize3dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size40Modifier as CommonsSize40Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Size40dp as CommonsSize40dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size50Modifier as CommonsSize50Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Size50ModifierOffset10 as CommonsSize50ModifierOffset10
+import com.vitorpamplona.amethyst.commons.ui.theme.Size50dp as CommonsSize50dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size55Modifier as CommonsSize55Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Size55dp as CommonsSize55dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size5Modifier as CommonsSize5Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Size5dp as CommonsSize5dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size6dp as CommonsSize6dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size75Modifier as CommonsSize75Modifier
+import com.vitorpamplona.amethyst.commons.ui.theme.Size75dp as CommonsSize75dp
+import com.vitorpamplona.amethyst.commons.ui.theme.Size8dp as CommonsSize8dp
+import com.vitorpamplona.amethyst.commons.ui.theme.SmallBorder as CommonsSmallBorder
+import com.vitorpamplona.amethyst.commons.ui.theme.SmallestBorder as CommonsSmallestBorder
+import com.vitorpamplona.amethyst.commons.ui.theme.SmallishBorder as CommonsSmallishBorder
+import com.vitorpamplona.amethyst.commons.ui.theme.SpacedBy10dp as CommonsSpacedBy10dp
+import com.vitorpamplona.amethyst.commons.ui.theme.SpacedBy2dp as CommonsSpacedBy2dp
+import com.vitorpamplona.amethyst.commons.ui.theme.SpacedBy3dp as CommonsSpacedBy3dp
+import com.vitorpamplona.amethyst.commons.ui.theme.SpacedBy55dp as CommonsSpacedBy55dp
+import com.vitorpamplona.amethyst.commons.ui.theme.SpacedBy5dp as CommonsSpacedBy5dp
+import com.vitorpamplona.amethyst.commons.ui.theme.SquaredQuoteBorderModifier as CommonsSquaredQuoteBorderModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.StdButtonSizeModifier as CommonsStdButtonSizeModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.StdEndPadding as CommonsStdEndPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.StdHorzSpacer as CommonsStdHorzSpacer
+import com.vitorpamplona.amethyst.commons.ui.theme.StdPadding as CommonsStdPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.StdStartPadding as CommonsStdStartPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.StdTopPadding as CommonsStdTopPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.StdVertSpacer as CommonsStdVertSpacer
+import com.vitorpamplona.amethyst.commons.ui.theme.StreamingHeaderModifier as CommonsStreamingHeaderModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.SuggestionListDefaultHeightChat as CommonsSuggestionListDefaultHeightChat
+import com.vitorpamplona.amethyst.commons.ui.theme.SuggestionListDefaultHeightPage as CommonsSuggestionListDefaultHeightPage
+import com.vitorpamplona.amethyst.commons.ui.theme.TabRowHeight as CommonsTabRowHeight
+import com.vitorpamplona.amethyst.commons.ui.theme.TextStyleBottomNavBar as CommonsTextStyleBottomNavBar
+import com.vitorpamplona.amethyst.commons.ui.theme.TinyBorders as CommonsTinyBorders
+import com.vitorpamplona.amethyst.commons.ui.theme.UserNameMaxRowHeight as CommonsUserNameMaxRowHeight
+import com.vitorpamplona.amethyst.commons.ui.theme.UserNameRowHeight as CommonsUserNameRowHeight
+import com.vitorpamplona.amethyst.commons.ui.theme.VertPadding as CommonsVertPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.VideoReactionColumnPadding as CommonsVideoReactionColumnPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.VoiceHeightModifier as CommonsVoiceHeightModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.VolumeBottomIconSize as CommonsVolumeBottomIconSize
+import com.vitorpamplona.amethyst.commons.ui.theme.Width16Space as CommonsWidth16Space
+import com.vitorpamplona.amethyst.commons.ui.theme.WidthAuthorPictureModifier as CommonsWidthAuthorPictureModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.WidthAuthorPictureModifierWithPadding as CommonsWidthAuthorPictureModifierWithPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.ZapPictureCommentModifier as CommonsZapPictureCommentModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.ZeroPadding as CommonsZeroPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.authorNotePictureForImageHeader as commonsAuthorNotePictureForImageHeader
+import com.vitorpamplona.amethyst.commons.ui.theme.bannerModifier as commonsBannerModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.boostedNoteModifier as commonsBoostedNoteModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.chatAuthorBox as commonsChatAuthorBox
+import com.vitorpamplona.amethyst.commons.ui.theme.chatAuthorImage as commonsChatAuthorImage
+import com.vitorpamplona.amethyst.commons.ui.theme.defaultTweenDuration as commonsDefaultTweenDuration
+import com.vitorpamplona.amethyst.commons.ui.theme.defaultTweenFloatSpec as commonsDefaultTweenFloatSpec
+import com.vitorpamplona.amethyst.commons.ui.theme.defaultTweenIntOffsetSpec as commonsDefaultTweenIntOffsetSpec
+import com.vitorpamplona.amethyst.commons.ui.theme.drawerSpacing as commonsDrawerSpacing
+import com.vitorpamplona.amethyst.commons.ui.theme.emptyLineItemModifier as commonsEmptyLineItemModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.hashVerifierMark as commonsHashVerifierMark
+import com.vitorpamplona.amethyst.commons.ui.theme.imageHeaderBannerSize as commonsImageHeaderBannerSize
+import com.vitorpamplona.amethyst.commons.ui.theme.inlinePlaceholder as commonsInlinePlaceholder
+import com.vitorpamplona.amethyst.commons.ui.theme.liveStreamTag as commonsLiveStreamTag
+import com.vitorpamplona.amethyst.commons.ui.theme.messageBubbleLimits as commonsMessageBubbleLimits
+import com.vitorpamplona.amethyst.commons.ui.theme.messageDetailsModifier as commonsMessageDetailsModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.normalWithTopMarginNoteModifier as commonsNormalWithTopMarginNoteModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.noteComposeRelayBox as commonsNoteComposeRelayBox
+import com.vitorpamplona.amethyst.commons.ui.theme.previewCardImageModifier as commonsPreviewCardImageModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.profileContentHeaderModifier as commonsProfileContentHeaderModifier
+import com.vitorpamplona.amethyst.commons.ui.theme.reactionBox as commonsReactionBox
+import com.vitorpamplona.amethyst.commons.ui.theme.ripple24dp as commonsRipple24dp
+
+val Shapes = CommonsShapes
+
+val RippleRadius45dp = CommonsRippleRadius45dp
+
+val BottomTopHeight = CommonsBottomTopHeight
+val TabRowHeight = CommonsTabRowHeight
+
+val SmallestBorder = CommonsSmallestBorder
+val SmallBorder = CommonsSmallBorder
+val SmallishBorder = CommonsSmallishBorder
+val QuoteBorder = CommonsQuoteBorder
+
+val ButtonBorder = CommonsButtonBorder
+val LeftHalfCircleButtonBorder = CommonsLeftHalfCircleButtonBorder
+val EditFieldBorder = CommonsEditFieldBorder
+
+val ChatBubbleShapeMe = CommonsChatBubbleShapeMe
+val ChatBubbleShapeThem = CommonsChatBubbleShapeThem
+
+val StdButtonSizeModifier = CommonsStdButtonSizeModifier
+
+val HalfVertSpacer = CommonsHalfVertSpacer
+
+val MinHorzSpacer = CommonsMinHorzSpacer
+
+val HalfHorzSpacer = CommonsHalfHorzSpacer
+
+val StdHorzSpacer = CommonsStdHorzSpacer
+val StdVertSpacer = CommonsStdVertSpacer
+
+val DoubleHorzSpacer = CommonsDoubleHorzSpacer
+val DoubleVertSpacer = CommonsDoubleVertSpacer
+
+val Height100Modifier = CommonsHeight100Modifier
+
+val HalfDoubleVertSpacer = CommonsHalfDoubleVertSpacer
+
+val Size0dp = CommonsSize0dp
+val Size2dp = CommonsSize2dp
+val Size3dp = CommonsSize3dp
+val Size5dp = CommonsSize5dp
+val Size6dp = CommonsSize6dp
+val Size8dp = CommonsSize8dp
+val Size10dp = CommonsSize10dp
+val Size12dp = CommonsSize12dp
+val Size13dp = CommonsSize13dp
+val Size14dp = CommonsSize14dp
+val Size15dp = CommonsSize15dp
+val Size16dp = CommonsSize16dp
+val Size17dp = CommonsSize17dp
+val Size18dp = CommonsSize18dp
+val Size19dp = CommonsSize19dp
+val Size20dp = CommonsSize20dp
+val Size22dp = CommonsSize22dp
+val Size23dp = CommonsSize23dp
+val Size24dp = CommonsSize24dp
+val Size25dp = CommonsSize25dp
+val Size30dp = CommonsSize30dp
+val Size34dp = CommonsSize34dp
+val Size35dp = CommonsSize35dp
+val Size40dp = CommonsSize40dp
+val Size50dp = CommonsSize50dp
+val Size55dp = CommonsSize55dp
+val Size75dp = CommonsSize75dp
+val Size100dp = CommonsSize100dp
+val Size110dp = CommonsSize110dp
+val Size165dp = CommonsSize165dp
+
+val StdEndPadding = CommonsStdEndPadding
+val HalfEndPadding = CommonsHalfEndPadding
+val HalfStartPadding = CommonsHalfStartPadding
+val StdStartPadding = CommonsStdStartPadding
+val StdTopPadding = CommonsStdTopPadding
+val HalfTopPadding = CommonsHalfTopPadding
+val HalfHalfTopPadding = CommonsHalfHalfTopPadding
+
+val HalfHalfVertPadding = CommonsHalfHalfVertPadding
+val HalfHalfHorzModifier = CommonsHalfHalfHorzModifier
+
+val HalfPadding = CommonsHalfPadding
+val StdPadding = CommonsStdPadding
+val BigPadding = CommonsBigPadding
+
+val RowColSpacing = CommonsRowColSpacing
+val RowColSpacing5dp = CommonsRowColSpacing5dp
+val RowColSpacing10dp = CommonsRowColSpacing10dp
+
+val HalfHorzPadding = CommonsHalfHorzPadding
+val HalfVertPadding = CommonsHalfVertPadding
+
+val HorzPadding = CommonsHorzPadding
+val VertPadding = CommonsVertPadding
+
+val HorzHalfVertPadding = CommonsHorzHalfVertPadding
+
+val DoubleHorzPadding = CommonsDoubleHorzPadding
+val DoubleVertPadding = CommonsDoubleVertPadding
+
+val MaxWidthWithHorzPadding = CommonsMaxWidthWithHorzPadding
+
+val Size5Modifier = CommonsSize5Modifier
+val Size10Modifier = CommonsSize10Modifier
+val Size14Modifier = CommonsSize14Modifier
+val Size15Modifier = CommonsSize15Modifier
+val Size16Modifier = CommonsSize16Modifier
+val Size17Modifier = CommonsSize17Modifier
+val Size18Modifier = CommonsSize18Modifier
+val Size19Modifier = CommonsSize19Modifier
+val Size20Modifier = CommonsSize20Modifier
+val Size22Modifier = CommonsSize22Modifier
+val Size24Modifier = CommonsSize24Modifier
+val Size25Modifier = CommonsSize25Modifier
+val Size26Modifier = CommonsSize26Modifier
+val Size28Modifier = CommonsSize28Modifier
+val Size30Modifier = CommonsSize30Modifier
+val Size35Modifier = CommonsSize35Modifier
+val Size39Modifier = CommonsSize39Modifier
+val Size40Modifier = CommonsSize40Modifier
+val Size50Modifier = CommonsSize50Modifier
+val Size55Modifier = CommonsSize55Modifier
+val Size75Modifier = CommonsSize75Modifier
+
+val TinyBorders = CommonsTinyBorders
+val NoSoTinyBorders = CommonsNoSoTinyBorders
+val ReactionRowZapraiserWithPadding = CommonsReactionRowZapraiserWithPadding
+val ReactionRowZapraiser = CommonsReactionRowZapraiser
+
+val ReactionRowExpandButton = CommonsReactionRowExpandButton
+
+val WidthAuthorPictureModifier = CommonsWidthAuthorPictureModifier
+val WidthAuthorPictureModifierWithPadding = CommonsWidthAuthorPictureModifierWithPadding
+
+val VideoReactionColumnPadding = CommonsVideoReactionColumnPadding
+
+val DividerThickness = CommonsDividerThickness
+
+val ReactionRowHeight = CommonsReactionRowHeight
+val ReactionRowHeightWithPadding = CommonsReactionRowHeightWithPadding
+val ReactionRowHeightChat = CommonsReactionRowHeightChat
+val ReactionRowHeightChatMaxWidth = CommonsReactionRowHeightChatMaxWidth
+val UserNameRowHeight = CommonsUserNameRowHeight
+val UserNameMaxRowHeight = CommonsUserNameMaxRowHeight
+
+val Height24dpModifier = CommonsHeight24dpModifier
+val Height4dpModifier = CommonsHeight4dpModifier
+val Height25Modifier = CommonsHeight25Modifier
+
+val Height24dpFilledModifier = CommonsHeight24dpFilledModifier
+val Height4dpFilledModifier = CommonsHeight4dpFilledModifier
+
+val AccountPictureModifier = CommonsAccountPictureModifier
+val HeaderPictureModifier = CommonsHeaderPictureModifier
+
+val ShowMoreRelaysButtonIconButtonModifier = CommonsShowMoreRelaysButtonIconButtonModifier
+val ShowMoreRelaysButtonIconModifier = CommonsShowMoreRelaysButtonIconModifier
+val ShowMoreRelaysButtonBoxModifer = CommonsShowMoreRelaysButtonBoxModifer
+
+val ChatBubbleMaxSizeModifier = CommonsChatBubbleMaxSizeModifier
+
+val ModifierWidth3dp = CommonsModifierWidth3dp
+
+val NotificationIconModifier = CommonsNotificationIconModifier
+val NotificationIconModifierSmaller = CommonsNotificationIconModifierSmaller
+
+val ZapPictureCommentModifier = CommonsZapPictureCommentModifier
+val ChatHeadlineBorders = CommonsChatHeadlineBorders
+
+val VolumeBottomIconSize = CommonsVolumeBottomIconSize
+val PinBottomIconSize = CommonsPinBottomIconSize
+val PlayIconSize = CommonsPlayIconSize
+val NIP05IconSize = CommonsNIP05IconSize
+
+val CashuCardBorders = CommonsCashuCardBorders
+
+val EditFieldModifier = CommonsEditFieldModifier
+val EditFieldTrailingIconModifier = CommonsEditFieldTrailingIconModifier
+
+val ZeroPadding = CommonsZeroPadding
+val HalfFeedPadding = CommonsHalfFeedPadding
+val FeedPadding = CommonsFeedPadding
+val ButtonPadding = CommonsButtonPadding
+
+val ChatPaddingInnerQuoteModifier = CommonsChatPaddingInnerQuoteModifier
+val ChatPaddingModifier = CommonsChatPaddingModifier
+
+val profileContentHeaderModifier = commonsProfileContentHeaderModifier
+val bannerModifier = commonsBannerModifier
+val drawerSpacing = commonsDrawerSpacing
+
+val IconRowTextModifier = CommonsIconRowTextModifier
+val IconRowModifier = CommonsIconRowModifier
+
+val Width16Space = CommonsWidth16Space
+
+val emptyLineItemModifier = commonsEmptyLineItemModifier
+
+val imageHeaderBannerSize = commonsImageHeaderBannerSize
+
+val authorNotePictureForImageHeader = commonsAuthorNotePictureForImageHeader
+
+val normalWithTopMarginNoteModifier = commonsNormalWithTopMarginNoteModifier
+
+val boostedNoteModifier = commonsBoostedNoteModifier
+
+val liveStreamTag = commonsLiveStreamTag
+
+val chatAuthorBox = commonsChatAuthorBox
+val chatAuthorImage = commonsChatAuthorImage
+val AuthorInfoVideoFeed = CommonsAuthorInfoVideoFeed
+
+val messageDetailsModifier = commonsMessageDetailsModifier
+val messageBubbleLimits = commonsMessageBubbleLimits
+
+val inlinePlaceholder = commonsInlinePlaceholder
+
+val IncognitoIconModifier = CommonsIncognitoIconModifier
+val IncognitoIconButtonModifier = CommonsIncognitoIconButtonModifier
+
+val hashVerifierMark = commonsHashVerifierMark
+
+val noteComposeRelayBox = commonsNoteComposeRelayBox
+
+val previewCardImageModifier = commonsPreviewCardImageModifier
+
+val reactionBox = commonsReactionBox
+
+val ripple24dp = commonsRipple24dp
+
+val defaultTweenDuration = commonsDefaultTweenDuration
+val defaultTweenFloatSpec = commonsDefaultTweenFloatSpec
+val defaultTweenIntOffsetSpec = commonsDefaultTweenIntOffsetSpec
+
+val StreamingHeaderModifier = CommonsStreamingHeaderModifier
+
+val PostKeyboard = CommonsPostKeyboard
+
+val SettingsCategoryFirstModifier = CommonsSettingsCategoryFirstModifier
+val SettingsCategorySpacingModifier = CommonsSettingsCategorySpacingModifier
+
+val SettingsCategoryFirstWithHorzBorderModifier = CommonsSettingsCategoryFirstWithHorzBorderModifier
+val SettingsCategorySpacingWithHorzBorderModifier = CommonsSettingsCategorySpacingWithHorzBorderModifier
+
+val SquaredQuoteBorderModifier = CommonsSquaredQuoteBorderModifier
+val FillWidthQuoteBorderModifier = CommonsFillWidthQuoteBorderModifier
+
+val MediumRelayIconModifier = CommonsMediumRelayIconModifier
+
+val LargeRelayIconModifier = CommonsLargeRelayIconModifier
+
+val FollowSetImageModifier = CommonsFollowSetImageModifier
+
+val SimpleImage75Modifier = CommonsSimpleImage75Modifier
+val SimpleImage35Modifier = CommonsSimpleImage35Modifier
+
+val SimpleImageBorder = CommonsSimpleImageBorder
+
+val SimpleHeaderImage = CommonsSimpleHeaderImage
+
+val BadgePictureModifier = CommonsBadgePictureModifier
+
+val MaxWidthPaddingTop5dp = CommonsMaxWidthPaddingTop5dp
+
+val VoiceHeightModifier = CommonsVoiceHeightModifier
+
+val PaddingHorizontal12Modifier = CommonsPaddingHorizontal12Modifier
+
+val QuickActionPopupShadow = CommonsQuickActionPopupShadow
+
+val SpacedBy2dp = CommonsSpacedBy2dp
+val SpacedBy3dp = CommonsSpacedBy3dp
+val SpacedBy5dp = CommonsSpacedBy5dp
+val SpacedBy10dp = CommonsSpacedBy10dp
+val SpacedBy55dp = CommonsSpacedBy55dp
+
+val PopupUpEffect = CommonsPopupUpEffect
+
+val Size50ModifierOffset10 = CommonsSize50ModifierOffset10
+
+val SuggestionListDefaultHeightChat = CommonsSuggestionListDefaultHeightChat
+val SuggestionListDefaultHeightPage = CommonsSuggestionListDefaultHeightPage
+
+val FollowPackHeaderModifier = CommonsFollowPackHeaderModifier
+
+val Size22ModifierWith4Padding = CommonsSize22ModifierWith4Padding
+
+val TextStyleBottomNavBar = CommonsTextStyleBottomNavBar

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/theme/Type.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/theme/Type.kt
@@ -20,113 +20,33 @@
  */
 package com.vitorpamplona.amethyst.ui.theme
 
-import androidx.compose.material3.Typography
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.TextUnit
-import androidx.compose.ui.unit.em
-import androidx.compose.ui.unit.sp
-import com.halilibo.richtext.ui.HeadingStyle
+// Backward-compatible re-exports — all typography definitions live in commons
+import com.vitorpamplona.amethyst.commons.ui.theme.DefaultHeadingStyle as CommonsDefaultHeadingStyle
+import com.vitorpamplona.amethyst.commons.ui.theme.DefaultParagraphSpacing as CommonsDefaultParagraphSpacing
+import com.vitorpamplona.amethyst.commons.ui.theme.Font10SP as CommonsFont10SP
+import com.vitorpamplona.amethyst.commons.ui.theme.Font12SP as CommonsFont12SP
+import com.vitorpamplona.amethyst.commons.ui.theme.Font14SP as CommonsFont14SP
+import com.vitorpamplona.amethyst.commons.ui.theme.Font17SP as CommonsFont17SP
+import com.vitorpamplona.amethyst.commons.ui.theme.Font18SP as CommonsFont18SP
+import com.vitorpamplona.amethyst.commons.ui.theme.Font4SP as CommonsFont4SP
+import com.vitorpamplona.amethyst.commons.ui.theme.Font6SP as CommonsFont6SP
+import com.vitorpamplona.amethyst.commons.ui.theme.Font8SP as CommonsFont8SP
+import com.vitorpamplona.amethyst.commons.ui.theme.MarkdownTextStyle as CommonsMarkdownTextStyle
+import com.vitorpamplona.amethyst.commons.ui.theme.Typography as CommonsTypography
 
-// Set of Material typography styles to start with
-val Typography =
-    Typography(
-        bodyLarge =
-            TextStyle(
-                fontFamily = FontFamily.Default,
-                fontWeight = FontWeight.Normal,
-                fontSize = 16.sp,
-            ),
-    /* Other default text styles to override
-    button = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.W500,
-        fontSize = Font14SP
-    ),
-    caption = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 12.sp
-    )
-     */
-    )
+val Typography = CommonsTypography
 
-val Font4SP = 4.sp
-val Font6SP = 6.sp
-val Font8SP = 8.sp
-val Font10SP = 10.sp
-val Font12SP = 12.sp
-val Font14SP = 14.sp
-val Font17SP = 17.sp
-val Font18SP = 18.sp
+val Font4SP = CommonsFont4SP
+val Font6SP = CommonsFont6SP
+val Font8SP = CommonsFont8SP
+val Font10SP = CommonsFont10SP
+val Font12SP = CommonsFont12SP
+val Font14SP = CommonsFont14SP
+val Font17SP = CommonsFont17SP
+val Font18SP = CommonsFont18SP
 
-val MarkdownTextStyle = TextStyle(lineHeight = 1.50.em)
+val MarkdownTextStyle = CommonsMarkdownTextStyle
 
-val DefaultParagraphSpacing: TextUnit = 20.sp
+val DefaultParagraphSpacing = CommonsDefaultParagraphSpacing
 
-internal val DefaultHeadingStyle: HeadingStyle = { level, textStyle ->
-    when (level) {
-        0 -> {
-            Typography.displayLarge.copy(
-                fontSize = 32.sp,
-                lineHeight = 40.sp,
-                fontWeight = FontWeight.Bold,
-                letterSpacing = (-0.5).sp,
-            )
-        }
-
-        1 -> {
-            Typography.displayMedium.copy(
-                fontSize = 26.sp,
-                lineHeight = 34.sp,
-                fontWeight = FontWeight.Bold,
-                letterSpacing = (-0.25).sp,
-            )
-        }
-
-        2 -> {
-            Typography.displaySmall.copy(
-                fontSize = 22.sp,
-                lineHeight = 30.sp,
-                fontWeight = FontWeight.SemiBold,
-            )
-        }
-
-        3 -> {
-            Typography.displaySmall.copy(
-                fontSize = 20.sp,
-                lineHeight = 28.sp,
-                fontWeight = FontWeight.SemiBold,
-            )
-        }
-
-        4 -> {
-            Typography.headlineLarge.copy(
-                fontSize = 18.sp,
-                lineHeight = 24.sp,
-                fontWeight = FontWeight.Medium,
-            )
-        }
-
-        5 -> {
-            Typography.headlineMedium.copy(
-                fontSize = 16.sp,
-                lineHeight = 22.sp,
-                fontWeight = FontWeight.Medium,
-            )
-        }
-
-        6 -> {
-            Typography.headlineSmall.copy(
-                fontSize = 15.sp,
-                lineHeight = 20.sp,
-                fontWeight = FontWeight.Medium,
-            )
-        }
-
-        else -> {
-            textStyle
-        }
-    }
-}
+val DefaultHeadingStyle = CommonsDefaultHeadingStyle

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/GenericLoadable.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/GenericLoadable.kt
@@ -18,20 +18,21 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.types
+package com.vitorpamplona.amethyst.commons.ui.components
 
-// Re-export from commons for backwards compatibility
-import androidx.compose.runtime.Composable
-import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.ui.navigation.navs.INav
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
-import com.vitorpamplona.amethyst.commons.ui.note.types.RenderNIP90Status as CommonsRenderNIP90Status
+import androidx.compose.runtime.Immutable
 
-@Composable
-fun RenderNIP90Status(
-    note: Note,
-    accountViewModel: AccountViewModel,
-    nav: INav,
-) {
-    CommonsRenderNIP90Status(note, accountViewModel)
+@Immutable
+sealed class GenericLoadable<T> {
+    @Immutable class Loading<T> : GenericLoadable<T>()
+
+    @Immutable class Loaded<T>(
+        val loaded: T,
+    ) : GenericLoadable<T>()
+
+    @Immutable class Empty<T> : GenericLoadable<T>()
+
+    @Immutable class Error<T>(
+        val errorMessage: String,
+    ) : GenericLoadable<T>()
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/navigation/navs/EmptyNav.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/navigation/navs/EmptyNav.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.navigation.navs
+
+import androidx.compose.material3.DrawerState
+import androidx.compose.material3.DrawerValue
+import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.ui.navigation.routes.Route
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlin.reflect.KClass
+
+@Stable
+class EmptyNav : INav {
+    override val navigationScope: CoroutineScope get() = TODO("Not yet implemented")
+    override val drawerState = DrawerState(DrawerValue.Closed)
+
+    override fun closeDrawer() = runBlocking { drawerState.close() }
+
+    override fun openDrawer() = runBlocking { drawerState.open() }
+
+    // All navigation methods are intentionally no-op; this is a stub for previews and tests
+    override fun nav(route: Route) {}
+
+    override fun nav(computeRoute: suspend () -> Route?) {}
+
+    override fun newStack(route: Route) {}
+
+    override fun popBack() {}
+
+    override fun <T : Route> popUpTo(
+        route: Route,
+        klass: KClass<T>,
+    ) {}
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/navigation/navs/INav.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/navigation/navs/INav.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.navigation.navs
+
+import androidx.compose.material3.DrawerState
+import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.ui.navigation.routes.Route
+import kotlinx.coroutines.CoroutineScope
+import kotlin.reflect.KClass
+
+@Stable
+interface INav {
+    val navigationScope: CoroutineScope
+    val drawerState: DrawerState
+
+    fun closeDrawer()
+
+    fun openDrawer()
+
+    fun nav(route: Route)
+
+    fun nav(computeRoute: suspend () -> Route?)
+
+    fun newStack(route: Route)
+
+    fun popBack()
+
+    fun <T : Route> popUpTo(
+        route: Route,
+        klass: KClass<T>,
+    )
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/navigation/routes/Route.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/navigation/routes/Route.kt
@@ -1,0 +1,441 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.navigation.routes
+
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.bookmarkgroups.BookmarkType
+import com.vitorpamplona.quartz.nip01Core.core.Address
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip17Dm.base.ChatroomKey
+import kotlinx.serialization.Serializable
+
+sealed class Route {
+    @Serializable object Home : Route()
+
+    @Serializable object Message : Route()
+
+    @Serializable object Video : Route()
+
+    @Serializable object Discover : Route()
+
+    @Serializable data class Notification(
+        val scrollToEventId: String? = null,
+    ) : Route()
+
+    @Serializable object Polls : Route()
+
+    @Serializable object Pictures : Route()
+
+    @Serializable object Shorts : Route()
+
+    @Serializable object Longs : Route()
+
+    @Serializable object Chess : Route()
+
+    @Serializable object Wallet : Route()
+
+    @Serializable object WalletSend : Route()
+
+    @Serializable object WalletReceive : Route()
+
+    @Serializable object WalletTransactions : Route()
+
+    @Serializable
+    data class WalletDetail(
+        val walletId: String,
+    ) : Route()
+
+    @Serializable object WalletAdd : Route()
+
+    @Serializable object Search : Route()
+
+    @Serializable object SecurityFilters : Route()
+
+    @Serializable object PrivacyOptions : Route()
+
+    @Serializable object NamecoinSettings : Route()
+
+    @Serializable object OtsSettings : Route()
+
+    @Serializable object Bookmarks : Route()
+
+    @Serializable object OldBookmarks : Route()
+
+    @Serializable object BookmarkGroups : Route()
+
+    @Serializable object ImportFollowsSelectUser : Route()
+
+    @Serializable data class ImportFollowsPickFollows(
+        val userHex: HexKey,
+    ) : Route()
+
+    @Serializable data class BookmarkGroupView(
+        val dTag: String,
+        val bookmarkType: BookmarkType,
+    ) : Route()
+
+    @Serializable data class BookmarkGroupMetadataEdit(
+        val dTag: String? = null,
+    ) : Route()
+
+    @Serializable data class PostBookmarkManagement(
+        val postId: String,
+    ) : Route()
+
+    @Serializable data class ArticleBookmarkManagement(
+        val kind: Int,
+        val pubKeyHex: HexKey,
+        val dTag: String,
+    ) : Route() {
+        constructor(address: Address) : this(
+            kind = address.kind,
+            pubKeyHex = address.pubKeyHex,
+            dTag = address.dTag,
+        )
+    }
+
+    @Serializable object WebBookmarks : Route()
+
+    @Serializable object Drafts : Route()
+
+    @Serializable object AllSettings : Route()
+
+    @Serializable object AccountBackup : Route()
+
+    @Serializable object Settings : Route()
+
+    @Serializable object UserSettings : Route()
+
+    @Serializable object ReactionsSettings : Route()
+
+    @Serializable object CallSettings : Route()
+
+    @Serializable object Lists : Route()
+
+    @Serializable data class MyPeopleListView(
+        val dTag: String,
+    ) : Route()
+
+    @Serializable data class MyFollowPackView(
+        val dTag: String,
+    ) : Route()
+
+    @Serializable data class PeopleListMetadataEdit(
+        val dTag: String? = null,
+    ) : Route()
+
+    @Serializable data class FollowPackMetadataEdit(
+        val dTag: String? = null,
+    ) : Route()
+
+    @Serializable data class PeopleListManagement(
+        val userToAdd: HexKey,
+    ) : Route()
+
+    @Serializable object EditProfile : Route()
+
+    @Serializable object EditRelays : Route()
+
+    @Serializable object EventSync : Route()
+
+    @Serializable object RequestToVanish : Route()
+
+    @Serializable object VanishEvents : Route()
+
+    @Serializable object EditMediaServers : Route()
+
+    @Serializable object EditPaymentTargets : Route()
+
+    @Serializable object UpdateReactionType : Route()
+
+    @Serializable data class Nip47NWCSetup(
+        val nip47: String? = null,
+    ) : Route()
+
+    @Serializable data class UpdateZapAmount(
+        val nip47: String? = null,
+    ) : Route()
+
+    @Serializable data class Profile(
+        val id: String,
+    ) : Route()
+
+    @Serializable data class QRDisplay(
+        val pubkey: String,
+    ) : Route()
+
+    @Serializable data class ContentDiscovery(
+        val id: String,
+    ) : Route()
+
+    @Serializable data class Note(
+        val id: String,
+    ) : Route()
+
+    @Serializable data class Hashtag(
+        val hashtag: String,
+    ) : Route()
+
+    @Serializable data class Geohash(
+        val geohash: String,
+    ) : Route()
+
+    @Serializable data class ChessGame(
+        val gameId: String,
+    ) : Route()
+
+    @Serializable data class Community(
+        val kind: Int,
+        val pubKeyHex: HexKey,
+        val dTag: String,
+    ) : Route() {
+        constructor(address: Address) : this(
+            kind = address.kind,
+            pubKeyHex = address.pubKeyHex,
+            dTag = address.dTag,
+        )
+    }
+
+    @Serializable data class FollowPack(
+        val kind: Int,
+        val pubKeyHex: HexKey,
+        val dTag: String,
+    ) : Route() {
+        constructor(address: Address) : this(
+            kind = address.kind,
+            pubKeyHex = address.pubKeyHex,
+            dTag = address.dTag,
+        )
+    }
+
+    @Serializable data class PublicChatChannel(
+        val id: String,
+        val draftId: HexKey? = null,
+        val replyTo: HexKey? = null,
+    ) : Route()
+
+    @Serializable data class LiveActivityChannel(
+        val kind: Int,
+        val pubKeyHex: HexKey,
+        val dTag: String,
+        val draftId: HexKey? = null,
+        val replyTo: HexKey? = null,
+    ) : Route()
+
+    @Serializable data class RelayInfo(
+        val url: String,
+    ) : Route()
+
+    @Serializable data class RelayManagement(
+        val url: String,
+    ) : Route()
+
+    @Serializable data class RelayMembers(
+        val url: String,
+    ) : Route()
+
+    @Serializable data class RelayFeed(
+        val url: String,
+    ) : Route()
+
+    @Serializable data class EphemeralChat(
+        val id: String,
+        val relayUrl: String,
+        val draftId: HexKey? = null,
+        val replyTo: HexKey? = null,
+    ) : Route()
+
+    @Serializable object NewEphemeralChat : Route()
+
+    @Serializable data class ChannelMetadataEdit(
+        val id: String? = null,
+    ) : Route()
+
+    @Serializable object MarmotGroupList : Route()
+
+    @Serializable data class MarmotGroupChat(
+        val nostrGroupId: String,
+    ) : Route()
+
+    @Serializable data class MarmotGroupInfo(
+        val nostrGroupId: String,
+    ) : Route()
+
+    @Serializable object CreateMarmotGroup : Route()
+
+    @Serializable data class MarmotGroupAddMember(
+        val nostrGroupId: String,
+    ) : Route()
+
+    @Serializable data class MarmotGroupRemoveMember(
+        val nostrGroupId: String,
+    ) : Route()
+
+    @Serializable data class MarmotGroupEditInfo(
+        val nostrGroupId: String,
+    ) : Route()
+
+    @Serializable data class NewGroupDM(
+        val message: String? = null,
+        val attachment: String? = null,
+    ) : Route()
+
+    @Serializable data class Room(
+        val id: String,
+        val message: String? = null,
+        val replyId: HexKey? = null,
+        val draftId: HexKey? = null,
+        val expiresDays: Int? = null,
+    ) : Route() {
+        constructor(key: ChatroomKey, message: String? = null, replyId: HexKey? = null, draftId: HexKey? = null, expiresDays: Int? = null) : this(
+            id = key.users.joinToString(","),
+            message = message,
+            replyId = replyId,
+            draftId = draftId,
+            expiresDays = expiresDays,
+        )
+
+        fun toKey(): ChatroomKey = ChatroomKey(id.split(",").toSet())
+    }
+
+    @Serializable data class NewPublicMessage(
+        val to: String,
+        val replyId: HexKey? = null,
+        val draftId: HexKey? = null,
+    ) : Route() {
+        constructor(users: Set<HexKey>, parentId: HexKey, draftId: HexKey? = null) : this(
+            to = users.joinToString(","),
+            replyId = parentId,
+            draftId = draftId,
+        )
+
+        fun toKey(): Set<HexKey> = to.split(",").toSet()
+    }
+
+    @Serializable data class RoomByAuthor(
+        val id: String,
+    ) : Route()
+
+    @Serializable data class ActiveCall(
+        val callId: String,
+        val peerPubKey: HexKey,
+    ) : Route()
+
+    @Serializable data class EventRedirect(
+        val id: String,
+    ) : Route()
+
+    @Serializable
+    data class NewProduct(
+        val message: String? = null,
+        val attachment: String? = null,
+        val quote: String? = null,
+        val draft: String? = null,
+    ) : Route()
+
+    @Serializable data object NewGoal : Route()
+
+    @Serializable
+    data class NewLongFormPost(
+        val draft: String? = null,
+        val version: String? = null,
+    ) : Route()
+
+    @Serializable
+    data class GeoPost(
+        val geohash: String? = null,
+        val message: String? = null,
+        val attachment: String? = null,
+        val replyTo: String? = null,
+        val quote: String? = null,
+        val draft: String? = null,
+    ) : Route()
+
+    @Serializable
+    data class HashtagPost(
+        val hashtag: String? = null,
+        val message: String? = null,
+        val attachment: String? = null,
+        val replyTo: String? = null,
+        val quote: String? = null,
+        val draft: String? = null,
+    ) : Route()
+
+    @Serializable
+    data class GenericCommentPost(
+        val message: String? = null,
+        val attachment: String? = null,
+        val replyTo: String? = null,
+        val quote: String? = null,
+        val draft: String? = null,
+    ) : Route()
+
+    @Serializable
+    data class NewShortNote(
+        val message: String? = null,
+        val attachment: String? = null,
+        val baseReplyTo: String? = null,
+        val quote: String? = null,
+        val fork: String? = null,
+        val version: String? = null,
+        val draft: String? = null,
+    ) : Route()
+
+    @Serializable
+    data class NewPoll(
+        val message: String? = null,
+        val draft: String? = null,
+    ) : Route()
+
+    @Serializable
+    data class VoiceReply(
+        val replyToNoteId: String,
+        val recordingFilePath: String,
+        val mimeType: String,
+        val duration: Int,
+        val amplitudes: String, // JSON-encoded List<Float>
+    ) : Route()
+
+    @Serializable
+    data class ManualZapSplitPayment(
+        val paymentId: String,
+    ) : Route()
+}
+
+fun isSameRoute(
+    currentRoute: Route?,
+    newRoute: Route,
+): Boolean {
+    if (currentRoute == null) return false
+
+    if (currentRoute == newRoute) {
+        return true
+    }
+
+    if (newRoute is Route.EventRedirect) {
+        return when (currentRoute) {
+            is Route.Note -> newRoute.id == currentRoute.id
+            is Route.PublicChatChannel -> newRoute.id == currentRoute.id
+            else -> false
+        }
+    }
+
+    return false
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/types/CodeSnippet.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/types/CodeSnippet.kt
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.note.types
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.ui.theme.QuoteBorder
+import com.vitorpamplona.amethyst.commons.ui.theme.StdHorzSpacer
+import com.vitorpamplona.amethyst.commons.ui.theme.StdVertSpacer
+import com.vitorpamplona.amethyst.commons.ui.theme.replyModifier
+import com.vitorpamplona.quartz.nipC0CodeSnippets.CodeSnippetEvent
+
+@Composable
+fun RenderCodeSnippetEvent(baseNote: Note) {
+    val noteEvent = baseNote.event as? CodeSnippetEvent ?: return
+
+    val name =
+        remember(noteEvent) {
+            noteEvent.snippetName()
+                ?: noteEvent.language()?.let { "$it snippet" }
+                ?: "Code Snippet"
+        }
+    val language = remember(noteEvent) { noteEvent.language() ?: noteEvent.extension() }
+    val description = remember(noteEvent) { noteEvent.snippetDescription() }
+    val codePreview =
+        remember(noteEvent) {
+            noteEvent.content
+                .lines()
+                .take(5)
+                .joinToString("\n")
+        }
+
+    Column(MaterialTheme.colorScheme.replyModifier) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 10.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = name,
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.weight(1f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            language?.let {
+                Spacer(modifier = StdHorzSpacer)
+                Box(
+                    modifier =
+                        Modifier
+                            .clip(QuoteBorder)
+                            .background(MaterialTheme.colorScheme.surfaceVariant)
+                            .padding(horizontal = 6.dp, vertical = 2.dp),
+                ) {
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+
+        description?.ifBlank { null }?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 10.dp),
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Spacer(modifier = StdVertSpacer)
+        }
+
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(10.dp)
+                    .clip(QuoteBorder)
+                    .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.05f))
+                    .border(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.3f), QuoteBorder)
+                    .padding(10.dp),
+        ) {
+            Text(
+                text = codePreview,
+                style =
+                    TextStyle(
+                        fontFamily = FontFamily.Monospace,
+                        fontSize = 12.sp,
+                    ),
+                maxLines = 5,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+fun RenderCodeSnippetHeaderForThread(noteEvent: CodeSnippetEvent) {
+    val name =
+        remember(noteEvent) {
+            noteEvent.snippetName()
+                ?: noteEvent.language()?.let { "$it snippet" }
+                ?: "Code Snippet"
+        }
+    val language = remember(noteEvent) { noteEvent.language() ?: noteEvent.extension() }
+    val description = remember(noteEvent) { noteEvent.snippetDescription() }
+    val license = remember(noteEvent) { noteEvent.license() }
+    val runtime = remember(noteEvent) { noteEvent.runtime() }
+    val deps = remember(noteEvent) { noteEvent.deps() }
+
+    Column(modifier = Modifier.padding(start = 12.dp, end = 12.dp, bottom = 12.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = name,
+                style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier.weight(1f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            language?.let {
+                Spacer(modifier = StdHorzSpacer)
+                Box(
+                    modifier =
+                        Modifier
+                            .clip(QuoteBorder)
+                            .background(MaterialTheme.colorScheme.surfaceVariant)
+                            .padding(horizontal = 8.dp, vertical = 3.dp),
+                ) {
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+
+        description?.ifBlank { null }?.let {
+            Spacer(modifier = StdVertSpacer)
+            Text(
+                text = it,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+
+        Spacer(modifier = StdVertSpacer)
+
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clip(QuoteBorder)
+                    .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.05f))
+                    .border(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.3f), QuoteBorder)
+                    .padding(12.dp),
+        ) {
+            Text(
+                text = noteEvent.content,
+                style =
+                    TextStyle(
+                        fontFamily = FontFamily.Monospace,
+                        fontSize = 13.sp,
+                    ),
+            )
+        }
+
+        license?.let {
+            Spacer(modifier = StdVertSpacer)
+            Text(
+                text = "License: $it",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        runtime?.let {
+            Text(
+                text = "Runtime: $it",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        if (deps.isNotEmpty()) {
+            Text(
+                text = "Deps: ${deps.joinToString(", ")}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/types/EcashMint.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/types/EcashMint.kt
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.note.types
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.vitorpamplona.amethyst.commons.ui.theme.QuoteBorder
+import com.vitorpamplona.amethyst.commons.ui.theme.SmallBorder
+import com.vitorpamplona.amethyst.commons.ui.theme.subtleBorder
+import com.vitorpamplona.quartz.nip87Ecash.cashu.CashuMintEvent
+import com.vitorpamplona.quartz.nip87Ecash.fedimint.FedimintEvent
+import com.vitorpamplona.quartz.nip87Ecash.recommendation.MintRecommendationEvent
+
+@Composable
+fun RenderCashuMint(noteEvent: CashuMintEvent) {
+    val mintUrl = remember(noteEvent) { noteEvent.mintUrl() }
+    val nuts = remember(noteEvent) { noteEvent.nuts() }
+    val network = remember(noteEvent) { noteEvent.network() }
+
+    MintAnnouncementCard(
+        title = "Cashu Mint",
+        url = mintUrl,
+        network = network.code,
+        capabilities = nuts,
+        capabilitiesLabel = "NUTs",
+        metadata = noteEvent.content.ifBlank { null },
+    )
+}
+
+@Composable
+fun RenderFedimint(noteEvent: FedimintEvent) {
+    val inviteCodes = remember(noteEvent) { noteEvent.inviteCodes() }
+    val modules = remember(noteEvent) { noteEvent.modules() }
+    val network = remember(noteEvent) { noteEvent.network() }
+
+    MintAnnouncementCard(
+        title = "Fedimint",
+        url = inviteCodes.firstOrNull(),
+        network = network.code,
+        capabilities = modules,
+        capabilitiesLabel = "Modules",
+        metadata = noteEvent.content.ifBlank { null },
+    )
+}
+
+@Composable
+fun RenderMintRecommendation(noteEvent: MintRecommendationEvent) {
+    val mintUrls = remember(noteEvent) { noteEvent.mintUrls() }
+    val mintType =
+        remember(noteEvent) {
+            when {
+                noteEvent.isCashuRecommendation() -> "Cashu Mint"
+                noteEvent.isFedimintRecommendation() -> "Fedimint"
+                else -> "Ecash Mint"
+            }
+        }
+
+    MintAnnouncementCard(
+        title = "$mintType Recommendation",
+        url = mintUrls.firstOrNull(),
+        network = null,
+        capabilities = emptyList(),
+        capabilitiesLabel = null,
+        metadata = noteEvent.content.ifBlank { null },
+    )
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun MintAnnouncementCard(
+    title: String,
+    url: String?,
+    network: String?,
+    capabilities: List<String>,
+    capabilitiesLabel: String?,
+    metadata: String?,
+) {
+    Row(
+        modifier =
+            Modifier
+                .clip(shape = QuoteBorder)
+                .border(
+                    1.dp,
+                    MaterialTheme.colorScheme.subtleBorder,
+                    QuoteBorder,
+                ).fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier.padding(10.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+
+                if (network != null) {
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = network,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary,
+                        fontWeight = FontWeight.Bold,
+                        modifier =
+                            Modifier
+                                .clip(SmallBorder)
+                                .border(1.dp, MaterialTheme.colorScheme.primary, SmallBorder)
+                                .padding(horizontal = 6.dp, vertical = 2.dp),
+                    )
+                }
+            }
+
+            url?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+            }
+
+            if (capabilities.isNotEmpty() && capabilitiesLabel != null) {
+                FlowRow(
+                    modifier = Modifier.padding(top = 6.dp),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        text = "$capabilitiesLabel: ",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = Color.Gray,
+                    )
+                    capabilities.forEach { capability ->
+                        Text(
+                            text = capability,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = Color.Gray,
+                            modifier =
+                                Modifier
+                                    .clip(SmallBorder)
+                                    .border(1.dp, Color.Gray.copy(alpha = 0.3f), SmallBorder)
+                                    .padding(horizontal = 4.dp, vertical = 1.dp),
+                        )
+                    }
+                }
+            }
+
+            metadata?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.Gray,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(top = 6.dp),
+                )
+            }
+        }
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/types/NIP90Status.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/types/NIP90Status.kt
@@ -18,20 +18,20 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.types
+package com.vitorpamplona.amethyst.commons.ui.note.types
 
-// Re-export from commons for backwards compatibility
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.ui.navigation.navs.INav
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
-import com.vitorpamplona.amethyst.commons.ui.note.types.RenderNIP90Status as CommonsRenderNIP90Status
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.IAccountViewModel
+import com.vitorpamplona.quartz.nip90Dvms.status.NIP90StatusEvent
 
 @Composable
 fun RenderNIP90Status(
     note: Note,
-    accountViewModel: AccountViewModel,
-    nav: INav,
+    accountViewModel: IAccountViewModel,
 ) {
-    CommonsRenderNIP90Status(note, accountViewModel)
+    val noteEvent = note.event as? NIP90StatusEvent ?: return
+
+    Text(text = noteEvent.content)
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/IAccountViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/IAccountViewModel.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.screen.loggedIn
+
+import com.vitorpamplona.amethyst.commons.model.AddressableNote
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.quartz.nip01Core.core.Address
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * Cross-platform interface for AccountViewModel.
+ *
+ * Provides the subset of AccountViewModel's API that can be expressed
+ * using only commonMain types (IAccount, Note, User, HexKey, etc.).
+ * The Android-specific AccountViewModel implements this interface so
+ * that UI files migrated to commonMain can accept IAccountViewModel
+ * as a parameter without depending on Android-only types.
+ *
+ * Usage pattern for migrated files:
+ *   Before: fun MyScreen(accountViewModel: AccountViewModel, ...)
+ *   After:  fun MyScreen(accountViewModel: IAccountViewModel, ...)
+ */
+interface IAccountViewModel {
+    // ---- Core account access ----
+
+    /** The underlying account, abstracted via IAccount for commonMain use. */
+    val account: IAccount
+
+    /** Coroutine scope tied to the ViewModel lifecycle. */
+    val scope: CoroutineScope
+
+    // ---- Identity helpers (used by 50+ files) ----
+
+    /** Current user's profile. Delegates to account.userProfile(). */
+    fun userProfile(): User
+
+    /** Whether the current account can sign events. */
+    fun isWriteable(): Boolean
+
+    /** Check if the given pubkey is the logged-in user. */
+    fun isLoggedUser(pubkeyHex: HexKey?): Boolean
+
+    /** Check if the given user is the logged-in user. */
+    fun isLoggedUser(user: User?): Boolean
+
+    /** Check if the current account follows the given user. */
+    fun isFollowing(user: User?): Boolean
+
+    /** Check if the current account follows the given pubkey. */
+    fun isFollowing(user: HexKey): Boolean
+
+    // ---- Cache lookups (used by 30+ files) ----
+
+    fun checkGetOrCreateUser(key: HexKey): User?
+
+    fun getUserIfExists(hex: HexKey): User?
+
+    fun checkGetOrCreateNote(key: HexKey): Note?
+
+    fun getNoteIfExists(hex: HexKey): Note?
+
+    fun getOrCreateAddressableNote(address: Address): AddressableNote?
+
+    fun getAddressableNoteIfExists(key: String): AddressableNote?
+
+    fun getAddressableNoteIfExists(key: Address): AddressableNote?
+
+    // ---- Async helpers ----
+
+    /** Launch a coroutine on IO dispatchers. */
+    fun runOnIO(runOnIO: suspend () -> Unit)
+
+    // ---- Actions (commonly used) ----
+
+    fun follow(user: User)
+
+    fun unfollow(user: User)
+
+    fun hide(user: User)
+
+    fun show(user: User)
+
+    fun boost(note: Note)
+
+    fun delete(note: Note)
+
+    fun delete(notes: List<Note>)
+
+    fun broadcast(note: Note)
+
+    fun reactToOrDelete(note: Note)
+
+    fun reactToOrDelete(
+        note: Note,
+        reaction: String,
+    )
+
+    fun decrypt(
+        note: Note,
+        onReady: (String) -> Unit,
+    )
+
+    fun cachedDecrypt(note: Note): String?
+
+    // ---- Bookmark / Pin (used by several files) ----
+
+    fun addPrivateBookmark(note: Note)
+
+    fun addPublicBookmark(note: Note)
+
+    fun removePrivateBookmark(note: Note)
+
+    fun removePublicBookmark(note: Note)
+
+    fun addPin(note: Note)
+
+    fun removePin(note: Note)
+
+    // ---- Navigation helpers ----
+
+    fun loadReactionTo(note: Note?): String?
+
+    fun loadAndMarkAsRead(
+        routeForLastRead: String,
+        createdAt: Long?,
+    ): Boolean
+
+    // ---- Settings delegates ----
+
+    fun defaultZapType(): LnZapEvent.ZapType
+
+    fun reactionChoices(): List<String>
+
+    fun zapAmountChoices(): List<Long>
+
+    fun showSensitiveContent(): MutableStateFlow<Boolean?>
+
+    fun dontTranslateFrom(): Set<String>
+
+    fun translateTo(): String
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/bookmarkgroups/BookmarkType.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/bookmarkgroups/BookmarkType.kt
@@ -18,20 +18,10 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.types
+package com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.bookmarkgroups
 
-// Re-export from commons for backwards compatibility
-import androidx.compose.runtime.Composable
-import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.ui.navigation.navs.INav
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
-import com.vitorpamplona.amethyst.commons.ui.note.types.RenderNIP90Status as CommonsRenderNIP90Status
+enum class BookmarkType {
+    PostBookmark,
 
-@Composable
-fun RenderNIP90Status(
-    note: Note,
-    accountViewModel: AccountViewModel,
-    nav: INav,
-) {
-    CommonsRenderNIP90Status(note, accountViewModel)
+    ArticleBookmark,
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/theme/Shape.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/theme/Shape.kt
@@ -1,0 +1,410 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.theme
+
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.foundation.shape.CutCornerShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Shapes
+import androidx.compose.material3.ripple
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.Placeholder
+import androidx.compose.ui.text.PlaceholderVerticalAlign
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+val Shapes =
+    Shapes(
+        small = RoundedCornerShape(4.dp),
+        medium = RoundedCornerShape(4.dp),
+        large = RoundedCornerShape(0.dp),
+    )
+
+val RippleRadius45dp = 45.dp // Ripple should be +10.dp over the component size
+
+val BottomTopHeight = Modifier.height(50.dp)
+val TabRowHeight = Modifier
+
+val SmallestBorder = RoundedCornerShape(5.dp)
+val SmallBorder = RoundedCornerShape(7.dp)
+val SmallishBorder = RoundedCornerShape(9.dp)
+val QuoteBorder = RoundedCornerShape(15.dp)
+
+val ButtonBorder = RoundedCornerShape(20.dp)
+val LeftHalfCircleButtonBorder = ButtonBorder.copy(topEnd = CornerSize(0f), bottomEnd = CornerSize(0f))
+val EditFieldBorder = RoundedCornerShape(25.dp)
+
+val ChatBubbleShapeMe = RoundedCornerShape(15.dp, 15.dp, 3.dp, 15.dp)
+val ChatBubbleShapeThem = RoundedCornerShape(3.dp, 15.dp, 15.dp, 15.dp)
+
+val StdButtonSizeModifier = Modifier.size(19.dp)
+
+val HalfVertSpacer = Modifier.height(2.dp)
+
+val MinHorzSpacer = Modifier.width(1.dp)
+
+val HalfHorzSpacer = Modifier.width(3.dp)
+
+val StdHorzSpacer = Modifier.width(5.dp)
+val StdVertSpacer = Modifier.height(5.dp)
+
+val DoubleHorzSpacer = Modifier.width(10.dp)
+val DoubleVertSpacer = Modifier.height(10.dp)
+
+val Height100Modifier = Modifier.height(100.dp)
+
+val HalfDoubleVertSpacer = Modifier.height(7.dp)
+
+val Size0dp = 0.dp
+val Size2dp = 2.dp
+val Size3dp = 3.dp
+val Size5dp = 5.dp
+val Size6dp = 6.dp
+val Size8dp = 8.dp
+val Size10dp = 10.dp
+val Size12dp = 12.dp
+val Size13dp = 13.dp
+val Size14dp = 14.dp
+val Size15dp = 15.dp
+val Size16dp = 16.dp
+val Size17dp = 17.dp
+val Size18dp = 18.dp
+val Size19dp = 19.dp
+val Size20dp = 20.dp
+val Size22dp = 22.dp
+val Size23dp = 23.dp
+val Size24dp = 24.dp
+val Size25dp = 25.dp
+val Size30dp = 30.dp
+val Size34dp = 34.dp
+val Size35dp = 35.dp
+val Size40dp = 40.dp
+val Size50dp = 50.dp
+val Size55dp = 55.dp
+val Size75dp = 75.dp
+val Size100dp = 100.dp
+val Size110dp = 110.dp
+val Size165dp = 165.dp
+
+val StdEndPadding = Modifier.padding(end = 10.dp)
+val HalfEndPadding = Modifier.padding(end = 5.dp)
+val HalfStartPadding = Modifier.padding(start = 5.dp)
+val StdStartPadding = Modifier.padding(start = 10.dp)
+val StdTopPadding = Modifier.padding(top = 10.dp)
+val HalfTopPadding = Modifier.padding(top = 5.dp)
+val HalfHalfTopPadding = Modifier.padding(top = 3.dp)
+
+val HalfHalfVertPadding = Modifier.padding(vertical = 3.dp)
+val HalfHalfHorzModifier = Modifier.padding(horizontal = 3.dp)
+
+val HalfPadding = Modifier.padding(5.dp)
+val StdPadding = Modifier.padding(10.dp)
+val BigPadding = Modifier.padding(15.dp)
+
+val RowColSpacing = Arrangement.spacedBy(3.dp)
+val RowColSpacing5dp = Arrangement.spacedBy(5.dp)
+val RowColSpacing10dp = Arrangement.spacedBy(10.dp)
+
+val HalfHorzPadding = Modifier.padding(horizontal = 5.dp)
+val HalfVertPadding = Modifier.padding(vertical = 5.dp)
+
+val HorzPadding = Modifier.padding(horizontal = 10.dp)
+val VertPadding = Modifier.padding(vertical = 10.dp)
+
+val HorzHalfVertPadding = Modifier.padding(horizontal = 10.dp, vertical = 5.dp)
+
+val DoubleHorzPadding = Modifier.padding(horizontal = 20.dp)
+val DoubleVertPadding = Modifier.padding(vertical = 20.dp)
+
+val MaxWidthWithHorzPadding = Modifier.fillMaxWidth().padding(horizontal = 10.dp)
+
+val Size5Modifier = Modifier.size(5.dp)
+val Size10Modifier = Modifier.size(10.dp)
+val Size14Modifier = Modifier.size(14.dp)
+val Size15Modifier = Modifier.size(15.dp)
+val Size16Modifier = Modifier.size(16.dp)
+val Size17Modifier = Modifier.size(17.dp)
+val Size18Modifier = Modifier.size(18.dp)
+val Size19Modifier = Modifier.size(19.dp)
+val Size20Modifier = Modifier.size(20.dp)
+val Size22Modifier = Modifier.size(22.dp)
+val Size24Modifier = Modifier.size(24.dp)
+val Size25Modifier = Modifier.size(25.dp)
+val Size26Modifier = Modifier.size(26.dp)
+val Size28Modifier = Modifier.size(28.dp)
+val Size30Modifier = Modifier.size(30.dp)
+val Size35Modifier = Modifier.size(35.dp)
+val Size39Modifier = Modifier.size(39.dp)
+val Size40Modifier = Modifier.size(40.dp)
+val Size50Modifier = Modifier.size(50.dp)
+val Size55Modifier = Modifier.size(55.dp)
+val Size75Modifier = Modifier.size(75.dp)
+
+val TinyBorders = Modifier.padding(2.dp)
+val NoSoTinyBorders = Modifier.padding(start = 5.dp, end = 5.dp, top = 2.dp, bottom = 2.dp)
+val ReactionRowZapraiserWithPadding = Modifier.defaultMinSize(minHeight = 4.dp).padding(start = Size75dp).fillMaxWidth()
+val ReactionRowZapraiser = Modifier.defaultMinSize(minHeight = 4.dp).fillMaxWidth()
+
+val ReactionRowExpandButton = Modifier.width(65.dp).padding(start = 31.dp)
+
+val WidthAuthorPictureModifier = Modifier.width(55.dp)
+val WidthAuthorPictureModifierWithPadding = Modifier.width(65.dp)
+
+val VideoReactionColumnPadding = Modifier.padding(bottom = 75.dp)
+
+val DividerThickness = 0.25.dp
+
+val ReactionRowHeight = Modifier.padding(vertical = 7.dp).heightIn(min = 24.dp)
+val ReactionRowHeightWithPadding = Modifier.padding(vertical = 6.dp).heightIn(min = 24.dp).padding(horizontal = 10.dp)
+val ReactionRowHeightChat = Modifier.height(20.dp)
+val ReactionRowHeightChatMaxWidth = Modifier.height(25.dp).fillMaxWidth()
+val UserNameRowHeight = Modifier.fillMaxWidth()
+val UserNameMaxRowHeight = Modifier.fillMaxWidth()
+
+val Height24dpModifier = Modifier.height(24.dp)
+val Height4dpModifier = Modifier.height(4.dp)
+val Height25Modifier = Modifier.height(Size25dp)
+
+val Height24dpFilledModifier = Modifier.fillMaxWidth().height(24.dp)
+val Height4dpFilledModifier = Modifier.fillMaxWidth().height(4.dp)
+
+val AccountPictureModifier = Modifier.size(55.dp).clip(shape = CircleShape)
+val HeaderPictureModifier = Modifier.size(34.dp).clip(shape = CircleShape)
+
+val ShowMoreRelaysButtonIconButtonModifier = Modifier.size(15.dp)
+val ShowMoreRelaysButtonIconModifier = Modifier.size(20.dp)
+val ShowMoreRelaysButtonBoxModifer = Modifier.width(55.dp).height(17.dp)
+
+val ChatBubbleMaxSizeModifier = Modifier.fillMaxWidth(0.85f)
+
+val ModifierWidth3dp = Modifier.width(3.dp)
+
+val NotificationIconModifier = Modifier.width(55.dp).padding(end = 5.dp)
+val NotificationIconModifierSmaller = Modifier.width(55.dp).padding(end = 4.dp)
+
+val ZapPictureCommentModifier = Modifier.height(35.dp).widthIn(min = 35.dp)
+val ChatHeadlineBorders = StdPadding
+
+val VolumeBottomIconSize = Modifier.size(60.dp).padding(5.dp)
+val PinBottomIconSize = Modifier.size(60.dp).padding(5.dp)
+val PlayIconSize = Modifier.size(110.dp).padding(10.dp)
+val NIP05IconSize = Modifier.size(13.dp).padding(top = 1.dp, start = 1.dp, end = 1.dp)
+
+val CashuCardBorders = Modifier.fillMaxWidth().padding(10.dp).clip(shape = QuoteBorder)
+
+val EditFieldModifier =
+    Modifier.padding(start = 10.dp, end = 10.dp, bottom = 10.dp, top = 5.dp).fillMaxWidth()
+val EditFieldTrailingIconModifier = Modifier.padding(start = 5.dp, end = 0.dp)
+
+val ZeroPadding = PaddingValues(0.dp)
+val HalfFeedPadding = PaddingValues(5.dp)
+val FeedPadding = PaddingValues(top = 10.dp, bottom = 10.dp)
+val ButtonPadding = PaddingValues(vertical = 6.dp, horizontal = 16.dp)
+
+val ChatPaddingInnerQuoteModifier = Modifier
+val ChatPaddingModifier =
+    Modifier
+        .fillMaxWidth(1f)
+        .padding(
+            start = 12.dp,
+            end = 12.dp,
+            top = 3.dp,
+            bottom = 3.dp,
+        )
+
+val profileContentHeaderModifier =
+    Modifier.fillMaxWidth().padding(top = 70.dp, start = Size25dp, end = Size25dp)
+val bannerModifier = Modifier.fillMaxWidth().height(120.dp)
+val drawerSpacing = Modifier.padding(top = Size10dp, start = Size25dp, end = Size25dp)
+
+val IconRowTextModifier = Modifier.padding(start = 16.dp)
+val IconRowModifier = Modifier.fillMaxWidth().padding(vertical = 15.dp, horizontal = 25.dp)
+
+val Width16Space = Modifier.width(Size16dp)
+
+val emptyLineItemModifier = Modifier.height(Size75dp).fillMaxWidth()
+
+val imageHeaderBannerSize = Modifier.fillMaxWidth().height(150.dp)
+
+val authorNotePictureForImageHeader = Modifier.size(75.dp).padding(10.dp)
+
+val normalWithTopMarginNoteModifier =
+    Modifier
+        .fillMaxWidth()
+        .padding(
+            start = 12.dp,
+            end = 12.dp,
+            top = 10.dp,
+        )
+
+val boostedNoteModifier =
+    Modifier
+        .fillMaxWidth()
+        .padding(
+            start = 0.dp,
+            end = 0.dp,
+            top = 0.dp,
+        )
+
+val liveStreamTag =
+    Modifier
+        .clip(SmallBorder)
+        .background(Color.Black)
+        .padding(horizontal = Size5dp)
+
+val chatAuthorBox = Modifier.size(20.dp)
+val chatAuthorImage = Modifier.size(20.dp).clip(shape = CircleShape)
+val AuthorInfoVideoFeed = Modifier.width(75.dp).padding(end = 15.dp)
+
+val messageDetailsModifier = Modifier.height(Size25dp)
+val messageBubbleLimits = Modifier.padding(start = 10.dp, end = 10.dp, top = 7.dp, bottom = 6.dp)
+
+val inlinePlaceholder =
+    Placeholder(
+        width = Font17SP,
+        height = Font17SP,
+        placeholderVerticalAlign = PlaceholderVerticalAlign.Center,
+    )
+
+val IncognitoIconModifier = Modifier.padding(top = 1.dp).size(14.dp)
+val IncognitoIconButtonModifier = Modifier.padding(top = 2.dp).size(20.dp)
+
+val hashVerifierMark = Modifier.width(40.dp).height(40.dp).padding(10.dp)
+
+val noteComposeRelayBox = Modifier.width(55.dp).heightIn(min = 17.dp).padding(start = 2.dp, end = 1.dp)
+
+val previewCardImageModifier = Modifier.fillMaxWidth().heightIn(max = 200.dp).padding(bottom = 5.dp)
+
+val reactionBox =
+    Modifier
+        .padding(horizontal = 6.dp, vertical = 6.dp)
+        .size(Size40dp)
+        .padding(5.dp)
+
+val ripple24dp = ripple(bounded = false, radius = Size24dp)
+
+val defaultTweenDuration = 100
+val defaultTweenFloatSpec = tween<Float>(durationMillis = defaultTweenDuration)
+val defaultTweenIntOffsetSpec = tween<IntOffset>(durationMillis = defaultTweenDuration)
+
+val StreamingHeaderModifier =
+    Modifier
+        .fillMaxWidth()
+        .heightIn(min = 50.dp, max = 300.dp)
+
+val PostKeyboard =
+    KeyboardOptions.Default.copy(
+        autoCorrectEnabled = true,
+        capitalization = KeyboardCapitalization.Sentences,
+    )
+
+val SettingsCategoryFirstModifier = Modifier.padding(bottom = 8.dp)
+val SettingsCategorySpacingModifier = Modifier.padding(top = 24.dp, bottom = 8.dp)
+
+val SettingsCategoryFirstWithHorzBorderModifier = Modifier.padding(bottom = 8.dp, start = 10.dp, end = 10.dp)
+val SettingsCategorySpacingWithHorzBorderModifier = Modifier.padding(top = 24.dp, bottom = 8.dp, start = 10.dp, end = 10.dp)
+
+val SquaredQuoteBorderModifier = Modifier.aspectRatio(1f).clip(shape = QuoteBorder)
+val FillWidthQuoteBorderModifier = Modifier.fillMaxWidth().clip(shape = QuoteBorder)
+
+val MediumRelayIconModifier =
+    Modifier
+        .size(Size35dp)
+        .clip(shape = CircleShape)
+
+val LargeRelayIconModifier =
+    Modifier
+        .size(Size55dp)
+        .clip(shape = CircleShape)
+
+val FollowSetImageModifier =
+    Modifier
+        .fillMaxWidth()
+        .clip(QuoteBorder)
+        .aspectRatio(ratio = 21f / 9f)
+
+val SimpleImage75Modifier = Modifier.size(Size75dp).clip(QuoteBorder)
+val SimpleImage35Modifier = Modifier.size(Size34dp).clip(shape = CircleShape)
+
+val SimpleImageBorder = Modifier.fillMaxSize().clip(QuoteBorder)
+
+val SimpleHeaderImage = Modifier.fillMaxWidth().heightIn(max = 200.dp)
+
+val BadgePictureModifier = Modifier.size(35.dp).clip(shape = CutCornerShape(20))
+
+val MaxWidthPaddingTop5dp = Modifier.fillMaxWidth().padding(top = 5.dp)
+
+val VoiceHeightModifier = Modifier.fillMaxWidth().height(100.dp)
+
+val PaddingHorizontal12Modifier = Modifier.padding(horizontal = 12.dp)
+
+val QuickActionPopupShadow = Modifier.shadow(elevation = Size6dp, shape = SmallestBorder)
+
+val SpacedBy2dp = Arrangement.spacedBy(Size2dp)
+val SpacedBy3dp = Arrangement.spacedBy(Size3dp)
+val SpacedBy5dp = Arrangement.spacedBy(Size5dp)
+val SpacedBy10dp = Arrangement.spacedBy(Size10dp)
+val SpacedBy55dp = Arrangement.spacedBy(Size55dp)
+
+val PopupUpEffect = RoundedCornerShape(0.dp, 0.dp, 15.dp, 15.dp)
+
+val Size50ModifierOffset10 = Modifier.size(50.dp).offset(y = (-10).dp)
+
+val SuggestionListDefaultHeightChat = Modifier.heightIn(0.dp, 200.dp)
+val SuggestionListDefaultHeightPage = Modifier.heightIn(0.dp, 300.dp)
+
+// TopBarSize inlined (50.dp) to avoid dependency on amethyst.ui.navigation
+val FollowPackHeaderModifier = Modifier.fillMaxWidth().height(50.dp)
+
+val Size22ModifierWith4Padding = Modifier.size(22.dp).padding(end = 4.dp)
+
+val TextStyleBottomNavBar =
+    TextLinkStyles(
+        SpanStyle(
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Bold,
+        ),
+    )

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/theme/ThemeExtensions.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/theme/ThemeExtensions.kt
@@ -20,9 +20,16 @@
  */
 package com.vitorpamplona.amethyst.commons.ui.theme
 
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ColorScheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.unit.dp
 
 /**
  * Determines if the color scheme is light mode.
@@ -36,3 +43,24 @@ val ColorScheme.isLight: Boolean
  */
 val ColorScheme.onBackgroundColorFilter: ColorFilter
     get() = ColorFilter.tint(onBackground)
+
+/**
+ * Subtle border color for cards and containers.
+ * Uses different alpha for light vs dark to maintain visual contrast.
+ */
+val ColorScheme.subtleBorder: Color
+    get() = if (isLight) onSurface.copy(alpha = 0.05f) else onSurface.copy(alpha = 0.12f)
+
+/**
+ * Reply/quote border modifier for embedded note content.
+ */
+@Suppress("ModifierFactoryExtensionFunction")
+val ColorScheme.replyModifier: Modifier
+    get() {
+        val borderColor = subtleBorder
+        return Modifier
+            .padding(top = 5.dp)
+            .fillMaxWidth()
+            .clip(shape = QuoteBorder)
+            .border(1.dp, borderColor, QuoteBorder)
+    }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/theme/Type.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/theme/Type.kt
@@ -20,33 +20,34 @@
  */
 package com.vitorpamplona.amethyst.commons.ui.theme
 
-import androidx.compose.material3.ColorScheme
-import androidx.compose.ui.graphics.Color
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
 
-// Chat-prefixed aliases for commons UI components that use these names.
-// The canonical definitions now live in Shape.kt.
-val ChatRowColSpacing5dp = RowColSpacing5dp
-val ChatHalfHalfVertPadding = HalfHalfVertPadding
-val ChatStdHorzSpacer = StdHorzSpacer
-val ChatStdPadding = StdPadding
-val ChatReactionRowHeight = ReactionRowHeightChat
-val ChatSize20dp = Size20dp
-val ChatSize34dp = Size34dp
+// Set of Material typography styles to start with
+val Typography =
+    Typography(
+        bodyLarge =
+            TextStyle(
+                fontFamily = FontFamily.Default,
+                fontWeight = FontWeight.Normal,
+                fontSize = 16.sp,
+            ),
+    )
 
-// Chat-prefixed aliases for PascalCase originals in Shape.kt
-val ChatAuthorBox = chatAuthorBox
-val ChatAuthorImage = chatAuthorImage
-val MessageBubbleLimits = messageBubbleLimits
+val Font4SP = 4.sp
+val Font6SP = 6.sp
+val Font8SP = 8.sp
+val Font10SP = 10.sp
+val Font12SP = 12.sp
+val Font14SP = 14.sp
+val Font17SP = 17.sp
+val Font18SP = 18.sp
 
-// Chat color extensions for ColorScheme
-val ColorScheme.chatBubbleBackground: Color
-    get() = if (isLight) onSurface.copy(alpha = 0.08f) else onSurface.copy(alpha = 0.12f)
+val MarkdownTextStyle = TextStyle(lineHeight = 1.50.em)
 
-val ColorScheme.chatBubbleDraftBackground: Color
-    get() = onSurface.copy(alpha = 0.15f)
-
-val ColorScheme.chatBubbleMeBackground: Color
-    get() = primary.copy(alpha = 0.32f)
-
-val ColorScheme.chatPlaceholderText: Color
-    get() = onSurface.copy(alpha = 0.42f)
+val DefaultParagraphSpacing: TextUnit = 20.sp

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/ui/theme/HeadingStyle.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/ui/theme/HeadingStyle.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.theme
+
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import com.halilibo.richtext.ui.HeadingStyle
+
+val DefaultHeadingStyle: HeadingStyle = { level, textStyle ->
+    when (level) {
+        0 -> {
+            Typography.displayLarge.copy(
+                fontSize = 32.sp,
+                lineHeight = 40.sp,
+                fontWeight = FontWeight.Bold,
+                letterSpacing = (-0.5).sp,
+            )
+        }
+
+        1 -> {
+            Typography.displayMedium.copy(
+                fontSize = 26.sp,
+                lineHeight = 34.sp,
+                fontWeight = FontWeight.Bold,
+                letterSpacing = (-0.25).sp,
+            )
+        }
+
+        2 -> {
+            Typography.displaySmall.copy(
+                fontSize = 22.sp,
+                lineHeight = 30.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+
+        3 -> {
+            Typography.displaySmall.copy(
+                fontSize = 20.sp,
+                lineHeight = 28.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+
+        4 -> {
+            Typography.headlineLarge.copy(
+                fontSize = 18.sp,
+                lineHeight = 24.sp,
+                fontWeight = FontWeight.Medium,
+            )
+        }
+
+        5 -> {
+            Typography.headlineMedium.copy(
+                fontSize = 16.sp,
+                lineHeight = 22.sp,
+                fontWeight = FontWeight.Medium,
+            )
+        }
+
+        6 -> {
+            Typography.headlineSmall.copy(
+                fontSize = 15.sp,
+                lineHeight = 20.sp,
+                fontWeight = FontWeight.Medium,
+            )
+        }
+
+        else -> {
+            textStyle
+        }
+    }
+}


### PR DESCRIPTION
Moves portable note/types/ composable files to commons for KMP.

## Files moved to commons/commonMain

### note/types/ composables
- **EcashMint.kt** — RenderCashuMint, RenderFedimint, RenderMintRecommendation
- **CodeSnippet.kt** — RenderCodeSnippetEvent, RenderCodeSnippetHeaderForThread  
- **NIP90Status.kt** — RenderNIP90Status

### Supporting types moved to commons
- **GenericLoadable** sealed class → commons/ui/components/
- **BookmarkType** enum → commons/ui/screen/loggedIn/bookmarkgroups/
- **subtleBorder** extension → commons/ui/theme/ThemeExtensions.kt
- **replyModifier** extension → commons/ui/theme/ThemeExtensions.kt

### Foundation cherry-picks (from architecture-unblocks)
- Route sealed class, INav interface, EmptyNav
- IAccountViewModel interface
- Shape.kt and Type.kt theme tokens

All original files retain backward-compatible wrappers that delegate to commons.

Part of the KMP iOS migration tracked in #2238.