### PR TITLE
Add restore-default button to bottom nav settings

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/BottomBarSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/BottomBarSettingsScreen.kt
@@ -147,7 +147,11 @@ fun BottomBarSettingsContent(accountViewModel: AccountViewModel) {
             horizontalArrangement = Arrangement.End,
         ) {
             TextButton(
-                onClick = { save(initialRows(DefaultBottomBarItems)) },
+                onClick = {
+                    draggedItemIndex = -1
+                    dragOffset = 0f
+                    save(initialRows(DefaultBottomBarItems))
+                },
             ) {
                 Text(stringRes(R.string.bottom_bar_settings_restore_default))
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/BottomBarSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/BottomBarSettingsScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -61,6 +62,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
+import com.vitorpamplona.amethyst.ui.navigation.bottombars.DefaultBottomBarItems
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.NavBarCatalog
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.NavBarItem
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.NavBarItemDef
@@ -134,8 +136,22 @@ fun BottomBarSettingsContent(accountViewModel: AccountViewModel) {
             text = stringRes(R.string.bottom_bar_settings_description),
             style = MaterialTheme.typography.bodyMedium,
             color = Color.Gray,
-            modifier = Modifier.padding(bottom = 16.dp, start = Size20dp, end = Size20dp),
+            modifier = Modifier.padding(bottom = 8.dp, start = Size20dp, end = Size20dp),
         )
+
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 8.dp, start = Size20dp, end = Size20dp),
+            horizontalArrangement = Arrangement.End,
+        ) {
+            TextButton(
+                onClick = { save(initialRows(DefaultBottomBarItems)) },
+            ) {
+                Text(stringRes(R.string.bottom_bar_settings_restore_default))
+            }
+        }
 
         items.forEachIndexed { index, row ->
             val rowIsDragging = draggedItemIndex == index

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -1734,6 +1734,7 @@
     <string name="bottom_bar_settings_description">Drag to reorder. Toggle to add or remove an item from the bottom bar. With zero items the bottom bar is hidden.</string>
     <string name="bottom_bar_settings_available">Available</string>
     <string name="bottom_bar_settings_reorder">Reorder</string>
+    <string name="bottom_bar_settings_restore_default">Restore Default</string>
     <string name="home_tabs_settings">Home Tabs</string>
     <string name="home_tabs_settings_description">Pick which tabs appear on the Home screen. When only one tab is active the tab bar is hidden.</string>
     <string name="home_tab_everything">Everything</string>


### PR DESCRIPTION
Summary

  - Adds a "Restore Default" TextButton at the top of the bottom-bar settings screen so users who've over-customized the nav bar can revert to the fresh-install layout (Home, Messages, Video, Discover, Notifications) in one
  tap, without manually toggling every item.
  - Reuses the existing DefaultBottomBarItems constant (the same default UiSettings, UiSettingsFlow, and UISharedPreferences already use), the existing initialRows() helper, and the local save() closure — same persistence
  path the toggle and drag actions take.
  - Defensive: the button clears in-flight drag state (draggedItemIndex / dragOffset) before swapping the items list, so a simultaneous drag-and-tap can't leave drag callbacks indexing past the new list's lastIndex.

  Changes

  - BottomBarSettingsScreen.kt — new restore-default TextButton row (right-aligned), drag-state reset in its onClick.
  - strings.xml — one new string bottom_bar_settings_restore_default.

 ## Test plan                                                                                                                                                                                                                
                                                                                                                                                                                                                                
  - [x] Open Settings → Bottom Bar; tap "Restore Default" with a custom layout — bar reverts to Home / Messages / Video / Discover / Notifications.                                                                             
  - [x] Tap "Restore Default" mid-drag — no crash, drag state clears, list resets cleanly.                                                                                                                                    
  - [x] Tap "Restore Default" when already on the default layout — no visible change, no crash.                                                                                                                                 
  - [x] Verify the new string renders in the user's locale (or falls back to English).
