### PR TITLE
feat(nests): bigger avatars + clearer mute/speaking state in participant grid

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/UsernameDisplay.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/UsernameDisplay.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -100,6 +101,7 @@ fun UsernameDisplay(
     weight: Modifier = Modifier,
     fontWeight: FontWeight = FontWeight.Bold,
     textColor: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
     accountViewModel: AccountViewModel,
 ) {
     val userMetadata by observeUserInfo(baseUser, accountViewModel)
@@ -107,9 +109,9 @@ fun UsernameDisplay(
     CrossfadeIfEnabled(targetState = userMetadata, modifier = weight, label = "UsernameDisplay", accountViewModel = accountViewModel) {
         val name = it?.info?.bestName()
         if (name != null) {
-            UserDisplay(name, it.tags, weight, fontWeight, textColor)
+            UserDisplay(name, it.tags, weight, fontWeight, textColor, textAlign)
         } else {
-            NPubDisplay(baseUser, weight, fontWeight, textColor)
+            NPubDisplay(baseUser, weight, fontWeight, textColor, textAlign)
         }
     }
 }
@@ -120,6 +122,7 @@ private fun NPubDisplay(
     modifier: Modifier,
     fontWeight: FontWeight = FontWeight.Bold,
     textColor: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     Text(
         text = remember { user.pubkeyDisplayHex() },
@@ -128,6 +131,7 @@ private fun NPubDisplay(
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
         color = textColor,
+        textAlign = textAlign,
     )
 }
 
@@ -138,11 +142,13 @@ private fun UserDisplay(
     modifier: Modifier,
     fontWeight: FontWeight = FontWeight.Bold,
     textColor: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
 ) {
     CreateTextWithEmoji(
         text = bestDisplayName,
         tags = tags,
         fontWeight = fontWeight,
+        textAlign = textAlign,
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
         modifier = modifier,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/lifecycle/NestRoomEventCollectors.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/lifecycle/NestRoomEventCollectors.kt
@@ -30,6 +30,7 @@ import com.vitorpamplona.quartz.nip25Reactions.ReactionEvent
 import com.vitorpamplona.quartz.nip53LiveActivities.chat.LiveActivitiesChatMessageEvent
 import com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.MeetingSpaceEvent
 import com.vitorpamplona.quartz.nip53LiveActivities.presence.MeetingRoomPresenceEvent
+import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 
@@ -167,13 +168,29 @@ private fun AdminCommandsCollector(
     localPubkey: String,
 ) {
     LaunchedEffect(viewModel, roomATag, localPubkey) {
+        // EGG-07 / nostrnests gate: ignore admin commands older than
+        // 60 s. The relay filter narrows the firehose; the per-cmd
+        // check below catches anything that slips through (cached
+        // events, system clock skew, etc.).
+        val sinceSec = TimeUtils.now() - ADMIN_COMMAND_FRESHNESS_SEC
         val filter =
             Filter(
                 kinds = listOf(AdminCommandEvent.KIND),
                 tags = mapOf("a" to listOf(roomATag), "p" to listOf(localPubkey)),
+                since = sinceSec,
             )
+        // Replay protection per EGG-07 #7: a single kick / mute must
+        // act exactly once even when re-delivered from multiple
+        // relays. Lifetime-of-collector dedup mirrors how nostrnests'
+        // useAdminCommands.ts uses a `processedRef` set.
+        val processed = mutableSetOf<String>()
         LocalCache.observeNewEvents<AdminCommandEvent>(filter).collect { cmd ->
             if (cmd.targetPubkey() != localPubkey) return@collect
+            // Defensive freshness re-check: relay might have served a
+            // cached older event despite the `since` hint, or the
+            // user's clock might have jumped forward.
+            if (TimeUtils.now() - cmd.createdAt > ADMIN_COMMAND_FRESHNESS_SEC) return@collect
+            if (!processed.add(cmd.id)) return@collect
             val signerIsAuthorised =
                 cmd.pubKey == event.pubKey ||
                     event.participants().any { it.pubKey == cmd.pubKey && (it.isHost() || it.isModerator()) }
@@ -186,6 +203,9 @@ private fun AdminCommandsCollector(
         }
     }
 }
+
+/** Spec window from EGG-07 #7 — 60-second freshness gate on kind-4312. */
+private const val ADMIN_COMMAND_FRESHNESS_SEC: Long = 60L
 
 private const val PRESENCE_EVICT_INTERVAL_MS = 60_000L
 private const val PRESENCE_STALE_THRESHOLD_SEC = 6L * 60L

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/lifecycle/NestRoomEventCollectors.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/lifecycle/NestRoomEventCollectors.kt
@@ -173,13 +173,16 @@ private fun AdminCommandsCollector(
                 tags = mapOf("a" to listOf(roomATag), "p" to listOf(localPubkey)),
             )
         LocalCache.observeNewEvents<AdminCommandEvent>(filter).collect { cmd ->
-            if (cmd.action() != AdminCommandEvent.Action.KICK) return@collect
             if (cmd.targetPubkey() != localPubkey) return@collect
             val signerIsAuthorised =
                 cmd.pubKey == event.pubKey ||
                     event.participants().any { it.pubKey == cmd.pubKey && (it.isHost() || it.isModerator()) }
             if (!signerIsAuthorised) return@collect
-            viewModel.onKick()
+            when (cmd.action()) {
+                AdminCommandEvent.Action.KICK -> viewModel.onKick()
+                AdminCommandEvent.Action.MUTE -> viewModel.onForceMuted()
+                null -> Unit // unknown verb, ignore
+            }
         }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/participants/ParticipantHostActionsSheet.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/participants/ParticipantHostActionsSheet.kt
@@ -302,7 +302,14 @@ internal fun ParticipantHostActionsSheet(
                     text = stringRes(R.string.nest_kick_action),
                     color = MaterialTheme.colorScheme.error,
                 ) {
+                    // Two-step kick mirroring nostrnests' ProfileCard.tsx:
+                    //   1. ephemeral kind-4312 ["action","kick"] kicks the
+                    //      user off the audio plane
+                    //   2. re-published kind-30312 with the target's p-tag
+                    //      dropped removes them from the participant grid
+                    //      so future presence events don't re-render them
                     broadcast(AdminCommandEvent.kick(roomATag, target))
+                    broadcast(RoomParticipantActions.removeParticipant(event, target))
                     onDismiss()
                 }
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/participants/ParticipantHostActionsSheet.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/participants/ParticipantHostActionsSheet.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -82,6 +83,7 @@ internal fun ParticipantHostActionsSheet(
     event: MeetingSpaceEvent,
     accountViewModel: AccountViewModel,
     onDismiss: () -> Unit,
+    nestViewModel: com.vitorpamplona.amethyst.commons.viewmodels.NestViewModel? = null,
     isLocalUserHost: Boolean = accountViewModel.account.signer.pubKey == event.pubKey,
     catalog: com.vitorpamplona.amethyst.commons.viewmodels.RoomSpeakerCatalog? = null,
 ) {
@@ -252,6 +254,28 @@ internal fun ParticipantHostActionsSheet(
                 onDismiss()
             }
 
+            // Local hush — silences only this speaker in our own
+            // playback. Available to anyone (not host-only) since it
+            // affects nothing on the wire. Skip self because we don't
+            // subscribe to our own broadcast loopback.
+            if (nestViewModel != null && target != accountViewModel.account.signer.pubKey) {
+                val nestUi by nestViewModel.uiState.collectAsState()
+                val isHushedLocally = target in nestUi.locallyHushed
+                ActionRow(
+                    text =
+                        stringRes(
+                            if (isHushedLocally) {
+                                R.string.nest_hush_local_restore
+                            } else {
+                                R.string.nest_hush_local
+                            },
+                        ),
+                ) {
+                    nestViewModel.setLocalHushed(target, !isHushedLocally)
+                    onDismiss()
+                }
+            }
+
             // Host-only rows.
             if (isLocalUserHost && target != event.pubKey) {
                 Spacer(Modifier.height(4.dp))
@@ -259,8 +283,19 @@ internal fun ParticipantHostActionsSheet(
                     broadcast(RoomParticipantActions.setRole(event, target, ROLE.SPEAKER))
                     onDismiss()
                 }
+                ActionRow(stringRes(R.string.nest_promote_moderator)) {
+                    broadcast(RoomParticipantActions.setRole(event, target, ROLE.MODERATOR))
+                    onDismiss()
+                }
                 ActionRow(stringRes(R.string.nest_demote_listener)) {
                     broadcast(RoomParticipantActions.demoteToListener(event, target))
+                    onDismiss()
+                }
+                ActionRow(
+                    text = stringRes(R.string.nest_force_mute),
+                    color = MaterialTheme.colorScheme.error,
+                ) {
+                    broadcast(AdminCommandEvent.forceMute(roomATag, target))
                     onDismiss()
                 }
                 ActionRow(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/participants/RoomParticipantActions.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/participants/RoomParticipantActions.kt
@@ -90,6 +90,28 @@ internal object RoomParticipantActions {
         targetPubkey: String,
     ): EventTemplate<MeetingSpaceEvent>? = setRole(original, targetPubkey, ROLE.PARTICIPANT)
 
+    /**
+     * Drop [targetPubkey]'s p-tag from the room event entirely.
+     * Mirrors nostrnests' kick follow-up (`updateRoomParticipant(_,
+     * null)` after `kickUser` in `ProfileCard.tsx`): the kind-4312
+     * boots them off the audio plane, this re-published kind-30312
+     * keeps them out of the participant grid.
+     *
+     * Refuses to drop the host — same reasoning as [setRole]. Returns
+     * null if the target isn't currently in the participant list (a
+     * pure-audience kick has no list-mutation to do).
+     */
+    fun removeParticipant(
+        original: MeetingSpaceEvent,
+        targetPubkey: String,
+    ): EventTemplate<MeetingSpaceEvent>? {
+        val all = original.participants()
+        val target = all.firstOrNull { it.pubKey == targetPubkey } ?: return null
+        if (target.role.equals(ROLE.HOST.code, ignoreCase = true)) return null
+        val remaining = all.filterNot { it.pubKey == targetPubkey }
+        return rebuild(original, remaining, original.status() ?: StatusTag.STATUS.OPEN)
+    }
+
     private fun rebuild(
         original: MeetingSpaceEvent,
         participants: List<ParticipantTag>,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/screen/NestFullScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/screen/NestFullScreen.kt
@@ -290,6 +290,7 @@ internal fun NestFullScreen(
             target = target,
             event = event,
             accountViewModel = accountViewModel,
+            nestViewModel = viewModel,
             onDismiss = { hostMenuTarget = null },
             catalog = speakerCatalogs[target],
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/screen/NestFullScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/screen/NestFullScreen.kt
@@ -134,6 +134,7 @@ internal fun NestFullScreen(
     val presences by viewModel.presences.collectAsState()
     val reactionsByPubkey by viewModel.recentReactions.collectAsState()
     val speakerCatalogs by viewModel.speakerCatalogs.collectAsState()
+    val audioLevels by viewModel.audioLevels.collectAsState()
 
     val onStageKeys = remember(onStage) { onStage.map { it.pubKey }.toSet() }
     val participantGrid =
@@ -225,6 +226,7 @@ internal fun NestFullScreen(
             StageGrid(
                 members = participantGrid.onStage,
                 speakingNow = ui.speakingNow,
+                audioLevels = audioLevels,
                 accountViewModel = accountViewModel,
                 reactionsByPubkey = reactionsByPubkey,
                 connectingSpeakers = ui.connectingSpeakers,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/screen/NestFullScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/screen/NestFullScreen.kt
@@ -223,6 +223,14 @@ internal fun NestFullScreen(
                 summary = event.summary(),
                 listenerCount = presences.size,
             )
+            // Self-cell tap toggles mic-mute when broadcasting; null
+            // when not broadcasting so the avatar falls back to the
+            // default no-op tap (rather than offering a button that
+            // does nothing).
+            val onTapSelf: (() -> Unit)? =
+                (ui.broadcast as? com.vitorpamplona.amethyst.commons.viewmodels.BroadcastUiState.Broadcasting)?.let { state ->
+                    { viewModel.setMicMuted(!state.isMuted) }
+                }
             StageGrid(
                 members = participantGrid.onStage,
                 speakingNow = ui.speakingNow,
@@ -231,6 +239,8 @@ internal fun NestFullScreen(
                 reactionsByPubkey = reactionsByPubkey,
                 connectingSpeakers = ui.connectingSpeakers,
                 onLongPressParticipant = onLongPressParticipant,
+                myPubkey = myPubkey,
+                onTapSelf = onTapSelf,
                 modifier = Modifier.padding(horizontal = 16.dp),
             )
             NestTabRow(
@@ -258,6 +268,7 @@ internal fun NestFullScreen(
                         members = participantGrid.audience,
                         accountViewModel = accountViewModel,
                         onLongPressParticipant = onLongPressParticipant,
+                        myPubkey = myPubkey,
                         modifier =
                             Modifier
                                 .weight(1f)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/stage/ParticipantsGrid.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/stage/ParticipantsGrid.kt
@@ -119,6 +119,8 @@ internal fun StageGrid(
     reactionsByPubkey: Map<String, List<RoomReaction>> = emptyMap(),
     connectingSpeakers: ImmutableSet<String> = persistentSetOf(),
     onLongPressParticipant: ((String) -> Unit)? = null,
+    myPubkey: String? = null,
+    onTapSelf: (() -> Unit)? = null,
 ) {
     // Float currently-speaking members to the top so the listener can
     // see who they're hearing without scrolling. sortedBy is stable in
@@ -160,6 +162,7 @@ internal fun StageGrid(
             verticalArrangement = Arrangement.spacedBy(GRID_SPACING),
         ) {
             items(items = sortedMembers, key = { it.pubkey }) { member ->
+                val isSelf = myPubkey != null && member.pubkey == myPubkey
                 MemberCell(
                     member = member,
                     avatarSize = STAGE_AVATAR,
@@ -170,6 +173,8 @@ internal fun StageGrid(
                     reactions = reactionsByPubkey[member.pubkey].orEmpty(),
                     accountViewModel = accountViewModel,
                     onLongPressParticipant = onLongPressParticipant,
+                    isSelf = isSelf,
+                    onTapSelf = if (isSelf) onTapSelf else null,
                     modifier = Modifier.animateItem(),
                 )
             }
@@ -194,6 +199,7 @@ internal fun AudienceGrid(
     accountViewModel: AccountViewModel,
     modifier: Modifier = Modifier,
     onLongPressParticipant: ((String) -> Unit)? = null,
+    myPubkey: String? = null,
 ) {
     if (members.isEmpty()) {
         Box(
@@ -235,6 +241,7 @@ internal fun AudienceGrid(
                 reactions = emptyList(),
                 accountViewModel = accountViewModel,
                 onLongPressParticipant = onLongPressParticipant,
+                isSelf = myPubkey != null && member.pubkey == myPubkey,
                 modifier = Modifier.animateItem(),
             )
         }
@@ -252,6 +259,8 @@ private fun MemberCell(
     reactions: List<RoomReaction>,
     accountViewModel: AccountViewModel,
     onLongPressParticipant: ((String) -> Unit)?,
+    isSelf: Boolean = false,
+    onTapSelf: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val mutedRingColor = MaterialTheme.colorScheme.error
@@ -292,6 +301,17 @@ private fun MemberCell(
         remember(member.pubkey, onLongPressParticipant) {
             onLongPressParticipant?.let { cb -> { hex: String -> cb(hex) } }
         }
+    // Self-cell tap shortcut: tap your own avatar to toggle mic-mute
+    // when broadcasting. For other cells we leave tap unhandled so
+    // the existing nav-to-profile path stays consistent (and there's
+    // nothing visually different from a non-clickable avatar).
+    val onClick =
+        if (isSelf && onTapSelf != null) {
+            remember(onTapSelf) { { _: String -> onTapSelf() } }
+        } else {
+            null
+        }
+    val selfTint = if (isSelf) MaterialTheme.colorScheme.primary else Color.Unspecified
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier.fillMaxWidth().padding(vertical = 4.dp),
@@ -302,6 +322,7 @@ private fun MemberCell(
                 size = avatarSize,
                 accountViewModel = accountViewModel,
                 modifier = avatarModifier,
+                onClick = onClick,
                 onLongClick = onLongClick,
             )
             if (isConnecting) {
@@ -330,19 +351,27 @@ private fun MemberCell(
                     modifier = Modifier.align(Alignment.BottomCenter),
                 )
             }
+            // Reactions float over the avatar's bottom-right corner so
+            // a 👏 burst no longer pushes the username down and reflows
+            // neighbouring cells. The mic badge sits at BottomCenter,
+            // so BottomEnd + a small outward offset keeps them clear.
+            if (reactions.isNotEmpty()) {
+                SpeakerReactionOverlay(
+                    reactions = reactions,
+                    modifier =
+                        Modifier
+                            .align(Alignment.BottomEnd)
+                            .offset(x = 6.dp, y = 6.dp),
+                )
+            }
         }
         UsernameDisplay(
             baseUser = user,
             weight = Modifier.fillMaxWidth().padding(top = 4.dp),
+            textColor = selfTint,
             textAlign = TextAlign.Center,
             accountViewModel = accountViewModel,
         )
-        if (reactions.isNotEmpty()) {
-            SpeakerReactionOverlay(
-                reactions = reactions,
-                modifier = Modifier.padding(top = 2.dp),
-            )
-        }
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/stage/ParticipantsGrid.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/stage/ParticipantsGrid.kt
@@ -20,10 +20,12 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.nests.room.stage
 
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
@@ -42,8 +44,10 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -51,12 +55,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
+import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbol
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
 import com.vitorpamplona.amethyst.commons.viewmodels.RoomMember
 import com.vitorpamplona.amethyst.commons.viewmodels.RoomReaction
@@ -72,7 +78,7 @@ private val STAGE_CELL_MIN = 96.dp
 private val STAGE_AVATAR = 100.dp
 private val AUDIENCE_CELL_MIN = 96.dp
 private val AUDIENCE_AVATAR = 100.dp
-private val GRID_SPACING = 6.dp
+private val GRID_SPACING = 8.dp
 private val AVATAR_RING_WIDTH = 3.dp
 
 // Upper bound for the live "voice" halo. Speaking with a peak audio
@@ -80,17 +86,26 @@ private val AVATAR_RING_WIDTH = 3.dp
 // quieter voices land somewhere in between.
 private val MAX_RING_WIDTH = 7.dp
 
+// Soft outer glow that scales with audio level. Drawn behind the
+// avatar via drawBehind so it doesn't change layout bounds; alpha
+// fades to 0 when not speaking.
+private val MAX_GLOW_RADIUS = 12.dp
+
 // Cap badge sizes so they stay legible without dominating the avatar
 // at 100.dp. The 0.42 ratio was tuned for ~48.dp avatars (giving
 // ~20.dp badges); without a cap, scaling to 100.dp produces 42.dp
 // badges that compete with the face for attention.
 private val MAX_BADGE_SIZE = 28.dp
 
+private val STAGE_CARD_SHAPE = RoundedCornerShape(20.dp)
+private val STAGE_CARD_PADDING_HORIZONTAL = 12.dp
+private val STAGE_CARD_PADDING_VERTICAL = 12.dp
+
 // Cell min sits 4.dp under the avatar diameter so 4 columns fit on a
 // 411.dp phone (Pixel 6/7/8). The 100.dp avatar overflows ~2.dp into
-// the 6.dp horizontal arrangement on each side, leaving a visible
-// ~2.dp gap between neighbors. Names below ellipsize to the cell
-// width, which is fine since they're short display handles.
+// the 8.dp horizontal arrangement on each side, leaving a visible
+// gap between neighbors. Names below ellipsize to the cell width,
+// which is fine since they're short display handles.
 
 // Two rows visible by default. Each cell is roughly avatar + name +
 // reaction headroom; with a 100dp avatar one row lifts to ~140dp, so
@@ -107,7 +122,8 @@ private val STAGE_MAX_HEIGHT = 320.dp
  * scroll inside the strip without pushing the tabs / chat below the
  * fold.
  *
- * Falls open: when [members] is empty, renders nothing.
+ * When [members] is empty, renders an "Waiting for speakers…" hint
+ * instead so the strip stays visually anchored.
  */
 @Composable
 internal fun StageGrid(
@@ -131,54 +147,85 @@ internal fun StageGrid(
         remember(members, speakingNow) {
             members.sortedBy { if (it.pubkey in speakingNow) 0 else 1 }
         }
-    Column(modifier = modifier.fillMaxWidth().padding(top = 8.dp)) {
-        Text(
-            text = stringRes(R.string.nest_stage),
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(bottom = 6.dp),
-        )
-        if (members.isEmpty()) {
-            // Keep the strip visible so the room doesn't look broken
-            // when nobody is on stage yet — the title plus a quiet
-            // hint signals "waiting state" without taking the chat /
-            // audience tab's space below.
-            Box(
-                modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    text = stringRes(R.string.nest_stage_empty),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            return@Column
-        }
-        LazyVerticalGrid(
-            columns = GridCells.Adaptive(STAGE_CELL_MIN),
-            modifier = Modifier.fillMaxWidth().heightIn(max = STAGE_MAX_HEIGHT),
-            horizontalArrangement = Arrangement.spacedBy(GRID_SPACING),
-            verticalArrangement = Arrangement.spacedBy(GRID_SPACING),
+    // Wrap the strip in a tonal card so the active speakers visually
+    // live in their own zone, separated from the chat / audience tab
+    // below. surfaceContainerLow is a quiet step up from the screen
+    // background — readable in both light and dark.
+    Surface(
+        modifier = modifier.fillMaxWidth().padding(top = 8.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        shape = STAGE_CARD_SHAPE,
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        horizontal = STAGE_CARD_PADDING_HORIZONTAL,
+                        vertical = STAGE_CARD_PADDING_VERTICAL,
+                    ),
         ) {
-            items(items = sortedMembers, key = { it.pubkey }) { member ->
-                val isSelf = myPubkey != null && member.pubkey == myPubkey
-                MemberCell(
-                    member = member,
-                    avatarSize = STAGE_AVATAR,
-                    isSpeaking = member.pubkey in speakingNow,
-                    audioLevel = audioLevels[member.pubkey] ?: 0f,
-                    isConnecting = member.pubkey in connectingSpeakers,
-                    showMicBadge = true,
-                    reactions = reactionsByPubkey[member.pubkey].orEmpty(),
-                    accountViewModel = accountViewModel,
-                    onLongPressParticipant = onLongPressParticipant,
-                    isSelf = isSelf,
-                    onTapSelf = if (isSelf) onTapSelf else null,
-                    modifier = Modifier.animateItem(),
-                )
+            Text(
+                text = stringRes(R.string.nest_stage),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 8.dp),
+            )
+            if (members.isEmpty()) {
+                EmptyStageHint()
+                return@Column
+            }
+            LazyVerticalGrid(
+                columns = GridCells.Adaptive(STAGE_CELL_MIN),
+                modifier = Modifier.fillMaxWidth().heightIn(max = STAGE_MAX_HEIGHT),
+                horizontalArrangement = Arrangement.spacedBy(GRID_SPACING),
+                verticalArrangement = Arrangement.spacedBy(GRID_SPACING),
+            ) {
+                items(items = sortedMembers, key = { it.pubkey }) { member ->
+                    val isSelf = myPubkey != null && member.pubkey == myPubkey
+                    MemberCell(
+                        member = member,
+                        avatarSize = STAGE_AVATAR,
+                        isSpeaking = member.pubkey in speakingNow,
+                        audioLevel = audioLevels[member.pubkey] ?: 0f,
+                        isConnecting = member.pubkey in connectingSpeakers,
+                        showMicBadge = true,
+                        reactions = reactionsByPubkey[member.pubkey].orEmpty(),
+                        accountViewModel = accountViewModel,
+                        onLongPressParticipant = onLongPressParticipant,
+                        isSelf = isSelf,
+                        onTapSelf = if (isSelf) onTapSelf else null,
+                        modifier = Modifier.animateItem(),
+                    )
+                }
             }
         }
+    }
+}
+
+/**
+ * Idle "Waiting for speakers…" placeholder for [StageGrid]. Pairs an
+ * hourglass glyph with the existing copy so the empty state reads as
+ * intentional rather than as a layout glitch.
+ */
+@Composable
+private fun EmptyStageHint() {
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Icon(
+            symbol = MaterialSymbols.HourglassEmpty,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+            modifier = Modifier.size(32.dp),
+        )
+        Text(
+            text = stringRes(R.string.nest_stage_empty),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 
@@ -264,30 +311,49 @@ private fun MemberCell(
     modifier: Modifier = Modifier,
 ) {
     val mutedRingColor = MaterialTheme.colorScheme.error
+    val clampedLevel = audioLevel.coerceIn(0f, 1f)
     // Tri-state ring around the avatar so a glance distinguishes:
     //   - green ring: actively speaking right now
     //   - red ring:   on stage and broadcasting but mic flagged muted
     //   - no ring:    idle, audience, or unknown mute state
-    val ringColor =
+    //
+    // Both color and width crossfade so going idle → speaking → idle
+    // doesn't snap; the color animates from Transparent through the
+    // speaking green and the width tracks the live peak amplitude.
+    val targetRingColor =
         when {
             isSpeaking -> NEST_SPEAKING_COLOR
             showMicBadge && member.publishing && member.muted == true -> mutedRingColor
-            else -> null
+            else -> Color.Transparent
         }
-    // Throb the ring width with the live peak amplitude — quiet voices
-    // sit at the base width, loud ones widen the halo. animateDpAsState
-    // smooths the 10 Hz raw signal into a continuous animation. The
-    // muted ring stays at base width because no audio is being decoded.
     val targetRingWidth =
         when {
-            isSpeaking -> AVATAR_RING_WIDTH + (audioLevel.coerceIn(0f, 1f) * (MAX_RING_WIDTH - AVATAR_RING_WIDTH).value).dp
-            ringColor != null -> AVATAR_RING_WIDTH
+            isSpeaking -> AVATAR_RING_WIDTH + (clampedLevel * (MAX_RING_WIDTH - AVATAR_RING_WIDTH).value).dp
+            targetRingColor != Color.Transparent -> AVATAR_RING_WIDTH
             else -> 0.dp
         }
     val animatedRingWidth by animateDpAsState(targetValue = targetRingWidth, label = "speaker-ring-width")
+    val animatedRingColor by animateColorAsState(targetValue = targetRingColor, label = "speaker-ring-color")
+    // Soft outer halo behind the avatar, scaled by audio level. Drawn
+    // via drawBehind on a transparent overlay so it doesn't push the
+    // cell layout out — the glow extends past the circle but never
+    // affects neighbour measurement. Capped so a loud peak doesn't
+    // bleed into the next column.
+    val animatedGlowAlpha by animateFloatAsState(
+        targetValue = if (isSpeaking) (clampedLevel * 0.45f) else 0f,
+        label = "speaker-ring-glow-alpha",
+    )
     val avatarModifier =
         Modifier
-            .let { if (ringColor != null) it.border(animatedRingWidth, ringColor, CircleShape) else it }
+            .drawBehind {
+                if (animatedGlowAlpha <= 0.001f) return@drawBehind
+                val baseRadius = size.minDimension / 2f
+                val extra = MAX_GLOW_RADIUS.toPx() * clampedLevel
+                drawCircle(
+                    color = NEST_SPEAKING_COLOR.copy(alpha = animatedGlowAlpha),
+                    radius = baseRadius + extra,
+                )
+            }.border(animatedRingWidth, animatedRingColor, CircleShape)
             .let { if (member.absent) it.alpha(0.5f) else it }
     val user =
         remember(member.pubkey) {
@@ -401,13 +467,13 @@ private fun HandRaiseBadge(modifier: Modifier = Modifier) {
             modifier
                 .offset(x = 2.dp, y = (-2).dp + offsetY.dp)
                 .size(MAX_BADGE_SIZE)
-                .background(NEST_HAND_RAISE_COLOR, CircleShape),
+                .background(MaterialTheme.colorScheme.tertiary, CircleShape),
         contentAlignment = Alignment.Center,
     ) {
         Icon(
             symbol = MaterialSymbols.PanTool,
             contentDescription = stringRes(R.string.nest_raise_hand),
-            tint = Color.White,
+            tint = MaterialTheme.colorScheme.onTertiary,
             modifier = Modifier.size(MAX_BADGE_SIZE - 4.dp),
         )
     }
@@ -423,28 +489,55 @@ private fun RoleBadge(
     role: ROLE,
     modifier: Modifier = Modifier,
 ) {
-    val (color, symbol, label) =
+    val scheme = MaterialTheme.colorScheme
+    val (bg, fg, symbol, label) =
         when (role) {
-            ROLE.HOST -> Triple(NEST_HOST_COLOR, MaterialSymbols.MilitaryTech, stringRes(R.string.nest_role_host))
-            ROLE.MODERATOR -> Triple(NEST_MODERATOR_COLOR, MaterialSymbols.Shield, stringRes(R.string.nest_role_moderator))
-            else -> return
+            ROLE.HOST -> {
+                BadgeStyle(
+                    background = scheme.primary,
+                    foreground = scheme.onPrimary,
+                    symbol = MaterialSymbols.MilitaryTech,
+                    label = stringRes(R.string.nest_role_host),
+                )
+            }
+
+            ROLE.MODERATOR -> {
+                BadgeStyle(
+                    background = scheme.secondary,
+                    foreground = scheme.onSecondary,
+                    symbol = MaterialSymbols.Shield,
+                    label = stringRes(R.string.nest_role_moderator),
+                )
+            }
+
+            else -> {
+                return
+            }
         }
     Box(
         modifier =
             modifier
                 .offset(x = (-2).dp, y = (-2).dp)
                 .size(MAX_BADGE_SIZE)
-                .background(color, CircleShape),
+                .background(bg, CircleShape),
         contentAlignment = Alignment.Center,
     ) {
         Icon(
             symbol = symbol,
             contentDescription = label,
-            tint = Color.White,
+            tint = fg,
             modifier = Modifier.size(MAX_BADGE_SIZE - 4.dp),
         )
     }
 }
+
+/** Tuple of resolved badge colors + content; trivially destructured by [RoleBadge]. */
+private data class BadgeStyle(
+    val background: Color,
+    val foreground: Color,
+    val symbol: MaterialSymbol,
+    val label: String,
+)
 
 /**
  * Mic-state pill anchored to the bottom-center of an on-stage
@@ -464,11 +557,12 @@ private fun MicStateBadge(
     isMuted: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val color =
+    val scheme = MaterialTheme.colorScheme
+    val (bg, fg) =
         when {
-            isSpeaking -> NEST_SPEAKING_COLOR
-            isMuted -> MaterialTheme.colorScheme.error
-            else -> MaterialTheme.colorScheme.primary
+            isSpeaking -> NEST_SPEAKING_COLOR to Color.White
+            isMuted -> scheme.error to scheme.onError
+            else -> scheme.primary to scheme.onPrimary
         }
     val description =
         when {
@@ -481,19 +575,20 @@ private fun MicStateBadge(
             modifier
                 .offset(y = 2.dp)
                 .size(MAX_BADGE_SIZE)
-                .background(color, CircleShape),
+                .background(bg, CircleShape),
         contentAlignment = Alignment.Center,
     ) {
         Icon(
             symbol = if (isMuted) MaterialSymbols.MicOff else MaterialSymbols.Mic,
             contentDescription = description,
-            tint = Color.White,
+            tint = fg,
             modifier = Modifier.size(MAX_BADGE_SIZE - 4.dp),
         )
     }
 }
 
-private val NEST_HAND_RAISE_COLOR = Color(0xFFEAB308) // tailwind yellow-500
+// Speaking-green is kept as a hardcoded brand-ish color rather than
+// pulled from the theme — "green = mic active" is a near-universal
+// convention (Spaces, Clubhouse, Discord) and a primary-tinted ring
+// would lose that signal in user themes that recolour primary.
 private val NEST_SPEAKING_COLOR = Color(0xFF22C55E) // tailwind green-500
-private val NEST_HOST_COLOR = Color(0xFFA855F7) // tailwind purple-500
-private val NEST_MODERATOR_COLOR = Color(0xFF0EA5E9) // tailwind sky-500

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/stage/ParticipantsGrid.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/stage/ParticipantsGrid.kt
@@ -63,6 +63,7 @@ import com.vitorpamplona.amethyst.ui.note.ClickableUserPicture
 import com.vitorpamplona.amethyst.ui.note.UsernameDisplay
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.quartz.nip53LiveActivities.streaming.tags.ROLE
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentSetOf
 
@@ -72,6 +73,12 @@ private val AUDIENCE_CELL_MIN = 96.dp
 private val AUDIENCE_AVATAR = 100.dp
 private val GRID_SPACING = 6.dp
 private val AVATAR_RING_WIDTH = 3.dp
+
+// Cap badge sizes so they stay legible without dominating the avatar
+// at 100.dp. The 0.42 ratio was tuned for ~48.dp avatars (giving
+// ~20.dp badges); without a cap, scaling to 100.dp produces 42.dp
+// badges that compete with the face for attention.
+private val MAX_BADGE_SIZE = 28.dp
 
 // Cell min sits 4.dp under the avatar diameter so 4 columns fit on a
 // 411.dp phone (Pixel 6/7/8). The 100.dp avatar overflows ~2.dp into
@@ -107,6 +114,15 @@ internal fun StageGrid(
     onLongPressParticipant: ((String) -> Unit)? = null,
 ) {
     if (members.isEmpty()) return
+    // Float currently-speaking members to the top so the listener can
+    // see who they're hearing without scrolling. sortedBy is stable in
+    // Kotlin — speakers retain relative order among themselves, as do
+    // non-speakers. Memoized on (members, speakingNow) so a 250ms
+    // speaking flip doesn't reallocate when neither input changed.
+    val sortedMembers =
+        remember(members, speakingNow) {
+            members.sortedBy { if (it.pubkey in speakingNow) 0 else 1 }
+        }
     Column(modifier = modifier.fillMaxWidth().padding(top = 8.dp)) {
         Text(
             text = stringRes(R.string.nest_stage),
@@ -120,7 +136,7 @@ internal fun StageGrid(
             horizontalArrangement = Arrangement.spacedBy(GRID_SPACING),
             verticalArrangement = Arrangement.spacedBy(GRID_SPACING),
         ) {
-            items(items = members, key = { it.pubkey }) { member ->
+            items(items = sortedMembers, key = { it.pubkey }) { member ->
                 MemberCell(
                     member = member,
                     avatarSize = STAGE_AVATAR,
@@ -130,6 +146,7 @@ internal fun StageGrid(
                     reactions = reactionsByPubkey[member.pubkey].orEmpty(),
                     accountViewModel = accountViewModel,
                     onLongPressParticipant = onLongPressParticipant,
+                    modifier = Modifier.animateItem(),
                 )
             }
         }
@@ -167,6 +184,13 @@ internal fun AudienceGrid(
         }
         return
     }
+    // Pull raised hands to the top of the audience so a moderator
+    // approving the queue isn't scrolling. Stable sort keeps everyone
+    // else in their incoming order.
+    val sortedMembers =
+        remember(members) {
+            members.sortedBy { if (it.handRaised) 0 else 1 }
+        }
     LazyVerticalGrid(
         columns = GridCells.Adaptive(AUDIENCE_CELL_MIN),
         modifier = modifier.fillMaxSize().padding(horizontal = 4.dp),
@@ -176,7 +200,7 @@ internal fun AudienceGrid(
             androidx.compose.foundation.layout
                 .PaddingValues(vertical = 8.dp),
     ) {
-        items(items = members, key = { it.pubkey }) { member ->
+        items(items = sortedMembers, key = { it.pubkey }) { member ->
             MemberCell(
                 member = member,
                 avatarSize = AUDIENCE_AVATAR,
@@ -186,6 +210,7 @@ internal fun AudienceGrid(
                 reactions = emptyList(),
                 accountViewModel = accountViewModel,
                 onLongPressParticipant = onLongPressParticipant,
+                modifier = Modifier.animateItem(),
             )
         }
     }
@@ -201,6 +226,7 @@ private fun MemberCell(
     reactions: List<RoomReaction>,
     accountViewModel: AccountViewModel,
     onLongPressParticipant: ((String) -> Unit)?,
+    modifier: Modifier = Modifier,
 ) {
     val mutedRingColor = MaterialTheme.colorScheme.error
     // Tri-state ring around the avatar so a glance distinguishes:
@@ -231,7 +257,7 @@ private fun MemberCell(
         }
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+        modifier = modifier.fillMaxWidth().padding(vertical = 4.dp),
     ) {
         Box(contentAlignment = Alignment.Center) {
             ClickableUserPicture(
@@ -248,9 +274,15 @@ private fun MemberCell(
                     color = MaterialTheme.colorScheme.primary,
                 )
             }
+            val role = member.role
+            if (role == ROLE.HOST || role == ROLE.MODERATOR) {
+                RoleBadge(
+                    role = role,
+                    modifier = Modifier.align(Alignment.TopStart),
+                )
+            }
             if (member.handRaised) {
                 HandRaiseBadge(
-                    avatarSize = avatarSize,
                     modifier = Modifier.align(Alignment.TopEnd),
                 )
             }
@@ -258,7 +290,6 @@ private fun MemberCell(
                 MicStateBadge(
                     isSpeaking = isSpeaking,
                     isMuted = member.muted == true,
-                    avatarSize = avatarSize,
                     modifier = Modifier.align(Alignment.BottomCenter),
                 )
             }
@@ -286,10 +317,7 @@ private fun MemberCell(
  * `ParticipantAvatar`.
  */
 @Composable
-private fun HandRaiseBadge(
-    avatarSize: Dp,
-    modifier: Modifier = Modifier,
-) {
+private fun HandRaiseBadge(modifier: Modifier = Modifier) {
     val transition = rememberInfiniteTransition(label = "hand-raise-bounce")
     val offsetY by
         transition.animateFloat(
@@ -302,12 +330,11 @@ private fun HandRaiseBadge(
                 ),
             label = "hand-raise-bounce-y",
         )
-    val badgeSize = (avatarSize.value * 0.42f).dp
     Box(
         modifier =
             modifier
                 .offset(x = 2.dp, y = (-2).dp + offsetY.dp)
-                .size(badgeSize)
+                .size(MAX_BADGE_SIZE)
                 .background(NEST_HAND_RAISE_COLOR, CircleShape),
         contentAlignment = Alignment.Center,
     ) {
@@ -315,7 +342,40 @@ private fun HandRaiseBadge(
             symbol = MaterialSymbols.PanTool,
             contentDescription = stringRes(R.string.nest_raise_hand),
             tint = Color.White,
-            modifier = Modifier.size(badgeSize - 4.dp),
+            modifier = Modifier.size(MAX_BADGE_SIZE - 4.dp),
+        )
+    }
+}
+
+/**
+ * Role indicator overlaid on the top-left of the avatar — only
+ * rendered for HOST and MODERATOR. Mirrors how nostrnests
+ * surfaces room ownership/staff at a glance.
+ */
+@Composable
+private fun RoleBadge(
+    role: ROLE,
+    modifier: Modifier = Modifier,
+) {
+    val (color, symbol, label) =
+        when (role) {
+            ROLE.HOST -> Triple(NEST_HOST_COLOR, MaterialSymbols.MilitaryTech, stringRes(R.string.nest_role_host))
+            ROLE.MODERATOR -> Triple(NEST_MODERATOR_COLOR, MaterialSymbols.Shield, stringRes(R.string.nest_role_moderator))
+            else -> return
+        }
+    Box(
+        modifier =
+            modifier
+                .offset(x = (-2).dp, y = (-2).dp)
+                .size(MAX_BADGE_SIZE)
+                .background(color, CircleShape),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            symbol = symbol,
+            contentDescription = label,
+            tint = Color.White,
+            modifier = Modifier.size(MAX_BADGE_SIZE - 4.dp),
         )
     }
 }
@@ -336,7 +396,6 @@ private fun HandRaiseBadge(
 private fun MicStateBadge(
     isSpeaking: Boolean,
     isMuted: Boolean,
-    avatarSize: Dp,
     modifier: Modifier = Modifier,
 ) {
     val color =
@@ -345,23 +404,30 @@ private fun MicStateBadge(
             isMuted -> MaterialTheme.colorScheme.error
             else -> MaterialTheme.colorScheme.primary
         }
-    val badgeSize = (avatarSize.value * 0.42f).dp
+    val description =
+        when {
+            isMuted -> stringRes(R.string.nest_state_muted)
+            isSpeaking -> stringRes(R.string.nest_state_speaking)
+            else -> stringRes(R.string.nest_state_mic_open)
+        }
     Box(
         modifier =
             modifier
                 .offset(y = 2.dp)
-                .size(badgeSize)
+                .size(MAX_BADGE_SIZE)
                 .background(color, CircleShape),
         contentAlignment = Alignment.Center,
     ) {
         Icon(
             symbol = if (isMuted) MaterialSymbols.MicOff else MaterialSymbols.Mic,
-            contentDescription = null,
+            contentDescription = description,
             tint = Color.White,
-            modifier = Modifier.size(badgeSize - 4.dp),
+            modifier = Modifier.size(MAX_BADGE_SIZE - 4.dp),
         )
     }
 }
 
 private val NEST_HAND_RAISE_COLOR = Color(0xFFEAB308) // tailwind yellow-500
 private val NEST_SPEAKING_COLOR = Color(0xFF22C55E) // tailwind green-500
+private val NEST_HOST_COLOR = Color(0xFFA855F7) // tailwind purple-500
+private val NEST_MODERATOR_COLOR = Color(0xFF0EA5E9) // tailwind sky-500

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/stage/ParticipantsGrid.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/stage/ParticipantsGrid.kt
@@ -22,6 +22,7 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.nests.room.stage
 
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
@@ -74,6 +75,11 @@ private val AUDIENCE_AVATAR = 100.dp
 private val GRID_SPACING = 6.dp
 private val AVATAR_RING_WIDTH = 3.dp
 
+// Upper bound for the live "voice" halo. Speaking with a peak audio
+// level of 1.0 grows the ring from AVATAR_RING_WIDTH to this value;
+// quieter voices land somewhere in between.
+private val MAX_RING_WIDTH = 7.dp
+
 // Cap badge sizes so they stay legible without dominating the avatar
 // at 100.dp. The 0.42 ratio was tuned for ~48.dp avatars (giving
 // ~20.dp badges); without a cap, scaling to 100.dp produces 42.dp
@@ -109,6 +115,7 @@ internal fun StageGrid(
     speakingNow: ImmutableSet<String>,
     accountViewModel: AccountViewModel,
     modifier: Modifier = Modifier,
+    audioLevels: Map<String, Float> = emptyMap(),
     reactionsByPubkey: Map<String, List<RoomReaction>> = emptyMap(),
     connectingSpeakers: ImmutableSet<String> = persistentSetOf(),
     onLongPressParticipant: ((String) -> Unit)? = null,
@@ -141,6 +148,7 @@ internal fun StageGrid(
                     member = member,
                     avatarSize = STAGE_AVATAR,
                     isSpeaking = member.pubkey in speakingNow,
+                    audioLevel = audioLevels[member.pubkey] ?: 0f,
                     isConnecting = member.pubkey in connectingSpeakers,
                     showMicBadge = true,
                     reactions = reactionsByPubkey[member.pubkey].orEmpty(),
@@ -205,6 +213,7 @@ internal fun AudienceGrid(
                 member = member,
                 avatarSize = AUDIENCE_AVATAR,
                 isSpeaking = false,
+                audioLevel = 0f,
                 isConnecting = false,
                 showMicBadge = false,
                 reactions = emptyList(),
@@ -221,6 +230,7 @@ private fun MemberCell(
     member: RoomMember,
     avatarSize: Dp,
     isSpeaking: Boolean,
+    audioLevel: Float,
     isConnecting: Boolean,
     showMicBadge: Boolean,
     reactions: List<RoomReaction>,
@@ -239,9 +249,20 @@ private fun MemberCell(
             showMicBadge && member.publishing && member.muted == true -> mutedRingColor
             else -> null
         }
+    // Throb the ring width with the live peak amplitude — quiet voices
+    // sit at the base width, loud ones widen the halo. animateDpAsState
+    // smooths the 10 Hz raw signal into a continuous animation. The
+    // muted ring stays at base width because no audio is being decoded.
+    val targetRingWidth =
+        when {
+            isSpeaking -> AVATAR_RING_WIDTH + (audioLevel.coerceIn(0f, 1f) * (MAX_RING_WIDTH - AVATAR_RING_WIDTH).value).dp
+            ringColor != null -> AVATAR_RING_WIDTH
+            else -> 0.dp
+        }
+    val animatedRingWidth by animateDpAsState(targetValue = targetRingWidth, label = "speaker-ring-width")
     val avatarModifier =
         Modifier
-            .let { if (ringColor != null) it.border(AVATAR_RING_WIDTH, ringColor, CircleShape) else it }
+            .let { if (ringColor != null) it.border(animatedRingWidth, ringColor, CircleShape) else it }
             .let { if (member.absent) it.alpha(0.5f) else it }
     val user =
         remember(member.pubkey) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/stage/ParticipantsGrid.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/stage/ParticipantsGrid.kt
@@ -120,7 +120,6 @@ internal fun StageGrid(
     connectingSpeakers: ImmutableSet<String> = persistentSetOf(),
     onLongPressParticipant: ((String) -> Unit)? = null,
 ) {
-    if (members.isEmpty()) return
     // Float currently-speaking members to the top so the listener can
     // see who they're hearing without scrolling. sortedBy is stable in
     // Kotlin — speakers retain relative order among themselves, as do
@@ -137,6 +136,23 @@ internal fun StageGrid(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(bottom = 6.dp),
         )
+        if (members.isEmpty()) {
+            // Keep the strip visible so the room doesn't look broken
+            // when nobody is on stage yet — the title plus a quiet
+            // hint signals "waiting state" without taking the chat /
+            // audience tab's space below.
+            Box(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = stringRes(R.string.nest_stage_empty),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            return@Column
+        }
         LazyVerticalGrid(
             columns = GridCells.Adaptive(STAGE_CELL_MIN),
             modifier = Modifier.fillMaxWidth().heightIn(max = STAGE_MAX_HEIGHT),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/stage/ParticipantsGrid.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/stage/ParticipantsGrid.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
@@ -62,21 +63,22 @@ import com.vitorpamplona.amethyst.ui.note.ClickableUserPicture
 import com.vitorpamplona.amethyst.ui.note.UsernameDisplay
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
-import com.vitorpamplona.amethyst.ui.theme.Size40dp
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentSetOf
 
-private val STAGE_CELL_MIN = 88.dp
-private val STAGE_AVATAR = 48.dp
-private val AUDIENCE_CELL_MIN = 76.dp
-private val AUDIENCE_AVATAR = Size40dp
+private val STAGE_CELL_MIN = 112.dp
+private val STAGE_AVATAR = 100.dp
+private val AUDIENCE_CELL_MIN = 112.dp
+private val AUDIENCE_AVATAR = 100.dp
 private val GRID_SPACING = 6.dp
+private val AVATAR_RING_WIDTH = 3.dp
 
 // Two rows visible by default. Each cell is roughly avatar + name +
-// reaction headroom, so this lifts to ~200dp on most phones — tall
-// enough to show 6-8 speakers without scrolling but small enough to
-// leave the chat / audience tab the majority of the viewport.
-private val STAGE_MAX_HEIGHT = 220.dp
+// reaction headroom; with a 100dp avatar one row lifts to ~140dp, so
+// two rows + label/padding lands near 320dp — tall enough to show a
+// handful of speakers without scrolling but small enough to leave the
+// chat / audience tab the majority of the viewport.
+private val STAGE_MAX_HEIGHT = 320.dp
 
 /**
  * Vertical adaptive grid for the on-stage section. Used as the
@@ -194,14 +196,21 @@ private fun MemberCell(
     accountViewModel: AccountViewModel,
     onLongPressParticipant: ((String) -> Unit)?,
 ) {
-    val ringColor = MaterialTheme.colorScheme.primary
-    val avatarModifier =
+    val mutedRingColor = MaterialTheme.colorScheme.error
+    // Tri-state ring around the avatar so a glance distinguishes:
+    //   - green ring: actively speaking right now
+    //   - red ring:   on stage and broadcasting but mic flagged muted
+    //   - no ring:    idle, audience, or unknown mute state
+    val ringColor =
         when {
-            isSpeaking && member.absent -> Modifier.border(2.dp, ringColor, CircleShape).then(Modifier.alpha(0.5f))
-            isSpeaking -> Modifier.border(2.dp, ringColor, CircleShape)
-            member.absent -> Modifier.alpha(0.5f)
-            else -> Modifier
+            isSpeaking -> NEST_SPEAKING_COLOR
+            showMicBadge && member.publishing && member.muted == true -> mutedRingColor
+            else -> null
         }
+    val avatarModifier =
+        Modifier
+            .let { if (ringColor != null) it.border(AVATAR_RING_WIDTH, ringColor, CircleShape) else it }
+            .let { if (member.absent) it.alpha(0.5f) else it }
     val user =
         remember(member.pubkey) {
             com.vitorpamplona.amethyst.model.LocalCache
@@ -251,6 +260,7 @@ private fun MemberCell(
         UsernameDisplay(
             baseUser = user,
             weight = Modifier.fillMaxWidth().padding(top = 4.dp),
+            textAlign = TextAlign.Center,
             accountViewModel = accountViewModel,
         )
         if (reactions.isNotEmpty()) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/stage/ParticipantsGrid.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/stage/ParticipantsGrid.kt
@@ -66,12 +66,18 @@ import com.vitorpamplona.amethyst.ui.stringRes
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentSetOf
 
-private val STAGE_CELL_MIN = 112.dp
+private val STAGE_CELL_MIN = 96.dp
 private val STAGE_AVATAR = 100.dp
-private val AUDIENCE_CELL_MIN = 112.dp
+private val AUDIENCE_CELL_MIN = 96.dp
 private val AUDIENCE_AVATAR = 100.dp
 private val GRID_SPACING = 6.dp
 private val AVATAR_RING_WIDTH = 3.dp
+
+// Cell min sits 4.dp under the avatar diameter so 4 columns fit on a
+// 411.dp phone (Pixel 6/7/8). The 100.dp avatar overflows ~2.dp into
+// the 6.dp horizontal arrangement on each side, leaving a visible
+// ~2.dp gap between neighbors. Names below ellipsize to the cell
+// width, which is fine since they're short display handles.
 
 // Two rows visible by default. Each cell is roughly avatar + name +
 // reaction headroom; with a 100dp avatar one row lifts to ~140dp, so

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/stage/SpeakerReactionOverlay.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/stage/SpeakerReactionOverlay.kt
@@ -20,6 +20,11 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.nests.room.stage
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
@@ -46,18 +51,24 @@ internal fun SpeakerReactionOverlay(
     reactions: List<RoomReaction>,
     modifier: Modifier = Modifier,
 ) {
-    if (reactions.isEmpty()) return
-    // Group by content so duplicate emojis collapse into a single
-    // "🔥 ×N" chip. Order by most recent so a fresh reaction lands
-    // at the front of the row.
-    val byContent = reactions.groupBy { it.content }
-    val ordered = byContent.toList().sortedByDescending { (_, list) -> list.maxOf { it.createdAtSec } }
-    Row(
+    // Wrap the row in AnimatedVisibility so the burst scales-and-fades
+    // in instead of snapping; a fading-out tail also smooths the
+    // 30 s eviction sweep instead of having chips just disappear.
+    AnimatedVisibility(
+        visible = reactions.isNotEmpty(),
+        enter = fadeIn() + scaleIn(initialScale = 0.6f),
+        exit = fadeOut() + scaleOut(targetScale = 0.6f),
         modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {
-        ordered.forEach { (content, list) ->
-            ReactionChip(content = content, count = list.size)
+        // Group by content so duplicate emojis collapse into a single
+        // "🔥 ×N" chip. Order by most recent so a fresh reaction lands
+        // at the front of the row.
+        val byContent = reactions.groupBy { it.content }
+        val ordered = byContent.toList().sortedByDescending { (_, list) -> list.maxOf { it.createdAtSec } }
+        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+            ordered.forEach { (content, list) ->
+                ReactionChip(content = content, count = list.size)
+            }
         }
     }
 }
@@ -67,14 +78,19 @@ private fun ReactionChip(
     content: String,
     count: Int,
 ) {
+    // Tonal Surface picks up the right elevation tint in both light
+    // and dark themes — softer than the flat secondaryContainer fill
+    // and keeps a tiny shadow so the chip reads as floating.
     Surface(
         shape = MaterialTheme.shapes.small,
-        color = MaterialTheme.colorScheme.secondaryContainer,
+        tonalElevation = 2.dp,
+        shadowElevation = 1.dp,
     ) {
         val label = if (count > 1) "$content ×$count" else content
         Text(
             text = label,
             style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
         )
     }

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -532,6 +532,11 @@
     <string name="nest_notification_stop">Stop</string>
     <string name="nest_join">Join nest</string>
     <string name="nest_lobby_host_label">Host</string>
+    <string name="nest_role_host">Host</string>
+    <string name="nest_role_moderator">Moderator</string>
+    <string name="nest_state_muted">Microphone muted</string>
+    <string name="nest_state_speaking">Speaking now</string>
+    <string name="nest_state_mic_open">Microphone open</string>
     <string name="nest_presence_raised_hand">raised their hand</string>
     <string name="nest_presence_on_stage">stepped on stage</string>
     <string name="nest_presence_speaking">is speaking</string>

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -492,6 +492,7 @@
     <string name="meeting_room_in_space">In %1$s</string>
     <string name="meeting_room_in_space_unknown">a Nest</string>
     <string name="nest_stage">Stage</string>
+    <string name="nest_stage_empty">Waiting for speakers…</string>
     <string name="nest_audience">Audience</string>
     <string name="nest_raise_hand">Raise hand</string>
     <string name="nest_lower_hand">Lower hand</string>
@@ -569,8 +570,12 @@
     <string name="nest_hand_raise_queue_title">Raised hands</string>
     <string name="nest_hand_raise_approve">Approve</string>
     <string name="nest_promote_speaker">Promote to speaker</string>
+    <string name="nest_promote_moderator">Promote to moderator</string>
     <string name="nest_demote_listener">Demote to listener</string>
+    <string name="nest_force_mute">Force-mute speaker</string>
     <string name="nest_kick_action">Kick</string>
+    <string name="nest_hush_local">Hush this speaker</string>
+    <string name="nest_hush_local_restore">Restore this speaker</string>
     <string name="nest_participant_view_profile">View profile</string>
     <string name="nest_participant_zap">Send zap</string>
     <string name="nest_participant_zap_split_unsupported">Split zaps are not supported from inside a nest. Open the profile screen to send.</string>

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/NestViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/NestViewModel.kt
@@ -656,7 +656,6 @@ class NestViewModel(
                     listener = l
                     observeListenerState(l)
                     observeAnnounces(l)
-                    startLevelEmitter()
                 } catch (ce: CancellationException) {
                     throw ce
                 } catch (t: Throwable) {
@@ -949,9 +948,9 @@ class NestViewModel(
     /**
      * Record the latest decoded peak amplitude for [pubkey]. Called
      * from the [NestPlayer] decode loop on the same dispatcher as the
-     * VM, so plain map mutation is safe. The actual StateFlow emission
-     * is coalesced by [startLevelEmitter] so a 50 Hz packet rate
-     * doesn't translate into 50 Hz recompositions.
+     * VM, so plain map mutation is safe. Boots the coalescing emitter
+     * on first activity; the emitter shuts itself down once all audio
+     * has gone quiet, so a long-idle room costs no scheduled work.
      */
     private fun onAudioLevel(
         pubkey: String,
@@ -959,6 +958,7 @@ class NestViewModel(
     ) {
         if (closed) return
         rawAudioLevels[pubkey] = level
+        startLevelEmitter()
     }
 
     /**
@@ -966,6 +966,11 @@ class NestViewModel(
      * per-speaker levels. Coalesces the high-frequency raw updates
      * into ~10 Hz UI state so the speaking-ring animation has a
      * smooth, lightweight signal to follow.
+     *
+     * Self-terminating: once a tick observes an empty raw map (and
+     * has flushed the empty snapshot to consumers) the loop exits.
+     * The next [onAudioLevel] restarts it. Idempotent — calling
+     * this while already active is a no-op.
      */
     private fun startLevelEmitter() {
         if (levelEmitterJob?.isActive == true) return
@@ -978,6 +983,7 @@ class NestViewModel(
                     if (snapshot != _audioLevels.value) {
                         _audioLevels.value = snapshot
                     }
+                    if (snapshot.isEmpty()) return@launch
                 }
             }
     }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/NestViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/NestViewModel.kt
@@ -231,6 +231,21 @@ class NestViewModel(
         disconnect()
     }
 
+    /**
+     * Honor an inbound kind-4312 force-mute targeted at the local
+     * user. No-ops when we aren't broadcasting; otherwise routes
+     * through the existing [setMicMuted] path so the wire mute and
+     * UI state both flip in sync. Caller (the AdminCommandsCollector)
+     * is responsible for verifying the signer is host/moderator on
+     * the active kind-30312 — the relay does not enforce that.
+     */
+    fun onForceMuted() {
+        if (closed) return
+        if (broadcastHandle == null) return
+        if ((_uiState.value.broadcast as? BroadcastUiState.Broadcasting)?.isMuted == true) return
+        setMicMuted(true)
+    }
+
     private var listener: NestsListener? = null
     private var connectJob: Job? = null
     private var stateObserverJob: Job? = null
@@ -305,6 +320,31 @@ class NestViewModel(
         if (closed) return
         _uiState.update { it.copy(isMuted = muted) }
         activeSubscriptions.values.forEach { it.player?.setMutedSafe(muted) }
+    }
+
+    /**
+     * Locally silence (hush) one speaker without affecting the rest of
+     * the room. Independent of [setMuted] (room-wide). The hush is
+     * applied via [AudioPlayer.setVolume] so the network + decode
+     * pipeline keeps running — re-enabling is sample-accurate.
+     *
+     * The set survives subscription churn: re-subscribing to a hushed
+     * speaker re-applies the gain on the new player at attach time.
+     */
+    fun setLocalHushed(
+        pubkey: String,
+        hushed: Boolean,
+    ) {
+        if (closed) return
+        val updated =
+            _uiState.value.locallyHushed.let {
+                if (hushed) it + pubkey else it - pubkey
+            }
+        if (updated == _uiState.value.locallyHushed) return
+        _uiState.update { it.copy(locallyHushed = updated.toPersistentSet()) }
+        activeSubscriptions[pubkey]?.player?.runCatching {
+            setVolume(if (hushed) 0f else 1f)
+        }
     }
 
     /**
@@ -787,10 +827,14 @@ class NestViewModel(
                 }
             try {
                 val isMuted = _uiState.value.isMuted
+                val isHushed = pubkey in _uiState.value.locallyHushed
                 val roomPlayer = NestPlayer(decoder, player, viewModelScope)
-                // Apply current mute state before play() opens the device so the
-                // first frame respects it.
+                // Apply current mute + per-speaker hush state before play()
+                // opens the device so the first frame respects them.
                 player.setMutedSafe(isMuted)
+                if (isHushed) {
+                    runCatching { player.setVolume(0f) }
+                }
                 // Tap the object flow to drive the speaking-now indicator before
                 // the decoder consumes it.
                 val instrumented = handle.objects.onEach { onSpeakerActivity(pubkey) }
@@ -1114,6 +1158,14 @@ data class NestUiState(
      * `["onstage", "0|1"]` tag on emitted kind-10312 presence events.
      */
     val onStageNow: Boolean = true,
+    /**
+     * Pubkeys the local user has chosen to silence in their own
+     * playback ("hush"). Independent of [isMuted]. Persists across
+     * subscription churn so re-subscribing to a hushed speaker stays
+     * silent. Drives a "Hush this speaker locally" toggle in the
+     * participant context sheet.
+     */
+    val locallyHushed: ImmutableSet<String> = persistentSetOf(),
 ) {
     /**
      * Derived: are we currently pushing audio packets to the relay?

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/NestViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/NestViewModel.kt
@@ -190,6 +190,24 @@ class NestViewModel(
     val announcedSpeakers: StateFlow<Set<String>> = _announcedSpeakers.asStateFlow()
 
     /**
+     * Per-speaker peak audio amplitude for the most recent decoded
+     * frame, normalized to `[0, 1]`. Drives the live "voice ring"
+     * around speaker avatars: while a pubkey is in [NestUiState.speakingNow],
+     * the UI reads this map to throb the green border in time with
+     * the voice.
+     *
+     * Updated by [NestPlayer]'s `onLevel` callback at ~50 Hz per speaker
+     * (one frame per 20 ms Opus packet); the VM coalesces those raw
+     * updates into a single StateFlow emission every [LEVEL_TICK_MS]
+     * via [levelEmitterJob]. Empty when no speaker is being decoded;
+     * an entry drops when its subscription closes.
+     */
+    private val rawAudioLevels = mutableMapOf<String, Float>()
+    private val _audioLevels = MutableStateFlow<Map<String, Float>>(emptyMap())
+    val audioLevels: StateFlow<Map<String, Float>> = _audioLevels.asStateFlow()
+    private var levelEmitterJob: Job? = null
+
+    /**
      * `true` once the local user has been kicked (#5) — the platform
      * layer flips this on a valid kind-4312 from a host/moderator and
      * the UI can show a toast + finish the activity. Set-once; never
@@ -638,6 +656,7 @@ class NestViewModel(
                     listener = l
                     observeListenerState(l)
                     observeAnnounces(l)
+                    startLevelEmitter()
                 } catch (ce: CancellationException) {
                     throw ce
                 } catch (t: Throwable) {
@@ -694,6 +713,9 @@ class NestViewModel(
         }
         if (_speakerCatalogs.value.containsKey(slot.pubkey)) {
             _speakerCatalogs.update { it - slot.pubkey }
+        }
+        if (rawAudioLevels.remove(slot.pubkey) != null) {
+            _audioLevels.value = rawAudioLevels.toMap()
         }
         if (roomPlayer != null || handle != null) {
             viewModelScope.launch {
@@ -773,7 +795,11 @@ class NestViewModel(
                 // Tap the object flow to drive the speaking-now indicator before
                 // the decoder consumes it.
                 val instrumented = handle.objects.onEach { onSpeakerActivity(pubkey) }
-                roomPlayer.play(instrumented, onError = { /* swallow per-packet decoder errors */ })
+                roomPlayer.play(
+                    instrumented,
+                    onError = { /* swallow per-packet decoder errors */ },
+                    onLevel = { onAudioLevel(pubkey, it) },
+                )
                 slot.attach(handle, roomPlayer, player)
                 publishActiveSpeakers()
                 // Enter the buffering window — UI renders a spinner
@@ -817,6 +843,12 @@ class NestViewModel(
         stateObserverJob = null
         announcesJob?.cancel()
         announcesJob = null
+        levelEmitterJob?.cancel()
+        levelEmitterJob = null
+        rawAudioLevels.clear()
+        if (_audioLevels.value.isNotEmpty()) {
+            _audioLevels.value = emptyMap()
+        }
         if (_announcedSpeakers.value.isNotEmpty()) {
             _announcedSpeakers.value = emptySet()
         }
@@ -906,6 +938,48 @@ class NestViewModel(
         if (_uiState.value.speakingNow.contains(pubkey)) {
             _uiState.update { it.copy(speakingNow = (it.speakingNow - pubkey).toPersistentSet()) }
         }
+        // Drop the latest level too — when the speaker goes quiet the
+        // ring should fall back to the static "in speakingNow" colour
+        // rather than freezing at the last loud peak.
+        if (rawAudioLevels.remove(pubkey) != null) {
+            _audioLevels.value = rawAudioLevels.toMap()
+        }
+    }
+
+    /**
+     * Record the latest decoded peak amplitude for [pubkey]. Called
+     * from the [NestPlayer] decode loop on the same dispatcher as the
+     * VM, so plain map mutation is safe. The actual StateFlow emission
+     * is coalesced by [startLevelEmitter] so a 50 Hz packet rate
+     * doesn't translate into 50 Hz recompositions.
+     */
+    private fun onAudioLevel(
+        pubkey: String,
+        level: Float,
+    ) {
+        if (closed) return
+        rawAudioLevels[pubkey] = level
+    }
+
+    /**
+     * Tick every [LEVEL_TICK_MS] and publish the current map of
+     * per-speaker levels. Coalesces the high-frequency raw updates
+     * into ~10 Hz UI state so the speaking-ring animation has a
+     * smooth, lightweight signal to follow.
+     */
+    private fun startLevelEmitter() {
+        if (levelEmitterJob?.isActive == true) return
+        levelEmitterJob =
+            viewModelScope.launch {
+                while (true) {
+                    delay(LEVEL_TICK_MS)
+                    if (closed) return@launch
+                    val snapshot = if (rawAudioLevels.isEmpty()) emptyMap() else rawAudioLevels.toMap()
+                    if (snapshot != _audioLevels.value) {
+                        _audioLevels.value = snapshot
+                    }
+                }
+            }
     }
 
     private class ActiveSubscription private constructor(
@@ -1073,6 +1147,16 @@ sealed class BroadcastUiState {
  * indicator flicker.
  */
 const val SPEAKING_TIMEOUT_MS: Long = 250L
+
+/**
+ * Coalescing interval for [NestViewModel.audioLevels]. The decode loop
+ * pushes a fresh peak every ~20 ms (one per Opus frame); we publish to
+ * the StateFlow at this cadence instead so the UI ring animates ~10 Hz
+ * instead of recomposing every frame. 100 ms is fast enough that the
+ * eye still reads the throb as live, slow enough that the cost across
+ * a busy stage stays trivial.
+ */
+const val LEVEL_TICK_MS: Long = 100L
 
 /**
  * How long a kind-7 reaction stays in

--- a/nestsClient/specs/EGG-07.md
+++ b/nestsClient/specs/EGG-07.md
@@ -170,3 +170,13 @@ moderation without speaking to the relay.
 
 Future EGGs MAY introduce additional `action` values (e.g. `"mute"`,
 `"warn"`). Implementers MUST treat unknown actions as no-ops.
+
+### Implemented extensions
+
+Amethyst additionally emits and honours `["action", "mute"]` as a
+host-issued *force-mute*: the targeted speaker's client flips its own
+mic-mute (the `["muted", "1"]` flag on its next kind:10312 heartbeat)
+and stops broadcasting audio. nostrnests' web client does not yet
+emit or recognise this verb, so cross-client force-mutes only land
+when both sides run a client that implements it. Authority gates,
+freshness window, and replay rules are identical to `kick`.

--- a/nestsClient/src/androidMain/kotlin/com/vitorpamplona/nestsclient/audio/AudioTrackPlayer.kt
+++ b/nestsClient/src/androidMain/kotlin/com/vitorpamplona/nestsclient/audio/AudioTrackPlayer.kt
@@ -42,6 +42,7 @@ class AudioTrackPlayer(
 ) : AudioPlayer {
     private var track: AudioTrack? = null
     private var muted: Boolean = false
+    private var volume: Float = 1f
 
     override fun start() {
         if (track != null) return
@@ -105,7 +106,7 @@ class AudioTrackPlayer(
                 t,
             )
         }
-        applyMuteVolume(newTrack, muted)
+        applyMuteVolume(newTrack)
         track = newTrack
     }
 
@@ -126,7 +127,12 @@ class AudioTrackPlayer(
 
     override fun setMuted(muted: Boolean) {
         this.muted = muted
-        track?.let { applyMuteVolume(it, muted) }
+        track?.let { applyMuteVolume(it) }
+    }
+
+    override fun setVolume(volume: Float) {
+        this.volume = volume.coerceIn(0f, 1f)
+        track?.let { applyMuteVolume(it) }
     }
 
     override fun stop() {
@@ -141,13 +147,14 @@ class AudioTrackPlayer(
     @Suppress("unused")
     val voiceCallUsage: Int get() = AudioManager.STREAM_VOICE_CALL // kept for documentation
 
-    private fun applyMuteVolume(
-        track: AudioTrack,
-        muted: Boolean,
-    ) {
+    private fun applyMuteVolume(track: AudioTrack) {
         // setVolume is preferred over pause(): it keeps the streaming pipeline
         // running so unmute is sample-accurate and there's no AudioTrack-restart
         // glitch. AudioTrack default gain is 1.0 (RFC: AudioTrack#setVolume).
-        runCatching { track.setVolume(if (muted) 0f else 1f) }
+        // Mute and per-stream volume compose multiplicatively — a muted stream
+        // is silent regardless of volume, and a stream at volume 0 is silent
+        // regardless of mute.
+        val gain = if (muted) 0f else volume
+        runCatching { track.setVolume(gain) }
     }
 }

--- a/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/audio/Audio.kt
+++ b/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/audio/Audio.kt
@@ -121,6 +121,21 @@ interface AudioPlayer {
      */
     fun setMuted(muted: Boolean)
 
+    /**
+     * Per-stream output gain, range `[0.0, 1.0]`. 1.0 is the device
+     * default; 0.0 silences this stream while leaving any other
+     * concurrent players untouched. Used to "hush" one speaker
+     * locally without affecting the rest of the room.
+     *
+     * Independent of [setMuted]: muted streams are silent regardless of
+     * gain, and an unmuted stream at gain 0 is still silent. The two
+     * controls compose multiplicatively. Default gain is 1.0.
+     *
+     * Default implementation is a no-op so existing fakes / capture-only
+     * actuals don't have to grow a method they'll never use.
+     */
+    fun setVolume(volume: Float) {}
+
     /** Stop playback and release resources. After this, the player is unusable. */
     fun stop()
 }

--- a/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/audio/NestPlayer.kt
+++ b/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/audio/NestPlayer.kt
@@ -56,10 +56,19 @@ class NestPlayer(
      *
      * Decoder errors are reported via [onError] but do NOT stop the loop —
      * one bad packet shouldn't tear down the room. Player errors are fatal.
+     *
+     * [onLevel] receives the peak amplitude of each successfully decoded
+     * frame, normalized to `[0, 1]`. Default no-op so callers that don't
+     * care about levels (tests, audio-only consumers) pay zero cost.
+     * Invoked on the same dispatcher as the decode loop — typically
+     * `viewModelScope`'s Main, so the consumer must keep its handler
+     * lightweight (e.g. a HashMap put followed by a coalesced StateFlow
+     * emission).
      */
     fun play(
         objects: Flow<MoqObject>,
         onError: (AudioException) -> Unit = { /* swallow */ },
+        onLevel: (Float) -> Unit = { /* no-op */ },
     ) {
         check(!stopped) { "NestPlayer already stopped" }
         check(job == null) { "NestPlayer.play already called" }
@@ -85,6 +94,7 @@ class NestPlayer(
                                 return@collect
                             }
                         if (pcm.isNotEmpty()) {
+                            onLevel(peakAmplitude(pcm))
                             player.enqueue(pcm)
                         }
                     }
@@ -100,6 +110,20 @@ class NestPlayer(
                     )
                 }
             }
+    }
+
+    /**
+     * Peak amplitude of a 16-bit PCM frame, normalized to `[0, 1]`. Peak
+     * (vs RMS) is jittery on its own but responds instantly to onsets,
+     * which suits a visual ring that the UI smooths via animateDpAsState.
+     */
+    private fun peakAmplitude(pcm: ShortArray): Float {
+        var maxAbs = 0
+        for (s in pcm) {
+            val abs = if (s.toInt() < 0) -s.toInt() else s.toInt()
+            if (abs > maxAbs) maxAbs = abs
+        }
+        return (maxAbs / 32768f).coerceIn(0f, 1f)
     }
 
     /**

--- a/nestsClient/src/commonTest/kotlin/com/vitorpamplona/nestsclient/audio/NestPlayerTest.kt
+++ b/nestsClient/src/commonTest/kotlin/com/vitorpamplona/nestsclient/audio/NestPlayerTest.kt
@@ -151,6 +151,50 @@ class NestPlayerTest {
         }
 
     @Test
+    fun on_level_reports_normalized_peak_per_decoded_frame() =
+        runTest {
+            // Decode each input byte to a single 16-bit sample with a
+            // known peak so we can assert the level math directly.
+            // 0x01 -> 1/32768 (~0), 0x40 -> 0x4000 (0.5), 0x7F -> 0x7FFF (max).
+            val decoder = FakeOpusDecoder { bytes -> ShortArray(1) { (bytes[0].toInt() shl 8).toShort() } }
+            val player = FakeAudioPlayer()
+            val levels = mutableListOf<Float>()
+
+            val sut = NestPlayer(decoder, player, this)
+            sut.play(
+                objects =
+                    flowOf(
+                        moqObject(byteArrayOf(0x40)),
+                        moqObject(byteArrayOf(0x7F)),
+                    ),
+                onLevel = { levels.add(it) },
+            )
+            testScheduler.advanceUntilIdle()
+
+            assertEquals(2, levels.size)
+            // 0x40 << 8 = 0x4000 = 16384 → 16384/32768 = 0.5
+            assertTrue(levels[0] in 0.49f..0.51f, "expected ~0.5, got ${levels[0]}")
+            // 0x7F << 8 = 0x7F00 → 0x7F00/32768 ≈ 0.992
+            assertTrue(levels[1] > 0.98f, "expected near-max, got ${levels[1]}")
+            sut.stop()
+        }
+
+    @Test
+    fun on_level_is_skipped_when_decoder_returns_empty_pcm() =
+        runTest {
+            val decoder = FakeOpusDecoder { ShortArray(0) }
+            val levels = mutableListOf<Float>()
+            val sut = NestPlayer(decoder, FakeAudioPlayer(), this)
+            sut.play(
+                objects = flowOf(moqObject(byteArrayOf(0x01))),
+                onLevel = { levels.add(it) },
+            )
+            testScheduler.advanceUntilIdle()
+            assertEquals(0, levels.size)
+            sut.stop()
+        }
+
+    @Test
     fun objects_arriving_after_play_are_streamed_through_the_pipeline() =
         runTest {
             val channel = Channel<MoqObject>(capacity = 8)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/nests/admin/AdminCommandEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/nests/admin/AdminCommandEvent.kt
@@ -71,6 +71,16 @@ class AdminCommandEvent(
         val code: String,
     ) {
         KICK("kick"),
+
+        /**
+         * Force the target speaker's mic to muted. Honor-based: the
+         * target's client receives the command and flips its own
+         * presence-side mic-mute. A non-cooperating client could
+         * ignore the event and keep broadcasting — same trust model
+         * as KICK, which a misbehaving client could also ignore by
+         * not disconnecting.
+         */
+        MUTE("mute"),
         ;
 
         companion object {
@@ -92,6 +102,19 @@ class AdminCommandEvent(
             target: HexKey,
             createdAt: Long = TimeUtils.now(),
         ) = eventTemplate<AdminCommandEvent>(KIND, Action.KICK.code, createdAt) {
+            aTag(room)
+            add(PTag(target).toTagArray())
+        }
+
+        /**
+         * Build a force-mute command. Same envelope as [kick] —
+         * tagged for [room] + [target], action verb in content.
+         */
+        fun forceMute(
+            room: ATag,
+            target: HexKey,
+            createdAt: Long = TimeUtils.now(),
+        ) = eventTemplate<AdminCommandEvent>(KIND, Action.MUTE.code, createdAt) {
             aTag(room)
             add(PTag(target).toTagArray())
         }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/nests/admin/AdminCommandEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/nests/admin/AdminCommandEvent.kt
@@ -36,13 +36,15 @@ import com.vitorpamplona.quartz.utils.TimeUtils
  *
  * Recipients filter on `kinds=[4312], #a=[room], #p=[me]` and only
  * honour commands whose signer is a participant marked HOST or
- * MODERATOR on the active kind-30312 — relays don't enforce this,
+ * "admin" on the active kind-30312 — relays don't enforce this,
  * the client must.
  *
- * The tag layout matches the action / role-mutation events
- * nostrnests emits today; the action keyword goes in `content`
- * rather than as a separate tag so we can extend it with new
- * verbs without re-versioning the spec.
+ * Wire format matches the nostrnests reference (`useAdminCommands.ts`)
+ * and EGG-07: the verb lives in an `["action", "kick"]` tag with
+ * empty `content`. An older Amethyst build briefly emitted the verb
+ * in `content` instead — the reader still accepts that format so
+ * any in-flight events deploy cleanly, but emission only writes the
+ * tag form.
  */
 @Immutable
 class AdminCommandEvent(
@@ -60,12 +62,16 @@ class AdminCommandEvent(
     fun targetPubkey(): HexKey? = tags.firstOrNull { it.firstOrNull() == "p" }?.getOrNull(1)
 
     /**
-     * The verb (e.g. "kick"). Returned uppercase so callers can
-     * `when (event.action()) { Action.KICK -> ... }` cleanly; the
-     * raw content is preserved on the event so a future verb can
-     * be inspected as a string.
+     * The verb (e.g. "kick"). Reads the spec-correct
+     * `["action", <verb>]` tag first; falls back to `content` for
+     * compatibility with the legacy Amethyst layout.
      */
-    fun action(): Action? = Action.fromCode(content)
+    fun action(): Action? {
+        val tagAction = tags.firstOrNull { it.firstOrNull() == ACTION_TAG }?.getOrNull(1)
+        if (tagAction != null) return Action.fromCode(tagAction)
+        if (content.isNotBlank()) return Action.fromCode(content)
+        return null
+    }
 
     enum class Action(
         val code: String,
@@ -91,32 +97,41 @@ class AdminCommandEvent(
     companion object {
         const val KIND = 4312
         const val ALT = "Audio room admin command"
+        const val ACTION_TAG = "action"
 
         /**
          * Build a kick command tagged for [room] and [target]. The
-         * content carries the verb so the same kind can grow new
-         * actions (mute, ban, …) without a wire schema bump.
+         * verb travels in the `["action", "kick"]` tag (matching
+         * nostrnests / EGG-07) with empty `content`, so future
+         * actions (mute, …) extend the same envelope without a
+         * wire schema bump.
          */
         fun kick(
             room: ATag,
             target: HexKey,
             createdAt: Long = TimeUtils.now(),
-        ) = eventTemplate<AdminCommandEvent>(KIND, Action.KICK.code, createdAt) {
-            aTag(room)
-            add(PTag(target).toTagArray())
-        }
+        ) = build(room, target, Action.KICK, createdAt)
 
         /**
-         * Build a force-mute command. Same envelope as [kick] —
-         * tagged for [room] + [target], action verb in content.
+         * Build a force-mute command. Amethyst extension — nostrnests
+         * doesn't emit or honor this verb today, so it's effectively
+         * a no-op when reaching a nostrnests listener.
          */
         fun forceMute(
             room: ATag,
             target: HexKey,
             createdAt: Long = TimeUtils.now(),
-        ) = eventTemplate<AdminCommandEvent>(KIND, Action.MUTE.code, createdAt) {
+        ) = build(room, target, Action.MUTE, createdAt)
+
+        private fun build(
+            room: ATag,
+            target: HexKey,
+            action: Action,
+            createdAt: Long,
+        ) = eventTemplate<AdminCommandEvent>(KIND, "", createdAt) {
             aTag(room)
             add(PTag(target).toTagArray())
+            add(arrayOf(ACTION_TAG, action.code))
         }
     }
 }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip53LiveActivities/streaming/tags/ParticipantTag.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip53LiveActivities/streaming/tags/ParticipantTag.kt
@@ -33,11 +33,24 @@ import com.vitorpamplona.quartz.utils.ensure
 
 enum class ROLE(
     val code: String,
+    /**
+     * Aliases recognised on inbound parse but never emitted. Used to
+     * keep reading kind-30312 events written by older Amethyst builds
+     * (which used `"moderator"` before we matched the nostrnests /
+     * EGG-07 `"admin"` wire string).
+     */
+    val legacyCodes: List<String> = emptyList(),
 ) {
     HOST("host"),
-    MODERATOR("moderator"),
+    MODERATOR("admin", legacyCodes = listOf("moderator")),
     SPEAKER("speaker"),
     PARTICIPANT("participant"),
+    ;
+
+    /** Whether [code] (case-insensitive) matches this role's primary or legacy spellings. */
+    fun matches(code: String): Boolean =
+        this.code.equals(code, ignoreCase = true) ||
+            legacyCodes.any { it.equals(code, ignoreCase = true) }
 }
 
 @Immutable
@@ -47,8 +60,8 @@ data class ParticipantTag(
     val role: String?,
     val proof: String?,
 ) : PubKeyReferenceTag {
-    /** Match the role string against [ROLE], case-insensitive. */
-    fun effectiveRole(): ROLE? = role?.let { r -> ROLE.entries.firstOrNull { it.code.equals(r, ignoreCase = true) } }
+    /** Match the role string against [ROLE], case-insensitive — primary code or legacy alias. */
+    fun effectiveRole(): ROLE? = role?.let { r -> ROLE.entries.firstOrNull { it.matches(r) } }
 
     fun isHost(): Boolean = effectiveRole() == ROLE.HOST
 

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/experimental/nests/admin/AdminCommandEventTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/experimental/nests/admin/AdminCommandEventTest.kt
@@ -32,16 +32,30 @@ class AdminCommandEventTest {
     private val roomATag = ATag(kind = 30312, pubKeyHex = host, dTag = "rt-1", relay = null)
 
     @Test
-    fun kickTemplateCarriesActionContentAddressAndTarget() {
+    fun kickTemplateUsesActionTagWithEmptyContent() {
+        // Spec / nostrnests wire format: ["action", "kick"] tag,
+        // empty content. An older Amethyst layout put the verb in
+        // content; the reader still accepts that for compat but
+        // emission is tag-only.
         val template = AdminCommandEvent.kick(roomATag, target, createdAt = 100L)
         assertEquals(AdminCommandEvent.KIND, template.kind)
-        assertEquals(AdminCommandEvent.Action.KICK.code, template.content)
+        assertEquals("", template.content)
+        val actionTag = template.tags.firstOrNull { it.firstOrNull() == AdminCommandEvent.ACTION_TAG }
+        assertEquals(AdminCommandEvent.Action.KICK.code, actionTag?.getOrNull(1))
         // Single `a` tag pointing at the room.
         val aTag = template.tags.firstOrNull { it.firstOrNull() == "a" }
         assertEquals(roomATag.toTag(), aTag?.getOrNull(1))
         // Single `p` tag pointing at the kicked user.
         val pTag = template.tags.firstOrNull { it.firstOrNull() == "p" }
         assertEquals(target, pTag?.getOrNull(1))
+    }
+
+    @Test
+    fun forceMuteTemplateUsesActionTag() {
+        val template = AdminCommandEvent.forceMute(roomATag, target, createdAt = 100L)
+        assertEquals("", template.content)
+        val actionTag = template.tags.firstOrNull { it.firstOrNull() == AdminCommandEvent.ACTION_TAG }
+        assertEquals(AdminCommandEvent.Action.MUTE.code, actionTag?.getOrNull(1))
     }
 
     @Test
@@ -62,14 +76,48 @@ class AdminCommandEventTest {
     }
 
     @Test
-    fun unknownActionReturnsNull() {
+    fun legacyContentVerbStillParsedForBackwardsCompat() {
+        // An Amethyst build briefly emitted the verb in content. After
+        // we switched to the tag form (matching nostrnests / EGG-07)
+        // the reader still accepts the old layout so any in-flight
+        // event during the rollout window is honored.
         val event =
             AdminCommandEvent(
                 id = "0".repeat(64),
                 pubKey = host,
                 createdAt = 100L,
                 tags = arrayOf(arrayOf("a", "30312:host:rt"), arrayOf("p", target)),
-                content = "haunt",
+                content = "kick",
+                sig = "0".repeat(128),
+            )
+        assertEquals(AdminCommandEvent.Action.KICK, event.action())
+    }
+
+    @Test
+    fun actionTagWinsOverContentWhenBothPresent() {
+        // Defensive: if both forms are present (e.g. mixed-source
+        // event), the tag — the spec-correct location — is preferred.
+        val event =
+            AdminCommandEvent(
+                id = "0".repeat(64),
+                pubKey = host,
+                createdAt = 100L,
+                tags = arrayOf(arrayOf("a", "30312:host:rt"), arrayOf("p", target), arrayOf("action", "mute")),
+                content = "kick",
+                sig = "0".repeat(128),
+            )
+        assertEquals(AdminCommandEvent.Action.MUTE, event.action())
+    }
+
+    @Test
+    fun unknownActionReturnsNull() {
+        val event =
+            AdminCommandEvent(
+                id = "0".repeat(64),
+                pubKey = host,
+                createdAt = 100L,
+                tags = arrayOf(arrayOf("a", "30312:host:rt"), arrayOf("p", target), arrayOf("action", "haunt")),
+                content = "",
                 sig = "0".repeat(128),
             )
         assertNull(event.action())

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip53LiveActivities/streaming/tags/ParticipantTagTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip53LiveActivities/streaming/tags/ParticipantTagTest.kt
@@ -70,4 +70,25 @@ class ParticipantTagTest {
         assertEquals(ROLE.SPEAKER, tag("speaker").effectiveRole())
         assertEquals(ROLE.PARTICIPANT, tag("participant").effectiveRole())
     }
+
+    @Test
+    fun nostrnestsAdminRoleIsAcceptedAsModerator() {
+        // nostrnests' useAdminCommands.ts emits role="admin" on the
+        // p-tag; we must recognise it for promote/demote/kick interop.
+        assertEquals(ROLE.MODERATOR, tag("admin").effectiveRole())
+        assertTrue(tag("admin").isModerator())
+        assertTrue(tag("admin").canSpeak())
+        // Case-insensitive too, like everything else.
+        assertEquals(ROLE.MODERATOR, tag("Admin").effectiveRole())
+        assertEquals(ROLE.MODERATOR, tag("ADMIN").effectiveRole())
+    }
+
+    @Test
+    fun moderatorCodeEmitsAdminWireString() {
+        // After matching nostrnests / EGG-07 the wire string is "admin";
+        // any code that builds a kind-30312 p-tag from ROLE.MODERATOR.code
+        // must produce "admin", not the legacy "moderator".
+        assertEquals("admin", ROLE.MODERATOR.code)
+        assertEquals(listOf("moderator"), ROLE.MODERATOR.legacyCodes)
+    }
 }


### PR DESCRIPTION
100dp avatars across stage and audience tabs, names centered under each
cell, and the avatar border now distinguishes actively speaking (green)
from publishing-but-muted (red) at a glance — the existing mic-pill
keeps its semantics underneath.

UsernameDisplay gains an optional textAlign so the grid can opt in to
centered labels without disturbing other call sites.