### PR TITLE
Fix navigation stack handling when creating marmot groups

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/CreateGroupScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/CreateGroupScreen.kt
@@ -80,7 +80,7 @@ fun CreateGroupScreen(
                     name = groupName.trim(),
                     description = "",
                 )
-                nav.nav(Route.MarmotGroupChat(nostrGroupId))
+                nav.popUpTo(Route.MarmotGroupChat(nostrGroupId), Route.CreateMarmotGroup::class)
             } catch (e: Exception) {
                 isCreating = false
                 launch(Dispatchers.Main) {


### PR DESCRIPTION
## Summary
Updated the navigation behavior when a marmot group is successfully created to properly manage the back stack instead of simply navigating forward.

## Key Changes
- Changed from `nav.nav()` to `nav.popUpTo()` when navigating to the newly created group chat
- Added `Route.CreateMarmotGroup::class` as the inclusive pop-up target to remove the group creation screen from the back stack
- This ensures users cannot navigate back to the creation screen after successfully creating a group

## Implementation Details
The navigation now uses `popUpTo()` with the creation route as the target, which will pop all screens up to and including the `CreateMarmotGroup` route before navigating to the new `MarmotGroupChat` screen. This provides a cleaner navigation experience and prevents users from returning to a stale creation form.

https://claude.ai/code/session_017QoFjctA1hfZgdhZzzCiAa