### PR TITLE
Simplify SwipeToDelete by using onDismiss callback

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/SwipeToDelete.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/SwipeToDelete.kt
@@ -34,7 +34,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxState
-import androidx.compose.material3.SwipeToDismissBoxValue.EndToStart
 import androidx.compose.material3.SwipeToDismissBoxValue.Settled
 import androidx.compose.material3.SwipeToDismissBoxValue.StartToEnd
 import androidx.compose.material3.Text
@@ -64,22 +63,6 @@ fun SwipeToDeleteContainer(
 ) {
     val dismissState =
         rememberSwipeToDismissBoxState(
-            confirmValueChange = {
-                when (it) {
-                    StartToEnd -> {
-                        onStartToEnd()
-                    }
-
-                    EndToStart -> {
-                        return@rememberSwipeToDismissBoxState false
-                    }
-
-                    Settled -> {
-                        return@rememberSwipeToDismissBoxState false
-                    }
-                }
-                return@rememberSwipeToDismissBoxState true
-            },
             positionalThreshold = { it * .40f },
         )
 
@@ -88,6 +71,7 @@ fun SwipeToDeleteContainer(
         modifier = modifier,
         backgroundContent = { DismissBackground(dismissState) },
         enableDismissFromEndToStart = false,
+        onDismiss = { if (it == StartToEnd) onStartToEnd() },
         content = content,
     )
 }


### PR DESCRIPTION
## Summary
Refactored the `SwipeToDeleteContainer` composable to use the `onDismiss` callback parameter instead of the `confirmValueChange` lambda, resulting in cleaner and more maintainable code.

## Key Changes
- Removed the `confirmValueChange` parameter from `rememberSwipeToDismissBoxState()` which contained conditional logic for handling different swipe directions
- Replaced it with the `onDismiss` callback parameter on `SwipeToDismissBox`, which is the more appropriate API for handling dismissal events
- Removed unused import of `EndToStart` from `SwipeToDismissBoxValue`
- The new implementation only triggers `onStartToEnd()` when the swipe direction is `StartToEnd`, maintaining the same behavior

## Implementation Details
The refactoring leverages the `onDismiss` callback which is specifically designed for handling dismissal events, making the code more idiomatic and easier to understand. The logic is now consolidated in a single line rather than spread across a multi-line when expression.

https://claude.ai/code/session_01CfYsUSGeuBnYsCqa6FDSPk