### PR TITLE
Fix back stack management in bottom navigation

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/navs/Nav.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/navs/Nav.kt
@@ -24,6 +24,7 @@ import android.annotation.SuppressLint
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
 import androidx.compose.runtime.Stable
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import com.vitorpamplona.amethyst.ui.navigation.SKIP_SLIDE_ANIMATION_KEY
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
@@ -78,7 +79,11 @@ class Nav(
     override fun navBottomBar(route: Route) {
         navigationScope.launch {
             controller.navigate(route) {
-                popUpTo(route) {
+                // Clear the back stack down to and including the graph's start
+                // destination so a bottom-nav tap leaves only the new route in
+                // the stack. Without inclusive=true, Home would remain below
+                // the new tab and canPop() would wrongly show a back arrow.
+                popUpTo(controller.graph.findStartDestination().id) {
                     inclusive = true
                 }
                 launchSingleTop = true


### PR DESCRIPTION
## Summary
Fixed back stack behavior when navigating via bottom navigation to ensure only the newly selected route remains in the stack, preventing unwanted back navigation and incorrect back arrow display.

## Key Changes
- Updated `navBottomBar()` to pop back to the graph's start destination instead of the current route
- Added `findStartDestination()` import from `androidx.navigation.NavGraph`
- Clarified the intent with detailed comments explaining the fix

## Implementation Details
The previous implementation used `popUpTo(route)` which would only pop routes up to (but not including) the target route. This caused the Home destination to remain in the back stack when navigating to other tabs, leading to:
- Incorrect `canPop()` behavior showing a back arrow when it shouldn't
- Unexpected back navigation when pressing the back button

The fix uses `popUpTo(controller.graph.findStartDestination().id)` with `inclusive = true` to clear the entire back stack down to and including the graph's start destination. This ensures that tapping a bottom navigation item leaves only that new route in the stack, providing the expected behavior for tab-based navigation.

https://claude.ai/code/session_01PrirRcL7g8iX7vTqqLTkBS