### PR TITLE
Fix race condition in MoQ subscription registration

### DIFF
--- a/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/moq/lite/MoqLiteSession.kt
+++ b/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/moq/lite/MoqLiteSession.kt
@@ -553,6 +553,16 @@ class MoqLiteSession internal constructor(
                         MoqLiteControlType.Subscribe -> {
                             val subPayload = buffer.readSizePrefixed() ?: return@collect
                             val sub = MoqLiteCodec.decodeSubscribe(subPayload)
+                            // Register the subscription BEFORE sending Ok so the
+                            // peer's observation of Ok is a happens-after of
+                            // `inboundSubs += sub`. Otherwise on dispatchers that
+                            // resume the peer's `bidi.incoming().first()`
+                            // continuation before this coroutine's continuation
+                            // (notably Windows under Dispatchers.Default), the
+                            // peer's first `publisher.send` after Ok races the
+                            // registration and observes an empty subscriber set.
+                            publisher.registerInboundSubscription(sub)
+                            inboundSub = sub
                             bidi.write(
                                 MoqLiteCodec.encodeSubscribeOk(
                                     MoqLiteSubscribeOk(
@@ -564,8 +574,6 @@ class MoqLiteSession internal constructor(
                                     ),
                                 ),
                             )
-                            publisher.registerInboundSubscription(sub)
-                            inboundSub = sub
                             dispatched = true
                         }
 


### PR DESCRIPTION
## Summary
Fixed a race condition in `MoqLiteSession` where subscription registration could occur after the subscription acknowledgment is sent to the peer, causing the peer's initial publish attempts to race against the subscription registration.

## Key Changes
- Moved `publisher.registerInboundSubscription(sub)` and `inboundSub = sub` to execute **before** sending the `SubscribeOk` message instead of after
- This ensures the subscription is registered before the peer observes the acknowledgment, preventing a happens-before violation

## Implementation Details
The issue manifested on certain dispatchers (notably Windows under `Dispatchers.Default`) where the peer's continuation could resume before the current coroutine's continuation, causing the peer's first `publisher.send` after receiving `Ok` to race against the subscription registration. By registering the subscription before sending the acknowledgment, we guarantee that any subsequent publish operations from the peer will observe the registered subscription.

https://claude.ai/code/session_014k6hjdAwcAUtXMt3uCg9j6