### PR TITLE
fix: use LocalActivity to resolve NestActivity (lint ContextCastToActivity)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/activity/NestActivityContent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/activity/NestActivityContent.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.nests.room.activity
 
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -40,7 +41,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.R
@@ -283,7 +283,7 @@ private fun NestActivityBody(
     // system mic indicator) and the listener close run on
     // cleanupScope/GlobalScope before the activity destruction
     // queue eats viewModelScope.
-    val activity = LocalContext.current as? NestActivity
+    val activity = LocalActivity.current as? NestActivity
     DisposableEffect(activity, viewModel) {
         activity?.setPipCleanupAction { viewModel.leave() }
         onDispose { activity?.setPipCleanupAction(null) }


### PR DESCRIPTION
## Summary
- `:amethyst:lintPlayBenchmark` was failing CI with the Jetpack Activity Compose lint rule `ContextCastToActivity` at `NestActivityContent.kt:286`.
- Swap `LocalContext.current as? NestActivity` for `LocalActivity.current as? NestActivity` (and update the import) so the cast goes through the proper Activity-aware composition local. Behavior is unchanged — `LocalActivity` resolves to the hosting `NestActivity` because `NestActivity.setContent` provides it via `androidx.activity.compose`.
- `androidx.activity:activity-compose` is already `1.13.0` (well above the `1.10.0` floor for `LocalActivity`), so no dependency changes are needed.

## Test plan
- [x] `./gradlew :amethyst:spotlessApply :amethyst:lintPlayBenchmark` — BUILD SUCCESSFUL, no errors
- [x] Pre-commit spotless hook passes
- [ ] CI green on `:amethyst:lintPlayBenchmark`

🤖 Generated with [Claude Code](https://claude.com/claude-code)