### PR TITLE
Keep screen on during active nest room connections

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/activity/NestActivityContent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/activity/NestActivityContent.kt
@@ -32,6 +32,7 @@ import com.vitorpamplona.amethyst.commons.model.AddressableNote
 import com.vitorpamplona.amethyst.commons.viewmodels.ConnectionUiState
 import com.vitorpamplona.amethyst.commons.viewmodels.NestViewModel
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.observeNoteEvent
+import com.vitorpamplona.amethyst.ui.call.KeepScreenOn
 import com.vitorpamplona.amethyst.ui.note.LoadAddressableNote
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.nests.datasource.NestRoomFilterAssemblerSubscription
@@ -175,6 +176,12 @@ private fun NestActivityBody(
     LeaveOnRoomClosed(event, onLeave)
 
     val ui by viewModel.uiState.collectAsState()
+
+    // Hold a screen-on lock while the user is actively in the room so the
+    // device doesn't lock and interrupt the audio session UI.
+    if (ui.connection is ConnectionUiState.Connected) {
+        KeepScreenOn()
+    }
 
     // System bridges: PIP overlay actions + foreground service.
     PipBridge(ui, pipMuteSignal, viewModel, onMuteState, onConnectedChange)


### PR DESCRIPTION
## Summary
Added screen-on lock functionality to prevent device lock during active audio sessions in nest rooms.

## Key Changes
- Imported `KeepScreenOn` composable from `com.vitorpamplona.amethyst.ui.call`
- Added conditional screen-on lock in `NestActivityBody` that activates when the user is actively connected to a nest room
- The lock is maintained only while `ConnectionUiState.Connected` to avoid unnecessary battery drain when disconnected

## Implementation Details
The `KeepScreenOn()` composable is invoked within the composition when a connected state is detected, ensuring the device screen remains active during audio sessions and preventing interruptions to the UI experience.

https://claude.ai/code/session_015tFMbjDVudP9JSqepyY7Wm