### PR TITLE
Refactor NestLobbyScreen layout: move header outside LazyColumn

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/lobby/NestLobbyScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/lobby/NestLobbyScreen.kt
@@ -197,30 +197,17 @@ private fun NestLobbyContent(
                     .consumeWindowInsets(padding)
                     .imePadding(),
         ) {
-            // Same chat list shape as NestFullScreen: a reverse-layout
-            // LazyColumn keyed by note id. The lobby uses cached
-            // LocalCache notes instead of an active NestViewModel.chat,
-            // and stacks the room metadata (header, listener count,
-            // "Recent chat" label) above the oldest message so the
-            // user can scroll up through history into the room info.
+            RoomHeader(event, accountViewModel, nav)
+            CachedListenerCount(roomATag)
+
+            // Reverse-layout LazyColumn keyed by note id, same shape as
+            // NestFullScreen's chat list. The lobby reads cached
+            // LocalCache notes instead of an active NestViewModel.chat.
             LazyColumn(
-                modifier = Modifier.weight(1f).fillMaxSize(),
+                modifier = Modifier.weight(1f).fillMaxWidth(),
                 state = listState,
                 reverseLayout = true,
             ) {
-                items(
-                    items = messages,
-                    key = { it.idHex },
-                ) { note ->
-                    ChatroomMessageCompose(
-                        baseNote = note,
-                        routeForLastRead = routeForLastRead,
-                        accountViewModel = accountViewModel,
-                        nav = nav,
-                        onWantsToReply = nestScreenModel::reply,
-                        onWantsToEditDraft = nestScreenModel::editFromDraft,
-                    )
-                }
                 if (messages.isEmpty()) {
                     item("chat-empty") {
                         Text(
@@ -233,18 +220,18 @@ private fun NestLobbyContent(
                         )
                     }
                 }
-                item("chat-header") {
-                    Text(
-                        text = stringRes(R.string.nest_lobby_recent_chat),
-                        style = MaterialTheme.typography.titleSmall,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                items(
+                    items = messages,
+                    key = { it.idHex },
+                ) { note ->
+                    ChatroomMessageCompose(
+                        baseNote = note,
+                        routeForLastRead = routeForLastRead,
+                        accountViewModel = accountViewModel,
+                        nav = nav,
+                        onWantsToReply = nestScreenModel::reply,
+                        onWantsToEditDraft = nestScreenModel::editFromDraft,
                     )
-                }
-                item("listeners") {
-                    CachedListenerCount(roomATag)
-                }
-                item("header") {
-                    RoomHeader(event, accountViewModel, nav)
                 }
             }
 


### PR DESCRIPTION
## Summary
Restructured the NestLobbyScreen layout to move the room header and listener count outside of the LazyColumn, improving the component hierarchy and layout logic.

## Key Changes
- Moved `RoomHeader` and `CachedListenerCount` components outside the LazyColumn to render as fixed elements above the message list
- Reordered LazyColumn items: empty state check now appears first, followed by message items
- Removed individual LazyColumn items for "chat-header", "listeners", and "header" that were previously stacked in reverse layout
- Changed LazyColumn modifier from `fillMaxSize()` to `fillMaxWidth()` since the header/listener count now occupy their own space above
- Updated code comments to reflect the new structure

## Implementation Details
The refactoring simplifies the layout by separating concerns: the header UI elements are now rendered as regular composables in the parent Column, while the LazyColumn focuses solely on displaying the message list. This eliminates the complexity of managing these elements as special items in a reverse-layout LazyColumn and makes the composition tree more intuitive.

https://claude.ai/code/session_01Vfvx5ZQu64V4afVF2RaHLL