### PR TITLE
Auto-scroll to newest messages in chat when new messages arrive

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/chat/NestChatPanel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/chat/NestChatPanel.kt
@@ -35,6 +35,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -99,6 +100,19 @@ internal fun ColumnScope.NestChatPanel(
     nestScreenModel.load(roomNote)
 
     val listState = rememberLazyListState()
+
+    // Auto-stick to the newest message. With reverseLayout=true, item 0
+    // is the bottom of the viewport (newest). When a new message is
+    // prepended, LazyColumn preserves visual position by shifting
+    // firstVisibleItemIndex from 0 → 1, leaving the new message just
+    // below the viewport. If the user was at (or near) the bottom,
+    // scroll back to 0 so the new message becomes visible. If they're
+    // reading older history, leave them where they are.
+    LaunchedEffect(messages.firstOrNull()?.idHex) {
+        if (listState.firstVisibleItemIndex <= 1) {
+            listState.animateScrollToItem(0)
+        }
+    }
 
     Column(modifier = modifier.fillMaxWidth()) {
         Box(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/lobby/NestLobbyScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/lobby/NestLobbyScreen.kt
@@ -164,6 +164,19 @@ private fun NestLobbyContent(
     val listState = rememberLazyListState()
     val scope = rememberCoroutineScope()
 
+    // Auto-stick to the newest message. With reverseLayout=true, item 0
+    // is the bottom of the viewport (newest). When a new message is
+    // prepended, LazyColumn preserves visual position by shifting
+    // firstVisibleItemIndex from 0 → 1, leaving the new message just
+    // below the viewport. If the user was at (or near) the bottom,
+    // scroll back to 0 so the new message becomes visible. If they're
+    // reading older history, leave them where they are.
+    LaunchedEffect(messages.firstOrNull()?.idHex) {
+        if (listState.firstVisibleItemIndex <= 1) {
+            listState.animateScrollToItem(0)
+        }
+    }
+
     Scaffold(
         contentWindowInsets = WindowInsets(0),
         topBar = {


### PR DESCRIPTION
## Summary
Added auto-scroll functionality to keep users at the bottom of chat conversations when new messages arrive, while preserving their reading position when browsing older message history.

## Key Changes
- Added `LaunchedEffect` hook to both `NestChatPanel` and `NestLobbyScreen` that monitors incoming messages
- Implemented smart scroll behavior: automatically scrolls to the newest message (item 0) only when the user is at or near the bottom of the list (`firstVisibleItemIndex <= 1`)
- Users reading older messages are not interrupted by automatic scrolling

## Implementation Details
The solution leverages the `reverseLayout=true` configuration of the LazyColumn where:
- Item 0 represents the newest message at the bottom of the viewport
- When new messages are prepended, the LazyColumn preserves visual position by shifting `firstVisibleItemIndex` from 0 → 1
- The `LaunchedEffect` triggers on `messages.firstOrNull()?.idHex` to detect new messages
- `animateScrollToItem(0)` smoothly scrolls back to the newest message for users at the bottom
- Users scrolled up in history are left undisturbed (when `firstVisibleItemIndex > 1`)

https://claude.ai/code/session_01Sk64FTAEnwK4xKGEEXY12p