### PR TITLE
Fix double padding in two-pane chat layout

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/twopane/ChatroomListPane.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/twopane/ChatroomListPane.kt
@@ -21,22 +21,15 @@
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.twopane
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.calculateEndPadding
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedContentState
 import com.vitorpamplona.amethyst.ui.feeds.ScrollStateKeys
 import com.vitorpamplona.amethyst.ui.feeds.WatchLifecycleAndUpdateModel
-import com.vitorpamplona.amethyst.ui.layouts.LocalDisappearingScaffoldPadding
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.datasource.ChatroomListFilterAssemblerSubscription
@@ -69,25 +62,6 @@ fun ChatroomList(
             }
         }
 
-    // The outer DisappearingScaffold publishes its top-app-bar height through
-    // LocalDisappearingScaffoldPadding so single-pane feeds can clear the bar via
-    // rememberFeedContentPadding. In the two-pane layout the tabs sit inside the
-    // column (not the scaffold's top slot), so the inner LazyColumn must not add
-    // that top inset again — otherwise it shows up as a gap below the TabRow.
-    // Drop only the top component; keep start/end/bottom so feeds still clear
-    // the bottom bar.
-    val outerScaffoldPadding = LocalDisappearingScaffoldPadding.current
-    val layoutDirection = LocalLayoutDirection.current
-    val innerScaffoldPadding =
-        remember(outerScaffoldPadding, layoutDirection) {
-            PaddingValues(
-                start = outerScaffoldPadding.calculateStartPadding(layoutDirection),
-                top = 0.dp,
-                end = outerScaffoldPadding.calculateEndPadding(layoutDirection),
-                bottom = outerScaffoldPadding.calculateBottomPadding(),
-            )
-        }
-
     Column {
         MessagesTabHeader(
             pagerState,
@@ -96,13 +70,11 @@ fun ChatroomList(
             { accountViewModel.markAllChatNotesAsRead(newFeedContentState.visibleNotes()) },
         )
 
-        CompositionLocalProvider(LocalDisappearingScaffoldPadding provides innerScaffoldPadding) {
-            MessagesPager(
-                pagerState,
-                tabs,
-                accountViewModel,
-                nav,
-            )
-        }
+        MessagesPager(
+            pagerState,
+            tabs,
+            accountViewModel,
+            nav,
+        )
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/twopane/ChatroomListPane.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/twopane/ChatroomListPane.kt
@@ -21,15 +21,22 @@
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.twopane
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedContentState
 import com.vitorpamplona.amethyst.ui.feeds.ScrollStateKeys
 import com.vitorpamplona.amethyst.ui.feeds.WatchLifecycleAndUpdateModel
+import com.vitorpamplona.amethyst.ui.layouts.LocalDisappearingScaffoldPadding
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.datasource.ChatroomListFilterAssemblerSubscription
@@ -62,6 +69,25 @@ fun ChatroomList(
             }
         }
 
+    // The outer DisappearingScaffold publishes its top-app-bar height through
+    // LocalDisappearingScaffoldPadding so single-pane feeds can clear the bar via
+    // rememberFeedContentPadding. In the two-pane layout the tabs sit inside the
+    // column (not the scaffold's top slot), so the inner LazyColumn must not add
+    // that top inset again — otherwise it shows up as a gap below the TabRow.
+    // Drop only the top component; keep start/end/bottom so feeds still clear
+    // the bottom bar.
+    val outerScaffoldPadding = LocalDisappearingScaffoldPadding.current
+    val layoutDirection = LocalLayoutDirection.current
+    val innerScaffoldPadding =
+        remember(outerScaffoldPadding, layoutDirection) {
+            PaddingValues(
+                start = outerScaffoldPadding.calculateStartPadding(layoutDirection),
+                top = 0.dp,
+                end = outerScaffoldPadding.calculateEndPadding(layoutDirection),
+                bottom = outerScaffoldPadding.calculateBottomPadding(),
+            )
+        }
+
     Column {
         MessagesTabHeader(
             pagerState,
@@ -70,11 +96,13 @@ fun ChatroomList(
             { accountViewModel.markAllChatNotesAsRead(newFeedContentState.visibleNotes()) },
         )
 
-        MessagesPager(
-            pagerState,
-            tabs,
-            accountViewModel,
-            nav,
-        )
+        CompositionLocalProvider(LocalDisappearingScaffoldPadding provides innerScaffoldPadding) {
+            MessagesPager(
+                pagerState,
+                tabs,
+                accountViewModel,
+                nav,
+            )
+        }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/twopane/MessagesTwoPane.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/twopane/MessagesTwoPane.kt
@@ -21,16 +21,19 @@
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.twopane
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import com.google.accompanist.adaptive.FoldAwareConfiguration
 import com.google.accompanist.adaptive.HorizontalTwoPaneStrategy
 import com.google.accompanist.adaptive.TwoPane
@@ -38,6 +41,7 @@ import com.google.accompanist.adaptive.calculateDisplayFeatures
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedContentState
 import com.vitorpamplona.amethyst.ui.components.getActivity
 import com.vitorpamplona.amethyst.ui.layouts.DisappearingScaffold
+import com.vitorpamplona.amethyst.ui.layouts.LocalDisappearingScaffoldPadding
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.AppBottomBar
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
@@ -92,20 +96,34 @@ fun MessagesTwoPane(
     ) { padding ->
         TwoPane(
             first = {
-                Box(Modifier.fillMaxSize().systemBarsPadding(), contentAlignment = Alignment.BottomEnd) {
-                    ChatroomList(
-                        knownFeedContentState,
-                        newFeedContentState,
-                        accountViewModel,
-                        twoPaneNav,
-                    )
+                // The chatroom-list pane owns its own TabRow, so it doesn't
+                // need the outer scaffold's top bar to layer over it. Apply
+                // the scaffold padding directly and reset
+                // LocalDisappearingScaffoldPadding to zero so descendants
+                // (e.g. the LazyColumn inside ChatroomListFeedView via
+                // rememberFeedContentPadding) don't add the bar inset a
+                // second time, which would otherwise show up as a gap
+                // between the TabRow and the first list item.
+                CompositionLocalProvider(LocalDisappearingScaffoldPadding provides PaddingValues(0.dp)) {
+                    Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.BottomEnd) {
+                        ChatroomList(
+                            knownFeedContentState,
+                            newFeedContentState,
+                            accountViewModel,
+                            twoPaneNav,
+                        )
 
-                    Box(Modifier.padding(Size20dp), contentAlignment = Alignment.Center) {
-                        ChannelFabColumn(nav)
+                        Box(Modifier.padding(Size20dp), contentAlignment = Alignment.Center) {
+                            ChannelFabColumn(nav)
+                        }
                     }
                 }
             },
             second = {
+                // The chat-view pane brings its own DisappearingScaffold
+                // (with its own chat header), so it stays edge-to-edge under
+                // the outer search bar via systemBarsPadding instead of the
+                // scaffold padding.
                 Box(Modifier.fillMaxSize().systemBarsPadding()) {
                     twoPaneNav.innerNav.value?.let {
                         if (it is Route.Room) {


### PR DESCRIPTION
## Summary
Fixed a layout issue in the two-pane chat view where the scaffold padding was being applied twice to the chatroom list pane, causing unwanted gaps between the TabRow and list items.

## Key Changes
- Wrapped the chatroom list pane in `CompositionLocalProvider` to override `LocalDisappearingScaffoldPadding` with zero padding
- Applied the scaffold padding directly to the Box containing the chatroom list instead of relying on the composition local
- Added clarifying comments explaining the padding strategy for each pane:
  - **Chatroom list pane**: Owns its own TabRow, so it applies scaffold padding directly and resets the composition local to prevent double-padding in descendants
  - **Chat view pane**: Brings its own DisappearingScaffold with header, so it uses `systemBarsPadding` to stay edge-to-edge under the outer search bar

## Implementation Details
- Added imports for `PaddingValues`, `CompositionLocalProvider`, `dp`, and `LocalDisappearingScaffoldPadding`
- The fix ensures that `rememberFeedContentPadding` and other descendants don't add the bar inset a second time
- Maintains proper visual hierarchy with the TabRow flush against the top and no gap before the first list item

https://claude.ai/code/session_018ZSkS5fDR8Vif1fD5mkp4V