### PR TITLE
ci: add Android Lint as first step of the Android job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,16 @@ jobs:
           java-version: 21
           cache: gradle
 
+      - name: Android Lint (gradle)
+        run: ./gradlew :amethyst:lintFdroidBenchmark :amethyst:lintPlayBenchmark --no-daemon
+
+      - name: Upload Android Lint Reports
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: Android Lint Reports
+          path: amethyst/build/reports/lint-results-*.html
+
       - name: Test + Build Android (gradle)
         run: ./gradlew test assembleBenchmark --no-daemon
 


### PR DESCRIPTION
Android Lint catches API-level, deprecation, accessibility, and resource issues that spotless and unit tests miss. Run lint on the same variants that get assembled (fdroidBenchmark, playBenchmark) before tests so a lint failure surfaces quickly without consuming the full test budget.

Lint reports are uploaded as artifacts for inspection.