### PR TITLE
fix(lint): observe locale via LocalConfiguration in composables

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/LiveActivity.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/LiveActivity.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -82,7 +83,6 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
-import java.util.Locale
 
 @Composable
 @Preview
@@ -272,6 +272,8 @@ fun RenderLiveActivityEventInner(
         }
     }
 
+    val locale = LocalConfiguration.current.locales.get(0)
+
     participantUsers.forEach {
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -288,7 +290,7 @@ fun RenderLiveActivityEventInner(
                 Text(
                     text =
                         it.replaceFirstChar {
-                            if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
+                            if (it.isLowerCase()) it.titlecase(locale) else it.toString()
                         },
                     color = MaterialTheme.colorScheme.placeholderText,
                     maxLines = 1,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/MeetingSpace.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/MeetingSpace.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -67,7 +68,6 @@ import com.vitorpamplona.quartz.nip53LiveActivities.streaming.tags.ParticipantTa
 import com.vitorpamplona.quartz.nip53LiveActivities.streaming.tags.StatusTag
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import java.util.Locale
 import com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.tags.StatusTag as MeetingSpaceStatusTag
 
 @Composable
@@ -250,6 +250,8 @@ private fun RenderParticipants(
         }
     }
 
+    val locale = LocalConfiguration.current.locales.get(0)
+
     participantUsers.forEach {
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -266,7 +268,7 @@ private fun RenderParticipants(
                 Text(
                     text =
                         it.replaceFirstChar {
-                            if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
+                            if (it.isLowerCase()) it.titlecase(locale) else it.toString()
                         },
                     color = MaterialTheme.colorScheme.placeholderText,
                     maxLines = 1,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/nip53LiveActivities/header/LongLiveActivityChannelHeader.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/nip53LiveActivities/header/LongLiveActivityChannelHeader.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
@@ -69,7 +70,6 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import java.util.Locale
 
 @Composable
 fun LongLiveActivityChannelHeader(
@@ -145,6 +145,8 @@ fun LongLiveActivityChannelHeader(
         }
     }
 
+    val locale = LocalConfiguration.current.locales.get(0)
+
     participantUsers.forEach {
         Row(
             lineModifier.clickable { nav.nav(routeFor(it.second)) },
@@ -154,7 +156,7 @@ fun LongLiveActivityChannelHeader(
                 Text(
                     text =
                         it1.replaceFirstChar {
-                            if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
+                            if (it.isLowerCase()) it.titlecase(locale) else it.toString()
                         },
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,


### PR DESCRIPTION
Replace Locale.getDefault() with LocalConfiguration.current.locales[0]
inside the participant role rendering composables to satisfy the
NonObservableLocale lint check, ensuring the UI recomposes when the
system locale changes.

https://claude.ai/code/session_01AikVWBbPuWhqCDDFCwbeA2