### PR TITLE
Switch audio playback to USAGE_MEDIA for hands-free rooms

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/nests/NestForegroundService.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/nests/NestForegroundService.kt
@@ -74,6 +74,11 @@ class NestForegroundService : Service() {
      * call lowers the room volume cleanly instead of mixing two
      * voices on top of each other. Acquired once per service
      * lifetime; released in [onDestroy].
+     *
+     * Matches the playback `AudioAttributes` we set on `AudioTrack`
+     * in `AudioTrackPlayer` (USAGE_MEDIA + CONTENT_TYPE_SPEECH) so
+     * the focus request applies to the same stream the audio
+     * actually renders on.
      */
     private fun requestAudioFocus() {
         if (audioFocusRequest != null) return
@@ -81,7 +86,7 @@ class NestForegroundService : Service() {
         val attrs =
             android.media.AudioAttributes
                 .Builder()
-                .setUsage(android.media.AudioAttributes.USAGE_VOICE_COMMUNICATION)
+                .setUsage(android.media.AudioAttributes.USAGE_MEDIA)
                 .setContentType(android.media.AudioAttributes.CONTENT_TYPE_SPEECH)
                 .build()
         val request =

--- a/nestsClient/src/androidMain/kotlin/com/vitorpamplona/nestsclient/audio/AudioTrackPlayer.kt
+++ b/nestsClient/src/androidMain/kotlin/com/vitorpamplona/nestsclient/audio/AudioTrackPlayer.kt
@@ -21,23 +21,36 @@
 package com.vitorpamplona.nestsclient.audio
 
 import android.media.AudioAttributes
-import android.media.AudioManager
 import android.media.AudioTrack
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import android.media.AudioFormat as AndroidAudioFormat
 
 /**
- * [AudioPlayer] backed by Android's [AudioTrack] in `MODE_STREAM`. Targets the
- * voice-call usage stream so the OS treats audio-room playback like a phone
- * call (volume rocker controls call volume, ducks notifications, etc.).
+ * [AudioPlayer] backed by Android's [AudioTrack] in `MODE_STREAM`.
+ *
+ * Routes through `USAGE_MEDIA` + `CONTENT_TYPE_SPEECH` (= `STREAM_MUSIC`)
+ * so audio-room playback comes out of the loudspeaker by default and the
+ * volume rocker controls media volume — same approach Twitter/X Spaces
+ * and Clubhouse use for hands-free audio rooms.
+ *
+ * Originally this used `USAGE_VOICE_COMMUNICATION` to get call-style
+ * volume / ducking, but that routes through `STREAM_VOICE_CALL`, which
+ * Android only services audibly while the device is in
+ * `MODE_IN_COMMUNICATION`. Nests doesn't drive `AudioManager.mode`
+ * (only the NIP-100 `CallAudioManager` does), so the playback either
+ * dropped to the earpiece at near-zero volume or produced no audio at
+ * all depending on the device — making rooms appear silent on both
+ * phones. Echo cancellation still works on the capture side via
+ * `MediaRecorder.AudioSource.VOICE_COMMUNICATION` regardless of the
+ * playback usage.
  *
  * Buffer sizing: 4× minimum so the producer can fall behind by ~80 ms before
  * dropouts, which roughly matches the jitter the WebTransport datagram path
  * introduces over typical mobile networks.
  */
 class AudioTrackPlayer(
-    private val usage: Int = AudioAttributes.USAGE_VOICE_COMMUNICATION,
+    private val usage: Int = AudioAttributes.USAGE_MEDIA,
     private val contentType: Int = AudioAttributes.CONTENT_TYPE_SPEECH,
 ) : AudioPlayer {
     private var track: AudioTrack? = null
@@ -143,9 +156,6 @@ class AudioTrackPlayer(
         runCatching { t.stop() }
         runCatching { t.release() }
     }
-
-    @Suppress("unused")
-    val voiceCallUsage: Int get() = AudioManager.STREAM_VOICE_CALL // kept for documentation
 
     private fun applyMuteVolume(track: AudioTrack) {
         // setVolume is preferred over pause(): it keeps the streaming pipeline


### PR DESCRIPTION
## Summary
Changes the audio routing strategy for Nests audio rooms from `USAGE_VOICE_COMMUNICATION` to `USAGE_MEDIA` with `CONTENT_TYPE_SPEECH`. This ensures audio plays through the loudspeaker by default and responds to media volume controls, matching the approach used by Twitter/X Spaces and Clubhouse.

## Key Changes
- **AudioTrackPlayer**: Changed default `usage` parameter from `USAGE_VOICE_COMMUNICATION` to `USAGE_MEDIA`
- **AudioTrackPlayer**: Updated documentation to explain the routing strategy and why `USAGE_VOICE_COMMUNICATION` was problematic
- **NestForegroundService**: Updated audio focus request to use `USAGE_MEDIA` instead of `USAGE_VOICE_COMMUNICATION`, ensuring it matches the actual playback stream
- **AudioTrackPlayer**: Removed unused `voiceCallUsage` property that was kept only for documentation

## Implementation Details
The previous approach using `USAGE_VOICE_COMMUNICATION` routed audio through `STREAM_VOICE_CALL`, which Android only services audibly when the device is in `MODE_IN_COMMUNICATION`. Since Nests doesn't control `AudioManager.mode` (only the NIP-100 `CallAudioManager` does), playback would either drop to the earpiece at near-zero volume or produce no audio at all depending on the device.

The new `USAGE_MEDIA` + `CONTENT_TYPE_SPEECH` approach:
- Routes through `STREAM_MUSIC` for loudspeaker playback by default
- Allows media volume rocker to control room volume
- Maintains echo cancellation on the capture side via `MediaRecorder.AudioSource.VOICE_COMMUNICATION`
- Aligns audio focus request with actual playback attributes for proper stream management

https://claude.ai/code/session_01F8DyVv7MuyjGVAs6LWm9Wg