### PR TITLE
fix(packaging): relax libicu dependency in .deb for cross-distro compat

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,16 @@ jobs:
       - name: Test + Build Desktop (gradle)
         run: ./gradlew :quartz:jvmTest :commons:jvmTest :nestsClient:jvmTest :cli:test :desktopApp:test :desktopApp:${{ matrix.desktop-task }} --no-daemon
 
+      # jpackage pins libicu to the build host's version (libicu74 on
+      # ubuntu-24.04). Rewrite the .deb so testers on other Debian/Ubuntu
+      # releases can install the uploaded artifact.
+      - name: Relax libicu dependency in .deb
+        if: matrix.desktop-task == 'packageDeb'
+        run: |
+          set -euo pipefail
+          chmod +x scripts/relax-deb-libicu.sh
+          scripts/relax-deb-libicu.sh desktopApp/build/compose/binaries/main/deb/*.deb
+
       - name: Upload Desktop Distribution
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -103,6 +103,15 @@ jobs:
           timeout_minutes: 15
           command: ./gradlew --no-daemon :desktopApp:${{ matrix.tasks }}
 
+      # jpackage pins libicu to the build host's version (libicu74 on
+      # ubuntu-24.04). Rewrite the .deb so it installs across Debian/Ubuntu.
+      - name: Relax libicu dependency in .deb
+        if: matrix.family == 'linux'
+        run: |
+          set -euo pipefail
+          chmod +x scripts/relax-deb-libicu.sh
+          scripts/relax-deb-libicu.sh desktopApp/build/compose/binaries/main-release/deb/*.deb
+
       - name: Build portable archives (windows + linux-portable)
         if: matrix.family == 'windows' || matrix.family == 'linux-portable'
         run: |
@@ -247,6 +256,15 @@ jobs:
           max_attempts: 2
           timeout_minutes: 15
           command: ./gradlew --no-daemon :cli:${{ matrix.tasks }}
+
+      # jpackage pins libicu to the build host's version (libicu74 on
+      # ubuntu-24.04). Rewrite the .deb so it installs across Debian/Ubuntu.
+      - name: Relax libicu dependency in .deb
+        if: matrix.family == 'linux'
+        run: |
+          set -euo pipefail
+          chmod +x scripts/relax-deb-libicu.sh
+          scripts/relax-deb-libicu.sh cli/build/jpackage/*.deb
 
       - name: Collect + rename assets
         run: |

--- a/scripts/relax-deb-libicu.sh
+++ b/scripts/relax-deb-libicu.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Broaden the libicu Depends clause in a jpackage-built .deb so it installs
+# across Debian/Ubuntu releases.
+#
+# jpackage shells out to `dpkg-shlibdeps` against the bundled JDK runtime's
+# native libraries (libfontmanager.so, etc., which link libicu). That pins the
+# Depends to whatever libicu the build host ships — libicu74 on ubuntu-24.04 —
+# even though the bundled JRE works fine against any reasonably recent ICU.
+# Without this rewrite, users on Ubuntu 22.04 (libicu70), Debian 12 (libicu72),
+# Debian 11 (libicu67), or Debian 13 (libicu76) cannot install the package.
+#
+# Neither jpackage nor the Compose Multiplatform DSL exposes a way to override
+# the auto-generated Depends, so we rewrite the .deb after the fact.
+#
+# Usage: relax-deb-libicu.sh <path-to-deb> [<path-to-deb> ...]
+set -euo pipefail
+
+# Spans Debian 11 → 13 and Ubuntu 20.04 → 26.04. Append new SONAMEs here when
+# a new Debian/Ubuntu release ships a bumped libicu.
+ALT='libicu66 | libicu67 | libicu70 | libicu72 | libicu74 | libicu76 | libicu77'
+
+for deb in "$@"; do
+    if [[ ! -f "$deb" ]]; then
+        echo "skip: not a file: $deb" >&2
+        continue
+    fi
+
+    work="$(mktemp -d)"
+    dpkg-deb -R "$deb" "$work/pkg"
+    control="$work/pkg/DEBIAN/control"
+
+    if grep -qE 'libicu[0-9]+' "$control"; then
+        sed -i -E "s/libicu[0-9]+([[:space:]]*\\|[[:space:]]*libicu[0-9]+)*/${ALT}/g" "$control"
+        dpkg-deb -b "$work/pkg" "$deb" >/dev/null
+        echo "Relaxed libicu dep: $deb"
+    else
+        echo "No libicu dep, leaving as-is: $deb"
+    fi
+
+    rm -rf "$work"
+done

--- a/scripts/relax-deb-libicu.sh
+++ b/scripts/relax-deb-libicu.sh
@@ -26,16 +26,18 @@ for deb in "$@"; do
     fi
 
     work="$(mktemp -d)"
+    trap 'rm -rf "$work"' EXIT
     dpkg-deb -R "$deb" "$work/pkg"
     control="$work/pkg/DEBIAN/control"
 
     if grep -qE 'libicu[0-9]+' "$control"; then
         sed -i -E "s/libicu[0-9]+([[:space:]]*\\|[[:space:]]*libicu[0-9]+)*/${ALT}/g" "$control"
-        dpkg-deb -b "$work/pkg" "$deb" >/dev/null
+        dpkg-deb --root-owner-group -Zxz -b "$work/pkg" "$deb" >/dev/null
         echo "Relaxed libicu dep: $deb"
     else
         echo "No libicu dep, leaving as-is: $deb"
     fi
 
     rm -rf "$work"
+    trap - EXIT
 done


### PR DESCRIPTION
## Summary

Builds on @davotoula's `fix-libicu74-dependency` branch with hardening improvements.

- **Root cause**: `jpackage` runs `dpkg-shlibdeps` against bundled JDK native libs, pinning `Depends:` to build host's libicu version (`libicu74` on ubuntu-24.04)
- **Fix**: Post-build script rewrites the dependency to accept `libicu66 | libicu67 | libicu70 | libicu72 | libicu74 | libicu76 | libicu77` (Debian 11–13, Ubuntu 20.04–26.04)

## Changes (on top of @davotoula's commit)

| Improvement | Rationale |
|-------------|-----------|
| `trap 'rm -rf "$work"' EXIT` | Clean up temp dir on script error |
| `dpkg-deb --root-owner-group` | Correct file ownership in repacked .deb |
| `dpkg-deb -Zxz` | Max distro compatibility (older dpkg lacks zstd) |

## Test plan

- [ ] CI builds .deb artifact with relaxed deps (`build.yml` ubuntu leg)
- [ ] Install .deb on Debian 13 / libicu76 (**requires Linux**)
- [ ] Install .deb on Ubuntu 22.04 / libicu70 (**requires Linux**)
- [ ] Script is idempotent (running twice = same output)

**Needs PoW** — `.deb` rewriting requires `dpkg-deb` (Linux only). CI artifact inspection will serve as proof once the workflow runs.

Closes #2579

🤖 Generated with [Claude Code](https://claude.com/claude-code)