### PR TITLE
Show placeholder notes for empty Marmot groups in chat list

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountFeedContentStates.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountFeedContentStates.kt
@@ -56,6 +56,8 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.shorts.dal.ShortsFeedFilter
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.video.dal.VideoFeedFilter
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.webBookmarks.dal.WebBookmarkFeedFilter
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class AccountFeedContentStates(
     val account: Account,
@@ -99,6 +101,19 @@ class AccountFeedContentStates(
     val drafts = FeedContentState(DraftEventsFeedFilter(account), scope, LocalCache)
 
     val webBookmarks = FeedContentState(WebBookmarkFeedFilter(account), scope, LocalCache)
+
+    init {
+        // Marmot group list changes (new group, group marked known, group
+        // metadata synced) don't flow through LocalCache.newEventBundles, so
+        // the additive update path can't see them. Force a full feed rebuild
+        // whenever the list changes so empty groups appear and placeholder
+        // rows get replaced by real messages.
+        scope.launch(Dispatchers.IO) {
+            account.marmotGroupList.groupListChanges.collect {
+                dmKnown.invalidateData()
+            }
+        }
+    }
 
     suspend fun init() {
         notificationSummary.initializeSuspend()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChatroomHeaderCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChatroomHeaderCompose.kt
@@ -85,7 +85,11 @@ fun ChatroomHeaderCompose(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    if (baseNote.event != null) {
+    val isEmptyMarmotPlaceholder =
+        baseNote.event == null &&
+            baseNote.inGatherers?.any { it is MarmotGroupChatroom } == true
+
+    if (baseNote.event != null || isEmptyMarmotPlaceholder) {
         ChatroomComposeChannelOrUser(baseNote, accountViewModel, nav)
     } else {
         val hasEvent by observeNoteHasEvent(baseNote, accountViewModel)
@@ -248,21 +252,27 @@ private fun MarmotGroupRoomCompose(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    val authorName by observeUserName(lastMessage.author!!, accountViewModel)
     val displayName by chatroom.displayName.collectAsStateWithLifecycle()
     val unread by chatroom.unreadCount.collectAsStateWithLifecycle()
 
+    val author = lastMessage.author
     val noteEvent = lastMessage.event
-    val description = noteEvent?.content?.take(200)
-
     val groupName = displayName?.takeIf { it.isNotBlank() } ?: "Group ${chatroom.nostrGroupId.take(8)}"
+
+    val lastContent =
+        if (author != null && noteEvent != null) {
+            val authorName by observeUserName(author, accountViewModel)
+            "$authorName: ${noteEvent.content.take(200)}"
+        } else {
+            stringRes(R.string.marmot_group_no_messages_yet)
+        }
 
     ChannelName(
         channelIdHex = chatroom.nostrGroupId,
         channelPicture = null,
         channelTitle = { modifier -> ChannelTitleWithLabelInfo(groupName, R.string.marmot_group, modifier) },
         channelLastTime = lastMessage.createdAt(),
-        channelLastContent = "$authorName: $description",
+        channelLastContent = lastContent,
         hasNewMessages = unread > 0,
         loadProfilePicture = accountViewModel.settings.showProfilePictures(),
         loadRobohash = accountViewModel.settings.isNotPerformanceMode(),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/dal/ChatroomListKnownFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/dal/ChatroomListKnownFeedFilter.kt
@@ -79,7 +79,7 @@ class ChatroomListKnownFeedFilter(
 
         val marmotGroups =
             account.marmotGroupList.rooms.mapNotNull { _, chatroom ->
-                chatroom.newestMessage
+                chatroom.newestMessage ?: chatroom.placeholderNote()
             }
 
         return (privateMessages + publicChannels + ephemeralChats + marmotGroups).sortedWith(DefaultFeedOrder)

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -284,6 +284,7 @@
 
     <string name="public_chat">Public Chat</string>
     <string name="marmot_group">MLS Group</string>
+    <string name="marmot_group_no_messages_yet">No messages yet</string>
     <string name="public_chat_title">Public Chat Metadata</string>
     <string name="public_chat_explainer">Public chats are visible to everyone on Nostr and anyone
         can participate on them. They are great for open communities around specific topics.

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/marmotGroups/MarmotGroupChatroom.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/marmotGroups/MarmotGroupChatroom.kt
@@ -59,6 +59,27 @@ class MarmotGroupChatroom(
      */
     var ownerSentMessage: Boolean = false
 
+    // Synthetic note used by list views to represent the group when no
+    // messages have been received yet. Lazily created and kept stable so
+    // equality-based feed diffing treats it as the same row across refreshes.
+    private var cachedPlaceholder: Note? = null
+
+    @Synchronized
+    fun placeholderNote(): Note {
+        val existing = cachedPlaceholder
+        if (existing != null) return existing
+        val created =
+            Note(placeholderIdHex(nostrGroupId)).apply {
+                addGatherer(this@MarmotGroupChatroom)
+            }
+        cachedPlaceholder = created
+        return created
+    }
+
+    companion object {
+        fun placeholderIdHex(nostrGroupId: HexKey): HexKey = "marmot-empty-$nostrGroupId"
+    }
+
     private var changesFlow: WeakReference<MutableSharedFlow<ListChange<Note>>> = WeakReference(null)
 
     fun changesFlow(): MutableSharedFlow<ListChange<Note>> {


### PR DESCRIPTION
## Summary
This PR improves the user experience for Marmot group chats by displaying placeholder entries in the chat list for groups that haven't received any messages yet, and properly handling the display of these empty groups in the UI.

## Key Changes
- **Placeholder note generation**: Added `placeholderNote()` method to `MarmotGroupChatroom` that creates and caches a synthetic `Note` object for groups with no messages, ensuring stable equality-based diffing in feed views
- **Chat list inclusion**: Modified `ChatroomListKnownFeedFilter` to include placeholder notes for empty Marmot groups alongside regular messages
- **UI rendering**: Updated `ChatroomHeaderCompose` to recognize and properly render placeholder notes (notes with no event but gathered by a `MarmotGroupChatroom`)
- **Empty state messaging**: Enhanced `MarmotGroupRoomCompose` to display "No messages yet" text for groups without messages, instead of attempting to show author/content from a non-existent message
- **Feed invalidation**: Added initialization logic in `AccountFeedContentStates` to invalidate the DM feed whenever the Marmot group list changes, ensuring empty groups appear and placeholders are replaced by real messages when they arrive
- **Localization**: Added new string resource `marmot_group_no_messages_yet` for the empty state message

## Notable Implementation Details
- The placeholder note uses a synthetic ID format (`marmot-empty-{groupId}`) to distinguish it from real notes
- Placeholder creation is synchronized to ensure thread-safe lazy initialization and caching
- The feed invalidation uses `Dispatchers.IO` to avoid blocking the main thread while listening to group list changes

https://claude.ai/code/session_012ZvL6SeoMgcseXguievK2f