### PR TITLE
Add Marmot group messages to notifications feed

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/RouteMaker.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/RouteMaker.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.ui.navigation.routes
 
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
+import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupChatroom
 import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatChannel
 import com.vitorpamplona.amethyst.commons.model.nip53LiveActivities.LiveActivitiesChannel
 import com.vitorpamplona.amethyst.model.Account
@@ -61,6 +62,12 @@ fun routeFor(
     note: Note,
     loggedIn: Account,
 ): Route? {
+    // Marmot group messages should navigate to the group chat
+    val marmotGroup = note.inGatherers?.firstNotNullOfOrNull { it as? MarmotGroupChatroom }
+    if (marmotGroup != null) {
+        return Route.MarmotGroupChat(marmotGroup.nostrGroupId)
+    }
+
     val noteEvent = note.event ?: return Route.EventRedirect(note.idHex)
 
     return routeFor(noteEvent, loggedIn)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChannelFabColumn.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChannelFabColumn.kt
@@ -106,7 +106,7 @@ fun ChannelFabColumn(nav: INav) {
 
                 FloatingActionButton(
                     onClick = {
-                        nav.nav(Route.MarmotGroupList)
+                        nav.nav(Route.CreateMarmotGroup)
                         isOpen = false
                     },
                     modifier = Size55Modifier,
@@ -114,7 +114,7 @@ fun ChannelFabColumn(nav: INav) {
                     containerColor = MaterialTheme.colorScheme.primary,
                 ) {
                     Text(
-                        text = "MLS\nGroups",
+                        text = stringRes(R.string.messages_create_group),
                         color = Color.White,
                         textAlign = TextAlign.Center,
                         fontSize = Font12SP,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/CardFeedContentState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/CardFeedContentState.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateOf
+import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupChatroom
 import com.vitorpamplona.amethyst.commons.ui.feeds.InvalidatableContent
 import com.vitorpamplona.amethyst.commons.ui.feeds.LoadedFeedState
 import com.vitorpamplona.amethyst.commons.ui.notifications.Card
@@ -306,7 +307,7 @@ class CardFeedContentState(
                         it.event !is GenericRepostEvent &&
                         it.event !is LnZapEvent
                 }.map {
-                    if (it.event is PrivateDmEvent || it.event is NIP17Group) {
+                    if (it.event is PrivateDmEvent || it.event is NIP17Group || it.isInMarmotGroup()) {
                         MessageSetCard(it)
                     } else if (it.event is BadgeAwardEvent) {
                         BadgeCard(it)
@@ -475,3 +476,5 @@ data class CombinedZap(
 
     fun idHex() = response.idHex
 }
+
+private fun Note.isInMarmotGroup(): Boolean = inGatherers?.any { it is MarmotGroupChatroom } == true

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationFeedFilter.kt
@@ -34,6 +34,7 @@ import com.vitorpamplona.quartz.experimental.audio.track.AudioTrackEvent
 import com.vitorpamplona.quartz.experimental.forks.IForkableEvent
 import com.vitorpamplona.quartz.experimental.nipsOnNostr.NipTextEvent
 import com.vitorpamplona.quartz.experimental.zapPolls.ZapPollEvent
+import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupChatroom
 import com.vitorpamplona.quartz.nip01Core.core.AddressableEvent
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.tags.people.isTaggedUser
@@ -151,7 +152,14 @@ class NotificationFeedFilter(
                     acceptableEvent(note, filterParams)
                 }
 
-        return sort(notifications)
+        // Include marmot group messages as notifications (like DMs)
+        val loggedInUserHex = account.userProfile().pubkeyHex
+        val marmotMessages =
+            account.marmotGroupList.rooms.mapFlatten { _, chatroom ->
+                chatroom.messages.filter { it.author?.pubkeyHex != loggedInUserHex }
+            }
+
+        return sort(notifications + marmotMessages)
     }
 
     override fun applyFilter(newItems: Set<Note>): Set<Note> = innerApplyFilter(newItems)
@@ -167,6 +175,12 @@ class NotificationFeedFilter(
         filterParams: FilterByListParams,
     ): Boolean {
         val loggedInUserHex = account.userProfile().pubkeyHex
+
+        // Marmot group messages are always acceptable (user is a group member)
+        val isMarmotGroupMessage = it.inGatherers?.any { g -> g is MarmotGroupChatroom } == true
+        if (isMarmotGroupMessage) {
+            return it.author?.pubkeyHex != loggedInUserHex
+        }
 
         val noteEvent = it.event
         val notifAuthor =

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -1090,6 +1090,7 @@
     <string name="new_feature_nip17_activate">Activate</string>
 
     <string name="messages_create_public_chat">Public</string>
+    <string name="messages_create_group">Group</string>
     <string name="messages_create_public_private_chat_description">New Public or Private Group</string>
     <string name="messages_relay_based">Relay</string>
     <string name="messages_new_message">Private</string>


### PR DESCRIPTION
## Summary
Integrate Marmot group chat messages into the notifications feed system, treating them similarly to direct messages. This allows users to see group messages as notifications and navigate to group chats from the notification feed.

## Key Changes
- **NotificationFeedFilter.kt**: 
  - Added import for `MarmotGroupChatroom`
  - Extended notification filtering to include messages from Marmot group chatrooms (excluding messages from the logged-in user)
  - Added `acceptableMarmotGroupMessage()` check to validate group messages as notifications

- **RouteMaker.kt**:
  - Added routing logic to navigate Marmot group messages to the appropriate group chat screen
  - Messages from Marmot groups now route to `Route.MarmotGroupChat()` instead of generic event handling

- **CardFeedContentState.kt**:
  - Added `isInMarmotGroup()` helper function to identify notes belonging to Marmot groups
  - Updated card rendering logic to display Marmot group messages as `MessageSetCard` (same as DMs and NIP17 groups)

- **ChannelFabColumn.kt**:
  - Changed FAB button action from navigating to `MarmotGroupList` to `CreateMarmotGroup`
  - Updated button label to use localized string resource for consistency

- **strings.xml**:
  - Added new string resource `messages_create_group` for the FAB button label

## Implementation Details
- Marmot group messages are filtered to exclude messages from the current user (similar to DM behavior)
- Messages are identified as belonging to Marmot groups via the `inGatherers` property on `Note` objects
- The notification feed now aggregates messages from all Marmot group chatrooms the user is a member of

https://claude.ai/code/session_012wbykgUYHNVdHVNbDDnMUt