### PR TITLE
fix(marmot): switch KeyStoreEncryption transformation to AES/GCM/NoPa…

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/preferences/KeyStoreEncryption.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/preferences/KeyStoreEncryption.kt
@@ -37,7 +37,7 @@ class KeyStoreEncryption {
         private const val ANDROID_KEY_STORE = "AndroidKeyStore"
         private const val ALGORITHM = KeyProperties.KEY_ALGORITHM_AES
         private const val BLOCK_MODE = KeyProperties.BLOCK_MODE_GCM
-        private const val PADDING = KeyProperties.ENCRYPTION_PADDING_PKCS7
+        private const val PADDING = KeyProperties.ENCRYPTION_PADDING_NONE
         private const val TRANSFORMATION = "$ALGORITHM/$BLOCK_MODE/$PADDING"
         private const val PURPOSE = KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
         private const val KEY_ALIAS = "AMETHYST_AES_KEY"


### PR DESCRIPTION
…dding

Logs from the real device showed that the AndroidMlsGroupStateStore constructor was throwing NoSuchAlgorithmException for "AES/GCM/PKCS7Padding" at Cipher.getInstance, which caused AccountCacheState to silently fall back to InMemoryMlsGroupStateStore for every account. That's why Marmot groups vanished on every restart.

GCM is an authenticated encryption mode and must not use a block padding scheme — the correct transformation is AES/GCM/NoPadding. PKCS7Padding was always wrong; no provider on this device accepts it for GCM. Switch PADDING to ENCRYPTION_PADDING_NONE.

This class is currently only wired to AndroidMlsGroupStateStore (AccountSecretsEncryptedStores is defined but not referenced anywhere in the runtime code path — only in docs/secure-key-storage-migration.md), so there is no on-disk data that was previously encrypted with the broken transformation to worry about.

https://claude.ai/code/session_014EKS8JBwSpap34aM6FnYLm