### PR TITLE
Filter non-displayable messages from Marmot group chat feed

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -914,6 +914,20 @@ object LocalCache : ILocalCache, ICacheProvider {
                 event.tagsWithoutCitations().mapNotNull { checkGetOrCreateNote(it) }
             }
 
+            is ChatEvent -> {
+                // Amethyst's own kind:9 replies carry the parent as a NIP-18
+                // `q` tag (see ChatEvent.replyingTo), but the broader Marmot
+                // ecosystem — WhiteNoise in particular — threads kind:9 chats
+                // with a plain NIP-10 `e` tag. Accept both so inbound replies
+                // from either client show their quote bubble in the feed.
+                val eTagTargets =
+                    event.tags
+                        .filter { it.size > 1 && it[0] == "e" }
+                        .map { it[1] }
+                val qTagTargets = event.quotedEvents().map { it.eventId }
+                (eTagTargets + qTagTargets).mapNotNull { checkGetOrCreateNote(it) }
+            }
+
             else -> {
                 emptyList()
             }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/marmotGroups/MarmotGroupList.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/marmotGroups/MarmotGroupList.kt
@@ -47,6 +47,7 @@ class MarmotGroupList(
         nostrGroupId: HexKey,
         msg: Note,
     ) {
+        if (!isDisplayableFeedMessage(msg)) return
         val chatroom = getOrCreateGroup(nostrGroupId)
         val isSelfAuthored = msg.author?.pubkeyHex == ownerPubKey
         // Use the quiet path for our own messages so the relay round-trip
@@ -74,6 +75,7 @@ class MarmotGroupList(
         nostrGroupId: HexKey,
         msg: Note,
     ) {
+        if (!isDisplayableFeedMessage(msg)) return
         val chatroom = getOrCreateGroup(nostrGroupId)
         if (chatroom.restoreMessageSync(msg)) {
             noteToGroupIndex.getOrCreate(msg.idHex) { nostrGroupId }
@@ -134,5 +136,28 @@ class MarmotGroupList(
         val result = mutableListOf<HexKey>()
         rooms.forEach { key, _ -> result.add(key) }
         return result
+    }
+
+    /**
+     * True if this inner event should appear as its own bubble in the group
+     * chat feed. Side-channel kinds (reactions, deletions) must still be
+     * consumed into LocalCache — they drive the reaction row on the target
+     * note and, for kind:5, revoke a prior reaction — but they must NOT show
+     * up as standalone messages.
+     *
+     * Needed because WhiteNoise emits plain kind:7 reactions (emoji content +
+     * `e` tag) and kind:5 unreacts inside kind:445, and the Marmot pipeline
+     * blindly routed every inner event into the chatroom. The reaction then
+     * rendered as a chat bubble containing just the emoji, with a quoted
+     * citation of the target message — which reads exactly like a reply.
+     */
+    private fun isDisplayableFeedMessage(msg: Note): Boolean {
+        val kind = msg.event?.kind ?: return true
+        return kind != MARMOT_INNER_KIND_REACTION && kind != MARMOT_INNER_KIND_DELETION
+    }
+
+    companion object {
+        private const val MARMOT_INNER_KIND_DELETION = 5
+        private const val MARMOT_INNER_KIND_REACTION = 7
     }
 }

--- a/tools/marmot-interop/marmot-interop.sh
+++ b/tools/marmot-interop/marmot-interop.sh
@@ -776,7 +776,11 @@ test_09_reply_react_unreact() {
   fi
 
   step "B replies to the anchor"
-  wn_b messages send "$gid" "replying via wn" --reply_to "$msg_id" >/dev/null 2>&1 || true
+  # clap v4 converts snake_case fields to kebab-case flags by default, so the
+  # `reply_to: Option<String>` field on `wn messages send` exposes as
+  # `--reply-to`. Passing `--reply_to` is silently rejected (the script's
+  # `|| true` hides the error) and the reply is never actually published.
+  wn_b messages send "$gid" "replying via wn" --reply-to "$msg_id" >/dev/null 2>&1 || true
   sleep 3
   if confirm "Does Amethyst show 'replying via wn' as a threaded reply to the anchor?"; then
     record_result "09 reply/react" pass


### PR DESCRIPTION
## Summary
This PR fixes an issue where side-channel message kinds (reactions and deletions) were appearing as standalone chat bubbles in Marmot group chats, when they should only be consumed for metadata purposes (driving reaction rows and revocations).

## Key Changes

- **MarmotGroupList**: Added `isDisplayableFeedMessage()` filter to prevent kind:7 (reactions) and kind:5 (deletions) from being added to the chat feed in both `addMessage()` and `restoreMessageSync()` methods. These message types are still processed by LocalCache for their side effects but no longer render as chat bubbles.

- **LocalCache**: Extended `ChatEvent` handling to support both NIP-18 `q` tags (Amethyst's native reply format) and NIP-10 `e` tags (used by WhiteNoise and other Marmot ecosystem clients) when determining quoted/replied-to messages. This ensures reply quote bubbles display correctly regardless of client origin.

- **marmot-interop.sh**: Fixed test script to use correct kebab-case flag `--reply-to` instead of snake_case `--reply_to` for WhiteNoise CLI compatibility (clap v4 converts snake_case fields to kebab-case by default).

## Implementation Details

The `isDisplayableFeedMessage()` function checks the event kind and filters out:
- Kind 5 (deletion/unreact events)
- Kind 7 (reaction/emoji events)

These events are still routed to LocalCache for processing their semantic meaning but are excluded from the group chat feed rendering, preventing reactions from appearing as reply-like chat bubbles with quoted citations.

https://claude.ai/code/session_01K3g1uWLhByoEdBS77zdF32