### PR TITLE
Add MarmotGroup chat room support to ChatroomHeaderCompose

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChatroomHeaderCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChatroomHeaderCompose.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
+import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupChatroom
 import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatChannel
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
@@ -118,6 +119,12 @@ private fun ChatroomEntry(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
+    val marmotGroup = lastMessage.inGatherers?.firstNotNullOfOrNull { it as? MarmotGroupChatroom }
+    if (marmotGroup != null) {
+        MarmotGroupRoomCompose(lastMessage, marmotGroup, accountViewModel, nav)
+        return
+    }
+
     val baseNoteEvent = lastMessage.event
     when (baseNoteEvent) {
         is ChannelMessageEvent -> {
@@ -231,6 +238,35 @@ private fun ChannelRoomCompose(
         loadProfilePicture = accountViewModel.settings.showProfilePictures(),
         loadRobohash = accountViewModel.settings.isNotPerformanceMode(),
         onClick = { nav.nav(routeFor(channel)) },
+    )
+}
+
+@Composable
+private fun MarmotGroupRoomCompose(
+    lastMessage: Note,
+    chatroom: MarmotGroupChatroom,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    val authorName by observeUserName(lastMessage.author!!, accountViewModel)
+    val displayName by chatroom.displayName.collectAsStateWithLifecycle()
+    val unread by chatroom.unreadCount.collectAsStateWithLifecycle()
+
+    val noteEvent = lastMessage.event
+    val description = noteEvent?.content?.take(200)
+
+    val groupName = displayName?.takeIf { it.isNotBlank() } ?: "Group ${chatroom.nostrGroupId.take(8)}"
+
+    ChannelName(
+        channelIdHex = chatroom.nostrGroupId,
+        channelPicture = null,
+        channelTitle = { modifier -> ChannelTitleWithLabelInfo(groupName, R.string.marmot_group, modifier) },
+        channelLastTime = lastMessage.createdAt(),
+        channelLastContent = "$authorName: $description",
+        hasNewMessages = unread > 0,
+        loadProfilePicture = accountViewModel.settings.showProfilePictures(),
+        loadRobohash = accountViewModel.settings.isNotPerformanceMode(),
+        onClick = { nav.nav(Route.MarmotGroupChat(chatroom.nostrGroupId)) },
     )
 }
 

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -283,6 +283,7 @@
     and thus chat messages disappear over time</string>
 
     <string name="public_chat">Public Chat</string>
+    <string name="marmot_group">MLS Group</string>
     <string name="public_chat_title">Public Chat Metadata</string>
     <string name="public_chat_explainer">Public chats are visible to everyone on Nostr and anyone
         can participate on them. They are great for open communities around specific topics.


### PR DESCRIPTION
## Summary
Added support for displaying Marmot Group (MLS Group) chat rooms in the chatroom header, allowing users to see group chat information alongside existing ephemeral and public chat types.

## Key Changes
- Added import for `MarmotGroupChatroom` model class
- Added detection logic in `ChatroomEntry()` to identify and handle Marmot Group chat rooms by checking `lastMessage.inGatherers`
- Created new `MarmotGroupRoomCompose()` composable function to render Marmot Group chat room headers with:
  - Group display name (with fallback to truncated group ID)
  - Last message author and content preview (first 200 characters)
  - Unread message count indicator
  - Navigation to the full group chat screen
- Added "MLS Group" string resource for UI labeling

## Implementation Details
- The Marmot Group detection uses `firstNotNullOfOrNull` to safely extract the group from the message's gatherers
- Group display name falls back to a formatted group ID if no custom name is set
- Reuses existing `ChannelName()` composable for consistent UI styling with other chat types
- Integrates with existing unread count tracking via `chatroom.unreadCount` state flow

https://claude.ai/code/session_01QTc5z8PoCdzUJjdeBNMAGV