### PR TITLE
Implement known/new group classification based on follow set

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountFeedContentStates.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountFeedContentStates.kt
@@ -124,6 +124,7 @@ class AccountFeedContentStates(
         scope.launch(Dispatchers.IO) {
             account.marmotGroupList.groupListChanges.collect {
                 dmKnown.invalidateData()
+                dmNew.invalidateData()
             }
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupListScreen.kt
@@ -93,8 +93,12 @@ fun MarmotGroupListScreen(
     // (Account.ensureMarmotKeyPackagePublished), so this screen no longer
     // needs to do anything to make sure invitees can find a KeyPackage.
 
-    val knownGroups = remember(groupList) { groupList.filter { it.second.ownerSentMessage } }
-    val newRequestGroups = remember(groupList) { groupList.filter { !it.second.ownerSentMessage } }
+    val followState by accountViewModel.account.kind3FollowList.flow
+        .collectAsStateWithLifecycle()
+    val followingKeySet = followState.authors
+
+    val knownGroups = remember(groupList, followingKeySet) { groupList.filter { it.second.isKnown(followingKeySet) } }
+    val newRequestGroups = remember(groupList, followingKeySet) { groupList.filter { !it.second.isKnown(followingKeySet) } }
     val visibleGroups = if (selectedTab == 0) knownGroups else newRequestGroups
 
     Scaffold(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/dal/ChatroomListKnownFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/dal/ChatroomListKnownFeedFilter.kt
@@ -79,7 +79,11 @@ class ChatroomListKnownFeedFilter(
 
         val marmotGroups =
             account.marmotGroupList.rooms.mapNotNull { _, chatroom ->
-                chatroom.newestMessage ?: chatroom.placeholderNote()
+                if (chatroom.isKnown(followingKeySet)) {
+                    chatroom.newestMessage ?: chatroom.placeholderNote()
+                } else {
+                    null
+                }
             }
 
         return (privateMessages + publicChannels + ephemeralChats + marmotGroups).sortedWith(DefaultFeedOrder)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/dal/ChatroomListNewFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/dal/ChatroomListNewFeedFilter.kt
@@ -47,7 +47,16 @@ class ChatroomListNewFeedFilter(
                 }
             }
 
-        return privateMessages.sortedWith(DefaultFeedOrder)
+        val marmotGroups =
+            account.marmotGroupList.rooms.mapNotNull { _, chatroom ->
+                if (!chatroom.isKnown(followingKeySet)) {
+                    chatroom.newestMessage ?: chatroom.placeholderNote()
+                } else {
+                    null
+                }
+            }
+
+        return (privateMessages + marmotGroups).sortedWith(DefaultFeedOrder)
     }
 
     override fun updateListWith(

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/marmotGroups/MarmotGroupChatroom.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/marmotGroups/MarmotGroupChatroom.kt
@@ -69,6 +69,21 @@ class MarmotGroupChatroom(
      */
     var ownerSentMessage: Boolean = false
 
+    /**
+     * Classifies this group for the Known/New Requests split.
+     *
+     * Rules:
+     * - If the local user has already participated ([ownerSentMessage]), Known.
+     * - If the group has no known members and no messages yet, New Requests
+     *   (we don't know who invited us, so it's untrusted by default).
+     * - Otherwise, Known iff at least one admin is in the follow set.
+     */
+    fun isKnown(followingKeySet: Set<HexKey>): Boolean {
+        if (ownerSentMessage) return true
+        if (memberCount.value == 0 && messages.isEmpty()) return false
+        return adminPubkeys.value.any { it in followingKeySet }
+    }
+
     // Synthetic note used by list views to represent the group when no
     // messages have been received yet. Lazily created and kept stable so
     // equality-based feed diffing treats it as the same row across refreshes.


### PR DESCRIPTION
## Summary
This PR refactors how Marmot groups are classified as "Known" or "New Requests" by introducing a centralized classification logic that considers the user's follow set, not just whether they've sent a message.

## Key Changes
- **Added `isKnown()` method to `MarmotGroupChatroom`**: Implements classification rules that determine if a group is "Known" based on:
  - Whether the local user has participated (sent a message)
  - Whether the group has members or messages
  - Whether at least one admin is in the user's follow set
  
- **Updated `MarmotGroupListScreen`**: Now uses the new `isKnown()` method with the follow set to properly split groups into Known and New Request tabs, replacing the previous simple check of `ownerSentMessage`

- **Updated `ChatroomListKnownFeedFilter`**: Added filtering to only include groups classified as "Known" in the known chats feed

- **Updated `ChatroomListNewFeedFilter`**: Added filtering to only include groups classified as "New" in the new requests feed

- **Fixed feed invalidation in `AccountFeedContentStates`**: Added missing invalidation of the new requests feed (`dmNew`) when the marmot group list changes

## Implementation Details
The classification logic prioritizes trust signals: groups where the user has already participated are always "Known", while new groups with no members/messages are "New Requests" by default. For other groups, membership of at least one admin in the follow set determines classification, ensuring users see trusted groups in their main feed.

https://claude.ai/code/session_016wHrerFbp44g5C9GHf9nYi