### PR TITLE
fix: filter in-progress chess games (kind 64) from home feed (#2191)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/dal/HomeNewThreadFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/dal/HomeNewThreadFeedFilter.kt
@@ -127,7 +127,7 @@ class HomeNewThreadFeedFilter(
                 noteEvent is AudioTrackEvent ||
                 noteEvent is VoiceEvent ||
                 noteEvent is AudioHeaderEvent ||
-                noteEvent is ChessGameEvent ||
+                (noteEvent is ChessGameEvent && noteEvent.isCompletedGame()) ||
                 noteEvent is LiveChessGameEndEvent ||
                 noteEvent is AttestationEvent ||
                 noteEvent is AttestationRequestEvent ||

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip64Chess/game/ChessGameEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip64Chess/game/ChessGameEvent.kt
@@ -55,6 +55,25 @@ class ChessGameEvent(
      */
     fun pgn(): String = content
 
+    /**
+     * Check if this is a completed game (has a definitive result).
+     *
+     * In-progress games have [Result "*"] in PGN. Completed games have
+     * [Result "1-0"], [Result "0-1"], or [Result "1/2-1/2"].
+     *
+     * Some chess apps (e.g. nostrchess) publish a new kind 64 event after
+     * every move with the running PGN. Only completed games should appear
+     * in general feeds to avoid spamming followers with every move.
+     */
+    fun isCompletedGame(): Boolean {
+        // Fast check: look for PGN Result tag without full parsing
+        val idx = content.indexOf("[Result ")
+        if (idx < 0) return false
+        return content.indexOf("\"1-0\"", idx) != -1 ||
+            content.indexOf("\"0-1\"", idx) != -1 ||
+            content.indexOf("\"1/2-1/2\"", idx) != -1
+    }
+
     companion object {
         const val KIND = 64
         const val ALT_DESCRIPTION = "Chess Game"


### PR DESCRIPTION
Fixes #2191

## Problem

Some chess apps (e.g. [nostrchess](https://nostrchess.vercel.app/)) publish a new kind 64 event after every move with the updated PGN. This floods followers' home feeds with a card for every individual move.

## Solution

Added `ChessGameEvent.isCompletedGame()` that performs a fast check on the PGN `[Result "..."]` tag to determine if the game is finished. The home feed filter now only shows completed games (result is `1-0`, `0-1`, or `1/2-1/2`). In-progress games (result `*` or missing result tag) are filtered out of the general home feed.

The dedicated chess feed is **unaffected** — it continues to show all chess games including in-progress ones.

## Changes

- **`ChessGameEvent.kt`**: Added `isCompletedGame()` method using fast string search on PGN content (no regex/full parsing overhead)
- **`HomeNewThreadFeedFilter.kt`**: Changed `noteEvent is ChessGameEvent` to `(noteEvent is ChessGameEvent && noteEvent.isCompletedGame())`