### PR TITLE
Replace unused lambda parameters with `_`

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/DebugUtils.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/DebugUtils.kt
@@ -128,7 +128,7 @@ fun debugState(context: Context) {
             "Private Chats $key: " +
                 room.rooms.size() +
                 " / " +
-                room.rooms.sumOf { key, value -> value.messages.size }
+                room.rooms.sumOf { _, value -> value.messages.size }
         }
     }
     Log.d(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -1046,7 +1046,7 @@ class Account(
                     client
                         .fetchFirst(
                             filters =
-                                note.relays.associateWith { relay ->
+                                note.relays.associateWith { _ ->
                                     listOf(
                                         Filter(
                                             kinds = listOf(host.kind),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/HashtagIcon.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/HashtagIcon.kt
@@ -61,7 +61,7 @@ fun RenderHashTagIconsPreview() {
         RenderRegular(
             "Testing rendering of hashtags: #flowerstr #Bitcoin, #nostr, #lightning, #zap, #amethyst, #cashu, #plebs, #coffee, #skullofsatoshi, #grownostr, #footstr, #tunestr, #weed, #mate, #gamestr, #gamechain",
             EmptyTagList,
-        ) { paragraph, state, spaceWidth, modifier ->
+        ) { paragraph, _, spaceWidth, modifier ->
             RenderTextParagraph(paragraph, spaceWidth, modifier) { word ->
                 when (word) {
                     is HashTagSegment -> HashTag(word, EmptyNav())

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LargeSoftCacheAddressExt.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LargeSoftCacheAddressExt.kt
@@ -44,7 +44,7 @@ fun kindStart(kind: Int) = kindStart(kind, START_KEY)
 
 fun kindEnd(kind: Int) = kindEnd(kind, END_KEY)
 
-val ACCEPT_ALL_FILTER = CacheCollectors.BiFilter<Address, AddressableNote> { key, note -> true }
+val ACCEPT_ALL_FILTER = CacheCollectors.BiFilter<Address, AddressableNote> { _, _ -> true }
 
 fun LargeSoftCache<Address, AddressableNote>.filter(
     kind: Int,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -1173,7 +1173,7 @@ object LocalCache : ILocalCache, ICacheProvider {
                         }
                     }
 
-                notes.forEach { key, note ->
+                notes.forEach { _, note ->
                     val noteEvent = note.event
                     if (noteEvent is AddressableEvent && noteEvent.addressTag() in addressSet) {
                         if (noteEvent.pubKey == event.pubKey && noteEvent.createdAt <= event.createdAt) {
@@ -2485,7 +2485,7 @@ object LocalCache : ILocalCache, ICacheProvider {
         val event = newNote.event as Event
 
         val observableBiConsumer =
-            java.util.function.BiConsumer<Observable, Observable> { t, u ->
+            java.util.function.BiConsumer<Observable, Observable> { _, u ->
                 u.new(event, newNote)
             }
 
@@ -2495,7 +2495,7 @@ object LocalCache : ILocalCache, ICacheProvider {
 
     private fun refreshDeletedNoteObservers(newNote: Note) {
         val observableBiConsumer =
-            java.util.function.BiConsumer<Observable, Observable> { t, u ->
+            java.util.function.BiConsumer<Observable, Observable> { _, u ->
                 u.remove(newNote)
             }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/ParticipantListBuilder.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/ParticipantListBuilder.kt
@@ -96,7 +96,7 @@ class ParticipantListBuilder {
             it.replyTo?.forEach { addFollowsThatDirectlyParticipateOnToSet(it, followingSet, mySet) }
         }
 
-        LocalCache.getPublicChatChannelIfExists(baseNote.idHex)?.notes?.forEach { key, it ->
+        LocalCache.getPublicChatChannelIfExists(baseNote.idHex)?.notes?.forEach { _, it ->
             addFollowsThatDirectlyParticipateOnToSet(it, followingSet, mySet)
         }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/controls/HorizontalLinearProgressIndicator.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/controls/HorizontalLinearProgressIndicator.kt
@@ -59,19 +59,19 @@ fun HorizontalLinearProgressIndicatorPreview() {
             HorizontalLinearProgressIndicator(
                 currentPositionProgress = { 0.00f },
                 bufferedPositionProgress = { 0.10f },
-                onLayoutWidthChanged = { widthPx -> },
+                onLayoutWidthChanged = { _ -> },
                 onSeek = {},
             )
             HorizontalLinearProgressIndicator(
                 currentPositionProgress = { 0.10f },
                 bufferedPositionProgress = { 0.20f },
-                onLayoutWidthChanged = { widthPx -> },
+                onLayoutWidthChanged = { _ -> },
                 onSeek = {},
             )
             HorizontalLinearProgressIndicator(
                 currentPositionProgress = { 1.00f },
                 bufferedPositionProgress = { 1.00f },
-                onLayoutWidthChanged = { widthPx -> },
+                onLayoutWidthChanged = { _ -> },
                 onSeek = {},
             )
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/account/follows/FilterFindFollowMetadataForKey.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/account/follows/FilterFindFollowMetadataForKey.kt
@@ -89,7 +89,7 @@ fun pickRelaysToLoadUsers(
     hasTried: EOSEAccountFast<User>,
 ): Map<NormalizedRelayUrl, Set<HexKey>> =
     mapOfSet {
-        users.forEachIndexed { idx, key ->
+        users.forEachIndexed { _, key ->
             val tried = (hasTried.since(key)?.keys ?: emptySet()) + cannotConnectRelays
 
             val outbox = key.authorRelayList()?.writeRelaysNorm()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/EventObservers.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/EventObservers.kt
@@ -348,7 +348,7 @@ fun observeNoteReferences(
                 note.flow().zaps.stateFlow,
                 note.flow().boosts.stateFlow,
                 note.flow().reactions.stateFlow,
-            ) { zapState, boostState, reactionState ->
+            ) { zapState, _, _ ->
                 zapState.note.hasZapsBoostsOrReactions()
             }.distinctUntilChanged()
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/speedLogger/FrameStat.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/speedLogger/FrameStat.kt
@@ -53,7 +53,7 @@ class FrameStat {
 
     fun reset() {
         eventCount.set(0)
-        kinds.forEach { key, value -> value.reset() }
+        kinds.forEach { _, value -> value.reset() }
     }
 
     fun log() {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/speedLogger/KindGroup.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/speedLogger/KindGroup.kt
@@ -63,8 +63,8 @@ class KindGroup(
     fun reset() {
         count.set(0)
         memory.set(0)
-        subs.forEach { key, value -> value.set(0) }
-        relays.forEach { key, value -> value.set(0) }
+        subs.forEach { _, value -> value.set(0) }
+        relays.forEach { _, value -> value.set(0) }
     }
 
     fun printSubs() = subs.joinToString(", ") { key, value -> if (value.get() > 0) "$key ($value)" else "" }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/mediaServers/AllMediaServersLIstView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/mediaServers/AllMediaServersLIstView.kt
@@ -103,10 +103,10 @@ fun AllMediaBody(blossomServersViewModel: BlossomServersViewModel) {
             }
             itemsIndexed(
                 it,
-                key = { index: Int, server: ServerName ->
+                key = { _: Int, server: ServerName ->
                     "Proposed" + server.baseUrl
                 },
-            ) { index, server ->
+            ) { _, server ->
                 MediaServerEntry(
                     serverEntry = server,
                     isAmethystDefault = true,
@@ -143,10 +143,10 @@ fun LazyListScope.renderMediaServerList(
     } else {
         itemsIndexed(
             mediaServersState,
-            key = { index: Int, server: ServerName ->
+            key = { _: Int, server: ServerName ->
                 keyType + server.baseUrl
             },
-        ) { index, entry ->
+        ) { _, entry ->
             MediaServerEntry(
                 serverEntry = entry,
                 onAddOrDelete = {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallActivity.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallActivity.kt
@@ -59,7 +59,7 @@ class CallActivity : AppCompatActivity() {
 
     // Launcher for requesting call permissions when accepting from notification
     private val permissionLauncher =
-        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { results ->
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { _ ->
             if (hasCallPermissions(this, isVideo = pendingAcceptIsVideo)) {
                 acceptCall()
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallPermissions.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/call/CallPermissions.kt
@@ -66,7 +66,7 @@ fun rememberCallWithPermission(
     val launcher =
         rememberLauncherForActivityResult(
             ActivityResultContracts.RequestMultiplePermissions(),
-        ) { results ->
+        ) { _ ->
             // Bluetooth is optional — proceed if core permissions are granted
             if (hasCallPermissions(context, isVideo)) onCall()
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/CashuRedeem.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/CashuRedeem.kt
@@ -130,8 +130,8 @@ fun CashuPreviewPreview() {
     ThemeComparisonColumn {
         CashuPreviewNew(
             token = CashuToken("token", "mint", 32400, listOf()),
-            melt = { token, context, onDone -> },
-            toast = { title, message -> },
+            melt = { _, _, _ -> },
+            toast = { _, _ -> },
         )
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/RichTextViewer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/RichTextViewer.kt
@@ -159,7 +159,7 @@ fun RenderStrangeNamePreview() {
         RenderRegular(
             "If you want to FreeFrom Official \uD80C\uDD66 stream or download the music from  nostr:npub1sctag667a7np6p6ety2up94pnwwxhd2ep8n8afr2gtr47cwd4ewsvdmmjm at wss://relay.damus.io can you here",
             EmptyTagList,
-        ) { paragraph, state, spaceWidth, modifier ->
+        ) { paragraph, _, spaceWidth, modifier ->
             RenderTextParagraph(paragraph, spaceWidth, modifier) { word ->
                 when (word) {
                     is BechSegment -> {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapPollNote.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapPollNote.kt
@@ -616,7 +616,7 @@ fun ZapVote(
                     zappingProgress = 0f
                 },
                 onChangeAmount = { wantsToZap = false },
-                onError = { title, message, user ->
+                onError = { title, message, _ ->
                     showErrorMessageDialog = StringToastMsg(title, message)
                     zappingProgress = 0f
                 },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/notify/Notifying.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/notify/Notifying.kt
@@ -65,7 +65,7 @@ fun Notifying(
                 modifier = Modifier.align(CenterVertically),
             )
 
-            mentions.forEachIndexed { idx, user ->
+            mentions.forEachIndexed { _, user ->
                 Button(
                     shape = ButtonBorder,
                     colors =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/feed/layouts/ChatBubbleLayout.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/feed/layouts/ChatBubbleLayout.kt
@@ -232,7 +232,7 @@ private fun BubblePreview() {
                 )
             },
             detailRow = { Text(RELAYS_AND_ACTIONS_TEXT) },
-        ) { bgColor ->
+        ) { _ ->
             Text("This is my note")
         }
 
@@ -266,7 +266,7 @@ private fun BubblePreview() {
                 )
             },
             detailRow = { Text(RELAYS_AND_ACTIONS_TEXT) },
-        ) { bgColor ->
+        ) { _ ->
             Text("This is a very long long loong note")
         }
 
@@ -300,7 +300,7 @@ private fun BubblePreview() {
                 )
             },
             detailRow = { Text(RELAYS_AND_ACTIONS_TEXT) },
-        ) { bgColor ->
+        ) { _ ->
             Text("This is a draft note")
         }
 
@@ -334,7 +334,7 @@ private fun BubblePreview() {
                 )
             },
             detailRow = { Text(RELAYS_AND_ACTIONS_TEXT) },
-        ) { bgColor ->
+        ) { _ ->
             Text("Short note")
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/NewGroupDMScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/NewGroupDMScreen.kt
@@ -287,7 +287,7 @@ fun GroupDMScreenContent(
                             selectedFiles,
                             accountViewModel.account.settings.defaultFileServer,
                             isUploading = uploading.mediaUploadTracker.isUploading,
-                            onAdd = { alt, server, sensitiveContent, mediaQuality, _, _, _ ->
+                            onAdd = { _, server, _, _, _, _, _ ->
                                 postViewModel.uploadAndHold(
                                     accountViewModel.toastManager::toast,
                                     context,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/PrivateMessageEditFieldRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/PrivateMessageEditFieldRow.kt
@@ -126,7 +126,7 @@ fun PrivateMessageEditFieldRow(
     }
 
     channelScreenModel.uploadState?.let { uploading ->
-        uploading.multiOrchestrator?.let { selectedFiles ->
+        uploading.multiOrchestrator?.let { _ ->
             RoomChatFileUploadDialog(
                 channelScreenModel = channelScreenModel,
                 state = uploading,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/dal/ChannelFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/dal/ChannelFeedFilter.kt
@@ -38,7 +38,7 @@ class ChannelFeedFilter(
     override fun changesFlow() = channel.changesFlow()
 
     // returns the last Note of each user.
-    override fun feed(): List<Note> = sort(channel.notes.filterIntoSet { key, it -> isChatEvent(it) && account.isAcceptable(it) })
+    override fun feed(): List<Note> = sort(channel.notes.filterIntoSet { _, it -> isChatEvent(it) && account.isAcceptable(it) })
 
     override fun applyFilter(newItems: Set<Note>): Set<Note> =
         newItems

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/nip28PublicChat/metadata/ChannelMetadataScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/nip28PublicChat/metadata/ChannelMetadataScreen.kt
@@ -220,7 +220,7 @@ private fun ChannelMetadataScaffold(
                 )
             }
 
-            itemsIndexed(feedState, key = { _, item -> "ChatRelays" + item.relay }) { index, item ->
+            itemsIndexed(feedState, key = { _, item -> "ChatRelays" + item.relay }) { _, item ->
                 BasicRelaySetupInfoDialog(
                     item,
                     onDelete = { postViewModel.deleteHomeRelay(item) },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/send/EditFieldRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/send/EditFieldRow.kt
@@ -81,7 +81,7 @@ fun EditFieldRow(
     }
 
     channelScreenModel.uploadState?.let { uploading ->
-        uploading.multiOrchestrator?.let { selectedFiles ->
+        uploading.multiOrchestrator?.let { _ ->
             ChannelFileUploadDialog(
                 channelScreenModel = channelScreenModel,
                 state = uploading,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/dal/ChatroomListKnownFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/dal/ChatroomListKnownFeedFilter.kt
@@ -60,7 +60,7 @@ class ChatroomListKnownFeedFilter(
                     LocalCache
                         .getOrCreatePublicChatChannel(it.eventId)
                         .notes
-                        .filter { key, it -> account.isAcceptable(it) && it.event != null }
+                        .filter { _, it -> account.isAcceptable(it) && it.event != null }
                         .sortedWith(DefaultFeedOrder)
                         .firstOrNull()
                 }
@@ -72,7 +72,7 @@ class ChatroomListKnownFeedFilter(
                     LocalCache
                         .getOrCreateEphemeralChannel(it)
                         .notes
-                        .filter { key, it -> account.isAcceptable(it) && it.event != null }
+                        .filter { _, it -> account.isAcceptable(it) && it.event != null }
                         .sortedWith(DefaultFeedOrder)
                         .firstOrNull()
                 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chess/ChessGameScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chess/ChessGameScreen.kt
@@ -345,7 +345,7 @@ fun ChessGameScreen(
                     modifier = Modifier.padding(paddingValues),
                     gameState = gameState,
                     opponentName = opponentDisplayName,
-                    onMoveMade = { from, to, san ->
+                    onMoveMade = { from, to, _ ->
                         chessViewModel.publishMove(gameId, from, to)
                     },
                     onResign = { chessViewModel.resign(gameId) },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/ChannelCardCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/ChannelCardCompose.kt
@@ -73,7 +73,7 @@ fun ChannelCardCompose(
                 showHiddenWarning = false,
                 accountViewModel = accountViewModel,
                 nav = nav,
-            ) { canPreview ->
+            ) { _ ->
                 NormalChannelCard(
                     baseNote = baseNote,
                     routeForLastRead = routeForLastRead,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip53LiveActivities/DiscoverLiveFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip53LiveActivities/DiscoverLiveFeedFilter.kt
@@ -59,7 +59,7 @@ open class DiscoverLiveFeedFilter(
 
     override fun feed(): List<Note> {
         val allChannelNotes = LocalCache.liveChatChannels.mapNotNull { _, channel -> LocalCache.getAddressableNoteIfExists(channel.address) }
-        val allMessageNotes = LocalCache.liveChatChannels.map { _, channel -> channel.notes.filter { key, it -> it.event is LiveActivitiesEvent } }.flatten()
+        val allMessageNotes = LocalCache.liveChatChannels.map { _, channel -> channel.notes.filter { _, it -> it.event is LiveActivitiesEvent } }.flatten()
 
         val notes = innerApplyFilter(allChannelNotes + allMessageNotes)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/dvms/dal/NIP90ContentDiscoveryResponseFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/dvms/dal/NIP90ContentDiscoveryResponseFilter.kt
@@ -48,7 +48,7 @@ open class NIP90ContentDiscoveryResponseFilter(
 
         latestNote =
             LocalCache.notes.maxOrNullOf(
-                filter = { idHex: String, note: Note ->
+                filter = { _: String, note: Note ->
                     acceptableEvent(note)
                 },
                 comparator = CreatedAtComparator,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/dal/HomeLiveFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/dal/HomeLiveFilter.kt
@@ -65,10 +65,10 @@ class HomeLiveFilter(
         val fifteenMinsAgo = limitTime()
 
         val list =
-            LocalCache.ephemeralChannels.filter { id, channel ->
+            LocalCache.ephemeralChannels.filter { _, channel ->
                 shouldIncludeChannel(channel, filterParams, fifteenMinsAgo)
             } +
-                LocalCache.liveChatChannels.filter { id, channel ->
+                LocalCache.liveChatChannels.filter { _, channel ->
                     shouldIncludeChannel(channel, filterParams, fifteenMinsAgo)
                 }
 
@@ -81,7 +81,7 @@ class HomeLiveFilter(
         timeLimit: Long,
     ): Boolean =
         channel.notes
-            .filter { key, value ->
+            .filter { _, value ->
                 acceptableChatEvent(value, filterParams, timeLimit)
             }.isNotEmpty()
 
@@ -104,7 +104,7 @@ class HomeLiveFilter(
         }
 
         return channel.notes
-            .filter { key, value ->
+            .filter { _, value ->
                 acceptableChatEvent(value, filterParams, timeLimit)
             }.isNotEmpty()
     }
@@ -275,7 +275,7 @@ class HomeLiveFilter(
     ): Int {
         var count = 0
 
-        channel.notes.forEach { key, value ->
+        channel.notes.forEach { _, value ->
             val author = value.author
             if (author != null) {
                 if (followingSet == null || author.pubkeyHex in followingSet) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/lists/PeopleListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/lists/PeopleListScreen.kt
@@ -310,7 +310,7 @@ private fun PeopleListViewPreview() {
         Column {
             PeopleListView(
                 memberList = persistentListOf(user1, user2, user3),
-                onDeleteUser = { user -> },
+                onDeleteUser = { _ -> },
                 accountViewModel = accountViewModel,
                 nav = EmptyNav(),
             )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/packs/FollowPackScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/display/packs/FollowPackScreen.kt
@@ -333,7 +333,7 @@ fun FollowPackViewPreview() {
         Column {
             PeopleListView(
                 memberList = persistentListOf(user1, user2, user3),
-                onDeleteUser = { user -> },
+                onDeleteUser = { _ -> },
                 accountViewModel = accountViewModel,
                 nav = EmptyNav(),
             )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/PeopleListItem.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/lists/list/PeopleListItem.kt
@@ -127,7 +127,7 @@ private fun PeopleListItemPreview() {
                 peopleList = samplePeopleList1,
                 onClick = {},
                 onEditMetadata = {},
-                onClone = { newName, newDesc -> },
+                onClone = { _, _ -> },
                 onDelete = {},
             )
             PeopleListItem(
@@ -135,7 +135,7 @@ private fun PeopleListItemPreview() {
                 peopleList = samplePeopleList2,
                 onClick = {},
                 onEditMetadata = {},
-                onClone = { newName, newDesc -> },
+                onClone = { _, _ -> },
                 onDelete = {},
             )
             PeopleListItem(
@@ -143,7 +143,7 @@ private fun PeopleListItemPreview() {
                 peopleList = samplePeopleList3,
                 onClick = {},
                 onEditMetadata = {},
-                onClone = { newName, newDesc -> },
+                onClone = { _, _ -> },
                 onDelete = {},
             )
             PeopleListItem(
@@ -151,7 +151,7 @@ private fun PeopleListItemPreview() {
                 peopleList = samplePeopleList4,
                 onClick = {},
                 onEditMetadata = {},
-                onClone = { newName, newDesc -> },
+                onClone = { _, _ -> },
                 onDelete = {},
             )
         }
@@ -341,7 +341,7 @@ private fun ListOptionsMenu(
             onCloneDescChange = {
                 optionalCloneDescription.value = it
             },
-            onCloneCreate = { name, description ->
+            onCloneCreate = { _, _ ->
                 onListClone(optionalCloneName.value, optionalCloneDescription.value)
             },
             onDismiss = { isCopyDialogOpen.value = false },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/livestreams/dal/LiveStreamsFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/livestreams/dal/LiveStreamsFeedFilter.kt
@@ -59,7 +59,7 @@ class LiveStreamsFeedFilter(
 
     override fun feed(): List<Note> {
         val allChannelNotes = LocalCache.liveChatChannels.mapNotNull { _, channel -> LocalCache.getAddressableNoteIfExists(channel.address) }
-        val allMessageNotes = LocalCache.liveChatChannels.map { _, channel -> channel.notes.filter { key, it -> it.event is LiveActivitiesEvent } }.flatten()
+        val allMessageNotes = LocalCache.liveChatChannels.map { _, channel -> channel.notes.filter { _, it -> it.event is LiveActivitiesEvent } }.flatten()
 
         val notes = innerApplyFilter(allChannelNotes + allMessageNotes)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/gallery/GalleryCardCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/gallery/GalleryCardCompose.kt
@@ -56,7 +56,7 @@ fun GalleryCardCompose(
             showHiddenWarning = true,
             accountViewModel = accountViewModel,
             nav = nav,
-        ) { canPreview ->
+        ) { _ ->
             val galleryEvent = baseNote.event
 
             val redirectToEventId =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/hashtags/TabFollowedTags.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/hashtags/TabFollowedTags.kt
@@ -53,7 +53,7 @@ fun TabFollowedTags(
         val items by observeUserTagFollows(baseUser, accountViewModel)
 
         LazyColumn(Modifier.fillMaxSize()) {
-            itemsIndexed(items) { index, hashtag ->
+            itemsIndexed(items) { _, hashtag ->
                 HashtagHeader(
                     tag = hashtag,
                     account = accountViewModel,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/common/BasicRelaySetupInfoModel.kt
@@ -80,7 +80,7 @@ abstract class BasicRelaySetupInfoModel : ViewModel() {
                     onInfo = {
                         togglePaidRelay(item, it.limitation?.payment_required ?: false)
                     },
-                    onError = { url, errorCode, exceptionMessage -> },
+                    onError = { _, _, _ -> },
                 )
             }
         }
@@ -163,7 +163,7 @@ abstract class BasicRelaySetupInfoModel : ViewModel() {
     }
 
     fun deleteAll() {
-        _relays.update { relays -> emptyList() }
+        _relays.update { _ -> emptyList() }
         hasModified = true
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/connected/ConnectedRelayListView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/connected/ConnectedRelayListView.kt
@@ -62,7 +62,7 @@ fun LazyListScope.renderConnectedItems(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    itemsIndexed(feedState, key = { _, item -> "Connected" + item.relay.url }) { index, item ->
+    itemsIndexed(feedState, key = { _, item -> "Connected" + item.relay.url }) { _, item ->
         BasicRelaySetupInfoDialog(
             item,
             onDelete = null,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/connected/ConnectedRelayListViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/connected/ConnectedRelayListViewModel.kt
@@ -39,7 +39,7 @@ class ConnectedRelayListViewModel : BasicRelaySetupInfoModel() {
                 val reqs = Amethyst.instance.client.activeRequests(it)
 
                 val users = mutableSetOf<HexKey>()
-                reqs.forEach { id, filters ->
+                reqs.forEach { _, filters ->
                     filters.forEach { filter ->
                         val isReportFilter = filter.kinds?.size == 1 && filter.kinds?.firstOrNull() == ReportEvent.KIND
                         if (!isReportFilter) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip65/Nip65RelayListViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip65/Nip65RelayListViewModel.kt
@@ -107,7 +107,7 @@ class Nip65RelayListViewModel : ViewModel() {
                     onInfo = {
                         toggleHomePaidRelay(item, it.limitation?.payment_required ?: false)
                     },
-                    onError = { url, errorCode, exceptionMessage -> },
+                    onError = { _, _, _ -> },
                 )
             }
 
@@ -117,7 +117,7 @@ class Nip65RelayListViewModel : ViewModel() {
                     onInfo = {
                         toggleNotifPaidRelay(item, it.limitation?.payment_required ?: false)
                     },
-                    onError = { url, errorCode, exceptionMessage -> },
+                    onError = { _, _, _ -> },
                 )
             }
         }
@@ -200,7 +200,7 @@ class Nip65RelayListViewModel : ViewModel() {
     }
 
     fun deleteHomeAll() {
-        _homeRelays.update { relays -> emptyList() }
+        _homeRelays.update { _ -> emptyList() }
         hasModified = true
     }
 
@@ -236,7 +236,7 @@ class Nip65RelayListViewModel : ViewModel() {
     }
 
     fun deleteNotifAll() {
-        _notificationRelays.update { relays -> emptyList() }
+        _notificationRelays.update { _ -> emptyList() }
         hasModified = true
     }
 


### PR DESCRIPTION
Resolves Sonar code-smell warnings flagging unused lambda parameters across 40 files in the amethyst module. Pure rename — bytecode and behavior unchanged. No public/internal function signatures, APIs, or call sites affected.                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                
Scope: only Sonar's "unused lambda parameter" hits were addressed. Sonar's "unused function parameter" hits (i.e. removing function signature args) were intentionally deferred — those have caller impact and need per-site triage.                                                                                                                                                               
                                                                                                                                                                                                                                
  ## Test plan                                                                                                                                                                                                                  
  - [x] `./gradlew :amethyst:spotlessApply` clean                                                                                                                                                                               
  - [x] `./gradlew :amethyst:compilePlayDebugKotlin` builds                                                                                                                                                                     
  - [x] pre-commit static analysis passes on both commits
  - [x] on device testing