### PR TITLE
Improve WakeUp event handling for multiple referenced events

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -923,6 +923,12 @@ object LocalCache : ILocalCache, ICacheProvider {
                     event.taggedAddresses().map { getOrCreateAddressableNote(it) }
             }
 
+            is WakeUpEvent -> {
+                // Link the referenced events so filterMissingEvents will query
+                // for them when the WakeUp note is in an EventFinder subscription.
+                event.eventIds().mapNotNull { checkGetOrCreateNote(it) }
+            }
+
             is ChannelMessageEvent -> {
                 event.tagsWithoutCitations().filter { it != event.channelId() }.mapNotNull { checkGetOrCreateNote(it) }
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
@@ -89,6 +89,11 @@ class EventNotificationConsumer(
 ) {
     companion object {
         private const val WAKELOCK_TIMEOUT_MS = 10 * 60 * 1000L // 10 minutes
+        private const val WAKEUP_WINDOW_MS = 30_000L
+
+        // Upper bound on referenced events we'll chase per WakeUp. Guards against
+        // a malicious sender opening hundreds of subscriptions per wake-up.
+        private const val MAX_WAKEUP_REFS = 16
     }
 
     /**
@@ -162,7 +167,7 @@ class EventNotificationConsumer(
             }
 
             is WakeUpEvent -> {
-                wakeUpFor(event, LocalCache.getOrCreateNote(event.id), account)
+                wakeUpFor(event, account)
                 return
             }
         }
@@ -185,40 +190,74 @@ class EventNotificationConsumer(
 
     suspend fun wakeUpFor(
         event: WakeUpEvent,
-        note: Note,
         account: Account,
     ) {
+        // A WakeUp's whole purpose is the events it references. If it carries
+        // none, there's nothing to fetch — skip the 30s subscription window.
+        val referencedTags =
+            event
+                .events()
+                .distinctBy { it.eventId }
+                .take(MAX_WAKEUP_REFS)
+        if (referencedTags.isEmpty()) {
+            Log.d(TAG) { "WakeUp ${event.id} has no referenced events — skipping" }
+            return
+        }
+
+        // The referenced event's author is who the user will see in the final
+        // notification ("Alice zapped you"). The WakeUp's own pubKey is typically
+        // a push bot and not useful. Fall back to it only when the `e` tag omits
+        // the author hint.
+        val referencedNotes = referencedTags.map { LocalCache.getOrCreateNote(it.eventId) }
+        val authorCandidates =
+            referencedTags
+                .mapNotNull { it.author }
+                .distinct()
+                .ifEmpty { listOf(event.pubKey) }
+                .map { LocalCache.getOrCreateUser(it) }
+
         coroutineScope {
             // keeps the relay connection active for 30 seconds.
             launch {
                 try {
-                    withTimeout(30_000L) {
+                    withTimeout(WAKEUP_WINDOW_MS) {
                         Amethyst.instance.relayProxyClientConnector.relayServices
                             .collect()
                     }
                 } catch (_: TimeoutCancellationException) {
+                    Log.d(TAG) { "WakeUp ${event.id} — ${WAKEUP_WINDOW_MS}ms relay window elapsed" }
                 }
             }
 
-            // keeps the subscription to download this event active for 30 seconds.
+            // keeps subscriptions active for 30 seconds so EventFinder can pull
+            // the referenced events from relays and UserFinder can resolve the
+            // referenced authors' metadata.
             launch {
                 val accountState = ScreenAuthAccount(account)
-                val eventState = EventFinderQueryState(note, account)
-                val authorState = UserFinderQueryState(note.author ?: LocalCache.getOrCreateUser(event.pubKey), account)
+                val eventStates = referencedNotes.map { EventFinderQueryState(it, account) }
+                val authorStates = authorCandidates.map { UserFinderQueryState(it, account) }
 
                 try {
                     Amethyst.instance.authCoordinator.subscribe(accountState)
-                    Amethyst.instance.sources.eventFinder
-                        .subscribe(eventState)
-                    Amethyst.instance.sources.userFinder
-                        .subscribe(authorState)
-                    delay(30_000)
+                    eventStates.forEach {
+                        Amethyst.instance.sources.eventFinder
+                            .subscribe(it)
+                    }
+                    authorStates.forEach {
+                        Amethyst.instance.sources.userFinder
+                            .subscribe(it)
+                    }
+                    delay(WAKEUP_WINDOW_MS)
                 } finally {
                     Amethyst.instance.authCoordinator.unsubscribe(accountState)
-                    Amethyst.instance.sources.eventFinder
-                        .unsubscribe(eventState)
-                    Amethyst.instance.sources.userFinder
-                        .unsubscribe(authorState)
+                    eventStates.forEach {
+                        Amethyst.instance.sources.eventFinder
+                            .unsubscribe(it)
+                    }
+                    authorStates.forEach {
+                        Amethyst.instance.sources.userFinder
+                            .unsubscribe(it)
+                    }
                 }
             }
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
@@ -90,10 +90,6 @@ class EventNotificationConsumer(
     companion object {
         private const val WAKELOCK_TIMEOUT_MS = 10 * 60 * 1000L // 10 minutes
         private const val WAKEUP_WINDOW_MS = 30_000L
-
-        // Upper bound on referenced events we'll chase per WakeUp. Guards against
-        // a malicious sender opening hundreds of subscriptions per wake-up.
-        private const val MAX_WAKEUP_REFS = 16
     }
 
     /**
@@ -194,11 +190,7 @@ class EventNotificationConsumer(
     ) {
         // A WakeUp's whole purpose is the events it references. If it carries
         // none, there's nothing to fetch — skip the 30s subscription window.
-        val referencedTags =
-            event
-                .events()
-                .distinctBy { it.eventId }
-                .take(MAX_WAKEUP_REFS)
+        val referencedTags = event.events().distinctBy { it.eventId }
         if (referencedTags.isEmpty()) {
             Log.d(TAG) { "WakeUp ${event.id} has no referenced events — skipping" }
             return
@@ -208,13 +200,10 @@ class EventNotificationConsumer(
         // events; those are whose metadata we need to render the notification.
         // Fall back to e-tag author hints and finally to the WakeUp signer.
         val referencedNotes = referencedTags.map { LocalCache.getOrCreateNote(it.eventId) }
-        val authorKeys =
+        val authorCandidates =
             (event.authorKeys() + referencedTags.mapNotNull { it.author })
                 .distinct()
                 .ifEmpty { listOf(event.pubKey) }
-        val authorCandidates =
-            authorKeys
-                .take(MAX_WAKEUP_REFS)
                 .map { LocalCache.getOrCreateUser(it) }
 
         coroutineScope {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
@@ -204,16 +204,17 @@ class EventNotificationConsumer(
             return
         }
 
-        // The referenced event's author is who the user will see in the final
-        // notification ("Alice zapped you"). The WakeUp's own pubKey is typically
-        // a push bot and not useful. Fall back to it only when the `e` tag omits
-        // the author hint.
+        // Per spec, p-tags on a WakeUp are the authors of the referenced
+        // events; those are whose metadata we need to render the notification.
+        // Fall back to e-tag author hints and finally to the WakeUp signer.
         val referencedNotes = referencedTags.map { LocalCache.getOrCreateNote(it.eventId) }
-        val authorCandidates =
-            referencedTags
-                .mapNotNull { it.author }
+        val authorKeys =
+            (event.authorKeys() + referencedTags.mapNotNull { it.author })
                 .distinct()
                 .ifEmpty { listOf(event.pubKey) }
+        val authorCandidates =
+            authorKeys
+                .take(MAX_WAKEUP_REFS)
                 .map { LocalCache.getOrCreateUser(it) }
 
         coroutineScope {

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/notifications/wake/WakeUpEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/notifications/wake/WakeUpEvent.kt
@@ -35,7 +35,7 @@ import com.vitorpamplona.quartz.nip01Core.tags.kinds.kind
 import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip01Core.tags.people.PTag.Companion.parse
 import com.vitorpamplona.quartz.nip01Core.tags.people.PTag.Companion.parseKey
-import com.vitorpamplona.quartz.nip01Core.tags.people.taggedUsers
+import com.vitorpamplona.quartz.nip01Core.tags.people.toPTag
 import com.vitorpamplona.quartz.nip31Alts.alt
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.serialization.json.JsonNull.content
@@ -68,10 +68,10 @@ class WakeUpEvent(
         const val KIND = 23903
         const val ALT_DESCRIPTION = "WakeUp"
 
-        // Tags the audience of [about] (its `p` tags) as the recipients to wake up.
-        // The about event's author is NOT tagged: a WakeUp about a zap from Alice
-        // to Bob should notify Bob, not Alice. Callers can add more recipients via
-        // [initializer].
+        // p-tags on a WakeUp identify the AUTHORS of the referenced events —
+        // the people whose events are the subject of the wake-up and who should
+        // come online to handle new activity on them. Callers can add extra
+        // e/p tags via [initializer] when waking up about multiple events.
         fun build(
             about: EventHintBundle<Event>,
             createdAt: Long = TimeUtils.now(),
@@ -79,7 +79,7 @@ class WakeUpEvent(
         ) = eventTemplate(KIND, content, createdAt) {
             alt(ALT_DESCRIPTION)
             about(about)
-            notify(about.event.tags.taggedUsers())
+            notify(about.toPTag())
             kind(about.event.kind)
             initializer()
         }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/notifications/wake/WakeUpEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/notifications/wake/WakeUpEvent.kt
@@ -35,7 +35,7 @@ import com.vitorpamplona.quartz.nip01Core.tags.kinds.kind
 import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip01Core.tags.people.PTag.Companion.parse
 import com.vitorpamplona.quartz.nip01Core.tags.people.PTag.Companion.parseKey
-import com.vitorpamplona.quartz.nip01Core.tags.people.toPTag
+import com.vitorpamplona.quartz.nip01Core.tags.people.taggedUsers
 import com.vitorpamplona.quartz.nip31Alts.alt
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.serialization.json.JsonNull.content
@@ -68,6 +68,10 @@ class WakeUpEvent(
         const val KIND = 23903
         const val ALT_DESCRIPTION = "WakeUp"
 
+        // Tags the audience of [about] (its `p` tags) as the recipients to wake up.
+        // The about event's author is NOT tagged: a WakeUp about a zap from Alice
+        // to Bob should notify Bob, not Alice. Callers can add more recipients via
+        // [initializer].
         fun build(
             about: EventHintBundle<Event>,
             createdAt: Long = TimeUtils.now(),
@@ -75,7 +79,7 @@ class WakeUpEvent(
         ) = eventTemplate(KIND, content, createdAt) {
             alt(ALT_DESCRIPTION)
             about(about)
-            notify(about.toPTag())
+            notify(about.event.tags.taggedUsers())
             kind(about.event.kind)
             initializer()
         }


### PR DESCRIPTION
## Summary
Enhanced the WakeUp event notification system to properly handle multiple referenced events and their authors, improving the reliability of fetching event data and author metadata during the wake-up window.

## Key Changes
- **Extract referenced events from WakeUp**: Modified `wakeUpFor()` to extract all events referenced by a WakeUp event and skip processing if none are found
- **Multi-event subscription support**: Changed from subscribing to a single event to subscribing to all referenced events via EventFinder
- **Improved author resolution**: Implemented a fallback chain for determining which authors' metadata to fetch:
  - Primary: p-tags on the WakeUp (per spec, these identify the referenced event authors)
  - Secondary: Author hints from e-tags on referenced events
  - Fallback: The WakeUp event signer
- **LocalCache linking**: Added WakeUpEvent handling in LocalCache to link referenced events so they're properly queried when the WakeUp note is in an EventFinder subscription
- **Constants extraction**: Introduced `WAKEUP_WINDOW_MS` constant (30 seconds) for consistency and maintainability
- **Enhanced logging**: Added debug logs to track WakeUp processing and relay window completion
- **Simplified call site**: Removed unnecessary `note` parameter from `wakeUpFor()` call since it's now derived from the event references

## Implementation Details
- The 30-second wake-up window now maintains subscriptions for multiple events and authors simultaneously
- Subscriptions are properly cleaned up in a finally block to ensure resources are released
- The change maintains backward compatibility while extending functionality to handle complex WakeUp scenarios with multiple referenced events

https://claude.ai/code/session_01QzfyErwYj1SGedarMEgr2U