### PR TITLE
Fix window insets handling in NestActionBar

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/screen/NestActionBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/screen/NestActionBar.kt
@@ -29,11 +29,14 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.BottomAppBarDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.FilledTonalIconButton
@@ -91,13 +94,20 @@ internal fun NestActionBar(
     onShowReactionPicker: () -> Unit,
     onLeave: () -> Unit,
 ) {
+    val insets = BottomAppBarDefaults.windowInsets
     Surface(
         modifier = Modifier.fillMaxWidth(),
         color = MaterialTheme.colorScheme.surface.copy(alpha = 0.96f),
         contentColor = MaterialTheme.colorScheme.onSurface,
         tonalElevation = 3.dp,
     ) {
-        Column(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .windowInsetsPadding(insets)
+                    .consumeWindowInsets(insets),
+        ) {
             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f))
             ActionBarStatusStrip(ui = ui)
             Row(


### PR DESCRIPTION
## Summary
Updated the NestActionBar composable to properly handle window insets, ensuring the action bar respects system UI insets (such as navigation bars) on Android devices.

## Key Changes
- Added imports for `consumeWindowInsets` and `windowInsetsPadding` layout modifiers
- Imported `BottomAppBarDefaults` to access standard window insets configuration
- Applied `BottomAppBarDefaults.windowInsets` to the Column modifier using both `windowInsetsPadding()` and `consumeWindowInsets()` to properly account for system UI insets

## Implementation Details
The changes ensure that the NestActionBar respects system window insets (navigation bars, status bars, etc.) by:
- Using `windowInsetsPadding()` to add appropriate padding around the insets
- Using `consumeWindowInsets()` to prevent child composables from also applying the same insets
- Leveraging Material Design 3's `BottomAppBarDefaults.windowInsets` for consistent, standard behavior with other bottom app bar components

https://claude.ai/code/session_01KmrBCpHWxyYphoh1twjCr2