### PR TITLE
fix(quartz): skip schnorr256k1 benchmark when native lib fails to load on Windows

### DIFF
--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/utils/secp256k1/Secp256k1TripleBenchmark.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/utils/secp256k1/Secp256k1TripleBenchmark.kt
@@ -112,14 +112,18 @@ class Secp256k1TripleBenchmark {
         // Verify signature compatibility
         assertTrue(acinqSig.contentEquals(kotlinSig), "ACINQ and Kotlin signatures must match")
 
-        // Probe libschnorr256k1's native lib — skip the C row if the JNI .so
-        // isn't packaged for this platform (e.g. obscure JVM target).
+        // Probe libschnorr256k1's native lib — skip the C row if the JNI lib
+        // isn't packaged for this platform (e.g. obscure JVM target, or
+        // Windows where the loader raises IllegalStateException instead of
+        // UnsatisfiedLinkError).
         var cAvailable = false
         try {
             Schnorr256k1.seckeyVerify(ByteArray(32) { 1 })
             cAvailable = true
         } catch (e: UnsatisfiedLinkError) {
             println("NOTE: libschnorr256k1 native lib not available (${e.message})")
+        } catch (e: Throwable) {
+            println("NOTE: libschnorr256k1 init failed (${e.message})")
         }
 
         val cPubKey = if (cAvailable) Schnorr256k1.pubkeyCompress(Schnorr256k1.pubkeyCreate(privKey)!!)!! else null


### PR DESCRIPTION
The triple benchmark probed libschnorr256k1 with a try/catch that only
handled UnsatisfiedLinkError. On Windows the loader raises
IllegalStateException when the JNI .dll for the platform isn't packaged,
which propagated out as a test failure instead of skipping the C row.

Mirror the broader catch already used in Secp256k1CrossValidationTest so
the benchmark prints a SKIP-style note and continues with the ACINQ +
Kotlin rows on platforms where the C lib isn't available.