### PR TITLE
Fix race condition in ReconnectingNestsSpeakerTest broadcast handle access

### DIFF
--- a/nestsClient/src/commonTest/kotlin/com/vitorpamplona/nestsclient/ReconnectingNestsSpeakerTest.kt
+++ b/nestsClient/src/commonTest/kotlin/com/vitorpamplona/nestsclient/ReconnectingNestsSpeakerTest.kt
@@ -124,12 +124,27 @@ class ReconnectingNestsSpeakerTest {
 
         private val _startCount = AtomicInteger(0)
         val startCount: Int get() = _startCount.get()
-        val handles = mutableListOf<ScriptedBroadcastHandle>()
+
+        // CopyOnWriteArrayList — the broadcast pump runs on
+        // Dispatchers.Default while tests read `handles[0]` from the
+        // runBlocking thread. A plain `mutableListOf` is neither
+        // thread-safe nor publishes its writes; observed flake on
+        // Ubuntu CI where the test thread sees startCount==1 (volatile
+        // read on AtomicInteger) before the subsequent list mutation
+        // becomes visible. Using a thread-safe list AND ordering the
+        // list mutation BEFORE the AtomicInteger increment ensures
+        // that any reader who sees startCount>=N also sees N entries
+        // already published into `handles`.
+        val handles: MutableList<ScriptedBroadcastHandle> =
+            java.util.concurrent.CopyOnWriteArrayList()
 
         override suspend fun startBroadcasting(): BroadcastHandle {
-            _startCount.incrementAndGet()
             val handle = ScriptedBroadcastHandle()
             handles += handle
+            // Increment AFTER appending to `handles` so the volatile
+            // write on AtomicInteger publishes the list mutation —
+            // tests poll on startCount and then read handles[index].
+            _startCount.incrementAndGet()
             // Mirror the production speaker's contract: transition
             // Connected → Broadcasting on startBroadcasting.
             val current = mutableState.value


### PR DESCRIPTION
## Summary
Fixed a race condition in `ReconnectingNestsSpeakerTest` where the test thread could read `handles` before mutations from the broadcast pump thread became visible, causing flaky test failures on CI.

## Key Changes
- Replaced `mutableListOf<ScriptedBroadcastHandle>()` with `CopyOnWriteArrayList()` to ensure thread-safe access to the handles list
- Reordered operations in `startBroadcasting()` to append the handle to the list **before** incrementing `_startCount`, establishing a happens-before relationship
- The volatile write from `AtomicInteger.incrementAndGet()` now publishes the preceding list mutation, ensuring tests that poll on `startCount` will see the corresponding entries in `handles`

## Implementation Details
The broadcast pump runs on `Dispatchers.Default` while tests read from the `runBlocking` thread. The original code used a non-thread-safe `mutableListOf` and incremented the counter before updating the list, allowing the test thread to observe `startCount >= N` before the Nth handle was visible in the list. By using `CopyOnWriteArrayList` and reordering the mutations, we guarantee that any reader seeing `startCount >= N` will also see N entries already published in `handles`.

https://claude.ai/code/session_01B6J7CA71DUYmBJTjZVm3sG