### PR TITLE
Simplify payment button logic and handle empty targets earlier

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/PaymentButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/PaymentButton.kt
@@ -64,7 +64,9 @@ fun PaymentButton(
             remember(note) {
                 (note?.event as? PaymentTargetsEvent)?.paymentTargets() ?: emptyList()
             }
-        PaymentButtonWithTargets(targets)
+        if (targets.isNotEmpty()) {
+            PaymentButtonWithTargets(targets)
+        }
     }
 }
 
@@ -94,31 +96,22 @@ fun PaymentButtonWithTargets(targets: List<PaymentTarget>) {
             onDismiss = { expanded = false },
         ) {
             M3ActionSection {
-                if (targets.isEmpty()) {
+                targets.forEach { target ->
                     M3ActionRow(
                         icon = Icons.Outlined.AccountBalanceWallet,
-                        text = stringRes(R.string.no_payment_targets_message),
-                        enabled = false,
-                        onClick = {},
+                        text = "${target.type.replaceFirstChar(Char::titlecase)}: ${target.authority}",
+                        onClick = {
+                            expanded = false
+                            try {
+                                val intent = Intent(Intent.ACTION_VIEW, "payto://${target.type}/${target.authority}".toUri())
+                                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                                context.startActivity(intent)
+                            } catch (e: Exception) {
+                                if (e is kotlinx.coroutines.CancellationException) throw e
+                                errorMessage = stringRes(context, R.string.no_payment_app_found)
+                            }
+                        },
                     )
-                } else {
-                    targets.forEach { target ->
-                        M3ActionRow(
-                            icon = Icons.Outlined.AccountBalanceWallet,
-                            text = "${target.type.replaceFirstChar(Char::titlecase)}: ${target.authority}",
-                            onClick = {
-                                expanded = false
-                                try {
-                                    val intent = Intent(Intent.ACTION_VIEW, "payto://${target.type}/${target.authority}".toUri())
-                                    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                                    context.startActivity(intent)
-                                } catch (e: Exception) {
-                                    if (e is kotlinx.coroutines.CancellationException) throw e
-                                    errorMessage = stringRes(context, R.string.no_payment_app_found)
-                                }
-                            },
-                        )
-                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
Refactored the payment button implementation to improve code clarity and user experience by moving the empty targets check to the parent component and removing unnecessary conditional logic.

## Key Changes
- Moved empty targets validation from `PaymentButtonWithTargets` to `PaymentButton` to prevent rendering the button entirely when no payment targets exist
- Removed the empty state UI (disabled "no payment targets" message) in favor of not showing the button at all
- Simplified `PaymentButtonWithTargets` by eliminating the if-else block that handled empty vs. populated targets
- Flattened the nested forEach loop structure for improved readability

## Implementation Details
- The `PaymentButton` composable now checks `if (targets.isNotEmpty())` before calling `PaymentButtonWithTargets`, preventing unnecessary composition
- `PaymentButtonWithTargets` now assumes it always receives a non-empty list and directly iterates through targets
- This approach provides a cleaner UX by not displaying an interactive button element when there's nothing to interact with

https://claude.ai/code/session_01X51KAzYWnqxkr5WdCm4a7J