### PR TITLE
Fix ringtone/notification stuck after rejecting consecutive calls

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallController.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallController.kt
@@ -134,6 +134,15 @@ class CallController(
             callManager.state.collect { state ->
                 when (state) {
                     is CallState.IncomingCall -> {
+                        // A new call session begins — arm cleanup() so it will
+                        // run for this session's Ended transition. This MUST
+                        // happen for every incoming call (even ones the user
+                        // ends up rejecting), otherwise a stale cleanedUp flag
+                        // from the previous call session would turn cleanup()
+                        // into a no-op and leave the ringtone/notification
+                        // playing forever. See the bug where rejecting a
+                        // second consecutive call required killing the app.
+                        cleanedUp.set(false)
                         ensureForegroundService()
                         withContext(Dispatchers.IO) { audioManager.startRinging() }
                         scope.launch {
@@ -142,6 +151,10 @@ class CallController(
                     }
 
                     is CallState.Offering -> {
+                        // Same rationale as IncomingCall above: ensure cleanup
+                        // can run for this session even if the previous one
+                        // already ran cleanup().
+                        cleanedUp.set(false)
                         audioManager.startRingbackTone()
                         ensureForegroundService()
                     }
@@ -642,14 +655,46 @@ class CallController(
      * Releases all WebRTC, audio, and foreground-service resources for the
      * current call session.
      *
-     * Idempotent within a call session: calling this multiple times in a row
-     * (e.g. once from the Ended state collector and once from [CallActivity]'s
-     * onDestroy safety net) executes the body at most once. The guard is
-     * re-armed when a new call starts via [initiateGroupCall] or
-     * [acceptIncomingCall], so subsequent call sessions still clean up
-     * correctly.
+     * Stopping the ringtone, ringback tone, and incoming-call notification
+     * runs UNCONDITIONALLY on every invocation — even if the heavy teardown
+     * has already been done. These three operations are idempotent and must
+     * never be skipped, otherwise a stale [cleanedUp] flag could leave the
+     * ringtone playing and the notification stuck on screen until the app is
+     * force-killed.
+     *
+     * The remainder (peer-session disposal, media manager, network callbacks,
+     * etc.) is guarded by [cleanedUp] and runs at most once per call session.
+     * The guard is re-armed when a new call starts: outgoing calls re-arm in
+     * [initiateGroupCall], accepted incoming calls in [acceptIncomingCall],
+     * and any new IncomingCall/Offering state transition in the state
+     * collector. This last path is critical for incoming calls the user
+     * rejects (or that the remote party hangs up), since neither
+     * [initiateGroupCall] nor [acceptIncomingCall] is invoked for them.
      */
     fun cleanup() {
+        // Stop the ringtone, ringback tone, and incoming-call notification
+        // UNCONDITIONALLY — these are idempotent and absolutely critical for
+        // the user experience. They must run on every cleanup() call, even if
+        // the heavy resource teardown below is already complete (cleanedUp ==
+        // true). Otherwise an unexpected double-cleanup or a stale cleanedUp
+        // flag from a previous session could leave the ringtone playing and
+        // the notification stuck on screen until the app is force-killed.
+        try {
+            audioManager.stopRinging()
+        } catch (e: Exception) {
+            Log.e(TAG, "cleanup: audioManager.stopRinging() failed", e)
+        }
+        try {
+            audioManager.stopRingbackTone()
+        } catch (e: Exception) {
+            Log.e(TAG, "cleanup: audioManager.stopRingbackTone() failed", e)
+        }
+        try {
+            NotificationUtils.cancelCallNotification(context)
+        } catch (e: Exception) {
+            Log.e(TAG, "cleanup: cancelCallNotification() failed", e)
+        }
+
         if (!cleanedUp.compareAndSet(false, true)) return
         unregisterNetworkCallback()
         try {
@@ -663,7 +708,6 @@ class CallController(
             Log.e(TAG, "cleanup: stopForegroundService() failed", e)
         }
         foregroundServiceStarted = false
-        NotificationUtils.cancelCallNotification(context)
 
         videoMonitor.dispose()
 
@@ -681,9 +725,11 @@ class CallController(
         videoSenders.clear()
         pendingRenegotiation.clear()
         // NOTE: cleanedUp intentionally stays true here so that a second,
-        // sequential cleanup() in the same call session is a no-op. The flag
-        // is re-armed in initiateGroupCall() / acceptIncomingCall() when a new
-        // call session begins.
+        // sequential cleanup() in the same call session is a no-op for the
+        // heavy teardown above. The flag is re-armed when a new call session
+        // begins, in initiateGroupCall() / acceptIncomingCall() AND in the
+        // state collector for IncomingCall / Offering transitions, so
+        // subsequent sessions still clean up correctly.
     }
 
     // ---- Foreground service ----

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallActivity.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallActivity.kt
@@ -263,6 +263,28 @@ class CallActivity : AppCompatActivity() {
         // is safe.
         controller?.cleanup()
 
+        // Hard guarantee: the ringtone, ringback tone, and incoming-call
+        // notification are tied to this Activity's lifecycle. When the
+        // Activity is destroyed for ANY reason (user reject, hangup, finish,
+        // process recreation, etc.), they MUST be gone — even if the
+        // CallController is missing, its cleanup guard is stale, or the
+        // state-collector hasn't fired yet. We had a bug where rejecting a
+        // call left the ringtone playing until the user killed the entire
+        // app from settings; this block is the ultimate stop signal.
+        try {
+            controller?.audioManager?.stopRinging()
+        } catch (_: Exception) {
+        }
+        try {
+            controller?.audioManager?.stopRingbackTone()
+        } catch (_: Exception) {
+        }
+        try {
+            com.vitorpamplona.amethyst.service.notifications.NotificationUtils
+                .cancelCallNotification(this)
+        } catch (_: Exception) {
+        }
+
         super.onDestroy()
     }
 


### PR DESCRIPTION
## Summary
Fixes a critical bug where rejecting a second consecutive incoming call would leave the ringtone and notification playing indefinitely until the app was force-killed. The issue was caused by a stale `cleanedUp` flag preventing proper cleanup of audio resources.

## Key Changes

- **CallController.kt**:
  - Reset `cleanedUp` flag to `false` when entering `IncomingCall` and `Offering` states to ensure cleanup can run for each new call session, even if the previous session already completed cleanup
  - Refactored `cleanup()` method to unconditionally stop ringtone, ringback tone, and cancel notifications on every invocation (these are idempotent operations that must never be skipped)
  - Moved heavy resource teardown (peer sessions, media manager, network callbacks) behind the `cleanedUp` guard to run at most once per session
  - Updated documentation to clarify the cleanup guard behavior and the critical importance of re-arming the flag for rejected/hung-up incoming calls

- **CallActivity.kt**:
  - Added a hard guarantee in `onDestroy()` that unconditionally stops ringtone, ringback tone, and cancels the notification as a final safety net
  - This ensures these audio/notification resources are cleaned up regardless of CallController state, providing defense-in-depth against stale cleanup guards or missed state transitions

## Implementation Details

The fix addresses two separate cleanup paths:
1. **Idempotent operations** (ringtone, ringback, notification): Run unconditionally on every `cleanup()` call with exception handling
2. **Heavy teardown** (WebRTC resources, media manager, etc.): Guarded by `compareAndSet()` to run at most once per session

The `cleanedUp` flag is now re-armed in three places:
- `initiateGroupCall()` for outgoing calls
- `acceptIncomingCall()` for accepted incoming calls  
- State collector for `IncomingCall`/`Offering` transitions (critical for rejected/hung-up calls)

This ensures every call session can properly clean up, including those where the user rejects the call before accepting it.

https://claude.ai/code/session_01VWQ1eReoSqsW8RPXVSozL5