### PR TITLE
fix(packaging): relax libicu dependency in .deb for cross-distro compat

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,6 +159,13 @@ jobs:
       - name: Build Desktop Distribution
         run: ./gradlew :desktopApp:${{ matrix.task }}
 
+      - name: Relax libicu dependency in .deb
+        if: matrix.task == 'packageDeb'
+        run: |
+          set -euo pipefail
+          chmod +x scripts/relax-deb-libicu.sh
+          scripts/relax-deb-libicu.sh desktopApp/build/compose/binaries/main/deb/*.deb
+
       - name: Stop Gradle Daemon
         if: always()
         run: ./gradlew --stop

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -103,6 +103,13 @@ jobs:
           timeout_minutes: 15
           command: ./gradlew --no-daemon :desktopApp:${{ matrix.tasks }}
 
+      - name: Relax libicu dependency in .deb
+        if: matrix.family == 'linux'
+        run: |
+          set -euo pipefail
+          chmod +x scripts/relax-deb-libicu.sh
+          scripts/relax-deb-libicu.sh desktopApp/build/compose/binaries/main-release/deb/*.deb
+
       - name: Build portable archives (windows + linux-portable)
         if: matrix.family == 'windows' || matrix.family == 'linux-portable'
         run: |

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/TopNavFilterState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/TopNavFilterState.kt
@@ -101,8 +101,8 @@ class TopNavFilterState(
         FeedDefinition(
             code = TopFilter.Mine,
             name = ResourceName(R.string.follow_list_mine),
-          )
-        
+        )
+
     val allFavoriteAlgoFeedsFollow =
         FeedDefinition(
             code = TopFilter.AllFavoriteAlgoFeeds,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AllSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AllSettingsScreen.kt
@@ -130,7 +130,7 @@ fun AllSettingsScreen(
                 tint = tint,
                 onClick = { nav.nav(Route.ProfileBadges) },
             )
-            HorizontalDivider()  
+            HorizontalDivider()
             SettingsNavigationRow(
                 title = R.string.favorite_dvms_title,
                 icon = Icons.Outlined.AutoAwesome,

--- a/scripts/relax-deb-libicu.sh
+++ b/scripts/relax-deb-libicu.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Broaden the libicu Depends clause in a jpackage-built .deb so it installs
+# across Debian/Ubuntu releases.
+#
+# jpackage shells out to `dpkg-shlibdeps` against the bundled JDK runtime's
+# native libraries (libfontmanager.so, etc., which link libicu). That pins the
+# Depends to whatever libicu the build host ships — libicu74 on ubuntu-24.04 —
+# even though the bundled JRE works fine against any reasonably recent ICU.
+# Without this rewrite, users on Ubuntu 22.04 (libicu70), Debian 12 (libicu72),
+# Debian 11 (libicu67), or Debian 13 (libicu76) cannot install the package.
+#
+# Neither jpackage nor the Compose Multiplatform DSL exposes a way to override
+# the auto-generated Depends, so we rewrite the .deb after the fact.
+#
+# Usage: relax-deb-libicu.sh <path-to-deb> [<path-to-deb> ...]
+set -euo pipefail
+
+# Spans Debian 11 → 13 and Ubuntu 20.04 → 26.04. Append new SONAMEs here when
+# a new Debian/Ubuntu release ships a bumped libicu.
+ALT='libicu66 | libicu67 | libicu70 | libicu72 | libicu74 | libicu76 | libicu77'
+
+for deb in "$@"; do
+    if [[ ! -f "$deb" ]]; then
+        echo "skip: not a file: $deb" >&2
+        continue
+    fi
+
+    work="$(mktemp -d)"
+    dpkg-deb -R "$deb" "$work/pkg"
+    control="$work/pkg/DEBIAN/control"
+
+    if grep -qE 'libicu[0-9]+' "$control"; then
+        sed -i -E "s/libicu[0-9]+([[:space:]]*\\|[[:space:]]*libicu[0-9]+)*/${ALT}/g" "$control"
+        dpkg-deb -b "$work/pkg" "$deb" >/dev/null
+        echo "Relaxed libicu dep: $deb"
+    else
+        echo "No libicu dep, leaving as-is: $deb"
+    fi
+
+    rm -rf "$work"
+done

--- a/scripts/relax-deb-libicu.sh
+++ b/scripts/relax-deb-libicu.sh
@@ -26,16 +26,18 @@ for deb in "$@"; do
     fi
 
     work="$(mktemp -d)"
+    trap 'rm -rf "$work"' EXIT
     dpkg-deb -R "$deb" "$work/pkg"
     control="$work/pkg/DEBIAN/control"
 
     if grep -qE 'libicu[0-9]+' "$control"; then
         sed -i -E "s/libicu[0-9]+([[:space:]]*\\|[[:space:]]*libicu[0-9]+)*/${ALT}/g" "$control"
-        dpkg-deb -b "$work/pkg" "$deb" >/dev/null
+        dpkg-deb --root-owner-group -Zxz -b "$work/pkg" "$deb" >/dev/null
         echo "Relaxed libicu dep: $deb"
     else
         echo "No libicu dep, leaving as-is: $deb"
     fi
 
     rm -rf "$work"
+    trap - EXIT
 done


### PR DESCRIPTION
## Summary

- Fixes .deb package failing to install on Debian 12/13, Ubuntu 22.04, etc. due to pinned `libicu74` dependency
- Adds `scripts/relax-deb-libicu.sh` that rewrites the `Depends:` clause to accept libicu66–libicu77
- Integrates the script into both `build.yml` (CI) and `create-release.yml` (releases)

## Problem

`jpackage` runs `dpkg-shlibdeps` against the bundled JDK's native libs (libfontmanager.so links libicu), pinning `Depends:` to the build host's version (`libicu74` on ubuntu-24.04). Neither jpackage nor Compose Desktop DSL expose a way to override auto-generated `Depends`.

## Changes

| File | Change |
|------|--------|
| `scripts/relax-deb-libicu.sh` | New script: extracts .deb, rewrites libicu dep, repacks with `-Zxz` |
| `.github/workflows/build.yml` | Add post-build step for `packageDeb` matrix leg |
| `.github/workflows/create-release.yml` | Add post-build step for `linux` family leg |

## Test plan

- [ ] CI builds .deb artifact successfully with relaxed deps
- [ ] Install resulting .deb on Debian 13 (libicu76)
- [ ] Install resulting .deb on Ubuntu 22.04 (libicu70)
- [ ] Verify script is idempotent (running twice produces same output)

Closes #2579

🤖 Generated with [Claude Code](https://claude.com/claude-code)