### PR TITLE
Add shared element transition animation to image/video dialogs

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
@@ -28,6 +28,9 @@ import android.os.Looper
 import android.view.WindowManager
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.clickable
@@ -59,12 +62,20 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.util.lerp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.core.net.toUri
@@ -102,11 +113,35 @@ import net.engawapg.lib.zoomable.zoomable
 fun ZoomableImageDialog(
     imageUrl: BaseMediaContent,
     allImages: ImmutableList<BaseMediaContent> = listOf(imageUrl).toImmutableList(),
+    sourceBounds: Rect? = null,
     onDismiss: () -> Unit,
     accountViewModel: AccountViewModel,
 ) {
+    // Animation progress: 0f = at source position/size, 1f = fullscreen.
+    val progress = remember { Animatable(0f) }
+    var isExiting by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        progress.animateTo(
+            targetValue = 1f,
+            animationSpec = tween(durationMillis = 300, easing = FastOutSlowInEasing),
+        )
+    }
+
+    LaunchedEffect(isExiting) {
+        if (isExiting) {
+            progress.animateTo(
+                targetValue = 0f,
+                animationSpec = tween(durationMillis = 250, easing = FastOutSlowInEasing),
+            )
+            onDismiss()
+        }
+    }
+
+    val dismissWithAnimation: () -> Unit = { if (!isExiting) isExiting = true }
+
     Dialog(
-        onDismissRequest = onDismiss,
+        onDismissRequest = dismissWithAnimation,
         properties =
             DialogProperties(
                 usePlatformDefaultWidth = true,
@@ -123,11 +158,52 @@ fun ZoomableImageDialog(
             val attributes = WindowManager.LayoutParams()
             attributes.copyFrom(activityWindow.attributes)
             attributes.type = dialogWindow.attributes.type
+            // Disable the system dim so the thumbnail stays visible behind the growing dialog.
+            attributes.dimAmount = 0f
+            attributes.flags = attributes.flags and WindowManager.LayoutParams.FLAG_DIM_BEHIND.inv()
             dialogWindow.attributes = attributes
         }
 
-        Surface(Modifier.fillMaxSize()) {
-            DialogContent(allImages, imageUrl, onDismiss, accountViewModel)
+        var fullBounds by remember { mutableStateOf<Rect?>(null) }
+
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .onGloballyPositioned { fullBounds = it.boundsInWindow() },
+        ) {
+            // Background surface that fades in as the content grows to fullscreen.
+            Surface(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .graphicsLayer { alpha = progress.value },
+            ) {}
+
+            // Content layer that grows from the source bounds to fullscreen (and back on exit).
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .graphicsLayer {
+                            val src = sourceBounds
+                            val full = fullBounds
+                            if (src != null && full != null && full.width > 0f && full.height > 0f) {
+                                transformOrigin = TransformOrigin(0f, 0f)
+                                val startScaleX = src.width / full.width
+                                val startScaleY = src.height / full.height
+                                scaleX = lerp(startScaleX, 1f, progress.value)
+                                scaleY = lerp(startScaleY, 1f, progress.value)
+                                translationX = lerp(src.left - full.left, 0f, progress.value)
+                                translationY = lerp(src.top - full.top, 0f, progress.value)
+                            } else {
+                                // No source bounds provided: fall back to a simple fade.
+                                alpha = progress.value
+                            }
+                        },
+            ) {
+                DialogContent(allImages, imageUrl, dismissWithAnimation, accountViewModel)
+            }
         }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
@@ -60,11 +60,12 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
@@ -105,6 +106,8 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import net.engawapg.lib.zoomable.rememberZoomState
 import net.engawapg.lib.zoomable.zoomable
@@ -120,18 +123,23 @@ fun ZoomableImageDialog(
     // Animation progress: 0f = at source position/size, 1f = fullscreen.
     val progress = remember { Animatable(0f) }
     var isExiting by remember { mutableStateOf(false) }
-    var boundsReady by remember { mutableStateOf(false) }
 
-    // Wait for the image's natural bounds to be measured before starting the grow
-    // animation. Without this, the first frame may use placeholder bounds and snap
-    // to the real bounds mid-animation, producing a hiccup around the middle.
-    LaunchedEffect(boundsReady) {
-        if (boundsReady) {
-            progress.animateTo(
-                targetValue = 1f,
-                animationSpec = tween(durationMillis = 300, easing = FastOutSlowInEasing),
-            )
-        }
+    // Natural layout bounds of the currently-visible image/video inside the dialog.
+    // Used as the "target" of the grow animation so the image itself — not the dialog
+    // viewport — aligns with the tapped thumbnail at progress = 0.
+    var imageBounds by remember { mutableStateOf<Rect?>(null) }
+
+    // Start the enter animation as soon as valid image bounds are available. Without
+    // this gate, the animation can begin before onGloballyPositioned has reported real
+    // bounds and the graphicsLayer falls back to its alpha-only branch.
+    LaunchedEffect(Unit) {
+        snapshotFlow { imageBounds }
+            .filter { it != null && it.width > 0f && it.height > 0f }
+            .first()
+        progress.animateTo(
+            targetValue = 1f,
+            animationSpec = tween(durationMillis = 300, easing = FastOutSlowInEasing),
+        )
     }
 
     LaunchedEffect(isExiting) {
@@ -146,8 +154,21 @@ fun ZoomableImageDialog(
 
     val dismissWithAnimation: () -> Unit = { if (!isExiting) isExiting = true }
     val progressProvider: () -> Float = { progress.value }
-    val isAnimatingProvider: () -> Boolean = { progress.isRunning }
-    val onBoundsReady: () -> Unit = { if (!boundsReady) boundsReady = true }
+
+    // Accept the first set of valid bounds unconditionally. Subsequent updates are
+    // only accepted while the progress Animatable is idle, so a layout change
+    // mid-transition (e.g. an async image finishing loading, or a pager settling)
+    // can't re-target the transform and cause a hiccup.
+    val updateImageBounds: (Rect) -> Unit = { newBounds ->
+        if (newBounds.width > 0f && newBounds.height > 0f) {
+            val current = imageBounds
+            if (current == null) {
+                imageBounds = newBounds
+            } else if (!progress.isRunning && current != newBounds) {
+                imageBounds = newBounds
+            }
+        }
+    }
 
     Dialog(
         onDismissRequest = dismissWithAnimation,
@@ -186,9 +207,9 @@ fun ZoomableImageDialog(
                 allImages = allImages,
                 imageUrl = imageUrl,
                 sourceBounds = sourceBounds,
+                imageBounds = imageBounds,
+                onImageBoundsChanged = updateImageBounds,
                 progress = progressProvider,
-                isAnimating = isAnimatingProvider,
-                onBoundsReady = onBoundsReady,
                 onDismiss = dismissWithAnimation,
                 accountViewModel = accountViewModel,
             )
@@ -202,32 +223,15 @@ private fun DialogContent(
     allImages: ImmutableList<BaseMediaContent>,
     imageUrl: BaseMediaContent,
     sourceBounds: Rect?,
+    imageBounds: Rect?,
+    onImageBoundsChanged: (Rect) -> Unit,
     progress: () -> Float,
-    isAnimating: () -> Boolean,
-    onBoundsReady: () -> Unit,
     onDismiss: () -> Unit,
     accountViewModel: AccountViewModel,
 ) {
     val pagerState: PagerState = rememberPagerState { allImages.size }
     val controllerVisible = remember { mutableStateOf(true) }
     val sharePopupExpanded = remember { mutableStateOf(false) }
-
-    // Natural layout bounds of the currently visible image/video inside the dialog.
-    // Used as the "target" of the grow animation so the image itself — not the dialog
-    // viewport — aligns with the source thumbnail at progress = 0. We block updates
-    // while the progress animation is running so a mid-flight layout change (e.g. an
-    // async image finishing loading, or a pager settling) can't snap the transform
-    // target and cause a visible hiccup.
-    var imageBounds by remember { mutableStateOf<Rect?>(null) }
-
-    val updateImageBounds: (Rect) -> Unit = { newBounds ->
-        if (!isAnimating()) {
-            if (imageBounds != newBounds) {
-                imageBounds = newBounds
-            }
-            onBoundsReady()
-        }
-    }
 
     LaunchedEffect(key1 = pagerState, key2 = imageUrl) {
         launch {
@@ -302,7 +306,7 @@ private fun DialogContent(
                                 accountViewModel = accountViewModel,
                                 onContentBoundsChanged =
                                     if (index == pagerState.currentPage) {
-                                        updateImageBounds
+                                        onImageBoundsChanged
                                     } else {
                                         null
                                     },
@@ -318,7 +322,7 @@ private fun DialogContent(
                         isFiniteHeight = true,
                         controllerVisible = controllerVisible,
                         accountViewModel = accountViewModel,
-                        onContentBoundsChanged = updateImageBounds,
+                        onContentBoundsChanged = onImageBoundsChanged,
                     )
                 }
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
@@ -120,12 +120,18 @@ fun ZoomableImageDialog(
     // Animation progress: 0f = at source position/size, 1f = fullscreen.
     val progress = remember { Animatable(0f) }
     var isExiting by remember { mutableStateOf(false) }
+    var boundsReady by remember { mutableStateOf(false) }
 
-    LaunchedEffect(Unit) {
-        progress.animateTo(
-            targetValue = 1f,
-            animationSpec = tween(durationMillis = 300, easing = FastOutSlowInEasing),
-        )
+    // Wait for the image's natural bounds to be measured before starting the grow
+    // animation. Without this, the first frame may use placeholder bounds and snap
+    // to the real bounds mid-animation, producing a hiccup around the middle.
+    LaunchedEffect(boundsReady) {
+        if (boundsReady) {
+            progress.animateTo(
+                targetValue = 1f,
+                animationSpec = tween(durationMillis = 300, easing = FastOutSlowInEasing),
+            )
+        }
     }
 
     LaunchedEffect(isExiting) {
@@ -140,6 +146,8 @@ fun ZoomableImageDialog(
 
     val dismissWithAnimation: () -> Unit = { if (!isExiting) isExiting = true }
     val progressProvider: () -> Float = { progress.value }
+    val isAnimatingProvider: () -> Boolean = { progress.isRunning }
+    val onBoundsReady: () -> Unit = { if (!boundsReady) boundsReady = true }
 
     Dialog(
         onDismissRequest = dismissWithAnimation,
@@ -179,6 +187,8 @@ fun ZoomableImageDialog(
                 imageUrl = imageUrl,
                 sourceBounds = sourceBounds,
                 progress = progressProvider,
+                isAnimating = isAnimatingProvider,
+                onBoundsReady = onBoundsReady,
                 onDismiss = dismissWithAnimation,
                 accountViewModel = accountViewModel,
             )
@@ -193,6 +203,8 @@ private fun DialogContent(
     imageUrl: BaseMediaContent,
     sourceBounds: Rect?,
     progress: () -> Float,
+    isAnimating: () -> Boolean,
+    onBoundsReady: () -> Unit,
     onDismiss: () -> Unit,
     accountViewModel: AccountViewModel,
 ) {
@@ -202,8 +214,20 @@ private fun DialogContent(
 
     // Natural layout bounds of the currently visible image/video inside the dialog.
     // Used as the "target" of the grow animation so the image itself — not the dialog
-    // viewport — aligns with the source thumbnail at progress = 0.
+    // viewport — aligns with the source thumbnail at progress = 0. We block updates
+    // while the progress animation is running so a mid-flight layout change (e.g. an
+    // async image finishing loading, or a pager settling) can't snap the transform
+    // target and cause a visible hiccup.
     var imageBounds by remember { mutableStateOf<Rect?>(null) }
+
+    val updateImageBounds: (Rect) -> Unit = { newBounds ->
+        if (!isAnimating()) {
+            if (imageBounds != newBounds) {
+                imageBounds = newBounds
+            }
+            onBoundsReady()
+        }
+    }
 
     LaunchedEffect(key1 = pagerState, key2 = imageUrl) {
         launch {
@@ -278,7 +302,7 @@ private fun DialogContent(
                                 accountViewModel = accountViewModel,
                                 onContentBoundsChanged =
                                     if (index == pagerState.currentPage) {
-                                        { imageBounds = it }
+                                        updateImageBounds
                                     } else {
                                         null
                                     },
@@ -294,7 +318,7 @@ private fun DialogContent(
                         isFiniteHeight = true,
                         controllerVisible = controllerVisible,
                         accountViewModel = accountViewModel,
-                        onContentBoundsChanged = { imageBounds = it },
+                        onContentBoundsChanged = updateImageBounds,
                     )
                 }
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
@@ -139,6 +139,7 @@ fun ZoomableImageDialog(
     }
 
     val dismissWithAnimation: () -> Unit = { if (!isExiting) isExiting = true }
+    val progressProvider: () -> Float = { progress.value }
 
     Dialog(
         onDismissRequest = dismissWithAnimation,
@@ -164,46 +165,23 @@ fun ZoomableImageDialog(
             dialogWindow.attributes = attributes
         }
 
-        var fullBounds by remember { mutableStateOf<Rect?>(null) }
-
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .onGloballyPositioned { fullBounds = it.boundsInWindow() },
-        ) {
+        Box(modifier = Modifier.fillMaxSize()) {
             // Background surface that fades in as the content grows to fullscreen.
             Surface(
                 modifier =
                     Modifier
                         .fillMaxSize()
-                        .graphicsLayer { alpha = progress.value },
+                        .graphicsLayer { alpha = progressProvider() },
             ) {}
 
-            // Content layer that grows from the source bounds to fullscreen (and back on exit).
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .graphicsLayer {
-                            val src = sourceBounds
-                            val full = fullBounds
-                            if (src != null && full != null && full.width > 0f && full.height > 0f) {
-                                transformOrigin = TransformOrigin(0f, 0f)
-                                val startScaleX = src.width / full.width
-                                val startScaleY = src.height / full.height
-                                scaleX = lerp(startScaleX, 1f, progress.value)
-                                scaleY = lerp(startScaleY, 1f, progress.value)
-                                translationX = lerp(src.left - full.left, 0f, progress.value)
-                                translationY = lerp(src.top - full.top, 0f, progress.value)
-                            } else {
-                                // No source bounds provided: fall back to a simple fade.
-                                alpha = progress.value
-                            }
-                        },
-            ) {
-                DialogContent(allImages, imageUrl, dismissWithAnimation, accountViewModel)
-            }
+            DialogContent(
+                allImages = allImages,
+                imageUrl = imageUrl,
+                sourceBounds = sourceBounds,
+                progress = progressProvider,
+                onDismiss = dismissWithAnimation,
+                accountViewModel = accountViewModel,
+            )
         }
     }
 }
@@ -213,12 +191,19 @@ fun ZoomableImageDialog(
 private fun DialogContent(
     allImages: ImmutableList<BaseMediaContent>,
     imageUrl: BaseMediaContent,
+    sourceBounds: Rect?,
+    progress: () -> Float,
     onDismiss: () -> Unit,
     accountViewModel: AccountViewModel,
 ) {
     val pagerState: PagerState = rememberPagerState { allImages.size }
     val controllerVisible = remember { mutableStateOf(true) }
     val sharePopupExpanded = remember { mutableStateOf(false) }
+
+    // Natural layout bounds of the currently visible image/video inside the dialog.
+    // Used as the "target" of the grow animation so the image itself — not the dialog
+    // viewport — aligns with the source thumbnail at progress = 0.
+    var imageBounds by remember { mutableStateOf<Rect?>(null) }
 
     LaunchedEffect(key1 = pagerState, key2 = imageUrl) {
         launch {
@@ -255,31 +240,63 @@ private fun DialogContent(
             ),
         Alignment.TopCenter,
     ) {
-        if (allImages.size > 1) {
-            SlidingCarousel(
-                pagerState = pagerState,
-            ) { index ->
-                allImages.getOrNull(index)?.let {
-                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        RenderImageOrVideo(
-                            content = it,
-                            roundedCorner = false,
-                            isFiniteHeight = true,
-                            controllerVisible = controllerVisible,
-                            accountViewModel = accountViewModel,
-                        )
+        // Transformed image/video container. Only this layer scales & translates so the
+        // image aligns with the tapped thumbnail on enter/exit. Controls stay put.
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .graphicsLayer {
+                        val src = sourceBounds
+                        val img = imageBounds
+                        if (src != null && img != null && img.width > 0f && img.height > 0f) {
+                            transformOrigin = TransformOrigin(0f, 0f)
+                            val startScaleX = src.width / img.width
+                            val startScaleY = src.height / img.height
+                            val p = progress()
+                            scaleX = lerp(startScaleX, 1f, p)
+                            scaleY = lerp(startScaleY, 1f, p)
+                            translationX = lerp(src.left - img.left * startScaleX, 0f, p)
+                            translationY = lerp(src.top - img.top * startScaleY, 0f, p)
+                        } else {
+                            // No source bounds: fall back to a plain fade.
+                            alpha = progress()
+                        }
+                    },
+        ) {
+            if (allImages.size > 1) {
+                SlidingCarousel(
+                    pagerState = pagerState,
+                ) { index ->
+                    allImages.getOrNull(index)?.let { pageContent ->
+                        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                            RenderImageOrVideo(
+                                content = pageContent,
+                                roundedCorner = false,
+                                isFiniteHeight = true,
+                                controllerVisible = controllerVisible,
+                                accountViewModel = accountViewModel,
+                                onContentBoundsChanged =
+                                    if (index == pagerState.currentPage) {
+                                        { imageBounds = it }
+                                    } else {
+                                        null
+                                    },
+                            )
+                        }
                     }
                 }
-            }
-        } else {
-            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                RenderImageOrVideo(
-                    content = imageUrl,
-                    roundedCorner = false,
-                    isFiniteHeight = true,
-                    controllerVisible = controllerVisible,
-                    accountViewModel = accountViewModel,
-                )
+            } else {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    RenderImageOrVideo(
+                        content = imageUrl,
+                        roundedCorner = false,
+                        isFiniteHeight = true,
+                        controllerVisible = controllerVisible,
+                        accountViewModel = accountViewModel,
+                        onContentBoundsChanged = { imageBounds = it },
+                    )
+                }
             }
         }
 
@@ -287,6 +304,8 @@ private fun DialogContent(
             visible = controllerVisible.value,
             enter = remember { fadeIn() },
             exit = remember { fadeOut() },
+            // Also fade with the grow animation so controls appear/disappear alongside it.
+            modifier = Modifier.graphicsLayer { alpha = progress().coerceIn(0f, 1f) },
         ) {
             Row(
                 modifier =
@@ -449,6 +468,7 @@ private fun RenderImageOrVideo(
     isFiniteHeight: Boolean,
     controllerVisible: MutableState<Boolean>,
     accountViewModel: AccountViewModel,
+    onContentBoundsChanged: ((Rect) -> Unit)? = null,
 ) {
     val contentScale =
         if (isFiniteHeight) {
@@ -457,7 +477,16 @@ private fun RenderImageOrVideo(
             ContentScale.FillWidth
         }
 
-    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.Center, modifier = Modifier.fillMaxWidth()) {
+    val rowModifier =
+        if (onContentBoundsChanged != null) {
+            Modifier
+                .fillMaxWidth()
+                .onGloballyPositioned { onContentBoundsChanged(it.boundsInWindow()) }
+        } else {
+            Modifier.fillMaxWidth()
+        }
+
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.Center, modifier = rowModifier) {
         when (content) {
             is MediaUrlImage -> {
                 val mainModifier =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
@@ -58,8 +58,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
@@ -139,6 +142,11 @@ fun ZoomableContentView(
     accountViewModel: AccountViewModel,
 ) {
     var dialogOpen by remember(content) { mutableStateOf(false) }
+    var sourceBounds by remember(content) { mutableStateOf<Rect?>(null) }
+    val boundsTrackingModifier =
+        Modifier.onGloballyPositioned { coordinates ->
+            sourceBounds = coordinates.boundsInWindow()
+        }
 
     when (content) {
         is MediaUrlImage -> {
@@ -147,6 +155,7 @@ fun ZoomableContentView(
                     val mainImageModifier =
                         Modifier
                             .fillMaxWidth()
+                            .then(boundsTrackingModifier)
                             .clickable { dialogOpen = true }
                     val loadedImageModifier = if (roundedCorner) MaterialTheme.colorScheme.imageModifier else Modifier.fillMaxWidth()
                     UrlImageView(content, contentScale, mainImageModifier, loadedImageModifier, controllerVisible, accountViewModel = accountViewModel)
@@ -156,7 +165,10 @@ fun ZoomableContentView(
 
         is MediaUrlVideo -> {
             SensitivityWarning(content.contentWarning, accountViewModel) {
-                Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                Box(
+                    modifier = Modifier.fillMaxWidth().then(boundsTrackingModifier),
+                    contentAlignment = Alignment.Center,
+                ) {
                     VideoView(
                         videoUri = content.url,
                         mimeType = content.mimeType,
@@ -180,6 +192,7 @@ fun ZoomableContentView(
                 val mainImageModifier =
                     Modifier
                         .fillMaxWidth()
+                        .then(boundsTrackingModifier)
                         .clickable { dialogOpen = true }
                 val loadedImageModifier = if (roundedCorner) MaterialTheme.colorScheme.imageModifier else Modifier.fillMaxWidth()
 
@@ -189,7 +202,10 @@ fun ZoomableContentView(
 
         is MediaLocalVideo -> {
             content.localFile?.let {
-                Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                Box(
+                    modifier = Modifier.fillMaxWidth().then(boundsTrackingModifier),
+                    contentAlignment = Alignment.Center,
+                ) {
                     VideoView(
                         videoUri = it.toUri().toString(),
                         mimeType = content.mimeType,
@@ -209,12 +225,13 @@ fun ZoomableContentView(
 
     if (dialogOpen) {
         ZoomableImageDialog(
-            content,
-            images,
+            imageUrl = content,
+            allImages = images,
+            sourceBounds = sourceBounds,
             onDismiss = {
                 dialogOpen = false
             },
-            accountViewModel,
+            accountViewModel = accountViewModel,
         )
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/AppDefinition.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/AppDefinition.kt
@@ -47,7 +47,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
@@ -101,6 +104,7 @@ fun RenderAppDefinition(
 
             if (!theAppMetadata.banner.isNullOrBlank()) {
                 var zoomImageDialogOpen by remember { mutableStateOf(false) }
+                var bannerSourceBounds by remember { mutableStateOf<Rect?>(null) }
 
                 AsyncImage(
                     model = theAppMetadata.banner,
@@ -110,6 +114,7 @@ fun RenderAppDefinition(
                         Modifier
                             .fillMaxWidth()
                             .height(125.dp)
+                            .onGloballyPositioned { bannerSourceBounds = it.boundsInWindow() }
                             .combinedClickable(
                                 onClick = {},
                                 onLongClick = {
@@ -125,6 +130,7 @@ fun RenderAppDefinition(
                 if (zoomImageDialogOpen) {
                     ZoomableImageDialog(
                         imageUrl = RichTextParser.parseImageOrVideo(theAppMetadata.banner!!),
+                        sourceBounds = bannerSourceBounds,
                         onDismiss = { zoomImageDialogOpen = false },
                         accountViewModel = accountViewModel,
                     )
@@ -153,6 +159,7 @@ fun RenderAppDefinition(
                     verticalAlignment = Alignment.Bottom,
                 ) {
                     var zoomImageDialogOpen by remember { mutableStateOf(false) }
+                    var pictureSourceBounds by remember { mutableStateOf<Rect?>(null) }
                     Box(Modifier.size(100.dp)) {
                         theAppMetadata.picture?.let { picture ->
                             AsyncImage(
@@ -168,6 +175,7 @@ fun RenderAppDefinition(
                                         ).clip(shape = CircleShape)
                                         .fillMaxSize()
                                         .background(MaterialTheme.colorScheme.background)
+                                        .onGloballyPositioned { pictureSourceBounds = it.boundsInWindow() }
                                         .combinedClickable(
                                             onClick = { zoomImageDialogOpen = true },
                                             onLongClick = {
@@ -181,6 +189,7 @@ fun RenderAppDefinition(
                             if (zoomImageDialogOpen) {
                                 ZoomableImageDialog(
                                     imageUrl = RichTextParser.parseImageOrVideo(theAppMetadata.picture!!),
+                                    sourceBounds = pictureSourceBounds,
                                     onDismiss = { zoomImageDialogOpen = false },
                                     accountViewModel = accountViewModel,
                                 )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/DrawBanner.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/DrawBanner.kt
@@ -32,7 +32,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
@@ -68,6 +71,7 @@ fun DrawBanner(
         val clipboardManager = LocalClipboard.current
         val scope = rememberCoroutineScope()
         var zoomImageDialogOpen by remember { mutableStateOf(false) }
+        var sourceBounds by remember { mutableStateOf<Rect?>(null) }
 
         AsyncImage(
             model = banner,
@@ -79,6 +83,7 @@ fun DrawBanner(
                 Modifier
                     .fillMaxWidth()
                     .height(150.dp)
+                    .onGloballyPositioned { sourceBounds = it.boundsInWindow() }
                     .combinedClickable(
                         onClick = { zoomImageDialogOpen = true },
                         onLongClick = {
@@ -92,6 +97,7 @@ fun DrawBanner(
         if (zoomImageDialogOpen) {
             ZoomableImageDialog(
                 imageUrl = RichTextParser.parseImageOrVideo(banner),
+                sourceBounds = sourceBounds,
                 onDismiss = { zoomImageDialogOpen = false },
                 accountViewModel = accountViewModel,
             )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/ProfileHeader.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/ProfileHeader.kt
@@ -51,6 +51,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
@@ -173,12 +176,15 @@ fun ZoomableUserPicture(
     val scope = rememberCoroutineScope()
 
     var zoomImageUrl by remember { mutableStateOf<String?>(null) }
+    var sourceBounds by remember { mutableStateOf<Rect?>(null) }
 
     ClickableUserPicture(
         baseUser = baseUser,
         accountViewModel = accountViewModel,
         size = size,
-        modifier = MaterialTheme.colorScheme.userProfileBorderModifier,
+        modifier =
+            MaterialTheme.colorScheme.userProfileBorderModifier
+                .onGloballyPositioned { sourceBounds = it.boundsInWindow() },
         onClick = {
             val pic = baseUser.profilePicture()
             if (pic != null) {
@@ -197,7 +203,8 @@ fun ZoomableUserPicture(
 
     zoomImageUrl?.let {
         ZoomableImageDialog(
-            RichTextParser.parseImageOrVideo(it),
+            imageUrl = RichTextParser.parseImageOrVideo(it),
+            sourceBounds = sourceBounds,
             onDismiss = { zoomImageUrl = null },
             accountViewModel = accountViewModel,
         )


### PR DESCRIPTION
## Summary
Implements a shared element transition animation for the `ZoomableImageDialog`, allowing images and videos to smoothly animate from their source position/size to fullscreen when opened, and back to the source when dismissed.

https://github.com/user-attachments/assets/5989445f-bdcf-4047-9de2-6d09a1b208c4

## Key Changes

- **Animation Infrastructure**: Added animation state management using `Animatable` to track progress from source bounds (0f) to fullscreen (1f) with 300ms enter and 250ms exit animations using `FastOutSlowInEasing`

- **Bounds Tracking**: Implemented bounds tracking across multiple components:
  - `ZoomableContentView` tracks the source bounds of images/videos before dialog opens
  - `RenderImageOrVideo` reports content bounds via new `onContentBoundsChanged` callback
  - `ProfileHeader` and `DrawBanner` track banner image bounds for profile pictures
  - `AppDefinition` tracks app banner bounds

- **Transform Animation**: Applied `graphicsLayer` transformations to scale and translate the dialog content based on animation progress:
  - Calculates start scale from source/image bounds ratio
  - Interpolates scale and translation values using `lerp`
  - Falls back to alpha-only fade when source bounds unavailable

- **Visual Improvements**:
  - Disabled system dim overlay so thumbnail remains visible during animation
  - Background surface fades in alongside the grow animation
  - Controls fade in/out with the animation progress
  - Image bounds updates are gated to prevent mid-animation layout changes from causing visual hiccups

- **API Updates**: Updated `ZoomableImageDialog` signature to accept optional `sourceBounds: Rect?` parameter and pass it through the composition hierarchy

## Implementation Details

- Uses `snapshotFlow` to gate animation start until valid image bounds are available
- Respects `Animatable.isRunning` state to prevent bounds updates during active animations
- Wraps transformed content in a separate `Box` layer so only the image/video scales while controls remain fixed
- Maintains backward compatibility with null source bounds (falls back to fade animation)

https://claude.ai/code/session_01GWXuH6uPdTEuvNwG4A6KwH