### PR TITLE
fix(android): silence StrictMode cleartext violations for 127.0.0.1 (Tor SOCKS)

### DIFF
--- a/amethyst/src/main/AndroidManifest.xml
+++ b/amethyst/src/main/AndroidManifest.xml
@@ -86,6 +86,7 @@
         android:theme="@style/Theme.Amethyst"
         android:largeHeap="true"
         android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:hardwareAccelerated="true"
         android:localeConfig="@xml/locales_config"
         tools:targetApi="34">

--- a/amethyst/src/main/res/xml/network_security_config.xml
+++ b/amethyst/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Cleartext traffic is permitted globally so user-configured ws:// relays keep working.
+    The explicit localhost domain-config silences StrictMode CleartextNetworkViolation
+    for the Tor SOCKS proxy on 127.0.0.1.
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">127.0.0.1</domain>
+        <domain includeSubdomains="false">localhost</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## Summary
- Add `amethyst/src/main/res/xml/network_security_config.xml` and reference it from the manifest.
- Base config keeps cleartext permitted globally (so user-configured `ws://` relays still work); a domain-config makes the `127.0.0.1` / `localhost` cleartext intent explicit, which is what StrictMode's `detectCleartextNetwork()` checks against.
- Eliminates the StrictMode `CleartextNetworkViolation to 127.0.0.1 ×220+` log spam from the Tor SOCKS path that was identified in the 2026-04-30 benchmark logcat triage.

## Test plan
- [x] `./gradlew :amethyst:assemblePlayDebug` — builds clean, merged manifest contains `networkSecurityConfig="@xml/network_security_config"`, resource is packaged.
- [x] `./gradlew :amethyst:installPlayBenchmark` on a Pixel 9a (API 36).
- [x] Launched benchmark app, captured ~75s of logcat plus a fresh ring-buffer dump after several minutes of runtime.
- [x] **Zero** `CleartextNetworkViolation` lines mentioning `127.0.0.1` (vs. 220+ per session pre-fix), even though the app continued attempting Tor SOCKS connections on `127.0.0.1:9050` (`RelayInfoFail` errors confirm sockets were opened — they would have produced violations under the old config).
- [x] `./gradlew spotlessCheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)