### PR TITLE
fix: preserve draft note text across process death when switching apps

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostScreen.kt
@@ -150,21 +150,28 @@ fun ShortNotePostScreen(
     }
 
     LaunchedEffect(postViewModel, accountViewModel) {
-        val baseReplyTo = baseReplyToId?.let { accountViewModel.getNoteIfExists(it) }
-        val quote = quoteId?.let { accountViewModel.getNoteIfExists(it) }
-        val fork = forkId?.let { accountViewModel.getNoteIfExists(it) }
-        val version = versionId?.let { accountViewModel.getNoteIfExists(it) }
-        val draft = draftId?.let { accountViewModel.getNoteIfExists(it) }
-        postViewModel.load(baseReplyTo, quote, fork, version, draft)
-        message?.ifBlank { null }?.let {
-            postViewModel.message.setTextAndPlaceCursorAtEnd(it)
-            postViewModel.onMessageChanged()
-        }
-        attachment?.ifBlank { null }?.toUri()?.let {
-            withContext(Dispatchers.IO) {
-                val mediaType = context.contentResolver.getType(it)
-                postViewModel.selectImage(persistentListOf(SelectedMedia(it, mediaType)))
+        // Skip load when restored from SavedStateHandle after process death —
+        // the message text is already present in the TextFieldState.
+        if (!postViewModel.restoredFromSavedState) {
+            val baseReplyTo = baseReplyToId?.let { accountViewModel.getNoteIfExists(it) }
+            val quote = quoteId?.let { accountViewModel.getNoteIfExists(it) }
+            val fork = forkId?.let { accountViewModel.getNoteIfExists(it) }
+            val version = versionId?.let { accountViewModel.getNoteIfExists(it) }
+            val draft = draftId?.let { accountViewModel.getNoteIfExists(it) }
+            postViewModel.load(baseReplyTo, quote, fork, version, draft)
+            message?.ifBlank { null }?.let {
+                postViewModel.message.setTextAndPlaceCursorAtEnd(it)
+                postViewModel.onMessageChanged()
             }
+            attachment?.ifBlank { null }?.toUri()?.let {
+                withContext(Dispatchers.IO) {
+                    val mediaType = context.contentResolver.getType(it)
+                    postViewModel.selectImage(persistentListOf(SelectedMedia(it, mediaType)))
+                }
+            }
+        } else {
+            // Restored from process death — update URL previews for the restored text.
+            postViewModel.urlPreviews.update(postViewModel.message.text.toString())
         }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostViewModel.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vitorpamplona.amethyst.Amethyst
@@ -165,8 +166,9 @@ enum class UserSuggestionAnchor {
 }
 
 @Stable
-open class ShortNotePostViewModel :
-    ViewModel(),
+open class ShortNotePostViewModel(
+    private val savedStateHandle: SavedStateHandle = SavedStateHandle(),
+) : ViewModel(),
     ILocationGrabber,
     IMessageField,
     IZapField,
@@ -177,7 +179,21 @@ open class ShortNotePostViewModel :
     lateinit var accountViewModel: AccountViewModel
     lateinit var account: Account
 
+    /** True when the ViewModel was restored from [SavedStateHandle] after process death. */
+    var restoredFromSavedState: Boolean = false
+        private set
+
     init {
+        // Restore draft tag and message text from SavedStateHandle after process death.
+        savedStateHandle.get<String>(KEY_DRAFT_TAG)?.let { savedTag ->
+            draftTag.set(savedTag)
+        }
+        savedStateHandle.get<String>(KEY_MESSAGE_TEXT)?.let { savedText ->
+            if (savedText.isNotBlank()) {
+                restoredFromSavedState = true
+            }
+        }
+
         viewModelScope.launch(Dispatchers.IO) {
             draftTag.versions.collectLatest {
                 // don't save the first
@@ -199,7 +215,10 @@ open class ShortNotePostViewModel :
     val iMetaAttachments = IMetaAttachments()
     var nip95attachments by mutableStateOf<List<Pair<FileStorageEvent, FileStorageHeaderEvent>>>(emptyList())
 
-    override val message = TextFieldState()
+    override val message =
+        TextFieldState(
+            initialText = savedStateHandle.get<String>(KEY_MESSAGE_TEXT) ?: "",
+        )
 
     val urlPreviews = PreviewState()
 
@@ -1156,6 +1175,7 @@ open class ShortNotePostViewModel :
         draftTag.rotate()
 
         message.setTextAndPlaceCursorAtEnd("")
+        clearSavedState()
 
         forkedFromNote = null
 
@@ -1238,7 +1258,20 @@ open class ShortNotePostViewModel :
         }
 
         precomputeAiResults()
+        saveToSavedState()
         draftTag.newVersion()
+    }
+
+    /** Persist message text and draft tag into [SavedStateHandle] so they survive process death. */
+    private fun saveToSavedState() {
+        savedStateHandle[KEY_MESSAGE_TEXT] = message.text.toString()
+        savedStateHandle[KEY_DRAFT_TAG] = draftTag.current
+    }
+
+    /** Clear saved state when the draft is intentionally discarded. */
+    private fun clearSavedState() {
+        savedStateHandle.remove<String>(KEY_MESSAGE_TEXT)
+        savedStateHandle.remove<String>(KEY_DRAFT_TAG)
     }
 
     override fun updateZapForwardTo(newZapForwardTo: TextFieldValue) {
@@ -1608,4 +1641,9 @@ open class ShortNotePostViewModel :
     }
 
     override fun locationManager(): LocationState = Amethyst.instance.locationManager
+
+    companion object {
+        private const val KEY_MESSAGE_TEXT = "draft_message_text"
+        private const val KEY_DRAFT_TAG = "draft_tag"
+    }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/polls/PollPostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/polls/PollPostScreen.kt
@@ -44,13 +44,17 @@ fun PollPostScreen(
     postViewModel.init(accountViewModel)
 
     LaunchedEffect(postViewModel, accountViewModel) {
-        val draft = draftId?.let { accountViewModel.getNoteIfExists(it) }
-        postViewModel.load(null, null, null, null, draft)
-        message?.ifBlank { null }?.let {
-            postViewModel.message.setTextAndPlaceCursorAtEnd(it)
-            postViewModel.onMessageChanged()
+        if (!postViewModel.restoredFromSavedState) {
+            val draft = draftId?.let { accountViewModel.getNoteIfExists(it) }
+            postViewModel.load(null, null, null, null, draft)
+            message?.ifBlank { null }?.let {
+                postViewModel.message.setTextAndPlaceCursorAtEnd(it)
+                postViewModel.onMessageChanged()
+            }
+            postViewModel.wantsPoll = true
+        } else {
+            postViewModel.urlPreviews.update(postViewModel.message.text.toString())
         }
-        postViewModel.wantsPoll = true
     }
 
     NewPostScreenInner(postViewModel, accountViewModel, nav)


### PR DESCRIPTION
## Problem

When composing a note and switching to another app (e.g. to copy a URL to paste into the note), Android may kill the process due to memory pressure. On returning, the compose screen loses all typed text because `ShortNotePostViewModel` uses a plain `TextFieldState()` with no process death survival mechanism.

The existing NIP-37 draft auto-save is excellent for relay-persisted recovery, but it doesn't help with the immediate UX — the user has to manually find and load their draft from the drafts screen instead of seeing their text right where they left it.

## Fix

Add `SavedStateHandle` to `ShortNotePostViewModel` to persist the message text and draft tag in Android's saved instance state bundle:

- **On every text change**: save message text + draft tag to `SavedStateHandle`
- **On ViewModel creation**: if `SavedStateHandle` contains saved text, initialize `TextFieldState` with it and skip re-loading from route args
- **On cancel/post**: clear saved state to avoid stale drafts

This is the standard Android mechanism for surviving process death — the `SavedStateHandle` is automatically provided by the Navigation component's `ViewModelStoreOwner`.

## Changes

- `ShortNotePostViewModel`: Accept `SavedStateHandle`, save/restore message text + draft tag
- `ShortNotePostScreen`: Skip `load()` when restored from saved state
- `PollPostScreen`: Same fix (shares the ViewModel)

## Testing

1. Open compose screen, type some text
2. Switch to another app
3. Use developer options → "Don't keep activities" or `adb shell am kill com.vitorpamplona.amethyst`
4. Switch back to Amethyst
5. **Before**: empty compose screen. **After**: text is preserved