### PR TITLE
Downgrade "Zap Request not found" log from error to debug

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -1673,7 +1673,7 @@ object LocalCache : ILocalCache, ICacheProvider {
             val zapRequest = event.zapRequest?.id?.let { getNoteIfExists(it) }
 
             if (zapRequest == null || zapRequest.event !is LnZapRequestEvent) {
-                Log.e("ZP") { "Zap Request not found. Unable to process Zap {${event.toJson()}}" }
+                Log.d("ZP") { "Zap Request not found. Unable to process Zap {${event.toJson()}}" }
                 return false
             }
 


### PR DESCRIPTION
 ## Summary
  - `LocalCache.processZapEvent` logs `Zap Request not found` whenever a kind-9735 receipt arrives before the matching kind-9734 zap-request is in cache. That race is **expected** when subscribed to receipt relays but not
  the zapper's outbox — it is not actionable from a user's perspective.
  - Previously this was `Log.e`, so logcat got 6+ full-JSON error stacks per receipt id within a 15-second window during normal use (see 2026-04-30 benchmark logcat triage, item A2: hundreds of `E/ZP` lines per session).
  - Downgraded to `Log.d` so the diagnostic stays available behind a debug filter without flooding error logs.

  ## Test plan
  - [x] `./gradlew :amethyst:installPlayBenchmark` on Pixel 9a (API 36).
  - [x] Active session: scrolled home feed, opened multiple profiles, opened notifications tab where zap receipts land.
  - [x] Logcat over the session: **0** `E/ZP` lines and **0** `Zap Request not found` lines (vs. ≥6 per id in 15s pre-fix).
  - [x] `./gradlew spotlessCheck` clean.

## Notes
This is the minimal log-level change. The triage doc also suggested de-duplicating receipts per id and retrying resolution after the next event batch — left as follow-ups.