### PR TITLE
fix for: release/benchmark crash on start-up

### DIFF
--- a/amethyst/proguard-rules.pro
+++ b/amethyst/proguard-rules.pro
@@ -63,3 +63,9 @@
 -keep class com.vitorpamplona.quartz.** { *; }
 -keep class com.vitorpamplona.amethyst.** { *; }
 -keep class com.vitorpamplona.ammolite.** { *; }
+
+# Room generates *_Impl subclasses instantiated reflectively via no-arg constructor.
+# -keepnames preserves the name but R8 still strips the unused <init>().
+-keep class * extends androidx.room.RoomDatabase {
+    <init>();
+}


### PR DESCRIPTION
Summary: keep no-arg constructor of Room *_Impl classes 
  - R8 in playBenchmark (and release) stripped the no-arg <init> from WorkDatabase_Impl. -keepnames class ** { *; } preserves names but not members, and nothing in the app directly calls that constructor — Room invokes it
  reflectively via Class.getDeclaredConstructor().                                                                                                                                                                              
  - Result: startup crashed in androidx.startup.InitializationProvider with StartupException: NoSuchMethodException: androidx.work.impl.WorkDatabase_Impl.<init> []. Only affected minified variants (playBenchmark, release);
  playDebug was unaffected.                                                                                                                                                                                                     
  - Fix: add a targeted keep rule for no-arg constructors of any RoomDatabase subclass (covers WorkDatabase_Impl today and any future Room DBs):                                                                                
  -keep class * extends androidx.room.RoomDatabase { <init>(); }                                                                                
                                                                                                                                                                                                                                
  Test plan                                                                                                                                                                                                                     
  - ./gradlew :amethyst:assemblePlayBenchmark — BUILD SUCCESSFUL                                                                                                                                                                
  - ./gradlew :amethyst:installPlayBenchmark on Pixel 9a                                                                                                                                                                        
  - Launched com.vitorpamplona.amethyst.benchmark/.ui.MainActivity — no crash, process alive
  - No AndroidRuntime / StartupException entries in logcat after launch                    