### PR TITLE
Skip audio animation when blurhash is present

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/RenderVideoPlayer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/RenderVideoPlayer.kt
@@ -87,6 +87,7 @@ fun RenderVideoPlayer(
     videoModifier: Modifier,
     onDialog: (() -> Unit)? = null,
     controllerVisible: MutableState<Boolean> = remember { mutableStateOf(false) },
+    hasBlurhash: Boolean = false,
     accountViewModel: AccountViewModel,
 ) {
     val containerSize = remember { mutableStateOf(IntSize.Zero) }
@@ -123,6 +124,7 @@ fun RenderVideoPlayer(
             controllerState,
             mediaItem.src.waveformData,
             Modifier.fillMaxSize().align(Alignment.Center),
+            hasBlurhash = hasBlurhash,
         )
 
         if (showControls) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/VideoView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/VideoView.kt
@@ -137,6 +137,7 @@ fun VideoView(
                     nostrUriCallback = nostrUriCallback,
                     automaticallyStartPlayback = automaticallyStartPlayback.value,
                     onZoom = onDialog,
+                    hasBlurhash = false,
                     accountViewModel = accountViewModel,
                     showControls = showControls,
                 )
@@ -183,6 +184,7 @@ fun VideoView(
                     nostrUriCallback = nostrUriCallback,
                     automaticallyStartPlayback = automaticallyStartPlayback.value,
                     onZoom = onDialog,
+                    hasBlurhash = true,
                     accountViewModel = accountViewModel,
                     showControls = showControls,
                 )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/VideoViewInner.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/VideoViewInner.kt
@@ -49,6 +49,7 @@ fun VideoViewInner(
     automaticallyStartPlayback: Boolean,
     controllerVisible: MutableState<Boolean> = mutableStateOf(false),
     onZoom: (() -> Unit)? = null,
+    hasBlurhash: Boolean = false,
     accountViewModel: AccountViewModel,
 ) {
     // keeps a copy of the value to avoid recompositions here when the DEFAULT value changes
@@ -82,6 +83,7 @@ fun VideoViewInner(
                     videoModifier = videoModifier,
                     controllerVisible = controllerVisible,
                     onDialog = onZoom,
+                    hasBlurhash = hasBlurhash,
                     accountViewModel = accountViewModel,
                 )
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/wavefront/AudioPlayingAnimation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/wavefront/AudioPlayingAnimation.kt
@@ -33,14 +33,17 @@ import androidx.media3.common.Tracks
 import com.vitorpamplona.amethyst.service.playback.composable.MediaControllerState
 import com.vitorpamplona.amethyst.service.playback.composable.WaveformData
 
-fun Tracks.isAudio() = groups.none { it.type == C.TRACK_TYPE_VIDEO }
+fun Tracks.isAudio() = groups.isNotEmpty() && groups.none { it.type == C.TRACK_TYPE_VIDEO }
 
 @Composable
 fun AudioPlayingAnimation(
     controllerState: MediaControllerState,
     waveform: WaveformData?,
     modifier: Modifier = Modifier,
+    hasBlurhash: Boolean = false,
 ) {
+    if (hasBlurhash) return
+
     var isAudio by remember { mutableStateOf(controllerState.controller.currentTracks.isAudio()) }
 
     DisposableEffect(controllerState.controller) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
@@ -568,6 +568,7 @@ private fun RenderImageOrVideo(
                         nostrUriCallback = content.uri,
                         automaticallyStartPlayback = true,
                         controllerVisible = controllerVisible,
+                        hasBlurhash = content.blurhash != null,
                         accountViewModel = accountViewModel,
                     )
                 }
@@ -626,6 +627,7 @@ private fun RenderImageOrVideo(
                             nostrUriCallback = content.uri,
                             automaticallyStartPlayback = true,
                             controllerVisible = controllerVisible,
+                            hasBlurhash = content.blurhash != null,
                             accountViewModel = accountViewModel,
                         )
                     }


### PR DESCRIPTION
## Summary
This PR optimizes video playback by skipping the audio playing animation when a blurhash (placeholder image) is available, improving the visual experience when loading media with pre-loaded thumbnails.

## Key Changes
- **AudioPlayingAnimation**: Added `hasBlurhash` parameter to skip rendering the audio animation when a blurhash placeholder is present
- **Tracks.isAudio()**: Fixed edge case by ensuring the groups list is not empty before checking track types
- **RenderVideoPlayer**: Propagated `hasBlurhash` parameter through the video player composition chain
- **VideoViewInner & VideoView**: Added `hasBlurhash` parameter and passed it through to child composables
- **ZoomableContentDialog**: Set `hasBlurhash` based on whether the content has a blurhash value available

## Implementation Details
The `hasBlurhash` parameter flows through the composition hierarchy:
- `VideoView` → `VideoViewInner` → `RenderVideoPlayer` → `AudioPlayingAnimation`
- In `VideoView`, the parameter is set to `false` for regular playback and `true` when rendering with a blurhash
- In `ZoomableContentDialog`, the parameter is determined by checking if `content.blurhash != null`
- The audio animation is skipped entirely when `hasBlurhash` is true, avoiding unnecessary visual elements when a thumbnail is already displayed

https://claude.ai/code/session_01CKfcdBfKX9AX9hoTyFRaTe