### PR TITLE
feat: extract posting ViewModel logic to commons (batch 11)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/CommentPostViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/CommentPostViewModel.kt
@@ -38,6 +38,8 @@ import com.vitorpamplona.amethyst.commons.compose.insertUrlAtCursor
 import com.vitorpamplona.amethyst.commons.compose.replaceCurrentWord
 import com.vitorpamplona.amethyst.commons.compose.setTextAndPlaceCursorAtBeginning
 import com.vitorpamplona.amethyst.commons.model.nip30CustomEmojis.EmojiPackState
+import com.vitorpamplona.amethyst.commons.viewmodels.posting.CommentPostState
+import com.vitorpamplona.amethyst.commons.viewmodels.posting.LongFormPostState
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
@@ -73,26 +75,15 @@ import com.vitorpamplona.quartz.nip01Core.core.AddressableEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip01Core.signers.SignerExceptions
-import com.vitorpamplona.quartz.nip01Core.tags.geohash.geohash
 import com.vitorpamplona.quartz.nip01Core.tags.geohash.hasGeohashes
-import com.vitorpamplona.quartz.nip01Core.tags.hashtags.hashtags
-import com.vitorpamplona.quartz.nip01Core.tags.references.references
-import com.vitorpamplona.quartz.nip10Notes.content.findHashtags
-import com.vitorpamplona.quartz.nip10Notes.content.findNostrUris
 import com.vitorpamplona.quartz.nip10Notes.content.findURLs
-import com.vitorpamplona.quartz.nip18Reposts.quotes.quotes
 import com.vitorpamplona.quartz.nip18Reposts.quotes.taggedQuoteIds
 import com.vitorpamplona.quartz.nip22Comments.CommentEvent
-import com.vitorpamplona.quartz.nip22Comments.notify
-import com.vitorpamplona.quartz.nip30CustomEmoji.CustomEmoji
-import com.vitorpamplona.quartz.nip30CustomEmoji.EmojiUrlTag
 import com.vitorpamplona.quartz.nip30CustomEmoji.emojis
-import com.vitorpamplona.quartz.nip36SensitiveContent.contentWarning
 import com.vitorpamplona.quartz.nip36SensitiveContent.contentWarningReason
 import com.vitorpamplona.quartz.nip36SensitiveContent.isSensitive
 import com.vitorpamplona.quartz.nip37Drafts.DraftWrapEvent
 import com.vitorpamplona.quartz.nip40Expiration.expiration
-import com.vitorpamplona.quartz.nip57Zaps.splits.zapSplits
 import com.vitorpamplona.quartz.nip57Zaps.zapraiser.zapraiser
 import com.vitorpamplona.quartz.nip57Zaps.zapraiser.zapraiserAmount
 import com.vitorpamplona.quartz.nip72ModCommunities.definition.CommunityDefinitionEvent
@@ -125,6 +116,7 @@ open class CommentPostViewModel :
     IZapRaiser,
     IExpiration {
     val draftTag = DraftTagState()
+    val postState = CommentPostState()
 
     init {
         viewModelScope.launch(Dispatchers.IO) {
@@ -384,16 +376,16 @@ open class CommentPostViewModel :
             )
         tagger.run()
 
-        val geoHash = (location?.value as? LocationState.LocationResult.Success)?.geoHash?.toString()
+        syncToPostState()
 
-        val emojis = findEmoji(tagger.message, account.emoji.myEmojis.value)
+        val emojiMedia = account.emoji.myEmojis.value
+        val emojis =
+            LongFormPostState.findEmoji(
+                tagger.message,
+                emojiMedia?.map { Pair(it.code, it.link) },
+            )
         val urls = findURLs(tagger.message)
         val usedAttachments = iMetaAttachments.filterIsIn(urls.toSet())
-
-        val zapReceiver = if (wantsForwardZapTo) forwardZapTo.value.toZapSplitSetup() else null
-        val localZapRaiserAmount = if (wantsZapraiser) zapRaiserAmount.value else null
-        val contentWarningReason = if (wantsToMarkAsSensitive) contentWarningDescription else null
-        val localExpirationDate = if (wantsExpirationDate) expirationDate else null
 
         val replyingTo = replyingTo
         val replyingToEvent = replyingTo?.event
@@ -402,79 +394,52 @@ open class CommentPostViewModel :
             if (replyingTo != null) {
                 val eventHint = replyingTo.toEventHint<Event>() ?: return null
 
-                CommentEvent.replyBuilder(
-                    msg = tagger.message,
-                    replyingTo = eventHint,
-                ) {
-                    val notifyPTags = tagger.pTags?.let { pTagList -> pTagList.map { it.toPTag() } } ?: emptyList()
+                val notifyPTags = tagger.pTags?.let { pTagList -> pTagList.map { it.toPTag() } } ?: emptyList()
 
-                    val extraNotificationAuthors =
-                        if (replyingToEvent is CommunityDefinitionEvent) {
-                            replyingToEvent.moderatorKeys().mapNotNull {
-                                if (it != replyingToEvent.pubKey) {
-                                    accountViewModel.checkGetOrCreateUser(it)?.toPTag()
-                                } else {
-                                    null
-                                }
+                val extraNotificationAuthors =
+                    if (replyingToEvent is CommunityDefinitionEvent) {
+                        replyingToEvent.moderatorKeys().mapNotNull {
+                            if (it != replyingToEvent.pubKey) {
+                                accountViewModel.checkGetOrCreateUser(it)?.toPTag()
+                            } else {
+                                null
                             }
-                        } else {
-                            emptyList()
                         }
+                    } else {
+                        emptyList()
+                    }
 
-                    notify((notifyPTags + extraNotificationAuthors).distinctBy { it.pubKey })
-
-                    hashtags(findHashtags(tagger.message))
-                    references(findURLs(tagger.message))
-                    quotes(findNostrUris(tagger.message))
-
-                    localZapRaiserAmount?.let { zapraiser(it) }
-                    zapReceiver?.let { zapSplits(it) }
-                    contentWarningReason?.let { contentWarning(it) }
-                    localExpirationDate?.let { expiration(it) }
-
-                    emojis(emojis)
-                    imetas(usedAttachments)
-                    geoHash?.let { geohash(it) }
-                }
+                postState.createReplyTemplate(
+                    tagger.message,
+                    eventHint,
+                    notifyPTags + extraNotificationAuthors,
+                    emojis,
+                    usedAttachments,
+                )
             } else {
                 val externalIdentity = externalIdentity ?: return null
-                CommentEvent.replyExternalIdentity(
-                    msg = tagger.message,
-                    extId = externalIdentity,
-                ) {
-                    tagger.pTags?.let { pTagList -> notify(pTagList.map { it.toPTag() }) }
+                val notifyPTags = tagger.pTags?.let { pTagList -> pTagList.map { it.toPTag() } } ?: emptyList()
 
-                    hashtags(findHashtags(tagger.message))
-                    references(findURLs(tagger.message))
-                    quotes(findNostrUris(tagger.message))
-
-                    localZapRaiserAmount?.let { zapraiser(it) }
-                    zapReceiver?.let { zapSplits(it) }
-                    contentWarningReason?.let { contentWarning(it) }
-                    localExpirationDate?.let { expiration(it) }
-
-                    emojis(emojis)
-                    imetas(usedAttachments)
-                    geoHash?.let { geohash(it) }
-                }
+                postState.createExternalReplyTemplate(
+                    tagger.message,
+                    externalIdentity,
+                    notifyPTags,
+                    emojis,
+                    usedAttachments,
+                )
             }
 
         return template
     }
 
-    fun findEmoji(
-        message: String,
-        myEmojiSet: List<EmojiPackState.EmojiMedia>?,
-    ): List<EmojiUrlTag> {
-        if (myEmojiSet == null) return emptyList()
-        return CustomEmoji.findAllEmojiCodes(message).mapNotNull { possibleEmoji ->
-            myEmojiSet.firstOrNull { it.code == possibleEmoji }?.let {
-                EmojiUrlTag(
-                    it.code,
-                    it.link,
-                )
-            }
-        }
+    /** Push Compose mutable state into the platform-independent state object. */
+    private fun syncToPostState() {
+        val geoHash = (location?.value as? LocationState.LocationResult.Success)?.geoHash?.toString()
+        postState.options.updateGeoHash(wantsToAddGeoHash, geoHash)
+        postState.options.updateZapRaiser(wantsZapraiser, zapRaiserAmount.value)
+        postState.options.updateZapSplits(if (wantsForwardZapTo) forwardZapTo.value.toZapSplitSetup() else null)
+        postState.options.updateContentWarning(wantsToMarkAsSensitive, contentWarningDescription)
+        postState.options.updateExpiration(wantsExpirationDate, expirationDate)
     }
 
     fun upload(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip23LongForm/LongFormPostViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip23LongForm/LongFormPostViewModel.kt
@@ -37,6 +37,7 @@ import com.vitorpamplona.amethyst.commons.compose.currentWord
 import com.vitorpamplona.amethyst.commons.compose.insertUrlAtCursor
 import com.vitorpamplona.amethyst.commons.compose.replaceCurrentWord
 import com.vitorpamplona.amethyst.commons.model.nip30CustomEmojis.EmojiPackState.EmojiMedia
+import com.vitorpamplona.amethyst.commons.viewmodels.posting.LongFormPostState
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
@@ -73,26 +74,14 @@ import com.vitorpamplona.quartz.nip01Core.core.AddressableEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip01Core.signers.SignerExceptions
-import com.vitorpamplona.quartz.nip01Core.tags.geohash.geohash
 import com.vitorpamplona.quartz.nip01Core.tags.geohash.getGeoHash
-import com.vitorpamplona.quartz.nip01Core.tags.hashtags.hashtags
-import com.vitorpamplona.quartz.nip01Core.tags.references.references
-import com.vitorpamplona.quartz.nip10Notes.content.findHashtags
-import com.vitorpamplona.quartz.nip10Notes.content.findNostrUris
 import com.vitorpamplona.quartz.nip10Notes.content.findURLs
-import com.vitorpamplona.quartz.nip18Reposts.quotes.quotes
 import com.vitorpamplona.quartz.nip22Comments.CommentEvent
 import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
-import com.vitorpamplona.quartz.nip30CustomEmoji.CustomEmoji
-import com.vitorpamplona.quartz.nip30CustomEmoji.EmojiUrlTag
-import com.vitorpamplona.quartz.nip30CustomEmoji.emojis
-import com.vitorpamplona.quartz.nip36SensitiveContent.contentWarning
 import com.vitorpamplona.quartz.nip36SensitiveContent.contentWarningReason
 import com.vitorpamplona.quartz.nip36SensitiveContent.isSensitive
 import com.vitorpamplona.quartz.nip37Drafts.DraftWrapEvent
 import com.vitorpamplona.quartz.nip40Expiration.expiration
-import com.vitorpamplona.quartz.nip57Zaps.splits.zapSplits
-import com.vitorpamplona.quartz.nip57Zaps.zapraiser.zapraiser
 import com.vitorpamplona.quartz.nip57Zaps.zapraiser.zapraiserAmount
 import com.vitorpamplona.quartz.nip92IMeta.IMetaTagBuilder
 import com.vitorpamplona.quartz.nip92IMeta.imetas
@@ -106,7 +95,6 @@ import com.vitorpamplona.quartz.nip94FileMetadata.originalHash
 import com.vitorpamplona.quartz.nip94FileMetadata.sensitiveContent
 import com.vitorpamplona.quartz.nip94FileMetadata.size
 import com.vitorpamplona.quartz.utils.Log
-import com.vitorpamplona.quartz.utils.RandomInstance
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.Dispatchers
@@ -125,6 +113,7 @@ class LongFormPostViewModel :
     IZapRaiser,
     IExpiration {
     val draftTag = DraftTagState()
+    val postState = LongFormPostState()
 
     lateinit var accountViewModel: AccountViewModel
     lateinit var account: Account
@@ -366,49 +355,36 @@ class LongFormPostViewModel :
             )
         tagger.run()
 
-        val zapReceiver = if (wantsForwardZapTo) forwardZapTo.value.toZapSplitSetup() else null
+        syncToPostState()
 
-        val geoHash = if (wantsToAddGeoHash) (location?.value as? LocationState.LocationResult.Success)?.geoHash?.toString() else null
-        val localZapRaiserAmount = if (wantsZapRaiser) zapRaiserAmount.value else null
-
-        val emojis = findEmoji(tagger.message, account.emoji.myEmojis.value)
+        val emojiMedia = account.emoji.myEmojis.value
+        val emojis =
+            LongFormPostState.findEmoji(
+                tagger.message,
+                emojiMedia?.map { Pair(it.code, it.link) },
+            )
         val urls = findURLs(tagger.message)
         val usedAttachments = iMetaAttachments.filterIsIn(urls.toSet())
 
-        val contentWarningReason = if (wantsToMarkAsSensitive) contentWarningDescription else null
-        val localExpirationDate = if (wantsExpirationDate) expirationDate else null
-
-        return LongTextNoteEvent.build(
-            description = tagger.message,
-            title = title.text.trim(),
-            summary = summary.text.trim().ifBlank { null },
-            image = coverImageUrl.trim().ifBlank { null },
-            publishedAt = publishedAt,
-            dTag = existingDTag ?: slug.ifBlank { RandomInstance.randomChars(16) },
-        ) {
-            hashtags(findHashtags(tagger.message) + tags)
-            references(findURLs(tagger.message))
-            quotes(findNostrUris(tagger.message))
-
-            geoHash?.let { geohash(it) }
-            localZapRaiserAmount?.let { zapraiser(it) }
-            zapReceiver?.let { zapSplits(it) }
-            contentWarningReason?.let { contentWarning(it) }
-            localExpirationDate?.let { expiration(it) }
-
-            emojis(emojis)
-            imetas(usedAttachments)
-        }
+        return postState.createTemplate(tagger.message, emojis, usedAttachments)
     }
 
-    private fun findEmoji(
-        message: String,
-        myEmojiSet: List<EmojiMedia>?,
-    ): List<EmojiUrlTag> {
-        if (myEmojiSet == null) return emptyList()
-        return CustomEmoji.findAllEmojiCodes(message).mapNotNull { possibleEmoji ->
-            myEmojiSet.firstOrNull { it.code == possibleEmoji }?.let { EmojiUrlTag(it.code, it.link) }
-        }
+    /** Push Compose mutable state into the platform-independent state object. */
+    private fun syncToPostState() {
+        postState.updateTitle(title.text)
+        postState.updateSummary(summary.text)
+        postState.updateCoverImageUrl(coverImageUrl)
+        postState.updatePublishedAt(publishedAt)
+        postState.updateTags(tags)
+        postState.updateSlug(slug)
+        postState.updateExistingDTag(existingDTag)
+
+        val geoHash = if (wantsToAddGeoHash) (location?.value as? LocationState.LocationResult.Success)?.geoHash?.toString() else null
+        postState.options.updateGeoHash(wantsToAddGeoHash, geoHash)
+        postState.options.updateZapRaiser(wantsZapRaiser, zapRaiserAmount.value)
+        postState.options.updateZapSplits(if (wantsForwardZapTo) forwardZapTo.value.toZapSplitSetup() else null)
+        postState.options.updateContentWarning(wantsToMarkAsSensitive, contentWarningDescription)
+        postState.options.updateExpiration(wantsExpirationDate, expirationDate)
     }
 
     fun uploadCoverImage(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/NewProductViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/NewProductViewModel.kt
@@ -37,6 +37,8 @@ import com.vitorpamplona.amethyst.commons.compose.currentWord
 import com.vitorpamplona.amethyst.commons.compose.insertUrlAtCursor
 import com.vitorpamplona.amethyst.commons.compose.replaceCurrentWord
 import com.vitorpamplona.amethyst.commons.model.nip30CustomEmojis.EmojiPackState
+import com.vitorpamplona.amethyst.commons.viewmodels.posting.ClassifiedsPostState
+import com.vitorpamplona.amethyst.commons.viewmodels.posting.LongFormPostState
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
@@ -72,29 +74,18 @@ import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.geohash.geohash
 import com.vitorpamplona.quartz.nip01Core.tags.geohash.getGeoHash
-import com.vitorpamplona.quartz.nip01Core.tags.hashtags.hashtags
-import com.vitorpamplona.quartz.nip01Core.tags.references.references
-import com.vitorpamplona.quartz.nip10Notes.content.findHashtags
-import com.vitorpamplona.quartz.nip10Notes.content.findNostrUris
 import com.vitorpamplona.quartz.nip10Notes.content.findURLs
-import com.vitorpamplona.quartz.nip18Reposts.quotes.quotes
-import com.vitorpamplona.quartz.nip30CustomEmoji.CustomEmoji
-import com.vitorpamplona.quartz.nip30CustomEmoji.EmojiUrlTag
 import com.vitorpamplona.quartz.nip30CustomEmoji.emojis
-import com.vitorpamplona.quartz.nip36SensitiveContent.contentWarning
 import com.vitorpamplona.quartz.nip36SensitiveContent.contentWarningReason
 import com.vitorpamplona.quartz.nip36SensitiveContent.isSensitive
 import com.vitorpamplona.quartz.nip37Drafts.DraftWrapEvent
 import com.vitorpamplona.quartz.nip40Expiration.expiration
-import com.vitorpamplona.quartz.nip57Zaps.splits.zapSplits
 import com.vitorpamplona.quartz.nip57Zaps.zapraiser.zapraiser
 import com.vitorpamplona.quartz.nip57Zaps.zapraiser.zapraiserAmount
 import com.vitorpamplona.quartz.nip92IMeta.imetas
 import com.vitorpamplona.quartz.nip99Classifieds.ClassifiedsEvent
 import com.vitorpamplona.quartz.nip99Classifieds.ProductImageMeta
-import com.vitorpamplona.quartz.nip99Classifieds.image
 import com.vitorpamplona.quartz.nip99Classifieds.tags.ConditionTag
-import com.vitorpamplona.quartz.nip99Classifieds.tags.PriceTag
 import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.collections.immutable.ImmutableList
@@ -113,6 +104,7 @@ open class NewProductViewModel :
     IZapRaiser,
     IExpiration {
     val draftTag = DraftTagState()
+    val postState = ClassifiedsPostState()
 
     lateinit var accountViewModel: AccountViewModel
     lateinit var account: Account
@@ -334,8 +326,6 @@ open class NewProductViewModel :
     }
 
     private suspend fun createTemplate(): EventTemplate<out Event>? {
-        val accountViewModel = accountViewModel
-
         val tagger =
             NewMessageTagger(
                 message = message.text.toString(),
@@ -343,54 +333,39 @@ open class NewProductViewModel :
             )
         tagger.run()
 
-        val emojis = findEmoji(tagger.message, account.emoji.myEmojis.value)
+        syncToPostState()
+
+        val emojiMedia = account.emoji.myEmojis.value
+        val emojis =
+            LongFormPostState.findEmoji(
+                tagger.message,
+                emojiMedia?.map { Pair(it.code, it.link) },
+            )
         val urls = findURLs(tagger.message)
         val usedAttachments = iMetaDescription.filterIsIn(urls.toSet()) + productImages.map { it.toIMeta() }
 
-        val geoHash = if (wantsToAddGeoHash) (location?.value as? LocationState.LocationResult.Success)?.geoHash?.toString() else null
-
-        val zapReceiver = if (wantsForwardZapTo) forwardZapTo.value.toZapSplitSetup() else null
-        val localZapRaiserAmount = if (wantsZapraiser) zapRaiserAmount.value else null
-        val contentWarningReason = if (wantsToMarkAsSensitive) contentWarningDescription else null
-        val localExpirationDate = if (wantsExpirationDate) expirationDate else null
-
-        val quotes = findNostrUris(tagger.message)
-
-        val template =
-            ClassifiedsEvent.build(
-                title.text.toString(),
-                PriceTag(price.text.toString(), "SATS", null),
-                tagger.message,
-                locationText.text.toString().ifBlank { null },
-                condition,
-            ) {
-                productImages.forEach { image(it.url) }
-
-                hashtags(listOfNotNull(category.text.toString().ifBlank { null }) + findHashtags(tagger.message))
-                quotes(quotes)
-
-                geoHash?.let { geohash(it) }
-                localZapRaiserAmount?.let { zapraiser(it) }
-                zapReceiver?.let { zapSplits(it) }
-                contentWarningReason?.let { contentWarning(it) }
-                localExpirationDate?.let { expiration(it) }
-
-                emojis(emojis)
-                imetas(usedAttachments)
-                references(urls)
-            }
-
-        return template
+        return postState.createTemplate(
+            tagger.message,
+            emojis,
+            usedAttachments,
+            productImages.map { it.url },
+        )
     }
 
-    fun findEmoji(
-        message: String,
-        myEmojiSet: List<EmojiPackState.EmojiMedia>?,
-    ): List<EmojiUrlTag> {
-        if (myEmojiSet == null) return emptyList()
-        return CustomEmoji.findAllEmojiCodes(message).mapNotNull { possibleEmoji ->
-            myEmojiSet.firstOrNull { it.code == possibleEmoji }?.let { EmojiUrlTag(it.code, it.link) }
-        }
+    /** Push Compose mutable state into the platform-independent state object. */
+    private fun syncToPostState() {
+        postState.updateTitle(title.text.toString())
+        postState.updatePrice(price.text.toString())
+        postState.updateLocation(locationText.text.toString())
+        postState.updateCategory(category.text.toString())
+        postState.updateCondition(condition)
+
+        val geoHash = if (wantsToAddGeoHash) (location?.value as? LocationState.LocationResult.Success)?.geoHash?.toString() else null
+        postState.options.updateGeoHash(wantsToAddGeoHash, geoHash)
+        postState.options.updateZapRaiser(wantsZapraiser, zapRaiserAmount.value)
+        postState.options.updateZapSplits(if (wantsForwardZapTo) forwardZapTo.value.toZapSplitSetup() else null)
+        postState.options.updateContentWarning(wantsToMarkAsSensitive, contentWarningDescription)
+        postState.options.updateExpiration(wantsExpirationDate, expirationDate)
     }
 
     fun upload(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostViewModel.kt
@@ -40,6 +40,8 @@ import com.vitorpamplona.amethyst.commons.compose.insertUrlAtCursor
 import com.vitorpamplona.amethyst.commons.compose.replaceCurrentWord
 import com.vitorpamplona.amethyst.commons.compose.setTextAndPlaceCursorAtBeginning
 import com.vitorpamplona.amethyst.commons.model.nip30CustomEmojis.EmojiPackState.EmojiMedia
+import com.vitorpamplona.amethyst.commons.viewmodels.posting.LongFormPostState
+import com.vitorpamplona.amethyst.commons.viewmodels.posting.PostOptions
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.BooleanType
 import com.vitorpamplona.amethyst.model.LocalCache
@@ -92,7 +94,6 @@ import com.vitorpamplona.quartz.nip01Core.core.AddressableEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip01Core.signers.SignerExceptions
-import com.vitorpamplona.quartz.nip01Core.tags.geohash.geohash
 import com.vitorpamplona.quartz.nip01Core.tags.geohash.getGeoHash
 import com.vitorpamplona.quartz.nip01Core.tags.hashtags.hashtags
 import com.vitorpamplona.quartz.nip01Core.tags.people.pTags
@@ -109,10 +110,7 @@ import com.vitorpamplona.quartz.nip10Notes.tags.prepareETagsAsReplyTo
 import com.vitorpamplona.quartz.nip18Reposts.quotes.quotes
 import com.vitorpamplona.quartz.nip18Reposts.quotes.taggedQuoteIds
 import com.vitorpamplona.quartz.nip22Comments.CommentEvent
-import com.vitorpamplona.quartz.nip30CustomEmoji.CustomEmoji
-import com.vitorpamplona.quartz.nip30CustomEmoji.EmojiUrlTag
 import com.vitorpamplona.quartz.nip30CustomEmoji.emojis
-import com.vitorpamplona.quartz.nip36SensitiveContent.contentWarning
 import com.vitorpamplona.quartz.nip36SensitiveContent.contentWarningReason
 import com.vitorpamplona.quartz.nip36SensitiveContent.isSensitive
 import com.vitorpamplona.quartz.nip36SensitiveContent.isSensitiveOrNSFW
@@ -121,8 +119,6 @@ import com.vitorpamplona.quartz.nip40Expiration.expiration
 import com.vitorpamplona.quartz.nip57Zaps.splits.ZapSplitSetup
 import com.vitorpamplona.quartz.nip57Zaps.splits.ZapSplitSetupLnAddress
 import com.vitorpamplona.quartz.nip57Zaps.splits.zapSplitSetup
-import com.vitorpamplona.quartz.nip57Zaps.splits.zapSplits
-import com.vitorpamplona.quartz.nip57Zaps.zapraiser.zapraiser
 import com.vitorpamplona.quartz.nip57Zaps.zapraiser.zapraiserAmount
 import com.vitorpamplona.quartz.nip72ModCommunities.definition.CommunityDefinitionEvent
 import com.vitorpamplona.quartz.nip88Polls.poll.PollEvent
@@ -173,6 +169,7 @@ open class ShortNotePostViewModel :
     IZapRaiser,
     IExpiration {
     val draftTag = DraftTagState()
+    val postOptions = PostOptions()
 
     lateinit var accountViewModel: AccountViewModel
     lateinit var account: Account
@@ -924,17 +921,16 @@ open class ShortNotePostViewModel :
             )
         tagger.run()
 
-        val zapReceiver = if (wantsForwardZapTo) forwardZapTo.value.toZapSplitSetup() else null
+        syncPostOptions()
 
-        val geoHash = if (wantsToAddGeoHash) (location?.value as? LocationState.LocationResult.Success)?.geoHash?.toString() else null
-        val localZapRaiserAmount = if (wantsZapRaiser) zapRaiserAmount.value else null
-
-        val emojis = findEmoji(tagger.message, account.emoji.myEmojis.value)
+        val emojiMedia = account.emoji.myEmojis.value
+        val emojis =
+            LongFormPostState.findEmoji(
+                tagger.message,
+                emojiMedia?.map { Pair(it.code, it.link) },
+            )
         val urls = findURLs(tagger.message)
         val usedAttachments = iMetaAttachments.filterIsIn(urls.toSet())
-
-        val contentWarningReason = if (wantsToMarkAsSensitive) contentWarningDescription else null
-        val localExpirationDate = if (wantsExpirationDate) expirationDate else null
 
         return if (wantsPoll) {
             val options = pollOptions.map { it.value }
@@ -951,11 +947,7 @@ open class ShortNotePostViewModel :
                 quotes(quotes)
                 hashtags(findHashtags(tagger.message))
 
-                geoHash?.let { geohash(it) }
-                localZapRaiserAmount?.let { zapraiser(it) }
-                zapReceiver?.let { zapSplits(it) }
-                contentWarningReason?.let { contentWarning(it) }
-                localExpirationDate?.let { expiration(it) }
+                postOptions.applyTo(this)
 
                 emojis(emojis)
                 imetas(usedAttachments)
@@ -974,11 +966,7 @@ open class ShortNotePostViewModel :
                 quotes(findNostrUris(tagger.message))
                 hashtags(findHashtags(tagger.message))
 
-                geoHash?.let { geohash(it) }
-                localZapRaiserAmount?.let { zapraiser(it) }
-                zapReceiver?.let { zapSplits(it) }
-                contentWarningReason?.let { contentWarning(it) }
-                localExpirationDate?.let { expiration(it) }
+                postOptions.applyTo(this)
 
                 emojis(emojis)
                 imetas(usedAttachments)
@@ -1030,11 +1018,7 @@ open class ShortNotePostViewModel :
                 references(findURLs(tagger.message))
                 quotes(findNostrUris(tagger.message))
 
-                geoHash?.let { geohash(it) }
-                localZapRaiserAmount?.let { zapraiser(it) }
-                zapReceiver?.let { zapSplits(it) }
-                contentWarningReason?.let { contentWarning(it) }
-                localExpirationDate?.let { expiration(it) }
+                postOptions.applyTo(this)
 
                 emojis(emojis)
                 imetas(usedAttachments)
@@ -1042,14 +1026,14 @@ open class ShortNotePostViewModel :
         }
     }
 
-    fun findEmoji(
-        message: String,
-        myEmojiSet: List<EmojiMedia>?,
-    ): List<EmojiUrlTag> {
-        if (myEmojiSet == null) return emptyList()
-        return CustomEmoji.findAllEmojiCodes(message).mapNotNull { possibleEmoji ->
-            myEmojiSet.firstOrNull { it.code == possibleEmoji }?.let { EmojiUrlTag(it.code, it.link) }
-        }
+    /** Push Compose mutable state into the platform-independent PostOptions. */
+    private fun syncPostOptions() {
+        val geoHash = if (wantsToAddGeoHash) (location?.value as? LocationState.LocationResult.Success)?.geoHash?.toString() else null
+        postOptions.updateGeoHash(wantsToAddGeoHash, geoHash)
+        postOptions.updateZapRaiser(wantsZapRaiser, zapRaiserAmount.value)
+        postOptions.updateZapSplits(if (wantsForwardZapTo) forwardZapTo.value.toZapSplitSetup() else null)
+        postOptions.updateContentWarning(wantsToMarkAsSensitive, contentWarningDescription)
+        postOptions.updateExpiration(wantsExpirationDate, expirationDate)
     }
 
     fun upload(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/nip75Goals/NewGoalViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/nip75Goals/NewGoalViewModel.kt
@@ -27,17 +27,23 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
+import com.vitorpamplona.amethyst.commons.viewmodels.posting.NewGoalState
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
-import com.vitorpamplona.quartz.nip01Core.core.Event
-import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
-import com.vitorpamplona.quartz.nip75ZapGoals.GoalEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
+/**
+ * Android ViewModel wrapper around [NewGoalState].
+ *
+ * Provides Compose [TextFieldValue] properties for UI binding and
+ * delegates validation and template creation to the commons state class.
+ */
 @Stable
 class NewGoalViewModel : ViewModel() {
     lateinit var accountViewModel: AccountViewModel
     lateinit var account: Account
+
+    val state = NewGoalState()
 
     var description by mutableStateOf(TextFieldValue(""))
     var amount by mutableStateOf(TextFieldValue(""))
@@ -53,13 +59,13 @@ class NewGoalViewModel : ViewModel() {
         this.account = accountVM.account
     }
 
-    fun canPost(): Boolean =
-        description.text.isNotBlank() &&
-            amount.text.isNotBlank() &&
-            amount.text.toLongOrNull() != null &&
-            (amount.text.toLongOrNull() ?: 0) > 0
+    fun canPost(): Boolean {
+        syncToState()
+        return state.canPost()
+    }
 
     fun cancel() {
+        state.cancel()
         description = TextFieldValue("")
         amount = TextFieldValue("")
         summary = TextFieldValue("")
@@ -70,32 +76,25 @@ class NewGoalViewModel : ViewModel() {
     }
 
     suspend fun sendPostSync() {
-        val template = createTemplate() ?: return
-        cancel()
-        account.signAndComputeBroadcast(template)
-    }
-
-    private fun createTemplate(): EventTemplate<out Event>? {
-        val amountSats = amount.text.toLongOrNull() ?: return null
-        val amountMillisats = amountSats * 1000L
+        syncToState()
 
         val relays =
             account.outboxRelays.flow.value
                 .toList()
 
-        val closedAt = if (wantsDeadline) deadlineTimestamp else null
-        val img = imageUrl.text.ifBlank { null }
-        val sum = summary.text.ifBlank { null }
-        val web = websiteUrl.text.ifBlank { null }
+        val template = state.createTemplate(relays) ?: return
+        cancel()
+        account.signAndComputeBroadcast(template)
+    }
 
-        return GoalEvent.build(
-            description = description.text,
-            amount = amountMillisats,
-            relays = relays,
-            closedAt = closedAt,
-            image = img,
-            summary = sum,
-            websiteUrl = web,
-        )
+    /** Push Compose mutable state into the platform-independent state object. */
+    private fun syncToState() {
+        state.updateDescription(description.text)
+        state.updateAmount(amount.text)
+        state.updateSummary(summary.text)
+        state.updateImageUrl(imageUrl.text)
+        state.updateWebsiteUrl(websiteUrl.text)
+        state.updateWantsDeadline(wantsDeadline)
+        state.updateDeadlineTimestamp(deadlineTimestamp)
     }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/posting/ClassifiedsPostState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/posting/ClassifiedsPostState.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.viewmodels.posting
+
+import androidx.compose.runtime.Stable
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
+import com.vitorpamplona.quartz.nip01Core.tags.hashtags.hashtags
+import com.vitorpamplona.quartz.nip01Core.tags.references.references
+import com.vitorpamplona.quartz.nip10Notes.content.findHashtags
+import com.vitorpamplona.quartz.nip10Notes.content.findNostrUris
+import com.vitorpamplona.quartz.nip10Notes.content.findURLs
+import com.vitorpamplona.quartz.nip18Reposts.quotes.quotes
+import com.vitorpamplona.quartz.nip30CustomEmoji.EmojiUrlTag
+import com.vitorpamplona.quartz.nip30CustomEmoji.emojis
+import com.vitorpamplona.quartz.nip92IMeta.IMetaTag
+import com.vitorpamplona.quartz.nip92IMeta.imetas
+import com.vitorpamplona.quartz.nip99Classifieds.ClassifiedsEvent
+import com.vitorpamplona.quartz.nip99Classifieds.image
+import com.vitorpamplona.quartz.nip99Classifieds.tags.ConditionTag
+import com.vitorpamplona.quartz.nip99Classifieds.tags.PriceTag
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Platform-independent state for creating a classified listing (NIP-99).
+ *
+ * Holds draft fields and builds the event template. Platform ViewModels
+ * wrap this to add uploads, drafts, user suggestions, and signing.
+ */
+@Stable
+class ClassifiedsPostState {
+    val options = PostOptions()
+
+    private val _title = MutableStateFlow("")
+    val title: StateFlow<String> = _title.asStateFlow()
+
+    private val _price = MutableStateFlow("")
+    val price: StateFlow<String> = _price.asStateFlow()
+
+    private val _location = MutableStateFlow("")
+    val location: StateFlow<String> = _location.asStateFlow()
+
+    private val _category = MutableStateFlow("")
+    val category: StateFlow<String> = _category.asStateFlow()
+
+    private val _condition = MutableStateFlow(ConditionTag.CONDITION.USED_LIKE_NEW)
+    val condition: StateFlow<ConditionTag.CONDITION> = _condition.asStateFlow()
+
+    private val _productImageUrls = MutableStateFlow(listOf<String>())
+    val productImageUrls: StateFlow<List<String>> = _productImageUrls.asStateFlow()
+
+    fun updateTitle(value: String) {
+        _title.value = value
+    }
+
+    fun updatePrice(value: String) {
+        _price.value = value
+    }
+
+    fun updateLocation(value: String) {
+        _location.value = value
+    }
+
+    fun updateCategory(value: String) {
+        _category.value = value
+    }
+
+    fun updateCondition(value: ConditionTag.CONDITION) {
+        _condition.value = value
+    }
+
+    fun updateProductImageUrls(value: List<String>) {
+        _productImageUrls.value = value
+    }
+
+    fun canPost(
+        messageText: String,
+        isUploading: Boolean,
+        wantsInvoice: Boolean,
+        wantsZapRaiser: Boolean,
+        zapRaiserAmount: Long?,
+        hasMediaToUpload: Boolean,
+    ): Boolean =
+        messageText.isNotBlank() &&
+            !isUploading &&
+            !wantsInvoice &&
+            (!wantsZapRaiser || zapRaiserAmount != null) &&
+            _title.value.isNotBlank() &&
+            _price.value.isNotBlank() &&
+            _category.value.isNotBlank() &&
+            !hasMediaToUpload
+
+    /**
+     * Build the ClassifiedsEvent template from current state.
+     *
+     * @param taggedMessage the message after tagging
+     * @param emojis custom emoji tags found in the message
+     * @param usedAttachments iMeta attachments referenced in the message (including product images)
+     * @param productImageUrls URLs of product images to tag
+     * @return the event template
+     */
+    fun createTemplate(
+        taggedMessage: String,
+        emojis: List<EmojiUrlTag>,
+        usedAttachments: List<IMetaTag>,
+        productImageUrls: List<String>,
+    ): EventTemplate<out Event> {
+        val quotes = findNostrUris(taggedMessage)
+
+        return ClassifiedsEvent.build(
+            _title.value,
+            PriceTag(_price.value, "SATS", null),
+            taggedMessage,
+            _location.value.ifBlank { null },
+            _condition.value,
+        ) {
+            productImageUrls.forEach { image(it) }
+
+            hashtags(listOfNotNull(_category.value.ifBlank { null }) + findHashtags(taggedMessage))
+            quotes(quotes)
+
+            options.applyTo(this)
+
+            emojis(emojis)
+            imetas(usedAttachments)
+            references(findURLs(taggedMessage))
+        }
+    }
+
+    fun cancel() {
+        _title.value = ""
+        _price.value = ""
+        _location.value = ""
+        _category.value = ""
+        _condition.value = ConditionTag.CONDITION.USED_LIKE_NEW
+        _productImageUrls.value = emptyList()
+        options.reset()
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/posting/CommentPostState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/posting/CommentPostState.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.viewmodels.posting
+
+import androidx.compose.runtime.Stable
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.hints.EventHintBundle
+import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
+import com.vitorpamplona.quartz.nip01Core.tags.hashtags.hashtags
+import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
+import com.vitorpamplona.quartz.nip01Core.tags.references.references
+import com.vitorpamplona.quartz.nip10Notes.content.findHashtags
+import com.vitorpamplona.quartz.nip10Notes.content.findNostrUris
+import com.vitorpamplona.quartz.nip10Notes.content.findURLs
+import com.vitorpamplona.quartz.nip18Reposts.quotes.quotes
+import com.vitorpamplona.quartz.nip22Comments.CommentEvent
+import com.vitorpamplona.quartz.nip22Comments.notify
+import com.vitorpamplona.quartz.nip30CustomEmoji.EmojiUrlTag
+import com.vitorpamplona.quartz.nip30CustomEmoji.emojis
+import com.vitorpamplona.quartz.nip73ExternalIds.ExternalId
+import com.vitorpamplona.quartz.nip92IMeta.IMetaTag
+import com.vitorpamplona.quartz.nip92IMeta.imetas
+
+/**
+ * Platform-independent state for composing a NIP-22 comment.
+ *
+ * Holds shared post options and builds event templates for both
+ * reply-to-event and reply-to-external-identity scenarios.
+ * Platform ViewModels wrap this to add uploads, drafts, and signing.
+ */
+@Stable
+class CommentPostState {
+    val options = PostOptions()
+
+    fun canPost(
+        messageText: String,
+        isUploading: Boolean,
+        wantsInvoice: Boolean,
+        wantsZapRaiser: Boolean,
+        zapRaiserAmount: Long?,
+        hasMediaToUpload: Boolean,
+    ): Boolean =
+        messageText.isNotBlank() &&
+            !isUploading &&
+            !wantsInvoice &&
+            (!wantsZapRaiser || zapRaiserAmount != null) &&
+            !hasMediaToUpload
+
+    /**
+     * Build a CommentEvent template as a reply to another event.
+     *
+     * @param taggedMessage the message after tagging
+     * @param replyingTo event hint for the event being replied to
+     * @param notifyPTags p-tags to notify (from tagger + moderators)
+     * @param emojis custom emoji tags found in the message
+     * @param usedAttachments iMeta attachments referenced in the message
+     * @return the event template
+     */
+    fun createReplyTemplate(
+        taggedMessage: String,
+        replyingTo: EventHintBundle<Event>,
+        notifyPTags: List<PTag>,
+        emojis: List<EmojiUrlTag>,
+        usedAttachments: List<IMetaTag>,
+    ): EventTemplate<out Event> =
+        CommentEvent.replyBuilder(
+            msg = taggedMessage,
+            replyingTo = replyingTo,
+        ) {
+            notify(notifyPTags.distinctBy { it.pubKey })
+
+            hashtags(findHashtags(taggedMessage))
+            references(findURLs(taggedMessage))
+            quotes(findNostrUris(taggedMessage))
+
+            options.applyTo(this)
+
+            emojis(emojis)
+            imetas(usedAttachments)
+        }
+
+    /**
+     * Build a CommentEvent template as a reply to an external identity (NIP-73).
+     *
+     * @param taggedMessage the message after tagging
+     * @param extId the external identity being commented on
+     * @param notifyPTags p-tags to notify
+     * @param emojis custom emoji tags found in the message
+     * @param usedAttachments iMeta attachments referenced in the message
+     * @return the event template
+     */
+    fun createExternalReplyTemplate(
+        taggedMessage: String,
+        extId: ExternalId,
+        notifyPTags: List<PTag>,
+        emojis: List<EmojiUrlTag>,
+        usedAttachments: List<IMetaTag>,
+    ): EventTemplate<out Event> =
+        CommentEvent.replyExternalIdentity(
+            msg = taggedMessage,
+            extId = extId,
+        ) {
+            notify(notifyPTags)
+
+            hashtags(findHashtags(taggedMessage))
+            references(findURLs(taggedMessage))
+            quotes(findNostrUris(taggedMessage))
+
+            options.applyTo(this)
+
+            emojis(emojis)
+            imetas(usedAttachments)
+        }
+
+    fun cancel() {
+        options.reset()
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/posting/LongFormPostState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/posting/LongFormPostState.kt
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.viewmodels.posting
+
+import androidx.compose.runtime.Stable
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
+import com.vitorpamplona.quartz.nip01Core.tags.hashtags.hashtags
+import com.vitorpamplona.quartz.nip01Core.tags.references.references
+import com.vitorpamplona.quartz.nip10Notes.content.findHashtags
+import com.vitorpamplona.quartz.nip10Notes.content.findNostrUris
+import com.vitorpamplona.quartz.nip10Notes.content.findURLs
+import com.vitorpamplona.quartz.nip18Reposts.quotes.quotes
+import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
+import com.vitorpamplona.quartz.nip30CustomEmoji.CustomEmoji
+import com.vitorpamplona.quartz.nip30CustomEmoji.EmojiUrlTag
+import com.vitorpamplona.quartz.nip30CustomEmoji.emojis
+import com.vitorpamplona.quartz.nip92IMeta.IMetaTag
+import com.vitorpamplona.quartz.nip92IMeta.imetas
+import com.vitorpamplona.quartz.utils.RandomInstance
+import com.vitorpamplona.quartz.utils.TimeUtils
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlin.uuid.ExperimentalUuidApi
+
+/**
+ * Platform-independent state for composing a long-form article (NIP-23).
+ *
+ * Holds draft fields and builds the event template. Platform ViewModels
+ * wrap this to add uploads, drafts, user suggestions, and signing.
+ */
+@Stable
+class LongFormPostState {
+    val options = PostOptions()
+
+    private val _title = MutableStateFlow("")
+    val title: StateFlow<String> = _title.asStateFlow()
+
+    private val _summary = MutableStateFlow("")
+    val summary: StateFlow<String> = _summary.asStateFlow()
+
+    private val _coverImageUrl = MutableStateFlow("")
+    val coverImageUrl: StateFlow<String> = _coverImageUrl.asStateFlow()
+
+    private val _publishedAt = MutableStateFlow(TimeUtils.now())
+    val publishedAt: StateFlow<Long> = _publishedAt.asStateFlow()
+
+    private val _tags = MutableStateFlow(listOf<String>())
+    val tags: StateFlow<List<String>> = _tags.asStateFlow()
+
+    private val _slug = MutableStateFlow("")
+    val slug: StateFlow<String> = _slug.asStateFlow()
+
+    private val _existingDTag = MutableStateFlow<String?>(null)
+    val existingDTag: StateFlow<String?> = _existingDTag.asStateFlow()
+
+    val isEditing: Boolean get() = _existingDTag.value != null
+
+    fun updateTitle(value: String) {
+        _title.value = value
+    }
+
+    fun updateSummary(value: String) {
+        _summary.value = value
+    }
+
+    fun updateCoverImageUrl(value: String) {
+        _coverImageUrl.value = value
+    }
+
+    fun updatePublishedAt(value: Long) {
+        _publishedAt.value = value
+    }
+
+    fun updateTags(value: List<String>) {
+        _tags.value = value
+    }
+
+    fun updateSlug(value: String) {
+        _slug.value = value
+    }
+
+    fun updateExistingDTag(value: String?) {
+        _existingDTag.value = value
+    }
+
+    fun canPost(
+        messageText: String,
+        isUploadingImage: Boolean,
+        wantsInvoice: Boolean,
+        wantsZapRaiser: Boolean,
+        zapRaiserAmount: Long?,
+        hasMediaToUpload: Boolean,
+    ): Boolean =
+        _title.value.isNotBlank() &&
+            messageText.isNotBlank() &&
+            !isUploadingImage &&
+            !wantsInvoice &&
+            (!wantsZapRaiser || zapRaiserAmount != null) &&
+            !hasMediaToUpload
+
+    /**
+     * Build the LongTextNoteEvent template from current state.
+     *
+     * @param taggedMessage the message after tagging (@mentions resolved to nostr: URIs)
+     * @param emojis custom emoji tags found in the message
+     * @param usedAttachments iMeta attachments referenced in the message
+     * @return the event template, or null if title is blank
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    fun createTemplate(
+        taggedMessage: String,
+        emojis: List<EmojiUrlTag>,
+        usedAttachments: List<IMetaTag>,
+    ): EventTemplate<out Event>? {
+        if (_title.value.isBlank()) return null
+
+        return LongTextNoteEvent.build(
+            description = taggedMessage,
+            title = _title.value.trim(),
+            summary = _summary.value.trim().ifBlank { null },
+            image = _coverImageUrl.value.trim().ifBlank { null },
+            publishedAt = _publishedAt.value,
+            dTag = _existingDTag.value ?: _slug.value.ifBlank { RandomInstance.randomChars(16) },
+        ) {
+            hashtags(findHashtags(taggedMessage) + _tags.value)
+            references(findURLs(taggedMessage))
+            quotes(findNostrUris(taggedMessage))
+
+            options.applyTo(this)
+
+            emojis(emojis)
+            imetas(usedAttachments)
+        }
+    }
+
+    fun cancel() {
+        _title.value = ""
+        _summary.value = ""
+        _coverImageUrl.value = ""
+        _publishedAt.value = TimeUtils.now()
+        _tags.value = emptyList()
+        _slug.value = ""
+        _existingDTag.value = null
+        options.reset()
+    }
+
+    companion object {
+        /**
+         * Find custom emojis in text that match the user's emoji set.
+         */
+        fun findEmoji(
+            message: String,
+            emojiCodes: List<Pair<String, String>>?,
+        ): List<EmojiUrlTag> {
+            if (emojiCodes == null) return emptyList()
+            return CustomEmoji.findAllEmojiCodes(message).mapNotNull { possibleEmoji ->
+                emojiCodes
+                    .firstOrNull { it.first == possibleEmoji }
+                    ?.let { EmojiUrlTag(it.first, it.second) }
+            }
+        }
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/posting/NewGoalState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/posting/NewGoalState.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.viewmodels.posting
+
+import androidx.compose.runtime.Stable
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
+import com.vitorpamplona.quartz.nip75ZapGoals.GoalEvent
+import com.vitorpamplona.quartz.utils.TimeUtils
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Platform-independent state for creating a new Zap Goal (NIP-75).
+ *
+ * Holds draft fields and builds the event template.
+ * Platform ViewModels wrap this and provide signing/broadcasting.
+ */
+@Stable
+class NewGoalState {
+    private val _description = MutableStateFlow("")
+    val description: StateFlow<String> = _description.asStateFlow()
+
+    private val _amount = MutableStateFlow("")
+    val amount: StateFlow<String> = _amount.asStateFlow()
+
+    private val _summary = MutableStateFlow("")
+    val summary: StateFlow<String> = _summary.asStateFlow()
+
+    private val _imageUrl = MutableStateFlow("")
+    val imageUrl: StateFlow<String> = _imageUrl.asStateFlow()
+
+    private val _websiteUrl = MutableStateFlow("")
+    val websiteUrl: StateFlow<String> = _websiteUrl.asStateFlow()
+
+    private val _wantsDeadline = MutableStateFlow(false)
+    val wantsDeadline: StateFlow<Boolean> = _wantsDeadline.asStateFlow()
+
+    private val _deadlineTimestamp = MutableStateFlow(TimeUtils.now() + TimeUtils.ONE_WEEK)
+    val deadlineTimestamp: StateFlow<Long> = _deadlineTimestamp.asStateFlow()
+
+    fun updateDescription(value: String) {
+        _description.value = value
+    }
+
+    fun updateAmount(value: String) {
+        _amount.value = value
+    }
+
+    fun updateSummary(value: String) {
+        _summary.value = value
+    }
+
+    fun updateImageUrl(value: String) {
+        _imageUrl.value = value
+    }
+
+    fun updateWebsiteUrl(value: String) {
+        _websiteUrl.value = value
+    }
+
+    fun updateWantsDeadline(value: Boolean) {
+        _wantsDeadline.value = value
+    }
+
+    fun updateDeadlineTimestamp(value: Long) {
+        _deadlineTimestamp.value = value
+    }
+
+    fun canPost(): Boolean {
+        val desc = _description.value
+        val amt = _amount.value
+        return desc.isNotBlank() &&
+            amt.isNotBlank() &&
+            amt.toLongOrNull() != null &&
+            (amt.toLongOrNull() ?: 0) > 0
+    }
+
+    /**
+     * Build the GoalEvent template from current state.
+     *
+     * @param relays the outbox relay list to include in the goal
+     * @return the event template, or null if validation fails
+     */
+    fun createTemplate(relays: List<NormalizedRelayUrl>): EventTemplate<out Event>? {
+        val amountSats = _amount.value.toLongOrNull() ?: return null
+        val amountMillisats = amountSats * 1000L
+
+        val closedAt = if (_wantsDeadline.value) _deadlineTimestamp.value else null
+        val img = _imageUrl.value.ifBlank { null }
+        val sum = _summary.value.ifBlank { null }
+        val web = _websiteUrl.value.ifBlank { null }
+
+        return GoalEvent.build(
+            description = _description.value,
+            amount = amountMillisats,
+            relays = relays,
+            closedAt = closedAt,
+            image = img,
+            summary = sum,
+            websiteUrl = web,
+        )
+    }
+
+    fun cancel() {
+        _description.value = ""
+        _amount.value = ""
+        _summary.value = ""
+        _imageUrl.value = ""
+        _websiteUrl.value = ""
+        _wantsDeadline.value = false
+        _deadlineTimestamp.value = TimeUtils.now() + TimeUtils.ONE_WEEK
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/posting/PostOptions.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/posting/PostOptions.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.viewmodels.posting
+
+import androidx.compose.runtime.Stable
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
+import com.vitorpamplona.quartz.nip01Core.tags.geohash.geohash
+import com.vitorpamplona.quartz.nip36SensitiveContent.contentWarning
+import com.vitorpamplona.quartz.nip40Expiration.expiration
+import com.vitorpamplona.quartz.nip57Zaps.splits.ZapSplitSetup
+import com.vitorpamplona.quartz.nip57Zaps.splits.zapSplits
+import com.vitorpamplona.quartz.nip57Zaps.zapraiser.zapraiser
+import com.vitorpamplona.quartz.utils.TimeUtils
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Common post options shared across posting ViewModels:
+ * content warning, geohash, expiration, zap raiser, and zap splits.
+ *
+ * Platform ViewModels can sync their Compose state to this object,
+ * then use [applyTo] to add the relevant tags to an event builder.
+ */
+@Stable
+class PostOptions {
+    // NSFW / Sensitive content
+    private val _wantsContentWarning = MutableStateFlow(false)
+    val wantsContentWarning: StateFlow<Boolean> = _wantsContentWarning.asStateFlow()
+
+    private val _contentWarningReason = MutableStateFlow("")
+    val contentWarningReason: StateFlow<String> = _contentWarningReason.asStateFlow()
+
+    // GeoHash
+    private val _wantsGeoHash = MutableStateFlow(false)
+    val wantsGeoHash: StateFlow<Boolean> = _wantsGeoHash.asStateFlow()
+
+    private val _geoHash = MutableStateFlow<String?>(null)
+    val geoHash: StateFlow<String?> = _geoHash.asStateFlow()
+
+    // Expiration (NIP-40)
+    private val _wantsExpiration = MutableStateFlow(false)
+    val wantsExpiration: StateFlow<Boolean> = _wantsExpiration.asStateFlow()
+
+    private val _expirationDate = MutableStateFlow(TimeUtils.oneDayAhead())
+    val expirationDate: StateFlow<Long> = _expirationDate.asStateFlow()
+
+    // Zap Raiser
+    private val _wantsZapRaiser = MutableStateFlow(false)
+    val wantsZapRaiser: StateFlow<Boolean> = _wantsZapRaiser.asStateFlow()
+
+    private val _zapRaiserAmount = MutableStateFlow<Long?>(null)
+    val zapRaiserAmount: StateFlow<Long?> = _zapRaiserAmount.asStateFlow()
+
+    // Zap Splits (kept as a list of setups; platform fills from its SplitBuilder)
+    private val _zapSplits = MutableStateFlow<List<ZapSplitSetup>?>(null)
+    val zapSplits: StateFlow<List<ZapSplitSetup>?> = _zapSplits.asStateFlow()
+
+    // -- Mutators --
+
+    fun updateContentWarning(
+        wants: Boolean,
+        reason: String = "",
+    ) {
+        _wantsContentWarning.value = wants
+        _contentWarningReason.value = reason
+    }
+
+    fun updateGeoHash(
+        wants: Boolean,
+        hash: String? = null,
+    ) {
+        _wantsGeoHash.value = wants
+        _geoHash.value = hash
+    }
+
+    fun updateExpiration(
+        wants: Boolean,
+        date: Long = TimeUtils.oneDayAhead(),
+    ) {
+        _wantsExpiration.value = wants
+        _expirationDate.value = date
+    }
+
+    fun updateZapRaiser(
+        wants: Boolean,
+        amount: Long? = null,
+    ) {
+        _wantsZapRaiser.value = wants
+        _zapRaiserAmount.value = amount
+    }
+
+    fun updateZapSplits(splits: List<ZapSplitSetup>?) {
+        _zapSplits.value = splits
+    }
+
+    /**
+     * Resolved values for template building.
+     */
+    fun resolvedContentWarning(): String? = if (_wantsContentWarning.value) _contentWarningReason.value else null
+
+    fun resolvedGeoHash(): String? = if (_wantsGeoHash.value) _geoHash.value else null
+
+    fun resolvedExpiration(): Long? = if (_wantsExpiration.value) _expirationDate.value else null
+
+    fun resolvedZapRaiser(): Long? = if (_wantsZapRaiser.value) _zapRaiserAmount.value else null
+
+    fun resolvedZapSplits(): List<ZapSplitSetup>? = _zapSplits.value
+
+    /**
+     * Apply resolved options as tags to an event builder.
+     * Call this inside the TagArrayBuilder lambda of an event build method.
+     */
+    fun <T : Event> applyTo(builder: TagArrayBuilder<T>) {
+        resolvedGeoHash()?.let { builder.geohash(it) }
+        resolvedZapRaiser()?.let { builder.zapraiser(it) }
+        resolvedZapSplits()?.let { builder.zapSplits(it) }
+        resolvedContentWarning()?.let { builder.contentWarning(it) }
+        resolvedExpiration()?.let { builder.expiration(it) }
+    }
+
+    fun reset() {
+        _wantsContentWarning.value = false
+        _contentWarningReason.value = ""
+        _wantsGeoHash.value = false
+        _geoHash.value = null
+        _wantsExpiration.value = false
+        _expirationDate.value = TimeUtils.oneDayAhead()
+        _wantsZapRaiser.value = false
+        _zapRaiserAmount.value = null
+        _zapSplits.value = null
+    }
+}


### PR DESCRIPTION
Extracts business logic from posting ViewModels into commons-compatible classes.

## What changed

### New commons classes in `commons/viewmodels/posting/`:

- **`NewGoalState`** — Full state management and template creation for NIP-75 Zap Goals
- **`LongFormPostState`** — Draft fields, validation, and template creation for NIP-23 long-form articles
- **`ClassifiedsPostState`** — Draft fields and template creation for NIP-99 classified listings
- **`CommentPostState`** — Template creation for NIP-22 comments (both reply-to-event and external identity)
- **`PostOptions`** — Shared post options (content warning, geohash, expiration, zap raiser, zap splits) with `applyTo()` helper for applying options to event tag builders

### Android ViewModel changes:

- **`NewGoalViewModel`** — Delegates to `NewGoalState` for validation and template creation
- **`LongFormPostViewModel`** — Delegates to `LongFormPostState` for template creation, syncs Compose state via `syncToPostState()`
- **`NewProductViewModel`** — Delegates to `ClassifiedsPostState` for template creation
- **`CommentPostViewModel`** — Delegates to `CommentPostState` for template creation (both reply paths)
- **`ShortNotePostViewModel`** — Uses `PostOptions.applyTo()` to consolidate repeated options-application pattern across poll/zap-poll/text-note builders

### Shared utilities:
- **`LongFormPostState.findEmoji()`** — Platform-independent emoji resolution, replaces duplicated `findEmoji()` methods across all VMs

Part of the KMP iOS migration tracked in #2238.