### PR TITLE
feat: move screen/loggedIn composables to commons (batch 19)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chess/datasource/ChessFeedFilterSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chess/datasource/ChessFeedFilterSubAssembler.kt
@@ -20,6 +20,8 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.chess.datasource
 
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.chess.datasource.ChessQueryState
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.chess.datasource.filterChessEvents
 import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUniqueIdEoseManager
 import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.nip01Core.core.Event
@@ -30,18 +32,6 @@ import com.vitorpamplona.quartz.nip01Core.relay.client.subscriptions.Subscriptio
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.utils.TimeUtils
-
-/**
- * Query state for chess subscription
- */
-data class ChessQueryState(
-    val userPubkey: String,
-    val inboxRelays: Set<NormalizedRelayUrl>,
-    val globalRelays: Set<NormalizedRelayUrl>,
-    val isGlobal: Boolean,
-    val activeGameIds: Set<String> = emptySet(),
-    val opponentPubkeys: Set<String> = emptySet(),
-)
 
 /**
  * Sub-assembler that creates the actual relay filters.

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chess/datasource/ChessFilterAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chess/datasource/ChessFilterAssembler.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.chess.datasource
 
 import com.vitorpamplona.amethyst.commons.relayClient.composeSubscriptionManagers.ComposeSubscriptionManager
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.chess.datasource.ChessQueryState
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chess/datasource/ChessSubscription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chess/datasource/ChessSubscription.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.KeyDataSourceSubscription
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.chess.datasource.ChessQueryState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chess.ChessViewModelNew
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/geohash/datasource/GeoHashFeedFilterSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/geohash/datasource/GeoHashFeedFilterSubAssembler.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.geohash.datasource
 
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.geohash.datasource.GeohashQueryState
 import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUniqueIdEoseManager
 import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/geohash/datasource/GeoHashFilterAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/geohash/datasource/GeoHashFilterAssembler.kt
@@ -22,16 +22,8 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.geohash.datasource
 
 import androidx.compose.runtime.Stable
 import com.vitorpamplona.amethyst.commons.relayClient.composeSubscriptionManagers.ComposeSubscriptionManager
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.geohash.datasource.GeohashQueryState
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
-import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
-
-// This allows multiple screen to be listening to tags, even the same tag
-class GeohashQueryState(
-    val geohash: String,
-    val relays: Set<NormalizedRelayUrl>,
-) {
-    val lowercaseGeohash = geohash.lowercase()
-}
 
 /**
  * Creates a filter for multiple geohashes at the same time.

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/geohash/datasource/GeoHashFilterAssemblerSubscription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/geohash/datasource/GeoHashFilterAssemblerSubscription.kt
@@ -24,6 +24,7 @@ import android.annotation.SuppressLint
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.KeyDataSourceSubscription
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.geohash.datasource.GeohashQueryState
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/datasource/HashtagFeedFilterSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/datasource/HashtagFeedFilterSubAssembler.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.hashtag.datasource
 
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.hashtag.datasource.HashtagQueryState
 import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUniqueIdEoseManager
 import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/datasource/HashtagFilterAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/datasource/HashtagFilterAssembler.kt
@@ -21,16 +21,8 @@
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.hashtag.datasource
 
 import com.vitorpamplona.amethyst.commons.relayClient.composeSubscriptionManagers.ComposeSubscriptionManager
+import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.hashtag.datasource.HashtagQueryState
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
-import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
-
-// This allows multiple screen to be listening to tags, even the same tag
-class HashtagQueryState(
-    val hashtag: String,
-    val relays: Set<NormalizedRelayUrl>,
-) {
-    val lowercaseHashtag = hashtag.lowercase()
-}
 
 class HashtagFilterAssembler(
     client: INostrClient,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/dal/SupportedContent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/dal/SupportedContent.kt
@@ -20,27 +20,5 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.video.dal
 
-class SupportedContent(
-    val blockedUrls: List<String>,
-    val mimeTypes: Set<String>,
-    val supportedFileExtensions: Set<String>,
-) {
-    private fun validExtension(fullUrl: String): Boolean {
-        val queryIndex = fullUrl.indexOf('?')
-        if (queryIndex > 0) {
-            return supportedFileExtensions.any { fullUrl.startsWith(it, queryIndex - it.length) }
-        }
-
-        val fragmentIndex = fullUrl.indexOf('#')
-        if (fragmentIndex > 0) {
-            return supportedFileExtensions.any { fullUrl.startsWith(it, fragmentIndex - it.length) }
-        }
-
-        return supportedFileExtensions.any { fullUrl.endsWith(it) }
-    }
-
-    fun acceptableUrl(
-        url: String,
-        mimeType: String?,
-    ) = blockedUrls.none { url.contains(it) } && ((mimeType != null && mimeTypes.contains(mimeType)) || validExtension(url))
-}
+// Re-exported from commons for backwards compatibility
+typealias SupportedContent = com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.video.dal.SupportedContent

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/datasource/FeedBasis.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/datasource/FeedBasis.kt
@@ -20,35 +20,12 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.video.datasource
 
-import com.vitorpamplona.quartz.experimental.nip95.header.FileStorageHeaderEvent
-import com.vitorpamplona.quartz.nip68Picture.PictureEvent
-import com.vitorpamplona.quartz.nip71Video.VideoHorizontalEvent
-import com.vitorpamplona.quartz.nip71Video.VideoNormalEvent
-import com.vitorpamplona.quartz.nip71Video.VideoShortEvent
-import com.vitorpamplona.quartz.nip71Video.VideoVerticalEvent
-import com.vitorpamplona.quartz.nip94FileMetadata.FileHeaderEvent
-
-val SUPPORTED_VIDEO_FEED_MIME_TYPES = listOf("image/jpeg", "image/gif", "image/png", "image/webp", "video/mp4", "video/mpeg", "video/webm", "audio/aac", "audio/mpeg", "audio/webm", "audio/wav", "image/avif")
-val SUPPORTED_VIDEO_FEED_MIME_TYPES_SET = SUPPORTED_VIDEO_FEED_MIME_TYPES.toSet()
-
-val PictureAndVideoKinds =
-    listOf(
-        PictureEvent.KIND,
-        VideoHorizontalEvent.KIND,
-        VideoVerticalEvent.KIND,
-        VideoNormalEvent.KIND,
-        VideoShortEvent.KIND,
-    )
-
-val PictureAndVideoKTags =
-    listOf(
-        PictureEvent.KIND.toString(),
-        VideoHorizontalEvent.KIND.toString(),
-        VideoVerticalEvent.KIND.toString(),
-        VideoNormalEvent.KIND.toString(),
-        VideoShortEvent.KIND.toString(),
-    )
-val PictureAndVideoLegacyKinds = listOf(FileHeaderEvent.KIND, FileStorageHeaderEvent.KIND)
-val PictureAndVideoLegacyKTags = listOf(FileHeaderEvent.KIND.toString(), FileStorageHeaderEvent.KIND.toString())
-val LegacyMimeTypes = SUPPORTED_VIDEO_FEED_MIME_TYPES
-val LegacyMimeTypeMap = mapOf("m" to LegacyMimeTypes)
+// Re-exported from commons for backwards compatibility
+val SUPPORTED_VIDEO_FEED_MIME_TYPES get() = com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.video.datasource.SUPPORTED_VIDEO_FEED_MIME_TYPES
+val SUPPORTED_VIDEO_FEED_MIME_TYPES_SET get() = com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.video.datasource.SUPPORTED_VIDEO_FEED_MIME_TYPES_SET
+val PictureAndVideoKinds get() = com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.video.datasource.PictureAndVideoKinds
+val PictureAndVideoKTags get() = com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.video.datasource.PictureAndVideoKTags
+val PictureAndVideoLegacyKinds get() = com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.video.datasource.PictureAndVideoLegacyKinds
+val PictureAndVideoLegacyKTags get() = com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.video.datasource.PictureAndVideoLegacyKTags
+val LegacyMimeTypes get() = com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.video.datasource.LegacyMimeTypes
+val LegacyMimeTypeMap get() = com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.video.datasource.LegacyMimeTypeMap

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/chess/datasource/ChessQueryState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/chess/datasource/ChessQueryState.kt
@@ -18,26 +18,15 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.hashtag.datasource
+package com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.chess.datasource
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.KeyDataSourceSubscription
-import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.hashtag.datasource.HashtagQueryState
-import com.vitorpamplona.amethyst.ui.navigation.routes.Route
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 
-@Composable
-fun HashtagFilterAssemblerSubscription(
-    tag: Route.Hashtag,
-    accountViewModel: AccountViewModel,
-) {
-    // different screens get different states
-    // even if they are tracking the same tag.
-    val state =
-        remember(tag) {
-            HashtagQueryState(tag.hashtag, accountViewModel.account.followOutboxesOrProxy.flow.value)
-        }
-
-    KeyDataSourceSubscription(state, accountViewModel.dataSources().hashtags)
-}
+data class ChessQueryState(
+    val userPubkey: String,
+    val inboxRelays: Set<NormalizedRelayUrl>,
+    val globalRelays: Set<NormalizedRelayUrl>,
+    val isGlobal: Boolean,
+    val activeGameIds: Set<String> = emptySet(),
+    val opponentPubkeys: Set<String> = emptySet(),
+)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/chess/datasource/FilterChessEvent.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/chess/datasource/FilterChessEvent.kt
@@ -18,7 +18,7 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.chess.datasource
+package com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.chess.datasource
 
 import com.vitorpamplona.amethyst.commons.chess.subscription.ChessFilterBuilder
 import com.vitorpamplona.amethyst.commons.chess.subscription.ChessSubscriptionState

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/geohash/datasource/GeohashQueryState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/geohash/datasource/GeohashQueryState.kt
@@ -18,26 +18,14 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.hashtag.datasource
+package com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.geohash.datasource
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.KeyDataSourceSubscription
-import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.hashtag.datasource.HashtagQueryState
-import com.vitorpamplona.amethyst.ui.navigation.routes.Route
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 
-@Composable
-fun HashtagFilterAssemblerSubscription(
-    tag: Route.Hashtag,
-    accountViewModel: AccountViewModel,
+// This allows multiple screens to be listening to tags, even the same tag
+class GeohashQueryState(
+    val geohash: String,
+    val relays: Set<NormalizedRelayUrl>,
 ) {
-    // different screens get different states
-    // even if they are tracking the same tag.
-    val state =
-        remember(tag) {
-            HashtagQueryState(tag.hashtag, accountViewModel.account.followOutboxesOrProxy.flow.value)
-        }
-
-    KeyDataSourceSubscription(state, accountViewModel.dataSources().hashtags)
+    val lowercaseGeohash = geohash.lowercase()
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/hashtag/datasource/HashtagQueryState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/hashtag/datasource/HashtagQueryState.kt
@@ -18,26 +18,14 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.hashtag.datasource
+package com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.hashtag.datasource
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.KeyDataSourceSubscription
-import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.hashtag.datasource.HashtagQueryState
-import com.vitorpamplona.amethyst.ui.navigation.routes.Route
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 
-@Composable
-fun HashtagFilterAssemblerSubscription(
-    tag: Route.Hashtag,
-    accountViewModel: AccountViewModel,
+// This allows multiple screens to be listening to tags, even the same tag
+class HashtagQueryState(
+    val hashtag: String,
+    val relays: Set<NormalizedRelayUrl>,
 ) {
-    // different screens get different states
-    // even if they are tracking the same tag.
-    val state =
-        remember(tag) {
-            HashtagQueryState(tag.hashtag, accountViewModel.account.followOutboxesOrProxy.flow.value)
-        }
-
-    KeyDataSourceSubscription(state, accountViewModel.dataSources().hashtags)
+    val lowercaseHashtag = hashtag.lowercase()
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/video/dal/SupportedContent.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/video/dal/SupportedContent.kt
@@ -18,26 +18,29 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.hashtag.datasource
+package com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.video.dal
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.KeyDataSourceSubscription
-import com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.hashtag.datasource.HashtagQueryState
-import com.vitorpamplona.amethyst.ui.navigation.routes.Route
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
-
-@Composable
-fun HashtagFilterAssemblerSubscription(
-    tag: Route.Hashtag,
-    accountViewModel: AccountViewModel,
+class SupportedContent(
+    val blockedUrls: List<String>,
+    val mimeTypes: Set<String>,
+    val supportedFileExtensions: Set<String>,
 ) {
-    // different screens get different states
-    // even if they are tracking the same tag.
-    val state =
-        remember(tag) {
-            HashtagQueryState(tag.hashtag, accountViewModel.account.followOutboxesOrProxy.flow.value)
+    private fun validExtension(fullUrl: String): Boolean {
+        val queryIndex = fullUrl.indexOf('?')
+        if (queryIndex > 0) {
+            return supportedFileExtensions.any { fullUrl.startsWith(it, queryIndex - it.length) }
         }
 
-    KeyDataSourceSubscription(state, accountViewModel.dataSources().hashtags)
+        val fragmentIndex = fullUrl.indexOf('#')
+        if (fragmentIndex > 0) {
+            return supportedFileExtensions.any { fullUrl.startsWith(it, fragmentIndex - it.length) }
+        }
+
+        return supportedFileExtensions.any { fullUrl.endsWith(it) }
+    }
+
+    fun acceptableUrl(
+        url: String,
+        mimeType: String?,
+    ) = blockedUrls.none { url.contains(it) } && ((mimeType != null && mimeTypes.contains(mimeType)) || validExtension(url))
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/video/datasource/FeedBasis.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/screen/loggedIn/video/datasource/FeedBasis.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.screen.loggedIn.video.datasource
+
+import com.vitorpamplona.quartz.experimental.nip95.header.FileStorageHeaderEvent
+import com.vitorpamplona.quartz.nip68Picture.PictureEvent
+import com.vitorpamplona.quartz.nip71Video.VideoHorizontalEvent
+import com.vitorpamplona.quartz.nip71Video.VideoNormalEvent
+import com.vitorpamplona.quartz.nip71Video.VideoShortEvent
+import com.vitorpamplona.quartz.nip71Video.VideoVerticalEvent
+import com.vitorpamplona.quartz.nip94FileMetadata.FileHeaderEvent
+
+val SUPPORTED_VIDEO_FEED_MIME_TYPES = listOf("image/jpeg", "image/gif", "image/png", "image/webp", "video/mp4", "video/mpeg", "video/webm", "audio/aac", "audio/mpeg", "audio/webm", "audio/wav", "image/avif")
+val SUPPORTED_VIDEO_FEED_MIME_TYPES_SET = SUPPORTED_VIDEO_FEED_MIME_TYPES.toSet()
+
+val PictureAndVideoKinds =
+    listOf(
+        PictureEvent.KIND,
+        VideoHorizontalEvent.KIND,
+        VideoVerticalEvent.KIND,
+        VideoNormalEvent.KIND,
+        VideoShortEvent.KIND,
+    )
+
+val PictureAndVideoKTags =
+    listOf(
+        PictureEvent.KIND.toString(),
+        VideoHorizontalEvent.KIND.toString(),
+        VideoVerticalEvent.KIND.toString(),
+        VideoNormalEvent.KIND.toString(),
+        VideoShortEvent.KIND.toString(),
+    )
+val PictureAndVideoLegacyKinds = listOf(FileHeaderEvent.KIND, FileStorageHeaderEvent.KIND)
+val PictureAndVideoLegacyKTags = listOf(FileHeaderEvent.KIND.toString(), FileStorageHeaderEvent.KIND.toString())
+val LegacyMimeTypes = SUPPORTED_VIDEO_FEED_MIME_TYPES
+val LegacyMimeTypeMap = mapOf("m" to LegacyMimeTypes)


### PR DESCRIPTION
Moves portable screen/loggedIn/ composable and DAL files to commons for KMP.

## Moved to commons (6 files):
- **video/datasource/FeedBasis.kt** — Video feed MIME types and event kind constants
- **video/dal/SupportedContent.kt** — URL content type validation utility
- **chess/datasource/FilterChessEvent.kt** — Chess relay filter builder function
- **chess/datasource/ChessQueryState.kt** — Chess subscription query state (extracted from SubAssembler)
- **geohash/datasource/GeohashQueryState.kt** — Geohash subscription query state (extracted from FilterAssembler)
- **hashtag/datasource/HashtagQueryState.kt** — Hashtag subscription query state (extracted from FilterAssembler)

## Changes to amethyst originals:
- FeedBasis.kt replaced with delegating getters to commons
- SupportedContent.kt replaced with typealias to commons
- FilterChessEvent.kt deleted (only consumer already imports from commons)
- Assembler and SubAssembler files updated with explicit commons imports for moved query states

Build-verified against both commons (compileKotlinJvm) and amethyst (compilePlayDebugKotlin).

Part of the KMP iOS migration tracked in #2238.