### PR TITLE
Refactor Marmot group members to use reactive state flow

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -2070,6 +2070,13 @@ class Account(
                 relays = groupRelays,
             )
 
+        // The MLS commit has already been applied to the local group state —
+        // surface the new member list in the chatroom now so observers (e.g.
+        // MarmotGroupInfoScreen) update without waiting for our own commit to
+        // loop back through the relay.
+        val chatroom = marmotGroupList.getOrCreateGroup(nostrGroupId)
+        manager.syncMetadataTo(nostrGroupId, chatroom)
+
         Log.d("MarmotDbg") {
             "addMarmotGroupMember: built commit kind=${commitEvent.signedEvent.kind} id=${commitEvent.signedEvent.id.take(8)}… " +
                 "welcomeDelivery=${if (welcomeDelivery != null) "present(giftWrapId=${welcomeDelivery.giftWrapEvent.id.take(8)}…)" else "null"}"
@@ -2270,6 +2277,8 @@ class Account(
         if (!isWriteable()) return
 
         val outbound = manager.removeMember(nostrGroupId, targetLeafIndex)
+        val chatroom = marmotGroupList.getOrCreateGroup(nostrGroupId)
+        manager.syncMetadataTo(nostrGroupId, chatroom)
         client.publish(outbound.signedEvent, groupRelays)
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupInfoScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupInfoScreen.kt
@@ -58,7 +58,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.commons.marmot.GroupMemberInfo
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -85,18 +84,12 @@ fun MarmotGroupInfoScreen(
     val groupDescription by chatroom.description.collectAsStateWithLifecycle()
     val adminPubkeys by chatroom.adminPubkeys.collectAsStateWithLifecycle()
     val groupRelays by chatroom.relays.collectAsStateWithLifecycle()
-    var members by remember { mutableStateOf(emptyList<GroupMemberInfo>()) }
+    val members by chatroom.members.collectAsStateWithLifecycle()
     var showLeaveDialog by remember { mutableStateOf(false) }
     var isLeaving by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
     val myPubkey = accountViewModel.account.signer.pubKey
     val context = LocalContext.current
-
-    LifecycleResumeEffect(nostrGroupId) {
-        members = accountViewModel.marmotGroupMembers(nostrGroupId)
-        chatroom.memberCount.value = members.size
-        onPauseOrDispose {}
-    }
 
     Scaffold(
         topBar = {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupInfoScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupInfoScreen.kt
@@ -47,7 +47,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -59,6 +58,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.commons.marmot.GroupMemberInfo
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -92,9 +92,10 @@ fun MarmotGroupInfoScreen(
     val myPubkey = accountViewModel.account.signer.pubKey
     val context = LocalContext.current
 
-    LaunchedEffect(nostrGroupId) {
+    LifecycleResumeEffect(nostrGroupId) {
         members = accountViewModel.marmotGroupMembers(nostrGroupId)
         chatroom.memberCount.value = members.size
+        onPauseOrDispose {}
     }
 
     Scaffold(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/RemoveMemberScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/RemoveMemberScreen.kt
@@ -44,7 +44,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -55,6 +54,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.commons.marmot.GroupMemberInfo
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.UserPicture
@@ -71,16 +71,16 @@ fun RemoveMemberScreen(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    var members by remember { mutableStateOf(emptyList<GroupMemberInfo>()) }
+    val chatroom =
+        remember(nostrGroupId) {
+            accountViewModel.account.marmotGroupList.getOrCreateGroup(nostrGroupId)
+        }
+    val members by chatroom.members.collectAsStateWithLifecycle()
     var memberToRemove by remember { mutableStateOf<GroupMemberInfo?>(null) }
     var isRemoving by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
     val myPubkey = accountViewModel.account.signer.pubKey
     val context = LocalContext.current
-
-    LaunchedEffect(nostrGroupId) {
-        members = accountViewModel.marmotGroupMembers(nostrGroupId)
-    }
 
     Scaffold(
         topBar = {
@@ -155,7 +155,6 @@ fun RemoveMemberScreen(
                 scope.launch(Dispatchers.IO) {
                     try {
                         accountViewModel.removeMarmotGroupMember(nostrGroupId, member.leafIndex)
-                        members = accountViewModel.marmotGroupMembers(nostrGroupId)
                         isRemoving = false
                         launch(Dispatchers.Main) {
                             Toast

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/marmot/MarmotManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/marmot/MarmotManager.kt
@@ -437,7 +437,9 @@ class MarmotManager(
             chatroom.adminPubkeys.value = metadata.adminPubkeys
             chatroom.relays.value = metadata.relays
         }
-        chatroom.memberCount.value = memberCount(nostrGroupId)
+        val members = memberPubkeys(nostrGroupId)
+        chatroom.members.value = members
+        chatroom.memberCount.value = members.size
     }
 }
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/marmotGroups/MarmotGroupChatroom.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/marmotGroups/MarmotGroupChatroom.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.commons.model.marmotGroups
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.marmot.GroupMemberInfo
 import com.vitorpamplona.amethyst.commons.model.Channel.Companion.DefaultFeedOrder
 import com.vitorpamplona.amethyst.commons.model.ListChange
 import com.vitorpamplona.amethyst.commons.model.Note
@@ -46,6 +47,7 @@ class MarmotGroupChatroom(
     var adminPubkeys = MutableStateFlow<List<HexKey>>(emptyList())
     var relays = MutableStateFlow<List<String>>(emptyList())
     var memberCount = MutableStateFlow(0)
+    var members = MutableStateFlow<List<GroupMemberInfo>>(emptyList())
     var newestMessage: Note? = null
     val unreadCount = MutableStateFlow(0)
 


### PR DESCRIPTION
## Summary
Refactored the Marmot group member management to use reactive `StateFlow` instead of imperative `LaunchedEffect` calls. This ensures UI screens automatically update when group membership changes without requiring manual state synchronization.

## Key Changes
- **MarmotGroupChatroom**: Added `members` StateFlow to store the list of `GroupMemberInfo` objects, making member data reactive and observable
- **MarmotManager.syncMetadataTo()**: Updated to populate the `members` StateFlow in addition to `memberCount`, ensuring the full member list is always synchronized
- **RemoveMemberScreen**: 
  - Replaced `LaunchedEffect` with `collectAsStateWithLifecycle()` to observe members from the chatroom's StateFlow
  - Removed manual member list refresh after removing a member (now handled automatically by reactive state)
  - Removed unused `LaunchedEffect` import
- **MarmotGroupInfoScreen**: 
  - Replaced `LaunchedEffect` with `collectAsStateWithLifecycle()` to observe members from the chatroom's StateFlow
  - Removed manual member list refresh logic
  - Removed unused `LaunchedEffect` import
- **Account.addMarmotGroupMember()** and **Account.removeMarmotGroupMember()**: Added explicit calls to `manager.syncMetadataTo()` to immediately surface member list changes to observers, preventing UI staleness while waiting for relay confirmation

## Notable Implementation Details
- The reactive pattern ensures that any screen observing `chatroom.members` will automatically update when the member list changes, eliminating the need for manual refresh calls
- Member list synchronization now happens immediately after local MLS operations, providing instant UI feedback before relay confirmation

https://claude.ai/code/session_017U2txQede1g6XcHU4j7MUy