### PR TITLE
Add MIP-00 KeyPackage Relay List support for group invitations

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -1788,23 +1788,32 @@ class Account(
         // Build filter for the member's KeyPackages
         val filter = manager.subscriptionManager.keyPackageFilter(memberPubKey)
 
-        // KeyPackages are published by the invitee to *their own* outbox
-        // (see publishMarmotKeyPackage), so look there first. Union with
-        // our own outbox so we still find packages that ended up on a
-        // shared relay, and as a fallback when we don't know the
-        // invitee's outbox yet.
+        // Per MIP-00, invitees advertise the relays that host their
+        // KeyPackages in a kind:10051 KeyPackageRelayListEvent. Look
+        // there first, then fall back to the invitee's NIP-65 outbox
+        // (where KeyPackages typically also land), and finally union
+        // with our own outbox so we still find packages that ended up
+        // on a shared relay.
         val myOutbox = outboxRelays.flow.value
+        val memberKeyPackageRelays =
+            (
+                cache
+                    .getAddressableNoteIfExists(
+                        com.vitorpamplona.quartz.marmot.mip00KeyPackages.KeyPackageRelayListEvent
+                            .createAddress(memberPubKey),
+                    )?.event as? com.vitorpamplona.quartz.marmot.mip00KeyPackages.KeyPackageRelayListEvent
+            )?.relays()?.toSet().orEmpty()
         val memberOutbox =
             cache
                 .getOrCreateUser(memberPubKey)
                 .outboxRelays()
                 ?.toSet()
                 .orEmpty()
-        val fetchRelays = memberOutbox + myOutbox
+        val fetchRelays = memberKeyPackageRelays + memberOutbox + myOutbox
 
         Log.d("MarmotDbg") {
             "fetchKeyPackageAndAddMember: querying ${fetchRelays.size} relay(s) for ${memberPubKey.take(8)}… KeyPackage " +
-                "(memberOutbox=${memberOutbox.size}, myOutbox=${myOutbox.size}): ${fetchRelays.map { it.url }}"
+                "(memberKeyPackageRelays=${memberKeyPackageRelays.size}, memberOutbox=${memberOutbox.size}, myOutbox=${myOutbox.size}): ${fetchRelays.map { it.url }}"
         }
 
         // Query across the combined relay set
@@ -1940,19 +1949,33 @@ class Account(
     }
 
     /**
+     * Relays where this account publishes kind:30443 KeyPackage events.
+     *
+     * Per MIP-00, these should match the relays advertised in the user's
+     * kind:10051 KeyPackage Relay List so that other clients can discover
+     * and fetch them. Falls back to the standard outbox set when no list
+     * has been configured yet, since that's also where the user's other
+     * write-oriented events land.
+     */
+    fun keyPackagePublishRelays(): Set<NormalizedRelayUrl> {
+        val list = keyPackageRelayList.flow.value
+        return if (list.isNotEmpty()) list else outboxRelays.flow.value
+    }
+
+    /**
      * Publish or rotate KeyPackage events.
      */
     suspend fun publishMarmotKeyPackages() {
         val manager = marmotManager ?: return
         if (!isWriteable()) return
 
-        val relays = outboxRelays.flow.value.toList()
+        val relays = keyPackagePublishRelays()
 
         if (manager.needsKeyPackageRotation()) {
-            val rotatedEvents = manager.rotateConsumedKeyPackages(relays)
+            val rotatedEvents = manager.rotateConsumedKeyPackages(relays.toList())
             rotatedEvents.forEach { event ->
                 cache.justConsumeMyOwnEvent(event)
-                client.publish(event, outboxRelays.flow.value)
+                client.publish(event, relays)
             }
         }
     }
@@ -1964,16 +1987,16 @@ class Account(
         val manager = marmotManager ?: return
         if (!isWriteable()) return
 
-        val relays = outboxRelays.flow.value.toList()
+        val relays = keyPackagePublishRelays()
         Log.d("MarmotDbg") {
             "publishMarmotKeyPackage: generating + publishing KeyPackage event → ${relays.size} relay(s): ${relays.map { it.url }}"
         }
-        val event = manager.generateKeyPackageEvent(relays)
+        val event = manager.generateKeyPackageEvent(relays.toList())
         Log.d("MarmotDbg") {
             "publishMarmotKeyPackage: signed kind:${event.kind} id=${event.id.take(8)}… authored=${event.pubKey.take(8)}…"
         }
         cache.justConsumeMyOwnEvent(event)
-        client.publish(event, outboxRelays.flow.value)
+        client.publish(event, relays)
     }
 
     /**

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -42,6 +42,7 @@ import com.vitorpamplona.amethyst.model.edits.PrivateStorageRelayListDecryptionC
 import com.vitorpamplona.amethyst.model.edits.PrivateStorageRelayListState
 import com.vitorpamplona.amethyst.model.localRelays.ForwardKind0ToLocalRelayState
 import com.vitorpamplona.amethyst.model.localRelays.LocalRelayListState
+import com.vitorpamplona.amethyst.model.marmot.KeyPackageRelayListState
 import com.vitorpamplona.amethyst.model.nip01UserMetadata.AccountHomeRelayState
 import com.vitorpamplona.amethyst.model.nip01UserMetadata.AccountOutboxRelayState
 import com.vitorpamplona.amethyst.model.nip01UserMetadata.NotificationInboxRelayState
@@ -280,6 +281,8 @@ class Account(
     val forwardKind0ToLocalRelay = ForwardKind0ToLocalRelayState(client, localRelayList, settings)
 
     val dmRelayList = DmRelayListState(signer, cache, scope, settings)
+
+    val keyPackageRelayList = KeyPackageRelayListState(signer, cache, scope, settings)
 
     val privateStorageDecryptionCache = PrivateStorageRelayListDecryptionCache(signer)
     val privateStorageRelayList = PrivateStorageRelayListState(signer, cache, privateStorageDecryptionCache, scope, settings)
@@ -2470,6 +2473,8 @@ class Account(
     }
 
     suspend fun saveDMRelayList(dmRelays: List<NormalizedRelayUrl>) = sendLiterallyEverywhere(dmRelayList.saveRelayList(dmRelays))
+
+    suspend fun saveKeyPackageRelayList(keyPackageRelays: List<NormalizedRelayUrl>) = sendLiterallyEverywhere(keyPackageRelayList.saveRelayList(keyPackageRelays))
 
     suspend fun savePrivateOutboxRelayList(relays: List<NormalizedRelayUrl>) = sendMyPublicAndPrivateOutbox(privateStorageRelayList.saveRelayList(relays))
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -29,6 +29,7 @@ import com.vitorpamplona.amethyst.ui.actions.mediaServers.ServerName
 import com.vitorpamplona.amethyst.ui.screen.FeedDefinition
 import com.vitorpamplona.quartz.experimental.ephemChat.list.EphemeralChatListEvent
 import com.vitorpamplona.quartz.experimental.nipA3.PaymentTargetsEvent
+import com.vitorpamplona.quartz.marmot.mip00KeyPackages.KeyPackageRelayListEvent
 import com.vitorpamplona.quartz.nip01Core.core.Address
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.crypto.KeyPair
@@ -181,6 +182,7 @@ class AccountSettings(
     var backupUserMetadata: MetadataEvent? = null,
     var backupContactList: ContactListEvent? = null,
     var backupDMRelayList: ChatMessageRelayListEvent? = null,
+    var backupKeyPackageRelayList: KeyPackageRelayListEvent? = null,
     var backupNIP65RelayList: AdvertisedRelayListEvent? = null,
     var backupSearchRelayList: SearchRelayListEvent? = null,
     var backupIndexRelayList: IndexerRelayListEvent? = null,
@@ -590,6 +592,16 @@ class AccountSettings(
         // Events might be different objects, we have to compare their ids.
         if (backupDMRelayList?.id != newDMRelayList.id) {
             backupDMRelayList = newDMRelayList
+            saveAccountSettings()
+        }
+    }
+
+    fun updateKeyPackageRelayList(newKeyPackageRelayList: KeyPackageRelayListEvent?) {
+        if (newKeyPackageRelayList == null || newKeyPackageRelayList.tags.isEmpty()) return
+
+        // Events might be different objects, we have to compare their ids.
+        if (backupKeyPackageRelayList?.id != newKeyPackageRelayList.id) {
+            backupKeyPackageRelayList = newKeyPackageRelayList
             saveAccountSettings()
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/marmot/KeyPackageRelayListState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/marmot/KeyPackageRelayListState.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.model.marmot
+
+import com.vitorpamplona.amethyst.model.AccountSettings
+import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.model.Note
+import com.vitorpamplona.amethyst.model.NoteState
+import com.vitorpamplona.quartz.marmot.mip00KeyPackages.KeyPackageRelayListEvent
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
+import com.vitorpamplona.quartz.utils.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+class KeyPackageRelayListState(
+    val signer: NostrSigner,
+    val cache: LocalCache,
+    val scope: CoroutineScope,
+    val settings: AccountSettings,
+) {
+    // Creates a long-term reference for this note so that the GC doesn't collect the note it self
+    val keyPackageListNote = cache.getOrCreateAddressableNote(getKeyPackageRelayListAddress())
+
+    fun getKeyPackageRelayListAddress() = KeyPackageRelayListEvent.createAddress(signer.pubKey)
+
+    fun getKeyPackageRelayListFlow(): StateFlow<NoteState> = keyPackageListNote.flow().metadata.stateFlow
+
+    fun getKeyPackageRelayList(): KeyPackageRelayListEvent? = keyPackageListNote.event as? KeyPackageRelayListEvent
+
+    fun normalizeKeyPackageRelayListWithBackup(note: Note): Set<NormalizedRelayUrl> {
+        val event = note.event as? KeyPackageRelayListEvent ?: settings.backupKeyPackageRelayList
+        return event?.relays()?.toSet() ?: emptySet()
+    }
+
+    val flow =
+        getKeyPackageRelayListFlow()
+            .map { normalizeKeyPackageRelayListWithBackup(it.note) }
+            .onStart { emit(normalizeKeyPackageRelayListWithBackup(keyPackageListNote)) }
+            .flowOn(Dispatchers.IO)
+            .stateIn(
+                scope,
+                SharingStarted.Eagerly,
+                emptySet(),
+            )
+
+    suspend fun saveRelayList(relays: List<NormalizedRelayUrl>): KeyPackageRelayListEvent {
+        val existing = getKeyPackageRelayList()
+        return if (existing != null && existing.tags.isNotEmpty()) {
+            KeyPackageRelayListEvent.updateRelayList(
+                earlierVersion = existing,
+                relays = relays,
+                signer = signer,
+            )
+        } else {
+            KeyPackageRelayListEvent.create(
+                relays = relays,
+                signer = signer,
+            )
+        }
+    }
+
+    init {
+        settings.backupKeyPackageRelayList?.let {
+            Log.d("AccountRegisterObservers") { "Loading saved KeyPackage Relay List ${it.toJson()}" }
+            @OptIn(DelicateCoroutinesApi::class)
+            scope.launch(Dispatchers.IO) {
+                cache.justConsumeMyOwnEvent(it)
+            }
+        }
+
+        scope.launch(Dispatchers.IO) {
+            Log.d("AccountRegisterObservers", "MIP-00 KeyPackage Relay List Collector Start")
+            getKeyPackageRelayListFlow().collect {
+                Log.d("AccountRegisterObservers") { "Updating KeyPackage Relay List for ${signer.pubKey}" }
+                (it.note.event as? KeyPackageRelayListEvent)?.let {
+                    settings.updateKeyPackageRelayList(it)
+                }
+            }
+        }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/account/metadata/FilterAccountInfoAndListsFromKey.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/account/metadata/FilterAccountInfoAndListsFromKey.kt
@@ -22,6 +22,7 @@ package com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.metada
 
 import com.vitorpamplona.amethyst.model.nip78AppSpecific.AppSpecificState.Companion.APP_SPECIFIC_DATA_D_TAG
 import com.vitorpamplona.quartz.experimental.nipA3.PaymentTargetsEvent
+import com.vitorpamplona.quartz.marmot.mip00KeyPackages.KeyPackageRelayListEvent
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
@@ -53,6 +54,7 @@ val AccountInfoAndListsFromKeyKinds =
         StatusEvent.KIND,
         AdvertisedRelayListEvent.KIND,
         ChatMessageRelayListEvent.KIND,
+        KeyPackageRelayListEvent.KIND,
         SearchRelayListEvent.KIND,
         FileServersEvent.KIND,
         BlossomServersEvent.KIND,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/account/metadata/FilterBasicAccountInfoFromKeys.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/account/metadata/FilterBasicAccountInfoFromKeys.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.metadata
 
+import com.vitorpamplona.quartz.marmot.mip00KeyPackages.KeyPackageRelayListEvent
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
@@ -47,6 +48,7 @@ val BasicAccountInfoKinds =
         ContactListEvent.KIND,
         AdvertisedRelayListEvent.KIND,
         ChatMessageRelayListEvent.KIND,
+        KeyPackageRelayListEvent.KIND,
         SearchRelayListEvent.KIND,
         FileServersEvent.KIND,
         BlossomServersEvent.KIND,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/user/watchers/FilterUserMetadataForKey.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/user/watchers/FilterUserMetadataForKey.kt
@@ -23,6 +23,7 @@ package com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.watchers
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.relays.EOSEAccountFast
+import com.vitorpamplona.quartz.marmot.mip00KeyPackages.KeyPackageRelayListEvent
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
@@ -41,6 +42,7 @@ val UserMetadataForKeyKinds =
         StatusEvent.KIND,
         AdvertisedRelayListEvent.KIND,
         ChatMessageRelayListEvent.KIND,
+        KeyPackageRelayListEvent.KIND,
     )
 
 fun filterUserMetadataForKey(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/AccountSessionManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/AccountSessionManager.kt
@@ -34,6 +34,7 @@ import com.vitorpamplona.amethyst.model.DefaultNIP65RelaySet
 import com.vitorpamplona.amethyst.model.DefaultSearchRelayList
 import com.vitorpamplona.amethyst.model.accountsCache.AccountCacheState
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
+import com.vitorpamplona.quartz.marmot.mip00KeyPackages.KeyPackageRelayListEvent
 import com.vitorpamplona.quartz.nip01Core.core.hexToByteArray
 import com.vitorpamplona.quartz.nip01Core.core.toHexKey
 import com.vitorpamplona.quartz.nip01Core.crypto.KeyPair
@@ -293,6 +294,7 @@ class AccountSessionManager(
                 accountSettings.backupContactList?.let { client.publish(it, toPost) }
                 accountSettings.backupNIP65RelayList?.let { client.publish(it, toPost) }
                 accountSettings.backupDMRelayList?.let { client.publish(it, toPost) }
+                accountSettings.backupKeyPackageRelayList?.let { client.publish(it, toPost) }
                 accountSettings.backupSearchRelayList?.let { client.publish(it, toPost) }
                 accountSettings.backupIndexRelayList?.let { client.publish(it, toPost) }
                 accountSettings.backupRelayFeedsList?.let { client.publish(it, toPost) }
@@ -317,6 +319,10 @@ class AccountSessionManager(
                 ),
             backupNIP65RelayList = AdvertisedRelayListEvent.create(DefaultNIP65List, tempSigner),
             backupDMRelayList = ChatMessageRelayListEvent.create(DefaultDMRelayList, tempSigner),
+            // MIP-00: advertise the default outbox relays as KeyPackage hosts
+            // so other users can discover and fetch this account's KeyPackage
+            // events without having to guess where they were published.
+            backupKeyPackageRelayList = KeyPackageRelayListEvent.create(DefaultNIP65RelaySet.toList(), tempSigner),
             backupSearchRelayList = SearchRelayListEvent.create(DefaultSearchRelayList.toList(), tempSigner),
             backupIndexRelayList = IndexerRelayListEvent.create(DefaultIndexerRelayList.toList(), tempSigner),
             backupChannelList = ChannelListEvent.create(emptyList(), DefaultChannels, tempSigner),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -1471,6 +1471,27 @@ class AccountViewModel(
 
     suspend fun hasPublishedKeyPackage(): Boolean = account.hasPublishedKeyPackage()
 
+    /**
+     * Whether this account has a kind:10051 KeyPackage Relay List (MIP-00)
+     * advertising where it publishes KeyPackages.
+     */
+    fun hasKeyPackageRelayList(): Boolean =
+        account.keyPackageRelayList.flow.value
+            .isNotEmpty()
+
+    /**
+     * Publishes a kind:10051 KeyPackage Relay List seeded from the account's
+     * current outbox relays. Used when the user opts in from the
+     * "Create Group" warning dialog.
+     */
+    suspend fun saveKeyPackageRelayListFromOutbox() {
+        val outbox =
+            account.outboxRelays.flow.value
+                .toList()
+        if (outbox.isEmpty()) return
+        account.saveKeyPackageRelayList(outbox)
+    }
+
     suspend fun leaveMarmotGroup(nostrGroupId: String) {
         val relays = marmotGroupRelays(nostrGroupId)
         account.leaveMarmotGroup(nostrGroupId, relays)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/CreateGroupScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/CreateGroupScreen.kt
@@ -26,10 +26,12 @@ import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -55,44 +57,53 @@ fun CreateGroupScreen(
 ) {
     var groupName by remember { mutableStateOf("") }
     var isCreating by remember { mutableStateOf(false) }
+    var showKeyPackageRelayDialog by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
+
+    fun proceedWithCreate() {
+        isCreating = true
+        scope.launch(Dispatchers.IO) {
+            try {
+                val nostrGroupId = RandomInstance.bytes(32).toHexKey()
+                accountViewModel.createMarmotGroup(nostrGroupId)
+                // Always commit an initial metadata extension so that
+                // (a) the name (if any) is persisted in MLS extensions
+                //     and survives app restarts,
+                // (b) the inviter's outbox relays land in the group
+                //     metadata so every member ends up with the same
+                //     canonical relay set for kind:445 — without this,
+                //     invitees would never receive the group's messages.
+                // Both are handled inside `updateMarmotGroupMetadata`.
+                accountViewModel.updateMarmotGroupMetadata(
+                    nostrGroupId = nostrGroupId,
+                    name = groupName.trim(),
+                    description = "",
+                )
+                nav.nav(Route.MarmotGroupChat(nostrGroupId))
+            } catch (e: Exception) {
+                isCreating = false
+                launch(Dispatchers.Main) {
+                    Toast
+                        .makeText(
+                            context,
+                            "Failed to create group: ${e.message}",
+                            Toast.LENGTH_LONG,
+                        ).show()
+                }
+            }
+        }
+    }
 
     Scaffold(
         topBar = {
             CreatingTopBar(
                 onCancel = { nav.popBack() },
                 onPost = {
-                    isCreating = true
-                    scope.launch(Dispatchers.IO) {
-                        try {
-                            val nostrGroupId = RandomInstance.bytes(32).toHexKey()
-                            accountViewModel.createMarmotGroup(nostrGroupId)
-                            // Always commit an initial metadata extension so that
-                            // (a) the name (if any) is persisted in MLS extensions
-                            //     and survives app restarts,
-                            // (b) the inviter's outbox relays land in the group
-                            //     metadata so every member ends up with the same
-                            //     canonical relay set for kind:445 — without this,
-                            //     invitees would never receive the group's messages.
-                            // Both are handled inside `updateMarmotGroupMetadata`.
-                            accountViewModel.updateMarmotGroupMetadata(
-                                nostrGroupId = nostrGroupId,
-                                name = groupName.trim(),
-                                description = "",
-                            )
-                            nav.nav(Route.MarmotGroupChat(nostrGroupId))
-                        } catch (e: Exception) {
-                            isCreating = false
-                            launch(Dispatchers.Main) {
-                                Toast
-                                    .makeText(
-                                        context,
-                                        "Failed to create group: ${e.message}",
-                                        Toast.LENGTH_LONG,
-                                    ).show()
-                            }
-                        }
+                    if (!accountViewModel.hasKeyPackageRelayList()) {
+                        showKeyPackageRelayDialog = true
+                    } else {
+                        proceedWithCreate()
                     }
                 },
                 isActive = { !isCreating },
@@ -129,4 +140,53 @@ fun CreateGroupScreen(
             )
         }
     }
+
+    if (showKeyPackageRelayDialog) {
+        MissingKeyPackageRelayListDialog(
+            onConfirm = {
+                showKeyPackageRelayDialog = false
+                scope.launch(Dispatchers.IO) {
+                    accountViewModel.saveKeyPackageRelayListFromOutbox()
+                }
+                proceedWithCreate()
+            },
+            onDismiss = {
+                showKeyPackageRelayDialog = false
+                proceedWithCreate()
+            },
+            onCancel = {
+                showKeyPackageRelayDialog = false
+            },
+        )
+    }
+}
+
+@Composable
+private fun MissingKeyPackageRelayListDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onCancel,
+        title = { Text("KeyPackage Relays not set") },
+        text = {
+            Text(
+                "You don't have a KeyPackage Relay List yet (MIP-00). " +
+                    "This list tells other people where your KeyPackage is " +
+                    "published so they can invite you to group chats.\n\n" +
+                    "Use your current outbox relays for this?",
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text("Use outbox relays")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Skip for now")
+            }
+        },
+    )
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/AllRelayListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/AllRelayListScreen.kt
@@ -75,6 +75,8 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.feeds.RelayFeedsList
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.feeds.renderRelayFeedsItems
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.indexer.IndexerRelayListViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.indexer.renderIndexerItems
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.keyPackage.KeyPackageRelayListViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.keyPackage.renderKeyPackageItems
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.local.LocalRelayListViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.local.renderLocalItems
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.nip37.PrivateOutboxRelayListViewModel
@@ -101,6 +103,7 @@ fun AllRelayListScreen(
     nav: INav,
 ) {
     val dmViewModel: DMRelayListViewModel = viewModel()
+    val keyPackageViewModel: KeyPackageRelayListViewModel = viewModel()
     val nip65ViewModel: Nip65RelayListViewModel = viewModel()
     val privateOutboxViewModel: PrivateOutboxRelayListViewModel = viewModel()
     val searchViewModel: SearchRelayListViewModel = viewModel()
@@ -114,6 +117,7 @@ fun AllRelayListScreen(
     val relayFeedsViewModel: RelayFeedsListViewModel = viewModel()
 
     dmViewModel.init(accountViewModel)
+    keyPackageViewModel.init(accountViewModel)
     nip65ViewModel.init(accountViewModel)
     searchViewModel.init(accountViewModel)
     localViewModel.init(accountViewModel)
@@ -128,6 +132,7 @@ fun AllRelayListScreen(
 
     LaunchedEffect(accountViewModel) {
         dmViewModel.load()
+        keyPackageViewModel.load()
         nip65ViewModel.load()
         searchViewModel.load()
         localViewModel.load()
@@ -143,6 +148,7 @@ fun AllRelayListScreen(
 
     MappedAllRelayListView(
         dmViewModel,
+        keyPackageViewModel,
         nip65ViewModel,
         searchViewModel,
         localViewModel,
@@ -163,6 +169,7 @@ fun AllRelayListScreen(
 @Composable
 fun MappedAllRelayListView(
     dmViewModel: DMRelayListViewModel,
+    keyPackageViewModel: KeyPackageRelayListViewModel,
     nip65ViewModel: Nip65RelayListViewModel,
     searchViewModel: SearchRelayListViewModel,
     localViewModel: LocalRelayListViewModel,
@@ -178,6 +185,7 @@ fun MappedAllRelayListView(
     nav: INav,
 ) {
     val dmFeedState by dmViewModel.relays.collectAsStateWithLifecycle()
+    val keyPackageFeedState by keyPackageViewModel.relays.collectAsStateWithLifecycle()
     val homeFeedState by nip65ViewModel.homeRelays.collectAsStateWithLifecycle()
     val notifFeedState by nip65ViewModel.notificationRelays.collectAsStateWithLifecycle()
     val privateOutboxFeedState by privateOutboxViewModel.relays.collectAsStateWithLifecycle()
@@ -194,6 +202,7 @@ fun MappedAllRelayListView(
     val outboxCounts by nip65ViewModel.homeCountResults.collectAsStateWithLifecycle()
     val inboxCounts by nip65ViewModel.notifCountResults.collectAsStateWithLifecycle()
     val dmCounts by dmViewModel.countResults.collectAsStateWithLifecycle()
+    val keyPackageCounts by keyPackageViewModel.countResults.collectAsStateWithLifecycle()
     val privateHomeCounts by privateOutboxViewModel.countResults.collectAsStateWithLifecycle()
     val proxyCounts by proxyViewModel.countResults.collectAsStateWithLifecycle()
     val indexerCounts by indexerViewModel.countResults.collectAsStateWithLifecycle()
@@ -213,6 +222,11 @@ fun MappedAllRelayListView(
         rememberRelayDragState(
             onMove = { from, to -> dmViewModel.moveRelay(from, to) },
             itemCount = { dmFeedState.size },
+        )
+    val keyPackageDragState =
+        rememberRelayDragState(
+            onMove = { from, to -> keyPackageViewModel.moveRelay(from, to) },
+            itemCount = { keyPackageFeedState.size },
         )
     val privateOutboxDragState =
         rememberRelayDragState(
@@ -284,6 +298,7 @@ fun MappedAllRelayListView(
                 },
                 onCancel = {
                     dmViewModel.clear()
+                    keyPackageViewModel.clear()
                     nip65ViewModel.clear()
                     searchViewModel.clear()
                     localViewModel.clear()
@@ -298,6 +313,7 @@ fun MappedAllRelayListView(
                 },
                 onPost = {
                     dmViewModel.create()
+                    keyPackageViewModel.create()
                     nip65ViewModel.create()
                     searchViewModel.create()
                     localViewModel.create()
@@ -315,7 +331,8 @@ fun MappedAllRelayListView(
     ) { pad ->
         val anyDragging =
             homeDragState.isDragging || notifDragState.isDragging ||
-                dmDragState.isDragging || privateOutboxDragState.isDragging ||
+                dmDragState.isDragging || keyPackageDragState.isDragging ||
+                privateOutboxDragState.isDragging ||
                 proxyDragState.isDragging || broadcastDragState.isDragging ||
                 indexerDragState.isDragging || searchDragState.isDragging ||
                 localDragState.isDragging || trustedDragState.isDragging ||
@@ -362,6 +379,15 @@ fun MappedAllRelayListView(
                 )
             }
             renderDMItems(dmFeedState, dmViewModel, accountViewModel, nav, dmCounts, dmDragState)
+
+            item {
+                SettingsCategory(
+                    R.string.keypackage_section,
+                    R.string.keypackage_section_explainer,
+                    SettingsCategorySpacingWithHorzBorderModifier,
+                )
+            }
+            renderKeyPackageItems(keyPackageFeedState, keyPackageViewModel, accountViewModel, nav, keyPackageCounts, keyPackageDragState)
 
             item {
                 SettingsCategory(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/keyPackage/KeyPackageRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/keyPackage/KeyPackageRelayListView.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.keyPackage
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.Amethyst
+import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.navs.rememberExtendedNav
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfo
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoDialog
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayCountResult
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayDragState
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.RelayUrlEditField
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.relaySetupInfoBuilder
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.rememberRelayDragState
+import com.vitorpamplona.amethyst.ui.theme.FeedPadding
+import com.vitorpamplona.amethyst.ui.theme.HorzHalfVertPadding
+import com.vitorpamplona.amethyst.ui.theme.HorzPadding
+import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+
+@Composable
+fun KeyPackageRelayList(
+    postViewModel: KeyPackageRelayListViewModel,
+    accountViewModel: AccountViewModel,
+    onClose: () -> Unit,
+    nav: INav,
+) {
+    val feedState by postViewModel.relays.collectAsStateWithLifecycle()
+    val newNav = rememberExtendedNav(nav, onClose)
+    val dragState =
+        rememberRelayDragState(
+            onMove = { from, to -> postViewModel.moveRelay(from, to) },
+            itemCount = { feedState.size },
+        )
+
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        LazyColumn(
+            contentPadding = FeedPadding,
+            userScrollEnabled = !dragState.isDragging,
+        ) {
+            renderKeyPackageItems(feedState, postViewModel, accountViewModel, newNav, dragState = dragState)
+        }
+    }
+}
+
+fun LazyListScope.renderKeyPackageItems(
+    feedState: List<BasicRelaySetupInfo>,
+    postViewModel: KeyPackageRelayListViewModel,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+    countResults: Map<NormalizedRelayUrl, RelayCountResult> = emptyMap(),
+    dragState: RelayDragState? = null,
+) {
+    itemsIndexed(feedState, key = { _, item -> "KeyPackage" + item.relay.url }) { index, item ->
+        BasicRelaySetupInfoDialog(
+            item,
+            onDelete = { postViewModel.deleteRelay(item) },
+            nip11CachedRetriever = Amethyst.instance.nip11Cache,
+            modifier = HorzHalfVertPadding,
+            countResult = countResults[item.relay],
+            index = index,
+            dragState = dragState,
+            accountViewModel = accountViewModel,
+            nav = nav,
+        )
+    }
+
+    item {
+        Spacer(modifier = StdVertSpacer)
+        RelayUrlEditField(
+            onNewRelay = { postViewModel.addRelay(relaySetupInfoBuilder(it)) },
+            modifier = HorzPadding,
+            accountViewModel = accountViewModel,
+            nav = nav,
+        )
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/keyPackage/KeyPackageRelayListViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/keyPackage/KeyPackageRelayListViewModel.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.keyPackage
+
+import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.BasicRelaySetupInfoModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.common.CountFilter
+import com.vitorpamplona.quartz.marmot.mip00KeyPackages.KeyPackageEvent
+import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+
+@Stable
+class KeyPackageRelayListViewModel : BasicRelaySetupInfoModel() {
+    override fun getRelayList(): List<NormalizedRelayUrl>? = account.keyPackageRelayList.getKeyPackageRelayList()?.relays()
+
+    override suspend fun saveRelayList(urlList: List<NormalizedRelayUrl>) {
+        account.saveKeyPackageRelayList(urlList)
+    }
+
+    override fun countFilters(relayUrl: NormalizedRelayUrl): List<CountFilter> =
+        listOf(
+            CountFilter(
+                label = R.string.keypackage_section,
+                filter =
+                    Filter(
+                        kinds = listOf(KeyPackageEvent.KIND),
+                        authors = listOf(account.pubKey),
+                    ),
+            ),
+        )
+}

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -1562,6 +1562,8 @@
     <string name="private_inbox_section">DM Inbox Relays</string>
     <string name="private_inbox_section_explainer_profile">User receives DMs on these relays</string>
     <string name="private_inbox_section_explainer">Insert between 1–3 relays to serve as your private inbox. Others will use these relays to send DMs to you. DM Inbox relays should accept any message from anyone, but only allow you to download them. Good options are:\n - inbox.nostr.wine (paid)\n - auth.nostr1.com (free)\n - you.nostr1.com (personal relays - paid)</string>
+    <string name="keypackage_section">KeyPackage Relays</string>
+    <string name="keypackage_section_explainer">Relays where your MLS KeyPackages are published (MIP-00). Other users fetch these KeyPackages to invite you into Marmot group chats. Insert between 1–3 relays that accept KeyPackage events from you and allow public reads.</string>
     <string name="private_outbox_section">Private Home Relays</string>
     <string name="private_outbox_section_explainer">Insert between 1–3 relays to store events no one else can see, like your Drafts and/or app settings. Ideally, these relays are either local or require authentication before downloading each user\'s content.</string>
     <string name="kind_3_section">General Relays</string>

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/marmot/mip00KeyPackages/KeyPackageRelayListEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/marmot/mip00KeyPackages/KeyPackageRelayListEvent.kt
@@ -69,6 +69,21 @@ class KeyPackageRelayListEvent(
             signer: NostrSigner,
             createdAt: Long = TimeUtils.now(),
         ): KeyPackageRelayListEvent = signer.sign(createdAt, KIND, createTagArray(relays), "")
+
+        suspend fun updateRelayList(
+            earlierVersion: KeyPackageRelayListEvent,
+            relays: List<NormalizedRelayUrl>,
+            signer: NostrSigner,
+            createdAt: Long = TimeUtils.now(),
+        ): KeyPackageRelayListEvent {
+            val tags =
+                earlierVersion.tags
+                    .filter { it.isEmpty() || it[0] != RelayTag.TAG_NAME }
+                    .plus(relays.map { RelayTag.assemble(it) })
+                    .toTypedArray()
+
+            return signer.sign(createdAt, KIND, tags, earlierVersion.content)
+        }
     }
 }
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/marmot/mip00KeyPackages/KeyPackageRelayListEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/marmot/mip00KeyPackages/KeyPackageRelayListEvent.kt
@@ -27,6 +27,7 @@ import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.isLocalHost
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerSync
 import com.vitorpamplona.quartz.nip31Alts.AltTag
 import com.vitorpamplona.quartz.utils.TimeUtils
 
@@ -67,6 +68,12 @@ class KeyPackageRelayListEvent(
         suspend fun create(
             relays: List<NormalizedRelayUrl>,
             signer: NostrSigner,
+            createdAt: Long = TimeUtils.now(),
+        ): KeyPackageRelayListEvent = signer.sign(createdAt, KIND, createTagArray(relays), "")
+
+        fun create(
+            relays: List<NormalizedRelayUrl>,
+            signer: NostrSignerSync,
             createdAt: Long = TimeUtils.now(),
         ): KeyPackageRelayListEvent = signer.sign(createdAt, KIND, createTagArray(relays), "")
 


### PR DESCRIPTION
## Summary
Implements MIP-00 KeyPackage Relay List support to allow users to advertise where their KeyPackage events are published, enabling other clients to discover and fetch them for group chat invitations.

## Key Changes

- **New KeyPackageRelayListState model**: Manages the kind:10051 KeyPackageRelayListEvent, tracking where the user publishes KeyPackages with fallback to outbox relays
- **KeyPackage relay discovery**: Updated group member invitation flow to check the invitee's advertised KeyPackage relays (MIP-00) before falling back to their outbox and the inviter's outbox
- **Create Group dialog**: Added warning dialog when creating a group without a KeyPackage Relay List configured, offering to seed it from the user's outbox relays
- **KeyPackage Relay List UI**: New relay management screen (KeyPackageRelayListView/ViewModel) for users to configure their KeyPackage relay list
- **Account integration**: 
  - Added `keyPackageRelayList` state to Account model
  - Added `keyPackagePublishRelays()` method to determine where KeyPackages should be published
  - Updated KeyPackage publishing to use the configured relay list
- **Settings persistence**: Added backup storage for KeyPackageRelayListEvent in AccountSettings
- **Event creation helpers**: Added synchronous and update methods to KeyPackageRelayListEvent for creating and updating relay lists

## Implementation Details

- KeyPackage relays are prioritized in the discovery order: advertised relays → member outbox → inviter outbox
- Falls back to outbox relays when no explicit KeyPackage relay list is configured
- Dialog provides user choice to configure relays immediately or skip for now
- Relay list is persisted and restored on app restart

https://claude.ai/code/session_01B7kTUFAPvWarWd6fvQKNBy