### PR TITLE
Fix memory leak when leaving Marmot groups

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -2319,6 +2319,12 @@ class Account(
         }
 
         val outbound = manager.leaveGroup(nostrGroupId)
+        // manager.leaveGroup already wiped MLS state, relay subscriptions and
+        // the persisted message log. Drop the in-memory chatroom too — that
+        // releases the strong refs to the decrypted inner notes so LocalCache
+        // (which holds them weakly) can GC them, and the Notification feed
+        // (which iterates marmotGroupList.rooms) stops surfacing the group.
+        marmotGroupList.removeGroup(nostrGroupId)
         client.publish(outbound.signedEvent, groupRelays)
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupInfoScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupInfoScreen.kt
@@ -316,7 +316,6 @@ fun MarmotGroupInfoScreen(
                 scope.launch(Dispatchers.IO) {
                     try {
                         accountViewModel.leaveMarmotGroup(nostrGroupId)
-                        accountViewModel.account.marmotGroupList.removeGroup(nostrGroupId)
                         nav.nav(Route.Message)
                     } catch (e: Exception) {
                         isLeaving = false

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/marmotGroups/MarmotGroupChatroom.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/marmotGroups/MarmotGroupChatroom.kt
@@ -202,4 +202,21 @@ class MarmotGroupChatroom(
         changesFlow.get()?.tryEmit(ListChange.SetDeletion<Note>(toRemove))
         return toRemove
     }
+
+    /**
+     * Drop every message from this chatroom. Used when the local user leaves
+     * the group: cuts the strong references held in [messages] so the
+     * decrypted inner notes become eligible for GC out of LocalCache (which
+     * holds them weakly).
+     */
+    @Synchronized
+    fun clearAllMessagesSync(): Set<Note> {
+        val toRemove = messages
+        if (toRemove.isEmpty()) return toRemove
+        messages = emptySet()
+        newestMessage = null
+        unreadCount.value = 0
+        changesFlow.get()?.tryEmit(ListChange.SetDeletion<Note>(toRemove))
+        return toRemove
+    }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/marmotGroups/MarmotGroupList.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/marmotGroups/MarmotGroupList.kt
@@ -127,8 +127,15 @@ class MarmotGroupList(
         }
     }
 
+    /**
+     * Drop a group from the in-memory list. Also clears the chatroom's own
+     * message set and the note→group index: LocalCache holds notes weakly, so
+     * once these strong references go away the decrypted inner messages
+     * become eligible for GC and stop appearing in the Notification feed.
+     */
     fun removeGroup(nostrGroupId: HexKey) {
-        rooms.remove(nostrGroupId)
+        val chatroom = rooms.remove(nostrGroupId)
+        chatroom?.clearAllMessagesSync()?.forEach { noteToGroupIndex.remove(it.idHex) }
         _groupListChanges.tryEmit(nostrGroupId)
     }
 


### PR DESCRIPTION
## Summary
This PR fixes a memory leak that occurred when users left Marmot groups. Decrypted messages were not being properly released from memory because strong references were held in the chatroom's message set even after the group was removed.

## Key Changes
- **MarmotGroupChatroom.kt**: Added `clearAllMessagesSync()` method to drop all messages from a chatroom, clearing strong references to decrypted notes and resetting related state (newest message, unread count)
- **MarmotGroupList.kt**: Updated `removeGroup()` to call `clearAllMessagesSync()` and remove entries from the note-to-group index, allowing LocalCache to garbage collect the decrypted messages
- **Account.kt**: Moved `marmotGroupList.removeGroup()` call into `leaveMarmotGroup()` so the in-memory cleanup happens automatically alongside the MLS state and relay subscription cleanup
- **MarmotGroupInfoScreen.kt**: Removed duplicate `removeGroup()` call since it's now handled in the account layer

## Implementation Details
- The `clearAllMessagesSync()` method is synchronized to prevent concurrent modification issues
- By releasing strong references to notes, LocalCache (which holds them weakly) can now garbage collect the decrypted inner messages
- The Notification feed will stop surfacing the group once it's removed from `marmotGroupList.rooms`
- This consolidates the cleanup logic into a single place (Account.leaveMarmotGroup) to prevent duplicate calls and ensure consistency

https://claude.ai/code/session_01SbWDN95PMu26g14h3bcu5s