### PR TITLE
Refactor call session lifecycle to Activity-owned CallSession

### DIFF
--- a/amethyst/src/main/AndroidManifest.xml
+++ b/amethyst/src/main/AndroidManifest.xml
@@ -214,7 +214,7 @@
         <activity
             android:name=".ui.call.CallActivity"
             android:autoRemoveFromRecents="true"
-            android:configChanges="orientation|screenLayout|screenSize|smallestScreenSize|keyboardHidden|keyboard|uiMode"
+            android:configChanges="orientation|screenLayout|screenSize|smallestScreenSize|keyboardHidden|keyboard|uiMode|navigation|fontScale|density"
             android:supportsPictureInPicture="true"
             android:launchMode="singleTop"
             android:exported="false"

--- a/amethyst/src/main/AndroidManifest.xml
+++ b/amethyst/src/main/AndroidManifest.xml
@@ -250,7 +250,7 @@
         <service
             android:name=".service.call.CallForegroundService"
             android:foregroundServiceType="microphone|camera|phoneCall"
-            android:stopWithTask="true"
+            android:stopWithTask="false"
             android:exported="false" />
 
         <provider

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallAudioManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallAudioManager.kt
@@ -33,7 +33,7 @@ import android.hardware.SensorManager
 import android.media.AudioAttributes
 import android.media.AudioDeviceInfo
 import android.media.AudioManager
-import android.media.Ringtone
+import android.media.MediaPlayer
 import android.media.RingtoneManager
 import android.media.ToneGenerator
 import android.os.Build
@@ -42,9 +42,12 @@ import android.os.VibrationEffect
 import android.os.Vibrator
 import android.os.VibratorManager
 import androidx.core.content.ContextCompat
+import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+
+private const val TAG = "CallAudioManager"
 
 enum class AudioRoute {
     EARPIECE,
@@ -55,13 +58,28 @@ enum class AudioRoute {
 class CallAudioManager(
     private val context: Context,
 ) {
-    private var ringtone: Ringtone? = null
+    /**
+     * Instance id — every log line from this audio manager is prefixed
+     * with this so we can trace whether multiple CallAudioManager
+     * instances are fighting over the ringtone.
+     */
+    private val instanceId = nextInstanceId.getAndIncrement()
+
+    private var ringtonePlayer: MediaPlayer? = null
     private var vibrator: Vibrator? = null
     private var proximityWakeLock: PowerManager.WakeLock? = null
     private var ringbackTone: ToneGenerator? = null
     private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
     private var previousAudioMode: Int = AudioManager.MODE_NORMAL
     private var scoReceiver: BroadcastReceiver? = null
+
+    init {
+        Log.d(TAG) { "[#$instanceId] created on ${Thread.currentThread().name}" }
+    }
+
+    companion object {
+        private val nextInstanceId = java.util.concurrent.atomic.AtomicInteger(0)
+    }
 
     private val _audioRoute = MutableStateFlow(AudioRoute.EARPIECE)
     val audioRoute: StateFlow<AudioRoute> = _audioRoute.asStateFlow()
@@ -97,6 +115,13 @@ class CallAudioManager(
         }
 
     fun startRinging() {
+        Log.d(TAG) { "[#$instanceId] startRinging on ${Thread.currentThread().name} — existing player=${ringtonePlayer?.hashCode()}" }
+        // IDEMPOTENT: always stop any existing player/vibrator before
+        // starting a new one. Without this, rapid re-entry (e.g. state
+        // flow re-emission when a group member rejects while we are
+        // ringing) would leak MediaPlayer/Ringtone instances that keep
+        // playing because the old reference is overwritten before stop.
+        stopRinging()
         val ringerMode = audioManager.ringerMode
         if (ringerMode != AudioManager.RINGER_MODE_SILENT) {
             if (ringerMode == AudioManager.RINGER_MODE_NORMAL) {
@@ -107,6 +132,7 @@ class CallAudioManager(
     }
 
     fun stopRinging() {
+        Log.d(TAG) { "[#$instanceId] stopRinging on ${Thread.currentThread().name} — player=${ringtonePlayer?.hashCode()}" }
         stopRingtone()
         stopVibration()
     }
@@ -216,6 +242,7 @@ class CallAudioManager(
     }
 
     fun release() {
+        Log.d(TAG) { "[#$instanceId] release on ${Thread.currentThread().name}" }
         stopRinging()
         stopRingbackTone()
         restoreAudioMode()
@@ -349,32 +376,57 @@ class CallAudioManager(
         scoReceiver = null
     }
 
+    /**
+     * Starts the ringtone via [MediaPlayer] (not [android.media.Ringtone]).
+     *
+     * Why MediaPlayer: `Ringtone.stop()` has documented reliability
+     * problems on older Android versions where stop() returns but
+     * playback continues, and `isLooping` is only settable on API 28+.
+     * `MediaPlayer` has reliable stop/release on all API levels and
+     * supports looping universally.
+     */
     private fun startRingtone() {
         try {
             val ringtoneUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE)
-            ringtone =
-                RingtoneManager.getRingtone(context, ringtoneUri)?.apply {
-                    audioAttributes =
+            val player =
+                MediaPlayer().apply {
+                    setAudioAttributes(
                         AudioAttributes
                             .Builder()
                             .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
                             .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                            .build()
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                        isLooping = true
+                            .build(),
+                    )
+                    setDataSource(context, ringtoneUri)
+                    isLooping = true
+                    setOnErrorListener { _, what, extra ->
+                        Log.e(TAG) { "[#$instanceId] ringtone MediaPlayer error what=$what extra=$extra" }
+                        true
                     }
-                    play()
+                    prepare()
+                    start()
                 }
-        } catch (_: Exception) {
+            ringtonePlayer = player
+            Log.d(TAG) { "[#$instanceId] startRingtone: player=${player.hashCode()} started" }
+        } catch (e: Exception) {
+            Log.e(TAG, "[#$instanceId] startRingtone failed", e)
         }
     }
 
     private fun stopRingtone() {
+        val player = ringtonePlayer ?: return
+        Log.d(TAG) { "[#$instanceId] stopRingtone: player=${player.hashCode()} isPlaying=${runCatching { player.isPlaying }.getOrDefault(false)}" }
         try {
-            ringtone?.stop()
-        } catch (_: Exception) {
+            if (player.isPlaying) player.stop()
+        } catch (e: Exception) {
+            Log.e(TAG, "[#$instanceId] stopRingtone: stop() failed", e)
         }
-        ringtone = null
+        try {
+            player.release()
+        } catch (e: Exception) {
+            Log.e(TAG, "[#$instanceId] stopRingtone: release() failed", e)
+        }
+        ringtonePlayer = null
     }
 
     private fun startVibration() {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallForegroundService.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallForegroundService.kt
@@ -35,8 +35,11 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.call.CallState
 import com.vitorpamplona.amethyst.ui.call.CallActivity
 import com.vitorpamplona.quartz.utils.Log
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 
 private const val TAG = "CallForegroundService"
 
@@ -123,6 +126,58 @@ class CallForegroundService : Service() {
             }
         }
         return START_NOT_STICKY
+    }
+
+    /**
+     * Called when the user swipes the app's task away from Recents. The
+     * manifest declares `stopWithTask="false"` so this callback fires
+     * BEFORE the service is killed, giving us a window to publish the
+     * hangup/reject signaling event synchronously.
+     *
+     * `runBlocking` is safe here because `onTaskRemoved` runs on the
+     * main thread with a 5-second ANR window and the network publish
+     * (via Nostr relay WebSocket) completes well within that. We cap
+     * it at 3 seconds as a safety net.
+     */
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        publishHangupBlocking()
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        stopSelf()
+        super.onTaskRemoved(rootIntent)
+    }
+
+    override fun onDestroy() {
+        // If onTaskRemoved already published the hangup, this is a no-op
+        // because CallManager.hangup() transitions to Ended and a second
+        // hangup() from Ended state returns immediately.
+        publishHangupBlocking()
+        super.onDestroy()
+    }
+
+    /**
+     * Synchronously publishes a hangup or reject event if a call is
+     * active. Uses [runBlocking] with a 3-second timeout so we never
+     * block the main thread past the ANR window.
+     */
+    private fun publishHangupBlocking() {
+        val manager = CallSessionBridge.callManager ?: return
+        val state = manager.state.value
+        try {
+            runBlocking {
+                withTimeoutOrNull(3_000L) {
+                    when (state) {
+                        is CallState.IncomingCall -> manager.rejectCall()
+                        is CallState.Offering,
+                        is CallState.Connecting,
+                        is CallState.Connected,
+                        -> manager.hangup()
+                        else -> { /* nothing to do */ }
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "publishHangupBlocking failed", e)
+        }
     }
 
     private fun createNotificationChannel() {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallForegroundService.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallForegroundService.kt
@@ -166,11 +166,17 @@ class CallForegroundService : Service() {
             runBlocking {
                 withTimeoutOrNull(3_000L) {
                     when (state) {
-                        is CallState.IncomingCall -> manager.rejectCall()
+                        is CallState.IncomingCall -> {
+                            manager.rejectCall()
+                        }
+
                         is CallState.Offering,
                         is CallState.Connecting,
                         is CallState.Connected,
-                        -> manager.hangup()
+                        -> {
+                            manager.hangup()
+                        }
+
                         else -> { /* nothing to do */ }
                     }
                 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallNotificationReceiver.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallNotificationReceiver.kt
@@ -24,10 +24,13 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import com.vitorpamplona.amethyst.service.call.notification.CallNotifier
+import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+
+private const val TAG = "CallNotificationReceiver"
 
 /**
  * Handles the Reject action from the incoming call notification.
@@ -41,19 +44,28 @@ class CallNotificationReceiver : BroadcastReceiver() {
         context: Context,
         intent: Intent,
     ) {
-        val callManager = CallSessionBridge.callManager ?: return
+        Log.d(TAG) { "onReceive action=${intent.action} thread=${Thread.currentThread().name}" }
+        val callManager = CallSessionBridge.callManager
+        if (callManager == null) {
+            Log.e(TAG) { "onReceive: callManager is null — cannot process ${intent.action}" }
+            return
+        }
         val pendingResult = goAsync()
         val scope = CoroutineScope(SupervisorJob() + kotlinx.coroutines.Dispatchers.Main.immediate)
         scope.launch {
             try {
                 when (intent.action) {
                     ACTION_REJECT_CALL -> {
+                        Log.d(TAG) { "REJECT_CALL: state=${callManager.state.value::class.simpleName}" }
                         CallNotifier.cancelIncomingCall(context)
                         callManager.rejectCall()
+                        Log.d(TAG) { "REJECT_CALL: after rejectCall(), state=${callManager.state.value::class.simpleName}" }
                     }
 
                     ACTION_HANGUP_CALL -> {
+                        Log.d(TAG) { "HANGUP_CALL: state=${callManager.state.value::class.simpleName}" }
                         callManager.hangup()
+                        Log.d(TAG) { "HANGUP_CALL: after hangup(), state=${callManager.state.value::class.simpleName}" }
                     }
                 }
             } finally {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallNotificationReceiver.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallNotificationReceiver.kt
@@ -23,7 +23,7 @@ package com.vitorpamplona.amethyst.service.call
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import com.vitorpamplona.amethyst.service.notifications.NotificationUtils
+import com.vitorpamplona.amethyst.service.call.notification.CallNotifier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
@@ -48,7 +48,7 @@ class CallNotificationReceiver : BroadcastReceiver() {
             try {
                 when (intent.action) {
                     ACTION_REJECT_CALL -> {
-                        NotificationUtils.cancelCallNotification(context)
+                        CallNotifier.cancelIncomingCall(context)
                         callManager.rejectCall()
                     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallSessionBridge.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallSessionBridge.kt
@@ -24,31 +24,31 @@ import com.vitorpamplona.amethyst.commons.call.CallManager
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
 /**
- * Process-level singleton that bridges the active call state between
- * the main activity (which owns [AccountViewModel]) and [com.vitorpamplona.amethyst.ui.call.CallActivity]
- * (which runs in its own window but in the same process).
+ * Process-level singleton that bridges the active [CallManager] and
+ * [AccountViewModel] between the main activity and
+ * [com.vitorpamplona.amethyst.ui.call.CallActivity] (which runs in its
+ * own window but in the same process).
+ *
+ * No call controller / session is held here — each [CallActivity]
+ * creates and owns its own [com.vitorpamplona.amethyst.ui.call.session.CallSession]
+ * whose lifetime is tied to the Activity's lifecycle.
  */
 object CallSessionBridge {
     var callManager: CallManager? = null
-        private set
-    var callController: CallController? = null
         private set
     var accountViewModel: AccountViewModel? = null
         private set
 
     fun set(
         callManager: CallManager,
-        callController: CallController?,
         accountViewModel: AccountViewModel,
     ) {
         this.callManager = callManager
-        this.callController = callController
         this.accountViewModel = accountViewModel
     }
 
     fun clear() {
         callManager = null
-        callController = null
         accountViewModel = null
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallSessionBridge.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallSessionBridge.kt
@@ -21,11 +21,7 @@
 package com.vitorpamplona.amethyst.service.call
 
 import com.vitorpamplona.amethyst.commons.call.CallManager
-import com.vitorpamplona.amethyst.commons.call.CallState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
-import com.vitorpamplona.quartz.utils.Log
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * Process-level singleton that bridges the active [CallManager] and
@@ -52,29 +48,18 @@ object CallSessionBridge {
     }
 
     /**
-     * Terminates any active call and clears all references. Called from
-     * [AccountViewModel.onCleared] during logout or account switch so
-     * that a stale CallSession cannot invoke signing/publishing lambdas
-     * on a disposed Account.
+     * Resets call state and clears all references. Called from
+     * [AccountViewModel.onCleared] during logout or account switch.
+     *
+     * Uses [CallManager.reset] (non-blocking, no mutex) instead of
+     * [CallManager.hangup] to avoid deadlocking on `stateMutex` if
+     * a cancelled coroutine on the dying `viewModelScope` still holds
+     * it. Hangup signaling to the remote peer is the responsibility
+     * of [CallActivity.onDestroy] and [CallForegroundService], not
+     * the bridge teardown.
      */
     fun clear() {
-        val mgr = callManager
-        if (mgr != null) {
-            val state = mgr.state.value
-            if (state is CallState.IncomingCall ||
-                state is CallState.Offering ||
-                state is CallState.Connecting ||
-                state is CallState.Connected
-            ) {
-                try {
-                    runBlocking {
-                        withTimeoutOrNull(3_000L) { mgr.hangup() }
-                    }
-                } catch (e: Exception) {
-                    Log.e("CallSessionBridge", "clear: hangup failed", e)
-                }
-            }
-        }
+        callManager?.reset()
         callManager = null
         accountViewModel = null
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallSessionBridge.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallSessionBridge.kt
@@ -21,7 +21,12 @@
 package com.vitorpamplona.amethyst.service.call
 
 import com.vitorpamplona.amethyst.commons.call.CallManager
+import com.vitorpamplona.amethyst.commons.call.CallState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 
 /**
  * Process-level singleton that bridges the active [CallManager] and
@@ -47,7 +52,26 @@ object CallSessionBridge {
         this.accountViewModel = accountViewModel
     }
 
+    /**
+     * Terminates any active call and clears all references. Called from
+     * [AccountViewModel.onCleared] during logout or account switch so
+     * that a stale CallSession cannot invoke signing/publishing lambdas
+     * on a disposed Account.
+     */
     fun clear() {
+        val mgr = callManager
+        if (mgr != null) {
+            val state = mgr.state.value
+            if (state is CallState.IncomingCall ||
+                state is CallState.Offering ||
+                state is CallState.Connecting ||
+                state is CallState.Connected
+            ) {
+                CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate).launch {
+                    mgr.hangup()
+                }
+            }
+        }
         callManager = null
         accountViewModel = null
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallSessionBridge.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/CallSessionBridge.kt
@@ -23,10 +23,9 @@ package com.vitorpamplona.amethyst.service.call
 import com.vitorpamplona.amethyst.commons.call.CallManager
 import com.vitorpamplona.amethyst.commons.call.CallState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.launch
+import com.vitorpamplona.quartz.utils.Log
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * Process-level singleton that bridges the active [CallManager] and
@@ -67,8 +66,12 @@ object CallSessionBridge {
                 state is CallState.Connecting ||
                 state is CallState.Connected
             ) {
-                CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate).launch {
-                    mgr.hangup()
+                try {
+                    runBlocking {
+                        withTimeoutOrNull(3_000L) { mgr.hangup() }
+                    }
+                } catch (e: Exception) {
+                    Log.e("CallSessionBridge", "clear: hangup failed", e)
                 }
             }
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/notification/CallNotifier.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/notification/CallNotifier.kt
@@ -176,6 +176,7 @@ object CallNotifier {
     ) {
         val callerUser = LocalCache.getOrCreateUser(callerPubKey)
         val callerName = callerUser.toBestDisplayName()
+
         @Suppress("UNUSED_VARIABLE")
         val uri = "nostr:${callerPubKey.hexToByteArray().toNpub()}"
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/notification/CallNotifier.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/call/notification/CallNotifier.kt
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.call.notification
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
+import androidx.core.app.NotificationCompat
+import coil3.asDrawable
+import coil3.request.ImageRequest
+import coil3.request.allowHardware
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.service.call.CallNotificationReceiver
+import com.vitorpamplona.amethyst.ui.call.CallActivity
+import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.quartz.nip01Core.core.hexToByteArray
+import com.vitorpamplona.quartz.nip19Bech32.toNpub
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Focused helper for incoming-call notification posting and lifecycle.
+ *
+ * Owns the "CALL_CHANNEL" NotificationChannel and the single
+ * incoming-call system notification. Intentionally decoupled from the
+ * generic notification helper (`NotificationUtils`) so that call UI
+ * lifecycle concerns stay in one place and callers do not have to pull
+ * in the whole DM/zap/reaction notification subsystem just to post a
+ * ring notification.
+ *
+ * Invoked from:
+ *  - [CallActivity]'s owning `CallSession` to cancel the incoming-call
+ *    notification once the call transitions out of the ringing state.
+ *  - `EventNotificationConsumer` to post the full-screen incoming-call
+ *    notification when a CallOffer event arrives while the app is in
+ *    the background.
+ */
+object CallNotifier {
+    private var callChannel: NotificationChannel? = null
+    private const val CALL_CHANNEL_ID = "com.vitorpamplona.amethyst.CALL_CHANNEL"
+    private const val CALL_NOTIFICATION_ID = 0x50000
+
+    fun getOrCreateCallChannel(applicationContext: Context): NotificationChannel {
+        callChannel?.let { return it }
+
+        val channel =
+            NotificationChannel(
+                CALL_CHANNEL_ID,
+                stringRes(applicationContext, R.string.app_notification_calls_channel_name),
+                NotificationManager.IMPORTANCE_HIGH,
+            ).apply {
+                description = stringRes(applicationContext, R.string.app_notification_calls_channel_description)
+                // Silence the notification sound — CallAudioManager plays the ringtone
+                setSound(null, null)
+                enableVibration(false)
+            }
+
+        val notificationManager: NotificationManager =
+            applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        notificationManager.createNotificationChannel(channel)
+        callChannel = channel
+        return channel
+    }
+
+    /**
+     * Posts the system incoming-call notification. The notification is a
+     * full-screen intent that opens [CallActivity] when the device is
+     * unlocked, and provides Accept / Reject actions.
+     */
+    fun send(
+        callerName: String,
+        callerBitmap: Bitmap?,
+        applicationContext: Context,
+    ) {
+        val notificationManager: NotificationManager =
+            applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        val channel = getOrCreateCallChannel(applicationContext)
+
+        // Tapping the notification opens the CallActivity
+        val contentIntent =
+            Intent(applicationContext, CallActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            }
+
+        val contentPendingIntent =
+            PendingIntent.getActivity(
+                applicationContext,
+                CALL_NOTIFICATION_ID,
+                contentIntent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+
+        // Accept launches CallActivity directly (not via BroadcastReceiver)
+        // to comply with Android 12+ notification trampoline restrictions.
+        val acceptIntent =
+            Intent(applicationContext, CallActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+                putExtra(CallActivity.EXTRA_ACCEPT_CALL, true)
+            }
+
+        val acceptPendingIntent =
+            PendingIntent.getActivity(
+                applicationContext,
+                CALL_NOTIFICATION_ID + 1,
+                acceptIntent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+
+        val rejectIntent =
+            Intent(applicationContext, CallNotificationReceiver::class.java).apply {
+                action = CallNotificationReceiver.ACTION_REJECT_CALL
+            }
+
+        val rejectPendingIntent =
+            PendingIntent.getBroadcast(
+                applicationContext,
+                CALL_NOTIFICATION_ID + 2,
+                rejectIntent,
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+
+        val builder =
+            NotificationCompat
+                .Builder(applicationContext, channel.id)
+                .setSmallIcon(R.drawable.amethyst)
+                .setContentTitle(stringRes(applicationContext, R.string.call_incoming))
+                .setContentText(callerName)
+                .setLargeIcon(callerBitmap)
+                .setContentIntent(contentPendingIntent)
+                .setFullScreenIntent(contentPendingIntent, true)
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setCategory(NotificationCompat.CATEGORY_CALL)
+                .setAutoCancel(true)
+                .setOngoing(true)
+                .setTimeoutAfter(60_000)
+                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+                .addAction(R.drawable.amethyst, stringRes(applicationContext, R.string.call_reject), rejectPendingIntent)
+                .addAction(R.drawable.amethyst, stringRes(applicationContext, R.string.call_accept), acceptPendingIntent)
+
+        notificationManager.notify("call", CALL_NOTIFICATION_ID, builder.build())
+    }
+
+    /**
+     * Loads the caller's display name + profile picture and posts the
+     * incoming-call notification. Invoked from the `CallSession` state
+     * collector when the call manager transitions to `IncomingCall`.
+     */
+    suspend fun showIncomingCall(
+        callerPubKey: String,
+        context: Context,
+    ) {
+        val callerUser = LocalCache.getOrCreateUser(callerPubKey)
+        val callerName = callerUser.toBestDisplayName()
+        @Suppress("UNUSED_VARIABLE")
+        val uri = "nostr:${callerPubKey.hexToByteArray().toNpub()}"
+
+        val callerBitmap =
+            callerUser.profilePicture()?.let { pictureUrl ->
+                withContext(Dispatchers.IO) {
+                    try {
+                        val request =
+                            ImageRequest
+                                .Builder(context)
+                                .data(pictureUrl)
+                                .allowHardware(false)
+                                .build()
+                        val result = coil3.ImageLoader(context).execute(request)
+                        (result.image?.asDrawable(context.resources) as? BitmapDrawable)?.bitmap
+                    } catch (_: Exception) {
+                        null
+                    }
+                }
+            }
+
+        send(
+            callerName = callerName,
+            callerBitmap = callerBitmap,
+            applicationContext = context,
+        )
+    }
+
+    /** Cancels the incoming-call notification, if shown. */
+    fun cancelIncomingCall(applicationContext: Context) {
+        val notificationManager: NotificationManager =
+            applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.cancel("call", CALL_NOTIFICATION_ID)
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
@@ -36,6 +36,7 @@ import com.vitorpamplona.amethyst.commons.call.CallManager
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
+import com.vitorpamplona.amethyst.service.call.notification.CallNotifier
 import com.vitorpamplona.amethyst.service.notifications.NotificationUtils.sendChessNotification
 import com.vitorpamplona.amethyst.service.notifications.NotificationUtils.sendDMNotification
 import com.vitorpamplona.amethyst.service.notifications.NotificationUtils.sendReactionNotification
@@ -810,13 +811,11 @@ class EventNotificationConsumer(
                 }
             }
 
-        NotificationUtils
-            .sendCallNotification(
-                callerName = callerName,
-                callerBitmap = callerBitmap,
-                uri = "nostr:${event.pubKey.hexToByteArray().toNpub()}",
-                applicationContext = applicationContext,
-            )
+        CallNotifier.send(
+            callerName = callerName,
+            callerBitmap = callerBitmap,
+            applicationContext = applicationContext,
+        )
     }
 
     fun notificationManager(): NotificationManager =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationUtils.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationUtils.kt
@@ -38,11 +38,8 @@ import coil3.asDrawable
 import coil3.request.ImageRequest
 import coil3.request.allowHardware
 import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.ui.MainActivity
 import com.vitorpamplona.amethyst.ui.stringRes
-import com.vitorpamplona.quartz.nip01Core.core.hexToByteArray
-import com.vitorpamplona.quartz.nip19Bech32.toNpub
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -51,14 +48,11 @@ object NotificationUtils {
     private var zapChannel: NotificationChannel? = null
     private var reactionChannel: NotificationChannel? = null
     private var chessChannel: NotificationChannel? = null
-    private var callChannel: NotificationChannel? = null
 
     private const val DM_GROUP_KEY = "com.vitorpamplona.amethyst.DM_NOTIFICATION"
     private const val ZAP_GROUP_KEY = "com.vitorpamplona.amethyst.ZAP_NOTIFICATION"
     private const val REACTION_GROUP_KEY = "com.vitorpamplona.amethyst.REACTION_NOTIFICATION"
     private const val CHESS_GROUP_KEY = "com.vitorpamplona.amethyst.CHESS_NOTIFICATION"
-    private const val CALL_CHANNEL_ID = "com.vitorpamplona.amethyst.CALL_CHANNEL"
-    private const val CALL_NOTIFICATION_ID = 0x50000
 
     const val REPLY_ACTION = "com.vitorpamplona.amethyst.REPLY_ACTION"
     const val MARK_READ_ACTION = "com.vitorpamplona.amethyst.MARK_READ_ACTION"
@@ -520,144 +514,6 @@ object NotificationUtils {
                 )
 
         notify(summaryId, summaryBuilder.build())
-    }
-
-    fun getOrCreateCallChannel(applicationContext: Context): NotificationChannel {
-        if (callChannel != null) return callChannel!!
-
-        callChannel =
-            NotificationChannel(
-                CALL_CHANNEL_ID,
-                stringRes(applicationContext, R.string.app_notification_calls_channel_name),
-                NotificationManager.IMPORTANCE_HIGH,
-            ).apply {
-                description = stringRes(applicationContext, R.string.app_notification_calls_channel_description)
-                // Silence the notification sound — CallAudioManager plays the ringtone
-                setSound(null, null)
-                enableVibration(false)
-            }
-
-        val notificationManager: NotificationManager =
-            applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-
-        notificationManager.createNotificationChannel(callChannel!!)
-
-        return callChannel!!
-    }
-
-    fun sendCallNotification(
-        callerName: String,
-        callerBitmap: Bitmap?,
-        uri: String,
-        applicationContext: Context,
-    ) {
-        val notificationManager: NotificationManager =
-            applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-
-        val channel = getOrCreateCallChannel(applicationContext)
-
-        // Tapping the notification opens the CallActivity
-        val contentIntent =
-            Intent(applicationContext, com.vitorpamplona.amethyst.ui.call.CallActivity::class.java).apply {
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
-            }
-
-        val contentPendingIntent =
-            PendingIntent.getActivity(
-                applicationContext,
-                CALL_NOTIFICATION_ID,
-                contentIntent,
-                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
-            )
-
-        // Accept launches CallActivity directly (not via BroadcastReceiver)
-        // to comply with Android 12+ notification trampoline restrictions.
-        val acceptIntent =
-            Intent(applicationContext, com.vitorpamplona.amethyst.ui.call.CallActivity::class.java).apply {
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
-                putExtra(com.vitorpamplona.amethyst.ui.call.CallActivity.EXTRA_ACCEPT_CALL, true)
-            }
-
-        val acceptPendingIntent =
-            PendingIntent.getActivity(
-                applicationContext,
-                CALL_NOTIFICATION_ID + 1,
-                acceptIntent,
-                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
-            )
-
-        val rejectIntent =
-            Intent(applicationContext, com.vitorpamplona.amethyst.service.call.CallNotificationReceiver::class.java).apply {
-                action = com.vitorpamplona.amethyst.service.call.CallNotificationReceiver.ACTION_REJECT_CALL
-            }
-
-        val rejectPendingIntent =
-            PendingIntent.getBroadcast(
-                applicationContext,
-                CALL_NOTIFICATION_ID + 2,
-                rejectIntent,
-                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
-            )
-
-        val builder =
-            NotificationCompat
-                .Builder(applicationContext, channel.id)
-                .setSmallIcon(R.drawable.amethyst)
-                .setContentTitle(stringRes(applicationContext, R.string.call_incoming))
-                .setContentText(callerName)
-                .setLargeIcon(callerBitmap)
-                .setContentIntent(contentPendingIntent)
-                .setFullScreenIntent(contentPendingIntent, true)
-                .setPriority(NotificationCompat.PRIORITY_HIGH)
-                .setCategory(NotificationCompat.CATEGORY_CALL)
-                .setAutoCancel(true)
-                .setOngoing(true)
-                .setTimeoutAfter(60_000)
-                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-                .addAction(R.drawable.amethyst, stringRes(applicationContext, R.string.call_reject), rejectPendingIntent)
-                .addAction(R.drawable.amethyst, stringRes(applicationContext, R.string.call_accept), acceptPendingIntent)
-
-        notificationManager.notify("call", CALL_NOTIFICATION_ID, builder.build())
-    }
-
-    fun cancelCallNotification(applicationContext: Context) {
-        val notificationManager: NotificationManager =
-            applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.cancel("call", CALL_NOTIFICATION_ID)
-    }
-
-    suspend fun showIncomingCallNotification(
-        callerPubKey: String,
-        context: Context,
-    ) {
-        val callerUser = LocalCache.getOrCreateUser(callerPubKey)
-        val callerName = callerUser.toBestDisplayName()
-        val uri = "nostr:${callerPubKey.hexToByteArray().toNpub()}"
-
-        val callerBitmap =
-            callerUser.profilePicture()?.let { pictureUrl ->
-                withContext(Dispatchers.IO) {
-                    try {
-                        val request =
-                            ImageRequest
-                                .Builder(context)
-                                .data(pictureUrl)
-                                .allowHardware(false)
-                                .build()
-                        val result = coil3.ImageLoader(context).execute(request)
-                        (result.image?.asDrawable(context.resources) as? BitmapDrawable)?.bitmap
-                    } catch (_: Exception) {
-                        null
-                    }
-                }
-            }
-
-        sendCallNotification(
-            callerName = callerName,
-            callerBitmap = callerBitmap,
-            uri = uri,
-            applicationContext = context,
-        )
     }
 
     private fun NotificationManager.isDuplicate(notId: Int): Boolean {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallActivity.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallActivity.kt
@@ -113,7 +113,7 @@ class CallActivity : AppCompatActivity() {
         // Create the Activity-owned call session.
         val callSession =
             CallSession(
-                context = applicationContext,
+                context = this,
                 callManager = callManager,
                 scope = lifecycleScope,
                 publishWrap = { wrap -> accountViewModel.account.publishCallSignaling(wrap) },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallActivity.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallActivity.kt
@@ -49,9 +49,6 @@ import com.vitorpamplona.amethyst.ui.screen.ManageRelayServices
 import com.vitorpamplona.amethyst.ui.screen.ManageWebOkHttp
 import com.vitorpamplona.amethyst.ui.theme.AmethystTheme
 import com.vitorpamplona.quartz.nipACWebRtcCalls.tags.CallType
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 
 class CallActivity : AppCompatActivity() {
@@ -228,40 +225,17 @@ class CallActivity : AppCompatActivity() {
     override fun onDestroy() {
         unregisterPipReceiver()
 
-        val manager = CallSessionBridge.callManager
-
-        // Release all WebRTC/audio/notification resources FIRST, before
-        // the signaling hangup. close() is synchronous and runs before
-        // super.onDestroy() cancels lifecycleScope, so the init
-        // collectors are still alive but close() gets to run first.
+        // Release all WebRTC/audio/notification resources. close() is
+        // synchronous and runs before super.onDestroy() cancels
+        // lifecycleScope.
         session?.close()
         session = null
 
-        // No callback nulling needed — CallSession collects from
-        // SharedFlows; the `closed` flag prevents processing after close().
-
-        // Publish reject/hangup so the remote side stops ringing.
-        // Use goAsync-style: the hangup is best-effort. If the process
-        // dies before it completes, the watchdog on the remote side
-        // (or our own CallManager watchdog) handles cleanup.
-        if (manager != null) {
-            when (manager.state.value) {
-                is CallState.IncomingCall -> {
-                    CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate).launch {
-                        manager.rejectCall()
-                    }
-                }
-                is CallState.Offering,
-                is CallState.Connecting,
-                is CallState.Connected,
-                -> {
-                    CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate).launch {
-                        manager.hangup()
-                    }
-                }
-                else -> {}
-            }
-        }
+        // Hangup signaling is NOT published here. It is handled by
+        // CallForegroundService.onTaskRemoved() / onDestroy() which
+        // runs synchronously via runBlocking with a 3-second timeout.
+        // This is more reliable than the previous fire-and-forget
+        // CoroutineScope that could be killed before completing.
 
         super.onDestroy()
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallActivity.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallActivity.kt
@@ -40,12 +40,15 @@ import androidx.lifecycle.lifecycleScope
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.call.CallState
 import com.vitorpamplona.amethyst.service.call.CallSessionBridge
+import com.vitorpamplona.amethyst.service.call.notification.CallNotifier
 import com.vitorpamplona.amethyst.service.relayClient.authCommand.compose.RelayAuthSubscription
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.AccountFilterAssemblerSubscription
 import com.vitorpamplona.amethyst.ui.StringResSetup
+import com.vitorpamplona.amethyst.ui.call.session.CallSession
 import com.vitorpamplona.amethyst.ui.screen.ManageRelayServices
 import com.vitorpamplona.amethyst.ui.screen.ManageWebOkHttp
 import com.vitorpamplona.amethyst.ui.theme.AmethystTheme
+import com.vitorpamplona.quartz.nipACWebRtcCalls.tags.CallType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -54,9 +57,8 @@ import kotlinx.coroutines.launch
 class CallActivity : AppCompatActivity() {
     val isInPipMode = mutableStateOf(false)
 
-    // Tracks whether we entered PiP at least once, so we can distinguish
-    // "user swiped PiP away" from "user pressed Home from full-screen call".
-    private var wasInPipMode = false
+    /** Activity-owned call session. Created in [onCreate], released in [onDestroy]. */
+    private var session: CallSession? = null
 
     // Launcher for requesting call permissions when accepting from notification
     private val permissionLauncher =
@@ -67,7 +69,6 @@ class CallActivity : AppCompatActivity() {
         }
 
     private var pendingAcceptIsVideo = false
-    private var hangupInitiated = false
 
     private val pipActionReceiver =
         object : BroadcastReceiver() {
@@ -81,7 +82,7 @@ class CallActivity : AppCompatActivity() {
                     }
 
                     ACTION_PIP_TOGGLE_MUTE -> {
-                        CallSessionBridge.callController?.toggleAudioMute()
+                        session?.toggleMute()
                         updatePipParams()
                     }
                 }
@@ -105,7 +106,6 @@ class CallActivity : AppCompatActivity() {
         }
 
         val callManager = CallSessionBridge.callManager
-        val callController = CallSessionBridge.callController
         val accountViewModel = CallSessionBridge.accountViewModel
 
         if (callManager == null || accountViewModel == null) {
@@ -113,9 +113,29 @@ class CallActivity : AppCompatActivity() {
             return
         }
 
+        // Create the Activity-owned call session.
+        val callSession =
+            CallSession(
+                context = applicationContext,
+                callManager = callManager,
+                scope = lifecycleScope,
+                publishWrap = { wrap -> accountViewModel.account.publishCallSignaling(wrap) },
+                signerProvider = { accountViewModel.account.signer },
+                localPubKey = accountViewModel.account.signer.pubKey,
+                settingsProvider = { accountViewModel.account.settings },
+            )
+        session = callSession
+
+        // Wire CallManager callbacks to this session's handlers.
+        callManager.onAnswerReceived = { event -> callSession.onCallAnswerReceived(event.pubKey, event.sdpAnswer()) }
+        callManager.onIceCandidateReceived = { event -> callSession.onIceCandidateReceived(event) }
+        callManager.onNewPeerInGroupCall = { peerPubKey -> callSession.onNewPeerInGroupCall(peerPubKey) }
+        callManager.onMidCallOfferReceived = { peerPubKey, sdpOffer -> callSession.onMidCallOfferReceived(peerPubKey, sdpOffer) }
+        callManager.onPeerLeft = { peerPubKey -> callSession.disposePeerSession(peerPubKey) }
+
         registerPipReceiver()
-        observeVideoStateForPip(callController)
-        handleAcceptCallIntent(intent)
+        observeVideoStateForPip(callSession)
+        handleIntent(intent)
 
         setContent {
             AmethystTheme {
@@ -133,7 +153,7 @@ class CallActivity : AppCompatActivity() {
 
                 CallScreen(
                     callManager = callManager,
-                    callController = callController,
+                    callSession = callSession,
                     accountViewModel = accountViewModel,
                     onCallEnded = { finish() },
                     isInPipMode = isInPipMode.value,
@@ -144,37 +164,57 @@ class CallActivity : AppCompatActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        handleAcceptCallIntent(intent)
+        handleIntent(intent)
     }
 
-    private fun handleAcceptCallIntent(intent: Intent?) {
-        if (intent?.getBooleanExtra(EXTRA_ACCEPT_CALL, false) != true) return
-        // Clear the extra so it doesn't re-trigger on config changes
-        intent.removeExtra(EXTRA_ACCEPT_CALL)
+    private fun handleIntent(intent: Intent?) {
+        intent ?: return
 
-        com.vitorpamplona.amethyst.service.notifications.NotificationUtils
-            .cancelCallNotification(this)
+        // Accept an incoming call (from notification action)
+        if (intent.getBooleanExtra(EXTRA_ACCEPT_CALL, false)) {
+            intent.removeExtra(EXTRA_ACCEPT_CALL)
+            CallNotifier.cancelIncomingCall(this)
 
-        val callManager = CallSessionBridge.callManager ?: return
-        val state = callManager.state.value
-        if (state !is CallState.IncomingCall) return
+            val callManager = CallSessionBridge.callManager ?: return
+            val state = callManager.state.value
+            if (state !is CallState.IncomingCall) return
 
-        val isVideo = state.callType == com.vitorpamplona.quartz.nipACWebRtcCalls.tags.CallType.VIDEO
-        pendingAcceptIsVideo = isVideo
+            val isVideo = state.callType == CallType.VIDEO
+            pendingAcceptIsVideo = isVideo
 
-        if (hasCallPermissions(this, isVideo)) {
-            acceptCall()
-        } else {
-            permissionLauncher.launch(buildCallPermissions(isVideo))
+            if (hasCallPermissions(this, isVideo)) {
+                acceptCall()
+            } else {
+                permissionLauncher.launch(buildCallPermissions(isVideo))
+            }
+            return
+        }
+
+        // Initiate an outgoing call (from ChatroomScreen)
+        if (intent.getBooleanExtra(EXTRA_INITIATE_CALL, false)) {
+            intent.removeExtra(EXTRA_INITIATE_CALL)
+            val peerPubKeys = intent.getStringArrayExtra(EXTRA_PEER_PUB_KEYS)?.toSet() ?: return
+            val callTypeName = intent.getStringExtra(EXTRA_CALL_TYPE) ?: return
+            val callType = CallType.valueOf(callTypeName)
+
+            pendingAcceptIsVideo = callType == CallType.VIDEO
+
+            if (hasCallPermissions(this, callType == CallType.VIDEO)) {
+                session?.initiate(peerPubKeys, callType)
+            } else {
+                // Store for after permission grant — will need separate handling
+                permissionLauncher.launch(buildCallPermissions(callType == CallType.VIDEO))
+            }
+            return
         }
     }
 
     private fun acceptCall() {
-        val callController = CallSessionBridge.callController ?: return
+        val session = session ?: return
         val callManager = CallSessionBridge.callManager ?: return
         val state = callManager.state.value
         if (state is CallState.IncomingCall) {
-            callController.acceptIncomingCall(state.sdpOffer)
+            session.accept(state.sdpOffer)
         }
     }
 
@@ -186,61 +226,20 @@ class CallActivity : AppCompatActivity() {
     override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean) {
         super.onPictureInPictureModeChanged(isInPictureInPictureMode)
         isInPipMode.value = isInPictureInPictureMode
-
-        if (isInPictureInPictureMode) {
-            wasInPipMode = true
-        }
-    }
-
-    override fun onStop() {
-        super.onStop()
-        // Only hang up if the user dismissed PiP (swiped it away).
-        // When PiP is dismissed, Android calls onStop with isInPictureInPictureMode == false
-        // after the activity was previously in PiP mode.
-        // We must NOT hang up when the user simply presses Home from the full-screen
-        // call UI (that enters PiP via onUserLeaveHint instead).
-        if (wasInPipMode && !isInPictureInPictureMode) {
-            hangupInitiated = true
-            val manager = CallSessionBridge.callManager
-            val controller = CallSessionBridge.callController
-            val state = manager?.state?.value
-            if (state is CallState.Connected || state is CallState.Connecting || state is CallState.Offering) {
-                // Publish the hangup signaling event on a detached scope so
-                // it survives activity teardown.
-                CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate).launch {
-                    manager.hangup()
-                }
-            }
-            // Synchronously release all WebRTC/audio resources before the
-            // activity is torn down so we don't leak a PeerConnection,
-            // camera capturer, wake lock, or audio mode change. cleanup() is
-            // idempotent within a call session, so the state-collector path
-            // triggered by hangup() above will be a no-op.
-            controller?.cleanup()
-            finishAndRemoveTask()
-        }
     }
 
     override fun onDestroy() {
         unregisterPipReceiver()
 
+        // Publish reject/hangup so the remote side stops ringing.
         val manager = CallSessionBridge.callManager
-        val controller = CallSessionBridge.callController
-
-        // Safety net: if the Activity is destroyed while a call is still
-        // ringing/offering, publish the reject/hangup signaling so the other
-        // side stops ringing. Skip if onStop already initiated the hangup to
-        // avoid double signaling.
-        if (!hangupInitiated && manager != null) {
+        if (manager != null) {
             when (manager.state.value) {
                 is CallState.IncomingCall -> {
-                    // Publish on a detached scope so the reject event goes out
-                    // even after the activity is gone.
                     CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate).launch {
                         manager.rejectCall()
                     }
                 }
-
                 is CallState.Offering,
                 is CallState.Connecting,
                 is CallState.Connected,
@@ -249,49 +248,22 @@ class CallActivity : AppCompatActivity() {
                         manager.hangup()
                     }
                 }
-
                 else -> {}
             }
         }
 
-        // Ultimate safety net: synchronously release all WebRTC/audio
-        // resources before the Activity reference goes away. The normal
-        // Ended → state-collector → cleanup() path runs asynchronously on
-        // viewModelScope and is not guaranteed to finish before this method
-        // returns. CallController.cleanup() is idempotent within a call
-        // session, so calling it here in addition to the state-collector path
-        // is safe.
-        controller?.cleanup()
-
-        // Hard guarantee: the ringtone, ringback tone, and incoming-call
-        // notification are tied to this Activity's lifecycle. When the
-        // Activity is destroyed for ANY reason (user reject, hangup, finish,
-        // process recreation, etc.), they MUST be gone — even if the
-        // CallController is missing, its cleanup guard is stale, or the
-        // state-collector hasn't fired yet. We had a bug where rejecting a
-        // call left the ringtone playing until the user killed the entire
-        // app from settings; this block is the ultimate stop signal.
-        try {
-            controller?.audioManager?.stopRinging()
-        } catch (_: Exception) {
-        }
-        try {
-            controller?.audioManager?.stopRingbackTone()
-        } catch (_: Exception) {
-        }
-        try {
-            com.vitorpamplona.amethyst.service.notifications.NotificationUtils
-                .cancelCallNotification(this)
-        } catch (_: Exception) {
-        }
+        // Single-shot release of all WebRTC/audio/notification resources.
+        // Guaranteed by Android lifecycle — when Activity dies, the call dies.
+        session?.close()
+        session = null
 
         super.onDestroy()
     }
 
-    private fun observeVideoStateForPip(controller: com.vitorpamplona.amethyst.service.call.CallController?) {
-        controller ?: return
+    private fun observeVideoStateForPip(callSession: CallSession?) {
+        callSession ?: return
         lifecycleScope.launch {
-            controller.isRemoteVideoActive.collect {
+            callSession.isRemoteVideoActive.collect {
                 updatePipParams()
             }
         }
@@ -336,9 +308,9 @@ class CallActivity : AppCompatActivity() {
     }
 
     private fun computePipAspectRatio(): Rational {
-        val controller = CallSessionBridge.callController ?: return Rational(9, 16)
-        val isVideoActive = controller.isRemoteVideoActive.value
-        val videoRatio = controller.remoteVideoAspectRatio.value
+        val s = session ?: return Rational(9, 16)
+        val isVideoActive = s.isRemoteVideoActive.value
+        val videoRatio = s.remoteVideoAspectRatio.value
 
         if (isVideoActive && videoRatio != null && videoRatio > 0f) {
             // Clamp to Android's allowed PiP range (roughly 1:2.39 to 2.39:1)
@@ -355,7 +327,7 @@ class CallActivity : AppCompatActivity() {
         val actions = mutableListOf<RemoteAction>()
 
         // Mute / Unmute toggle
-        val isMuted = CallSessionBridge.callController?.isAudioMuted?.value == true
+        val isMuted = session?.isAudioMuted?.value == true
         val muteIntent =
             PendingIntent.getBroadcast(
                 this,
@@ -413,6 +385,9 @@ class CallActivity : AppCompatActivity() {
 
     companion object {
         const val EXTRA_ACCEPT_CALL = "com.vitorpamplona.amethyst.EXTRA_ACCEPT_CALL"
+        const val EXTRA_INITIATE_CALL = "com.vitorpamplona.amethyst.EXTRA_INITIATE_CALL"
+        const val EXTRA_PEER_PUB_KEYS = "com.vitorpamplona.amethyst.EXTRA_PEER_PUB_KEYS"
+        const val EXTRA_CALL_TYPE = "com.vitorpamplona.amethyst.EXTRA_CALL_TYPE"
         private const val ACTION_PIP_HANGUP = "com.vitorpamplona.amethyst.PIP_HANGUP"
         private const val ACTION_PIP_TOGGLE_MUTE = "com.vitorpamplona.amethyst.PIP_TOGGLE_MUTE"
         private const val PIP_HANGUP_REQUEST_CODE = 0x60001
@@ -422,6 +397,21 @@ class CallActivity : AppCompatActivity() {
             context.startActivity(
                 Intent(context, CallActivity::class.java).apply {
                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                },
+            )
+        }
+
+        fun launchForOutgoingCall(
+            context: Context,
+            peerPubKeys: Set<String>,
+            callType: CallType,
+        ) {
+            context.startActivity(
+                Intent(context, CallActivity::class.java).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    putExtra(EXTRA_INITIATE_CALL, true)
+                    putExtra(EXTRA_PEER_PUB_KEYS, peerPubKeys.toTypedArray())
+                    putExtra(EXTRA_CALL_TYPE, callType.name)
                 },
             )
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallActivity.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallActivity.kt
@@ -231,11 +231,42 @@ class CallActivity : AppCompatActivity() {
         session?.close()
         session = null
 
-        // Hangup signaling is NOT published here. It is handled by
-        // CallForegroundService.onTaskRemoved() / onDestroy() which
-        // runs synchronously via runBlocking with a 3-second timeout.
-        // This is more reliable than the previous fire-and-forget
-        // CoroutineScope that could be killed before completing.
+        // Publish hangup/reject so the remote side stops ringing.
+        // This is the PRIMARY signaling path (covers PiP dismiss,
+        // back press, finish()). CallForegroundService.onTaskRemoved
+        // is the BACKUP for task-swipe-from-Recents where Activity
+        // onDestroy may not complete in time.
+        //
+        // hangup()/rejectCall() are idempotent — if the state is
+        // already Ended/Idle from a prior transition, they return
+        // immediately. So double-publishing from both Activity and
+        // Service is safe.
+        val manager = CallSessionBridge.callManager
+        if (manager != null) {
+            when (manager.state.value) {
+                is CallState.IncomingCall -> {
+                    // Best-effort on a detached scope. If the process
+                    // dies before completion, the remote 60s timeout
+                    // or our 65s watchdog handles it.
+                    kotlinx.coroutines.CoroutineScope(
+                        kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.Main.immediate,
+                    ).launch {
+                        manager.rejectCall()
+                    }
+                }
+                is CallState.Offering,
+                is CallState.Connecting,
+                is CallState.Connected,
+                -> {
+                    kotlinx.coroutines.CoroutineScope(
+                        kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.Main.immediate,
+                    ).launch {
+                        manager.hangup()
+                    }
+                }
+                else -> {}
+            }
+        }
 
         super.onDestroy()
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallActivity.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallActivity.kt
@@ -231,8 +231,29 @@ class CallActivity : AppCompatActivity() {
     override fun onDestroy() {
         unregisterPipReceiver()
 
-        // Publish reject/hangup so the remote side stops ringing.
         val manager = CallSessionBridge.callManager
+
+        // Release all WebRTC/audio/notification resources FIRST, before
+        // the signaling hangup. close() is synchronous and runs before
+        // super.onDestroy() cancels lifecycleScope, so the init
+        // collectors are still alive but close() gets to run first.
+        session?.close()
+        session = null
+
+        // Null out callbacks so signaling events arriving after this
+        // Activity is gone don't route to a dead CallSession.
+        if (manager != null) {
+            manager.onAnswerReceived = null
+            manager.onIceCandidateReceived = null
+            manager.onNewPeerInGroupCall = null
+            manager.onMidCallOfferReceived = null
+            manager.onPeerLeft = null
+        }
+
+        // Publish reject/hangup so the remote side stops ringing.
+        // Use goAsync-style: the hangup is best-effort. If the process
+        // dies before it completes, the watchdog on the remote side
+        // (or our own CallManager watchdog) handles cleanup.
         if (manager != null) {
             when (manager.state.value) {
                 is CallState.IncomingCall -> {
@@ -251,11 +272,6 @@ class CallActivity : AppCompatActivity() {
                 else -> {}
             }
         }
-
-        // Single-shot release of all WebRTC/audio/notification resources.
-        // Guaranteed by Android lifecycle — when Activity dies, the call dies.
-        session?.close()
-        session = null
 
         super.onDestroy()
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallActivity.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallActivity.kt
@@ -248,22 +248,26 @@ class CallActivity : AppCompatActivity() {
                     // Best-effort on a detached scope. If the process
                     // dies before completion, the remote 60s timeout
                     // or our 65s watchdog handles it.
-                    kotlinx.coroutines.CoroutineScope(
-                        kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.Main.immediate,
-                    ).launch {
-                        manager.rejectCall()
-                    }
+                    kotlinx.coroutines
+                        .CoroutineScope(
+                            kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.Main.immediate,
+                        ).launch {
+                            manager.rejectCall()
+                        }
                 }
+
                 is CallState.Offering,
                 is CallState.Connecting,
                 is CallState.Connected,
                 -> {
-                    kotlinx.coroutines.CoroutineScope(
-                        kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.Main.immediate,
-                    ).launch {
-                        manager.hangup()
-                    }
+                    kotlinx.coroutines
+                        .CoroutineScope(
+                            kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.Main.immediate,
+                        ).launch {
+                            manager.hangup()
+                        }
                 }
+
                 else -> {}
             }
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallActivity.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallActivity.kt
@@ -126,12 +126,9 @@ class CallActivity : AppCompatActivity() {
             )
         session = callSession
 
-        // Wire CallManager callbacks to this session's handlers.
-        callManager.onAnswerReceived = { event -> callSession.onCallAnswerReceived(event.pubKey, event.sdpAnswer()) }
-        callManager.onIceCandidateReceived = { event -> callSession.onIceCandidateReceived(event) }
-        callManager.onNewPeerInGroupCall = { peerPubKey -> callSession.onNewPeerInGroupCall(peerPubKey) }
-        callManager.onMidCallOfferReceived = { peerPubKey, sdpOffer -> callSession.onMidCallOfferReceived(peerPubKey, sdpOffer) }
-        callManager.onPeerLeft = { peerPubKey -> callSession.disposePeerSession(peerPubKey) }
+        // No callback wiring needed — CallSession collects from
+        // callManager.sessionEvents and renegotiationEvents SharedFlows
+        // in its init block.
 
         registerPipReceiver()
         observeVideoStateForPip(callSession)
@@ -240,15 +237,8 @@ class CallActivity : AppCompatActivity() {
         session?.close()
         session = null
 
-        // Null out callbacks so signaling events arriving after this
-        // Activity is gone don't route to a dead CallSession.
-        if (manager != null) {
-            manager.onAnswerReceived = null
-            manager.onIceCandidateReceived = null
-            manager.onNewPeerInGroupCall = null
-            manager.onMidCallOfferReceived = null
-            manager.onPeerLeft = null
-        }
+        // No callback nulling needed — CallSession collects from
+        // SharedFlows; the `closed` flag prevents processing after close().
 
         // Publish reject/hangup so the remote side stops ringing.
         // Use goAsync-style: the hangup is best-effort. If the process

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallScreen.kt
@@ -59,7 +59,7 @@ import androidx.compose.ui.unit.sp
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.call.CallManager
 import com.vitorpamplona.amethyst.commons.call.CallState
-import com.vitorpamplona.amethyst.service.call.CallController
+import com.vitorpamplona.amethyst.ui.call.session.CallSession
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
 import kotlinx.coroutines.delay
@@ -68,7 +68,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun CallScreen(
     callManager: CallManager,
-    callController: CallController?,
+    callSession: CallSession?,
     accountViewModel: AccountViewModel,
     onCallEnded: () -> Unit,
     isInPipMode: Boolean = false,
@@ -77,7 +77,7 @@ fun CallScreen(
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
     val emptyStringFlow = remember { kotlinx.coroutines.flow.MutableStateFlow<String?>(null) }
-    val errorMessage by (callController?.errorMessage ?: emptyStringFlow).collectAsState()
+    val errorMessage by (callSession?.errorMessage ?: emptyStringFlow).collectAsState()
 
     BackHandler(enabled = callState !is CallState.Idle && callState !is CallState.Ended) {
         scope.launch { callManager.hangup() }
@@ -124,7 +124,7 @@ fun CallScreen(
                     val isVideoCall = state.callType == com.vitorpamplona.quartz.nipACWebRtcCalls.tags.CallType.VIDEO
                     val acceptWithPermission =
                         rememberCallWithPermission(context, isVideo = isVideoCall) {
-                            callController?.acceptIncomingCall(state.sdpOffer)
+                            callSession?.accept(state.sdpOffer)
                         }
                     IncomingCallUI(
                         groupMembers = otherMembers,
@@ -155,17 +155,17 @@ fun CallScreen(
 
             is CallState.Connected -> {
                 if (isInPipMode) {
-                    PipConnectedCallUI(state = state, callController = callController, accountViewModel = accountViewModel)
+                    PipConnectedCallUI(state = state, callSession = callSession, accountViewModel = accountViewModel)
                 } else {
                     ConnectedCallUI(
                         state = state,
-                        callController = callController,
+                        callSession = callSession,
                         accountViewModel = accountViewModel,
                         onHangup = { scope.launch { callManager.hangup() } },
-                        onToggleMute = { callController?.toggleAudioMute() },
-                        onToggleVideo = { callController?.toggleVideo() },
-                        onCycleAudioRoute = { callController?.cycleAudioRoute() },
-                        onInvitePeer = { peerPubKey -> callController?.invitePeer(peerPubKey) },
+                        onToggleMute = { callSession?.toggleMute() },
+                        onToggleVideo = { callSession?.toggleVideo() },
+                        onCycleAudioRoute = { callSession?.cycleAudioRoute() },
+                        onInvitePeer = { peerPubKey -> callSession?.invitePeer(peerPubKey) },
                     )
                 }
             }
@@ -196,7 +196,7 @@ fun CallScreen(
                     modifier = Modifier.align(Alignment.BottomCenter).padding(16.dp),
                     action = {
                         androidx.compose.material3.TextButton(
-                            onClick = { callController?.clearError() },
+                            onClick = { callSession?.clearError() },
                         ) {
                             Text(
                                 stringRes(R.string.call_dismiss),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/ConnectedCallUI.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/ConnectedCallUI.kt
@@ -71,7 +71,7 @@ import androidx.compose.ui.unit.sp
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.call.CallState
 import com.vitorpamplona.amethyst.service.call.AudioRoute
-import com.vitorpamplona.amethyst.service.call.CallController
+import com.vitorpamplona.amethyst.ui.call.session.CallSession
 import com.vitorpamplona.amethyst.ui.note.creators.userSuggestions.ShowUserSuggestionList
 import com.vitorpamplona.amethyst.ui.note.creators.userSuggestions.UserSuggestionState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -83,7 +83,7 @@ import org.webrtc.VideoTrack
 @Composable
 fun ConnectedCallUI(
     state: CallState.Connected,
-    callController: CallController?,
+    callSession: CallSession?,
     accountViewModel: AccountViewModel,
     onHangup: () -> Unit,
     onToggleMute: () -> Unit,
@@ -103,15 +103,15 @@ fun ConnectedCallUI(
     val emptyVideoFlow = remember { kotlinx.coroutines.flow.MutableStateFlow<VideoTrack?>(null) }
     val emptyTracksFlow = remember { kotlinx.coroutines.flow.MutableStateFlow<Map<String, VideoTrack>>(emptyMap()) }
     val emptySetFlow = remember { kotlinx.coroutines.flow.MutableStateFlow<Set<String>>(emptySet()) }
-    val remoteVideoTracks by (callController?.remoteVideoTracks ?: emptyTracksFlow).collectAsState()
-    val activePeerVideos by (callController?.activePeerVideos ?: emptySetFlow).collectAsState()
-    val localVideoTrack by (callController?.localVideoTrack ?: emptyVideoFlow).collectAsState()
+    val remoteVideoTracks by (callSession?.remoteVideoTracks ?: emptyTracksFlow).collectAsState()
+    val activePeerVideos by (callSession?.activePeerVideos ?: emptySetFlow).collectAsState()
+    val localVideoTrack by (callSession?.localVideoTrack ?: emptyVideoFlow).collectAsState()
     val defaultFalse = remember { kotlinx.coroutines.flow.MutableStateFlow(false) }
     val defaultTrue = remember { kotlinx.coroutines.flow.MutableStateFlow(true) }
-    val isAudioMuted by (callController?.isAudioMuted ?: defaultFalse).collectAsState()
-    val isVideoEnabled by (callController?.isVideoEnabled ?: defaultTrue).collectAsState()
-    val isFrontCamera by (callController?.isFrontCamera ?: defaultTrue).collectAsState()
-    val currentAudioRoute by (callController?.audioRoute ?: remember { kotlinx.coroutines.flow.MutableStateFlow(AudioRoute.EARPIECE) }).collectAsState()
+    val isAudioMuted by (callSession?.isAudioMuted ?: defaultFalse).collectAsState()
+    val isVideoEnabled by (callSession?.isVideoEnabled ?: defaultTrue).collectAsState()
+    val isFrontCamera by (callSession?.isFrontCamera ?: defaultTrue).collectAsState()
+    val currentAudioRoute by (callSession?.audioRoute ?: remember { kotlinx.coroutines.flow.MutableStateFlow(AudioRoute.EARPIECE) }).collectAsState()
     val hasActiveVideo =
         state.callType == com.vitorpamplona.quartz.nipACWebRtcCalls.tags.CallType.VIDEO ||
             isVideoEnabled ||
@@ -148,7 +148,7 @@ fun ConnectedCallUI(
                 pendingPeerPubKeys = state.pendingPeerPubKeys,
                 remoteVideoTracks = remoteVideoTracks,
                 activePeerVideos = activePeerVideos,
-                eglBase = callController?.getEglBase(),
+                eglBase = callSession?.getEglBase(),
                 accountViewModel = accountViewModel,
                 modifier = Modifier.fillMaxSize(),
             )
@@ -157,7 +157,7 @@ fun ConnectedCallUI(
                 localVideoTrack?.let { track ->
                     VideoRenderer(
                         videoTrack = track,
-                        eglBase = callController?.getEglBase(),
+                        eglBase = callSession?.getEglBase(),
                         modifier =
                             Modifier
                                 .size(120.dp, 160.dp)
@@ -220,7 +220,7 @@ fun ConnectedCallUI(
             currentAudioRoute = currentAudioRoute,
             onToggleMute = onToggleMute,
             onToggleVideo = onToggleVideo,
-            onSwitchCamera = { callController?.switchCamera() },
+            onSwitchCamera = { callSession?.switchCamera() },
             onCycleAudioRoute = onCycleAudioRoute,
             onAddParticipant = { showAddParticipant = true },
             onHangup = onHangup,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/PipCallUI.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/PipCallUI.kt
@@ -43,7 +43,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.vitorpamplona.amethyst.commons.call.CallState
-import com.vitorpamplona.amethyst.service.call.CallController
+import com.vitorpamplona.amethyst.ui.call.session.CallSession
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.delay
@@ -84,7 +84,7 @@ fun PipCallUI(
 @Composable
 fun PipConnectedCallUI(
     state: CallState.Connected,
-    callController: CallController?,
+    callSession: CallSession?,
     accountViewModel: AccountViewModel,
 ) {
     var elapsed by remember { mutableLongStateOf(0L) }
@@ -98,10 +98,10 @@ fun PipConnectedCallUI(
 
     val emptyTracksFlow = remember { kotlinx.coroutines.flow.MutableStateFlow<Map<String, VideoTrack>>(emptyMap()) }
     val emptySetFlow = remember { kotlinx.coroutines.flow.MutableStateFlow<Set<String>>(emptySet()) }
-    val remoteVideoTracks by (callController?.remoteVideoTracks ?: emptyTracksFlow).collectAsState()
-    val activePeerVideos by (callController?.activePeerVideos ?: emptySetFlow).collectAsState()
+    val remoteVideoTracks by (callSession?.remoteVideoTracks ?: emptyTracksFlow).collectAsState()
+    val activePeerVideos by (callSession?.activePeerVideos ?: emptySetFlow).collectAsState()
     val defaultFalse = remember { kotlinx.coroutines.flow.MutableStateFlow(false) }
-    val isVideoEnabled by (callController?.isVideoEnabled ?: defaultFalse).collectAsState()
+    val isVideoEnabled by (callSession?.isVideoEnabled ?: defaultFalse).collectAsState()
     val hasActiveVideo =
         state.callType == com.vitorpamplona.quartz.nipACWebRtcCalls.tags.CallType.VIDEO ||
             isVideoEnabled ||
@@ -124,7 +124,7 @@ fun PipConnectedCallUI(
             if (activeTrack != null) {
                 VideoRenderer(
                     videoTrack = activeTrack,
-                    eglBase = callController?.getEglBase(),
+                    eglBase = callSession?.getEglBase(),
                     modifier = Modifier.fillMaxSize(),
                     mirror = false,
                 )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/session/CallSession.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/session/CallSession.kt
@@ -589,22 +589,36 @@ class CallSession(
             WebRtcCallSession(
                 peerConnectionFactory = factory,
                 iceServers = IceServerConfig.buildIceServers(settingsProvider().callTurnServers),
-                onIceCandidate = { candidate -> onLocalIceCandidate(peerPubKey, candidate) },
+                onIceCandidate = { candidate ->
+                    if (!closed) onLocalIceCandidate(peerPubKey, candidate)
+                },
                 onPeerConnected = {
+                    if (closed) return@WebRtcCallSession
                     Log.d(TAG) { "Peer ${peerPubKey.take(8)} connected!" }
                     scope.launch {
+                        if (closed) return@launch
                         callManager.onPeerConnected()
                         if (callManager.state.value is CallState.Connected) {
                             ensureForegroundService()
                         }
                     }
                 },
-                onRemoteVideoTrack = { track -> videoMonitor.onRemoteVideoTrack(peerPubKey, track) },
-                onDisconnected = { scope.launch { onPeerDisconnected(peerPubKey) } },
-                onError = { error -> _errorMessage.value = error },
-                onRenegotiationNeeded = { performRenegotiation(peerPubKey) },
+                onRemoteVideoTrack = { track ->
+                    if (!closed) videoMonitor.onRemoteVideoTrack(peerPubKey, track)
+                },
+                onDisconnected = {
+                    if (!closed) scope.launch { onPeerDisconnected(peerPubKey) }
+                },
+                onError = { error ->
+                    if (!closed) _errorMessage.value = error
+                },
+                onRenegotiationNeeded = {
+                    if (!closed) performRenegotiation(peerPubKey)
+                },
                 onIceRestartOffer = { sdp ->
-                    scope.launch { callManager.sendRenegotiation(sdp.description, peerPubKey) }
+                    if (!closed) {
+                        scope.launch { callManager.sendRenegotiation(sdp.description, peerPubKey) }
+                    }
                 },
             )
         try {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/session/CallSession.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/session/CallSession.kt
@@ -113,6 +113,7 @@ class CallSession(
     val isBluetoothAvailable: StateFlow<Boolean> = audioManager.isBluetoothAvailable
 
     @Volatile private var videoPausedByProximity = false
+    @Volatile private var closed = false
 
     @Volatile private var foregroundServiceStarted = false
     private val videoSenders = ConcurrentHashMap<HexKey, org.webrtc.RtpSender>()
@@ -145,12 +146,13 @@ class CallSession(
         // restarts.
         scope.launch {
             callManager.renegotiationEvents.collect { event ->
-                onRenegotiationOfferReceived(event)
+                if (!closed) onRenegotiationOfferReceived(event)
             }
         }
 
         scope.launch {
             callManager.state.collect { state ->
+                if (closed) return@collect
                 when (state) {
                     is CallState.IncomingCall -> {
                         ensureForegroundService()
@@ -660,6 +662,9 @@ class CallSession(
      * once from [onDestroy].
      */
     override fun close() {
+        // Signal the init collectors to stop touching resources.
+        closed = true
+
         try {
             audioManager.stopRinging()
         } catch (e: Exception) {
@@ -691,12 +696,16 @@ class CallSession(
 
         videoMonitor.dispose()
 
-        try {
-            peerSessionMgr.disposeAll()
-        } catch (e: Exception) {
-            Log.e(TAG, "close: sessionManager.disposeAll() failed", e)
+        // Synchronized to prevent a concurrent collector from reading
+        // the old manager after disposeAll() but before reassignment.
+        synchronized(this) {
+            try {
+                peerSessionMgr.disposeAll()
+            } catch (e: Exception) {
+                Log.e(TAG, "close: sessionManager.disposeAll() failed", e)
+            }
+            peerSessionMgr = PeerSessionManager(peerSessionMgr.localPubKey)
         }
-        peerSessionMgr = PeerSessionManager(peerSessionMgr.localPubKey)
 
         mediaManager.dispose()
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/session/CallSession.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/session/CallSession.kt
@@ -18,7 +18,7 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.service.call
+package com.vitorpamplona.amethyst.ui.call.session
 
 import android.content.Context
 import android.content.Intent
@@ -35,7 +35,15 @@ import com.vitorpamplona.amethyst.commons.call.PeerSession
 import com.vitorpamplona.amethyst.commons.call.PeerSessionManager
 import com.vitorpamplona.amethyst.commons.call.SdpType
 import com.vitorpamplona.amethyst.commons.call.SignalingState
-import com.vitorpamplona.amethyst.service.notifications.NotificationUtils
+import com.vitorpamplona.amethyst.service.call.AudioRoute
+import com.vitorpamplona.amethyst.service.call.CallAudioManager
+import com.vitorpamplona.amethyst.service.call.CallForegroundService
+import com.vitorpamplona.amethyst.service.call.CallMediaManager
+import com.vitorpamplona.amethyst.service.call.IceServerConfig
+import com.vitorpamplona.amethyst.service.call.RemoteVideoMonitor
+import com.vitorpamplona.amethyst.service.call.WebRtcCallSession
+import com.vitorpamplona.amethyst.service.call.WebRtcPeerSessionAdapter
+import com.vitorpamplona.amethyst.service.call.notification.CallNotifier
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip59Giftwrap.wraps.EphemeralGiftWrapEvent
 import com.vitorpamplona.quartz.nipACWebRtcCalls.WebRtcCallFactory
@@ -55,13 +63,18 @@ import org.webrtc.IceCandidate
 import org.webrtc.VideoTrack
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicBoolean
 
-private const val TAG = "CallController"
+private const val TAG = "CallSession"
 private const val VIDEO_MAX_BITRATE_BPS_DEFAULT = 1_500_000
 
+/**
+ * One-per-Activity call session. Created in [CallActivity.onCreate],
+ * destroyed in [CallActivity.onDestroy] via [close]. This guarantees
+ * that every WebRTC/audio/notification resource is released when the
+ * Activity dies — no guard flags, no race-sensitive state observing.
+ */
 @Stable
-class CallController(
+class CallSession(
     private val context: Context,
     val callManager: CallManager,
     private val scope: CoroutineScope,
@@ -69,7 +82,7 @@ class CallController(
     private val signerProvider: suspend () -> com.vitorpamplona.quartz.nip01Core.signers.NostrSigner,
     localPubKey: HexKey,
     private val settingsProvider: () -> com.vitorpamplona.amethyst.model.AccountSettings,
-) {
+) : AutoCloseable {
     private var peerSessionMgr = PeerSessionManager(localPubKey)
 
     private fun webRtcSession(peerPubKey: HexKey): WebRtcCallSession? = (peerSessionMgr.getSession(peerPubKey)?.session as? WebRtcPeerSessionAdapter)?.webRtcSession
@@ -102,7 +115,6 @@ class CallController(
     @Volatile private var videoPausedByProximity = false
 
     @Volatile private var foregroundServiceStarted = false
-    private val cleanedUp = AtomicBoolean(false)
     private val videoSenders = ConcurrentHashMap<HexKey, org.webrtc.RtpSender>()
 
     private val pendingRenegotiation = ConcurrentHashMap<HexKey, Boolean>()
@@ -128,33 +140,27 @@ class CallController(
     // ---- Initialization ----
 
     init {
-        callManager.onRenegotiationOfferReceived = { event -> onRenegotiationOfferReceived(event) }
+        // Subscribe to renegotiation events via SharedFlow instead of a
+        // mutable callback, so we never miss an event across Activity
+        // restarts.
+        scope.launch {
+            callManager.renegotiationEvents.collect { event ->
+                onRenegotiationOfferReceived(event)
+            }
+        }
 
         scope.launch {
             callManager.state.collect { state ->
                 when (state) {
                     is CallState.IncomingCall -> {
-                        // A new call session begins — arm cleanup() so it will
-                        // run for this session's Ended transition. This MUST
-                        // happen for every incoming call (even ones the user
-                        // ends up rejecting), otherwise a stale cleanedUp flag
-                        // from the previous call session would turn cleanup()
-                        // into a no-op and leave the ringtone/notification
-                        // playing forever. See the bug where rejecting a
-                        // second consecutive call required killing the app.
-                        cleanedUp.set(false)
                         ensureForegroundService()
                         withContext(Dispatchers.IO) { audioManager.startRinging() }
                         scope.launch {
-                            NotificationUtils.showIncomingCallNotification(state.callerPubKey, context)
+                            CallNotifier.showIncomingCall(state.callerPubKey, context)
                         }
                     }
 
                     is CallState.Offering -> {
-                        // Same rationale as IncomingCall above: ensure cleanup
-                        // can run for this session even if the previous one
-                        // already ran cleanup().
-                        cleanedUp.set(false)
                         audioManager.startRingbackTone()
                         ensureForegroundService()
                     }
@@ -164,7 +170,7 @@ class CallController(
                         audioManager.stopRingbackTone()
                         withContext(Dispatchers.IO) { audioManager.switchToCallAudioMode() }
                         audioManager.acquireProximityWakeLock()
-                        NotificationUtils.cancelCallNotification(context)
+                        CallNotifier.cancelIncomingCall(context)
                         updateForegroundServiceNotification()
                         registerNetworkCallback()
                     }
@@ -174,19 +180,21 @@ class CallController(
                         audioManager.stopRingbackTone()
                         withContext(Dispatchers.IO) { audioManager.switchToCallAudioMode() }
                         audioManager.acquireProximityWakeLock()
-                        NotificationUtils.cancelCallNotification(context)
+                        CallNotifier.cancelIncomingCall(context)
                         updateForegroundServiceNotification()
                         registerNetworkCallback()
                     }
 
                     is CallState.Ended -> {
-                        cleanup()
+                        // Stop ringing/ringback — close() handles the
+                        // full teardown when the Activity is destroyed.
+                        audioManager.stopRinging()
+                        audioManager.stopRingbackTone()
+                        CallNotifier.cancelIncomingCall(context)
                     }
 
                     is CallState.Idle -> {
-                        // No cleanup here — Ended already handled it.
-                        // Ended auto-resets to Idle after 2 seconds;
-                        // running cleanup twice is wasteful and logs errors.
+                        // No action — Ended already stopped audio/notification.
                     }
                 }
             }
@@ -216,18 +224,14 @@ class CallController(
 
     // ---- Call initiation (caller side) ----
 
-    fun initiateGroupCall(
+    fun initiate(
         peerPubKeys: Set<String>,
         callType: CallType,
     ) {
-        Log.d(TAG) { "initiateCallInternal: peers=${peerPubKeys.map { it.take(8) }}, callType=$callType" }
+        Log.d(TAG) { "initiate: peers=${peerPubKeys.map { it.take(8) }}, callType=$callType" }
         scope.launch {
             val callId = UUID.randomUUID().toString()
             _errorMessage.value = null
-
-            // A new call session begins — arm cleanup() so it will run again
-            // for this session's Ended transition.
-            cleanedUp.set(false)
             applyCallSettings()
             try {
                 withContext(Dispatchers.IO) { mediaManager.initialize(callType) }
@@ -266,17 +270,13 @@ class CallController(
 
     // ---- Accept incoming call (callee side) ----
 
-    fun acceptIncomingCall(sdpOffer: String) {
+    fun accept(sdpOffer: String) {
         val state = callManager.state.value
         if (state !is CallState.IncomingCall) return
 
         val callerPubKey = state.callerPubKey
         scope.launch {
             _errorMessage.value = null
-
-            // A new call session begins — arm cleanup() so it will run again
-            // for this session's Ended transition.
-            cleanedUp.set(false)
             applyCallSettings()
             try {
                 withContext(Dispatchers.IO) { mediaManager.initialize(state.callType) }
@@ -505,7 +505,7 @@ class CallController(
 
     // ---- UI toggle controls ----
 
-    fun toggleAudioMute() {
+    fun toggleMute() {
         val muted = !_isAudioMuted.value
         _isAudioMuted.value = muted
         mediaManager.setAudioMuted(muted)
@@ -649,63 +649,43 @@ class CallController(
         }
     }
 
-    // ---- Cleanup ----
+    // ---- Close (AutoCloseable) ----
 
     /**
-     * Releases all WebRTC, audio, and foreground-service resources for the
-     * current call session.
-     *
-     * Stopping the ringtone, ringback tone, and incoming-call notification
-     * runs UNCONDITIONALLY on every invocation — even if the heavy teardown
-     * has already been done. These three operations are idempotent and must
-     * never be skipped, otherwise a stale [cleanedUp] flag could leave the
-     * ringtone playing and the notification stuck on screen until the app is
-     * force-killed.
-     *
-     * The remainder (peer-session disposal, media manager, network callbacks,
-     * etc.) is guarded by [cleanedUp] and runs at most once per call session.
-     * The guard is re-armed when a new call starts: outgoing calls re-arm in
-     * [initiateGroupCall], accepted incoming calls in [acceptIncomingCall],
-     * and any new IncomingCall/Offering state transition in the state
-     * collector. This last path is critical for incoming calls the user
-     * rejects (or that the remote party hangs up), since neither
-     * [initiateGroupCall] nor [acceptIncomingCall] is invoked for them.
+     * Single-shot teardown tied to Activity destruction. Unconditionally
+     * releases every resource this session owns: audio, ringtone, ringback,
+     * notification, WebRTC peer connections, network callback, foreground
+     * service, and proximity wake lock. No guard flags — each Activity
+     * instance creates exactly one [CallSession] and calls [close] exactly
+     * once from [onDestroy].
      */
-    fun cleanup() {
-        // Stop the ringtone, ringback tone, and incoming-call notification
-        // UNCONDITIONALLY — these are idempotent and absolutely critical for
-        // the user experience. They must run on every cleanup() call, even if
-        // the heavy resource teardown below is already complete (cleanedUp ==
-        // true). Otherwise an unexpected double-cleanup or a stale cleanedUp
-        // flag from a previous session could leave the ringtone playing and
-        // the notification stuck on screen until the app is force-killed.
+    override fun close() {
         try {
             audioManager.stopRinging()
         } catch (e: Exception) {
-            Log.e(TAG, "cleanup: audioManager.stopRinging() failed", e)
+            Log.e(TAG, "close: audioManager.stopRinging() failed", e)
         }
         try {
             audioManager.stopRingbackTone()
         } catch (e: Exception) {
-            Log.e(TAG, "cleanup: audioManager.stopRingbackTone() failed", e)
+            Log.e(TAG, "close: audioManager.stopRingbackTone() failed", e)
         }
         try {
-            NotificationUtils.cancelCallNotification(context)
+            CallNotifier.cancelIncomingCall(context)
         } catch (e: Exception) {
-            Log.e(TAG, "cleanup: cancelCallNotification() failed", e)
+            Log.e(TAG, "close: cancelIncomingCall() failed", e)
         }
 
-        if (!cleanedUp.compareAndSet(false, true)) return
         unregisterNetworkCallback()
         try {
             audioManager.release()
         } catch (e: Exception) {
-            Log.e(TAG, "cleanup: audioManager.release() failed", e)
+            Log.e(TAG, "close: audioManager.release() failed", e)
         }
         try {
             stopForegroundService()
         } catch (e: Exception) {
-            Log.e(TAG, "cleanup: stopForegroundService() failed", e)
+            Log.e(TAG, "close: stopForegroundService() failed", e)
         }
         foregroundServiceStarted = false
 
@@ -714,7 +694,7 @@ class CallController(
         try {
             peerSessionMgr.disposeAll()
         } catch (e: Exception) {
-            Log.e(TAG, "cleanup: sessionManager.disposeAll() failed", e)
+            Log.e(TAG, "close: sessionManager.disposeAll() failed", e)
         }
         peerSessionMgr = PeerSessionManager(peerSessionMgr.localPubKey)
 
@@ -724,12 +704,6 @@ class CallController(
         videoPausedByProximity = false
         videoSenders.clear()
         pendingRenegotiation.clear()
-        // NOTE: cleanedUp intentionally stays true here so that a second,
-        // sequential cleanup() in the same call session is a no-op for the
-        // heavy teardown above. The flag is re-armed when a new call session
-        // begins, in initiateGroupCall() / acceptIncomingCall() AND in the
-        // state collector for IncomingCall / Offering transitions, so
-        // subsequent sessions still clean up correctly.
     }
 
     // ---- Foreground service ----

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/session/CallSession.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/session/CallSession.kt
@@ -141,9 +141,28 @@ class CallSession(
     // ---- Initialization ----
 
     init {
-        // Subscribe to renegotiation events via SharedFlow instead of a
-        // mutable callback, so we never miss an event across Activity
-        // restarts.
+        // Collect all session-level events (answers, ICE candidates,
+        // peer joins/leaves, mid-call offers) from the single SharedFlow.
+        scope.launch {
+            callManager.sessionEvents.collect { event ->
+                if (closed) return@collect
+                when (event) {
+                    is com.vitorpamplona.amethyst.commons.call.CallSessionEvent.AnswerReceived ->
+                        onCallAnswerReceived(event.event.pubKey, event.event.sdpAnswer())
+                    is com.vitorpamplona.amethyst.commons.call.CallSessionEvent.IceCandidateReceived ->
+                        onIceCandidateReceived(event.event)
+                    is com.vitorpamplona.amethyst.commons.call.CallSessionEvent.NewPeerInGroupCall ->
+                        onNewPeerInGroupCall(event.peerPubKey)
+                    is com.vitorpamplona.amethyst.commons.call.CallSessionEvent.MidCallOfferReceived ->
+                        onMidCallOfferReceived(event.peerPubKey, event.sdpOffer)
+                    is com.vitorpamplona.amethyst.commons.call.CallSessionEvent.PeerLeft ->
+                        disposePeerSession(event.peerPubKey)
+                }
+            }
+        }
+
+        // Renegotiation events have their own flow because they go
+        // through dedicated glare-resolution logic.
         scope.launch {
             callManager.renegotiationEvents.collect { event ->
                 if (!closed) onRenegotiationOfferReceived(event)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/session/CallSession.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/session/CallSession.kt
@@ -181,6 +181,7 @@ class CallSession(
 
         scope.launch {
             callManager.state.collect { state ->
+                Log.d(TAG) { "state collector received: ${state::class.simpleName} closed=$closed thread=${Thread.currentThread().name}" }
                 if (closed) return@collect
                 when (state) {
                     is CallState.IncomingCall -> {
@@ -705,6 +706,7 @@ class CallSession(
      * once from [onDestroy].
      */
     override fun close() {
+        Log.d(TAG) { "close() called on ${Thread.currentThread().name} state=${callManager.state.value::class.simpleName}" }
         // Signal the init collectors to stop touching resources.
         closed = true
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/session/CallSession.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/session/CallSession.kt
@@ -113,6 +113,7 @@ class CallSession(
     val isBluetoothAvailable: StateFlow<Boolean> = audioManager.isBluetoothAvailable
 
     @Volatile private var videoPausedByProximity = false
+
     @Volatile private var closed = false
 
     @Volatile private var foregroundServiceStarted = false
@@ -147,16 +148,25 @@ class CallSession(
             callManager.sessionEvents.collect { event ->
                 if (closed) return@collect
                 when (event) {
-                    is com.vitorpamplona.amethyst.commons.call.CallSessionEvent.AnswerReceived ->
+                    is com.vitorpamplona.amethyst.commons.call.CallSessionEvent.AnswerReceived -> {
                         onCallAnswerReceived(event.event.pubKey, event.event.sdpAnswer())
-                    is com.vitorpamplona.amethyst.commons.call.CallSessionEvent.IceCandidateReceived ->
+                    }
+
+                    is com.vitorpamplona.amethyst.commons.call.CallSessionEvent.IceCandidateReceived -> {
                         onIceCandidateReceived(event.event)
-                    is com.vitorpamplona.amethyst.commons.call.CallSessionEvent.NewPeerInGroupCall ->
+                    }
+
+                    is com.vitorpamplona.amethyst.commons.call.CallSessionEvent.NewPeerInGroupCall -> {
                         onNewPeerInGroupCall(event.peerPubKey)
-                    is com.vitorpamplona.amethyst.commons.call.CallSessionEvent.MidCallOfferReceived ->
+                    }
+
+                    is com.vitorpamplona.amethyst.commons.call.CallSessionEvent.MidCallOfferReceived -> {
                         onMidCallOfferReceived(event.peerPubKey, event.sdpOffer)
-                    is com.vitorpamplona.amethyst.commons.call.CallSessionEvent.PeerLeft ->
+                    }
+
+                    is com.vitorpamplona.amethyst.commons.call.CallSessionEvent.PeerLeft -> {
                         disposePeerSession(event.peerPubKey)
+                    }
                 }
             }
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -41,7 +41,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.call.CallState
-
 import com.vitorpamplona.amethyst.service.crashreports.DisplayCrashMessages
 import com.vitorpamplona.amethyst.service.relayClient.notifyCommand.compose.DisplayNotifyMessages
 import com.vitorpamplona.amethyst.ui.actions.NewUserMetadataScreen

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -41,7 +41,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.call.CallState
-import com.vitorpamplona.amethyst.service.call.CallSessionBridge
+
 import com.vitorpamplona.amethyst.service.crashreports.DisplayCrashMessages
 import com.vitorpamplona.amethyst.service.relayClient.notifyCommand.compose.DisplayNotifyMessages
 import com.vitorpamplona.amethyst.ui.actions.NewUserMetadataScreen
@@ -192,8 +192,7 @@ private fun ObserveIncomingCalls(accountViewModel: AccountViewModel) {
 
     LaunchedEffect(callState) {
         val state = callState
-        if (state is CallState.IncomingCall) {
-            CallSessionBridge.set(accountViewModel.callManager, accountViewModel.callController, accountViewModel)
+        if (state is CallState.IncomingCall || state is CallState.Offering) {
             CallActivity.launch(context)
         }
     }
@@ -204,11 +203,6 @@ fun BuildNavigation(
     accountViewModel: AccountViewModel,
     nav: Nav,
 ) {
-    val context = androidx.compose.ui.platform.LocalContext.current
-    androidx.compose.runtime.LaunchedEffect(Unit) {
-        accountViewModel.initCallController(context)
-    }
-
     NavHost(
         navController = nav.controller,
         startDestination = Route.Home,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -67,7 +67,6 @@ import com.vitorpamplona.amethyst.model.privacyOptions.RoleBasedHttpClientBuilde
 import com.vitorpamplona.amethyst.service.OnlineChecker
 import com.vitorpamplona.amethyst.service.ZapPaymentHandler
 import com.vitorpamplona.amethyst.service.broadcast.BroadcastTracker
-
 import com.vitorpamplona.amethyst.service.cashu.CashuToken
 import com.vitorpamplona.amethyst.service.cashu.melt.MeltProcessor
 import com.vitorpamplona.amethyst.service.checkNotInMainThread

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -67,7 +67,7 @@ import com.vitorpamplona.amethyst.model.privacyOptions.RoleBasedHttpClientBuilde
 import com.vitorpamplona.amethyst.service.OnlineChecker
 import com.vitorpamplona.amethyst.service.ZapPaymentHandler
 import com.vitorpamplona.amethyst.service.broadcast.BroadcastTracker
-import com.vitorpamplona.amethyst.service.call.CallController
+
 import com.vitorpamplona.amethyst.service.cashu.CashuToken
 import com.vitorpamplona.amethyst.service.cashu.melt.MeltProcessor
 import com.vitorpamplona.amethyst.service.checkNotInMainThread
@@ -205,39 +205,17 @@ class AccountViewModel(
             isCallsEnabled = { account.settings.callsEnabled.value },
         )
 
-    var callController: CallController? = null
-        private set
-
-    @Synchronized
-    fun initCallController(context: Context) {
-        if (callController != null) return
-
-        // Wire EventProcessor before creating CallController so events aren't dropped
+    init {
+        // Wire the signaling event processor eagerly so incoming call
+        // events are routed to CallManager even before any CallActivity
+        // is launched. Previously this was deferred to initCallController,
+        // which could miss events if the UI hadn't mounted yet.
         account.newNotesPreProcessor.callManager = callManager
 
-        val controller =
-            CallController(
-                context = context,
-                callManager = callManager,
-                scope = viewModelScope,
-                publishWrap = { wrap -> account.publishCallSignaling(wrap) },
-                signerProvider = { account.signer },
-                localPubKey = account.signer.pubKey,
-                settingsProvider = { account.settings },
-            )
-
-        // Set callbacks before exposing controller to avoid timing races
-        callManager.onAnswerReceived = { event -> controller.onCallAnswerReceived(event.pubKey, event.sdpAnswer()) }
-        callManager.onIceCandidateReceived = { event -> controller.onIceCandidateReceived(event) }
-        callManager.onNewPeerInGroupCall = { peerPubKey -> controller.onNewPeerInGroupCall(peerPubKey) }
-        callManager.onMidCallOfferReceived = { peerPubKey, sdpOffer -> controller.onMidCallOfferReceived(peerPubKey, sdpOffer) }
-        callManager.onPeerLeft = { peerPubKey -> controller.disposePeerSession(peerPubKey) }
-        callController = controller
-
-        // Populate CallSessionBridge so CallActivity can launch even when the app
-        // is in the background (e.g. full-screen incoming call intent).
+        // Populate CallSessionBridge so CallActivity and background
+        // receivers can reach callManager + accountViewModel.
         com.vitorpamplona.amethyst.service.call.CallSessionBridge
-            .set(callManager, controller, this)
+            .set(callManager, this)
     }
 
     val eventSync =
@@ -1575,7 +1553,7 @@ class AccountViewModel(
 
     override fun onCleared() {
         Log.d("AccountViewModel", "onCleared")
-        callController?.cleanup()
+        callManager.dispose()
         com.vitorpamplona.amethyst.service.call.CallSessionBridge
             .clear()
         feedStates.destroy()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/ChatroomScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/ChatroomScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import com.vitorpamplona.amethyst.service.call.CallSessionBridge
 import com.vitorpamplona.amethyst.ui.call.CallActivity
 import com.vitorpamplona.amethyst.ui.call.rememberCallWithPermission
 import com.vitorpamplona.amethyst.ui.layouts.DisappearingScaffold
@@ -56,15 +55,19 @@ fun ChatroomScreen(
     val isCallSupported = roomId.users.size <= 5 && callsEnabled
     val startVoiceCall =
         rememberCallWithPermission(context) {
-            CallSessionBridge.set(accountViewModel.callManager, accountViewModel.callController, accountViewModel)
-            accountViewModel.callController?.initiateGroupCall(roomId.users.toSet(), CallType.VOICE)
-            CallActivity.launch(context)
+            CallActivity.launchForOutgoingCall(
+                context,
+                roomId.users.toSet(),
+                CallType.VOICE,
+            )
         }
     val startVideoCall =
         rememberCallWithPermission(context, isVideo = true) {
-            CallSessionBridge.set(accountViewModel.callManager, accountViewModel.callController, accountViewModel)
-            accountViewModel.callController?.initiateGroupCall(roomId.users.toSet(), CallType.VIDEO)
-            CallActivity.launch(context)
+            CallActivity.launchForOutgoingCall(
+                context,
+                roomId.users.toSet(),
+                CallType.VIDEO,
+            )
         }
 
     DisappearingScaffold(

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
@@ -113,6 +113,7 @@ class CallManager(
      */
     private val watchdogScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private var ringingWatchdogJob: Job? = null
+    private var connectingWatchdogJob: Job? = null
 
     /** Per-peer invite timeout jobs.  A separate 30-second timer is scheduled
      *  for each peer we are waiting on (initial group-call offerees and
@@ -152,6 +153,7 @@ class CallManager(
     companion object {
         const val CALL_TIMEOUT_MS = 60_000L // 60 seconds ringing timeout (callee side)
         const val PEER_INVITE_TIMEOUT_MS = 30_000L // 30 seconds per-peer invite timeout (caller side)
+        const val CONNECTING_TIMEOUT_MS = 30_000L // 30 seconds to establish ICE connection
         const val ENDED_DISPLAY_MS = 2_000L // show "call ended" briefly before resetting
         const val MAX_EVENT_AGE_SECONDS = 20L // discard signaling events older than this
         const val MAX_PROCESSED_EVENT_IDS = 2_000 // cap dedup set to prevent unbounded growth
@@ -415,6 +417,7 @@ class CallManager(
                 )
             cancelTimeout()
             disarmRingingWatchdog()
+            armConnectingWatchdog(current.callId)
             // Local watchdog timers only — we are not the inviter for these
             // peers, so [handlePeerTimeout] will silently drop them without
             // publishing any hangup (see `peersInvitedByUs`).
@@ -512,7 +515,8 @@ class CallManager(
                 // still in `pending` keep theirs (scheduled in beginOffering).
                 cancelPeerTimeout(answeringPeer)
                 disarmRingingWatchdog()
-                Log.d("CallManager") { "onCallAnswered: Offering -> Connecting, forwarding answer to CallController" }
+                armConnectingWatchdog(current.callId)
+                Log.d("CallManager") { "onCallAnswered: Offering -> Connecting, forwarding answer to CallSession" }
                 onAnswerReceived?.invoke(event)
             }
 
@@ -710,6 +714,7 @@ class CallManager(
             }
 
             Log.d("CallManager") { "onPeerConnected: Connecting -> Connected! callId=${current.callId}" }
+            disarmConnectingWatchdog()
             _state.value =
                 CallState.Connected(
                     callId = current.callId,
@@ -998,6 +1003,7 @@ class CallManager(
         cancelTimeout()
         cancelAllPeerTimeouts()
         disarmRingingWatchdog()
+        disarmConnectingWatchdog()
         resetJob?.cancel()
         resetJob = null
         processedEventIds.clear()
@@ -1017,6 +1023,7 @@ class CallManager(
         cancelTimeout()
         cancelAllPeerTimeouts()
         disarmRingingWatchdog()
+        disarmConnectingWatchdog()
         resetJob?.cancel()
         resetJob =
             scope.launch {
@@ -1065,12 +1072,41 @@ class CallManager(
         ringingWatchdogJob = null
     }
 
+    // ---- Connecting watchdog ----
+
+    /**
+     * Arms a timer for [callId] in `Connecting` state. If ICE negotiation
+     * does not promote the state to `Connected` within
+     * [CONNECTING_TIMEOUT_MS], the call ends with [EndReason.TIMEOUT].
+     * Disarmed when entering `Connected`, `Ended`, or `Idle`.
+     */
+    private fun armConnectingWatchdog(callId: String) {
+        connectingWatchdogJob?.cancel()
+        connectingWatchdogJob =
+            watchdogScope.launch {
+                delay(CONNECTING_TIMEOUT_MS)
+                stateMutex.withLock {
+                    val cur = _state.value
+                    if (cur is CallState.Connecting && cur.callId == callId) {
+                        Log.d("CallManager") { "Connecting watchdog fired for $callId — forcing Ended(TIMEOUT)" }
+                        transitionToEnded(callId, cur.peerPubKeys + cur.pendingPeerPubKeys, EndReason.TIMEOUT)
+                    }
+                }
+            }
+    }
+
+    private fun disarmConnectingWatchdog() {
+        connectingWatchdogJob?.cancel()
+        connectingWatchdogJob = null
+    }
+
     /**
      * Cancels all long-lived coroutines owned by this manager. Called when
      * the owning account scope is torn down (logout / process shutdown).
      */
     fun dispose() {
         disarmRingingWatchdog()
+        disarmConnectingWatchdog()
         watchdogScope.cancel()
     }
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
@@ -86,10 +86,13 @@ class CallManager(
      *    missing buffered events.
      *  - No null-check on every emit site.
      *
-     * Buffer size 16 covers bursts of ICE candidates + answers arriving
-     * in quick succession during call setup.
+     * Buffer size 256 handles worst-case bursts (20+ ICE candidates per
+     * peer × multiple peers + answers + peer-left events). tryEmit is
+     * used instead of emit to avoid suspending while holding stateMutex
+     * (which would block all signaling). Drops are logged but should
+     * never happen in practice with this buffer size.
      */
-    private val _sessionEvents = MutableSharedFlow<CallSessionEvent>(extraBufferCapacity = 16)
+    private val _sessionEvents = MutableSharedFlow<CallSessionEvent>(extraBufferCapacity = 256)
     val sessionEvents: SharedFlow<CallSessionEvent> = _sessionEvents.asSharedFlow()
 
     /**
@@ -97,7 +100,14 @@ class CallManager(
      * because renegotiation has its own glare-resolution logic in
      * CallSession and benefits from a dedicated collector.
      */
-    private val _renegotiationEvents = MutableSharedFlow<CallRenegotiateEvent>(extraBufferCapacity = 8)
+    /** Emits a session event, logging a warning if the buffer overflows. */
+    private fun emitSessionEvent(event: CallSessionEvent) {
+        if (!emitSessionEvent(event)) {
+            Log.e("CallManager") { "sessionEvents buffer overflow — dropped: $event" }
+        }
+    }
+
+    private val _renegotiationEvents = MutableSharedFlow<CallRenegotiateEvent>(extraBufferCapacity = 32)
     val renegotiationEvents: SharedFlow<CallRenegotiateEvent> = _renegotiationEvents.asSharedFlow()
 
     private var timeoutJob: Job? = null
@@ -350,7 +360,7 @@ class CallManager(
 
                     else -> {}
                 }
-                _sessionEvents.tryEmit(CallSessionEvent.MidCallOfferReceived(callerPubKey, event.sdpOffer()))
+                emitSessionEvent(CallSessionEvent.MidCallOfferReceived(callerPubKey, event.sdpOffer()))
                 return
             }
         }
@@ -451,7 +461,7 @@ class CallManager(
         if (discovered.isNotEmpty()) {
             Log.d("CallManager") { "acceptCall: triggering mesh setup with ${discovered.size} discovered peers: ${discovered.map { it.take(8) }}" }
             for (peer in discovered) {
-                _sessionEvents.tryEmit(CallSessionEvent.NewPeerInGroupCall(peer))
+                emitSessionEvent(CallSessionEvent.NewPeerInGroupCall(peer))
             }
         }
     }
@@ -518,7 +528,7 @@ class CallManager(
                 disarmRingingWatchdog()
                 armConnectingWatchdog(current.callId)
                 Log.d("CallManager") { "onCallAnswered: Offering -> Connecting, forwarding answer to CallSession" }
-                _sessionEvents.tryEmit(CallSessionEvent.AnswerReceived(event))
+                emitSessionEvent(CallSessionEvent.AnswerReceived(event))
             }
 
             is CallState.Connecting -> {
@@ -547,7 +557,7 @@ class CallManager(
                 // Forward to CallController — it routes to the correct PeerSession
                 // and internally triggers callee-to-callee mesh setup if needed.
                 Log.d("CallManager") { "onCallAnswered: additional peer ${answeringPeer.take(8)} in Connecting, forwarding to CallController" }
-                _sessionEvents.tryEmit(CallSessionEvent.AnswerReceived(event))
+                emitSessionEvent(CallSessionEvent.AnswerReceived(event))
             }
 
             is CallState.IncomingCall -> {
@@ -586,7 +596,7 @@ class CallManager(
                 // Forward to CallController — it routes to the correct PeerSession
                 // and internally triggers callee-to-callee mesh setup if needed.
                 Log.d("CallManager") { "onCallAnswered: peer ${answeringPeer.take(8)} answer in Connected, forwarding to CallController" }
-                _sessionEvents.tryEmit(CallSessionEvent.AnswerReceived(event))
+                emitSessionEvent(CallSessionEvent.AnswerReceived(event))
             }
 
             else -> {
@@ -626,7 +636,7 @@ class CallManager(
                     transitionToEnded(current.callId, current.peerPubKeys, EndReason.PEER_REJECTED)
                 } else {
                     _state.value = current.copy(peerPubKeys = remaining)
-                    _sessionEvents.tryEmit(CallSessionEvent.PeerLeft(rejectingPeer))
+                    emitSessionEvent(CallSessionEvent.PeerLeft(rejectingPeer))
                 }
             }
 
@@ -635,7 +645,7 @@ class CallManager(
                 cancelPeerTimeout(rejectingPeer)
                 _state.value =
                     current.copy(pendingPeerPubKeys = current.pendingPeerPubKeys - rejectingPeer)
-                _sessionEvents.tryEmit(CallSessionEvent.PeerLeft(rejectingPeer))
+                emitSessionEvent(CallSessionEvent.PeerLeft(rejectingPeer))
             }
 
             is CallState.Connected -> {
@@ -643,7 +653,7 @@ class CallManager(
                 cancelPeerTimeout(rejectingPeer)
                 _state.value =
                     current.copy(pendingPeerPubKeys = current.pendingPeerPubKeys - rejectingPeer)
-                _sessionEvents.tryEmit(CallSessionEvent.PeerLeft(rejectingPeer))
+                emitSessionEvent(CallSessionEvent.PeerLeft(rejectingPeer))
             }
 
             is CallState.IncomingCall -> {
@@ -670,7 +680,7 @@ class CallManager(
     }
 
     private fun onIceCandidate(event: CallIceCandidateEvent) {
-        _sessionEvents.tryEmit(CallSessionEvent.IceCandidateReceived(event))
+        emitSessionEvent(CallSessionEvent.IceCandidateReceived(event))
     }
 
     private fun onRenegotiate(event: CallRenegotiateEvent) {
@@ -683,7 +693,9 @@ class CallManager(
                 else -> return
             }
         if (callId != currentCallId) return
-        _renegotiationEvents.tryEmit(event)
+        if (!_renegotiationEvents.tryEmit(event)) {
+            Log.e("CallManager") { "renegotiationEvents buffer overflow — dropped renegotiation from ${event.pubKey.take(8)}" }
+        }
     }
 
     suspend fun sendRenegotiation(
@@ -832,7 +844,7 @@ class CallManager(
                             peerPubKeys = connectedRemaining,
                             pendingPeerPubKeys = pendingRemaining,
                         )
-                    _sessionEvents.tryEmit(CallSessionEvent.PeerLeft(leavingPeer))
+                    emitSessionEvent(CallSessionEvent.PeerLeft(leavingPeer))
                 }
             }
 
@@ -857,7 +869,7 @@ class CallManager(
                             peerPubKeys = connectedRemaining,
                             pendingPeerPubKeys = pendingRemaining,
                         )
-                    _sessionEvents.tryEmit(CallSessionEvent.PeerLeft(leavingPeer))
+                    emitSessionEvent(CallSessionEvent.PeerLeft(leavingPeer))
                 }
             }
 
@@ -869,7 +881,7 @@ class CallManager(
                     transitionToEnded(callId, current.peerPubKeys, EndReason.PEER_HANGUP)
                 } else {
                     _state.value = current.copy(peerPubKeys = remaining)
-                    _sessionEvents.tryEmit(CallSessionEvent.PeerLeft(leavingPeer))
+                    emitSessionEvent(CallSessionEvent.PeerLeft(leavingPeer))
                 }
             }
 
@@ -1187,7 +1199,7 @@ class CallManager(
                         transitionToEnded(current.callId, current.peerPubKeys, EndReason.TIMEOUT)
                     } else {
                         _state.value = current.copy(peerPubKeys = remaining)
-                        _sessionEvents.tryEmit(CallSessionEvent.PeerLeft(peerPubKey))
+                        emitSessionEvent(CallSessionEvent.PeerLeft(peerPubKey))
                     }
                 }
 
@@ -1205,7 +1217,7 @@ class CallManager(
                         )
                     } else {
                         _state.value = current.copy(pendingPeerPubKeys = newPending)
-                        _sessionEvents.tryEmit(CallSessionEvent.PeerLeft(peerPubKey))
+                        emitSessionEvent(CallSessionEvent.PeerLeft(peerPubKey))
                     }
                 }
 
@@ -1215,7 +1227,7 @@ class CallManager(
                     Log.d("CallManager") { "Per-peer timeout: dropping ${peerPubKey.take(8)} from Connected (invitedByUs=$wasInvitedByUs)" }
                     shouldPublishHangup = wasInvitedByUs
                     _state.value = current.copy(pendingPeerPubKeys = current.pendingPeerPubKeys - peerPubKey)
-                    _sessionEvents.tryEmit(CallSessionEvent.PeerLeft(peerPubKey))
+                    emitSessionEvent(CallSessionEvent.PeerLeft(peerPubKey))
                 }
 
                 else -> {

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
@@ -95,11 +95,12 @@ class CallManager(
     private val _sessionEvents = MutableSharedFlow<CallSessionEvent>(extraBufferCapacity = 256)
     val sessionEvents: SharedFlow<CallSessionEvent> = _sessionEvents.asSharedFlow()
 
-    /**
+    /*
      * Renegotiation offers from remote peers. Separate from [sessionEvents]
      * because renegotiation has its own glare-resolution logic in
      * CallSession and benefits from a dedicated collector.
      */
+
     /** Emits a session event, logging a warning if the buffer overflows. */
     private fun emitSessionEvent(event: CallSessionEvent) {
         if (!emitSessionEvent(event)) {

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
@@ -35,10 +35,16 @@ import com.vitorpamplona.quartz.nipACWebRtcCalls.tags.CallType
 import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -73,7 +79,16 @@ class CallManager(
     /** Called for every answer that should be applied to a PeerConnection (includes peer pubkey). */
     var onAnswerReceived: ((CallAnswerEvent) -> Unit)? = null
     var onIceCandidateReceived: ((CallIceCandidateEvent) -> Unit)? = null
-    var onRenegotiationOfferReceived: ((CallRenegotiateEvent) -> Unit)? = null
+
+    /**
+     * Renegotiation offers from remote peers are emitted as flow events so the
+     * Activity-scoped `CallSession` can (re)subscribe via `repeatOnLifecycle`
+     * without losing messages across Activity restarts. Buffered so a short
+     * gap between Activity teardown and re-collection cannot drop a
+     * renegotiation.
+     */
+    private val _renegotiationEvents = MutableSharedFlow<CallRenegotiateEvent>(extraBufferCapacity = 8)
+    val renegotiationEvents: SharedFlow<CallRenegotiateEvent> = _renegotiationEvents.asSharedFlow()
 
     /** Called when a new peer joins the group call (callee-to-callee mesh setup). */
     var onNewPeerInGroupCall: ((peerPubKey: HexKey) -> Unit)? = null
@@ -87,6 +102,17 @@ class CallManager(
     private var timeoutJob: Job? = null
     private var resetJob: Job? = null
     private val processedEventIds = LinkedHashSet<String>()
+
+    /**
+     * Detached scope for the ringing watchdog so the timer survives the
+     * `scope` being cancelled by the owning ViewModel. The watchdog is a
+     * fail-safe that unconditionally forces an `Ended(TIMEOUT)` transition
+     * if the state stays in `IncomingCall`/`Offering` past
+     * `RINGING_WATCHDOG_MS`, regardless of whether any collector observes
+     * the state. Cancelled explicitly via [dispose].
+     */
+    private val watchdogScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private var ringingWatchdogJob: Job? = null
 
     /** Per-peer invite timeout jobs.  A separate 30-second timer is scheduled
      *  for each peer we are waiting on (initial group-call offerees and
@@ -130,6 +156,16 @@ class CallManager(
         const val MAX_EVENT_AGE_SECONDS = 20L // discard signaling events older than this
         const val MAX_PROCESSED_EVENT_IDS = 2_000 // cap dedup set to prevent unbounded growth
         const val MAX_COMPLETED_CALL_IDS = 200 // cap completed-call set
+
+        /**
+         * Hard ceiling on how long a call may remain in a ringing state
+         * (`IncomingCall` or `Offering`). Deliberately longer than
+         * [CALL_TIMEOUT_MS] (60s) so the normal timeout path gets a chance
+         * to fire first; this is purely the fail-safe for when that path
+         * never runs (e.g. a stuck coroutine, a canceled `scope`, or a
+         * dropped state transition).
+         */
+        const val RINGING_WATCHDOG_MS = 65_000L
     }
 
     /** Adds [value] to a [LinkedHashSet], evicting the oldest entries when
@@ -173,6 +209,7 @@ class CallManager(
         cancelAllPeerTimeouts()
         peersInvitedByUs.addAll(calleePubKeys)
         calleePubKeys.forEach { schedulePeerTimeout(it, callId) }
+        armRingingWatchdog(callId)
     }
 
     /**
@@ -236,6 +273,7 @@ class CallManager(
             cancelAllPeerTimeouts()
             peersInvitedByUs.add(calleePubKey)
             schedulePeerTimeout(calleePubKey, callId)
+            armRingingWatchdog(callId)
         }
         publishEvent(result.wrap)
         Log.d("CallManager") { "initiateCall: offer published, per-peer timeout started" }
@@ -332,6 +370,7 @@ class CallManager(
                 callType = callType,
                 sdpOffer = event.sdpOffer(),
             )
+        armRingingWatchdog(callId)
         startTimeout(callId)
     }
 
@@ -375,6 +414,7 @@ class CallManager(
                     pendingPeerPubKeys = pendingOnJoin,
                 )
             cancelTimeout()
+            disarmRingingWatchdog()
             // Local watchdog timers only — we are not the inviter for these
             // peers, so [handlePeerTimeout] will silently drop them without
             // publishing any hangup (see `peersInvitedByUs`).
@@ -471,6 +511,7 @@ class CallManager(
                 // The answered peer no longer needs its invite timer. Peers
                 // still in `pending` keep theirs (scheduled in beginOffering).
                 cancelPeerTimeout(answeringPeer)
+                disarmRingingWatchdog()
                 Log.d("CallManager") { "onCallAnswered: Offering -> Connecting, forwarding answer to CallController" }
                 onAnswerReceived?.invoke(event)
             }
@@ -637,7 +678,7 @@ class CallManager(
                 else -> return
             }
         if (callId != currentCallId) return
-        onRenegotiationOfferReceived?.invoke(event)
+        _renegotiationEvents.tryEmit(event)
     }
 
     suspend fun sendRenegotiation(
@@ -956,6 +997,7 @@ class CallManager(
         _state.value = CallState.Idle
         cancelTimeout()
         cancelAllPeerTimeouts()
+        disarmRingingWatchdog()
         resetJob?.cancel()
         resetJob = null
         processedEventIds.clear()
@@ -974,6 +1016,7 @@ class CallManager(
         _state.value = CallState.Ended(callId, peerPubKeys, reason)
         cancelTimeout()
         cancelAllPeerTimeouts()
+        disarmRingingWatchdog()
         resetJob?.cancel()
         resetJob =
             scope.launch {
@@ -983,6 +1026,52 @@ class CallManager(
                     processedEventIds.clear()
                 }
             }
+    }
+
+    // ---- Ringing watchdog ----
+
+    /**
+     * Arms the watchdog for [callId]. If the state is still
+     * `IncomingCall(callId)` or `Offering(callId)` when the watchdog
+     * fires, forces `Ended(TIMEOUT)` so nothing can keep ringing
+     * indefinitely. Calling this replaces any previously armed watchdog.
+     */
+    private fun armRingingWatchdog(callId: String) {
+        ringingWatchdogJob?.cancel()
+        ringingWatchdogJob =
+            watchdogScope.launch {
+                delay(RINGING_WATCHDOG_MS)
+                stateMutex.withLock {
+                    val cur = _state.value
+                    val hit =
+                        (cur is CallState.IncomingCall && cur.callId == callId) ||
+                            (cur is CallState.Offering && cur.callId == callId)
+                    if (hit) {
+                        Log.d("CallManager") { "Ringing watchdog fired for $callId — forcing Ended(TIMEOUT)" }
+                        val peers =
+                            when (cur) {
+                                is CallState.IncomingCall -> cur.peerPubKeys()
+                                is CallState.Offering -> cur.peerPubKeys
+                                else -> emptySet()
+                            }
+                        transitionToEnded(callId, peers, EndReason.TIMEOUT)
+                    }
+                }
+            }
+    }
+
+    private fun disarmRingingWatchdog() {
+        ringingWatchdogJob?.cancel()
+        ringingWatchdogJob = null
+    }
+
+    /**
+     * Cancels all long-lived coroutines owned by this manager. Called when
+     * the owning account scope is torn down (logout / process shutdown).
+     */
+    fun dispose() {
+        disarmRingingWatchdog()
+        watchdogScope.cancel()
     }
 
     // ---- Per-peer invite timeout ----

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
@@ -468,12 +468,17 @@ class CallManager(
     }
 
     suspend fun rejectCall() {
+        Log.d("CallManager") { "rejectCall: enter state=${_state.value::class.simpleName}" }
         val current: CallState.IncomingCall
         stateMutex.withLock {
             val s = _state.value
-            if (s !is CallState.IncomingCall) return
+            if (s !is CallState.IncomingCall) {
+                Log.d("CallManager") { "rejectCall: state is ${s::class.simpleName}, not IncomingCall — ignoring" }
+                return
+            }
             current = s
             transitionToEnded(current.callId, current.peerPubKeys(), EndReason.REJECTED)
+            Log.d("CallManager") { "rejectCall: transitioned to Ended, publishing reject events" }
         }
 
         val otherMembers = current.groupMembers - signer.pubKey
@@ -1031,6 +1036,7 @@ class CallManager(
         peerPubKeys: Set<HexKey>,
         reason: EndReason,
     ) {
+        Log.d("CallManager") { "transitionToEnded: callId=$callId reason=$reason peers=${peerPubKeys.size}" }
         cappedAdd(completedCallIds, callId, MAX_COMPLETED_CALL_IDS)
         discoveredCalleePeers.clear()
         _state.value = CallState.Ended(callId, peerPubKeys, reason)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
@@ -103,7 +103,7 @@ class CallManager(
 
     /** Emits a session event, logging a warning if the buffer overflows. */
     private fun emitSessionEvent(event: CallSessionEvent) {
-        if (!emitSessionEvent(event)) {
+        if (!_sessionEvents.tryEmit(event)) {
             Log.e("CallManager") { "sessionEvents buffer overflow — dropped: $event" }
         }
     }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallManager.kt
@@ -76,28 +76,29 @@ class CallManager(
     private val _state = MutableStateFlow<CallState>(CallState.Idle)
     val state: StateFlow<CallState> = _state.asStateFlow()
 
-    /** Called for every answer that should be applied to a PeerConnection (includes peer pubkey). */
-    var onAnswerReceived: ((CallAnswerEvent) -> Unit)? = null
-    var onIceCandidateReceived: ((CallIceCandidateEvent) -> Unit)? = null
+    /**
+     * All events that the Activity-scoped `CallSession` must handle are
+     * emitted through this single flow. Using a SharedFlow instead of
+     * mutable `var` callbacks means:
+     *  - No stale references to a dead CallSession between Activity
+     *    destroy and recreate.
+     *  - The collector can (re)subscribe via `repeatOnLifecycle` without
+     *    missing buffered events.
+     *  - No null-check on every emit site.
+     *
+     * Buffer size 16 covers bursts of ICE candidates + answers arriving
+     * in quick succession during call setup.
+     */
+    private val _sessionEvents = MutableSharedFlow<CallSessionEvent>(extraBufferCapacity = 16)
+    val sessionEvents: SharedFlow<CallSessionEvent> = _sessionEvents.asSharedFlow()
 
     /**
-     * Renegotiation offers from remote peers are emitted as flow events so the
-     * Activity-scoped `CallSession` can (re)subscribe via `repeatOnLifecycle`
-     * without losing messages across Activity restarts. Buffered so a short
-     * gap between Activity teardown and re-collection cannot drop a
-     * renegotiation.
+     * Renegotiation offers from remote peers. Separate from [sessionEvents]
+     * because renegotiation has its own glare-resolution logic in
+     * CallSession and benefits from a dedicated collector.
      */
     private val _renegotiationEvents = MutableSharedFlow<CallRenegotiateEvent>(extraBufferCapacity = 8)
     val renegotiationEvents: SharedFlow<CallRenegotiateEvent> = _renegotiationEvents.asSharedFlow()
-
-    /** Called when a new peer joins the group call (callee-to-callee mesh setup). */
-    var onNewPeerInGroupCall: ((peerPubKey: HexKey) -> Unit)? = null
-
-    /** Called when a mid-call offer is received from another callee in a group call. */
-    var onMidCallOfferReceived: ((peerPubKey: HexKey, sdpOffer: String) -> Unit)? = null
-
-    /** Called when a peer leaves the call (hangup) but the call continues with remaining peers. */
-    var onPeerLeft: ((peerPubKey: HexKey) -> Unit)? = null
 
     private var timeoutJob: Job? = null
     private var resetJob: Job? = null
@@ -349,7 +350,7 @@ class CallManager(
 
                     else -> {}
                 }
-                onMidCallOfferReceived?.invoke(callerPubKey, event.sdpOffer())
+                _sessionEvents.tryEmit(CallSessionEvent.MidCallOfferReceived(callerPubKey, event.sdpOffer()))
                 return
             }
         }
@@ -450,7 +451,7 @@ class CallManager(
         if (discovered.isNotEmpty()) {
             Log.d("CallManager") { "acceptCall: triggering mesh setup with ${discovered.size} discovered peers: ${discovered.map { it.take(8) }}" }
             for (peer in discovered) {
-                onNewPeerInGroupCall?.invoke(peer)
+                _sessionEvents.tryEmit(CallSessionEvent.NewPeerInGroupCall(peer))
             }
         }
     }
@@ -517,7 +518,7 @@ class CallManager(
                 disarmRingingWatchdog()
                 armConnectingWatchdog(current.callId)
                 Log.d("CallManager") { "onCallAnswered: Offering -> Connecting, forwarding answer to CallSession" }
-                onAnswerReceived?.invoke(event)
+                _sessionEvents.tryEmit(CallSessionEvent.AnswerReceived(event))
             }
 
             is CallState.Connecting -> {
@@ -546,7 +547,7 @@ class CallManager(
                 // Forward to CallController — it routes to the correct PeerSession
                 // and internally triggers callee-to-callee mesh setup if needed.
                 Log.d("CallManager") { "onCallAnswered: additional peer ${answeringPeer.take(8)} in Connecting, forwarding to CallController" }
-                onAnswerReceived?.invoke(event)
+                _sessionEvents.tryEmit(CallSessionEvent.AnswerReceived(event))
             }
 
             is CallState.IncomingCall -> {
@@ -585,7 +586,7 @@ class CallManager(
                 // Forward to CallController — it routes to the correct PeerSession
                 // and internally triggers callee-to-callee mesh setup if needed.
                 Log.d("CallManager") { "onCallAnswered: peer ${answeringPeer.take(8)} answer in Connected, forwarding to CallController" }
-                onAnswerReceived?.invoke(event)
+                _sessionEvents.tryEmit(CallSessionEvent.AnswerReceived(event))
             }
 
             else -> {
@@ -603,7 +604,7 @@ class CallManager(
         // still ringing (IncomingCall).  In every other state it is our own
         // echo from a relay after a sibling device rejected a call that we
         // have already accepted and are now actively in — treating it as a
-        // peer rejection would drop ourselves from the call (onPeerLeft
+        // peer rejection would drop ourselves from the call (PeerLeft
         // would dispose our own PeerConnection, killing the live audio on
         // the device that picked up).  Just drop the echo.
         if (rejectingPeer == signer.pubKey) {
@@ -625,7 +626,7 @@ class CallManager(
                     transitionToEnded(current.callId, current.peerPubKeys, EndReason.PEER_REJECTED)
                 } else {
                     _state.value = current.copy(peerPubKeys = remaining)
-                    onPeerLeft?.invoke(rejectingPeer)
+                    _sessionEvents.tryEmit(CallSessionEvent.PeerLeft(rejectingPeer))
                 }
             }
 
@@ -634,7 +635,7 @@ class CallManager(
                 cancelPeerTimeout(rejectingPeer)
                 _state.value =
                     current.copy(pendingPeerPubKeys = current.pendingPeerPubKeys - rejectingPeer)
-                onPeerLeft?.invoke(rejectingPeer)
+                _sessionEvents.tryEmit(CallSessionEvent.PeerLeft(rejectingPeer))
             }
 
             is CallState.Connected -> {
@@ -642,7 +643,7 @@ class CallManager(
                 cancelPeerTimeout(rejectingPeer)
                 _state.value =
                     current.copy(pendingPeerPubKeys = current.pendingPeerPubKeys - rejectingPeer)
-                onPeerLeft?.invoke(rejectingPeer)
+                _sessionEvents.tryEmit(CallSessionEvent.PeerLeft(rejectingPeer))
             }
 
             is CallState.IncomingCall -> {
@@ -669,7 +670,7 @@ class CallManager(
     }
 
     private fun onIceCandidate(event: CallIceCandidateEvent) {
-        onIceCandidateReceived?.invoke(event)
+        _sessionEvents.tryEmit(CallSessionEvent.IceCandidateReceived(event))
     }
 
     private fun onRenegotiate(event: CallRenegotiateEvent) {
@@ -831,7 +832,7 @@ class CallManager(
                             peerPubKeys = connectedRemaining,
                             pendingPeerPubKeys = pendingRemaining,
                         )
-                    onPeerLeft?.invoke(leavingPeer)
+                    _sessionEvents.tryEmit(CallSessionEvent.PeerLeft(leavingPeer))
                 }
             }
 
@@ -856,7 +857,7 @@ class CallManager(
                             peerPubKeys = connectedRemaining,
                             pendingPeerPubKeys = pendingRemaining,
                         )
-                    onPeerLeft?.invoke(leavingPeer)
+                    _sessionEvents.tryEmit(CallSessionEvent.PeerLeft(leavingPeer))
                 }
             }
 
@@ -868,7 +869,7 @@ class CallManager(
                     transitionToEnded(callId, current.peerPubKeys, EndReason.PEER_HANGUP)
                 } else {
                     _state.value = current.copy(peerPubKeys = remaining)
-                    onPeerLeft?.invoke(leavingPeer)
+                    _sessionEvents.tryEmit(CallSessionEvent.PeerLeft(leavingPeer))
                 }
             }
 
@@ -1160,7 +1161,7 @@ class CallManager(
      *   at least one other peer is connected by definition, so the call
      *   always continues.
      *
-     * Fires [onPeerLeft] so the CallController disposes the per-peer
+     * Emits [CallSessionEvent.PeerLeft] so the CallSession disposes the per-peer
      * PeerConnection (and any pending ICE buffers) for the dropped peer.
      */
     private suspend fun handlePeerTimeout(
@@ -1186,7 +1187,7 @@ class CallManager(
                         transitionToEnded(current.callId, current.peerPubKeys, EndReason.TIMEOUT)
                     } else {
                         _state.value = current.copy(peerPubKeys = remaining)
-                        onPeerLeft?.invoke(peerPubKey)
+                        _sessionEvents.tryEmit(CallSessionEvent.PeerLeft(peerPubKey))
                     }
                 }
 
@@ -1204,7 +1205,7 @@ class CallManager(
                         )
                     } else {
                         _state.value = current.copy(pendingPeerPubKeys = newPending)
-                        onPeerLeft?.invoke(peerPubKey)
+                        _sessionEvents.tryEmit(CallSessionEvent.PeerLeft(peerPubKey))
                     }
                 }
 
@@ -1214,7 +1215,7 @@ class CallManager(
                     Log.d("CallManager") { "Per-peer timeout: dropping ${peerPubKey.take(8)} from Connected (invitedByUs=$wasInvitedByUs)" }
                     shouldPublishHangup = wasInvitedByUs
                     _state.value = current.copy(pendingPeerPubKeys = current.pendingPeerPubKeys - peerPubKey)
-                    onPeerLeft?.invoke(peerPubKey)
+                    _sessionEvents.tryEmit(CallSessionEvent.PeerLeft(peerPubKey))
                 }
 
                 else -> {

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallSessionEvent.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallSessionEvent.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.call
+
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nipACWebRtcCalls.events.CallAnswerEvent
+import com.vitorpamplona.quartz.nipACWebRtcCalls.events.CallIceCandidateEvent
+
+/**
+ * Events emitted by [CallManager] that the Activity-scoped `CallSession`
+ * must handle. Delivered via `SharedFlow` so the collector can
+ * (re)subscribe across Activity restarts without missing buffered events.
+ */
+sealed interface CallSessionEvent {
+    /** A peer answered our offer (or we received an answer in a group call). */
+    data class AnswerReceived(val event: CallAnswerEvent) : CallSessionEvent
+
+    /** An ICE candidate arrived from a peer. */
+    data class IceCandidateReceived(val event: CallIceCandidateEvent) : CallSessionEvent
+
+    /** A new peer joined the group call and needs callee-to-callee mesh setup. */
+    data class NewPeerInGroupCall(val peerPubKey: HexKey) : CallSessionEvent
+
+    /** A mid-call offer arrived from another callee in a group call. */
+    data class MidCallOfferReceived(val peerPubKey: HexKey, val sdpOffer: String) : CallSessionEvent
+
+    /** A peer left the call (hangup/reject/timeout) but the call continues. */
+    data class PeerLeft(val peerPubKey: HexKey) : CallSessionEvent
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallSessionEvent.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/CallSessionEvent.kt
@@ -31,17 +31,28 @@ import com.vitorpamplona.quartz.nipACWebRtcCalls.events.CallIceCandidateEvent
  */
 sealed interface CallSessionEvent {
     /** A peer answered our offer (or we received an answer in a group call). */
-    data class AnswerReceived(val event: CallAnswerEvent) : CallSessionEvent
+    data class AnswerReceived(
+        val event: CallAnswerEvent,
+    ) : CallSessionEvent
 
     /** An ICE candidate arrived from a peer. */
-    data class IceCandidateReceived(val event: CallIceCandidateEvent) : CallSessionEvent
+    data class IceCandidateReceived(
+        val event: CallIceCandidateEvent,
+    ) : CallSessionEvent
 
     /** A new peer joined the group call and needs callee-to-callee mesh setup. */
-    data class NewPeerInGroupCall(val peerPubKey: HexKey) : CallSessionEvent
+    data class NewPeerInGroupCall(
+        val peerPubKey: HexKey,
+    ) : CallSessionEvent
 
     /** A mid-call offer arrived from another callee in a group call. */
-    data class MidCallOfferReceived(val peerPubKey: HexKey, val sdpOffer: String) : CallSessionEvent
+    data class MidCallOfferReceived(
+        val peerPubKey: HexKey,
+        val sdpOffer: String,
+    ) : CallSessionEvent
 
     /** A peer left the call (hangup/reject/timeout) but the call continues. */
-    data class PeerLeft(val peerPubKey: HexKey) : CallSessionEvent
+    data class PeerLeft(
+        val peerPubKey: HexKey,
+    ) : CallSessionEvent
 }

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/call/CallManagerTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/call/CallManagerTest.kt
@@ -1167,7 +1167,12 @@ class CallManagerTest {
             assertIs<CallState.Connected>(state)
             assertTrue(carol in state.peerPubKeys, "Mid-call joiner must be added to peerPubKeys")
             assertTrue(alice in state.peerPubKeys, "Existing peer must still be present")
-            val forwardedPeer = events.filterIsInstance<CallSessionEvent.AnswerReceived>().firstOrNull()?.event?.pubKey
+            val forwardedPeer =
+                events
+                    .filterIsInstance<CallSessionEvent.AnswerReceived>()
+                    .firstOrNull()
+                    ?.event
+                    ?.pubKey
             assertEquals(carol, forwardedPeer, "Answer must still be emitted to CallSession")
             job.cancel()
         }
@@ -1318,7 +1323,12 @@ class CallManagerTest {
             val bobAfterCarolAnswer = bobManager.state.value
             assertIs<CallState.Connected>(bobAfterCarolAnswer)
             assertTrue(carol in bobAfterCarolAnswer.peerPubKeys, "Bob should add Carol to his membership")
-            val bobForwardedAnswer = bobEvents.filterIsInstance<CallSessionEvent.AnswerReceived>().firstOrNull()?.event?.pubKey
+            val bobForwardedAnswer =
+                bobEvents
+                    .filterIsInstance<CallSessionEvent.AnswerReceived>()
+                    .firstOrNull()
+                    ?.event
+                    ?.pubKey
             assertEquals(carol, bobForwardedAnswer, "Bob must emit Carol's answer to his CallSession")
             bobJob.cancel()
         }

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/call/CallManagerTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/call/CallManagerTest.kt
@@ -33,6 +33,8 @@ import com.vitorpamplona.quartz.nipACWebRtcCalls.events.CallRenegotiateEvent
 import com.vitorpamplona.quartz.nipACWebRtcCalls.tags.CallType
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -98,6 +100,16 @@ class CallManagerTest {
                 isCallsEnabled = isCallsEnabled,
             )
         return manager to published
+    }
+
+    /**
+     * Starts collecting [CallManager.sessionEvents] into a list.
+     * Returns (events, job) — cancel the job when done.
+     */
+    private fun TestScope.collectSessionEvents(manager: CallManager): Pair<MutableList<CallSessionEvent>, Job> {
+        val events = mutableListOf<CallSessionEvent>()
+        val job = launch { manager.sessionEvents.collect { events.add(it) } }
+        return events to job
     }
 
     // ---- Event construction helpers ----
@@ -323,15 +335,15 @@ class CallManagerTest {
             manager.initiateCall(bob, CallType.VOICE, callId, sdpOffer)
             assertIs<CallState.Offering>(manager.state.value)
 
-            var answerReceived = false
-            manager.onAnswerReceived = { answerReceived = true }
+            val (events, job) = collectSessionEvents(manager)
 
             val answer = makeAnswer(from = bob, to = alice)
             manager.onSignalingEvent(answer)
 
             val state = manager.state.value
             assertIs<CallState.Connecting>(state)
-            assertTrue(answerReceived, "onAnswerReceived callback should fire")
+            assertTrue(events.any { it is CallSessionEvent.AnswerReceived }, "AnswerReceived event should be emitted")
+            job.cancel()
         }
 
     // ========================================================================
@@ -461,14 +473,14 @@ class CallManagerTest {
             manager.onSignalingEvent(makeOffer(from = alice, to = bob))
             manager.acceptCall(sdpAnswer)
 
-            var iceCalled = false
-            manager.onIceCandidateReceived = { iceCalled = true }
+            val (events, job) = collectSessionEvents(manager)
 
             // ICE candidate from self (echoed back by relay)
             val selfIce = makeIceCandidate(from = bob, to = alice)
             manager.onSignalingEvent(selfIce)
 
-            assertTrue(!iceCalled, "Self ICE candidates MUST be ignored")
+            assertTrue(events.none { it is CallSessionEvent.IceCandidateReceived }, "Self ICE candidates MUST be ignored")
+            job.cancel()
         }
 
     @Test
@@ -533,13 +545,14 @@ class CallManagerTest {
             manager.onSignalingEvent(makeOffer(from = alice, to = bob))
             manager.acceptCall(sdpAnswer)
 
-            var receivedIce: CallIceCandidateEvent? = null
-            manager.onIceCandidateReceived = { receivedIce = it }
+            val (events, job) = collectSessionEvents(manager)
 
             val ice = makeIceCandidate(from = alice, to = bob)
             manager.onSignalingEvent(ice)
 
-            assertNotNull(receivedIce, "ICE candidate should be forwarded via callback")
+            val iceEvent = events.filterIsInstance<CallSessionEvent.IceCandidateReceived>().firstOrNull()
+            assertNotNull(iceEvent, "ICE candidate should be emitted via sessionEvents")
+            job.cancel()
         }
 
     // ========================================================================
@@ -794,15 +807,16 @@ class CallManagerTest {
             // Bob still ringing
             assertIs<CallState.IncomingCall>(manager.state.value)
 
-            // Track mesh setup callback
-            val newPeers = mutableListOf<HexKey>()
-            manager.onNewPeerInGroupCall = { newPeers.add(it) }
+            // Track mesh setup events
+            val (events, job) = collectSessionEvents(manager)
 
             // Bob accepts
             manager.acceptCall(sdpAnswer)
 
             // Should trigger callee-to-callee mesh setup with carol
+            val newPeers = events.filterIsInstance<CallSessionEvent.NewPeerInGroupCall>().map { it.peerPubKey }
             assertTrue(carol in newPeers, "Should discover carol for mesh setup after accepting")
+            job.cancel()
         }
 
     // ========================================================================
@@ -819,19 +833,17 @@ class CallManagerTest {
             manager.onPeerConnected()
             assertIs<CallState.Connected>(manager.state.value)
 
-            var midCallPeer: HexKey? = null
-            var midCallSdp: String? = null
-            manager.onMidCallOfferReceived = { peer, sdp ->
-                midCallPeer = peer
-                midCallSdp = sdp
-            }
+            val (events, job) = collectSessionEvents(manager)
 
             // Carol sends a mid-call offer (callee-to-callee mesh)
             val carolOffer = makeOffer(from = carol, to = bob, callId = callId, sdp = "carol-sdp")
             manager.onSignalingEvent(carolOffer)
 
-            assertEquals(carol, midCallPeer)
-            assertEquals("carol-sdp", midCallSdp)
+            val midCallEvent = events.filterIsInstance<CallSessionEvent.MidCallOfferReceived>().firstOrNull()
+            assertNotNull(midCallEvent)
+            assertEquals(carol, midCallEvent.peerPubKey)
+            assertEquals("carol-sdp", midCallEvent.sdpOffer)
+            job.cancel()
         }
 
     // ========================================================================
@@ -882,12 +894,13 @@ class CallManagerTest {
             manager.onPeerConnected()
             manager.onSignalingEvent(makeAnswer(from = carol, to = alice))
 
-            val leftPeers = mutableListOf<HexKey>()
-            manager.onPeerLeft = { leftPeers.add(it) }
+            val (events, job) = collectSessionEvents(manager)
 
             manager.onSignalingEvent(makeHangup(from = bob, to = alice))
 
-            assertTrue(bob in leftPeers, "onPeerLeft should fire when a peer hangs up")
+            val leftPeers = events.filterIsInstance<CallSessionEvent.PeerLeft>().map { it.peerPubKey }
+            assertTrue(bob in leftPeers, "PeerLeft should be emitted when a peer hangs up")
+            job.cancel()
         }
 
     // ========================================================================
@@ -1128,8 +1141,8 @@ class CallManagerTest {
      * Bob is already in a Connected group call with Alice. Alice invites Carol.
      * Carol's broadcast CallAnswer reaches Bob. Bob's state must expand to
      * include Carol in [CallState.Connected.peerPubKeys] and the answer must
-     * still be forwarded via [CallManager.onAnswerReceived] so the caller-side
-     * [CallController] can unconditionally initiate a mesh offer to Carol.
+     * still be emitted via [CallManager.sessionEvents] so the caller-side
+     * CallSession can unconditionally initiate a mesh offer to Carol.
      */
     @Test
     fun midCallInviteAnswerFromUnknownPeerInConnectedExpandsMembership() =
@@ -1142,8 +1155,7 @@ class CallManagerTest {
             manager.onPeerConnected()
             assertIs<CallState.Connected>(manager.state.value)
 
-            var forwardedPeer: HexKey? = null
-            manager.onAnswerReceived = { event -> forwardedPeer = event.pubKey }
+            val (events, job) = collectSessionEvents(manager)
 
             // Alice invited Carol mid-call; Carol broadcasts her acceptance.
             // Bob sees a CallAnswer from Carol (unknown peer, same call-id)
@@ -1155,7 +1167,9 @@ class CallManagerTest {
             assertIs<CallState.Connected>(state)
             assertTrue(carol in state.peerPubKeys, "Mid-call joiner must be added to peerPubKeys")
             assertTrue(alice in state.peerPubKeys, "Existing peer must still be present")
-            assertEquals(carol, forwardedPeer, "Answer must still be forwarded to CallController")
+            val forwardedPeer = events.filterIsInstance<CallSessionEvent.AnswerReceived>().firstOrNull()?.event?.pubKey
+            assertEquals(carol, forwardedPeer, "Answer must still be emitted to CallSession")
+            job.cancel()
         }
 
     /**
@@ -1296,16 +1310,17 @@ class CallManagerTest {
 
             // Step 6: Bob receives Carol's answer broadcast. Bob's state must
             // expand to include Carol (mid-call join), and the answer must be
-            // forwarded so Bob's CallController can initiate a mesh offer.
-            var bobForwardedAnswer: HexKey? = null
-            bobManager.onAnswerReceived = { event -> bobForwardedAnswer = event.pubKey }
+            // emitted so Bob's CallSession can initiate a mesh offer.
+            val (bobEvents, bobJob) = collectSessionEvents(bobManager)
             bobManager.onSignalingEvent(
                 makeGroupAnswer(from = carol, members = setOf(alice, bob, carol), sdp = "carol-answer-sdp"),
             )
             val bobAfterCarolAnswer = bobManager.state.value
             assertIs<CallState.Connected>(bobAfterCarolAnswer)
             assertTrue(carol in bobAfterCarolAnswer.peerPubKeys, "Bob should add Carol to his membership")
-            assertEquals(carol, bobForwardedAnswer, "Bob must forward Carol's answer to his CallController")
+            val bobForwardedAnswer = bobEvents.filterIsInstance<CallSessionEvent.AnswerReceived>().firstOrNull()?.event?.pubKey
+            assertEquals(carol, bobForwardedAnswer, "Bob must emit Carol's answer to his CallSession")
+            bobJob.cancel()
         }
 
     // ========================================================================
@@ -1528,15 +1543,16 @@ class CallManagerTest {
             assertTrue(carol in connecting.pendingPeerPubKeys)
 
             // Carol publishes a mesh offer to Bob (same call-id).
-            var midCallOfferPeer: HexKey? = null
-            manager.onMidCallOfferReceived = { peer, _ -> midCallOfferPeer = peer }
+            val (events, job) = collectSessionEvents(manager)
             manager.onSignalingEvent(makeGroupOffer(from = carol, members = setOf(alice, bob, carol)))
 
             val after = manager.state.value
             assertIs<CallState.Connecting>(after)
             assertTrue(carol in after.peerPubKeys, "Carol should move into peerPubKeys")
             assertTrue(carol !in after.pendingPeerPubKeys, "Carol should leave pending")
-            assertEquals(carol, midCallOfferPeer, "CallController must still receive the mid-call offer")
+            val midCallOfferPeer = events.filterIsInstance<CallSessionEvent.MidCallOfferReceived>().firstOrNull()?.peerPubKey
+            assertEquals(carol, midCallOfferPeer, "CallSession must still receive the mid-call offer")
+            job.cancel()
 
             // And her watchdog should be cancelled — advancing past the
             // 30 s budget must not further alter state.
@@ -1929,7 +1945,7 @@ class CallManagerTest {
 
     /**
      * Regression for the subtle bug where a self-reject echo would trigger
-     * onPeerLeft(signer.pubKey) on a device that had already accepted,
+     * PeerLeft(signer.pubKey) on a device that had already accepted,
      * disposing its own PeerSession and killing the live call.
      */
     @Test
@@ -1937,8 +1953,7 @@ class CallManagerTest {
         runTest {
             val (manager, _) = createManager(localPubKey = bob, followedKeys = setOf(alice))
 
-            var peerLeftCalled = false
-            manager.onPeerLeft = { peerLeftCalled = true }
+            val (events, job) = collectSessionEvents(manager)
 
             manager.onSignalingEvent(makeOffer(from = alice, to = bob))
             manager.acceptCall(sdpAnswer)
@@ -1950,29 +1965,29 @@ class CallManagerTest {
             val siblingReject = makeReject(from = bob, to = alice)
             manager.onSignalingEvent(siblingReject)
 
-            // Our live call must survive — the echo must not fire
-            // onPeerLeft (which would dispose our own PeerSession) and must
+            // Our live call must survive — the echo must not emit
+            // PeerLeft (which would dispose our own PeerSession) and must
             // not change state.
             assertIs<CallState.Connected>(manager.state.value)
             assertTrue(
-                !peerLeftCalled,
-                "onPeerLeft must not fire for a self-reject echo — the UI would " +
+                events.none { it is CallSessionEvent.PeerLeft },
+                "PeerLeft must not be emitted for a self-reject echo — the UI would " +
                     "tear down our own PeerSession, killing the live call audio.",
             )
+            job.cancel()
         }
 
     /**
      * Same guard for the Connecting state: a self-reject arriving during
      * the connection handshake must not drop us from our own pending set
-     * and must not invoke onPeerLeft(self).
+     * and must not emit PeerLeft(self).
      */
     @Test
     fun selfRejectEchoDuringConnectingDoesNotFireOnPeerLeft() =
         runTest {
             val (manager, _) = createManager(localPubKey = bob, followedKeys = setOf(alice))
 
-            var peerLeftCalled = false
-            manager.onPeerLeft = { peerLeftCalled = true }
+            val (events, job) = collectSessionEvents(manager)
 
             manager.onSignalingEvent(makeOffer(from = alice, to = bob))
             manager.acceptCall(sdpAnswer)
@@ -1982,7 +1997,8 @@ class CallManagerTest {
             manager.onSignalingEvent(siblingReject)
 
             assertIs<CallState.Connecting>(manager.state.value)
-            assertTrue(!peerLeftCalled, "onPeerLeft must not fire for a self-reject echo during Connecting")
+            assertTrue(events.none { it is CallSessionEvent.PeerLeft }, "PeerLeft must not be emitted for a self-reject echo during Connecting")
+            job.cancel()
         }
 
     /**


### PR DESCRIPTION
## Summary

This PR refactors the call session architecture to tie the lifetime of WebRTC and audio resources directly to the `CallActivity` lifecycle, eliminating race conditions and resource leaks that occurred when the Activity was destroyed and recreated.

## Key Changes

- **Renamed `CallController` → `CallSession`** and moved it from `service.call` to `ui.call.session` package to reflect its Activity-scoped ownership model
- **Activity-owned lifecycle**: `CallSession` is now created in `CallActivity.onCreate()` and destroyed in `onDestroy()` via `AutoCloseable.close()`, guaranteeing all WebRTC/audio/notification resources are released when the Activity dies
- **Event-driven architecture**: Replaced mutable `var` callbacks in `CallManager` with `SharedFlow`-based event emission (`sessionEvents` and `renegotiationEvents`), eliminating stale references between Activity destroy/recreate cycles
- **Extracted `CallNotifier`**: Moved incoming-call notification logic from `NotificationUtils` into a focused `CallNotifier` object that owns the CALL_CHANNEL and handles notification lifecycle
- **Simplified intent handling**: Consolidated `handleAcceptCallIntent()` into `handleIntent()` to support both incoming call acceptance and outgoing call initiation from `ChatroomScreen`
- **Removed PiP state tracking**: Eliminated `wasInPipMode` flag and complex `onStop()` logic by relying on `CallSession.close()` to unconditionally clean up resources
- **Watchdog timers**: Added ringing and connecting watchdog timers in `CallManager` to force timeout transitions if state gets stuck (fail-safe for canceled coroutines or dropped transitions)
- **Synchronized hangup on task removal**: `CallForegroundService.onTaskRemoved()` now publishes hangup/reject signaling synchronously before the service is killed

## Notable Implementation Details

- `CallSession` collects from `callManager.sessionEvents` and `renegotiationEvents` in its `init` block, eliminating the need for callback wiring
- `CallManager` uses `tryEmit()` instead of `emit()` to avoid suspending while holding `stateMutex`, with buffer overflow logged but not fatal
- Outgoing calls can now be initiated via Intent extras (`EXTRA_INITIATE_CALL`, `EXTRA_PEER_PUB_KEYS`, `EXTRA_CALL_TYPE`) from `ChatroomScreen`
- Tests updated to collect `sessionEvents` instead of setting callbacks, ensuring event-driven semantics are validated

https://claude.ai/code/session_019yNnDjGKmJb19gadmojq54