### PR TITLE
Fix flaky test by waiting for mute state instead of start count

### DIFF
--- a/nestsClient/src/commonTest/kotlin/com/vitorpamplona/nestsclient/ReconnectingNestsSpeakerTest.kt
+++ b/nestsClient/src/commonTest/kotlin/com/vitorpamplona/nestsclient/ReconnectingNestsSpeakerTest.kt
@@ -346,9 +346,16 @@ class ReconnectingNestsSpeakerTest {
                 }
                 assertTrue(first.handles[0].isMuted, "first handle should be muted by user toggle")
 
-                // Wait for refresh to swap to the second session.
+                // Wait for refresh to swap to the second session AND
+                // for the pump to replay mute intent on the new handle.
+                // `startCount > 0` is published from inside
+                // ScriptedSpeaker.startBroadcasting BEFORE the pump
+                // gets to run `if (desiredMuted) handle.setMuted(true)`,
+                // so polling startCount alone races the replay step
+                // under load (observed flake on CI). Wait for the
+                // post-condition the assertion is about instead.
                 withTimeout(5_000L) {
-                    while (second.startCount == 0) delay(5)
+                    while (second.handles.isEmpty() || !second.handles[0].isMuted) delay(5)
                 }
 
                 // Critical postcondition: the new underlying handle


### PR DESCRIPTION
## Summary
Fixed a race condition in `ReconnectingNestsSpeakerTest` that caused intermittent test failures under load on CI. The test was polling for an intermediate state that could complete before the actual postcondition was satisfied.

## Key Changes
- Changed the polling condition in the reconnection test from waiting for `second.startCount == 0` to waiting for `second.handles.isEmpty() || !second.handles[0].isMuted`
- Updated the comment to explain why the original approach was racy: `startCount` is published from inside `ScriptedSpeaker.startBroadcasting` before the pump executes the mute intent replay logic
- Now the test waits for the actual postcondition (muted state on the new handle) rather than an intermediate state, eliminating the race condition

## Implementation Details
The issue occurred because:
1. `startCount > 0` is published early in the broadcast startup sequence
2. The mute intent replay (`if (desiredMuted) handle.setMuted(true)`) happens later in the pump
3. Under load, the test could observe `startCount > 0` and proceed before the mute state was actually applied
4. By polling the final desired state instead, the test now reliably waits for the complete operation to finish

https://claude.ai/code/session_01PnH1EixoSrY7QhxGRBXLqE