### PR TITLE
Update Android SDK to platform 37 and build-tools 37.0.0

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -129,17 +129,17 @@ install_sdk_package() {
   echo "Installed to $dest_dir"
 }
 
-# Install Android platform 36
+# Install Android platform 37
 install_sdk_package \
-  "$SDK_REPO_BASE/platform-36_r02.zip" \
-  "$ANDROID_SDK_DIR/platforms/android-36" \
-  "android-36"
+  "$SDK_REPO_BASE/platform-37.0_r01.zip" \
+  "$ANDROID_SDK_DIR/platforms/android-37" \
+  "android-37.0"
 
-# Install build-tools 36.0.0 (zip uses "android-16" as inner dir name)
+# Install build-tools 37.0.0 (zip uses "android-37.0" as inner dir name)
 install_sdk_package \
-  "$SDK_REPO_BASE/build-tools_r36_linux.zip" \
-  "$ANDROID_SDK_DIR/build-tools/36.0.0" \
-  "android-16"
+  "$SDK_REPO_BASE/build-tools_r37_linux.zip" \
+  "$ANDROID_SDK_DIR/build-tools/37.0.0" \
+  "android-37.0"
 
 # Install platform-tools
 install_sdk_package \


### PR DESCRIPTION
## Summary
Updates the Android SDK installation in the session-start hook from version 36 to version 37, including both the platform and build-tools packages.

## Key Changes
- Updated Android platform from `android-36` to `android-37`
  - Changed platform package from `platform-36_r02.zip` to `platform-37.0_r01.zip`
  - Updated installation path from `platforms/android-36` to `platforms/android-37`
- Updated build-tools from `36.0.0` to `37.0.0`
  - Changed build-tools package from `build-tools_r36_linux.zip` to `build-tools_r37_linux.zip`
  - Updated installation path from `build-tools/36.0.0` to `build-tools/37.0.0`
  - Updated inner directory reference from `android-16` to `android-37.0` to match the new package structure

## Implementation Details
The changes maintain the existing installation pattern and function signatures while updating all version references and paths to align with the Android 37 SDK components.

https://claude.ai/code/session_01WqaFocptnrsAYcvrLNzWwD