### PR TITLE
Ci/split android job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
           cache: gradle
 
       - name: Test + Build Desktop (gradle)
-        run: ./gradlew :quartz:test :commons:test :nestsClient:test :cli:test :desktopApp:test :desktopApp:${{ matrix.desktop-task }} --no-daemon
+        run: ./gradlew :quartz:jvmTest :commons:jvmTest :nestsClient:jvmTest :cli:test :desktopApp:test :desktopApp:${{ matrix.desktop-task }} --no-daemon
 
       - name: Upload Desktop Distribution
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
           cache: gradle
 
       - name: Test + Build Desktop (gradle)
-        run: ./gradlew :quartz:test :commons:test :cli:test :desktopApp:test :desktopApp:${{ matrix.desktop-task }} --no-daemon
+        run: ./gradlew :quartz:test :commons:test :nestsClient:test :cli:test :desktopApp:test :desktopApp:${{ matrix.desktop-task }} --no-daemon
 
       - name: Upload Desktop Distribution
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Linter (gradle)
         run: ./gradlew spotlessCheck
 
-  test-and-build:
+  build-desktop:
     needs: lint
     strategy:
       fail-fast: false
@@ -66,22 +66,7 @@ jobs:
           cache: gradle
 
       - name: Test + Build Desktop (gradle)
-        run: ./gradlew test :desktopApp:${{ matrix.desktop-task }} --no-daemon
-
-      - name: Build Android Benchmark APKs (gradle)
-        if: matrix.os == 'ubuntu-latest'
-        run: ./gradlew assembleBenchmark --no-daemon
-
-      - name: Android Test Report
-        uses: asadmansr/android-test-report-action@v1.2.0
-        if: ${{ always() && matrix.os == 'ubuntu-latest' }}
-
-      - name: Upload Test Results
-        uses: actions/upload-artifact@v7
-        if: ${{ always() && matrix.os == 'ubuntu-latest' }}
-        with:
-          name: Test Reports
-          path: amethyst/build/reports
+        run: ./gradlew :quartz:test :commons:test :cli:test :desktopApp:test :desktopApp:${{ matrix.desktop-task }} --no-daemon
 
       - name: Upload Desktop Distribution
         uses: actions/upload-artifact@v7
@@ -89,23 +74,49 @@ jobs:
           name: ${{ matrix.desktop-artifact-name }}
           path: ${{ matrix.desktop-artifact-path }}
 
+  test-and-build-android:
+    needs: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: 21
+          cache: gradle
+
+      - name: Test + Build Android (gradle)
+        run: ./gradlew test assembleBenchmark --no-daemon
+
+      - name: Android Test Report
+        uses: asadmansr/android-test-report-action@v1.2.0
+        if: always()
+
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: Test Reports
+          path: amethyst/build/reports
+
       - name: Upload Play APK Benchmark
         uses: actions/upload-artifact@v7
-        if: matrix.os == 'ubuntu-latest'
         with:
           name: Play Benchmark APK
           path: amethyst/build/outputs/apk/play/benchmark/amethyst-play-universal-benchmark.apk
 
       - name: Upload FDroid APK Benchmark
         uses: actions/upload-artifact@v7
-        if: matrix.os == 'ubuntu-latest'
         with:
           name: FDroid Benchmark APK
           path: amethyst/build/outputs/apk/fdroid/benchmark/amethyst-fdroid-universal-benchmark.apk
 
       - name: Upload Compose Reports
         uses: actions/upload-artifact@v7
-        if: matrix.os == 'ubuntu-latest'
         with:
           name: Compose Reports
           path: amethyst/build/compose_compiler

--- a/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/InliningTagArrayPrettyPrinterTest.kt
+++ b/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/InliningTagArrayPrettyPrinterTest.kt
@@ -49,7 +49,7 @@ class InliningTagArrayPrettyPrinterTest {
             }
             """.trimIndent()
         val json = writer.writeValueAsString(data)
-        assertEquals(expected, json)
+        assertEquals(expected.replace("\r\n", "\n"), json)
 
         val data2 =
             mapOf(
@@ -65,7 +65,7 @@ class InliningTagArrayPrettyPrinterTest {
             }
             """.trimIndent()
         val json2 = writer.writeValueAsString(data2)
-        assertEquals(expected2, json2)
+        assertEquals(expected2.replace("\r\n", "\n"), json2)
     }
 
     @Test
@@ -90,6 +90,6 @@ class InliningTagArrayPrettyPrinterTest {
 
         val prettified = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(tree)
 
-        assertEquals(nostrObject, prettified)
+        assertEquals(nostrObject.replace("\r\n", "\n"), prettified)
     }
 }

--- a/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/InliningTagArrayPrettyPrinterTest.kt
+++ b/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/InliningTagArrayPrettyPrinterTest.kt
@@ -49,7 +49,7 @@ class InliningTagArrayPrettyPrinterTest {
             }
             """.trimIndent()
         val json = writer.writeValueAsString(data)
-        assertEquals(expected.replace("\r\n", "\n"), json)
+        assertEquals(expected.replace("\r\n", "\n"), json.replace("\r\n", "\n"))
 
         val data2 =
             mapOf(
@@ -65,7 +65,7 @@ class InliningTagArrayPrettyPrinterTest {
             }
             """.trimIndent()
         val json2 = writer.writeValueAsString(data2)
-        assertEquals(expected2.replace("\r\n", "\n"), json2)
+        assertEquals(expected2.replace("\r\n", "\n"), json2.replace("\r\n", "\n"))
     }
 
     @Test
@@ -90,6 +90,6 @@ class InliningTagArrayPrettyPrinterTest {
 
         val prettified = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(tree)
 
-        assertEquals(nostrObject.replace("\r\n", "\n"), prettified)
+        assertEquals(nostrObject.replace("\r\n", "\n"), prettified.replace("\r\n", "\n"))
     }
 }


### PR DESCRIPTION
CI: split Android into its own visible job

 The merged test-and-build matrix hid Android behind an OS-keyed leg. Restore visibility by splitting into two parallel jobs after lint:                                                                                       
   
  - build-desktop (matrix: ubuntu/macos/windows) — JVM tests for KMP/JVM modules + native installer per OS.                                                                                                                     
  - test-and-build-android (ubuntu) — full test sweep + assembleBenchmark, uploads APKs and reports.
                                                                                                                                                                                                                                
Also fixes a latent CRLF bug in InliningTagArrayPrettyPrinterTest surfaced now that :quartz:jvmTest actually runs on Windows. 

<img width="755" height="476" alt="Screenshot 2026-04-25 at 15 44 15" src="https://github.com/user-attachments/assets/b1dae0f2-9fc4-4555-abbe-fc0171882155" />
