### PR TITLE
Organize drawer navigation into collapsible sections

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerContent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerContent.kt
@@ -127,6 +127,7 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.DividerThickness
 import com.vitorpamplona.amethyst.ui.theme.DoubleHorzSpacer
+import com.vitorpamplona.amethyst.ui.theme.DrawerSectionHeaderModifier
 import com.vitorpamplona.amethyst.ui.theme.Font14SP
 import com.vitorpamplona.amethyst.ui.theme.Font18SP
 import com.vitorpamplona.amethyst.ui.theme.IconRowTextModifier
@@ -742,33 +743,22 @@ fun CollapsibleSection(
 ) {
     var expanded by remember { mutableStateOf(true) }
     val sectionTitle = stringRes(title)
-    val toggleLabel =
-        stringRes(
-            if (expanded) R.string.drawer_collapse_section else R.string.drawer_expand_section,
-            sectionTitle,
-        )
 
     Column(modifier = Modifier.animateContentSize()) {
         Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .clickable(
-                        onClick = { expanded = !expanded },
-                        onClickLabel = toggleLabel,
-                    ).padding(top = 12.dp, bottom = 4.dp, start = 25.dp, end = 15.dp),
+            modifier = DrawerSectionHeaderModifier.clickable { expanded = !expanded },
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
                 modifier = Modifier.weight(1f),
-                text = sectionTitle.uppercase(),
+                text = sectionTitle,
                 fontSize = Font14SP,
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Icon(
                 imageVector = if (expanded) Icons.Outlined.ExpandLess else Icons.Outlined.ExpandMore,
-                contentDescription = null,
+                contentDescription = sectionTitle,
                 modifier = Size22Modifier,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerContent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerContent.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.navigation.drawer
 
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -58,6 +59,8 @@ import androidx.compose.material.icons.outlined.AccountBalanceWallet
 import androidx.compose.material.icons.outlined.CollectionsBookmark
 import androidx.compose.material.icons.outlined.Drafts
 import androidx.compose.material.icons.outlined.EmojiEmotions
+import androidx.compose.material.icons.outlined.ExpandLess
+import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.GroupAdd
 import androidx.compose.material.icons.outlined.Groups
 import androidx.compose.material.icons.outlined.Language
@@ -124,6 +127,7 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.DividerThickness
 import com.vitorpamplona.amethyst.ui.theme.DoubleHorzSpacer
+import com.vitorpamplona.amethyst.ui.theme.Font14SP
 import com.vitorpamplona.amethyst.ui.theme.Font18SP
 import com.vitorpamplona.amethyst.ui.theme.IconRowTextModifier
 import com.vitorpamplona.amethyst.ui.theme.Size20Modifier
@@ -538,179 +542,187 @@ fun ListContent(
     nav: INav,
 ) {
     Column(modifier) {
-        NavigationRow(
-            title = R.string.profile,
-            icon = Icons.Default.AccountCircle,
-            tint = MaterialTheme.colorScheme.primary,
-            nav = nav,
-            computeRoute = {
-                Route.Profile(accountViewModel.userProfile().pubkeyHex)
-            },
-        )
-
-        NavigationRow(
-            title = R.string.my_lists,
-            icon = Icons.AutoMirrored.Filled.FormatListBulleted,
-            tint = MaterialTheme.colorScheme.onBackground,
-            nav = nav,
-            route = Route.Lists,
-        )
-
-        NavigationRow(
-            title = R.string.bookmarks,
-            icon = Icons.Outlined.CollectionsBookmark,
-            tint = MaterialTheme.colorScheme.onBackground,
-            nav = nav,
-            route = Route.BookmarkGroups,
-        )
-
-        NavigationRow(
-            title = R.string.manage_emoji_packs,
-            icon = Icons.Outlined.EmojiEmotions,
-            tint = MaterialTheme.colorScheme.onBackground,
-            nav = nav,
-            route = Route.EmojiPacks,
-        )
-
-        NavigationRow(
-            title = R.string.interest_sets_title,
-            icon = Icons.Outlined.Tag,
-            tint = MaterialTheme.colorScheme.onBackground,
-            nav = nav,
-            route = Route.InterestSets,
-        )
-
-        NavigationRow(
-            title = R.string.web_bookmarks,
-            icon = Icons.Outlined.Language,
-            tint = MaterialTheme.colorScheme.onBackground,
-            nav = nav,
-            route = Route.WebBookmarks,
-        )
-
-        NavigationRow(
-            title = R.string.drafts,
-            icon = Icons.Outlined.Drafts,
-            tint = MaterialTheme.colorScheme.onBackground,
-            nav = nav,
-            route = Route.Drafts,
-        )
-
-        NavigationRow(
-            title = R.string.badges,
-            icon = Icons.Outlined.MilitaryTech,
-            tint = MaterialTheme.colorScheme.onBackground,
-            nav = nav,
-            route = Route.Badges,
-        )
-
-        NavigationRow(
-            title = R.string.communities,
-            icon = Icons.Outlined.Groups,
-            tint = MaterialTheme.colorScheme.onBackground,
-            nav = nav,
-            route = Route.Communities,
-        )
-
-        NavigationRow(
-            title = R.string.discover_marketplace,
-            icon = Icons.Outlined.Storefront,
-            tint = MaterialTheme.colorScheme.onBackground,
-            nav = nav,
-            route = Route.Products,
-        )
-
-        NavigationRow(
-            title = R.string.pictures,
-            icon = Icons.Outlined.Photo,
-            tint = MaterialTheme.colorScheme.onBackground,
-            nav = nav,
-            route = Route.Pictures,
-        )
-
-        NavigationRow(
-            title = R.string.polls,
-            icon = R.drawable.ic_poll,
-            iconReference = 1,
-            tint = MaterialTheme.colorScheme.onBackground,
-            nav = nav,
-            route = Route.Polls,
-        )
-
-        NavigationRow(
-            title = R.string.discover_reads,
-            icon = Icons.AutoMirrored.Outlined.Article,
-            tint = MaterialTheme.colorScheme.onBackground,
-            nav = nav,
-            route = Route.Articles,
-        )
-
-        NavigationRow(
-            title = R.string.shorts,
-            icon = Icons.Outlined.PlayCircle,
-            tint = MaterialTheme.colorScheme.onBackground,
-            nav = nav,
-            route = Route.Shorts,
-        )
-
-        NavigationRow(
-            title = R.string.longs,
-            icon = Icons.Outlined.SmartDisplay,
-            tint = MaterialTheme.colorScheme.onBackground,
-            nav = nav,
-            route = Route.Longs,
-        )
-
-        NavigationRow(
-            title = R.string.wallet,
-            icon = Icons.Outlined.AccountBalanceWallet,
-            tint = MaterialTheme.colorScheme.onBackground,
-            nav = nav,
-            route = Route.Wallet,
-        )
-
-        NavigationRow(
-            title = R.string.emoji_sets,
-            icon = Icons.Outlined.EmojiEmotions,
-            tint = MaterialTheme.colorScheme.onBackground,
-            nav = nav,
-            route = Route.BrowseEmojiSets,
-        )
-
-        NavigationRow(
-            title = R.string.share_hls_video,
-            icon = Icons.Outlined.SettingsInputAntenna,
-            tint = MaterialTheme.colorScheme.onBackground,
-            nav = nav,
-            route = Route.NewHlsVideo,
-        )
-
-        if (isDebug) {
+        CollapsibleSection(title = R.string.drawer_section_you) {
             NavigationRow(
-                title = R.string.route_chess,
-                icon = R.drawable.ic_chess,
-                iconReference = 1,
+                title = R.string.profile,
+                icon = Icons.Default.AccountCircle,
+                tint = MaterialTheme.colorScheme.primary,
+                nav = nav,
+                computeRoute = {
+                    Route.Profile(accountViewModel.userProfile().pubkeyHex)
+                },
+            )
+
+            NavigationRow(
+                title = R.string.my_lists,
+                icon = Icons.AutoMirrored.Filled.FormatListBulleted,
                 tint = MaterialTheme.colorScheme.onBackground,
                 nav = nav,
-                route = Route.Chess,
+                route = Route.Lists,
+            )
+
+            NavigationRow(
+                title = R.string.bookmarks,
+                icon = Icons.Outlined.CollectionsBookmark,
+                tint = MaterialTheme.colorScheme.onBackground,
+                nav = nav,
+                route = Route.BookmarkGroups,
+            )
+
+            NavigationRow(
+                title = R.string.web_bookmarks,
+                icon = Icons.Outlined.Language,
+                tint = MaterialTheme.colorScheme.onBackground,
+                nav = nav,
+                route = Route.WebBookmarks,
+            )
+
+            NavigationRow(
+                title = R.string.drafts,
+                icon = Icons.Outlined.Drafts,
+                tint = MaterialTheme.colorScheme.onBackground,
+                nav = nav,
+                route = Route.Drafts,
+            )
+
+            NavigationRow(
+                title = R.string.interest_sets_title,
+                icon = Icons.Outlined.Tag,
+                tint = MaterialTheme.colorScheme.onBackground,
+                nav = nav,
+                route = Route.InterestSets,
+            )
+
+            NavigationRow(
+                title = R.string.manage_emoji_packs,
+                icon = Icons.Outlined.EmojiEmotions,
+                tint = MaterialTheme.colorScheme.onBackground,
+                nav = nav,
+                route = Route.EmojiPacks,
+            )
+
+            NavigationRow(
+                title = R.string.wallet,
+                icon = Icons.Outlined.AccountBalanceWallet,
+                tint = MaterialTheme.colorScheme.onBackground,
+                nav = nav,
+                route = Route.Wallet,
             )
         }
 
-        IconRowRelays(
-            accountViewModel = accountViewModel,
-            onClick = {
-                nav.closeDrawer()
-                nav.nav(Route.EditRelays)
-            },
-        )
+        CollapsibleSection(title = R.string.drawer_section_feeds) {
+            NavigationRow(
+                title = R.string.communities,
+                icon = Icons.Outlined.Groups,
+                tint = MaterialTheme.colorScheme.onBackground,
+                nav = nav,
+                route = Route.Communities,
+            )
 
-        NavigationRow(
-            title = R.string.settings,
-            icon = Icons.Outlined.Settings,
-            tint = MaterialTheme.colorScheme.onBackground,
-            nav = nav,
-            route = Route.AllSettings,
-        )
+            NavigationRow(
+                title = R.string.discover_reads,
+                icon = Icons.AutoMirrored.Outlined.Article,
+                tint = MaterialTheme.colorScheme.onBackground,
+                nav = nav,
+                route = Route.Articles,
+            )
+
+            NavigationRow(
+                title = R.string.pictures,
+                icon = Icons.Outlined.Photo,
+                tint = MaterialTheme.colorScheme.onBackground,
+                nav = nav,
+                route = Route.Pictures,
+            )
+
+            NavigationRow(
+                title = R.string.shorts,
+                icon = Icons.Outlined.PlayCircle,
+                tint = MaterialTheme.colorScheme.onBackground,
+                nav = nav,
+                route = Route.Shorts,
+            )
+
+            NavigationRow(
+                title = R.string.longs,
+                icon = Icons.Outlined.SmartDisplay,
+                tint = MaterialTheme.colorScheme.onBackground,
+                nav = nav,
+                route = Route.Longs,
+            )
+
+            NavigationRow(
+                title = R.string.polls,
+                icon = R.drawable.ic_poll,
+                iconReference = 1,
+                tint = MaterialTheme.colorScheme.onBackground,
+                nav = nav,
+                route = Route.Polls,
+            )
+
+            NavigationRow(
+                title = R.string.badges,
+                icon = Icons.Outlined.MilitaryTech,
+                tint = MaterialTheme.colorScheme.onBackground,
+                nav = nav,
+                route = Route.Badges,
+            )
+
+            NavigationRow(
+                title = R.string.discover_marketplace,
+                icon = Icons.Outlined.Storefront,
+                tint = MaterialTheme.colorScheme.onBackground,
+                nav = nav,
+                route = Route.Products,
+            )
+
+            NavigationRow(
+                title = R.string.emoji_sets,
+                icon = Icons.Outlined.EmojiEmotions,
+                tint = MaterialTheme.colorScheme.onBackground,
+                nav = nav,
+                route = Route.BrowseEmojiSets,
+            )
+        }
+
+        CollapsibleSection(title = R.string.drawer_section_create) {
+            NavigationRow(
+                title = R.string.share_hls_video,
+                icon = Icons.Outlined.SettingsInputAntenna,
+                tint = MaterialTheme.colorScheme.onBackground,
+                nav = nav,
+                route = Route.NewHlsVideo,
+            )
+
+            if (isDebug) {
+                NavigationRow(
+                    title = R.string.route_chess,
+                    icon = R.drawable.ic_chess,
+                    iconReference = 1,
+                    tint = MaterialTheme.colorScheme.onBackground,
+                    nav = nav,
+                    route = Route.Chess,
+                )
+            }
+        }
+
+        CollapsibleSection(title = R.string.drawer_section_system) {
+            IconRowRelays(
+                accountViewModel = accountViewModel,
+                onClick = {
+                    nav.closeDrawer()
+                    nav.nav(Route.EditRelays)
+                },
+            )
+
+            NavigationRow(
+                title = R.string.settings,
+                icon = Icons.Outlined.Settings,
+                tint = MaterialTheme.colorScheme.onBackground,
+                nav = nav,
+                route = Route.AllSettings,
+            )
+        }
 
         Spacer(modifier = Modifier.weight(1f))
 
@@ -720,6 +732,51 @@ fun ListContent(
             tint = MaterialTheme.colorScheme.onBackground,
             onClick = openSheet,
         )
+    }
+}
+
+@Composable
+fun CollapsibleSection(
+    title: Int,
+    content: @Composable () -> Unit,
+) {
+    var expanded by remember { mutableStateOf(true) }
+    val sectionTitle = stringRes(title)
+    val toggleLabel =
+        stringRes(
+            if (expanded) R.string.drawer_collapse_section else R.string.drawer_expand_section,
+            sectionTitle,
+        )
+
+    Column(modifier = Modifier.animateContentSize()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clickable(
+                        onClick = { expanded = !expanded },
+                        onClickLabel = toggleLabel,
+                    ).padding(top = 12.dp, bottom = 4.dp, start = 25.dp, end = 15.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                modifier = Modifier.weight(1f),
+                text = sectionTitle.uppercase(),
+                fontSize = Font14SP,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Icon(
+                imageVector = if (expanded) Icons.Outlined.ExpandLess else Icons.Outlined.ExpandMore,
+                contentDescription = null,
+                modifier = Size22Modifier,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        if (expanded) {
+            content()
+        }
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerContent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerContent.kt
@@ -103,6 +103,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withLink
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -119,11 +120,13 @@ import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUse
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserStatuses
 import com.vitorpamplona.amethyst.ui.components.CreateTextWithEmoji
 import com.vitorpamplona.amethyst.ui.components.RobohashFallbackAsyncImage
+import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.navigation.routes.routeFor
 import com.vitorpamplona.amethyst.ui.painterRes
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.mockAccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.DividerThickness
 import com.vitorpamplona.amethyst.ui.theme.DoubleHorzSpacer
@@ -138,6 +141,7 @@ import com.vitorpamplona.amethyst.ui.theme.Size24Modifier
 import com.vitorpamplona.amethyst.ui.theme.Size26Modifier
 import com.vitorpamplona.amethyst.ui.theme.StdHorzSpacer
 import com.vitorpamplona.amethyst.ui.theme.TextStyleBottomNavBar
+import com.vitorpamplona.amethyst.ui.theme.ThemeComparisonColumn
 import com.vitorpamplona.amethyst.ui.theme.Width16Space
 import com.vitorpamplona.amethyst.ui.theme.bannerModifier
 import com.vitorpamplona.amethyst.ui.theme.drawerSpacing
@@ -1015,5 +1019,61 @@ fun BottomContent(
                 )
             }
         }
+    }
+}
+
+@Preview
+@Composable
+private fun CollapsibleSectionPreview() {
+    ThemeComparisonColumn {
+        Column {
+            CollapsibleSection(title = R.string.drawer_section_you) {
+                IconRow(
+                    title = R.string.profile,
+                    icon = Icons.Default.AccountCircle,
+                    tint = MaterialTheme.colorScheme.primary,
+                    onClick = {},
+                )
+                IconRow(
+                    title = R.string.bookmarks,
+                    icon = Icons.Outlined.CollectionsBookmark,
+                    tint = MaterialTheme.colorScheme.onBackground,
+                    onClick = {},
+                )
+                IconRow(
+                    title = R.string.drafts,
+                    icon = Icons.Outlined.Drafts,
+                    tint = MaterialTheme.colorScheme.onBackground,
+                    onClick = {},
+                )
+            }
+            CollapsibleSection(title = R.string.drawer_section_feeds) {
+                IconRow(
+                    title = R.string.pictures,
+                    icon = Icons.Outlined.Photo,
+                    tint = MaterialTheme.colorScheme.onBackground,
+                    onClick = {},
+                )
+                IconRow(
+                    title = R.string.longs,
+                    icon = Icons.Outlined.SmartDisplay,
+                    tint = MaterialTheme.colorScheme.onBackground,
+                    onClick = {},
+                )
+            }
+        }
+    }
+}
+
+@Preview(widthDp = 320, heightDp = 1400)
+@Composable
+private fun ListContentPreview() {
+    ThemeComparisonColumn {
+        ListContent(
+            modifier = Modifier.fillMaxWidth(),
+            openSheet = {},
+            accountViewModel = mockAccountViewModel(),
+            nav = EmptyNav(),
+        )
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/theme/Shape.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/theme/Shape.kt
@@ -263,6 +263,7 @@ val drawerSpacing = Modifier.padding(top = Size10dp, start = Size25dp, end = Siz
 
 val IconRowTextModifier = Modifier.padding(start = 16.dp)
 val IconRowModifier = Modifier.fillMaxWidth().padding(vertical = 15.dp, horizontal = 25.dp)
+val DrawerSectionHeaderModifier = Modifier.fillMaxWidth().padding(top = 12.dp, bottom = 4.dp, start = 25.dp, end = 15.dp)
 
 val Width16Space = Modifier.width(Size16dp)
 

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -369,6 +369,12 @@
     <string name="private_conversation_notification">"&lt;Unable to decrypt private message&gt;\n\nYou were cited in a private/encrypted conversation between %1$s and %2$s."</string>
     <string name="account_switch_add_account_dialog_title">Add New Account</string>
     <string name="drawer_accounts">Accounts</string>
+    <string name="drawer_section_you">You</string>
+    <string name="drawer_section_feeds">Feeds</string>
+    <string name="drawer_section_create">Create</string>
+    <string name="drawer_section_system">System</string>
+    <string name="drawer_expand_section">Expand %1$s section</string>
+    <string name="drawer_collapse_section">Collapse %1$s section</string>
     <string name="account_switch_select_account">Select Account</string>
     <string name="account_switch_add_account_btn">Add New Account</string>
     <string name="account_switch_active_account">Active account</string>

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -373,8 +373,6 @@
     <string name="drawer_section_feeds">Feeds</string>
     <string name="drawer_section_create">Create</string>
     <string name="drawer_section_system">System</string>
-    <string name="drawer_expand_section">Expand %1$s section</string>
-    <string name="drawer_collapse_section">Collapse %1$s section</string>
     <string name="account_switch_select_account">Select Account</string>
     <string name="account_switch_add_account_btn">Add New Account</string>
     <string name="account_switch_active_account">Active account</string>


### PR DESCRIPTION
## Summary
Reorganized the drawer navigation menu by grouping related items into collapsible sections, improving navigation structure and reducing visual clutter.

## Key Changes
- **New `CollapsibleSection` composable**: Created a reusable component that wraps navigation items in expandable/collapsible sections with animated content size transitions
- **Drawer reorganization**: Grouped navigation items into four logical sections:
  - "You" - Profile, lists, bookmarks, drafts, wallet, and personal settings
  - "Feeds" - Communities, articles, pictures, videos, polls, badges, and marketplace
  - "Create" - Content creation tools (HLS video sharing, chess in debug mode)
  - "System" - Relays and settings
- **UI enhancements**:
  - Added expand/collapse icons (ExpandLess/ExpandMore) to section headers
  - Applied `animateContentSize()` for smooth expand/collapse animations
  - Styled section headers with `DrawerSectionHeaderModifier` and `Font14SP`
  - Made sections clickable to toggle expansion state
- **Added preview composables**: Created `CollapsibleSectionPreview` and `ListContentPreview` for design validation
- **String resources**: Added new localization strings for section titles (`drawer_section_you`, `drawer_section_feeds`, `drawer_section_create`, `drawer_section_system`)
- **Reordered items**: Reorganized navigation items within sections for better logical grouping (e.g., moved emoji packs and interest sets into the "You" section)

## Implementation Details
- Sections default to expanded state (`expanded = true`)
- Each section maintains its own expansion state using `remember { mutableStateOf() }`
- Content is conditionally rendered based on expansion state
- All existing navigation functionality preserved; only visual organization changed

https://claude.ai/code/session_01Hz6FNHsNxFzmfVKxYtWng2