### PR TITLE
Fix Marmot group message filtering for multi-account scenarios

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationFeedFilter.kt
@@ -176,9 +176,20 @@ class NotificationFeedFilter(
     ): Boolean {
         val loggedInUserHex = account.userProfile().pubkeyHex
 
-        // Marmot group messages are always acceptable (user is a group member)
-        val isMarmotGroupMessage = it.inGatherers?.any { g -> g is MarmotGroupChatroom } == true
-        if (isMarmotGroupMessage) {
+        // Marmot group messages are only acceptable if the gathering chatroom is
+        // actually in the current account's group list. Notes are stored in the
+        // global LocalCache and accumulate a gatherer reference from every
+        // account's chatroom that has ever touched them, so seeing any
+        // MarmotGroupChatroom is not enough — it could belong to a prior account
+        // or a group the user has since left. Verify the chatroom is the same
+        // instance held by this account's list.
+        val marmotGatherers = it.inGatherers?.filterIsInstance<MarmotGroupChatroom>()
+        if (!marmotGatherers.isNullOrEmpty()) {
+            val inCurrentAccount =
+                marmotGatherers.any { room ->
+                    account.marmotGroupList.rooms.get(room.nostrGroupId) === room
+                }
+            if (!inCurrentAccount) return false
             return it.author?.pubkeyHex != loggedInUserHex
         }
 


### PR DESCRIPTION
## Summary
Fixed a bug in notification filtering where Marmot group messages from other accounts or left groups were incorrectly being accepted as notifications for the current account.

## Key Changes
- Enhanced the Marmot group message validation logic to verify that the gathering chatroom belongs to the current account's group list, not just that any `MarmotGroupChatroom` reference exists
- Changed from a simple type check (`any { g is MarmotGroupChatroom }`) to filtering for `MarmotGroupChatroom` instances and verifying they are the same instance held by the current account
- Added identity comparison (`===`) to ensure the chatroom object is the exact same instance in the account's group list, preventing false positives from notes that have accumulated gatherer references from multiple accounts

## Implementation Details
The fix addresses a scenario where notes stored in the global `LocalCache` can accumulate gatherer references from every account's chatroom that has ever touched them. Simply checking for the presence of a `MarmotGroupChatroom` is insufficient—the chatroom could belong to a prior account or a group the user has since left. The solution verifies that the chatroom is the same instance held by the current account's `marmotGroupList.rooms` collection.

https://claude.ai/code/session_014LjiaieDsMuSb6y383cxan