### PR TITLE
Fix expiration timing in ExpirationTest

### DIFF
--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/ExpirationTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/ExpirationTest.kt
@@ -50,7 +50,7 @@ class ExpirationTest : BaseDBTest() {
             val noteToExpire =
                 signer.sign(
                     TextNoteEvent.build("test1", createdAt = time + 1) {
-                        expiration(time + 1)
+                        expiration(time + 5)
                     },
                 )
 
@@ -58,7 +58,7 @@ class ExpirationTest : BaseDBTest() {
 
             db.assertQuery(noteToExpire, Filter(ids = listOf(noteToExpire.id)))
 
-            delay(2000)
+            delay(6000)
 
             db.deleteExpiredEvents()
 


### PR DESCRIPTION
## Summary
Updated the expiration test to use consistent timing values that properly allow the expiration delay to elapse before the cleanup operation.

## Key Changes
- Increased expiration time from `time + 1` to `time + 5` to provide a larger time window
- Increased delay from 2000ms to 6000ms to ensure sufficient time passes before `deleteExpiredEvents()` is called

## Details
The test was setting an expiration time that was too close to the event creation time, and the delay was insufficient to guarantee the event would be expired before the cleanup operation. These changes ensure the test reliably validates that expired events are properly deleted by the database.

https://claude.ai/code/session_01GoqXtcFnwgyjBict1EURyA