### PR TITLE
Make ChatroomLazyKey types Serializable for LazyColumn state

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/feed/ChatroomListFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/feed/ChatroomListFeedView.kt
@@ -158,7 +158,7 @@ private data class EphemeralChannelLazyKey(
 ) : ChatroomLazyKey
 
 private data class PrivateChatLazyKey(
-    val key: String,
+    val users: HashSet<HexKey>,
 ) : ChatroomLazyKey
 
 private data class FallbackChatroomLazyKey(
@@ -192,13 +192,10 @@ private fun chatroomLazyKey(
         }
 
         is ChatroomKeyable -> {
-            PrivateChatLazyKey(
-                event
-                    .chatroomKey(myPubKey)
-                    .users
-                    .sorted()
-                    .joinToString(","),
-            )
+            // ChatroomKey.users may be a kotlinx PersistentOrderedSet, which
+            // is not Serializable. Copy into a HashSet so the key survives
+            // Bundle round-trips; Set equality stays order-independent.
+            PrivateChatLazyKey(HashSet(event.chatroomKey(myPubKey).users))
         }
 
         else -> {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/feed/ChatroomListFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/feed/ChatroomListFeedView.kt
@@ -48,13 +48,12 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.ChatroomHeaderC
 import com.vitorpamplona.amethyst.ui.theme.DividerThickness
 import com.vitorpamplona.amethyst.ui.theme.FeedPadding
 import com.vitorpamplona.quartz.experimental.ephemChat.chat.EphemeralChatEvent
-import com.vitorpamplona.quartz.experimental.ephemChat.chat.RoomId
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
-import com.vitorpamplona.quartz.nip17Dm.base.ChatroomKey
 import com.vitorpamplona.quartz.nip17Dm.base.ChatroomKeyable
 import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelCreateEvent
 import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelMetadataEvent
 import com.vitorpamplona.quartz.nip28PublicChat.message.ChannelMessageEvent
+import java.io.Serializable
 
 @Composable
 fun ChatroomListFeedView(
@@ -139,10 +138,11 @@ private fun FeedLoaded(
 }
 
 // Stable per-chatroom key — derived from chatroom identity, not the latest
-// message id, so reorders move the row instead of recreating it. Uses a
-// sealed wrapper around an existing String/RoomId/ChatroomKey to avoid the
-// StringBuilder + concatenation allocations of a typed-prefix string key.
-private sealed interface ChatroomLazyKey
+// message id, so reorders move the row instead of recreating it. Compose
+// stores LazyColumn item keys in a SaveableStateHolder, which on Android
+// requires Bundle-storable types, so each variant is Serializable and only
+// holds primitives.
+private sealed interface ChatroomLazyKey : Serializable
 
 private data class MarmotChatroomLazyKey(
     val groupId: HexKey,
@@ -153,11 +153,12 @@ private data class PublicChannelLazyKey(
 ) : ChatroomLazyKey
 
 private data class EphemeralChannelLazyKey(
-    val roomId: RoomId,
+    val id: String,
+    val relayUrl: String,
 ) : ChatroomLazyKey
 
 private data class PrivateChatLazyKey(
-    val key: ChatroomKey,
+    val key: String,
 ) : ChatroomLazyKey
 
 private data class FallbackChatroomLazyKey(
@@ -186,12 +187,12 @@ private fun chatroomLazyKey(
         }
 
         is EphemeralChatEvent -> {
-            event.roomId()?.let { EphemeralChannelLazyKey(it) }
+            event.roomId()?.let { EphemeralChannelLazyKey(it.id, it.relayUrl.url) }
                 ?: FallbackChatroomLazyKey(item.idHex)
         }
 
         is ChatroomKeyable -> {
-            PrivateChatLazyKey(event.chatroomKey(myPubKey))
+            PrivateChatLazyKey(event.chatroomKey(myPubKey).users.sorted().joinToString(","))
         }
 
         else -> {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/feed/ChatroomListFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/feed/ChatroomListFeedView.kt
@@ -192,7 +192,13 @@ private fun chatroomLazyKey(
         }
 
         is ChatroomKeyable -> {
-            PrivateChatLazyKey(event.chatroomKey(myPubKey).users.sorted().joinToString(","))
+            PrivateChatLazyKey(
+                event
+                    .chatroomKey(myPubKey)
+                    .users
+                    .sorted()
+                    .joinToString(","),
+            )
         }
 
         else -> {


### PR DESCRIPTION
## Summary
Updated the `ChatroomLazyKey` sealed interface and its implementations to be `Serializable`, ensuring compatibility with Compose's `SaveableStateHolder` which requires Bundle-storable types on Android.

## Key Changes
- Made `ChatroomLazyKey` sealed interface extend `Serializable`
- Replaced complex type references with primitive String values:
  - `EphemeralChannelLazyKey`: Changed `roomId: RoomId` to `id: String` and `relayUrl: String` (extracted from `RoomId` object)
  - `PrivateChatLazyKey`: Changed `key: ChatroomKey` to `key: String` (derived from sorted, comma-joined user list)
- Removed unused imports (`RoomId`, `ChatroomKey`)
- Added `java.io.Serializable` import

## Implementation Details
- The key generation logic now extracts primitive values from complex objects at the point of key creation
- For ephemeral channels, the relay URL is extracted via `.relayUrl.url`
- For private chats, the key is computed from the sorted list of users in the chatroom, ensuring stable ordering independent of the original `ChatroomKey` object structure
- This maintains the original intent of stable, identity-based keys that don't recreate on message reordering, while satisfying Android's serialization requirements

https://claude.ai/code/session_01D9CLrqvSJyDLrU8ddsF8ss