### PR TITLE
Improve call notification display with user metadata resolution

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
@@ -71,8 +71,10 @@ import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import java.math.BigDecimal
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -699,11 +701,32 @@ class EventNotificationConsumer(
 
         if (TimeUtils.now() - event.createdAt > CallManager.MAX_EVENT_AGE_SECONDS) return
 
-        val callerUser = LocalCache.getUserIfExists(event.pubKey)
-        val callerName = callerUser?.toBestDisplayName() ?: event.pubKey.take(8) + "..."
+        val callerUser = LocalCache.getOrCreateUser(event.pubKey)
+
+        // If the caller's metadata hasn't been loaded yet (e.g. fresh process from
+        // a push notification), briefly subscribe to the user finder so we can
+        // resolve the user's display name instead of showing the raw pubkey.
+        if (callerUser.metadataOrNull()?.bestName() == null) {
+            val authorState = UserFinderQueryState(callerUser, account)
+            try {
+                Amethyst.instance.sources.userFinder
+                    .subscribe(authorState)
+                withTimeoutOrNull(5_000L) {
+                    callerUser
+                        .metadata()
+                        .flow
+                        .first { it?.info?.bestName() != null }
+                }
+            } finally {
+                Amethyst.instance.sources.userFinder
+                    .unsubscribe(authorState)
+            }
+        }
+
+        val callerName = callerUser.toBestDisplayName()
 
         val callerBitmap =
-            callerUser?.profilePicture()?.let { pictureUrl ->
+            callerUser.profilePicture()?.let { pictureUrl ->
                 kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
                     try {
                         val request =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationUtils.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationUtils.kt
@@ -630,12 +630,12 @@ object NotificationUtils {
         callerPubKey: String,
         context: Context,
     ) {
-        val callerUser = LocalCache.getUserIfExists(callerPubKey)
-        val callerName = callerUser?.toBestDisplayName() ?: callerPubKey.take(8) + "..."
+        val callerUser = LocalCache.getOrCreateUser(callerPubKey)
+        val callerName = callerUser.toBestDisplayName()
         val uri = "nostr:${callerPubKey.hexToByteArray().toNpub()}"
 
         val callerBitmap =
-            callerUser?.profilePicture()?.let { pictureUrl ->
+            callerUser.profilePicture()?.let { pictureUrl ->
                 withContext(Dispatchers.IO) {
                     try {
                         val request =


### PR DESCRIPTION
## Summary
Enhanced call notification handling to properly resolve and display caller information by ensuring user metadata is loaded before displaying notifications, rather than falling back to truncated public keys.

## Key Changes
- Changed `LocalCache.getUserIfExists()` to `LocalCache.getOrCreateUser()` in call notification flows to guarantee a user object exists
- Added metadata resolution logic in `EventNotificationConsumer.handleCallNotification()` that:
  - Subscribes to the user finder to load caller metadata if not already available
  - Waits up to 5 seconds for metadata to be resolved using `withTimeoutOrNull`
  - Properly unsubscribes from the user finder in a finally block
- Updated `NotificationUtils.showCallNotification()` to use the same user creation pattern
- Removed null-coalescing fallbacks (e.g., `?: event.pubKey.take(8) + "..."`) since user objects are now guaranteed to exist
- Simplified profile picture retrieval by removing unnecessary null checks

## Implementation Details
- Uses `UserFinderQueryState` to manage the subscription lifecycle for metadata resolution
- Leverages `flow.first()` with a predicate to wait for non-null metadata
- Gracefully handles timeout scenarios with `withTimeoutOrNull` to prevent blocking notification display
- Ensures proper resource cleanup with try-finally pattern

https://claude.ai/code/session_01BMeQZGACjD1UYEjobnKGYo