### PR TITLE
Add PDF viewing support with preview cards and full-page viewer

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/previews/UrlPreview.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/previews/UrlPreview.kt
@@ -71,6 +71,8 @@ class UrlPreview {
                             UrlInfoItem(url, image = url, mimeType = mimeType.toString())
                         } else if (mimeType.type == "video") {
                             UrlInfoItem(url, image = url, mimeType = mimeType.toString())
+                        } else if (mimeType.type == "application" && mimeType.subtype == "pdf") {
+                            UrlInfoItem(url, image = url, mimeType = mimeType.toString())
                         } else {
                             throw IllegalArgumentException("Website returned unknown encoding for previews: $mimeType")
                         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/LoadUrlPreview.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/LoadUrlPreview.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
 import androidx.compose.ui.layout.ContentScale
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlImage
+import com.vitorpamplona.amethyst.commons.richtext.MediaUrlPdf
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlVideo
 import com.vitorpamplona.amethyst.model.UrlCachedPreviewer
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
@@ -107,6 +108,15 @@ fun RenderLoaded(
         Box(modifier = HalfVertPadding) {
             ZoomableContentView(
                 content = MediaUrlVideo(url, uri = callbackUri),
+                roundedCorner = true,
+                contentScale = ContentScale.FillWidth,
+                accountViewModel = accountViewModel,
+            )
+        }
+    } else if (state.previewInfo.mimeType.startsWith("application/pdf")) {
+        Box(modifier = HalfVertPadding) {
+            ZoomableContentView(
+                content = MediaUrlPdf(url, uri = callbackUri, mimeType = state.previewInfo.mimeType),
                 roundedCorner = true,
                 contentScale = ContentScale.FillWidth,
                 accountViewModel = accountViewModel,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/RichTextViewer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/RichTextViewer.kt
@@ -81,6 +81,7 @@ import com.vitorpamplona.amethyst.commons.richtext.ImageSegment
 import com.vitorpamplona.amethyst.commons.richtext.InvoiceSegment
 import com.vitorpamplona.amethyst.commons.richtext.LinkSegment
 import com.vitorpamplona.amethyst.commons.richtext.ParagraphState
+import com.vitorpamplona.amethyst.commons.richtext.PdfSegment
 import com.vitorpamplona.amethyst.commons.richtext.PhoneSegment
 import com.vitorpamplona.amethyst.commons.richtext.RegularTextSegment
 import com.vitorpamplona.amethyst.commons.richtext.RelayUrlSegment
@@ -480,6 +481,9 @@ private fun RenderWordWithoutPreview(
         // Don't preview Videos
         is VideoSegment -> ClickableUrl(word.segmentText, word.segmentText)
 
+        // Don't preview PDFs
+        is PdfSegment -> ClickableUrl(word.segmentText, word.segmentText)
+
         is LinkSegment -> ClickableUrl(word.segmentText, word.segmentText)
 
         is EmojiSegment -> RenderCustomEmoji(word.segmentText, state)
@@ -529,6 +533,7 @@ private fun RenderWordWithPreview(
     when (word) {
         is ImageSegment -> ZoomableContentView(word.segmentText, state, accountViewModel)
         is VideoSegment -> ZoomableContentView(word.segmentText, state, accountViewModel)
+        is PdfSegment -> ZoomableContentView(word.segmentText, state, accountViewModel)
         is LinkSegment -> LoadUrlPreview(word.segmentText, word.segmentText, callbackUri, accountViewModel)
         is EmojiSegment -> RenderCustomEmoji(word.segmentText, state)
         is InvoiceSegment -> MayBeInvoicePreview(word.segmentText, accountViewModel)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
@@ -535,6 +535,7 @@ private fun RenderImageOrVideo(
                     controllerVisible = controllerVisible,
                     accountViewModel = accountViewModel,
                     alwayShowImage = true,
+                    fullResolution = true,
                 )
             }
 
@@ -593,6 +594,7 @@ private fun RenderImageOrVideo(
                     controllerVisible = controllerVisible,
                     accountViewModel = accountViewModel,
                     alwayShowImage = true,
+                    fullResolution = true,
                 )
             }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
@@ -77,6 +77,8 @@ import coil3.compose.AsyncImage
 import coil3.compose.AsyncImagePainter
 import coil3.compose.SubcomposeAsyncImage
 import coil3.compose.SubcomposeAsyncImageContent
+import coil3.request.ImageRequest
+import coil3.size.Size
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
@@ -276,6 +278,7 @@ fun LocalImageView(
     controllerVisible: MutableState<Boolean>,
     accountViewModel: AccountViewModel,
     alwayShowImage: Boolean = false,
+    fullResolution: Boolean = false,
 ) {
     if (content.localFileExists()) {
         val showImage =
@@ -286,10 +289,23 @@ fun LocalImageView(
             }
 
         val ratio = remember(content) { content.dim?.aspectRatio() ?: MediaAspectRatioCache.get(content.localFile.toString()) }
+        val context = LocalContext.current
+        val imageModel =
+            if (fullResolution) {
+                remember(content.localFile, context) {
+                    ImageRequest
+                        .Builder(context)
+                        .data(content.localFile)
+                        .size(Size.ORIGINAL)
+                        .build()
+                }
+            } else {
+                content.localFile
+            }
         CrossfadeIfEnabled(targetState = showImage.value, contentAlignment = Alignment.Center, accountViewModel = accountViewModel) { imageVisible ->
             if (imageVisible) {
                 SubcomposeAsyncImage(
-                    model = content.localFile,
+                    model = imageModel,
                     contentDescription = content.description,
                     contentScale = contentScale,
                     modifier = mainImageModifier,
@@ -391,6 +407,7 @@ fun UrlImageView(
     controllerVisible: MutableState<Boolean>,
     accountViewModel: AccountViewModel,
     alwayShowImage: Boolean = false,
+    fullResolution: Boolean = false,
 ) {
     val ratio = content.dim?.aspectRatio() ?: MediaAspectRatioCache.get(content.url)
 
@@ -401,10 +418,24 @@ fun UrlImageView(
             )
         }
 
+    val context = LocalContext.current
+    val imageModel =
+        if (fullResolution) {
+            remember(content.url, context) {
+                ImageRequest
+                    .Builder(context)
+                    .data(content.url)
+                    .size(Size.ORIGINAL)
+                    .build()
+            }
+        } else {
+            content.url
+        }
+
     CrossfadeIfEnabled(targetState = showImage.value, contentAlignment = Alignment.Center, accountViewModel = accountViewModel) {
         if (it) {
             SubcomposeAsyncImage(
-                model = content.url,
+                model = imageModel,
                 contentDescription = content.description,
                 contentScale = contentScale,
                 modifier = mainImageModifier,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
@@ -86,6 +86,7 @@ import com.vitorpamplona.amethyst.commons.richtext.MediaLocalVideo
 import com.vitorpamplona.amethyst.commons.richtext.MediaPreloadedContent
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlContent
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlImage
+import com.vitorpamplona.amethyst.commons.richtext.MediaUrlPdf
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlVideo
 import com.vitorpamplona.amethyst.model.MediaAspectRatioCache
 import com.vitorpamplona.amethyst.service.images.BlurhashWrapper
@@ -93,6 +94,8 @@ import com.vitorpamplona.amethyst.service.playback.composable.VideoView
 import com.vitorpamplona.amethyst.service.uploads.blossom.bud10.openBlossomUriAsIntent
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.actions.InformationDialog
+import com.vitorpamplona.amethyst.ui.components.pdf.PdfPreviewCard
+import com.vitorpamplona.amethyst.ui.components.pdf.PdfViewerDialog
 import com.vitorpamplona.amethyst.ui.components.util.setText
 import com.vitorpamplona.amethyst.ui.note.BlankNote
 import com.vitorpamplona.amethyst.ui.note.DownloadForOfflineIcon
@@ -221,18 +224,36 @@ fun ZoomableContentView(
                 }
             }
         }
+
+        is MediaUrlPdf -> {
+            Box(modifier = Modifier.fillMaxWidth().then(boundsTrackingModifier)) {
+                PdfPreviewCard(
+                    content = content,
+                    accountViewModel = accountViewModel,
+                    onOpen = { dialogOpen = true },
+                )
+            }
+        }
     }
 
     if (dialogOpen) {
-        ZoomableImageDialog(
-            imageUrl = content,
-            allImages = images,
-            sourceBounds = sourceBounds,
-            onDismiss = {
-                dialogOpen = false
-            },
-            accountViewModel = accountViewModel,
-        )
+        if (content is MediaUrlPdf) {
+            PdfViewerDialog(
+                content = content,
+                accountViewModel = accountViewModel,
+                onDismiss = { dialogOpen = false },
+            )
+        } else {
+            ZoomableImageDialog(
+                imageUrl = content,
+                allImages = images,
+                sourceBounds = sourceBounds,
+                onDismiss = {
+                    dialogOpen = false
+                },
+                accountViewModel = accountViewModel,
+            )
+        }
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfFetcher.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfFetcher.kt
@@ -20,70 +20,56 @@
  */
 package com.vitorpamplona.amethyst.ui.components.pdf
 
-import android.content.Context
-import com.vitorpamplona.quartz.nip01Core.core.toHexKey
-import com.vitorpamplona.quartz.utils.sha256.sha256
+import coil3.disk.DiskCache
+import com.vitorpamplona.amethyst.Amethyst
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.coroutines.executeAsync
-import okio.sink
-import java.io.File
 import java.io.IOException
 
 object PdfFetcher {
-    private const val CACHE_DIR_NAME = "pdf_cache"
-
-    private fun cacheDir(context: Context): File = File(context.cacheDir, CACHE_DIR_NAME).also { it.mkdirs() }
-
-    fun cachedFileOrNull(
-        context: Context,
-        url: String,
-    ): File? {
-        val file = cacheFile(context, url)
-        return if (file.exists() && file.length() > 0) file else null
-    }
-
-    fun cacheFile(
-        context: Context,
-        url: String,
-    ): File {
-        val key = sha256(url.toByteArray()).toHexKey()
-        return File(cacheDir(context), "$key.pdf")
-    }
-
-    suspend fun fetch(
-        context: Context,
+    /**
+     * Returns a snapshot of the cached PDF for [url], downloading it if necessary. The caller is
+     * responsible for closing the returned snapshot; while it's open the cache entry cannot be
+     * evicted, so the underlying file stays valid for `PdfRenderer`.
+     *
+     * Reuses the Coil disk cache (`Amethyst.instance.diskCache`) so PDFs share the same LRU
+     * eviction and disk budget as images.
+     */
+    suspend fun fetchSnapshot(
         url: String,
         okHttpClient: (String) -> OkHttpClient,
-    ): File =
-        withContext(Dispatchers.IO) {
-            val file = cacheFile(context, url)
-            if (file.exists() && file.length() > 0) return@withContext file
+    ): DiskCache.Snapshot {
+        val diskCache = Amethyst.instance.diskCache
+        diskCache.openSnapshot(url)?.let { return it }
 
-            val request =
-                Request
-                    .Builder()
-                    .url(url)
-                    .get()
-                    .build()
+        return withContext(Dispatchers.IO) {
+            val editor = diskCache.openEditor(url) ?: throw IOException("Unable to open cache editor for $url")
+            try {
+                val request =
+                    Request
+                        .Builder()
+                        .url(url)
+                        .get()
+                        .build()
 
-            okHttpClient(url).newCall(request).executeAsync().use { response ->
-                if (!response.isSuccessful) {
-                    throw IOException("PDF download failed: ${response.code}")
+                okHttpClient(url).newCall(request).executeAsync().use { response ->
+                    if (!response.isSuccessful) {
+                        throw IOException("PDF download failed: ${response.code}")
+                    }
+                    diskCache.fileSystem.write(editor.data) {
+                        val bytes = writeAll(response.body.source())
+                        if (bytes == 0L) throw IOException("PDF download failed: empty response body")
+                    }
                 }
-                val tmp = File(file.parentFile, "${file.name}.tmp")
-                tmp.outputStream().use { out ->
-                    val bytes = response.body.source().readAll(out.sink())
-                    if (bytes == 0L) throw IOException("PDF download failed: empty response body")
-                }
-                if (!tmp.renameTo(file)) {
-                    tmp.copyTo(file, overwrite = true)
-                    tmp.delete()
-                }
+
+                editor.commitAndOpenSnapshot() ?: throw IOException("Unable to commit cache editor for $url")
+            } catch (t: Throwable) {
+                runCatching { editor.abort() }
+                throw t
             }
-
-            file
         }
+    }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfFetcher.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfFetcher.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.components.pdf
+
+import android.content.Context
+import com.vitorpamplona.quartz.nip01Core.core.toHexKey
+import com.vitorpamplona.quartz.utils.sha256.sha256
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.coroutines.executeAsync
+import okio.sink
+import java.io.File
+import java.io.IOException
+
+object PdfFetcher {
+    private const val CACHE_DIR_NAME = "pdf_cache"
+
+    private fun cacheDir(context: Context): File = File(context.cacheDir, CACHE_DIR_NAME).also { it.mkdirs() }
+
+    fun cachedFileOrNull(
+        context: Context,
+        url: String,
+    ): File? {
+        val file = cacheFile(context, url)
+        return if (file.exists() && file.length() > 0) file else null
+    }
+
+    fun cacheFile(
+        context: Context,
+        url: String,
+    ): File {
+        val key = sha256(url.toByteArray()).toHexKey()
+        return File(cacheDir(context), "$key.pdf")
+    }
+
+    suspend fun fetch(
+        context: Context,
+        url: String,
+        okHttpClient: (String) -> OkHttpClient,
+    ): File =
+        withContext(Dispatchers.IO) {
+            val file = cacheFile(context, url)
+            if (file.exists() && file.length() > 0) return@withContext file
+
+            val request =
+                Request
+                    .Builder()
+                    .url(url)
+                    .get()
+                    .build()
+
+            okHttpClient(url).newCall(request).executeAsync().use { response ->
+                if (!response.isSuccessful) {
+                    throw IOException("PDF download failed: ${response.code}")
+                }
+                val tmp = File(file.parentFile, "${file.name}.tmp")
+                tmp.outputStream().use { out ->
+                    val bytes = response.body.source().readAll(out.sink())
+                    if (bytes == 0L) throw IOException("PDF download failed: empty response body")
+                }
+                if (!tmp.renameTo(file)) {
+                    tmp.copyTo(file, overwrite = true)
+                    tmp.delete()
+                }
+            }
+
+            file
+        }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfPreviewCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfPreviewCard.kt
@@ -47,14 +47,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlPdf
 import com.vitorpamplona.amethyst.ui.components.ClickableUrl
-import com.vitorpamplona.amethyst.ui.components.DisplayUrlWithLoadingSymbol
 import com.vitorpamplona.amethyst.ui.components.ShareMediaAction
-import com.vitorpamplona.amethyst.ui.components.WaitAndDisplay
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.theme.DoubleVertSpacer
 import com.vitorpamplona.amethyst.ui.theme.MaxWidthWithHorzPadding
@@ -64,6 +63,9 @@ import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+
+// Hard ceiling on the inline thumbnail bitmap, in pixels. Prevents OOM on very tall/large pages.
+private const val THUMBNAIL_MAX_DIM_PX = 1600
 
 data class PdfPreview(
     val thumbnail: Bitmap,
@@ -81,47 +83,55 @@ private sealed class PdfLoadState {
     data object Failed : PdfLoadState()
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun PdfPreviewCard(
     content: MediaUrlPdf,
     accountViewModel: AccountViewModel,
     onOpen: () -> Unit,
 ) {
-    val context = LocalContext.current
+    val showPdf = remember { mutableStateOf(accountViewModel.settings.showImages()) }
+
+    if (showPdf.value) {
+        LoadedPdfPreviewCard(content, accountViewModel, onOpen)
+    } else {
+        PlaceholderPdfCard(content) { showPdf.value = true }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun LoadedPdfPreviewCard(
+    content: MediaUrlPdf,
+    accountViewModel: AccountViewModel,
+    onOpen: () -> Unit,
+) {
     val sharePopupExpanded = remember { mutableStateOf(false) }
 
+    val density = LocalDensity.current
+    val configuration = LocalConfiguration.current
+    val targetWidthPx =
+        remember(density, configuration) {
+            val screenPx =
+                with(density) {
+                    configuration.screenWidthDp.dp
+                        .toPx()
+                        .toInt()
+                }
+            screenPx.coerceAtMost(THUMBNAIL_MAX_DIM_PX).coerceAtLeast(1)
+        }
+
     @Suppress("ProduceStateDoesNotAssignValue")
-    val state by produceState<PdfLoadState>(initialValue = PdfLoadState.Loading, key1 = content.url) {
+    val state by produceState<PdfLoadState>(initialValue = PdfLoadState.Loading, key1 = content.url, key2 = targetWidthPx) {
         value =
             try {
-                val file =
-                    PdfFetcher.fetch(context, content.url) { url ->
+                PdfFetcher
+                    .fetchSnapshot(content.url) { url ->
                         accountViewModel.httpClientBuilder.okHttpClientForPreview(url)
-                    }
-                withContext(Dispatchers.IO) {
-                    ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY).use { pfd ->
-                        PdfRenderer(pfd).use { renderer ->
-                            val pageCount = renderer.pageCount
-                            if (pageCount <= 0) {
-                                PdfLoadState.Failed
-                            } else {
-                                renderer.openPage(0).use { page ->
-                                    val bitmap = Bitmap.createBitmap(page.width, page.height, Bitmap.Config.ARGB_8888)
-                                    bitmap.eraseColor(android.graphics.Color.WHITE)
-                                    page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
-                                    PdfLoadState.Ready(
-                                        PdfPreview(
-                                            thumbnail = bitmap,
-                                            pageCount = pageCount,
-                                            aspectRatio = page.width.toFloat() / page.height.toFloat(),
-                                        ),
-                                    )
-                                }
-                            }
+                    }.use { snapshot ->
+                        withContext(Dispatchers.IO) {
+                            renderFirstPage(snapshot.data.toFile(), targetWidthPx)
                         }
                     }
-                }
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
                 Log.w("PdfPreviewCard", "Failed to render PDF preview: ${content.url}", e)
@@ -136,11 +146,11 @@ fun PdfPreviewCard(
         onDismiss = { sharePopupExpanded.value = false },
     )
 
+    val filename = remember(content.url) { extractFilename(content.url) }
+
     when (val current = state) {
         is PdfLoadState.Loading -> {
-            WaitAndDisplay {
-                DisplayUrlWithLoadingSymbol(content, accountViewModel.toastManager::toast)
-            }
+            PdfSkeletonCard(filename)
         }
 
         is PdfLoadState.Failed -> {
@@ -148,7 +158,6 @@ fun PdfPreviewCard(
         }
 
         is PdfLoadState.Ready -> {
-            val filename = remember(content.url) { extractFilename(content.url) }
             Column(
                 modifier =
                     MaterialTheme.colorScheme.innerPostModifier
@@ -167,33 +176,7 @@ fun PdfPreviewCard(
                             .aspectRatio(current.preview.aspectRatio.coerceAtLeast(0.2f)),
                 )
 
-                Row(
-                    modifier = MaxWidthWithHorzPadding.padding(vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    Icon(
-                        imageVector = Icons.Outlined.PictureAsPdf,
-                        contentDescription = null,
-                        modifier = Size20Modifier,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = filename,
-                            style = MaterialTheme.typography.bodyMedium,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                        Text(
-                            text = pageCountLabel(current.preview.pageCount),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1,
-                        )
-                    }
-                }
+                FilenameRow(filename = filename, subtitle = pageCountLabel(current.preview.pageCount))
 
                 Spacer(modifier = DoubleVertSpacer)
             }
@@ -201,10 +184,112 @@ fun PdfPreviewCard(
     }
 }
 
-private fun extractFilename(url: String): String {
+@Composable
+private fun PlaceholderPdfCard(
+    content: MediaUrlPdf,
+    onLoad: () -> Unit,
+) {
+    val filename = remember(content.url) { extractFilename(content.url) }
+    Column(
+        modifier =
+            MaterialTheme.colorScheme.innerPostModifier
+                .fillMaxWidth()
+                .combinedClickable(onClick = onLoad, onLongClick = onLoad),
+    ) {
+        FilenameRow(filename = filename, subtitle = "Tap to load PDF")
+        Spacer(modifier = DoubleVertSpacer)
+    }
+}
+
+@Composable
+private fun PdfSkeletonCard(filename: String) {
+    Column(modifier = MaterialTheme.colorScheme.innerPostModifier.fillMaxWidth()) {
+        FilenameRow(filename = filename, subtitle = "Loading…")
+        Spacer(modifier = DoubleVertSpacer)
+    }
+}
+
+@Composable
+private fun FilenameRow(
+    filename: String,
+    subtitle: String,
+) {
+    Row(
+        modifier = MaxWidthWithHorzPadding.padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.PictureAsPdf,
+            contentDescription = null,
+            modifier = Size20Modifier,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = filename,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+            )
+        }
+    }
+}
+
+private fun renderFirstPage(
+    file: java.io.File,
+    targetWidthPx: Int,
+): PdfLoadState =
+    ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY).use { pfd ->
+        PdfRenderer(pfd).use { renderer ->
+            val pageCount = renderer.pageCount
+            if (pageCount <= 0) return@use PdfLoadState.Failed
+
+            renderer.openPage(0).use { page ->
+                val (renderW, renderH) = cappedRenderSize(page.width, page.height, targetWidthPx)
+                val bitmap = Bitmap.createBitmap(renderW, renderH, Bitmap.Config.ARGB_8888)
+                bitmap.eraseColor(android.graphics.Color.WHITE)
+                page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+                PdfLoadState.Ready(
+                    PdfPreview(
+                        thumbnail = bitmap,
+                        pageCount = pageCount,
+                        aspectRatio = page.width.toFloat() / page.height.toFloat(),
+                    ),
+                )
+            }
+        }
+    }
+
+/**
+ * Scales the page's native point size to fit within [maxDim] on the longest side, preserving
+ * aspect ratio. Falls back to native size if it's already smaller.
+ */
+internal fun cappedRenderSize(
+    pageWidth: Int,
+    pageHeight: Int,
+    maxDim: Int,
+): Pair<Int, Int> {
+    if (pageWidth <= 0 || pageHeight <= 0) return 1 to 1
+    val longest = maxOf(pageWidth, pageHeight)
+    if (longest <= maxDim) return pageWidth to pageHeight
+    val scale = maxDim.toFloat() / longest
+    val w = (pageWidth * scale).toInt().coerceAtLeast(1)
+    val h = (pageHeight * scale).toInt().coerceAtLeast(1)
+    return w to h
+}
+
+internal fun extractFilename(url: String): String {
     val afterQuery = url.substringBefore('?').substringBefore('#')
     val name = afterQuery.substringAfterLast('/', afterQuery)
     return if (name.isBlank()) url else name
 }
 
-private fun pageCountLabel(pageCount: Int): String = if (pageCount == 1) "1 page" else "$pageCount pages"
+internal fun pageCountLabel(pageCount: Int): String = if (pageCount == 1) "1 page" else "$pageCount pages"

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfPreviewCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfPreviewCard.kt
@@ -271,18 +271,20 @@ private fun renderFirstPage(
     }
 
 /**
- * Scales the page's native point size to fit within [maxDim] on the longest side, preserving
- * aspect ratio. Falls back to native size if it's already smaller.
+ * Returns the bitmap dimensions to render a PDF page at, scaled so the longest side equals
+ * [targetDim] while preserving aspect ratio. Always scales, never returns native size: a PDF
+ * page's native width/height are in PostScript points (1/72"), which is far below any useful
+ * display resolution. Since PDFs are vector, rendering at a larger target is essentially free
+ * and avoids a 72-DPI-blurry bitmap.
  */
 internal fun cappedRenderSize(
     pageWidth: Int,
     pageHeight: Int,
-    maxDim: Int,
+    targetDim: Int,
 ): Pair<Int, Int> {
     if (pageWidth <= 0 || pageHeight <= 0) return 1 to 1
     val longest = maxOf(pageWidth, pageHeight)
-    if (longest <= maxDim) return pageWidth to pageHeight
-    val scale = maxDim.toFloat() / longest
+    val scale = targetDim.toFloat() / longest
     val w = (pageWidth * scale).toInt().coerceAtLeast(1)
     val h = (pageHeight * scale).toInt().coerceAtLeast(1)
     return w to h

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfPreviewCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfPreviewCard.kt
@@ -256,7 +256,9 @@ private fun renderFirstPage(
 
             renderer.openPage(0).use { page ->
                 val (renderW, renderH) = cappedRenderSize(page.width, page.height, targetWidthPx)
-                val bitmap = Bitmap.createBitmap(renderW, renderH, Bitmap.Config.ARGB_8888)
+                // RGB_565 halves memory vs ARGB_8888 and is visually identical for
+                // opaque PDF renders.
+                val bitmap = Bitmap.createBitmap(renderW, renderH, Bitmap.Config.RGB_565)
                 bitmap.eraseColor(android.graphics.Color.WHITE)
                 page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
                 PdfLoadState.Ready(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfPreviewCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfPreviewCard.kt
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.components.pdf
+
+import android.graphics.Bitmap
+import android.graphics.pdf.PdfRenderer
+import android.os.ParcelFileDescriptor
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.PictureAsPdf
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.vitorpamplona.amethyst.commons.richtext.MediaUrlPdf
+import com.vitorpamplona.amethyst.ui.components.ClickableUrl
+import com.vitorpamplona.amethyst.ui.components.DisplayUrlWithLoadingSymbol
+import com.vitorpamplona.amethyst.ui.components.ShareMediaAction
+import com.vitorpamplona.amethyst.ui.components.WaitAndDisplay
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.theme.DoubleVertSpacer
+import com.vitorpamplona.amethyst.ui.theme.MaxWidthWithHorzPadding
+import com.vitorpamplona.amethyst.ui.theme.Size20Modifier
+import com.vitorpamplona.amethyst.ui.theme.innerPostModifier
+import com.vitorpamplona.quartz.utils.Log
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+data class PdfPreview(
+    val thumbnail: Bitmap,
+    val pageCount: Int,
+    val aspectRatio: Float,
+)
+
+private sealed class PdfLoadState {
+    data object Loading : PdfLoadState()
+
+    data class Ready(
+        val preview: PdfPreview,
+    ) : PdfLoadState()
+
+    data object Failed : PdfLoadState()
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun PdfPreviewCard(
+    content: MediaUrlPdf,
+    accountViewModel: AccountViewModel,
+    onOpen: () -> Unit,
+) {
+    val context = LocalContext.current
+    val sharePopupExpanded = remember { mutableStateOf(false) }
+
+    @Suppress("ProduceStateDoesNotAssignValue")
+    val state by produceState<PdfLoadState>(initialValue = PdfLoadState.Loading, key1 = content.url) {
+        value =
+            try {
+                val file =
+                    PdfFetcher.fetch(context, content.url) { url ->
+                        accountViewModel.httpClientBuilder.okHttpClientForPreview(url)
+                    }
+                withContext(Dispatchers.IO) {
+                    ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY).use { pfd ->
+                        PdfRenderer(pfd).use { renderer ->
+                            val pageCount = renderer.pageCount
+                            if (pageCount <= 0) {
+                                PdfLoadState.Failed
+                            } else {
+                                renderer.openPage(0).use { page ->
+                                    val bitmap = Bitmap.createBitmap(page.width, page.height, Bitmap.Config.ARGB_8888)
+                                    bitmap.eraseColor(android.graphics.Color.WHITE)
+                                    page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+                                    PdfLoadState.Ready(
+                                        PdfPreview(
+                                            thumbnail = bitmap,
+                                            pageCount = pageCount,
+                                            aspectRatio = page.width.toFloat() / page.height.toFloat(),
+                                        ),
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                Log.w("PdfPreviewCard", "Failed to render PDF preview: ${content.url}", e)
+                PdfLoadState.Failed
+            }
+    }
+
+    ShareMediaAction(
+        accountViewModel = accountViewModel,
+        popupExpanded = sharePopupExpanded,
+        content = content,
+        onDismiss = { sharePopupExpanded.value = false },
+    )
+
+    when (val current = state) {
+        is PdfLoadState.Loading -> {
+            WaitAndDisplay {
+                DisplayUrlWithLoadingSymbol(content, accountViewModel.toastManager::toast)
+            }
+        }
+
+        is PdfLoadState.Failed -> {
+            ClickableUrl(urlText = content.url, url = content.url)
+        }
+
+        is PdfLoadState.Ready -> {
+            val filename = remember(content.url) { extractFilename(content.url) }
+            Column(
+                modifier =
+                    MaterialTheme.colorScheme.innerPostModifier
+                        .combinedClickable(
+                            onClick = onOpen,
+                            onLongClick = { sharePopupExpanded.value = true },
+                        ),
+            ) {
+                Image(
+                    bitmap = current.preview.thumbnail.asImageBitmap(),
+                    contentDescription = content.description ?: filename,
+                    contentScale = ContentScale.FillWidth,
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(current.preview.aspectRatio.coerceAtLeast(0.2f)),
+                )
+
+                Row(
+                    modifier = MaxWidthWithHorzPadding.padding(vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.PictureAsPdf,
+                        contentDescription = null,
+                        modifier = Size20Modifier,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = filename,
+                            style = MaterialTheme.typography.bodyMedium,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            text = pageCountLabel(current.preview.pageCount),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                        )
+                    }
+                }
+
+                Spacer(modifier = DoubleVertSpacer)
+            }
+        }
+    }
+}
+
+private fun extractFilename(url: String): String {
+    val afterQuery = url.substringBefore('?').substringBefore('#')
+    val name = afterQuery.substringAfterLast('/', afterQuery)
+    return if (name.isBlank()) url else name
+}
+
+private fun pageCountLabel(pageCount: Int): String = if (pageCount == 1) "1 page" else "$pageCount pages"

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfPreviewCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfPreviewCard.kt
@@ -256,9 +256,8 @@ private fun renderFirstPage(
 
             renderer.openPage(0).use { page ->
                 val (renderW, renderH) = cappedRenderSize(page.width, page.height, targetWidthPx)
-                // RGB_565 halves memory vs ARGB_8888 and is visually identical for
-                // opaque PDF renders.
-                val bitmap = Bitmap.createBitmap(renderW, renderH, Bitmap.Config.RGB_565)
+                // PdfRenderer requires ARGB_8888; RGB_565 silently produces blank output.
+                val bitmap = Bitmap.createBitmap(renderW, renderH, Bitmap.Config.ARGB_8888)
                 bitmap.eraseColor(android.graphics.Color.WHITE)
                 page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
                 PdfLoadState.Ready(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfPreviewCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfPreviewCard.kt
@@ -45,6 +45,7 @@ import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
@@ -170,6 +171,7 @@ private fun LoadedPdfPreviewCard(
                     bitmap = current.preview.thumbnail.asImageBitmap(),
                     contentDescription = content.description ?: filename,
                     contentScale = ContentScale.FillWidth,
+                    filterQuality = FilterQuality.High,
                     modifier =
                         Modifier
                             .fillMaxWidth()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfViewerDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfViewerDialog.kt
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.components.pdf
+
+import android.graphics.Bitmap
+import android.graphics.pdf.PdfRenderer
+import android.os.ParcelFileDescriptor
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement.spacedBy
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.richtext.MediaUrlPdf
+import com.vitorpamplona.amethyst.ui.components.ShareMediaAction
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.amethyst.ui.theme.Size10dp
+import com.vitorpamplona.amethyst.ui.theme.Size15dp
+import com.vitorpamplona.amethyst.ui.theme.Size20Modifier
+import com.vitorpamplona.amethyst.ui.theme.Size5dp
+import com.vitorpamplona.quartz.utils.Log
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import net.engawapg.lib.zoomable.rememberZoomState
+import net.engawapg.lib.zoomable.zoomable
+import java.io.File
+
+private class PdfDocumentHandle(
+    val file: File,
+    val pfd: ParcelFileDescriptor,
+    val renderer: PdfRenderer,
+) {
+    val pageCount: Int get() = renderer.pageCount
+    val mutex: Mutex = Mutex()
+
+    fun close() {
+        try {
+            renderer.close()
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Log.w("PdfViewerDialog", "Failed to close PdfRenderer", e)
+        }
+        try {
+            pfd.close()
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Log.w("PdfViewerDialog", "Failed to close ParcelFileDescriptor", e)
+        }
+    }
+}
+
+@Composable
+fun PdfViewerDialog(
+    content: MediaUrlPdf,
+    accountViewModel: AccountViewModel,
+    onDismiss: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties =
+            DialogProperties(
+                usePlatformDefaultWidth = false,
+                decorFitsSystemWindows = false,
+            ),
+    ) {
+        Surface(modifier = Modifier.fillMaxSize(), color = Color.Black) {
+            PdfViewerContent(
+                content = content,
+                accountViewModel = accountViewModel,
+                onDismiss = onDismiss,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PdfViewerContent(
+    content: MediaUrlPdf,
+    accountViewModel: AccountViewModel,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+
+    @Suppress("ProduceStateDoesNotAssignValue")
+    val handleState by produceState<PdfDocumentHandle?>(initialValue = null, key1 = content.url) {
+        value =
+            try {
+                val file =
+                    PdfFetcher.fetch(context, content.url) { url ->
+                        accountViewModel.httpClientBuilder.okHttpClientForPreview(url)
+                    }
+                withContext(Dispatchers.IO) {
+                    val pfd = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+                    val renderer = PdfRenderer(pfd)
+                    PdfDocumentHandle(file, pfd, renderer)
+                }
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                Log.w("PdfViewerDialog", "Failed to open PDF: ${content.url}", e)
+                null
+            }
+    }
+
+    DisposableEffect(handleState) {
+        onDispose {
+            handleState?.close()
+        }
+    }
+
+    val sharePopupExpanded = remember { mutableStateOf(false) }
+
+    ShareMediaAction(
+        accountViewModel = accountViewModel,
+        popupExpanded = sharePopupExpanded,
+        content = content,
+        onDismiss = { sharePopupExpanded.value = false },
+    )
+
+    val handle = handleState
+    if (handle == null) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator(color = Color.White)
+        }
+    } else if (handle.pageCount == 0) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text(
+                text = "Unable to open PDF",
+                color = Color.White,
+            )
+        }
+    } else {
+        val pagerState = rememberPagerState { handle.pageCount }
+        val pageCache = remember(handle) { mutableStateMapOf<Int, Bitmap>() }
+
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier.fillMaxSize(),
+        ) { pageIndex ->
+            PdfPageView(
+                handle = handle,
+                pageIndex = pageIndex,
+                cache = pageCache,
+            )
+        }
+
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = Size15dp, vertical = Size10dp)
+                    .statusBarsPadding()
+                    .systemBarsPadding(),
+            horizontalArrangement = spacedBy(Size10dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            OutlinedButton(
+                onClick = onDismiss,
+                contentPadding = PaddingValues(horizontal = Size5dp),
+                colors = ButtonDefaults.outlinedButtonColors().copy(containerColor = MaterialTheme.colorScheme.background),
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = stringRes(R.string.back),
+                )
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            Text(
+                text = "${pagerState.currentPage + 1} / ${handle.pageCount}",
+                color = Color.White,
+                modifier =
+                    Modifier
+                        .background(Color.Black.copy(alpha = 0.4f), shape = MaterialTheme.shapes.small)
+                        .padding(horizontal = Size10dp, vertical = Size5dp),
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            OutlinedButton(
+                onClick = { sharePopupExpanded.value = true },
+                contentPadding = PaddingValues(horizontal = Size5dp),
+                colors = ButtonDefaults.outlinedButtonColors().copy(containerColor = MaterialTheme.colorScheme.background),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Share,
+                    modifier = Size20Modifier,
+                    contentDescription = stringRes(R.string.quick_action_share),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PdfPageView(
+    handle: PdfDocumentHandle,
+    pageIndex: Int,
+    cache: MutableMap<Int, Bitmap>,
+) {
+    val cached = cache[pageIndex]
+
+    @Suppress("ProduceStateDoesNotAssignValue")
+    val bitmap by produceState<Bitmap?>(initialValue = cached, key1 = handle, key2 = pageIndex) {
+        if (value != null) return@produceState
+        val rendered =
+            try {
+                handle.mutex.withLock {
+                    withContext(Dispatchers.IO) {
+                        handle.renderer.openPage(pageIndex).use { page ->
+                            val scale = 2f
+                            val width = (page.width * scale).toInt().coerceAtLeast(1)
+                            val height = (page.height * scale).toInt().coerceAtLeast(1)
+                            val bmp = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+                            bmp.eraseColor(android.graphics.Color.WHITE)
+                            page.render(bmp, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+                            bmp
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                Log.w("PdfViewerDialog", "Failed to render page $pageIndex", e)
+                null
+            }
+
+        rendered?.let { cache[pageIndex] = it }
+        value = rendered
+    }
+
+    val zoomState = rememberZoomState()
+    val current = bitmap
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        if (current != null) {
+            Image(
+                bitmap = current.asImageBitmap(),
+                contentDescription = null,
+                contentScale = ContentScale.Fit,
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .zoomable(zoomState),
+            )
+        } else {
+            CircularProgressIndicator(color = Color.White)
+        }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfViewerDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfViewerDialog.kt
@@ -89,16 +89,18 @@ import net.engawapg.lib.zoomable.toggleScale
 import net.engawapg.lib.zoomable.zoomable
 
 // Hard ceiling on each base-rendered page bitmap, in pixels. Higher = sharper when
-// the user pinch-zooms inside the dialog, but each page costs ~maxDim^2 * 4 bytes
-// of RAM (ARGB_8888). 3072 gives ~26 MB per A4-shaped page.
+// the user pinch-zooms inside the dialog, but each page costs ~maxDim^2 * 2 bytes
+// of RAM (RGB_565). 3072 gives ~13 MB per A4-shaped page.
 private const val VIEWER_MAX_DIM_PX = 3072
 
 // Hard ceiling for the per-page zoom-aware detail render. When the user zooms in
 // past HI_RES_ZOOM_THRESHOLD we re-render the current page at
-// (VIEWER_MAX_DIM_PX * scale) capped at this value. 6144 allows up to 2x sharper
-// than the base render at peak cost of ~100 MB for one page (ARGB_8888, A4 shape).
-private const val HI_RES_MAX_DIM_PX = 6144
-private const val HI_RES_ZOOM_THRESHOLD = 1.2f
+// (VIEWER_MAX_DIM_PX * scale) capped at this value. 4096 keeps the bitmap within
+// common GPU texture limits (so drawing stays hardware-accelerated) and caps
+// memory at ~24 MB for an A4-shaped page (RGB_565). Above 4096 most mid-range
+// GPUs fall back to software rendering, which is what caused the pan/zoom jitter.
+private const val HI_RES_MAX_DIM_PX = 4096
+private const val HI_RES_ZOOM_THRESHOLD = 1.5f
 private const val HI_RES_DEBOUNCE_MS = 200L
 
 // Zoom level the viewer animates to when the user double-taps. Matches the
@@ -352,13 +354,21 @@ private fun PdfPageView(
     }
 
     val current = hiResBitmap ?: baseBitmap
+    // Cache the ImageBitmap wrapper so each recomposition doesn't allocate a new
+    // one and push Compose into thinking the texture changed.
+    val imageBitmap = remember(current) { current?.asImageBitmap() }
+
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        if (current != null) {
+        if (imageBitmap != null) {
             Image(
-                bitmap = current.asImageBitmap(),
+                bitmap = imageBitmap,
                 contentDescription = null,
                 contentScale = ContentScale.Fit,
-                filterQuality = FilterQuality.High,
+                // Medium = bilinear. High is bicubic/Mitchell and gets recomputed on every
+                // frame during pan/zoom, which is the main source of jitter when the
+                // source bitmap is several megapixels. Bilinear on a 3072-4096 px source
+                // looks effectively identical on-screen.
+                filterQuality = FilterQuality.Medium,
                 modifier =
                     Modifier
                         .fillMaxSize()
@@ -388,7 +398,10 @@ private suspend fun renderPageCatching(
                 withContext(Dispatchers.IO) {
                     handle.renderer.openPage(pageIndex).use { page ->
                         val (width, height) = cappedRenderSize(page.width, page.height, maxDim)
-                        val bmp = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+                        // RGB_565 uses half the memory of ARGB_8888 and is indistinguishable
+                        // for PDFs (opaque white background, no alpha). Halves GPU texture
+                        // upload size and sampling cost during pan/zoom.
+                        val bmp = Bitmap.createBitmap(width, height, Bitmap.Config.RGB_565)
                         bmp.eraseColor(android.graphics.Color.WHITE)
                         page.render(bmp, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
                         bmp

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfViewerDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfViewerDialog.kt
@@ -161,9 +161,15 @@ private fun PdfViewerContent(
             }
     }
 
-    DisposableEffect(handleState) {
+    // Capture the handle as a local val so the onDispose lambda closes *this* handle,
+    // not whatever the delegated property reads at dispose time. Without this, the
+    // DisposableEffect keyed on handleState runs its onDispose when handleState
+    // transitions from null -> handle, and `handleState?.close()` reads the new handle
+    // and closes it right after it was created.
+    val handleForDispose = handleState
+    DisposableEffect(handleForDispose) {
         onDispose {
-            handleState?.close()
+            handleForDispose?.close()
         }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfViewerDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfViewerDialog.kt
@@ -60,9 +60,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import coil3.disk.DiskCache
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlPdf
 import com.vitorpamplona.amethyst.ui.components.ShareMediaAction
@@ -80,10 +80,12 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import net.engawapg.lib.zoomable.rememberZoomState
 import net.engawapg.lib.zoomable.zoomable
-import java.io.File
+
+// Hard ceiling on each rendered page bitmap, in pixels. Prevents OOM on very large pages.
+private const val VIEWER_MAX_DIM_PX = 2048
 
 private class PdfDocumentHandle(
-    val file: File,
+    val snapshot: DiskCache.Snapshot,
     val pfd: ParcelFileDescriptor,
     val renderer: PdfRenderer,
 ) {
@@ -91,18 +93,9 @@ private class PdfDocumentHandle(
     val mutex: Mutex = Mutex()
 
     fun close() {
-        try {
-            renderer.close()
-        } catch (e: Exception) {
-            if (e is CancellationException) throw e
-            Log.w("PdfViewerDialog", "Failed to close PdfRenderer", e)
-        }
-        try {
-            pfd.close()
-        } catch (e: Exception) {
-            if (e is CancellationException) throw e
-            Log.w("PdfViewerDialog", "Failed to close ParcelFileDescriptor", e)
-        }
+        runCatching { renderer.close() }.onFailure { Log.w("PdfViewerDialog", "renderer close failed", it) }
+        runCatching { pfd.close() }.onFailure { Log.w("PdfViewerDialog", "pfd close failed", it) }
+        runCatching { snapshot.close() }.onFailure { Log.w("PdfViewerDialog", "snapshot close failed", it) }
     }
 }
 
@@ -136,20 +129,23 @@ private fun PdfViewerContent(
     accountViewModel: AccountViewModel,
     onDismiss: () -> Unit,
 ) {
-    val context = LocalContext.current
-
     @Suppress("ProduceStateDoesNotAssignValue")
     val handleState by produceState<PdfDocumentHandle?>(initialValue = null, key1 = content.url) {
         value =
             try {
-                val file =
-                    PdfFetcher.fetch(context, content.url) { url ->
-                        accountViewModel.httpClientBuilder.okHttpClientForPreview(url)
-                    }
                 withContext(Dispatchers.IO) {
-                    val pfd = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
-                    val renderer = PdfRenderer(pfd)
-                    PdfDocumentHandle(file, pfd, renderer)
+                    val snapshot =
+                        PdfFetcher.fetchSnapshot(content.url) { url ->
+                            accountViewModel.httpClientBuilder.okHttpClientForPreview(url)
+                        }
+                    try {
+                        val pfd = ParcelFileDescriptor.open(snapshot.data.toFile(), ParcelFileDescriptor.MODE_READ_ONLY)
+                        val renderer = PdfRenderer(pfd)
+                        PdfDocumentHandle(snapshot, pfd, renderer)
+                    } catch (t: Throwable) {
+                        runCatching { snapshot.close() }
+                        throw t
+                    }
                 }
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
@@ -265,9 +261,7 @@ private fun PdfPageView(
                 handle.mutex.withLock {
                     withContext(Dispatchers.IO) {
                         handle.renderer.openPage(pageIndex).use { page ->
-                            val scale = 2f
-                            val width = (page.width * scale).toInt().coerceAtLeast(1)
-                            val height = (page.height * scale).toInt().coerceAtLeast(1)
+                            val (width, height) = cappedRenderSize(page.width, page.height, VIEWER_MAX_DIM_PX)
                             val bmp = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
                             bmp.eraseColor(android.graphics.Color.WHITE)
                             page.render(bmp, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfViewerDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfViewerDialog.kt
@@ -85,6 +85,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import net.engawapg.lib.zoomable.rememberZoomState
+import net.engawapg.lib.zoomable.toggleScale
 import net.engawapg.lib.zoomable.zoomable
 
 // Hard ceiling on each base-rendered page bitmap, in pixels. Higher = sharper when
@@ -99,6 +100,10 @@ private const val VIEWER_MAX_DIM_PX = 3072
 private const val HI_RES_MAX_DIM_PX = 6144
 private const val HI_RES_ZOOM_THRESHOLD = 1.2f
 private const val HI_RES_DEBOUNCE_MS = 200L
+
+// Zoom level the viewer animates to when the user double-taps. Matches the
+// threshold region where we swap in the hi-res bitmap.
+private const val DOUBLE_TAP_ZOOM_SCALE = 2.5f
 
 // How many recently-rendered pages to keep around. Pager already pre-composes the
 // current page plus one neighbor; this just speeds up small back/forward swipes.
@@ -357,7 +362,12 @@ private fun PdfPageView(
                 modifier =
                     Modifier
                         .fillMaxSize()
-                        .zoomable(zoomState),
+                        .zoomable(
+                            zoomState = zoomState,
+                            onDoubleTap = { position ->
+                                zoomState.toggleScale(targetScale = DOUBLE_TAP_ZOOM_SCALE, position = position)
+                            },
+                        ),
             )
         } else {
             CircularProgressIndicator(color = Color.White)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfViewerDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfViewerDialog.kt
@@ -49,14 +49,17 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.window.Dialog
@@ -74,16 +77,28 @@ import com.vitorpamplona.amethyst.ui.theme.Size5dp
 import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import net.engawapg.lib.zoomable.rememberZoomState
 import net.engawapg.lib.zoomable.zoomable
 
-// Hard ceiling on each rendered page bitmap, in pixels. Higher = sharper when the
-// user pinch-zooms inside the dialog, but each page costs ~maxDim^2 * 4 bytes of
-// RAM (ARGB_8888). 3072 gives ~26 MB per A4-shaped page.
+// Hard ceiling on each base-rendered page bitmap, in pixels. Higher = sharper when
+// the user pinch-zooms inside the dialog, but each page costs ~maxDim^2 * 4 bytes
+// of RAM (ARGB_8888). 3072 gives ~26 MB per A4-shaped page.
 private const val VIEWER_MAX_DIM_PX = 3072
+
+// Hard ceiling for the per-page zoom-aware detail render. When the user zooms in
+// past HI_RES_ZOOM_THRESHOLD we re-render the current page at
+// (VIEWER_MAX_DIM_PX * scale) capped at this value. 6144 allows up to 2x sharper
+// than the base render at peak cost of ~100 MB for one page (ARGB_8888, A4 shape).
+private const val HI_RES_MAX_DIM_PX = 6144
+private const val HI_RES_ZOOM_THRESHOLD = 1.2f
+private const val HI_RES_DEBOUNCE_MS = 200L
 
 // How many recently-rendered pages to keep around. Pager already pre-composes the
 // current page plus one neighbor; this just speeds up small back/forward swipes.
@@ -285,6 +300,7 @@ private fun PdfViewerContent(
     }
 }
 
+@OptIn(FlowPreview::class)
 @Composable
 private fun PdfPageView(
     handle: PdfDocumentHandle,
@@ -294,43 +310,50 @@ private fun PdfPageView(
     val cached = cache.get(pageIndex)
 
     @Suppress("ProduceStateDoesNotAssignValue")
-    val bitmap by produceState<Bitmap?>(initialValue = cached, key1 = handle, key2 = pageIndex) {
+    val baseBitmap by produceState<Bitmap?>(initialValue = cached, key1 = handle, key2 = pageIndex) {
         if (value != null) return@produceState
-        val rendered =
-            try {
-                handle.mutex.withLock {
-                    if (handle.closed) {
-                        null
-                    } else {
-                        withContext(Dispatchers.IO) {
-                            handle.renderer.openPage(pageIndex).use { page ->
-                                val (width, height) = cappedRenderSize(page.width, page.height, VIEWER_MAX_DIM_PX)
-                                val bmp = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
-                                bmp.eraseColor(android.graphics.Color.WHITE)
-                                page.render(bmp, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
-                                bmp
-                            }
-                        }
-                    }
-                }
-            } catch (e: Exception) {
-                if (e is CancellationException) throw e
-                Log.w("PdfViewerDialog", "Failed to render page $pageIndex", e)
-                null
-            }
-
+        val rendered = renderPageCatching(handle, pageIndex, VIEWER_MAX_DIM_PX)
         rendered?.let { cache.put(pageIndex, it) }
         value = rendered
     }
 
     val zoomState = rememberZoomState()
-    val current = bitmap
+
+    // Re-render the page at a higher resolution once the user zooms in and settles,
+    // so pinch-zoomed text stays crisp instead of getting GPU-upscaled from the base
+    // bitmap. Released when zoom drops back under threshold or the page leaves view.
+    var hiResBitmap by remember(handle, pageIndex) { mutableStateOf<Bitmap?>(null) }
+
+    LaunchedEffect(handle, pageIndex, baseBitmap) {
+        if (baseBitmap == null) return@LaunchedEffect
+        snapshotFlow { zoomState.scale }
+            .debounce(HI_RES_DEBOUNCE_MS)
+            .distinctUntilChanged()
+            .collectLatest { scale ->
+                if (scale < HI_RES_ZOOM_THRESHOLD) {
+                    hiResBitmap = null
+                } else {
+                    val target = (VIEWER_MAX_DIM_PX * scale).toInt().coerceAtMost(HI_RES_MAX_DIM_PX)
+                    // Skip if the hi-res render wouldn't beat what we already have.
+                    val base = baseBitmap ?: return@collectLatest
+                    val baseLongest = maxOf(base.width, base.height)
+                    if (target <= baseLongest) {
+                        hiResBitmap = null
+                    } else {
+                        hiResBitmap = renderPageCatching(handle, pageIndex, target)
+                    }
+                }
+            }
+    }
+
+    val current = hiResBitmap ?: baseBitmap
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         if (current != null) {
             Image(
                 bitmap = current.asImageBitmap(),
                 contentDescription = null,
                 contentScale = ContentScale.Fit,
+                filterQuality = FilterQuality.High,
                 modifier =
                     Modifier
                         .fillMaxSize()
@@ -341,3 +364,30 @@ private fun PdfPageView(
         }
     }
 }
+
+private suspend fun renderPageCatching(
+    handle: PdfDocumentHandle,
+    pageIndex: Int,
+    maxDim: Int,
+): Bitmap? =
+    try {
+        handle.mutex.withLock {
+            if (handle.closed) {
+                null
+            } else {
+                withContext(Dispatchers.IO) {
+                    handle.renderer.openPage(pageIndex).use { page ->
+                        val (width, height) = cappedRenderSize(page.width, page.height, maxDim)
+                        val bmp = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+                        bmp.eraseColor(android.graphics.Color.WHITE)
+                        page.render(bmp, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+                        bmp
+                    }
+                }
+            }
+        }
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        Log.w("PdfViewerDialog", "Failed to render page $pageIndex at $maxDim px", e)
+        null
+    }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfViewerDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfViewerDialog.kt
@@ -89,10 +89,17 @@ private class PdfDocumentHandle(
     val pfd: ParcelFileDescriptor,
     val renderer: PdfRenderer,
 ) {
-    val pageCount: Int get() = renderer.pageCount
+    // Snapshot eagerly. Compose's saveable PagerState reads pageCount during
+    // teardown, which can run *after* close() — so we can't query the renderer
+    // lazily without tripping IllegalStateException("Document already closed").
+    val pageCount: Int = renderer.pageCount
     val mutex: Mutex = Mutex()
 
+    @Volatile var closed: Boolean = false
+        private set
+
     fun close() {
+        closed = true
         runCatching { renderer.close() }.onFailure { Log.w("PdfViewerDialog", "renderer close failed", it) }
         runCatching { pfd.close() }.onFailure { Log.w("PdfViewerDialog", "pfd close failed", it) }
         runCatching { snapshot.close() }.onFailure { Log.w("PdfViewerDialog", "snapshot close failed", it) }
@@ -259,13 +266,17 @@ private fun PdfPageView(
         val rendered =
             try {
                 handle.mutex.withLock {
-                    withContext(Dispatchers.IO) {
-                        handle.renderer.openPage(pageIndex).use { page ->
-                            val (width, height) = cappedRenderSize(page.width, page.height, VIEWER_MAX_DIM_PX)
-                            val bmp = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
-                            bmp.eraseColor(android.graphics.Color.WHITE)
-                            page.render(bmp, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
-                            bmp
+                    if (handle.closed) {
+                        null
+                    } else {
+                        withContext(Dispatchers.IO) {
+                            handle.renderer.openPage(pageIndex).use { page ->
+                                val (width, height) = cappedRenderSize(page.width, page.height, VIEWER_MAX_DIM_PX)
+                                val bmp = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+                                bmp.eraseColor(android.graphics.Color.WHITE)
+                                page.render(bmp, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+                                bmp
+                            }
                         }
                     }
                 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfViewerDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfViewerDialog.kt
@@ -50,7 +50,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
@@ -81,8 +80,33 @@ import kotlinx.coroutines.withContext
 import net.engawapg.lib.zoomable.rememberZoomState
 import net.engawapg.lib.zoomable.zoomable
 
-// Hard ceiling on each rendered page bitmap, in pixels. Prevents OOM on very large pages.
-private const val VIEWER_MAX_DIM_PX = 2048
+// Hard ceiling on each rendered page bitmap, in pixels. Higher = sharper when the
+// user pinch-zooms inside the dialog, but each page costs ~maxDim^2 * 4 bytes of
+// RAM (ARGB_8888). 3072 gives ~26 MB per A4-shaped page.
+private const val VIEWER_MAX_DIM_PX = 3072
+
+// How many recently-rendered pages to keep around. Pager already pre-composes the
+// current page plus one neighbor; this just speeds up small back/forward swipes.
+// At VIEWER_MAX_DIM_PX = 3072 this caps memory at ~80 MB worth of page bitmaps.
+private const val PAGE_CACHE_SIZE = 3
+
+private class PageBitmapCache(
+    private val maxSize: Int,
+) {
+    private val cache =
+        object : java.util.LinkedHashMap<Int, Bitmap>(maxSize, 0.75f, true) {
+            override fun removeEldestEntry(eldest: Map.Entry<Int, Bitmap>): Boolean = size > maxSize
+        }
+
+    @Synchronized fun get(key: Int): Bitmap? = cache[key]
+
+    @Synchronized fun put(
+        key: Int,
+        value: Bitmap,
+    ) {
+        cache[key] = value
+    }
+}
 
 private class PdfDocumentHandle(
     val snapshot: DiskCache.Snapshot,
@@ -196,63 +220,66 @@ private fun PdfViewerContent(
         }
     } else {
         val pagerState = rememberPagerState { handle.pageCount }
-        val pageCache = remember(handle) { mutableStateMapOf<Int, Bitmap>() }
+        val pageCache = remember(handle) { PageBitmapCache(PAGE_CACHE_SIZE) }
 
-        HorizontalPager(
-            state = pagerState,
-            modifier = Modifier.fillMaxSize(),
-        ) { pageIndex ->
-            PdfPageView(
-                handle = handle,
-                pageIndex = pageIndex,
-                cache = pageCache,
-            )
-        }
-
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = Size15dp, vertical = Size10dp)
-                    .statusBarsPadding()
-                    .systemBarsPadding(),
-            horizontalArrangement = spacedBy(Size10dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            OutlinedButton(
-                onClick = onDismiss,
-                contentPadding = PaddingValues(horizontal = Size5dp),
-                colors = ButtonDefaults.outlinedButtonColors().copy(containerColor = MaterialTheme.colorScheme.background),
-            ) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = stringRes(R.string.back),
+        Box(modifier = Modifier.fillMaxSize()) {
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.fillMaxSize(),
+            ) { pageIndex ->
+                PdfPageView(
+                    handle = handle,
+                    pageIndex = pageIndex,
+                    cache = pageCache,
                 )
             }
 
-            Spacer(modifier = Modifier.weight(1f))
-
-            Text(
-                text = "${pagerState.currentPage + 1} / ${handle.pageCount}",
-                color = Color.White,
+            Row(
                 modifier =
                     Modifier
-                        .background(Color.Black.copy(alpha = 0.4f), shape = MaterialTheme.shapes.small)
-                        .padding(horizontal = Size10dp, vertical = Size5dp),
-            )
-
-            Spacer(modifier = Modifier.weight(1f))
-
-            OutlinedButton(
-                onClick = { sharePopupExpanded.value = true },
-                contentPadding = PaddingValues(horizontal = Size5dp),
-                colors = ButtonDefaults.outlinedButtonColors().copy(containerColor = MaterialTheme.colorScheme.background),
+                        .align(Alignment.TopCenter)
+                        .fillMaxWidth()
+                        .statusBarsPadding()
+                        .systemBarsPadding()
+                        .padding(horizontal = Size15dp, vertical = Size10dp),
+                horizontalArrangement = spacedBy(Size10dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                Icon(
-                    imageVector = Icons.Default.Share,
-                    modifier = Size20Modifier,
-                    contentDescription = stringRes(R.string.quick_action_share),
+                OutlinedButton(
+                    onClick = onDismiss,
+                    contentPadding = PaddingValues(horizontal = Size5dp),
+                    colors = ButtonDefaults.outlinedButtonColors().copy(containerColor = MaterialTheme.colorScheme.background),
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringRes(R.string.back),
+                    )
+                }
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                Text(
+                    text = "${pagerState.currentPage + 1} / ${handle.pageCount}",
+                    color = Color.White,
+                    modifier =
+                        Modifier
+                            .background(Color.Black.copy(alpha = 0.4f), shape = MaterialTheme.shapes.small)
+                            .padding(horizontal = Size10dp, vertical = Size5dp),
                 )
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                OutlinedButton(
+                    onClick = { sharePopupExpanded.value = true },
+                    contentPadding = PaddingValues(horizontal = Size5dp),
+                    colors = ButtonDefaults.outlinedButtonColors().copy(containerColor = MaterialTheme.colorScheme.background),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Share,
+                        modifier = Size20Modifier,
+                        contentDescription = stringRes(R.string.quick_action_share),
+                    )
+                }
             }
         }
     }
@@ -262,9 +289,9 @@ private fun PdfViewerContent(
 private fun PdfPageView(
     handle: PdfDocumentHandle,
     pageIndex: Int,
-    cache: MutableMap<Int, Bitmap>,
+    cache: PageBitmapCache,
 ) {
-    val cached = cache[pageIndex]
+    val cached = cache.get(pageIndex)
 
     @Suppress("ProduceStateDoesNotAssignValue")
     val bitmap by produceState<Bitmap?>(initialValue = cached, key1 = handle, key2 = pageIndex) {
@@ -292,7 +319,7 @@ private fun PdfPageView(
                 null
             }
 
-        rendered?.let { cache[pageIndex] = it }
+        rendered?.let { cache.put(pageIndex, it) }
         value = rendered
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfViewerDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/pdf/PdfViewerDialog.kt
@@ -89,16 +89,16 @@ import net.engawapg.lib.zoomable.toggleScale
 import net.engawapg.lib.zoomable.zoomable
 
 // Hard ceiling on each base-rendered page bitmap, in pixels. Higher = sharper when
-// the user pinch-zooms inside the dialog, but each page costs ~maxDim^2 * 2 bytes
-// of RAM (RGB_565). 3072 gives ~13 MB per A4-shaped page.
+// the user pinch-zooms inside the dialog, but each page costs ~maxDim^2 * 4 bytes
+// of RAM (PdfRenderer requires ARGB_8888). 3072 gives ~26 MB per A4-shaped page.
 private const val VIEWER_MAX_DIM_PX = 3072
 
 // Hard ceiling for the per-page zoom-aware detail render. When the user zooms in
 // past HI_RES_ZOOM_THRESHOLD we re-render the current page at
 // (VIEWER_MAX_DIM_PX * scale) capped at this value. 4096 keeps the bitmap within
 // common GPU texture limits (so drawing stays hardware-accelerated) and caps
-// memory at ~24 MB for an A4-shaped page (RGB_565). Above 4096 most mid-range
-// GPUs fall back to software rendering, which is what caused the pan/zoom jitter.
+// memory at ~48 MB for an A4-shaped page. Above 4096 most mid-range GPUs fall
+// back to software rendering, which is what caused the pan/zoom jitter.
 private const val HI_RES_MAX_DIM_PX = 4096
 private const val HI_RES_ZOOM_THRESHOLD = 1.5f
 private const val HI_RES_DEBOUNCE_MS = 200L
@@ -398,10 +398,9 @@ private suspend fun renderPageCatching(
                 withContext(Dispatchers.IO) {
                     handle.renderer.openPage(pageIndex).use { page ->
                         val (width, height) = cappedRenderSize(page.width, page.height, maxDim)
-                        // RGB_565 uses half the memory of ARGB_8888 and is indistinguishable
-                        // for PDFs (opaque white background, no alpha). Halves GPU texture
-                        // upload size and sampling cost during pan/zoom.
-                        val bmp = Bitmap.createBitmap(width, height, Bitmap.Config.RGB_565)
+                        // PdfRenderer requires ARGB_8888 bitmaps — RGB_565 is silently
+                        // rejected and produces blank output.
+                        val bmp = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
                         bmp.eraseColor(android.graphics.Color.WHITE)
                         page.render(bmp, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
                         bmp

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/MediaContentModels.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/MediaContentModels.kt
@@ -69,6 +69,17 @@ class EncryptedMediaUrlImage(
 ) : MediaUrlImage(url, description, hash, blurhash, dim, uri, contentWarning, mimeType)
 
 @Immutable
+open class MediaUrlPdf(
+    url: String,
+    description: String? = null,
+    hash: String? = null,
+    blurhash: String? = null,
+    dim: DimensionTag? = null,
+    uri: String? = null,
+    mimeType: String? = null,
+) : MediaUrlContent(url, description, hash, dim, blurhash, uri, mimeType)
+
+@Immutable
 open class MediaUrlVideo(
     url: String,
     description: String? = null,

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
@@ -58,17 +58,21 @@ class RichTextParser {
 
         val isImage: Boolean
         val isVideo: Boolean
+        val isPdf: Boolean
 
         if (contentType != null) {
             isImage = contentType.startsWith("image/")
             isVideo = contentType.startsWith("video/") || contentType.startsWith("audio/")
+            isPdf = contentType.startsWith("application/pdf")
         } else if (fullUrl.startsWith("data:")) {
             isImage = fullUrl.startsWith("data:image/")
             isVideo = fullUrl.startsWith("data:video/") || fullUrl.startsWith("data:audio/")
+            isPdf = fullUrl.startsWith("data:application/pdf")
         } else {
             val removedParamsFromUrl = removeQueryParamsForExtensionComparison(fullUrl)
             isImage = imageExtensions.any { removedParamsFromUrl.endsWith(it) }
             isVideo = videoExtensions.any { removedParamsFromUrl.endsWith(it) }
+            isPdf = pdfExtensions.any { removedParamsFromUrl.endsWith(it) }
         }
 
         return if (isImage) {
@@ -90,6 +94,16 @@ class RichTextParser {
                 blurhash = frags[BlurhashTag.TAG_NAME] ?: tags[BlurhashTag.TAG_NAME]?.firstOrNull(),
                 dim = frags[DimensionTag.TAG_NAME]?.let { DimensionTag.parse(it) } ?: tags[DimensionTag.TAG_NAME]?.firstOrNull()?.let { DimensionTag.parse(it) },
                 contentWarning = frags[ContentWarningTag.TAG_NAME] ?: tags[ContentWarningTag.TAG_NAME]?.firstOrNull(),
+                uri = callbackUri,
+                mimeType = contentType,
+            )
+        } else if (isPdf) {
+            MediaUrlPdf(
+                url = fullUrl,
+                description = description ?: frags[AltTag.TAG_NAME] ?: tags[AltTag.TAG_NAME]?.firstOrNull(),
+                hash = frags[HashSha256Tag.TAG_NAME] ?: tags[HashSha256Tag.TAG_NAME]?.firstOrNull(),
+                blurhash = frags[BlurhashTag.TAG_NAME] ?: tags[BlurhashTag.TAG_NAME]?.firstOrNull(),
+                dim = frags[DimensionTag.TAG_NAME]?.let { DimensionTag.parse(it) } ?: tags[DimensionTag.TAG_NAME]?.firstOrNull()?.let { DimensionTag.parse(it) },
                 uri = callbackUri,
                 mimeType = contentType,
             )
@@ -158,6 +172,7 @@ class RichTextParser {
 
         val imageUrls = mediaForPager.filterValues { it is MediaUrlImage }.keys
         val videoUrls = mediaForPager.filterValues { it is MediaUrlVideo }.keys
+        val pdfUrls = mediaForPager.filterValues { it is MediaUrlPdf }.keys
 
         val emojiMap = CustomEmoji.createEmojiMap(tags.lists)
 
@@ -165,7 +180,7 @@ class RichTextParser {
 
         val newContent = fixMissingSpaces(content, allUrls)
 
-        val segments = findTextSegments(newContent, imageUrls, videoUrls, urlSet, emojiMap, tags)
+        val segments = findTextSegments(newContent, imageUrls, videoUrls, pdfUrls, urlSet, emojiMap, tags)
 
         val mediaForPagerWithBase64 =
             mediaForPager +
@@ -197,6 +212,7 @@ class RichTextParser {
         content: String,
         images: Set<String>,
         videos: Set<String>,
+        pdfs: Set<String>,
         urls: Urls,
         emojis: Map<String, String>,
         tags: ImmutableListOfLists<String>,
@@ -211,7 +227,7 @@ class RichTextParser {
 
             val segments = ArrayList<Segment>(wordList.size)
             wordList.forEach { word ->
-                segments.add(wordIdentifier(word, images, videos, urls, emojis, tags))
+                segments.add(wordIdentifier(word, images, videos, pdfs, urls, emojis, tags))
             }
 
             paragraphSegments.add(ParagraphState(segments.toPersistentList(), isRTL))
@@ -262,6 +278,7 @@ class RichTextParser {
         word: String,
         images: Set<String>,
         videos: Set<String>,
+        pdfs: Set<String>,
         urls: Urls,
         emojis: Map<String, String>,
         tags: ImmutableListOfLists<String>,
@@ -285,6 +302,14 @@ class RichTextParser {
                 VideoSegment("https://$word")
             } else {
                 VideoSegment(word)
+            }
+        }
+
+        if (pdfs.contains(word)) {
+            return if (urls.withoutScheme.contains(word)) {
+                PdfSegment("https://$word")
+            } else {
+                PdfSegment(word)
             }
         }
 
@@ -377,9 +402,11 @@ class RichTextParser {
 
         val imageExt = listOf("png", "jpg", "gif", "bmp", "jpeg", "webp", "svg", "avif")
         val videoExt = listOf("mp4", "avi", "wmv", "mpg", "amv", "webm", "mov", "mp3", "m3u8", "ogg", "wav", "flac", "aac", "opus", "m4a")
+        val pdfExt = listOf("pdf")
 
         val imageExtensions = imageExt + imageExt.map { it.uppercase() }
         val videoExtensions = videoExt + videoExt.map { it.uppercase() }
+        val pdfExtensions = pdfExt + pdfExt.map { it.uppercase() }
 
         val tagIndex = Regex("\\#\\[([0-9]+)\\](.*)")
         val hashTagsPattern: Regex =
@@ -419,6 +446,11 @@ class RichTextParser {
         fun isVideoUrl(url: String): Boolean {
             val removedParamsFromUrl = removeQueryParamsForExtensionComparison(url)
             return videoExtensions.any { removedParamsFromUrl.endsWith(it) }
+        }
+
+        fun isPdfUrl(url: String): Boolean {
+            val removedParamsFromUrl = removeQueryParamsForExtensionComparison(url)
+            return pdfExtensions.any { removedParamsFromUrl.endsWith(it) }
         }
 
         fun isValidURL(url: String?): Boolean =
@@ -496,4 +528,6 @@ val mimeTypeMap: Map<String, String> =
         "m4a" to "audio/mp4",
         "aac" to "audio/aac",
         "flac" to "audio/flac",
+        // Documents
+        "pdf" to "application/pdf",
     )

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParserSegments.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParserSegments.kt
@@ -63,6 +63,11 @@ class VideoSegment(
 ) : Segment(segment)
 
 @Immutable
+class PdfSegment(
+    segment: String,
+) : Segment(segment)
+
+@Immutable
 class LinkSegment(
     segment: String,
 ) : Segment(segment)

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/PdfParserTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/PdfParserTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.richtext
+
+import com.vitorpamplona.amethyst.commons.model.EmptyTagList
+import com.vitorpamplona.amethyst.commons.model.ImmutableListOfLists
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PdfParserTest {
+    @Test
+    fun detectsPdfByExtension() {
+        val url = "https://example.com/docs/paper.pdf"
+        val state = RichTextParser().parseText(url, EmptyTagList, null)
+
+        val pdfMedia = state.mediaForPager[url]
+        assertTrue(pdfMedia is MediaUrlPdf, "Expected MediaUrlPdf for .pdf URL")
+
+        val segment = state.paragraphs[0].words[0]
+        assertTrue(segment is PdfSegment, "Expected PdfSegment for .pdf URL, got ${segment::class.simpleName}")
+        assertEquals(url, segment.segmentText)
+    }
+
+    @Test
+    fun detectsPdfFromImetaMimeTypeWithoutExtension() {
+        val url = "https://files.example.com/abcd1234"
+        val tags =
+            ImmutableListOfLists(
+                arrayOf(
+                    arrayOf("imeta", "url $url", "m application/pdf"),
+                ),
+            )
+
+        val state = RichTextParser().parseText(url, tags, null)
+
+        val pdfMedia = state.mediaForPager[url]
+        assertTrue(pdfMedia is MediaUrlPdf, "Expected MediaUrlPdf from imeta MIME tag")
+        assertEquals("application/pdf", (pdfMedia as MediaUrlPdf).mimeType)
+
+        val segment = state.paragraphs[0].words[0]
+        assertTrue(segment is PdfSegment, "Expected PdfSegment from imeta MIME tag, got ${segment::class.simpleName}")
+    }
+
+    @Test
+    fun isPdfUrlHelperMatchesPdfExtension() {
+        assertTrue(RichTextParser.isPdfUrl("https://example.com/doc.pdf"))
+        assertTrue(RichTextParser.isPdfUrl("https://example.com/doc.PDF"))
+        assertTrue(RichTextParser.isPdfUrl("https://example.com/doc.pdf?sig=abc"))
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive PDF support to Amethyst, enabling users to preview and view PDF documents inline. PDFs are now detected by file extension or MIME type, displayed as preview cards with thumbnails, and can be opened in a full-screen viewer with zoom and pan capabilities.

## Key Changes

### New PDF Components
- **PdfViewerDialog.kt**: Full-screen PDF viewer with:
  - Horizontal paging through PDF pages
  - Pinch-to-zoom and double-tap zoom (2.5x) with smooth animations
  - Adaptive resolution rendering: base render at 3072px, hi-res render up to 4096px when zoomed past 1.5x threshold
  - Debounced hi-res re-rendering (200ms) to prevent jitter during pan/zoom
  - Page cache (LRU, 3 pages) to optimize memory usage (~80MB max)
  - Share button and page counter in header
  - Proper resource cleanup with mutex-protected renderer access

- **PdfPreviewCard.kt**: Inline PDF preview with:
  - First-page thumbnail rendering (capped at 1600px)
  - Page count display and filename extraction
  - Loading/failed/ready states
  - Long-press to share, click to open full viewer
  - Respects user's image display settings

- **PdfFetcher.kt**: PDF download and caching utility:
  - Reuses Coil's disk cache for PDFs (shared LRU with images)
  - Handles HTTP download with OkHttpClient
  - Snapshot-based access to prevent cache eviction during rendering

### Rich Text Parser Updates
- Added PDF detection by `.pdf` extension (case-insensitive) and `application/pdf` MIME type
- New `MediaUrlPdf` model class for PDF content metadata
- New `PdfSegment` for parsed PDF URLs in rich text
- PDF extension list (`pdfExtensions`) for URL matching

### Integration Points
- **ZoomableContentView.kt**: Routes PDF content to `PdfPreviewCard` instead of image handling
- **LoadUrlPreview.kt**: Handles PDF MIME type in URL preview detection
- **RichTextViewer.kt**: Renders `PdfSegment` appropriately
- **UrlPreview.kt**: Detects PDF MIME types in preview metadata

### Testing
- Added `PdfParserTest.kt` with tests for:
  - PDF detection by `.pdf` extension
  - PDF detection from `imeta` MIME type tags
  - `isPdfUrl()` helper function validation

## Notable Implementation Details

- **Memory Management**: Carefully tuned bitmap dimensions (3072px base, 4096px hi-res max) to stay within typical GPU texture limits and prevent software rendering fallback
- **Rendering Strategy**: Uses `FilterQuality.Medium` (bilinear) instead of `High` (bicubic) to reduce per-frame recomputation during pan/zoom, eliminating jitter
- **Thread Safety**: Mutex-protected PDF renderer access with closed-state checking to handle async lifecycle
- **Resource Cleanup**: Proper disposal of `PdfRenderer`, `ParcelFileDescriptor`, and disk cache snapshots via `DisposableEffect`
- **Adaptive Quality**: Automatically re-renders at higher resolution when user zooms in, with debouncing to avoid excessive rendering

https://claude.ai/code/session_016YzSgf1x5mHJMSXHxTSkw1