### PR TITLE
Update AndroidBleTransport for Android 13+ Bluetooth API changes

### DIFF
--- a/quartz/src/androidMain/kotlin/com/vitorpamplona/quartz/nipBEBle/transport/AndroidBleTransport.kt
+++ b/quartz/src/androidMain/kotlin/com/vitorpamplona/quartz/nipBEBle/transport/AndroidBleTransport.kt
@@ -32,6 +32,7 @@ import android.bluetooth.BluetoothGattServerCallback
 import android.bluetooth.BluetoothGattService
 import android.bluetooth.BluetoothManager
 import android.bluetooth.BluetoothProfile
+import android.bluetooth.BluetoothStatusCodes
 import android.bluetooth.le.AdvertiseCallback
 import android.bluetooth.le.AdvertiseData
 import android.bluetooth.le.AdvertiseSettings
@@ -40,6 +41,7 @@ import android.bluetooth.le.ScanFilter
 import android.bluetooth.le.ScanResult
 import android.bluetooth.le.ScanSettings
 import android.content.Context
+import android.os.Build
 import android.os.ParcelUuid
 import com.vitorpamplona.quartz.nipBEBle.AndroidBleTransportContract
 import com.vitorpamplona.quartz.nipBEBle.BleConfig
@@ -88,6 +90,11 @@ class AndroidBleTransport(
     private val readCharUuid = UUID.fromString(BleConfig.READ_CHARACTERISTIC_UUID)
 
     private var readCharacteristic: BluetoothGattCharacteristic? = null
+
+    // Caches the most recently notified payload so that GATT read requests on the
+    // read characteristic can return a meaningful value without relying on the
+    // deprecated BluetoothGattCharacteristic.value field.
+    private var lastNotifiedValue: ByteArray = ByteArray(0)
 
     /**
      * Sets the listener for transport events. Must be called before [startAdvertising] or [startScanning].
@@ -206,7 +213,14 @@ class AndroidBleTransport(
             }
 
         peerMap[peer.deviceUuid] = peer
-        val gatt = device.connectGatt(context, false, gattClientCallback, BluetoothDevice.TRANSPORT_LE)
+        val gatt =
+            device.connectGatt(
+                context,
+                false,
+                gattClientCallback,
+                BluetoothDevice.TRANSPORT_LE,
+                BluetoothDevice.PHY_LE_1M_MASK,
+            )
         gattConnections[peer.deviceUuid] = gatt
     }
 
@@ -227,8 +241,18 @@ class AndroidBleTransport(
         val service = gatt.getService(serviceUuid) ?: return false
         val char = service.getCharacteristic(writeCharUuid) ?: return false
 
-        char.value = chunk
-        return gatt.writeCharacteristic(char)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            gatt.writeCharacteristic(
+                char,
+                chunk,
+                BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT,
+            ) == BluetoothStatusCodes.SUCCESS
+        } else {
+            @Suppress("DEPRECATION")
+            char.value = chunk
+            @Suppress("DEPRECATION")
+            gatt.writeCharacteristic(char)
+        }
     }
 
     override fun notifyChunk(
@@ -239,8 +263,15 @@ class AndroidBleTransport(
         val device = connectedDevices[peer.deviceUuid] ?: return false
         val char = readCharacteristic ?: return false
 
-        char.value = chunk
-        return server.notifyCharacteristicChanged(device, char, false)
+        lastNotifiedValue = chunk
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            server.notifyCharacteristicChanged(device, char, false, chunk) == BluetoothStatusCodes.SUCCESS
+        } else {
+            @Suppress("DEPRECATION")
+            char.value = chunk
+            @Suppress("DEPRECATION")
+            server.notifyCharacteristicChanged(device, char, false)
+        }
     }
 
     override fun requestMtu(
@@ -341,7 +372,7 @@ class AndroidBleTransport(
                         requestId,
                         BluetoothGatt.GATT_SUCCESS,
                         0,
-                        characteristic.value ?: ByteArray(0),
+                        lastNotifiedValue,
                     )
                 }
             }
@@ -398,13 +429,20 @@ class AndroidBleTransport(
 
                 val cccd = readChar.getDescriptor(UUID.fromString("00002902-0000-1000-8000-00805f9b34fb"))
                 cccd?.let {
-                    it.value = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
-                    gatt.writeDescriptor(it)
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        gatt.writeDescriptor(it, BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE)
+                    } else {
+                        @Suppress("DEPRECATION")
+                        it.value = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+                        @Suppress("DEPRECATION")
+                        gatt.writeDescriptor(it)
+                    }
                 }
 
                 listener?.onPeerConnected(peer)
             }
 
+            @Deprecated("Used on Android 12 and lower. API 33+ uses the overload with the value parameter.")
             override fun onCharacteristicChanged(
                 gatt: BluetoothGatt,
                 characteristic: BluetoothGattCharacteristic,
@@ -412,7 +450,21 @@ class AndroidBleTransport(
                 if (characteristic.uuid == readCharUuid) {
                     val peerUuid = deviceUuidMap[gatt.device.address] ?: return
                     val peer = peerMap[peerUuid] ?: return
+                    @Suppress("DEPRECATION")
                     val value = characteristic.value ?: return
+
+                    listener?.onChunkReceived(peer, value)
+                }
+            }
+
+            override fun onCharacteristicChanged(
+                gatt: BluetoothGatt,
+                characteristic: BluetoothGattCharacteristic,
+                value: ByteArray,
+            ) {
+                if (characteristic.uuid == readCharUuid) {
+                    val peerUuid = deviceUuidMap[gatt.device.address] ?: return
+                    val peer = peerMap[peerUuid] ?: return
 
                     listener?.onChunkReceived(peer, value)
                 }


### PR DESCRIPTION
## Summary
Updates the AndroidBleTransport class to support Android 13 (TIRAMISU) and later Bluetooth API changes while maintaining backward compatibility with Android 12 and earlier versions.

## Key Changes
- **Added Android 13+ API support**: Implemented version-aware code paths using `Build.VERSION.SDK_INT` checks to use new non-deprecated Bluetooth APIs on Android 13+ while falling back to deprecated APIs on older versions
- **Updated characteristic write operations**: Modified `writeChunk()` to use the new `gatt.writeCharacteristic(char, chunk, writeType)` overload on Android 13+ instead of setting the deprecated `char.value` field
- **Updated notification operations**: Modified `notifyChunk()` to use the new `server.notifyCharacteristicChanged(device, char, confirm, value)` overload on Android 13+ with explicit value parameter
- **Updated descriptor write operations**: Modified CCCD descriptor writes to use the new `gatt.writeDescriptor(descriptor, value)` overload on Android 13+
- **Added characteristic change callback overload**: Implemented the new `onCharacteristicChanged(gatt, characteristic, value)` callback for Android 13+ alongside the deprecated version
- **Introduced value caching**: Added `lastNotifiedValue` field to cache the most recently notified payload, allowing GATT read requests to return meaningful values without relying on the deprecated `BluetoothGattCharacteristic.value` field
- **Enhanced connection parameters**: Added `BluetoothDevice.PHY_LE_1M_MASK` parameter to `connectGatt()` call for explicit PHY specification
- **Added imports**: Imported `BluetoothStatusCodes` and `Build` for version checking and status code handling

## Implementation Details
- All deprecated API calls are wrapped with `@Suppress("DEPRECATION")` annotations
- The deprecated `onCharacteristicChanged()` callback is marked with `@Deprecated` annotation
- Status code checks on Android 13+ compare against `BluetoothStatusCodes.SUCCESS` instead of relying on boolean return values
- Backward compatibility is maintained through conditional compilation at runtime

https://claude.ai/code/session_012cnvcKVu39XAoAzcR2vnVh