### PR TITLE
Fix Bluetooth SCO receiver registration for Android 12+

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallAudioManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallAudioManager.kt
@@ -143,7 +143,9 @@ class CallAudioManager(
             } else {
                 routeToEarpiece()
             }
-            registerBluetoothScoReceiver()
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+                registerBluetoothScoReceiver()
+            }
         } else {
             _isBluetoothAvailable.value = false
             routeToEarpiece()
@@ -301,6 +303,7 @@ class CallAudioManager(
         }
     }
 
+    @Suppress("DEPRECATION")
     private fun registerBluetoothScoReceiver() {
         if (scoReceiver != null) return
         scoReceiver =


### PR DESCRIPTION
## Summary
Updated Bluetooth audio handling to be compatible with Android 12 (API 31) and later by conditionally registering the Bluetooth SCO receiver only on older API levels.

## Key Changes
- Added API level check (`Build.VERSION.SDK_INT < Build.VERSION_CODES.S`) before calling `registerBluetoothScoReceiver()` to prevent issues on Android 12+
- Added `@Suppress("DEPRECATION")` annotation to the `registerBluetoothScoReceiver()` method to acknowledge the use of deprecated Bluetooth SCO APIs on older Android versions

## Implementation Details
The Bluetooth SCO (Synchronous Connection Oriented) receiver registration is now skipped on Android 12 and later, as the underlying APIs have changed in newer Android versions. The deprecation suppression allows the method to continue functioning on older API levels where these APIs are still available and necessary for proper Bluetooth audio routing during calls.

https://claude.ai/code/session_011tQiA56fBUUzxsUS3zeYAE