### PR TITLE
Gate Nest room launches by liveness status

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/NestsFeedLoaded.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/NestsFeedLoaded.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.Alignment.Companion.TopEnd
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -77,6 +78,8 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.nip53L
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.nip53LiveActivities.ScheduledFlag
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.discover.nip53LiveActivities.LoadParticipants
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.nests.datasource.NestRoomFilterAssemblerSubscription
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.nests.room.activity.NestActivity
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.nests.room.activity.NestBridge
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.DividerThickness
 import com.vitorpamplona.amethyst.ui.theme.DoubleVertSpacer
@@ -134,11 +137,15 @@ fun NestsFeedLoaded(
 }
 
 /**
- * Audio-rooms list card. Mirrors [ObserveAndRenderSpace] visually but
- * routes a tap into the in-app [NestLobbyScreen] when the underlying
- * event is a joinable [MeetingSpaceEvent]. The lobby is read-only —
- * launching the audio activity (and any host-side kind-30312 refresh)
- * still requires an explicit tap on the lobby's Open Room button.
+ * Audio-rooms list card. Mirrors [ObserveAndRenderSpace] visually and
+ * gates a tap on the underlying [MeetingSpaceEvent] by the same liveness
+ * heuristic the badge uses: cards rendering as [EndedFlag] (status =
+ * ENDED, status = LIVE with stale presence, or unknown status) route
+ * through the read-only [NestLobbyScreen] so re-entry can't accidentally
+ * boot the audio pipeline or trigger a host-side kind-30312 refresh on
+ * a dead room. Cards that the UI still shows as live, scheduled, or
+ * private launch [NestActivity] directly — the lobby's purpose is only
+ * to gate stale rooms.
  */
 @Composable
 private fun NestFeedCard(
@@ -148,15 +155,44 @@ private fun NestFeedCard(
     nav: INav,
 ) {
     val meetingEvent = baseNote.event as? MeetingSpaceEvent ?: return
+    val context = LocalContext.current
+    val status = meetingEvent.checkStatus(meetingEvent.status())
+
+    val isUiClosed =
+        when (status) {
+            StatusTag.STATUS.LIVE -> {
+                val latestPresence by observeRoomLatestPresence(meetingEvent.address(), accountViewModel)
+                val presence = latestPresence
+                presence != null && presence <= TimeUtils.now() - PRESENCE_FRESHNESS_WINDOW_SECONDS
+            }
+
+            StatusTag.STATUS.PLANNED,
+            StatusTag.STATUS.PRIVATE,
+            -> {
+                false
+            }
+
+            else -> {
+                true
+            }
+        }
 
     val onClick =
-        remember(meetingEvent) {
+        remember(meetingEvent, isUiClosed) {
             {
                 val service = meetingEvent.service()
                 val endpoint = meetingEvent.endpoint()
                 val dTag = meetingEvent.address().dTag
                 if (!service.isNullOrBlank() && !endpoint.isNullOrBlank() && dTag.isNotBlank()) {
-                    nav.nav(Route.NestLobby(meetingEvent.address().toValue()))
+                    if (isUiClosed) {
+                        nav.nav(Route.NestLobby(meetingEvent.address().toValue()))
+                    } else {
+                        NestBridge.set(accountViewModel)
+                        NestActivity.launch(
+                            context = context,
+                            addressValue = meetingEvent.address().toValue(),
+                        )
+                    }
                 } else {
                     nav.nav { routeFor(baseNote, accountViewModel.account) }
                 }


### PR DESCRIPTION
## Summary
Modified the Nest feed card tap behavior to intelligently route users based on room liveness status. Live rooms now launch directly into the audio activity, while ended or stale rooms route through the read-only lobby to prevent accidental pipeline activation.

## Key Changes
- Added liveness status detection using the same heuristic as the UI badge (checking for stale presence data)
- Implemented conditional routing logic:
  - **Live/Scheduled/Private rooms**: Launch `NestActivity` directly for immediate audio access
  - **Ended/Stale rooms**: Route through `NestLobbyScreen` (read-only) to prevent unintended audio pipeline activation or host-side kind-30312 refresh on dead rooms
- Added necessary imports: `LocalContext`, `NestActivity`, and `NestBridge`
- Updated KDoc to reflect the new gating behavior and clarify the lobby's purpose as a safety mechanism for stale rooms

## Implementation Details
- Presence freshness is determined by comparing the latest presence timestamp against `PRESENCE_FRESHNESS_WINDOW_SECONDS`
- The `isUiClosed` flag consolidates status checking logic and is included in the `remember` dependency to ensure proper recomposition
- Uses `NestBridge.set()` to pass the account view model before launching the activity

https://claude.ai/code/session_011yKYbBz6L3Y8Qg6bk1NXSP