### PR TITLE
ci(desktop): retry vlcDownload on transient network failures

### DIFF
--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -1,3 +1,4 @@
+import de.undercouch.gradle.tasks.download.Download
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import java.nio.file.Files
 
@@ -142,6 +143,25 @@ vlcSetup {
 
 tasks.named("spotlessKotlin") {
     mustRunAfter("vlcSetup")
+}
+
+// `ir.mahozad.vlc-setup` registers `vlcDownload` / `upxDownload` tasks that
+// extend `de.undercouch.gradle.tasks.download.Download`. Defaults are 0 retries
+// and a short read timeout, so a transient blip on get.videolan.org fails the
+// whole desktop build on CI (Windows MSI, macOS DMG, Linux DEB). Configure all
+// Download tasks in this project to retry with generous timeouts so flaky
+// network conditions do not break packaging jobs.
+tasks.withType<Download>().configureEach {
+    // 5 attempts total (initial + 4 retries) before failing the task.
+    retries(4)
+    // 30s to establish a TCP / TLS connection.
+    connectTimeout(30_000)
+    // 5 minutes per attempt for the body — VLC archives are 40-90 MB and
+    // get.videolan.org can be slow under load.
+    readTimeout(5 * 60_000)
+    // Stage to a temp file and rename only on full success, so a partial
+    // download from one attempt cannot poison the next.
+    tempAndMove(true)
 }
 
 // --- AppImage packaging (Linux) ---


### PR DESCRIPTION
## Problem

Every desktop packaging job (Windows MSI, macOS DMG, Linux DEB) currently breaks the moment `get.videolan.org` blips. The `ir.mahozad.vlc-setup` plugin registers `vlcDownload` / `upxDownload` tasks that extend `de.undercouch.gradle.tasks.download.Download`, but it does not configure retries or a generous read timeout, so a single `SocketTimeoutException` aborts the whole build.

A quick scan of recent runs on `main` shows the same failure repeating across PRs and pushes:

| Run | Job | Error |
|---|---|---|
| [25100634157](https://github.com/vitorpamplona/amethyst/actions/runs/25100634157) (PR #2642) | windows-latest / packageMsi | `SocketTimeoutException: Read timed out` |
| [25099183941](https://github.com/vitorpamplona/amethyst/actions/runs/25099183941) | windows-latest / packageMsi | timeout fetching `vlc-3.0.21-win64.zip` |
| [25090065483](https://github.com/vitorpamplona/amethyst/actions/runs/25090065483) | macos-latest / packageDmg | timeout fetching `vlc-3.0.21-universal.dmg` |
| [25086826740](https://github.com/vitorpamplona/amethyst/actions/runs/25086826740) | macos-latest / packageDmg | timeout fetching `vlc-3.0.21-universal.dmg` |
| [25085082827](https://github.com/vitorpamplona/amethyst/actions/runs/25085082827) | windows-latest / packageMsi | timeout fetching `vlc-3.0.21-win64.zip` |
| [25080695545](https://github.com/vitorpamplona/amethyst/actions/runs/25080695545) | win + mac + linux | all three legs failed at `vlcDownload` |
| [25076011555](https://github.com/vitorpamplona/amethyst/actions/runs/25076011555) | win + mac + linux | same |

The failure is always the same shape:

```
> Task :desktopApp:vlcDownload FAILED
> A failure occurred while executing ...DefaultWorkAction
   > java.net.SocketTimeoutException: Read timed out
```

## Fix

Configure all `Download` tasks in `:desktopApp` (which the vlc-setup plugin's `vlcDownload` and `upxDownload` both extend) with:

- **5 attempts total** (initial + 4 retries) before failing the task,
- **30 s** connect timeout,
- **5 min** read timeout — VLC archives are 40-90 MB and the mirror can be slow under load,
- `tempAndMove` so a partial download from one attempt cannot poison the next.

This is a CI-only change. It does not alter what gets bundled, only makes the fetch resilient to transient network conditions.

## Verification

- `./gradlew :desktopApp:vlcDownload --rerun --no-daemon` succeeds with the new config.
- `./gradlew :desktopApp:spotlessCheck --no-daemon` is clean.
- Buildscript evaluates without errors (`./gradlew :desktopApp:help` returns normally and `vlcDownload` is still resolvable).
- The full pre-commit `spotlessCheck` ran across the whole repo at commit time.

## Implementation note

`tasks.withType<Download>().configureEach { ... }` reaches the vlc-setup tasks because the plugin's `VlcDownloadTask` (and `UpxDownloadTask`) extend `de.undercouch.gradle.tasks.download.Download` directly \u2014 verified by inspecting the plugin jar (`javap -p`).