### PR TITLE
feat: expand ICacheProvider with notes/addressables properties — unblock DAL filters

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -267,8 +267,8 @@ object LocalCache : ILocalCache, ICacheProvider {
     val antiSpam = AntiSpamFilter()
 
     val users = LargeSoftCache<HexKey, User>()
-    val notes = LargeSoftCache<HexKey, Note>()
-    val addressables = LargeSoftCache<Address, AddressableNote>()
+    override val notes = LargeSoftCache<HexKey, Note>()
+    override val addressables = LargeSoftCache<Address, AddressableNote>()
 
     val chatroomList = LargeCache<HexKey, ChatroomList>()
     val publicChatChannels = LargeCache<HexKey, PublicChatChannel>()

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/cache/AddressableCacheExt.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/cache/AddressableCacheExt.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model.cache
+
+import com.vitorpamplona.amethyst.commons.model.AddressableNote
+import com.vitorpamplona.quartz.nip01Core.core.Address
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.utils.cache.CacheCollectors
+import com.vitorpamplona.quartz.utils.cache.ICacheOperations
+
+const val START_KEY = "0000000000000000000000000000000000000000000000000000000000000000"
+const val END_KEY = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+const val START_D_TAG = ""
+const val END_D_TAG = "\uFFFF\uFFFF\uFFFF\uFFFF"
+
+fun kindStart(
+    kind: Int,
+    pubKey: HexKey,
+) = Address(kind, pubKey, "")
+
+fun kindEnd(
+    kind: Int,
+    pubKey: HexKey,
+) = Address(kind, pubKey, END_D_TAG)
+
+fun kindStart(kind: Int) = kindStart(kind, START_KEY)
+
+fun kindEnd(kind: Int) = kindEnd(kind, END_KEY)
+
+val ACCEPT_ALL_FILTER = CacheCollectors.BiFilter<Address, AddressableNote> { _, _ -> true }
+
+// -- filter --
+
+fun ICacheOperations<Address, AddressableNote>.filter(
+    kind: Int,
+    consumer: CacheCollectors.BiFilter<Address, AddressableNote> = ACCEPT_ALL_FILTER,
+): List<AddressableNote> = filter(kindStart(kind), kindEnd(kind), consumer)
+
+fun ICacheOperations<Address, AddressableNote>.filter(
+    kinds: List<Int>,
+    consumer: CacheCollectors.BiFilter<Address, AddressableNote> = ACCEPT_ALL_FILTER,
+): List<AddressableNote> {
+    val set = mutableSetOf<AddressableNote>()
+    kinds.forEach {
+        set.addAll(filter(kindStart(it), kindEnd(it), consumer))
+    }
+    return set.toList()
+}
+
+fun ICacheOperations<Address, AddressableNote>.filter(
+    kind: Int,
+    pubKey: HexKey,
+    consumer: CacheCollectors.BiFilter<Address, AddressableNote> = ACCEPT_ALL_FILTER,
+): List<AddressableNote> = filter(kindStart(kind, pubKey), kindEnd(kind, pubKey), consumer)
+
+fun ICacheOperations<Address, AddressableNote>.filter(
+    kinds: List<Int>,
+    pubKey: HexKey,
+    consumer: CacheCollectors.BiFilter<Address, AddressableNote> = ACCEPT_ALL_FILTER,
+): Set<AddressableNote> {
+    val set = mutableSetOf<AddressableNote>()
+    kinds.forEach {
+        set.addAll(filterIntoSet(kindStart(it, pubKey), kindEnd(it, pubKey), consumer))
+    }
+    return set
+}
+
+// -- filterIntoSet --
+
+fun ICacheOperations<Address, AddressableNote>.filterIntoSet(
+    kind: Int,
+    consumer: CacheCollectors.BiFilter<Address, AddressableNote> = ACCEPT_ALL_FILTER,
+): Set<AddressableNote> = filterIntoSet(kindStart(kind), kindEnd(kind), consumer)
+
+fun ICacheOperations<Address, AddressableNote>.filterIntoSet(
+    kinds: List<Int>,
+    consumer: CacheCollectors.BiFilter<Address, AddressableNote> = ACCEPT_ALL_FILTER,
+): Set<AddressableNote> {
+    val set = mutableSetOf<AddressableNote>()
+    kinds.forEach {
+        set.addAll(filterIntoSet(kindStart(it), kindEnd(it), consumer))
+    }
+    return set
+}
+
+fun ICacheOperations<Address, AddressableNote>.filterIntoSet(
+    kind: Int,
+    pubKey: HexKey,
+    consumer: CacheCollectors.BiFilter<Address, AddressableNote> = ACCEPT_ALL_FILTER,
+): Set<AddressableNote> = filterIntoSet(kindStart(kind, pubKey), kindEnd(kind, pubKey), consumer)
+
+// -- mapNotNullIntoSet --
+
+fun <R> ICacheOperations<Address, AddressableNote>.mapNotNullIntoSet(
+    kind: Int,
+    consumer: CacheCollectors.BiMapper<Address, AddressableNote, R?>,
+): Set<R> = mapNotNullIntoSet(kindStart(kind), kindEnd(kind), consumer)
+
+fun <R> ICacheOperations<Address, AddressableNote>.mapNotNullIntoSet(
+    kind: Int,
+    pubKey: HexKey,
+    consumer: CacheCollectors.BiMapper<Address, AddressableNote, R?>,
+): Set<R> = mapNotNullIntoSet(kindStart(kind, pubKey), kindEnd(kind, pubKey), consumer)
+
+// -- mapFlattenIntoSet --
+
+fun <R> ICacheOperations<Address, AddressableNote>.mapFlattenIntoSet(
+    kind: Int,
+    consumer: CacheCollectors.BiMapper<Address, AddressableNote, Collection<R>?>,
+): Set<R> = mapFlattenIntoSet(kindStart(kind), kindEnd(kind), consumer)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/cache/ICacheProvider.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/cache/ICacheProvider.kt
@@ -27,6 +27,7 @@ import com.vitorpamplona.amethyst.commons.model.User
 import com.vitorpamplona.quartz.nip01Core.core.Address
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.utils.cache.ICacheOperations
 
 /**
  * Cache provider interface for accessing cached Notes, Users, and Channels.
@@ -135,4 +136,16 @@ interface ICacheProvider {
     fun getOrCreateUser(pubkey: HexKey): User?
 
     fun justConsumeMyOwnEvent(event: Event): Boolean
+
+    /**
+     * Provides cache operations over all Note objects.
+     * Used by DAL FeedFilter subclasses for filtering and querying notes.
+     */
+    val notes: ICacheOperations<HexKey, Note>
+
+    /**
+     * Provides cache operations over all AddressableNote objects.
+     * Used by DAL FeedFilter subclasses for filtering and querying addressable notes.
+     */
+    val addressables: ICacheOperations<Address, AddressableNote>
 }

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/cache/DesktopLocalCache.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/cache/DesktopLocalCache.kt
@@ -68,8 +68,9 @@ import java.util.concurrent.ConcurrentHashMap
  */
 class DesktopLocalCache : ICacheProvider {
     val users = LargeSoftCache<HexKey, User>()
-    val notes = LargeSoftCache<HexKey, Note>()
+    override val notes = LargeSoftCache<HexKey, Note>()
     val addressableNotes = LargeSoftCache<String, AddressableNote>()
+    override val addressables = LargeSoftCache<Address, AddressableNote>()
     private val deletedEvents = ConcurrentHashMap.newKeySet<HexKey>()
 
     val eventStream = DesktopCacheEventStream()


### PR DESCRIPTION
Adds `notes` and `addressables` properties to `ICacheProvider`, exposing `ICacheOperations<HexKey, Note>` and `ICacheOperations<Address, AddressableNote>` respectively.

Also adds `AddressableCacheExt.kt` in commons with kind-based extension functions (`filterIntoSet`, `filter`, `mapNotNullIntoSet`, `mapFlattenIntoSet`) on `ICacheOperations<Address, AddressableNote>`, mirroring the existing `LargeSoftCacheAddressExt.kt` extensions so they work against the interface.

This unblocks ~40 remaining DAL FeedFilter subclasses from moving to commons, since they can now use `ICacheProvider.notes.filterIntoSet { ... }` instead of `LocalCache.notes.filterIntoSet { ... }`.

Part of the KMP iOS migration tracked in #2238.