### PR TITLE
feat: move ThreadFeedViewModel, ChannelFeedFilter+VM to commons

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/dal/ChannelFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/dal/ChannelFeedViewModel.kt
@@ -25,12 +25,11 @@ import androidx.lifecycle.ViewModelProvider
 import com.vitorpamplona.amethyst.commons.model.Channel
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.privateDM.dal.ListChangeFeedViewModel
 
 class ChannelFeedViewModel(
-    val channel: Channel,
-    val account: Account,
-) : ListChangeFeedViewModel(ChannelFeedFilter(channel, account), LocalCache) {
+    channel: Channel,
+    account: Account,
+) : com.vitorpamplona.amethyst.commons.viewmodels.ChannelFeedViewModel(channel, account, LocalCache) {
     class Factory(
         val channel: Channel,
         val account: Account,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/dal/ThreadFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/dal/ThreadFeedViewModel.kt
@@ -22,14 +22,13 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.threadview.dal
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import com.vitorpamplona.amethyst.commons.viewmodels.thread.ThreadFeedFilter
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 
 class ThreadFeedViewModel(
     account: Account,
     noteId: String,
-) : com.vitorpamplona.amethyst.commons.viewmodels.thread.LevelFeedViewModel(ThreadFeedFilter(account, noteId, LocalCache), LocalCache) {
+) : com.vitorpamplona.amethyst.commons.viewmodels.thread.ThreadFeedViewModel(account, noteId, LocalCache) {
     class Factory(
         val account: Account,
         val noteId: String,

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/ChannelFeedFilter.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/ChannelFeedFilter.kt
@@ -18,7 +18,28 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.dal
+package com.vitorpamplona.amethyst.commons.ui.feeds
 
-// Re-export from commons for backwards compatibility
-typealias ChannelFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.ChannelFeedFilter
+import com.vitorpamplona.amethyst.commons.model.Channel
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.Note
+
+class ChannelFeedFilter(
+    val channel: Channel,
+    val account: IAccount,
+) : AdditiveFeedFilter<Note>(),
+    ChangesFlowFilter<Note> {
+    override fun feedKey() = channel
+
+    override fun changesFlow() = channel.changesFlow()
+
+    // returns the last Note of each user.
+    override fun feed(): List<Note> = sort(channel.notes.filterIntoSet { key, it -> account.isAcceptable(it) })
+
+    override fun applyFilter(newItems: Set<Note>): Set<Note> =
+        newItems
+            .filter { channel.notes.containsKey(it.idHex) && account.isAcceptable(it) }
+            .toSet()
+
+    override fun sort(items: Set<Note>): List<Note> = items.sortedWith(DefaultFeedOrder)
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/ChannelFeedViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/ChannelFeedViewModel.kt
@@ -18,7 +18,22 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.dal
+package com.vitorpamplona.amethyst.commons.viewmodels
 
-// Re-export from commons for backwards compatibility
-typealias ChannelFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.ChannelFeedFilter
+import com.vitorpamplona.amethyst.commons.model.Channel
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+import com.vitorpamplona.amethyst.commons.ui.feeds.ChannelFeedFilter
+
+/**
+ * Platform-agnostic ChannelFeedViewModel for public channel (NIP-28) feeds.
+ *
+ * @param channel The public channel to display
+ * @param account The current user's account
+ * @param cacheProvider The cache provider for note lookups
+ */
+open class ChannelFeedViewModel(
+    val channel: Channel,
+    val account: IAccount,
+    cacheProvider: ICacheProvider,
+) : ListChangeFeedViewModel(ChannelFeedFilter(channel, account), cacheProvider)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/thread/ThreadFeedViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/thread/ThreadFeedViewModel.kt
@@ -18,7 +18,24 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.dal
+package com.vitorpamplona.amethyst.commons.viewmodels.thread
 
-// Re-export from commons for backwards compatibility
-typealias ChannelFeedFilter = com.vitorpamplona.amethyst.commons.ui.feeds.ChannelFeedFilter
+import com.vitorpamplona.amethyst.commons.model.IAccount
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+
+/**
+ * Platform-agnostic ThreadFeedViewModel.
+ *
+ * Assembles a thread view by combining the ThreadFeedFilter (which uses
+ * ThreadAssembler + ThreadLevelCalculator) with the LevelFeedViewModel
+ * (which computes per-note indentation levels).
+ *
+ * @param account The current user's account
+ * @param noteId The root note ID of the thread
+ * @param cacheProvider The cache provider for note lookups
+ */
+open class ThreadFeedViewModel(
+    val account: IAccount,
+    val noteId: String,
+    cacheProvider: ICacheProvider,
+) : LevelFeedViewModel(ThreadFeedFilter(account, noteId, cacheProvider), cacheProvider)


### PR DESCRIPTION
Move platform-agnostic versions of three feed components to commons for KMP/iOS:

- **ThreadFeedViewModel** → commons (ThreadFeedFilter was already in commons)
- **ChannelFeedFilter** → commons (all types—Channel, IAccount, Note, AdditiveFeedFilter, ChangesFlowFilter, DefaultFeedOrder—already resolved to commons)
- **ChannelFeedViewModel** → commons (wraps the now-commons filter via ListChangeFeedViewModel)

Android wrappers remain in place, extending the commons versions with LocalCache and ViewModelProvider.Factory.

Build-verified: `:commons:compileKotlinJvm` and `:amethyst:compilePlayDebugKotlin` both pass.

Part of the KMP iOS migration tracked in #2238.