### PR TITLE
Isolate MLS and Marmot stores per account

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/accountsCache/AccountCacheState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/accountsCache/AccountCacheState.kt
@@ -100,13 +100,14 @@ class AccountCacheState(
 
         val signerWithClientTag = NostrSignerWithClientTag(signer, CLIENT_TAG_NAME)
 
+        val accountDir = File(rootFilesDir(), "accounts/${signer.pubKey}").apply { mkdirs() }
+
         val mlsStore =
             try {
-                val dir = rootFilesDir()
                 Log.d("AccountCacheState") {
-                    "Initializing AndroidMlsGroupStateStore for ${signer.pubKey.take(8)}… at ${dir.absolutePath}"
+                    "Initializing AndroidMlsGroupStateStore for ${signer.pubKey.take(8)}… at ${accountDir.absolutePath}"
                 }
-                AndroidMlsGroupStateStore(dir)
+                AndroidMlsGroupStateStore(accountDir)
             } catch (e: Exception) {
                 Log.e(
                     "AccountCacheState",
@@ -121,7 +122,7 @@ class AccountCacheState(
 
         val marmotMessageStore =
             try {
-                AndroidMarmotMessageStore(rootFilesDir())
+                AndroidMarmotMessageStore(accountDir)
             } catch (e: Exception) {
                 Log.e(
                     "AccountCacheState",
@@ -133,7 +134,7 @@ class AccountCacheState(
 
         val marmotKeyPackageStore =
             try {
-                AndroidKeyPackageBundleStore(rootFilesDir())
+                AndroidKeyPackageBundleStore(accountDir)
             } catch (e: Exception) {
                 Log.e(
                     "AccountCacheState",


### PR DESCRIPTION
## Summary
This change isolates MLS (Messaging Layer Security) and Marmot message/key package stores to account-specific directories instead of sharing a single root directory across all accounts.

## Key Changes
- Created account-specific directory structure at `accounts/{pubKey}` for each signer
- Updated `AndroidMlsGroupStateStore` initialization to use account directory
- Updated `AndroidMarmotMessageStore` initialization to use account directory
- Updated `AndroidKeyPackageBundleStore` initialization to use account directory
- Improved logging to reference the account-specific directory path

## Implementation Details
- The `accountDir` is created once and reused across all three store initializations, reducing redundant directory creation calls
- Directory creation is ensured via `mkdirs()` before passing to store constructors
- This change prevents potential data conflicts when multiple accounts are used on the same device by maintaining separate storage for each account's cryptographic state

https://claude.ai/code/session_01R2pxeMRKHsayp88wtT3p3y