### PR TITLE
feat: move note/elements composables to commons (batch 18)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/AddRemoveButtons.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/AddRemoveButtons.kt
@@ -21,19 +21,15 @@
 package com.vitorpamplona.amethyst.ui.note.elements
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.ui.stringRes
-import com.vitorpamplona.amethyst.ui.theme.ButtonBorder
 import com.vitorpamplona.amethyst.ui.theme.ThemeComparisonColumn
+import com.vitorpamplona.amethyst.commons.ui.components.AddButton as CommonsAddButton
+import com.vitorpamplona.amethyst.commons.ui.components.RemoveButton as CommonsRemoveButton
 
 @Composable
 @Preview
@@ -60,15 +56,12 @@ fun AddButton(
     isActive: Boolean = true,
     onClick: () -> Unit,
 ) {
-    OutlinedButton(
-        modifier = modifier,
-        enabled = isActive,
+    CommonsAddButton(
         onClick = onClick,
-        shape = ButtonBorder,
-        contentPadding = PaddingValues(vertical = 0.dp, horizontal = 16.dp),
-    ) {
-        Text(text = stringRes(text), textAlign = TextAlign.Center)
-    }
+        modifier = modifier,
+        text = stringRes(text),
+        enabled = isActive,
+    )
 }
 
 @Composable
@@ -78,13 +71,10 @@ fun RemoveButton(
     isActive: Boolean = true,
     onClick: () -> Unit,
 ) {
-    OutlinedButton(
-        modifier = modifier,
+    CommonsRemoveButton(
         onClick = onClick,
-        shape = ButtonBorder,
+        modifier = modifier,
+        text = stringRes(text),
         enabled = isActive,
-        contentPadding = PaddingValues(vertical = 0.dp, horizontal = 16.dp),
-    ) {
-        Text(text = stringRes(text))
-    }
+    )
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DisplayCommunity.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DisplayCommunity.kt
@@ -26,13 +26,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.text.style.TextOverflow
+import com.vitorpamplona.amethyst.commons.ui.note.elements.getCommunityShortName
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.components.ClickableTextColor
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.theme.HalfStartPadding
-import com.vitorpamplona.quartz.nip01Core.core.Address
 import com.vitorpamplona.quartz.nip72ModCommunities.communityAddress
 
 @Composable
@@ -67,13 +67,5 @@ private fun DisplayCommunity(
     }
 }
 
-fun getCommunityShortName(communityAddress: Address): String {
-    val name =
-        if (communityAddress.dTag.length > 10) {
-            communityAddress.dTag.take(10) + "..."
-        } else {
-            communityAddress.dTag.take(10)
-        }
-
-    return "/n/$name"
-}
+// getCommunityShortName moved to commons:
+// com.vitorpamplona.amethyst.commons.ui.note.elements.getCommunityShortName

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DisplayPoW.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DisplayPoW.kt
@@ -20,14 +20,10 @@
  */
 package com.vitorpamplona.amethyst.ui.note.elements
 
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
-import com.vitorpamplona.amethyst.ui.theme.Font14SP
 import com.vitorpamplona.amethyst.ui.theme.ThemeComparisonColumn
-import com.vitorpamplona.amethyst.ui.theme.lessImportantLink
+import com.vitorpamplona.amethyst.commons.ui.note.elements.DisplayPoW as CommonsDisplayPoW
 
 @Composable
 @Preview
@@ -39,11 +35,5 @@ fun DisplayPoWPreview() {
 
 @Composable
 fun DisplayPoW(pow: Int) {
-    Text(
-        "PoW-$pow",
-        color = MaterialTheme.colorScheme.lessImportantLink,
-        fontSize = Font14SP,
-        fontWeight = FontWeight.Bold,
-        maxLines = 1,
-    )
+    CommonsDisplayPoW(pow)
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/elements/BoostedMark.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/elements/BoostedMark.kt
@@ -18,14 +18,27 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.elements
+package com.vitorpamplona.amethyst.commons.ui.note.elements
 
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.ui.stringRes
-import com.vitorpamplona.amethyst.commons.ui.note.elements.BoostedMark as CommonsBoostedMark
+import androidx.compose.ui.text.font.FontWeight
+import com.vitorpamplona.amethyst.commons.ui.theme.HalfStartPadding
+import com.vitorpamplona.amethyst.commons.ui.theme.placeholderText
 
+/**
+ * Displays a "Boosted" label for reposted notes.
+ *
+ * @param text The localized "boosted" text to display.
+ */
 @Composable
-fun BoostedMark() {
-    CommonsBoostedMark(text = stringRes(id = R.string.boosted))
+fun BoostedMark(text: String) {
+    Text(
+        text,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.placeholderText,
+        maxLines = 1,
+        modifier = HalfStartPadding,
+    )
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/elements/CommunityUtils.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/elements/CommunityUtils.kt
@@ -18,14 +18,21 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.elements
+package com.vitorpamplona.amethyst.commons.ui.note.elements
 
-import androidx.compose.runtime.Composable
-import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.ui.stringRes
-import com.vitorpamplona.amethyst.commons.ui.note.elements.BoostedMark as CommonsBoostedMark
+import com.vitorpamplona.quartz.nip01Core.core.Address
 
-@Composable
-fun BoostedMark() {
-    CommonsBoostedMark(text = stringRes(id = R.string.boosted))
+/**
+ * Returns a short display name for a community address.
+ * Truncates the dTag to 10 characters if needed.
+ */
+fun getCommunityShortName(communityAddress: Address): String {
+    val name =
+        if (communityAddress.dTag.length > 10) {
+            communityAddress.dTag.take(10) + "..."
+        } else {
+            communityAddress.dTag.take(10)
+        }
+
+    return "/n/$name"
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/elements/DisplayPoW.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/elements/DisplayPoW.kt
@@ -18,14 +18,22 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note.elements
+package com.vitorpamplona.amethyst.commons.ui.note.elements
 
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.ui.stringRes
-import com.vitorpamplona.amethyst.commons.ui.note.elements.BoostedMark as CommonsBoostedMark
+import androidx.compose.ui.text.font.FontWeight
+import com.vitorpamplona.amethyst.commons.ui.theme.Font14SP
+import com.vitorpamplona.amethyst.commons.ui.theme.lessImportantLink
 
 @Composable
-fun BoostedMark() {
-    CommonsBoostedMark(text = stringRes(id = R.string.boosted))
+fun DisplayPoW(pow: Int) {
+    Text(
+        "PoW-$pow",
+        color = MaterialTheme.colorScheme.lessImportantLink,
+        fontSize = Font14SP,
+        fontWeight = FontWeight.Bold,
+        maxLines = 1,
+    )
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/theme/ThemeExtensions.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/theme/ThemeExtensions.kt
@@ -20,9 +20,15 @@
  */
 package com.vitorpamplona.amethyst.commons.ui.theme
 
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ColorScheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 /**
  * Determines if the color scheme is light mode.
@@ -36,3 +42,27 @@ val ColorScheme.isLight: Boolean
  */
 val ColorScheme.onBackgroundColorFilter: ColorFilter
     get() = ColorFilter.tint(onBackground)
+
+/**
+ * Placeholder text color (42% alpha onSurface).
+ */
+val ColorScheme.placeholderText: Color
+    get() = onSurface.copy(alpha = 0.42f)
+
+/**
+ * Less important link color (52% alpha primary).
+ */
+val ColorScheme.lessImportantLink: Color
+    get() = primary.copy(alpha = 0.52f)
+
+/** Standard font size for secondary text. */
+val Font14SP = 14.sp
+
+/** Half-width start padding modifier. */
+val HalfStartPadding = Modifier.padding(start = 5.dp)
+
+/** Half-width top padding modifier. */
+val HalfTopPadding = Modifier.padding(top = 5.dp)
+
+/** Standard button border shape. */
+val ButtonBorder = RoundedCornerShape(20.dp)


### PR DESCRIPTION
Moves portable note/elements/ composable files to commons for KMP.

## Changes

### New commons files
- **DisplayPoW.kt** — Pure compose `DisplayPoW(pow: Int)` composable
- **BoostedMark.kt** — `BoostedMark(text: String)` composable (takes localized string)
- **CommunityUtils.kt** — `getCommunityShortName(Address)` utility function

### Theme extensions added to commons ThemeExtensions.kt
- `ColorScheme.placeholderText` — 42% alpha onSurface
- `ColorScheme.lessImportantLink` — 52% alpha primary
- `Font14SP`, `HalfStartPadding`, `HalfTopPadding`, `ButtonBorder`

### Updated Android files
- **DisplayPoW.kt** — Thin wrapper delegating to commons
- **BoostedMark.kt** — Resolves `R.string.boosted` then delegates to commons
- **AddRemoveButtons.kt** — Delegates to existing commons ActionButtons
- **DisplayCommunity.kt** — Uses `getCommunityShortName` from commons

Part of the KMP iOS migration tracked in #2238.