### PR TITLE
Remove stop action from notification service and update icon imports

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationRelayService.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationRelayService.kt
@@ -78,7 +78,6 @@ class NotificationRelayService : Service() {
         private const val NOTIFICATION_ID = 9832
 
         private const val ACTION_START = "com.vitorpamplona.amethyst.START_NOTIFICATION_SERVICE"
-        private const val ACTION_STOP = "com.vitorpamplona.amethyst.STOP_NOTIFICATION_SERVICE"
 
         const val ACTION_AUTO_RESTART = "com.vitorpamplona.amethyst.AUTO_RESTART_NOTIFICATION_SERVICE"
 
@@ -129,21 +128,11 @@ class NotificationRelayService : Service() {
         flags: Int,
         startId: Int,
     ): Int {
-        when (intent?.action) {
-            ACTION_STOP -> {
-                Log.d(TAG, "Stopping service")
-                stopSelf()
-                return START_NOT_STICKY
-            }
-
-            else -> {
-                Log.d(TAG, "Starting service")
-                // Safety: also call startForeground from onStartCommand in case
-                // onCreate didn't complete before onStartCommand fired (ntfy #1520)
-                initializeForeground()
-                startRelayConnection()
-            }
-        }
+        Log.d(TAG, "Starting service")
+        // Safety: also call startForeground from onStartCommand in case
+        // onCreate didn't complete before onStartCommand fired (ntfy #1520)
+        initializeForeground()
+        startRelayConnection()
         return START_STICKY
     }
 
@@ -288,25 +277,12 @@ class NotificationRelayService : Service() {
                 PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
             )
 
-        val stopIntent =
-            Intent(this, NotificationRelayService::class.java).apply {
-                action = ACTION_STOP
-            }
-        val stopPendingIntent =
-            PendingIntent.getService(
-                this,
-                1,
-                stopIntent,
-                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
-            )
-
         return NotificationCompat
             .Builder(this, CHANNEL_ID)
             .setContentTitle(getString(R.string.always_on_notif_title))
             .setContentText(contentText)
             .setSmallIcon(R.drawable.amethyst)
             .setContentIntent(pendingIntent)
-            .addAction(0, getString(R.string.always_on_notif_stop), stopPendingIntent)
             .setOngoing(true)
             .setSilent(true)
             .setPriority(NotificationCompat.PRIORITY_LOW)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/uploads/ImageVideoDescription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/uploads/ImageVideoDescription.kt
@@ -114,7 +114,11 @@ fun ImageVideoDescription(
     val context = LocalContext.current
     val firstImageUri =
         remember(uris) {
-            uris.first().takeIf { it.media.isImage() == true && it.media.isGif().not() }?.media?.uri
+            uris
+                .first()
+                .takeIf { it.media.isImage() == true && it.media.isGif().not() }
+                ?.media
+                ?.uri
         }
     val labelService = remember { MLKitImageLabelService(context.applicationContext) }
     var isLabeling by remember { mutableStateOf(false) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/uploads/ImageVideoDescription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/uploads/ImageVideoDescription.kt
@@ -31,16 +31,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AutoAwesome
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -66,6 +62,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
+import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
 import com.vitorpamplona.amethyst.service.ai.MLKitImageLabelService
 import com.vitorpamplona.amethyst.service.uploads.MultiOrchestrator
 import com.vitorpamplona.amethyst.ui.actions.mediaServers.DEFAULT_MEDIA_SERVERS
@@ -322,14 +320,14 @@ fun ImageVideoDescription(
                         label = { Text(text = stringRes(R.string.ai_suggested_alt_text_hint)) },
                         leadingIcon = {
                             Icon(
-                                imageVector = Icons.Default.AutoAwesome,
+                                symbol = MaterialSymbols.AutoAwesome,
                                 contentDescription = null,
                                 modifier = Modifier.size(AssistChipDefaults.IconSize),
                             )
                         },
                         trailingIcon = {
                             Icon(
-                                imageVector = Icons.Default.Close,
+                                symbol = MaterialSymbols.Close,
                                 contentDescription = stringRes(R.string.ai_suggested_alt_text_dismiss),
                                 modifier = Modifier.size(AssistChipDefaults.IconSize),
                             )

--- a/amethyst/src/main/res/values-cs-rCZ/strings.xml
+++ b/amethyst/src/main/res/values-cs-rCZ/strings.xml
@@ -832,7 +832,6 @@
     <string name="always_on_notif_title">Amethyst oznámení aktivní</string>
     <string name="always_on_notif_connected">Připojeno k %1$d inbox relayím</string>
     <string name="always_on_notif_connecting">Připojování k inbox relayím\u2026</string>
-    <string name="always_on_notif_stop">Pozastavit</string>
     <string name="always_on_notif_setting_title">Služba trvalých oznámení</string>
     <string name="always_on_notif_setting_description">Udržuje trvalé připojení k vašim inbox relayím pro okamžité doručování oznámení. Zobrazuje průběžné oznámení. Spotřebovává více baterie, ale zajišťuje, že nezmeškáte žádnou zprávu.</string>
     <string name="battery_optimization_title">Optimalizace baterie aktivní</string>

--- a/amethyst/src/main/res/values-de-rDE/strings.xml
+++ b/amethyst/src/main/res/values-de-rDE/strings.xml
@@ -837,7 +837,6 @@ anz der Bedingungen ist erforderlich</string>
     <string name="always_on_notif_title">Amethyst-Benachrichtigungen aktiv</string>
     <string name="always_on_notif_connected">Mit %1$d Inbox-Relays verbunden</string>
     <string name="always_on_notif_connecting">Verbinde mit Inbox-Relays\u2026</string>
-    <string name="always_on_notif_stop">Pausieren</string>
     <string name="always_on_notif_setting_title">Dauerhafter Benachrichtigungsdienst</string>
     <string name="always_on_notif_setting_description">Hält eine dauerhafte Verbindung zu deinen Inbox-Relays für sofortige Benachrichtigungen aufrecht. Zeigt eine fortlaufende Benachrichtigung an. Verbraucht mehr Akku, stellt aber sicher, dass du keine Nachricht verpasst.</string>
     <string name="battery_optimization_title">Akkuoptimierung aktiv</string>

--- a/amethyst/src/main/res/values-hi-rIN/strings.xml
+++ b/amethyst/src/main/res/values-hi-rIN/strings.xml
@@ -836,7 +836,6 @@
     <string name="always_on_notif_title">अमेथिस्ट सूचनाएँ सक्रिय</string>
     <string name="always_on_notif_connected">संयोजित %1$d आगतपेटिका पुनःप्रसारकों के साथ</string>
     <string name="always_on_notif_connecting">आगतपेटिका पुनःप्रसारकों के साथ संयोजन किया जा रहा है \u2026</string>
-    <string name="always_on_notif_stop">विराम</string>
     <string name="always_on_notif_setting_title">सदैव सक्रिय सूचना सेवा</string>
     <string name="always_on_notif_setting_description">अनवरत संयोजन बनाए रखता है आपके आगतपेटिका पुनःप्रसारकों के साथ तत्काल सूचना वितरण के लिए। एक स्थायी सूचना दिखाता है। विद्युत्कोष का अधिक उपयोग करता है पर निश्चित करता है कि आप कभी भी सन्देश नहीं खोएँगे।</string>
     <string name="battery_optimization_title">विद्युत्कोष अनुकूलन सक्रिय</string>

--- a/amethyst/src/main/res/values-hu-rHU/strings.xml
+++ b/amethyst/src/main/res/values-hu-rHU/strings.xml
@@ -836,7 +836,6 @@
     <string name="always_on_notif_title">Amethyst értesítések aktíválva</string>
     <string name="always_on_notif_connected">Kapcsolódva %1$d beérkező üzenetátjátszóhoz</string>
     <string name="always_on_notif_connecting">Kapcsolódás a beérkező üzenetátjátszókhoz\u2026</string>
-    <string name="always_on_notif_stop">Szüneteltetés</string>
     <string name="always_on_notif_setting_title">Folyamatos értesítési szolgáltatás</string>
     <string name="always_on_notif_setting_description">Folyamatos kapcsolatot tart fenn a beérkező üzenetek átjátszóival az értesítések azonnali kézbesítése érdekében. Megjeleníti a folyamatban lévő értesítéseket. Több akkumulátort fogyaszt, de így biztosan nem marad le egyetlen üzenetről sem.</string>
     <string name="battery_optimization_title">Akkumulátor-optimalizálás aktív</string>

--- a/amethyst/src/main/res/values-pl-rPL/strings.xml
+++ b/amethyst/src/main/res/values-pl-rPL/strings.xml
@@ -833,7 +833,6 @@
     <string name="always_on_notif_title">Powiadomienia Ametyst Aktywne</string>
     <string name="always_on_notif_connected">Połączono z %1$d transmiterami odbiorczymi</string>
     <string name="always_on_notif_connecting">Łączenie z transmiterami odbiorczymi\u2026</string>
-    <string name="always_on_notif_stop">Pauza</string>
     <string name="always_on_notif_setting_title">Usługa powiadomień zawsze włączona</string>
     <string name="always_on_notif_setting_description">Utrzymuje stałe połączenie z transmiterami odbiorczymi, aby zapewnić natychmiastowe dostarczanie powiadomień. Wyświetla bieżące powiadomienia. Zużywa więcej baterii, ale gwarantuje, że nigdy nie przegapisz żadnej wiadomości.</string>
     <string name="battery_optimization_title">Optymalizacja baterii aktywna</string>

--- a/amethyst/src/main/res/values-pt-rBR/strings.xml
+++ b/amethyst/src/main/res/values-pt-rBR/strings.xml
@@ -832,7 +832,6 @@
     <string name="always_on_notif_title">Notificações do Amethyst ativas</string>
     <string name="always_on_notif_connected">Conectado a %1$d relays de caixa de entrada</string>
     <string name="always_on_notif_connecting">Conectando aos relays de caixa de entrada\u2026</string>
-    <string name="always_on_notif_stop">Pausar</string>
     <string name="always_on_notif_setting_title">Serviço de notificações sempre ativo</string>
     <string name="always_on_notif_setting_description">Mantém uma conexão persistente com seus relays de caixa de entrada para entrega instantânea de notificações. Mostra uma notificação contínua. Usa mais bateria, mas garante que você nunca perca uma mensagem.</string>
     <string name="battery_optimization_title">Otimização de bateria ativa</string>

--- a/amethyst/src/main/res/values-sl-rSI/strings.xml
+++ b/amethyst/src/main/res/values-sl-rSI/strings.xml
@@ -847,7 +847,6 @@ Za podpisovanje se je potrebno prijaviti s privatnim ključem</string>
     <string name="always_on_notif_title">Amethyst obvestila so aktivna</string>
     <string name="always_on_notif_connected">Povezan z %1$d vhodnimi releji</string>
     <string name="always_on_notif_connecting">Povezovanje vhodnih relejev\u2026</string>
-    <string name="always_on_notif_stop">Premor</string>
     <string name="always_on_notif_setting_title">Vedno aktivna obvestila</string>
     <string name="always_on_notif_setting_description">Ohranja stalno povezavo z vašimi releji za takojšnjo dostavo obvestil. Prikazuje trajno obvestilo. Porabi več baterije, a zagotavlja, da ne zamudite nobenega sporočila.</string>
     <string name="battery_optimization_title">Optimizacija baterije je aktivna</string>

--- a/amethyst/src/main/res/values-sv-rSE/strings.xml
+++ b/amethyst/src/main/res/values-sv-rSE/strings.xml
@@ -831,7 +831,6 @@
     <string name="always_on_notif_title">Amethyst-notifieringar aktiva</string>
     <string name="always_on_notif_connected">Ansluten till %1$d inbox-relän</string>
     <string name="always_on_notif_connecting">Ansluter till inbox-relän\u2026</string>
-    <string name="always_on_notif_stop">Pausa</string>
     <string name="always_on_notif_setting_title">Alltid på-notifieringstjänst</string>
     <string name="always_on_notif_setting_description">Upprätthåller en konstant anslutning till dina inbox-relän för omedelbar leverans av notifieringar. Visar en pågående notifiering. Använder mer batteri men säkerställer att du aldrig missar ett meddelande.</string>
     <string name="battery_optimization_title">Batterioptimering aktiv</string>

--- a/amethyst/src/main/res/values-zh-rCN/strings.xml
+++ b/amethyst/src/main/res/values-zh-rCN/strings.xml
@@ -836,7 +836,6 @@
     <string name="always_on_notif_title">Amethyst 通知活跃</string>
     <string name="always_on_notif_connected">已连接到 %1$d 个收件箱中继</string>
     <string name="always_on_notif_connecting">正在连接到收件箱中继\u2026</string>
-    <string name="always_on_notif_stop">暂停</string>
     <string name="always_on_notif_setting_title">始终开启通知服务</string>
     <string name="always_on_notif_setting_description">保持与收件箱中继的持续连接以便即时发送通知。 显示正在进行的通知。使用更多电量，但确保您永远不会错过消息。</string>
     <string name="battery_optimization_title">电池优化已启用</string>

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -943,7 +943,6 @@
     <string name="always_on_notif_title">Amethyst Notifications Active</string>
     <string name="always_on_notif_connected">Connected to %1$d inbox relays</string>
     <string name="always_on_notif_connecting">Connecting to inbox relays\u2026</string>
-    <string name="always_on_notif_stop">Pause</string>
     <string name="always_on_notif_setting_title">Always-on notification service</string>
     <string name="always_on_notif_setting_description">Keeps a persistent connection to your inbox relays for instant notification delivery. Shows an ongoing notification. Uses more battery but ensures you never miss a message.</string>
 

--- a/amethyst/src/play/java/com/vitorpamplona/amethyst/service/ai/MLKitImageLabelService.kt
+++ b/amethyst/src/play/java/com/vitorpamplona/amethyst/service/ai/MLKitImageLabelService.kt
@@ -54,8 +54,7 @@ class MLKitImageLabelService(
     // mid-session in practice, and one composer mount only needs to ask AICore once.
     @Volatile private var cachedGenAiStatus: Int? = null
 
-    private fun ensureLabeler(): ImageLabeler =
-        labeler ?: ImageLabeling.getClient(ImageLabelerOptions.DEFAULT_OPTIONS).also { labeler = it }
+    private fun ensureLabeler(): ImageLabeler = labeler ?: ImageLabeling.getClient(ImageLabelerOptions.DEFAULT_OPTIONS).also { labeler = it }
 
     private fun ensureDescriber(): ImageDescriber? =
         describer


### PR DESCRIPTION
## Summary
This PR removes the ability to stop the notification relay service via a notification action and updates the image description UI to use custom Material Symbols icons instead of Material Design icons.

## Key Changes

### NotificationRelayService
- Removed `ACTION_STOP` constant and its associated intent handling logic
- Simplified `onStartCommand()` to always start the service (removed the conditional stop action)
- Removed the "Pause" action button from the foreground notification
- Removed the stop PendingIntent creation
- Service now always returns `START_STICKY` to ensure it restarts if terminated

### ImageVideoDescription UI
- Migrated from Material Design icons (`Icons.Default.AutoAwesome`, `Icons.Default.Close`) to custom Material Symbols icons
- Updated imports to use `com.vitorpamplona.amethyst.commons.icons.symbols.Icon` and `MaterialSymbols`
- Reformatted code for better readability in the `firstImageUri` assignment

### Code Quality
- Minor formatting improvement in `MLKitImageLabelService.kt` for the `ensureLabeler()` function

### Localization
- Removed `always_on_notif_stop` string resource from all language files (cs, de, hi, hu, pl, pt-br, sl, sv, zh-cn, and default values)

## Implementation Details
The notification service is now designed to run continuously without user-initiated stop capability. Users can still stop it through system settings or app management. This simplifies the service lifecycle and removes the need for handling the stop action in `onStartCommand()`.

https://claude.ai/code/session_01QWFpq1kvnV14VRyAPW5g53