### PR TITLE
Auto-republish account settings when relay lists change

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -2773,15 +2773,68 @@ class Account(
 
     suspend fun saveDMRelayList(dmRelays: List<NormalizedRelayUrl>) = sendLiterallyEverywhere(dmRelayList.saveRelayList(dmRelays))
 
-    suspend fun saveKeyPackageRelayList(keyPackageRelays: List<NormalizedRelayUrl>) = sendLiterallyEverywhere(keyPackageRelayList.saveRelayList(keyPackageRelays))
+    suspend fun saveKeyPackageRelayList(keyPackageRelays: List<NormalizedRelayUrl>) {
+        val oldRelays = keyPackageRelayList.flow.value
+        val newRelays = keyPackageRelays.toSet()
+        sendLiterallyEverywhere(keyPackageRelayList.saveRelayList(keyPackageRelays))
+        if (oldRelays != newRelays) {
+            republishEventsTo(myKeyPackageEvents(), newRelays)
+        }
+    }
 
-    suspend fun savePrivateOutboxRelayList(relays: List<NormalizedRelayUrl>) = sendMyPublicAndPrivateOutbox(privateStorageRelayList.saveRelayList(relays))
+    suspend fun savePrivateOutboxRelayList(relays: List<NormalizedRelayUrl>) {
+        val oldRelays = privateStorageRelayList.flow.value
+        val newRelays = relays.toSet()
+        sendMyPublicAndPrivateOutbox(privateStorageRelayList.saveRelayList(relays))
+        if (oldRelays != newRelays) {
+            republishEventsTo(accountSettingsEvents(), newRelays)
+        }
+    }
 
-    suspend fun saveSearchRelayList(searchRelays: List<NormalizedRelayUrl>) = sendMyPublicAndPrivateOutbox(searchRelayList.saveRelayList(searchRelays))
+    suspend fun saveSearchRelayList(searchRelays: List<NormalizedRelayUrl>) {
+        val oldRelays = searchRelayList.flowNoDefaults.value
+        val newRelays = searchRelays.toSet()
+        sendMyPublicAndPrivateOutbox(searchRelayList.saveRelayList(searchRelays))
+        if (oldRelays != newRelays) {
+            republishEventsTo(
+                listOfNotNull(userMetadata.getUserMetadataEvent()),
+                newRelays,
+            )
+        }
+    }
 
-    suspend fun saveIndexerRelayList(trustedRelays: List<NormalizedRelayUrl>) = sendMyPublicAndPrivateOutbox(indexerRelayList.saveRelayList(trustedRelays))
+    suspend fun saveIndexerRelayList(trustedRelays: List<NormalizedRelayUrl>) {
+        val oldRelays = indexerRelayList.flowNoDefaults.value
+        val newRelays = trustedRelays.toSet()
+        sendMyPublicAndPrivateOutbox(indexerRelayList.saveRelayList(trustedRelays))
+        if (oldRelays != newRelays) {
+            republishEventsTo(
+                listOfNotNull(
+                    userMetadata.getUserMetadataEvent(),
+                    kind3FollowList.getFollowListEvent(),
+                ),
+                newRelays,
+            )
+        }
+    }
 
-    suspend fun saveBroadcastRelayList(trustedRelays: List<NormalizedRelayUrl>) = sendMyPublicAndPrivateOutbox(broadcastRelayList.saveRelayList(trustedRelays))
+    suspend fun saveBroadcastRelayList(trustedRelays: List<NormalizedRelayUrl>) {
+        val oldRelays = broadcastRelayList.flow.value
+        val newRelays = trustedRelays.toSet()
+        sendMyPublicAndPrivateOutbox(broadcastRelayList.saveRelayList(trustedRelays))
+        if (oldRelays != newRelays) {
+            republishEventsTo(accountSettingsEvents(), newRelays)
+        }
+    }
+
+    suspend fun saveLocalRelayList(relays: List<NormalizedRelayUrl>) {
+        val oldRelays = localRelayList.flow.value
+        val newRelays = relays.toSet()
+        localRelayList.saveRelayList(relays) {}
+        if (oldRelays != newRelays) {
+            republishEventsTo(accountSettingsEvents(), newRelays)
+        }
+    }
 
     suspend fun saveProxyRelayList(trustedRelays: List<NormalizedRelayUrl>) = sendMyPublicAndPrivateOutbox(proxyRelayList.saveRelayList(trustedRelays))
 
@@ -2794,6 +2847,53 @@ class Account(
     suspend fun unfollowRelayFeed(url: NormalizedRelayUrl) = sendMyPublicAndPrivateOutbox(relayFeedsList.removeRelay(url))
 
     suspend fun saveBlockedRelayList(blockedRelays: List<NormalizedRelayUrl>) = sendMyPublicAndPrivateOutbox(blockedRelayList.saveRelayList(blockedRelays))
+
+    /**
+     * Returns all known signed replaceable events that configure this account
+     * (profile, contact list, relay lists, mute list, bookmarks, etc.). Events
+     * that have never been created or downloaded are omitted.
+     */
+    fun accountSettingsEvents(): List<Event> =
+        listOfNotNull(
+            userMetadata.getUserMetadataEvent(),
+            userMetadata.getExternalIdentitiesEvent(),
+            kind3FollowList.getFollowListEvent(),
+            nip65RelayList.getNIP65RelayList(),
+            dmRelayList.getDMRelayList(),
+            keyPackageRelayList.getKeyPackageRelayList(),
+            privateStorageRelayList.getPrivateOutboxRelayList(),
+            searchRelayList.getSearchRelayList(),
+            trustedRelayList.getTrustedRelayList(),
+            proxyRelayList.getProxyRelayList(),
+            broadcastRelayList.getBroadcastRelayList(),
+            indexerRelayList.getIndexerRelayList(),
+            relayFeedsList.getRelayFeedsList(),
+            blockedRelayList.getBlockedRelayList(),
+            muteList.getMuteList(),
+            bookmarkState.getBookmarkList(),
+            pinState.getPinList(),
+            blossomServers.getBlossomServersList(),
+            paymentTargetsState.getPaymentTargetsEvent(),
+            trustProviderList.getTrustProviderList(),
+            cache.getAddressableNoteIfExists(appSpecific.getAppSpecificDataAddress())?.event,
+        )
+
+    /**
+     * Returns all currently-known signed KeyPackage events authored by this account.
+     */
+    fun myKeyPackageEvents(): List<Event> =
+        cache.addressables
+            .filter(KeyPackageEvent.KIND, signer.pubKey)
+            .mapNotNull { it.event }
+
+    /** Publishes the given events to each of the given relays. No-op if either list is empty. */
+    fun republishEventsTo(
+        events: List<Event>,
+        relays: Set<NormalizedRelayUrl>,
+    ) {
+        if (relays.isEmpty() || events.isEmpty()) return
+        events.forEach { client.publish(it, relays) }
+    }
 
     suspend fun requestToVanish(
         relays: List<NormalizedRelayUrl>,
@@ -2820,7 +2920,24 @@ class Account(
         client.publish(signedEvent, followPlusAllMineWithIndex.flow.value + client.availableRelaysFlow().value)
     }
 
-    suspend fun sendNip65RelayList(relays: List<AdvertisedRelayInfo>) = sendLiterallyEverywhere(nip65RelayList.saveRelayList(relays))
+    suspend fun sendNip65RelayList(relays: List<AdvertisedRelayInfo>) {
+        val oldOutbox = nip65RelayList.outboxFlowNoDefaults.value
+        val oldInbox = nip65RelayList.inboxFlowNoDefaults.value
+        val newOutbox =
+            relays
+                .filter { it.type.isWrite() }
+                .map { it.relayUrl }
+                .toSet()
+        val newInbox =
+            relays
+                .filter { it.type.isRead() }
+                .map { it.relayUrl }
+                .toSet()
+        sendLiterallyEverywhere(nip65RelayList.saveRelayList(relays))
+        if (oldOutbox != newOutbox || oldInbox != newInbox) {
+            republishEventsTo(accountSettingsEvents(), newOutbox)
+        }
+    }
 
     suspend fun sendBlossomServersList(servers: List<String>) = sendMyPublicAndPrivateOutbox(blossomServers.saveBlossomServersList(servers))
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/local/LocalRelayListViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/local/LocalRelayListViewModel.kt
@@ -31,6 +31,6 @@ class LocalRelayListViewModel : BasicRelaySetupInfoModel() {
             .toList()
 
     override suspend fun saveRelayList(urlList: List<NormalizedRelayUrl>) {
-        account.localRelayList.saveRelayList(urlList) {}
+        account.saveLocalRelayList(urlList)
     }
 }


### PR DESCRIPTION
## Summary
Enhanced relay list management to automatically republish relevant account settings events when relay configurations change. This ensures that when a user updates which relays they use for specific purposes (key packages, private storage, search, etc.), those settings are properly propagated to the new relays.

## Key Changes
- **Enhanced relay list save functions** to detect changes and republish affected events:
  - `saveKeyPackageRelayList()` - republishes key package events to new relays
  - `savePrivateOutboxRelayList()` - republishes account settings to new relays
  - `saveSearchRelayList()` - republishes user metadata to new relays
  - `saveIndexerRelayList()` - republishes user metadata and follow list to new relays
  - `saveBroadcastRelayList()` - republishes account settings to new relays
  - `sendNip65RelayList()` - republishes account settings when inbox/outbox relays change

- **New helper functions**:
  - `accountSettingsEvents()` - collects all signed replaceable events that configure the account (profile, contacts, relay lists, mutes, bookmarks, etc.)
  - `myKeyPackageEvents()` - retrieves all KeyPackage events authored by the account
  - `republishEventsTo()` - publishes given events to specified relays

- **New `saveLocalRelayList()` function** - added to Account class for consistency, called from LocalRelayListViewModel

## Implementation Details
- Change detection uses set comparison to avoid unnecessary republishing when relay lists haven't actually changed
- Events are only republished if the new relay set differs from the old one
- The `accountSettingsEvents()` function uses `listOfNotNull()` to safely handle events that may not exist yet
- Different relay list types republish different event sets based on their purpose (e.g., key package relays only republish key package events)

https://claude.ai/code/session_01PcvDaNyzT6Tk4D7jn75Jbm