### PR TITLE
Add multi-device call handling and architecture documentation

### DIFF
--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/ARCHITECTURE.md
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/ARCHITECTURE.md
@@ -1,0 +1,273 @@
+# WebRTC Call Architecture
+
+A map of how P2P and group voice/video calls work in Amethyst, aimed at future
+contributors (human or AI) who need to change call code without spending an
+hour grepping.
+
+## 1. Protocol (NIP-AC)
+
+Calls are signaled over Nostr using the NIP-AC event family. Every signaling
+event is sealed inside a NIP-59 gift wrap of kind `21059`
+(`EphemeralGiftWrapEvent`) addressed to a single recipient per wrap.
+
+| Kind  | Event                    | Purpose                                                    |
+|-------|--------------------------|------------------------------------------------------------|
+| 25050 | `CallOfferEvent`         | Offer + SDP, starts ringing on the callee                  |
+| 25051 | `CallAnswerEvent`        | Answer + SDP, callee accepts                               |
+| 25052 | `CallIceCandidateEvent`  | Trickle ICE candidate for a specific peer                  |
+| 25053 | `CallHangupEvent`        | End the call / drop a peer                                 |
+| 25054 | `CallRejectEvent`        | Decline ringing (only valid while ringing)                 |
+| 25055 | `CallRenegotiateEvent`   | Mid-call SDP renegotiation (e.g. voice → video)            |
+
+Specification: `quartz/.../nipACWebRtcCalls/NIP-AC.md`.
+
+Gift-wrap recipient is set via `EphemeralGiftWrapEvent.create(event, recipientPubKey)`.
+The wrap's outer `p` tag is the recipient's pubkey; relay subscriptions
+filter gift wraps by `p == myPubKey`, so **a device only receives signaling
+addressed explicitly to its account**.
+
+## 2. Module layout
+
+```
+quartz/commonMain/.../nipACWebRtcCalls/
+├── events/                      # Event classes (KIND constants, builders, accessors)
+├── tags/                        # CallType, CallIdTag, etc.
+└── WebRtcCallFactory.kt         # Sign + gift-wrap helpers (P2P + group variants)
+
+commons/commonMain/.../call/     # ← this package
+├── CallState.kt                 # Sealed state + EndReason enum
+├── CallManager.kt               # State machine, signaling dispatch, timeouts
+├── PeerSession.kt               # Platform-neutral per-peer signaling interface
+└── PeerSessionManager.kt        # Map<pubKey, PeerSession> + ICE buffering
+
+amethyst/.../service/call/       # Android platform layer
+├── CallController.kt            # Wires CallManager ↔ WebRTC, audio routing
+├── WebRtcCallSession.kt         # org.webrtc.PeerConnection wrapper
+├── WebRtcPeerSessionAdapter.kt  # Implements PeerSession over org.webrtc
+├── CallAudioManager.kt          # Speakerphone / Bluetooth SCO routing
+├── CallMediaManager.kt          # Camera / microphone tracks
+├── CallForegroundService.kt     # Android foreground service while in a call
+└── CallNotificationReceiver.kt  # Accept / reject from notification actions
+
+amethyst/.../ui/call/            # Android call UI
+└── CallScreen.kt                # IncomingCallUI, InCallUI, etc.
+```
+
+`quartz` is pure Kotlin/Multiplatform protocol code with **zero** WebRTC or
+Android dependencies. `commons/.../call/` is also platform-neutral — it holds
+the state machine and a `PeerSession` abstraction. All `org.webrtc` code lives
+in `amethyst/service/call/`.
+
+## 3. State machine
+
+```
+                ┌──────────────────────────────────────────────┐
+                │                                              │
+                ▼                                              │
+              Idle ─────initiateCall()─────▶ Offering          │
+                │                               │              │
+                │                         onCallAnswered       │
+                │                               │              │
+                │                               ▼              │
+     onIncomingCallEvent                    Connecting         │
+                │                               │              │
+                ▼                         onPeerConnected      │
+         IncomingCall ──acceptCall()─────▶     │               │
+                │                               ▼              │
+           rejectCall()                     Connected          │
+                │                               │              │
+                │                          hangup() /          │
+                │                         PEER_HANGUP          │
+                │                               │              │
+                └───────────────▶  Ended ◀─────┘              │
+                                     │                         │
+                                     └─────after 2s────────────┘
+```
+
+States (`CallState.kt`):
+
+- **`Idle`** — no call.
+- **`Offering`** — we sent the offer, waiting for answers. Carries
+  `peerPubKeys` (pending callees).
+- **`IncomingCall`** — we received an offer and are ringing. Carries the
+  caller, `groupMembers`, and the SDP offer.
+- **`Connecting`** — the handshake is in progress. Carries `peerPubKeys`
+  (peers we're handshaking with) and `pendingPeerPubKeys` (known group
+  members we haven't heard from yet).
+- **`Connected`** — at least one peer session is live. Same fields as
+  `Connecting` plus `startedAtEpoch`.
+- **`Ended(reason)`** — terminal transition. After `ENDED_DISPLAY_MS` (2 s)
+  the state automatically resets to `Idle`.
+
+`EndReason`: `HANGUP`, `REJECTED`, `TIMEOUT`, `ERROR`, `PEER_HANGUP`,
+`PEER_REJECTED`, `ANSWERED_ELSEWHERE`.
+
+## 4. `CallManager` responsibilities
+
+`CallManager` (in this package) is the single owner of call state. It:
+
+1. Runs the state machine. All mutations go through `stateMutex` — signaling
+   events arrive on multiple relay coroutines concurrently.
+2. Dispatches signaling events (`onSignalingEvent`) to per-kind handlers
+   (`onIncomingCallEvent`, `onCallAnswered`, `onCallRejected`, `onPeerHangup`,
+   `onIceCandidate`, `onRenegotiate`).
+3. Publishes outbound signaling via `factory: WebRtcCallFactory` and the
+   injected `publishEvent: (EphemeralGiftWrapEvent) -> Unit` lambda.
+4. Forwards SDP/ICE payloads to the platform WebRTC layer via callback
+   properties (`onAnswerReceived`, `onIceCandidateReceived`,
+   `onRenegotiationOfferReceived`, `onNewPeerInGroupCall`,
+   `onMidCallOfferReceived`, `onPeerLeft`). **These callbacks are the only
+   `CallManager` → `CallController` contact surface.**
+5. Manages two kinds of timers:
+   - **Global timeout** (`CALL_TIMEOUT_MS = 60 s`) — fires while in `Offering`
+     or `IncomingCall`. Transitions to `Ended(TIMEOUT)` and, if `Offering`,
+     publishes a group hangup so callees stop ringing immediately.
+   - **Per-peer invite timeout** (`PEER_INVITE_TIMEOUT_MS = 30 s`) — one timer
+     per pending peer. See §7 for the invited-vs-watchdog distinction.
+6. Deduplicates incoming events (`processedEventIds`) and drops events older
+   than 20 s or from before `initTimestamp` (`isEventTooOld`). Remembers
+   already-terminated call-ids (`completedCallIds`) so relay replays after an
+   app restart don't re-ring for a dead call.
+
+`CallManager` is created by `CallController`, which injects the current
+account's `NostrSigner`, a coroutine scope tied to the account's lifetime,
+`isFollowing` to gate incoming offers, the `publishEvent` lambda that goes
+through the relay client, and `isCallsEnabled` (settings toggle).
+
+## 5. Incoming call pipeline
+
+```
+relay → GiftWrap subscription on p=myPubKey
+      → DecryptAndIndexProcessor decrypts & unwraps
+      → routes kind-25050..25055 events to CallManager.onSignalingEvent
+      → stateMutex.withLock { … dedup, age-gate, dispatch … }
+      → per-kind handler mutates _state and/or forwards to CallController
+      → CallController drives org.webrtc.PeerConnection via WebRtcCallSession
+```
+
+Relay subscription: `amethyst/.../service/relayClient/.../FilterGiftWrapsToPubkey.kt`
+(filter: `kind ∈ {1059, 21059}, #p = [myPubKey]`).
+
+Decryption + dispatch: `DecryptAndIndexProcessor.kt` routes every
+`CallOfferEvent | CallAnswerEvent | CallIceCandidateEvent | CallHangupEvent |
+CallRejectEvent | CallRenegotiateEvent` to `callManager?.onSignalingEvent(event)`.
+
+## 6. Outgoing call pipeline
+
+- **P2P**: `CallController.initiateCall(peer, type)` → generates SDP →
+  `CallManager.initiateCall(peer, type, callId, sdpOffer)` → transitions to
+  `Offering`, publishes one wrap to the callee.
+- **Group**: `CallController.beginGroupCall(peers, type)` →
+  `CallManager.beginOffering(callId, peers, type)` transitions to `Offering`
+  and schedules per-peer timers, then CallController creates a separate SDP
+  per peer and calls `CallManager.publishOfferToPeer` once for each.
+
+`WebRtcCallFactory.createGroupCallOffer` / `createGroupCallAnswer` /
+`createGroupHangup` / `createGroupReject` each sign a **single** inner event
+(with `p` tags listing all members) and produce one `EphemeralGiftWrapEvent`
+per recipient — the inner event is shared, only the outer wrap envelope
+differs.
+
+## 7. Group calls: invited vs. watchdog timers
+
+Two sources drop a pending peer from the state after 30 s, but they publish
+different signals:
+
+- **Invited by us** (we sent the offer): added to `peersInvitedByUs`.
+  On timeout we publish a `CallHangup` addressed to them so their device
+  stops ringing.
+- **Watched by us** (we accepted a group call and are waiting on siblings
+  we never invited): we only run a local watchdog. Terminating their ringing
+  is the *original caller's* responsibility; we must not publish anything on
+  their behalf.
+
+Distinguishing these two is the job of `peersInvitedByUs` and the
+`wasInvitedByUs` flag in `handlePeerTimeout`. Do not collapse them.
+
+Callee-to-callee mesh (group calls): when `acceptCall` runs, any answers we
+already observed during `IncomingCall` (`discoveredCalleePeers`) trigger
+`onNewPeerInGroupCall` callbacks so the CallController opens additional peer
+connections. Mid-call offers from other callees arrive via `onMidCallOfferReceived`.
+
+## 8. Multi-device ("answered elsewhere") handling
+
+A user can be logged in on multiple devices. All of them are subscribed to
+gift wraps for the same pubkey, so all of them receive the caller's offer and
+ring simultaneously. The rules:
+
+1. **`acceptCall` and `rejectCall`** publish two sets of wraps:
+   - The "real" wraps for every other group member (carrying SDP where
+     relevant).
+   - **An extra wrap of the same signed event addressed to `signer.pubKey`**
+     so sibling devices on the same account observe it.
+2. **Sibling device receives a self-answer in `IncomingCall`** →
+   `onCallAnswered` transitions to `Ended(ANSWERED_ELSEWHERE)`. Self-reject
+   in `IncomingCall` → `Ended(REJECTED)`. Both are purely local state
+   changes; neither publishes any signaling. **This is why the device that
+   picked up is never disturbed.**
+3. **The device that published the self-wrap also receives its own echo**.
+   It is ignored: the self-pubkey guard at the top of both `onCallAnswered`
+   and `onCallRejected` returns early in any state other than `IncomingCall`.
+   Without the self-reject guard, an echo arriving while in
+   `Connecting`/`Connected` would fire `onPeerLeft(signer.pubKey)` and the
+   CallController would dispose its *own* PeerSession, killing the live
+   audio — do not remove that guard.
+4. **Self-ICE and self-hangup** are unconditionally filtered at the top of
+   `onSignalingEvent` (they are never useful). Self-answers and self-rejects
+   are **not** filtered there — they are the "answered/rejected elsewhere"
+   signal and must reach the handler.
+5. **Stale offer replays**: `completedCallIds` is populated by hangup, reject,
+   **and self-answer** events. If a relay replays events out of order so a
+   self-answer arrives before the original offer, the later offer is dropped
+   by the `callId in completedCallIds` check in `onIncomingCallEvent`.
+
+See `CallManagerTest.kt`'s "Multi-Device" section for the full scenario
+coverage.
+
+## 9. Invariants and pitfalls
+
+- **All state mutations must happen under `stateMutex`.** The lock also
+  guards `processedEventIds`, `completedCallIds`, `peersInvitedByUs`, and
+  `perPeerTimeoutJobs`. Methods that are called from outside
+  `onSignalingEvent` (e.g. `acceptCall`, `hangup`, `onPeerConnected`) take
+  the lock themselves.
+- **Publish outside the lock.** The lock protects state; the signing + gift
+  wrap is slow and must not block other signaling. Pattern: read/mutate state
+  inside the lock, collect the bytes to publish, then `publishEvent` after
+  releasing.
+- **`transitionToEnded` is local-only.** It never publishes anything.
+  Publishers (`hangup`, `rejectCall`, timeout handlers) publish *around* it.
+- **`onPeerLeft(pubKey)` must never be called with `signer.pubKey`.** It
+  tells CallController to dispose a peer session; passing self tears down
+  the local call. The self-pubkey early-returns in `onCallAnswered` and
+  `onCallRejected` enforce this.
+- **`ENDED_DISPLAY_MS` auto-reset.** After ending, state lingers in `Ended`
+  for 2 s so the UI can show "Call ended" before resetting to `Idle`.
+  `resetJob` is cancelled on any new transition.
+- **`isEventTooOld` rejects events older than 20 s** (`MAX_EVENT_AGE_SECONDS`)
+  or created before `CallManager` was constructed. This prevents relays from
+  ringing the phone with a day-old offer on app startup.
+- **`isFollowing` gates incoming offers only.** Once a call is in flight,
+  all mid-call signaling is accepted regardless of the follow relationship.
+- **Do NOT add event kinds to `onSignalingEvent`'s self-filter without
+  thinking.** Self-answers and self-rejects are load-bearing for
+  multi-device.
+
+## 10. Testing
+
+`commons/commonTest/.../call/CallManagerTest.kt` is the canonical reference
+for expected state transitions. It uses real `NostrSignerInternal` keys so
+the factory-sign-wrap pipeline is exercised end-to-end, with `publishEvent`
+captured into a list for assertions. Construct events directly with the
+`makeOffer` / `makeAnswer` / `makeHangup` / `makeReject` / `makeIceCandidate`
+helpers — they mirror real event shapes but skip signing.
+
+The "Multi-Device: Second Logged-In Device Must Stop Ringing" section at the
+bottom of the test file shows how to simulate two phones with the same
+signer. Prefer extending it over creating new test files.
+
+Run just the CallManager tests:
+
+```bash
+./gradlew :commons:commonTest --tests "com.vitorpamplona.amethyst.commons.call.CallManagerTest"
+```

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
@@ -386,6 +386,20 @@ class CallManager(
         Log.d("CallManager") { "acceptCall: publishing answer to ${otherMembers.size} recipients" }
         val result = factory.createGroupCallAnswer(sdpAnswer, otherMembers, current.callId, signer)
         result.wraps.forEach { publishEvent(it) }
+
+        // Notify our own other devices so they stop ringing. We wrap the
+        // *same* signed answer event for our own pubkey and publish it as
+        // an extra gift wrap. A sibling device in IncomingCall will observe
+        // the self-answer and transition to Ended(ANSWERED_ELSEWHERE)
+        // locally (see onCallAnswered). This call is the only place the
+        // "answered elsewhere" signal is generated — without it, a second
+        // logged-in device keeps ringing until its 60-second local timeout.
+        //
+        // The echo that arrives back at *this* device is ignored in
+        // Connecting/Connected state by the self-answer guard at the top
+        // of onCallAnswered, so it cannot disturb the live call.
+        val selfWrap = EphemeralGiftWrapEvent.create(event = result.msg, recipientPubKey = signer.pubKey)
+        publishEvent(selfWrap)
         Log.d("CallManager") { "acceptCall: answer published, now in Connecting state" }
 
         // Trigger callee-to-callee mesh connections with peers we discovered
@@ -410,6 +424,12 @@ class CallManager(
         val otherMembers = current.groupMembers - signer.pubKey
         val result = factory.createGroupReject(otherMembers, current.callId, signer = signer)
         result.wraps.forEach { publishEvent(it) }
+
+        // Notify our own other devices so they stop ringing. See the
+        // matching comment in acceptCall — sibling devices in IncomingCall
+        // pick up this echo and transition to Ended(REJECTED) locally.
+        val selfWrap = EphemeralGiftWrapEvent.create(event = result.msg, recipientPubKey = signer.pubKey)
+        publishEvent(selfWrap)
     }
 
     private fun onCallAnswered(event: CallAnswerEvent) {
@@ -534,6 +554,23 @@ class CallManager(
         val callId = event.callId()
         val rejectingPeer = event.pubKey
 
+        // Self-reject: only meaningful as "rejected elsewhere" while we are
+        // still ringing (IncomingCall).  In every other state it is our own
+        // echo from a relay after a sibling device rejected a call that we
+        // have already accepted and are now actively in — treating it as a
+        // peer rejection would drop ourselves from the call (onPeerLeft
+        // would dispose our own PeerConnection, killing the live audio on
+        // the device that picked up).  Just drop the echo.
+        if (rejectingPeer == signer.pubKey) {
+            if (current is CallState.IncomingCall && callId == current.callId) {
+                Log.d("CallManager") { "onCallRejected: self-reject detected in IncomingCall — rejected elsewhere" }
+                transitionToEnded(current.callId, current.peerPubKeys(), EndReason.REJECTED)
+            } else {
+                Log.d("CallManager") { "onCallRejected: ignoring self-reject echo in ${current::class.simpleName}" }
+            }
+            return
+        }
+
         when (current) {
             is CallState.Offering -> {
                 if (callId != current.callId) return
@@ -565,10 +602,7 @@ class CallManager(
 
             is CallState.IncomingCall -> {
                 if (callId != current.callId) return
-                if (rejectingPeer == signer.pubKey) {
-                    // Own rejection from another device
-                    transitionToEnded(current.callId, current.peerPubKeys(), EndReason.REJECTED)
-                } else if (rejectingPeer == current.callerPubKey) {
+                if (rejectingPeer == current.callerPubKey) {
                     // Caller rejected/cancelled the call
                     transitionToEnded(current.callId, current.groupMembers, EndReason.PEER_REJECTED)
                 } else {
@@ -860,17 +894,20 @@ class CallManager(
 
             // Record call-ids from termination signals so that a later offer
             // for the same call is recognised as stale (common after app restart
-            // when relay replays events out of order).
-            if (event is CallHangupEvent || event is CallRejectEvent) {
-                val terminatedCallId =
-                    when (event) {
-                        is CallHangupEvent -> event.callId()
-                        is CallRejectEvent -> event.callId()
-                        else -> null
-                    }
-                if (terminatedCallId != null) {
-                    cappedAdd(completedCallIds, terminatedCallId, MAX_COMPLETED_CALL_IDS)
+            // when relay replays events out of order).  For answers, only
+            // *self*-answers count as a termination signal: they mean another
+            // of our devices picked up, so ringing on this device should never
+            // start for the same call-id.  Peer answers to our own offer are
+            // not terminal — they are what moves us into Connecting.
+            val terminatedCallId =
+                when (event) {
+                    is CallHangupEvent -> event.callId()
+                    is CallRejectEvent -> event.callId()
+                    is CallAnswerEvent -> if (event.pubKey == signer.pubKey) event.callId() else null
+                    else -> null
                 }
+            if (terminatedCallId != null) {
+                cappedAdd(completedCallIds, terminatedCallId, MAX_COMPLETED_CALL_IDS)
             }
 
             when (event) {

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/call/CallManagerTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/call/CallManagerTest.kt
@@ -1830,4 +1830,195 @@ class CallManagerTest {
 
             assertIs<CallState.IncomingCall>(manager.state.value)
         }
+
+    // ========================================================================
+    // Multi-Device: Second Logged-In Device Must Stop Ringing
+    // ========================================================================
+    // When the user is logged in on two phones and Alice calls them, both
+    // devices ring.  When one picks up (or rejects), the other must stop
+    // ringing without disturbing the device that answered.
+    //
+    // Mechanism: acceptCall / rejectCall publish an extra gift wrap of the
+    // same signed answer/reject event addressed to the user's own pubkey,
+    // so a sibling device (subscribed to gift wraps for its own pubkey)
+    // observes the echo, detects a self-answer/self-reject in IncomingCall
+    // state and transitions to Ended(ANSWERED_ELSEWHERE / REJECTED).
+
+    private fun EphemeralGiftWrapEvent.recipientPubKey(): HexKey? =
+        tags.firstOrNull { it.size >= 2 && it[0] == "p" }?.get(1)
+
+    @Test
+    fun acceptCallPublishesAnswerWrappedForSelfSoSiblingDeviceCanStopRinging() =
+        runTest {
+            val (manager, published) = createManager(localPubKey = bob, followedKeys = setOf(alice))
+
+            manager.onSignalingEvent(makeOffer(from = alice, to = bob))
+            assertIs<CallState.IncomingCall>(manager.state.value)
+            published.clear()
+
+            manager.acceptCall(sdpAnswer)
+
+            val recipients = published.mapNotNull { it.recipientPubKey() }.toSet()
+            assertTrue(
+                alice in recipients,
+                "Answer must be wrapped for the caller (alice), recipients=$recipients",
+            )
+            assertTrue(
+                bob in recipients,
+                "Answer must also be wrapped for the callee's own pubkey (bob) so " +
+                    "sibling devices stop ringing, recipients=$recipients",
+            )
+        }
+
+    @Test
+    fun rejectCallPublishesRejectWrappedForSelfSoSiblingDeviceCanStopRinging() =
+        runTest {
+            val (manager, published) = createManager(localPubKey = bob, followedKeys = setOf(alice))
+
+            manager.onSignalingEvent(makeOffer(from = alice, to = bob))
+            assertIs<CallState.IncomingCall>(manager.state.value)
+            published.clear()
+
+            manager.rejectCall()
+
+            val recipients = published.mapNotNull { it.recipientPubKey() }.toSet()
+            assertTrue(
+                alice in recipients,
+                "Reject must be wrapped for the caller (alice), recipients=$recipients",
+            )
+            assertTrue(
+                bob in recipients,
+                "Reject must also be wrapped for the callee's own pubkey (bob) so " +
+                    "sibling devices stop ringing, recipients=$recipients",
+            )
+        }
+
+    /**
+     * Simulates the full multi-device scenario:
+     *   1. Alice calls Bob.  Bob is logged in on two phones (two separate
+     *      CallManagers backed by the same bobSigner).
+     *   2. Both phones receive the offer and enter IncomingCall.
+     *   3. Phone 1 accepts — this publishes an answer gift-wrapped for
+     *      alice AND for bob.
+     *   4. Phone 2 (subscribed to its own pubkey) receives the self-
+     *      addressed echo and must transition to Ended(ANSWERED_ELSEWHERE).
+     *   5. Phone 1 must remain in Connecting — the echo it also receives
+     *      must not disturb its in-progress session.
+     */
+    @Test
+    fun answeringOnDeviceOneStopsDeviceTwoRingingWithoutDisturbingDeviceOne() =
+        runTest {
+            val (phone1, published1) = createManager(localPubKey = bob, followedKeys = setOf(alice))
+            val (phone2, _) = createManager(localPubKey = bob, followedKeys = setOf(alice))
+
+            val offer = makeOffer(from = alice, to = bob)
+            phone1.onSignalingEvent(offer)
+            phone2.onSignalingEvent(offer)
+            assertIs<CallState.IncomingCall>(phone1.state.value)
+            assertIs<CallState.IncomingCall>(phone2.state.value)
+            published1.clear()
+
+            // Phone 1 picks up.  It will publish one wrap for alice and one
+            // wrap for bob (the self-echo).
+            phone1.acceptCall(sdpAnswer)
+            assertIs<CallState.Connecting>(phone1.state.value)
+
+            // Deliver the self-echo to phone 2. The inner event is what
+            // another CallManager would see after unwrapping the gift wrap,
+            // so construct a parallel CallAnswerEvent directly (the wrap
+            // payload is opaque in the test harness because published1
+            // stores EphemeralGiftWrapEvents, not the unwrapped inner).
+            val selfAnswer = makeAnswer(from = bob, to = alice)
+            phone2.onSignalingEvent(selfAnswer)
+
+            // Phone 2 stops ringing with ANSWERED_ELSEWHERE.
+            val phone2State = phone2.state.value
+            assertIs<CallState.Ended>(phone2State)
+            assertEquals(EndReason.ANSWERED_ELSEWHERE, phone2State.reason)
+
+            // Phone 1 ALSO receives the self-echo (it is addressed to bob).
+            // It must stay in Connecting — the live call cannot be torn down
+            // by its own answer bouncing off the relay.
+            phone1.onSignalingEvent(selfAnswer)
+            assertIs<CallState.Connecting>(phone1.state.value)
+        }
+
+    /**
+     * Regression for the subtle bug where a self-reject echo would trigger
+     * onPeerLeft(signer.pubKey) on a device that had already accepted,
+     * disposing its own PeerSession and killing the live call.
+     */
+    @Test
+    fun selfRejectEchoDoesNotDisturbDeviceAlreadyInCall() =
+        runTest {
+            val (manager, _) = createManager(localPubKey = bob, followedKeys = setOf(alice))
+
+            var peerLeftCalled = false
+            manager.onPeerLeft = { peerLeftCalled = true }
+
+            manager.onSignalingEvent(makeOffer(from = alice, to = bob))
+            manager.acceptCall(sdpAnswer)
+            manager.onPeerConnected()
+            assertIs<CallState.Connected>(manager.state.value)
+
+            // A sibling device rejects the call after we already answered.
+            // Its reject event is wrapped for us too (multi-device signal).
+            val siblingReject = makeReject(from = bob, to = alice)
+            manager.onSignalingEvent(siblingReject)
+
+            // Our live call must survive — the echo must not fire
+            // onPeerLeft (which would dispose our own PeerSession) and must
+            // not change state.
+            assertIs<CallState.Connected>(manager.state.value)
+            assertTrue(
+                !peerLeftCalled,
+                "onPeerLeft must not fire for a self-reject echo — the UI would " +
+                    "tear down our own PeerSession, killing the live call audio.",
+            )
+        }
+
+    /**
+     * Same guard for the Connecting state: a self-reject arriving during
+     * the connection handshake must not drop us from our own pending set
+     * and must not invoke onPeerLeft(self).
+     */
+    @Test
+    fun selfRejectEchoDuringConnectingDoesNotFireOnPeerLeft() =
+        runTest {
+            val (manager, _) = createManager(localPubKey = bob, followedKeys = setOf(alice))
+
+            var peerLeftCalled = false
+            manager.onPeerLeft = { peerLeftCalled = true }
+
+            manager.onSignalingEvent(makeOffer(from = alice, to = bob))
+            manager.acceptCall(sdpAnswer)
+            assertIs<CallState.Connecting>(manager.state.value)
+
+            val siblingReject = makeReject(from = bob, to = alice)
+            manager.onSignalingEvent(siblingReject)
+
+            assertIs<CallState.Connecting>(manager.state.value)
+            assertTrue(!peerLeftCalled, "onPeerLeft must not fire for a self-reject echo during Connecting")
+        }
+
+    /**
+     * If the relay replays events out of order — self-answer arriving
+     * before the original offer — the second device must NOT start ringing
+     * for a call-id it already knows was answered elsewhere.
+     */
+    @Test
+    fun offerReplayedAfterSelfAnswerDoesNotStartRinging() =
+        runTest {
+            val (manager, _) = createManager(localPubKey = bob, followedKeys = setOf(alice))
+
+            // Self-answer arrives first (while we're in Idle — nothing to
+            // do with it except remember the call-id so a later offer for
+            // it is treated as stale).
+            manager.onSignalingEvent(makeAnswer(from = bob, to = alice))
+            assertIs<CallState.Idle>(manager.state.value)
+
+            // Now the offer finally arrives.  We must NOT start ringing.
+            manager.onSignalingEvent(makeOffer(from = alice, to = bob))
+            assertIs<CallState.Idle>(manager.state.value)
+        }
 }


### PR DESCRIPTION
## Summary

This PR implements multi-device call handling for WebRTC calls and adds comprehensive architecture documentation. When a user is logged in on multiple devices, all devices now properly coordinate when accepting or rejecting incoming calls, ensuring only the device that answered continues the call while others stop ringing.

## Key Changes

- **Multi-device call coordination**: When `acceptCall()` or `rejectCall()` is invoked, an additional gift-wrapped event is now published to the user's own pubkey. Sibling devices receive this "self-echo" and transition to `Ended(ANSWERED_ELSEWHERE)` or `Ended(REJECTED)` state, stopping their ringing without disturbing the active call.

- **Self-reject echo filtering**: Added explicit guards in `onCallRejected()` to prevent self-reject echoes from being misinterpreted as peer rejections in `Connecting`/`Connected` states. This prevents the live call from being torn down by the device's own echo bouncing off the relay.

- **Stale offer replay protection**: Extended `completedCallIds` tracking to include self-answers, preventing relay replays of old offers from triggering ringing on a device that already knows the call was answered elsewhere.

- **Architecture documentation**: Added `ARCHITECTURE.md` providing a comprehensive map of the WebRTC call system including:
  - Protocol overview (NIP-AC event kinds and gift-wrap structure)
  - Module layout across quartz, commons, and amethyst packages
  - State machine diagram and transitions
  - CallManager responsibilities and event pipeline
  - Group call handling (invited vs. watchdog timers)
  - Multi-device coordination mechanism
  - Key invariants and pitfalls
  - Testing guidance

- **Test coverage**: Added 6 new test cases covering:
  - Answer/reject publishing self-wrapped events
  - Full multi-device scenario with two phones
  - Self-reject echo not disturbing active calls
  - Stale offer replays after self-answers

## Implementation Details

The multi-device mechanism works by having `acceptCall()` and `rejectCall()` create an additional `EphemeralGiftWrapEvent` wrapping the same signed inner event but addressed to `signer.pubKey`. This leverages the existing relay subscription filter (`#p = [myPubKey]`) so all devices on the same account receive the signal. The self-echo is then filtered appropriately based on call state to prevent disruption of active calls while enabling the "answered elsewhere" UX on idle devices.

https://claude.ai/code/session_01QVUnhr79hYqQuXFiEb8puk