### PR TITLE
Move NestActivity to activity subdirectory

### DIFF
--- a/amethyst/src/main/AndroidManifest.xml
+++ b/amethyst/src/main/AndroidManifest.xml
@@ -219,7 +219,7 @@
             tools:ignore="DiscouragedApi" />
 
         <activity
-            android:name=".ui.screen.loggedIn.nests.room.NestActivity"
+            android:name=".ui.screen.loggedIn.nests.room.activity.NestActivity"
             android:autoRemoveFromRecents="true"
             android:configChanges="orientation|screenLayout|screenSize|smallestScreenSize|keyboardHidden|keyboard|uiMode|navigation|fontScale|density"
             android:supportsPictureInPicture="true"


### PR DESCRIPTION
## Summary
Updated the AndroidManifest.xml to reflect the relocation of NestActivity to a new package structure.

## Changes
- Updated NestActivity class path in AndroidManifest.xml from `.ui.screen.loggedIn.nests.room.NestActivity` to `.ui.screen.loggedIn.nests.room.activity.NestActivity`

## Details
This change indicates that NestActivity has been moved into a new `activity` subdirectory within the `room` package. The manifest declaration has been updated to point to the new location, ensuring the activity can be properly resolved at runtime.

https://claude.ai/code/session_017RTEjFZ4aajUGgQACw5yUK