### PR TITLE
feat: move notification and settings VM state to commons (batch 14)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
@@ -1885,14 +1885,7 @@ fun ZapAmountChoicePopup(
     }
 }
 
-fun showCount(count: Int?): String {
-    if (count == null) return ""
-    if (count == 0) return ""
-
-    return when {
-        count >= 1000000000 -> "${(count / 1000000000f).roundToInt()}G"
-        count >= 1000000 -> "${(count / 1000000f).roundToInt()}M"
-        count >= 10000 -> "${(count / 1000f).roundToInt()}k"
-        else -> "$count"
-    }
-}
+// Re-export from commons for backwards compatibility
+fun showCount(count: Int?): String =
+    com.vitorpamplona.amethyst.commons.util
+        .showCount(count)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationFeedFilter.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications.dal
 
+import com.vitorpamplona.amethyst.commons.ui.notifications.NotificationKinds
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.AddressableNote
 import com.vitorpamplona.amethyst.model.LocalCache
@@ -29,97 +30,33 @@ import com.vitorpamplona.amethyst.model.filterIntoSet
 import com.vitorpamplona.amethyst.ui.dal.AdditiveFeedFilter
 import com.vitorpamplona.amethyst.ui.dal.DefaultFeedOrder
 import com.vitorpamplona.amethyst.ui.dal.FilterByListParams
-import com.vitorpamplona.quartz.experimental.attestations.request.AttestationRequestEvent
-import com.vitorpamplona.quartz.experimental.audio.track.AudioTrackEvent
 import com.vitorpamplona.quartz.experimental.forks.IForkableEvent
-import com.vitorpamplona.quartz.experimental.nipsOnNostr.NipTextEvent
-import com.vitorpamplona.quartz.experimental.zapPolls.ZapPollEvent
 import com.vitorpamplona.quartz.nip01Core.core.AddressableEvent
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.tags.people.isTaggedUser
 import com.vitorpamplona.quartz.nip04Dm.messages.PrivateDmEvent
 import com.vitorpamplona.quartz.nip10Notes.BaseNoteEvent
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
-import com.vitorpamplona.quartz.nip17Dm.files.ChatMessageEncryptedFileHeaderEvent
-import com.vitorpamplona.quartz.nip17Dm.messages.ChatMessageEvent
 import com.vitorpamplona.quartz.nip18Reposts.GenericRepostEvent
 import com.vitorpamplona.quartz.nip18Reposts.RepostEvent
 import com.vitorpamplona.quartz.nip22Comments.CommentEvent
-import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
 import com.vitorpamplona.quartz.nip25Reactions.ReactionEvent
 import com.vitorpamplona.quartz.nip34Git.issue.GitIssueEvent
 import com.vitorpamplona.quartz.nip34Git.patch.GitPatchEvent
-import com.vitorpamplona.quartz.nip52Calendar.appt.day.CalendarDateSlotEvent
-import com.vitorpamplona.quartz.nip52Calendar.appt.time.CalendarTimeSlotEvent
-import com.vitorpamplona.quartz.nip52Calendar.rsvp.CalendarRSVPEvent
-import com.vitorpamplona.quartz.nip53LiveActivities.chat.LiveActivitiesChatMessageEvent
-import com.vitorpamplona.quartz.nip53LiveActivities.streaming.LiveActivitiesEvent
-import com.vitorpamplona.quartz.nip54Wiki.WikiNoteEvent
 import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
-import com.vitorpamplona.quartz.nip58Badges.award.BadgeAwardEvent
 import com.vitorpamplona.quartz.nip64Chess.challenge.accept.LiveChessGameAcceptEvent
 import com.vitorpamplona.quartz.nip64Chess.move.LiveChessMoveEvent
-import com.vitorpamplona.quartz.nip68Picture.PictureEvent
-import com.vitorpamplona.quartz.nip71Video.VideoHorizontalEvent
-import com.vitorpamplona.quartz.nip71Video.VideoNormalEvent
-import com.vitorpamplona.quartz.nip71Video.VideoShortEvent
-import com.vitorpamplona.quartz.nip71Video.VideoVerticalEvent
 import com.vitorpamplona.quartz.nip72ModCommunities.communityAddress
 import com.vitorpamplona.quartz.nip72ModCommunities.definition.CommunityDefinitionEvent
 import com.vitorpamplona.quartz.nip84Highlights.HighlightEvent
-import com.vitorpamplona.quartz.nip88Polls.poll.PollEvent
-import com.vitorpamplona.quartz.nip99Classifieds.ClassifiedsEvent
-import com.vitorpamplona.quartz.nipA0VoiceMessages.VoiceEvent
-import com.vitorpamplona.quartz.nipA0VoiceMessages.VoiceReplyEvent
-import com.vitorpamplona.quartz.nipA4PublicMessages.PublicMessageEvent
 
 class NotificationFeedFilter(
     val account: Account,
 ) : AdditiveFeedFilter<Note>() {
     companion object {
-        val ADDRESSABLE_KINDS =
-            listOf(
-                AudioTrackEvent.KIND,
-                CalendarTimeSlotEvent.KIND,
-                CalendarDateSlotEvent.KIND,
-                CalendarRSVPEvent.KIND,
-                ClassifiedsEvent.KIND,
-                LiveActivitiesEvent.KIND,
-                LiveChessGameAcceptEvent.KIND,
-                LiveChessMoveEvent.KIND,
-                LongTextNoteEvent.KIND,
-                NipTextEvent.KIND,
-                VideoVerticalEvent.KIND,
-                VideoHorizontalEvent.KIND,
-                WikiNoteEvent.KIND,
-                AttestationRequestEvent.KIND,
-            )
+        val ADDRESSABLE_KINDS = NotificationKinds.ADDRESSABLE_KINDS
 
-        val NOTIFICATION_KINDS =
-            setOf(
-                BadgeAwardEvent.KIND,
-                ChatMessageEvent.KIND,
-                ChatMessageEncryptedFileHeaderEvent.KIND,
-                CommentEvent.KIND,
-                GenericRepostEvent.KIND,
-                GitIssueEvent.KIND,
-                GitPatchEvent.KIND,
-                HighlightEvent.KIND,
-                TextNoteEvent.KIND,
-                ReactionEvent.KIND,
-                RepostEvent.KIND,
-                LnZapEvent.KIND,
-                LiveActivitiesChatMessageEvent.KIND,
-                PictureEvent.KIND,
-                PollEvent.KIND,
-                ZapPollEvent.KIND,
-                PrivateDmEvent.KIND,
-                PublicMessageEvent.KIND,
-                VideoNormalEvent.KIND,
-                VideoShortEvent.KIND,
-                VoiceEvent.KIND,
-                VoiceReplyEvent.KIND,
-            ) + ADDRESSABLE_KINDS
+        val NOTIFICATION_KINDS = NotificationKinds.NOTIFICATION_KINDS
     }
 
     override fun feedKey(): String = account.userProfile().pubkeyHex + "-" + followList().code

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedView.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.ui.settings.StringFeedState
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.feeds.FeedError
 import com.vitorpamplona.amethyst.ui.feeds.LoadingFeed

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/StringFeedViewModel.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vitorpamplona.amethyst.commons.ui.feeds.InvalidatableContent
+import com.vitorpamplona.amethyst.commons.ui.settings.StringFeedState
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.service.BundledUpdate
 import com.vitorpamplona.amethyst.service.checkNotInMainThread

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/notifications/NotificationKinds.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/notifications/NotificationKinds.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.notifications
+
+import com.vitorpamplona.quartz.experimental.attestations.request.AttestationRequestEvent
+import com.vitorpamplona.quartz.experimental.audio.track.AudioTrackEvent
+import com.vitorpamplona.quartz.experimental.nipsOnNostr.NipTextEvent
+import com.vitorpamplona.quartz.experimental.zapPolls.ZapPollEvent
+import com.vitorpamplona.quartz.nip04Dm.messages.PrivateDmEvent
+import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
+import com.vitorpamplona.quartz.nip17Dm.files.ChatMessageEncryptedFileHeaderEvent
+import com.vitorpamplona.quartz.nip17Dm.messages.ChatMessageEvent
+import com.vitorpamplona.quartz.nip18Reposts.GenericRepostEvent
+import com.vitorpamplona.quartz.nip18Reposts.RepostEvent
+import com.vitorpamplona.quartz.nip22Comments.CommentEvent
+import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
+import com.vitorpamplona.quartz.nip25Reactions.ReactionEvent
+import com.vitorpamplona.quartz.nip34Git.issue.GitIssueEvent
+import com.vitorpamplona.quartz.nip34Git.patch.GitPatchEvent
+import com.vitorpamplona.quartz.nip52Calendar.appt.day.CalendarDateSlotEvent
+import com.vitorpamplona.quartz.nip52Calendar.appt.time.CalendarTimeSlotEvent
+import com.vitorpamplona.quartz.nip52Calendar.rsvp.CalendarRSVPEvent
+import com.vitorpamplona.quartz.nip53LiveActivities.chat.LiveActivitiesChatMessageEvent
+import com.vitorpamplona.quartz.nip53LiveActivities.streaming.LiveActivitiesEvent
+import com.vitorpamplona.quartz.nip54Wiki.WikiNoteEvent
+import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
+import com.vitorpamplona.quartz.nip58Badges.award.BadgeAwardEvent
+import com.vitorpamplona.quartz.nip64Chess.challenge.accept.LiveChessGameAcceptEvent
+import com.vitorpamplona.quartz.nip64Chess.move.LiveChessMoveEvent
+import com.vitorpamplona.quartz.nip68Picture.PictureEvent
+import com.vitorpamplona.quartz.nip71Video.VideoHorizontalEvent
+import com.vitorpamplona.quartz.nip71Video.VideoNormalEvent
+import com.vitorpamplona.quartz.nip71Video.VideoShortEvent
+import com.vitorpamplona.quartz.nip71Video.VideoVerticalEvent
+import com.vitorpamplona.quartz.nip84Highlights.HighlightEvent
+import com.vitorpamplona.quartz.nip88Polls.poll.PollEvent
+import com.vitorpamplona.quartz.nip99Classifieds.ClassifiedsEvent
+import com.vitorpamplona.quartz.nipA0VoiceMessages.VoiceEvent
+import com.vitorpamplona.quartz.nipA0VoiceMessages.VoiceReplyEvent
+import com.vitorpamplona.quartz.nipA4PublicMessages.PublicMessageEvent
+
+/**
+ * Centralized notification event kind constants for the notification feed.
+ *
+ * These define which event kinds are treated as addressable (replaceable)
+ * and which are shown in the notification feed.
+ */
+object NotificationKinds {
+    /**
+     * Addressable (replaceable) event kinds that appear in notifications.
+     */
+    val ADDRESSABLE_KINDS =
+        listOf(
+            AudioTrackEvent.KIND,
+            CalendarTimeSlotEvent.KIND,
+            CalendarDateSlotEvent.KIND,
+            CalendarRSVPEvent.KIND,
+            ClassifiedsEvent.KIND,
+            LiveActivitiesEvent.KIND,
+            LiveChessGameAcceptEvent.KIND,
+            LiveChessMoveEvent.KIND,
+            LongTextNoteEvent.KIND,
+            NipTextEvent.KIND,
+            VideoVerticalEvent.KIND,
+            VideoHorizontalEvent.KIND,
+            WikiNoteEvent.KIND,
+            AttestationRequestEvent.KIND,
+        )
+
+    /**
+     * All event kinds that should appear in the notification feed.
+     * Includes both regular and addressable kinds.
+     */
+    val NOTIFICATION_KINDS: Set<Int> =
+        setOf(
+            BadgeAwardEvent.KIND,
+            ChatMessageEvent.KIND,
+            ChatMessageEncryptedFileHeaderEvent.KIND,
+            CommentEvent.KIND,
+            GenericRepostEvent.KIND,
+            GitIssueEvent.KIND,
+            GitPatchEvent.KIND,
+            HighlightEvent.KIND,
+            TextNoteEvent.KIND,
+            ReactionEvent.KIND,
+            RepostEvent.KIND,
+            LnZapEvent.KIND,
+            LiveActivitiesChatMessageEvent.KIND,
+            PictureEvent.KIND,
+            PollEvent.KIND,
+            ZapPollEvent.KIND,
+            PrivateDmEvent.KIND,
+            PublicMessageEvent.KIND,
+            VideoNormalEvent.KIND,
+            VideoShortEvent.KIND,
+            VoiceEvent.KIND,
+            VoiceReplyEvent.KIND,
+        ) + ADDRESSABLE_KINDS
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/settings/StringFeedState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/settings/StringFeedState.kt
@@ -18,19 +18,34 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.note
+package com.vitorpamplona.amethyst.commons.ui.settings
 
-import java.math.BigDecimal
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.coroutines.flow.MutableStateFlow
 
-// Re-export from commons for backwards compatibility
-fun showAmountInteger(amount: BigDecimal?): String =
-    com.vitorpamplona.amethyst.commons.util
-        .showAmountInteger(amount)
+/**
+ * Feed state for string-based feeds (e.g., hidden words lists).
+ *
+ * Follows the same pattern as FeedState and CardFeedState but for
+ * simple string content used in settings screens.
+ */
+@Stable
+sealed class StringFeedState {
+    @Immutable
+    object Loading : StringFeedState()
 
-fun showAmountInteger(amount: Int?): String =
-    com.vitorpamplona.amethyst.commons.util
-        .showAmountInteger(amount)
+    @Stable
+    class Loaded(
+        val feed: MutableStateFlow<ImmutableList<String>>,
+    ) : StringFeedState()
 
-fun showAmountIntegerWithZero(amount: BigDecimal?): String =
-    com.vitorpamplona.amethyst.commons.util
-        .showAmountIntegerWithZero(amount)
+    @Immutable
+    object Empty : StringFeedState()
+
+    @Immutable
+    class FeedError(
+        val errorMessage: String,
+    ) : StringFeedState()
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/util/CountFormatter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/util/CountFormatter.kt
@@ -18,21 +18,29 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings
+package com.vitorpamplona.amethyst.commons.util
 
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlin.math.roundToInt
 
-sealed class StringFeedState {
-    object Loading : StringFeedState()
+/**
+ * Formats an integer count to a human-readable abbreviated string.
+ *
+ * Examples:
+ * - null -> ""
+ * - 0 -> ""
+ * - 999 -> "999"
+ * - 10000 -> "10k"
+ * - 1500000 -> "2M"
+ * - 2000000000 -> "2G"
+ */
+fun showCount(count: Int?): String {
+    if (count == null) return ""
+    if (count == 0) return ""
 
-    class Loaded(
-        val feed: MutableStateFlow<ImmutableList<String>>,
-    ) : StringFeedState()
-
-    object Empty : StringFeedState()
-
-    class FeedError(
-        val errorMessage: String,
-    ) : StringFeedState()
+    return when {
+        count >= 1_000_000_000 -> "${(count / 1_000_000_000f).roundToInt()}G"
+        count >= 1_000_000 -> "${(count / 1_000_000f).roundToInt()}M"
+        count >= 10_000 -> "${(count / 1_000f).roundToInt()}k"
+        else -> "$count"
+    }
 }

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/util/ZapFormatter.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/util/ZapFormatter.kt
@@ -38,6 +38,12 @@ private val dfMSmall = ThreadLocal.withInitial { DecimalFormat("#.0M") }
 private val dfK = ThreadLocal.withInitial { DecimalFormat("#.#k") }
 private val dfN = ThreadLocal.withInitial { DecimalFormat("#") }
 
+// No-decimal formatters for integer display
+private val dfGInt = ThreadLocal.withInitial { DecimalFormat("#G") }
+private val dfMInt = ThreadLocal.withInitial { DecimalFormat("#M") }
+private val dfKInt = ThreadLocal.withInitial { DecimalFormat("#k") }
+private val dfNInt = ThreadLocal.withInitial { DecimalFormat("#") }
+
 /**
  * Formats a BigDecimal amount to human-readable format with G/M/K suffixes.
  * Returns empty string for null or very small amounts.
@@ -69,6 +75,46 @@ fun showAmountWithZero(amount: BigDecimal?): String {
     if (amount == null) return "0"
     if (amount.abs() < BigDecimal(0.01)) return "0"
     return showAmount(amount)
+}
+
+/**
+ * Formats a BigDecimal amount to human-readable format without decimals.
+ * Returns empty string for null or very small amounts.
+ *
+ * Examples:
+ * - 1500 -> "2k"
+ * - 2500000 -> "3M"
+ * - 10000000000 -> "10G"
+ */
+fun showAmountInteger(amount: BigDecimal?): String {
+    if (amount == null) return ""
+    if (amount.abs() < BigDecimal(0.01)) return ""
+
+    return when {
+        amount >= OneGiga -> dfGInt.get()!!.format(amount.div(OneGiga).setScale(0, RoundingMode.HALF_UP))
+        amount >= OneMega -> dfMInt.get()!!.format(amount.div(OneMega).setScale(0, RoundingMode.HALF_UP))
+        amount >= TenKilo -> dfKInt.get()!!.format(amount.div(OneKilo).setScale(0, RoundingMode.HALF_UP))
+        else -> dfNInt.get()!!.format(amount)
+    }
+}
+
+/**
+ * Formats an Int amount using the integer formatter.
+ * Returns "0" for null values.
+ */
+fun showAmountInteger(amount: Int?): String {
+    if (amount == null) return "0"
+    return showAmountIntegerWithZero(BigDecimal.valueOf(amount.toLong()))
+}
+
+/**
+ * Formats a BigDecimal amount without decimals.
+ * Returns "0" for null or very small amounts instead of empty string.
+ */
+fun showAmountIntegerWithZero(amount: BigDecimal?): String {
+    if (amount == null) return "0"
+    if (amount.abs() < BigDecimal(0.01)) return "0"
+    return showAmountInteger(amount)
 }
 
 /**


### PR DESCRIPTION
Moves notification and settings-related state management to commons for KMP.

## Changes
- **StringFeedState** sealed class → `commons/ui/settings/` (pure state, no Android deps)
- **NotificationKinds** object → `commons/ui/notifications/` (ADDRESSABLE_KINDS + NOTIFICATION_KINDS constants)
- **showCount()** → `commons/util/CountFormatter` (integer count abbreviation: 10000 → "10k")
- **showAmountInteger/showAmountIntegerWithZero** → `commons/util/ZapFormatter` (no-decimal BigDecimal formatting)

Android code updated with backwards-compatible re-exports.

Part of the KMP iOS migration tracked in #2238.