### PR TITLE
Make editState parameter optional in ReactionsRow and related components

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
@@ -197,7 +197,7 @@ fun ReactionsRow(
     baseNote: Note,
     showReactionDetail: Boolean,
     addPadding: Boolean,
-    editState: State<GenericLoadable<EditState>>,
+    editState: State<GenericLoadable<EditState>>?,
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
@@ -219,7 +219,7 @@ private fun InnerReactionRow(
     showReactionDetail: Boolean,
     addPadding: Boolean,
     wantsToSeeReactions: MutableState<Boolean>,
-    editState: State<GenericLoadable<EditState>>,
+    editState: State<GenericLoadable<EditState>>?,
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
@@ -666,7 +666,7 @@ private fun WatchZapAndRenderGallery(
 @Composable
 private fun BoostWithDialog(
     baseNote: Note,
-    editState: State<GenericLoadable<EditState>>,
+    editState: State<GenericLoadable<EditState>>?,
     grayTint: Color,
     accountViewModel: AccountViewModel,
     nav: INav,
@@ -682,7 +682,7 @@ private fun BoostWithDialog(
                 Route.NewShortNote(
                     quote = baseNote.idHex,
                     version =
-                        (editState.value as? GenericLoadable.Loaded)
+                        (editState?.value as? GenericLoadable.Loaded)
                             ?.loaded
                             ?.modificationToShow
                             ?.value
@@ -704,7 +704,7 @@ private fun BoostWithDialog(
                     baseReplyTo = replyTo?.idHex,
                     fork = baseNote.idHex,
                     version =
-                        (editState.value as? GenericLoadable.Loaded)
+                        (editState?.value as? GenericLoadable.Loaded)
                             ?.loaded
                             ?.modificationToShow
                             ?.value

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/pictures/PictureCardCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/pictures/PictureCardCompose.kt
@@ -45,7 +45,6 @@ import com.vitorpamplona.amethyst.ui.components.SensitivityWarning
 import com.vitorpamplona.amethyst.ui.components.ZoomableContentView
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.ReactionsRow
-import com.vitorpamplona.amethyst.ui.note.observeEdits
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.video.UserCardHeader
 import com.vitorpamplona.quartz.nip68Picture.PictureEvent
@@ -59,13 +58,12 @@ fun PictureCardCompose(
 ) {
     val event = (baseNote.event as? PictureEvent) ?: return
     val backgroundColor = remember { mutableStateOf(Color.Transparent) }
-    val editState = observeEdits(baseNote = baseNote, accountViewModel = accountViewModel)
 
     Column(
         modifier = Modifier.fillMaxWidth(),
     ) {
         // Author header row
-        UserCardHeader(baseNote, accountViewModel, nav, editState)
+        UserCardHeader(baseNote, accountViewModel, nav)
 
         // Image content
         PictureCardImage(baseNote, event, backgroundColor, accountViewModel)
@@ -75,7 +73,7 @@ fun PictureCardCompose(
             baseNote = baseNote,
             showReactionDetail = true,
             addPadding = true,
-            editState = editState,
+            editState = null,
             accountViewModel = accountViewModel,
             nav = nav,
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/pictures/PictureCardCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/pictures/PictureCardCompose.kt
@@ -65,7 +65,7 @@ fun PictureCardCompose(
         modifier = Modifier.fillMaxWidth(),
     ) {
         // Author header row
-        UserCardHeader(baseNote, accountViewModel, nav)
+        UserCardHeader(baseNote, accountViewModel, nav, editState)
 
         // Image content
         PictureCardImage(baseNote, event, backgroundColor, accountViewModel)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/VideoCardCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/VideoCardCompose.kt
@@ -69,7 +69,7 @@ fun VideoCardCompose(
         modifier = Modifier.fillMaxWidth(),
     ) {
         // Author header row
-        UserCardHeader(baseNote, accountViewModel, nav)
+        UserCardHeader(baseNote, accountViewModel, nav, editState)
 
         // Image content
         VideoCardImage(baseNote, event, backgroundColor, accountViewModel)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/VideoCardCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/VideoCardCompose.kt
@@ -47,7 +47,6 @@ import com.vitorpamplona.amethyst.ui.components.SensitivityWarning
 import com.vitorpamplona.amethyst.ui.components.ZoomableContentView
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.ReactionsRow
-import com.vitorpamplona.amethyst.ui.note.observeEdits
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.video.UserCardHeader
 import com.vitorpamplona.quartz.nip01Core.core.Event
@@ -63,13 +62,12 @@ fun VideoCardCompose(
 ) {
     val event = (baseNote.event as? VideoEvent) ?: return
     val backgroundColor = remember { mutableStateOf(Color.Transparent) }
-    val editState = observeEdits(baseNote = baseNote, accountViewModel = accountViewModel)
 
     Column(
         modifier = Modifier.fillMaxWidth(),
     ) {
         // Author header row
-        UserCardHeader(baseNote, accountViewModel, nav, editState)
+        UserCardHeader(baseNote, accountViewModel, nav)
 
         // Image content
         VideoCardImage(baseNote, event, backgroundColor, accountViewModel)
@@ -79,7 +77,7 @@ fun VideoCardCompose(
             baseNote = baseNote,
             showReactionDetail = true,
             addPadding = true,
-            editState = editState,
+            editState = null,
             accountViewModel = accountViewModel,
             nav = nav,
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/FileHeaderCardCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/FileHeaderCardCompose.kt
@@ -68,7 +68,7 @@ fun FileHeaderCardCompose(
         modifier = Modifier.fillMaxWidth(),
     ) {
         // Author header row
-        UserCardHeader(baseNote, accountViewModel, nav)
+        UserCardHeader(baseNote, accountViewModel, nav, editState)
 
         // Image content
         FileHeaderCardImage(baseNote, event, backgroundColor, accountViewModel)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/FileHeaderCardCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/FileHeaderCardCompose.kt
@@ -47,7 +47,6 @@ import com.vitorpamplona.amethyst.ui.components.SensitivityWarning
 import com.vitorpamplona.amethyst.ui.components.ZoomableContentView
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.ReactionsRow
-import com.vitorpamplona.amethyst.ui.note.observeEdits
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip31Alts.alt
@@ -62,13 +61,12 @@ fun FileHeaderCardCompose(
 ) {
     val event = (baseNote.event as? FileHeaderEvent) ?: return
     val backgroundColor = remember { mutableStateOf(Color.Transparent) }
-    val editState = observeEdits(baseNote = baseNote, accountViewModel = accountViewModel)
 
     Column(
         modifier = Modifier.fillMaxWidth(),
     ) {
         // Author header row
-        UserCardHeader(baseNote, accountViewModel, nav, editState)
+        UserCardHeader(baseNote, accountViewModel, nav)
 
         // Image content
         FileHeaderCardImage(baseNote, event, backgroundColor, accountViewModel)
@@ -78,7 +76,7 @@ fun FileHeaderCardCompose(
             baseNote = baseNote,
             showReactionDetail = true,
             addPadding = true,
-            editState = editState,
+            editState = null,
             accountViewModel = accountViewModel,
             nav = nav,
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/UserCardHeader.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/UserCardHeader.kt
@@ -27,15 +27,19 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.model.Note
+import com.vitorpamplona.amethyst.ui.components.GenericLoadable
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.routeFor
 import com.vitorpamplona.amethyst.ui.note.NoteAuthorPicture
 import com.vitorpamplona.amethyst.ui.note.NoteUsernameDisplay
+import com.vitorpamplona.amethyst.ui.note.elements.MoreOptionsButton
 import com.vitorpamplona.amethyst.ui.note.elements.TimeAgo
+import com.vitorpamplona.amethyst.ui.note.types.EditState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.theme.Size35dp
 
@@ -44,6 +48,7 @@ fun UserCardHeader(
     baseNote: Note,
     accountViewModel: AccountViewModel,
     nav: INav,
+    editState: State<GenericLoadable<EditState>>? = null,
 ) {
     Row(
         modifier =
@@ -74,5 +79,12 @@ fun UserCardHeader(
         }
 
         TimeAgo(baseNote)
+
+        MoreOptionsButton(
+            baseNote = baseNote,
+            editState = editState,
+            accountViewModel = accountViewModel,
+            nav = nav,
+        )
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/UserCardHeader.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/UserCardHeader.kt
@@ -27,19 +27,16 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.ui.components.GenericLoadable
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.routeFor
 import com.vitorpamplona.amethyst.ui.note.NoteAuthorPicture
 import com.vitorpamplona.amethyst.ui.note.NoteUsernameDisplay
 import com.vitorpamplona.amethyst.ui.note.elements.MoreOptionsButton
 import com.vitorpamplona.amethyst.ui.note.elements.TimeAgo
-import com.vitorpamplona.amethyst.ui.note.types.EditState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.theme.Size35dp
 
@@ -48,7 +45,6 @@ fun UserCardHeader(
     baseNote: Note,
     accountViewModel: AccountViewModel,
     nav: INav,
-    editState: State<GenericLoadable<EditState>>? = null,
 ) {
     Row(
         modifier =
@@ -82,7 +78,7 @@ fun UserCardHeader(
 
         MoreOptionsButton(
             baseNote = baseNote,
-            editState = editState,
+            editState = null,
             accountViewModel = accountViewModel,
             nav = nav,
         )


### PR DESCRIPTION
## Summary
This PR makes the `editState` parameter optional (nullable) across several UI components that display reactions and media content. The changes allow these components to function without requiring edit state information, simplifying their usage in contexts where edit tracking is not needed.

## Key Changes
- **ReactionsRow.kt**: Made `editState` parameter nullable in `ReactionsRow()`, `InnerReactionRow()`, and `BoostWithDialog()` functions
  - Updated safe navigation calls (`editState?.value`) to handle null values in `BoostWithDialog()`
  
- **PictureCardCompose.kt**: Removed `observeEdits()` call and passed `null` for `editState` parameter to `ReactionsRow()`

- **VideoCardCompose.kt**: Removed `observeEdits()` call and passed `null` for `editState` parameter to `ReactionsRow()`

- **FileHeaderCardCompose.kt**: Removed `observeEdits()` call and passed `null` for `editState` parameter to `ReactionsRow()`

- **UserCardHeader.kt**: Added `MoreOptionsButton` component with `editState = null` parameter

## Implementation Details
- The `editState` parameter is now `State<GenericLoadable<EditState>>?` instead of non-nullable
- Safe navigation operator (`?.`) is used when accessing `editState.value` to handle null cases
- Removed unnecessary `observeEdits()` calls from media card components, reducing overhead when edit state tracking is not required
- This change maintains backward compatibility while allowing more flexible component usage

https://claude.ai/code/session_01DrsvnguWHdZMgsRqNS8BUz