### PR TITLE
 Jump-to-parent icon on replies in Full UI mode 

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteCompose.kt
@@ -1709,18 +1709,12 @@ fun JumpToParentReplyButton(
     val parentNote =
         remember(baseNote) {
             val noteEvent = baseNote.event as? BaseThreadedEvent ?: return@remember null
-            val replyingTo = noteEvent.replyingToAddressOrEvent()
-            val resolved =
-                if (replyingTo != null) {
-                    val newNote = accountViewModel.getNoteIfExists(replyingTo)
-                    if (newNote != null && LocalCache.getAnyChannel(newNote) == null && newNote.event?.kind != CommunityDefinitionEvent.KIND) {
-                        newNote
-                    } else {
-                        baseNote.replyTo?.lastOrNull { it.event?.kind != CommunityDefinitionEvent.KIND }
-                    }
-                } else {
-                    baseNote.replyTo?.lastOrNull { it.event?.kind != CommunityDefinitionEvent.KIND }
-                }
+            val direct =
+                noteEvent
+                    .replyingToAddressOrEvent()
+                    ?.let { accountViewModel.getNoteIfExists(it) }
+                    ?.takeIf { it.event !is CommunityDefinitionEvent && LocalCache.getAnyChannel(it) == null }
+            val resolved = direct ?: baseNote.replyTo?.lastOrNull { it.event !is CommunityDefinitionEvent }
             resolved?.takeIf { LocalCache.getAnyChannel(it) == null }
         } ?: return
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteCompose.kt
@@ -62,11 +62,13 @@ import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
 import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatChannel
 import com.vitorpamplona.amethyst.model.AddressableNote
+import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.channel.observeChannelPicture
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.observeCommunityApprovalNeedStatus
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.observeNoteEdits
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.observeNoteEvent
+import com.vitorpamplona.amethyst.ui.components.ClickableBox
 import com.vitorpamplona.amethyst.ui.components.GenericLoadable
 import com.vitorpamplona.amethyst.ui.components.RobohashFallbackAsyncImage
 import com.vitorpamplona.amethyst.ui.layouts.GenericRepostLayout
@@ -210,6 +212,7 @@ import com.vitorpamplona.quartz.experimental.nipsOnNostr.NipTextEvent
 import com.vitorpamplona.quartz.experimental.zapPolls.ZapPollEvent
 import com.vitorpamplona.quartz.nip01Core.tags.geohash.geoHashOrScope
 import com.vitorpamplona.quartz.nip04Dm.messages.PrivateDmEvent
+import com.vitorpamplona.quartz.nip10Notes.BaseThreadedEvent
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
 import com.vitorpamplona.quartz.nip13Pow.strongPoWOrNull
 import com.vitorpamplona.quartz.nip17Dm.files.ChatMessageEncryptedFileHeaderEvent
@@ -1672,6 +1675,8 @@ fun FirstUserInfoRow(
 
         Expiration(baseNote)
 
+        JumpToParentReplyButton(baseNote, accountViewModel, nav)
+
         TimeAgo(baseNote)
 
         if (moreOptions == null) {
@@ -1690,6 +1695,48 @@ fun PinnedMark() {
         modifier = Modifier.padding(start = 5.dp).size(16.dp),
         tint = MaterialTheme.colorScheme.placeholderText,
     )
+}
+
+@Composable
+fun JumpToParentReplyButton(
+    baseNote: Note,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    if (!accountViewModel.settings.isCompleteUIMode()) return
+    if (baseNote.event !is BaseThreadedEvent) return
+
+    val parentNote =
+        remember(baseNote) {
+            val noteEvent = baseNote.event as? BaseThreadedEvent ?: return@remember null
+            val replyingTo = noteEvent.replyingToAddressOrEvent()
+            val resolved =
+                if (replyingTo != null) {
+                    val newNote = accountViewModel.getNoteIfExists(replyingTo)
+                    if (newNote != null && LocalCache.getAnyChannel(newNote) == null && newNote.event?.kind != CommunityDefinitionEvent.KIND) {
+                        newNote
+                    } else {
+                        baseNote.replyTo?.lastOrNull { it.event?.kind != CommunityDefinitionEvent.KIND }
+                    }
+                } else {
+                    baseNote.replyTo?.lastOrNull { it.event?.kind != CommunityDefinitionEvent.KIND }
+                }
+            resolved?.takeIf { LocalCache.getAnyChannel(it) == null }
+        } ?: return
+
+    ClickableBox(
+        modifier = Modifier.padding(start = 5.dp).size(20.dp),
+        onClick = {
+            nav.nav { routeFor(parentNote, accountViewModel.account) }
+        },
+    ) {
+        Icon(
+            symbol = MaterialSymbols.KeyboardArrowUp,
+            contentDescription = stringRes(R.string.jump_to_parent_reply),
+            modifier = Modifier.size(18.dp),
+            tint = MaterialTheme.colorScheme.placeholderText,
+        )
+    }
 }
 
 @Composable

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -1724,6 +1724,7 @@
     <string name="close_all_reactions_to_this_post">Close all reactions to this post</string>
 
     <string name="reply_description">Reply</string>
+    <string name="jump_to_parent_reply">Jump to the note this reply is replying to</string>
     <string name="boost_or_quote_description">Boost Or Quote</string>
     <string name="like_description">Like</string>
     <string name="zap_description">Zap</string>


### PR DESCRIPTION
Using simple routing to the parent note which refreshes the screen. Nav stack gets populated for each navigation. I think it's a good start that can be enhanced after user feedback.

## Summary

Adds an upward-arrow icon next to the timestamp in the note header when the displayed note is a reply (`BaseThreadedEvent`). Tapping it navigates to the parent note's thread.
                                                                                                                                                                                                                                
  - Visible only in **Full UI mode** (`accountViewModel.settings.isCompleteUIMode()`)
  - Resolves the parent via `replyingToAddressOrEvent()` then falls back to `replyTo.lastOrNull { ... }`, filtering out community kinds and channel notes so the jump only walks within thread replies                          
  - Uses the same `routeFor(...)` + `nav.nav` pattern the rest of the app uses for note navigation, so back-stack semantics are unchanged: each jump pushes one entry; back walks the chain back down                         
                                                                                                                                                                                                                                
  ## Why                                                                                                                                                                                                                        
                                                                                                                                                                                                                                
Full UI mode users browsing thread feeds wanted a one-tap way to jump up the conversation without long-pressing or opening a context menu.                                                                                    
                                                                                                                                            
  ## Test plan                            
                                                                                                                                                                                                                                
  - [x] In Full UI mode, open a thread feed; tap the up-arrow next to the timestamp on a reply → lands on the parent's thread, parent highlighted
  - [x] Repeat tapping climbs the parent chain                                                                                                                                                                                  
  - [x] Press back from a chained thread → returns to the previous thread in the chain (one step at a time)
  - [x] Switch to Performance UI mode → icon is hidden                                                                                                                                                                          
  - [x] Open a top-level note (kind 1 with no parent) → no icon shown
  - [x] Open a community/channel post → no icon shown (parent resolution filters those out)