### PR TITLE
Add image upload functionality to CreateNestSheet

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/create/CreateNestSheet.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/create/CreateNestSheet.kt
@@ -53,11 +53,13 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.ui.actions.uploads.SelectSingleFromGallery
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.nests.NestsScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.nests.room.NestActivity
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.nests.room.NestBridge
 import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.amethyst.ui.theme.placeholderText
 import kotlinx.coroutines.launch
 
 /**
@@ -142,6 +144,19 @@ fun CreateNestSheet(
                 onValueChange = viewModel::onImageUrlChange,
                 label = { Text(stringRes(R.string.nest_create_field_image)) },
                 singleLine = true,
+                leadingIcon = {
+                    SelectSingleFromGallery(
+                        isUploading = state.isUploadingImage,
+                        tint = MaterialTheme.colorScheme.placeholderText,
+                        modifier = Modifier.padding(start = 5.dp),
+                    ) { media ->
+                        viewModel.uploadForImage(
+                            uri = media,
+                            context = context,
+                            onError = accountViewModel.toastManager::toast,
+                        )
+                    }
+                },
                 modifier = Modifier.fillMaxWidth(),
             )
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/create/CreateNestViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/create/CreateNestViewModel.kt
@@ -20,9 +20,21 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.nests.create
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
+import com.vitorpamplona.amethyst.Amethyst
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.model.Account
+import com.vitorpamplona.amethyst.service.uploads.CompressorQuality
+import com.vitorpamplona.amethyst.service.uploads.MediaCompressor
+import com.vitorpamplona.amethyst.service.uploads.MetadataStripper
+import com.vitorpamplona.amethyst.service.uploads.blossom.BlossomUploader
+import com.vitorpamplona.amethyst.service.uploads.nip96.Nip96Uploader
+import com.vitorpamplona.amethyst.ui.actions.mediaServers.ServerType
+import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.nests.room.NestActivity
+import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.MeetingSpaceEvent
 import com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.endpoint
 import com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.image
@@ -36,6 +48,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Backing ViewModel for [CreateNestSheet]. Holds form state, runs
@@ -79,6 +92,102 @@ class CreateNestViewModel : ViewModel() {
     fun onEndpointUrlChange(value: String) = _state.update { it.copy(endpointUrl = value.trim(), error = null) }
 
     fun onImageUrlChange(value: String) = _state.update { it.copy(imageUrl = value.trim(), error = null) }
+
+    fun uploadForImage(
+        uri: SelectedMedia,
+        context: Context,
+        onError: (String, String) -> Unit,
+    ) {
+        val avm = account ?: return
+        avm.launchSigner {
+            upload(
+                galleryUri = uri,
+                account = avm.account,
+                context = context,
+                onError = onError,
+            )?.let { url ->
+                _state.update { it.copy(imageUrl = url, error = null) }
+            }
+        }
+    }
+
+    private suspend fun upload(
+        galleryUri: SelectedMedia,
+        account: Account,
+        context: Context,
+        onError: (String, String) -> Unit,
+    ): String? {
+        _state.update { it.copy(isUploadingImage = true) }
+        try {
+            val strippingResult =
+                if (account.settings.stripLocationOnUpload) {
+                    MetadataStripper.strip(galleryUri.uri, galleryUri.mimeType, context.applicationContext)
+                } else {
+                    null
+                }
+
+            val sourceUri =
+                if (account.settings.stripLocationOnUpload &&
+                    strippingResult != null &&
+                    !strippingResult.stripped
+                ) {
+                    onError(
+                        stringRes(context, R.string.metadata_strip_failed_title),
+                        stringRes(context, R.string.metadata_strip_failed_upload_cancelled),
+                    )
+                    return null
+                } else {
+                    strippingResult?.uri ?: galleryUri.uri
+                }
+
+            val compResult = MediaCompressor().compress(sourceUri, galleryUri.mimeType, CompressorQuality.MEDIUM, context.applicationContext)
+
+            return try {
+                val result =
+                    if (account.settings.defaultFileServer.type == ServerType.NIP96) {
+                        Nip96Uploader().upload(
+                            uri = compResult.uri,
+                            contentType = compResult.contentType,
+                            size = compResult.size,
+                            alt = null,
+                            sensitiveContent = null,
+                            serverBaseUrl = account.settings.defaultFileServer.baseUrl,
+                            okHttpClient = Amethyst.instance.roleBasedHttpClientBuilder::okHttpClientForUploads,
+                            onProgress = {},
+                            httpAuth = account::createHTTPAuthorization,
+                            context = context,
+                        )
+                    } else {
+                        BlossomUploader().upload(
+                            uri = compResult.uri,
+                            contentType = compResult.contentType,
+                            size = compResult.size,
+                            alt = null,
+                            sensitiveContent = null,
+                            serverBaseUrl = account.settings.defaultFileServer.baseUrl,
+                            okHttpClient = Amethyst.instance.roleBasedHttpClientBuilder::okHttpClientForUploads,
+                            httpAuth = account::createBlossomUploadAuth,
+                            context = context,
+                        )
+                    }
+
+                if (result.url == null) {
+                    onError(
+                        stringRes(context, R.string.failed_to_upload_media_no_details),
+                        stringRes(context, R.string.server_did_not_provide_a_url_after_uploading),
+                    )
+                }
+
+                result.url
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                onError(stringRes(context, R.string.failed_to_upload_media_no_details), e.message ?: e.javaClass.simpleName)
+                null
+            }
+        } finally {
+            _state.update { it.copy(isUploadingImage = false) }
+        }
+    }
 
     /**
      * Toggle scheduled-vs-now mode. When [scheduled] is true the
@@ -200,6 +309,7 @@ class CreateNestViewModel : ViewModel() {
         val imageUrl: String,
         val isPublishing: Boolean,
         val error: String?,
+        val isUploadingImage: Boolean = false,
         /** When true, publish as `status=PLANNED` + `["starts", <unix>]`. */
         val scheduled: Boolean = false,
         /** Unix seconds of the scheduled start; 0 = not yet picked. */


### PR DESCRIPTION
## Summary
Added image upload capability to the Create Nest form, allowing users to select images from their gallery and automatically upload them to their configured media server.

## Key Changes
- **CreateNestViewModel**: 
  - Added `uploadForImage()` public function to handle image selection and upload initiation
  - Added private `upload()` suspend function that handles the complete upload workflow including:
    - Metadata stripping based on user settings
    - Media compression with MEDIUM quality
    - Support for both NIP96 and Blossom upload protocols based on server configuration
    - Error handling with user-friendly error messages
  - Added `isUploadingImage` state flag to track upload progress
  - Added necessary imports for upload services, media handling, and context

- **CreateNestSheet**:
  - Added `SelectSingleFromGallery` UI component as a leading icon in the image URL text field
  - Integrated gallery selection with the upload workflow
  - Connected upload errors to the account's toast notification system
  - Added import for `placeholderText` theme color

## Implementation Details
- The upload process respects user privacy settings (metadata stripping)
- Supports both NIP96 and Blossom server protocols automatically based on account configuration
- Includes proper error handling with cancellation exception awareness
- Upload state is tracked in the UI to show loading feedback to users
- Metadata stripping failures prevent upload and notify the user
- Server response validation ensures a URL was returned before updating the form

https://claude.ai/code/session_015xKs8XzasYqyg2D4y1eHjM