### PR TITLE
Fix: hand raised toggle bug and sonar fixes

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/audiorooms/room/AudioRoomStage.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/audiorooms/room/AudioRoomStage.kt
@@ -30,7 +30,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.FilledTonalIconToggleButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -178,9 +178,12 @@ private fun AudioRoomStageContent(
                 horizontalArrangement = Arrangement.End,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                FilledTonalIconButton(onClick = { handRaised = !handRaised }) {
+                FilledTonalIconToggleButton(
+                    checked = handRaised,
+                    onCheckedChange = { handRaised = it },
+                ) {
                     Icon(
-                        symbol = if (handRaised) MaterialSymbols.PanTool else MaterialSymbols.PanTool,
+                        symbol = MaterialSymbols.PanTool,
                         contentDescription =
                             stringRes(
                                 if (handRaised) R.string.audio_room_lower_hand else R.string.audio_room_raise_hand,

--- a/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/stores/FileStores.kt
+++ b/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/stores/FileStores.kt
@@ -23,7 +23,14 @@ package com.vitorpamplona.amethyst.cli.stores
 import com.vitorpamplona.quartz.marmot.mip00KeyPackages.KeyPackageBundleStore
 import com.vitorpamplona.quartz.marmot.mls.group.MarmotMessageStore
 import com.vitorpamplona.quartz.marmot.mls.group.MlsGroupStateStore
+import com.vitorpamplona.quartz.utils.Log
 import java.io.File
+
+private fun File.deleteOrWarn(tag: String) {
+    if (!delete() && exists()) {
+        Log.w(tag) { "Failed to delete $absolutePath" }
+    }
+}
 
 /**
  * Test-harness file stores. **Unencrypted** — the production interfaces
@@ -53,8 +60,8 @@ class FileMlsGroupStateStore(
     override suspend fun load(nostrGroupId: String): ByteArray? = stateFile(nostrGroupId).takeIf { it.exists() }?.readBytes()
 
     override suspend fun delete(nostrGroupId: String) {
-        stateFile(nostrGroupId).delete()
-        retainedFile(nostrGroupId).delete()
+        stateFile(nostrGroupId).deleteOrWarn("FileMlsGroupStateStore")
+        retainedFile(nostrGroupId).deleteOrWarn("FileMlsGroupStateStore")
     }
 
     override suspend fun listGroups(): List<String> =
@@ -112,7 +119,7 @@ class FileKeyPackageBundleStore(
     override suspend fun load(): ByteArray? = file.takeIf { it.exists() }?.readBytes()
 
     override suspend fun delete() {
-        file.delete()
+        file.deleteOrWarn("FileKeyPackageBundleStore")
     }
 }
 
@@ -137,6 +144,6 @@ class FileMarmotMessageStore(
     override suspend fun loadMessages(nostrGroupId: String): List<String> = file(nostrGroupId).takeIf { it.exists() }?.readLines()?.filter { it.isNotBlank() } ?: emptyList()
 
     override suspend fun delete(nostrGroupId: String) {
-        file(nostrGroupId).delete()
+        file(nostrGroupId).deleteOrWarn("FileMarmotMessageStore")
     }
 }


### PR DESCRIPTION
- Use `FilledIconToggleButton` with `checked = handRaised`. The button's container colour flips on its own
- `deleteOrWarn` helper that logs via the KMP-safe `quartz.utils.Log` (lambda form) when a file still exists after `delete()` returns `false`