### PR TITLE
Fix IME padding and window insets in NestFullScreen

### DIFF
--- a/amethyst/src/main/AndroidManifest.xml
+++ b/amethyst/src/main/AndroidManifest.xml
@@ -226,6 +226,7 @@
             android:launchMode="singleTask"
             android:exported="false"
             android:resizeableActivity="true"
+            android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.Amethyst" />
 
         <activity

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/screen/NestFullScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/screen/NestFullScreen.kt
@@ -23,8 +23,10 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.nests.room.screen
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
@@ -205,7 +207,9 @@ internal fun NestFullScreen(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .padding(padding),
+                    .padding(padding)
+                    .consumeWindowInsets(padding)
+                    .imePadding(),
         ) {
             if (summaryExpanded) {
                 RoomSummaryStrip(summary = event.summary())


### PR DESCRIPTION
## Summary
Improved handling of soft keyboard (IME) and window insets in the NestFullScreen composable to prevent content overlap when the keyboard is displayed.

## Key Changes
- Added `consumeWindowInsets(padding)` to properly consume padding insets and prevent double-padding
- Added `imePadding()` modifier to automatically adjust layout when the soft keyboard appears
- Added `android:windowSoftInputMode="adjustResize"` to NestFullScreen activity manifest to ensure the activity resizes when the IME is shown

## Implementation Details
These changes ensure that:
1. The composable layout properly accounts for system insets (status bar, navigation bar)
2. Content is automatically shifted up when the soft keyboard appears, preventing it from being hidden behind the IME
3. The window insets are consumed at the appropriate level to avoid conflicting padding calculations

https://claude.ai/code/session_01F4RfyyKsrBRXoUiuQAMHMj