### PR TITLE
Add payment targets navigation to settings screen

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AllSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AllSettingsScreen.kt
@@ -181,6 +181,13 @@ fun AllSettingsScreen(
             )
             HorizontalDivider()
             SettingsNavigationRow(
+                title = R.string.payment_targets,
+                icon = MaterialSymbols.Payment,
+                tint = tint,
+                onClick = { nav.nav(Route.EditPaymentTargets) },
+            )
+            HorizontalDivider()
+            SettingsNavigationRow(
                 title = R.string.security_filters,
                 icon = MaterialSymbols.Security,
                 tint = tint,


### PR DESCRIPTION
## Summary
Added a new navigation option to the All Settings screen that allows users to access payment targets configuration.

## Key Changes
- Added a new `SettingsNavigationRow` for "Payment Targets" in the settings menu
- Positioned between "Update Zap Amount" and "Security Filters" options
- Routes to `Route.EditPaymentTargets` when clicked
- Uses the `Payment` Material Symbol icon with consistent styling

## Implementation Details
- The new settings row follows the existing pattern used for other navigation items in the settings screen
- Includes a `HorizontalDivider` for visual separation from adjacent menu items
- Uses the same `tint` color parameter for icon consistency with other settings options

https://claude.ai/code/session_0197gYrSzoV1bRgvnY5EecAo