### PR TITLE
Fix MIP-03 inner event verification in group messages

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -3018,7 +3018,12 @@ class Account(
                                 val innerEvent =
                                     com.vitorpamplona.quartz.nip01Core.core.Event
                                         .fromJson(json)
-                                val isNew = cache.justConsume(innerEvent, null, false)
+                                // wasVerified=true: these events were already verified
+                                // via MLS credential identity when first decrypted (see
+                                // GroupEventHandler). Persisted inner events are
+                                // unsigned per MIP-03, so justVerify would fail and
+                                // reactions/deletions would silently drop here.
+                                val isNew = cache.justConsume(innerEvent, null, true)
                                 val innerNote = cache.getOrCreateNote(innerEvent.id)
                                 if (isNew) {
                                     innerNote.event = innerEvent

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/DecryptAndIndexProcessor.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/DecryptAndIndexProcessor.kt
@@ -592,7 +592,15 @@ class GroupEventHandler(
                         "GroupEventHandler.add: ApplicationMessage decrypted innerKind=${innerEvent.kind} " +
                             "innerId=${innerEvent.id.take(8)}… author=${innerEvent.pubKey.take(8)}…"
                     }
-                    if (cache.justConsume(innerEvent, null, false)) {
+                    // wasVerified=true: MIP-03 inner events are unsigned (sig is empty
+                    // or placeholder), so justVerify() would fail. Authenticity is
+                    // already guaranteed by the MLS layer — MarmotInboundProcessor
+                    // enforces innerEvent.pubKey == MLS sender credential identity
+                    // before returning ApplicationMessage. Without this, side-channel
+                    // inner events from other Marmot clients (kind:7 reactions,
+                    // kind:5 deletions) are silently dropped by LocalCache, so a
+                    // WhiteNoise reaction never attaches to its target chat bubble.
+                    if (cache.justConsume(innerEvent, null, true)) {
                         val innerNote = cache.getOrCreateNote(innerEvent.id)
                         innerNote.event = innerEvent
 


### PR DESCRIPTION
## Summary
This PR fixes the handling of MIP-03 inner events (unsigned messages from MLS groups) by skipping signature verification when consuming them from cache. Inner events are already authenticated by the MLS layer, and signature verification would fail since they are unsigned per the MIP-03 specification.

## Changes
- **DecryptAndIndexProcessor.kt**: Changed `cache.justConsume(innerEvent, null, false)` to `cache.justConsume(innerEvent, null, true)` when processing decrypted ApplicationMessages. Inner events are authenticated via MLS credential identity verification by MarmotInboundProcessor, so signature verification is unnecessary and would cause valid events to be silently dropped.

- **Account.kt**: Changed `cache.justConsume(innerEvent, null, false)` to `cache.justConsume(innerEvent, null, true)` when loading persisted inner events from storage. These events were already verified via MLS when first decrypted, and are unsigned per MIP-03, so re-verification would fail.

## Implementation Details
The `wasVerified` parameter (third argument) is set to `true` to indicate that authenticity has already been guaranteed by the MLS layer. Without this change, side-channel inner events from other Marmot clients (such as kind:7 reactions and kind:5 deletions) are silently dropped by LocalCache, preventing reactions from attaching to their target chat bubbles and deletions from taking effect.

https://claude.ai/code/session_01KhVtLJAEkNCwpRWUUTqDFM