### PR TITLE
fix(quartz): harden event deserializer (size caps + drop intern() + WS frame cap)

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/EventKSerializer.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/EventKSerializer.kt
@@ -105,7 +105,7 @@ object EventKSerializer : KSerializer<Event> {
             throw IllegalArgumentException("Event not found")
         }
 
-        EventLimits.validate(content, tags)
+        EventLimits.validateContent(content)
 
         return EventFactory.create(id, pubKey, createdAt, kind, tags, content, sig)
     }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/EventKSerializer.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/EventKSerializer.kt
@@ -24,6 +24,7 @@ import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.Kind
 import com.vitorpamplona.quartz.nip01Core.core.TagArray
+import com.vitorpamplona.quartz.nip01Core.limits.EventLimits
 import com.vitorpamplona.quartz.utils.EventFactory
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -103,6 +104,8 @@ object EventKSerializer : KSerializer<Event> {
         if (pubKey.isEmpty()) {
             throw IllegalArgumentException("Event not found")
         }
+
+        EventLimits.validate(content, tags)
 
         return EventFactory.create(id, pubKey, createdAt, kind, tags, content, sig)
     }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/TagArrayKSerializer.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/TagArrayKSerializer.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.quartz.nip01Core.kotlinSerialization
 
 import com.vitorpamplona.quartz.nip01Core.core.TagArray
+import com.vitorpamplona.quartz.nip01Core.limits.EventLimits
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
@@ -68,15 +69,25 @@ object TagArrayKSerializer : KSerializer<TagArray> {
 
     fun deserializeFromElement(element: JsonElement): TagArray {
         val array = element.jsonArray
+        require(array.size <= EventLimits.MAX_TAG_COUNT) {
+            "Event has ${array.size} tags; max is ${EventLimits.MAX_TAG_COUNT}"
+        }
         val outerList = ArrayList<Array<String>>(array.size)
         for (inner in array) {
             val innerArray = inner.jsonArray
+            require(innerArray.size <= EventLimits.MAX_TAG_ELEMENTS_PER_TAG) {
+                "Tag has ${innerArray.size} elements; max is ${EventLimits.MAX_TAG_ELEMENTS_PER_TAG}"
+            }
             val innerList = ArrayList<String>(innerArray.size.coerceAtLeast(5))
             for (s in innerArray) {
                 if (s is JsonNull) {
                     innerList.add("")
                 } else {
-                    innerList.add(s.jsonPrimitive.content)
+                    val text = s.jsonPrimitive.content
+                    require(text.length <= EventLimits.MAX_TAG_VALUE_LENGTH) {
+                        "Tag value length ${text.length} exceeds max ${EventLimits.MAX_TAG_VALUE_LENGTH}"
+                    }
+                    innerList.add(text)
                 }
             }
             outerList.add(innerList.toTypedArray())

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimits.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimits.kt
@@ -37,13 +37,17 @@ object EventLimits {
     const val MAX_CONTENT_LENGTH = 64 * 1024
     const val MAX_RELAY_MESSAGE_LENGTH = 256 * 1024
 
-    fun validate(
-        content: String,
-        tags: TagArray,
-    ) {
+    fun validateContent(content: String) {
         require(content.length <= MAX_CONTENT_LENGTH) {
             "Event content length ${content.length} exceeds max $MAX_CONTENT_LENGTH"
         }
+    }
+
+    // Used by callers that have a TagArray in hand (e.g. constructed without going through
+    // a tag deserializer). The streaming Jackson and kotlinx tag deserializers already
+    // enforce these caps inline during parse, so the deserializer hot path does not call
+    // this helper.
+    fun validateTags(tags: TagArray) {
         require(tags.size <= MAX_TAG_COUNT) {
             "Event has ${tags.size} tags; max is $MAX_TAG_COUNT"
         }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimits.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimits.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.limits
+
+import com.vitorpamplona.quartz.nip01Core.core.TagArray
+
+// Defense-in-depth caps on relay-supplied event payloads.
+// A hostile relay can otherwise OOM the client with one giant event or a flood of large tags
+// (security review 2026-04-24 §2.3). Numbers are conservative: well above any legitimate
+// real-world event seen in production, well below sizes that would meaningfully impact memory.
+object EventLimits {
+    const val MAX_TAG_COUNT = 2_000
+
+    // Sized to accommodate observed real-world events (max ~104 inner elements in Vitor's
+    // startup-data fixture) with ~2.5x headroom; still small enough that an attacker can't
+    // amplify a single tag into a meaningful allocation.
+    const val MAX_TAG_ELEMENTS_PER_TAG = 256
+    const val MAX_TAG_VALUE_LENGTH = 16 * 1024
+    const val MAX_CONTENT_LENGTH = 64 * 1024
+    const val MAX_RELAY_MESSAGE_LENGTH = 256 * 1024
+
+    fun validate(
+        content: String,
+        tags: TagArray,
+    ) {
+        require(content.length <= MAX_CONTENT_LENGTH) {
+            "Event content length ${content.length} exceeds max $MAX_CONTENT_LENGTH"
+        }
+        require(tags.size <= MAX_TAG_COUNT) {
+            "Event has ${tags.size} tags; max is $MAX_TAG_COUNT"
+        }
+        for (tag in tags) {
+            require(tag.size <= MAX_TAG_ELEMENTS_PER_TAG) {
+                "Tag has ${tag.size} elements; max is $MAX_TAG_ELEMENTS_PER_TAG"
+            }
+            for (value in tag) {
+                require(value.length <= MAX_TAG_VALUE_LENGTH) {
+                    "Tag value length ${value.length} exceeds max $MAX_TAG_VALUE_LENGTH"
+                }
+            }
+        }
+    }
+}

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTest.kt
@@ -21,35 +21,17 @@
 package com.vitorpamplona.quartz.nip01Core.limits
 
 import com.vitorpamplona.quartz.nip01Core.kotlinSerialization.KotlinSerializationMapper
+import com.vitorpamplona.quartz.nip01Core.limits.EventLimitsTestSupport.buildEventJson
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 // Regression for security review 2026-04-24 §2.3 / Finding #5: the deserializers used to
 // materialize whole events with no upper bound. A hostile relay could OOM the client with
-// one giant event or a flood of large tags. Caps are now enforced via EventLimits.validate()
-// and inside TagArrayKSerializer.
+// one giant event or a flood of large tags. Caps are enforced inline by the tag deserializers
+// and post-parse by EventLimits.validateContent.
 class EventLimitsTest {
-    private val id = "0".repeat(63) + "1"
-    private val pubKey = "0".repeat(63) + "2"
-    private val sig = "0".repeat(128)
-
     private fun parse(json: String) = KotlinSerializationMapper.fromJson(json)
-
-    private fun buildEventJson(
-        contentLength: Int = 10,
-        tagCount: Int = 1,
-        tagInnerCount: Int = 2,
-        tagValueLength: Int = 5,
-    ): String {
-        val content = "x".repeat(contentLength)
-        val tagValue = "v".repeat(tagValueLength)
-        // First element is a short tag key "t"; remaining (tagInnerCount - 1) are values of length tagValueLength.
-        val inner = "\"t\"" + ",\"$tagValue\"".repeat((tagInnerCount - 1).coerceAtLeast(0))
-        val tag = "[$inner]"
-        val tags = (1..tagCount).joinToString(",") { tag }
-        return """{"id":"$id","pubkey":"$pubKey","created_at":1,"kind":1,"tags":[$tags],"content":"$content","sig":"$sig"}"""
-    }
 
     @Test
     fun acceptsEventWithinLimits() {

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.limits
+
+import com.vitorpamplona.quartz.nip01Core.kotlinSerialization.KotlinSerializationMapper
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+// Regression for security review 2026-04-24 §2.3 / Finding #5: the deserializers used to
+// materialize whole events with no upper bound. A hostile relay could OOM the client with
+// one giant event or a flood of large tags. Caps are now enforced via EventLimits.validate()
+// and inside TagArrayKSerializer.
+class EventLimitsTest {
+    private val id = "0".repeat(63) + "1"
+    private val pubKey = "0".repeat(63) + "2"
+    private val sig = "0".repeat(128)
+
+    private fun parse(json: String) = KotlinSerializationMapper.fromJson(json)
+
+    private fun buildEventJson(
+        contentLength: Int = 10,
+        tagCount: Int = 1,
+        tagInnerCount: Int = 2,
+        tagValueLength: Int = 5,
+    ): String {
+        val content = "x".repeat(contentLength)
+        val tagValue = "v".repeat(tagValueLength)
+        // First element is a short tag key "t"; remaining (tagInnerCount - 1) are values of length tagValueLength.
+        val inner = "\"t\"" + ",\"$tagValue\"".repeat((tagInnerCount - 1).coerceAtLeast(0))
+        val tag = "[$inner]"
+        val tags = (1..tagCount).joinToString(",") { tag }
+        return """{"id":"$id","pubkey":"$pubKey","created_at":1,"kind":1,"tags":[$tags],"content":"$content","sig":"$sig"}"""
+    }
+
+    @Test
+    fun acceptsEventWithinLimits() {
+        val event =
+            parse(buildEventJson(contentLength = 100, tagCount = 5, tagInnerCount = 3, tagValueLength = 50))
+        assertEquals(5, event.tags.size)
+        assertEquals(100, event.content.length)
+        assertEquals(3, event.tags[0].size)
+    }
+
+    @Test
+    fun rejectsOversizedContent() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(contentLength = EventLimits.MAX_CONTENT_LENGTH + 1))
+            }
+        assertEquals(true, ex.message?.contains("content length"), ex.message)
+    }
+
+    @Test
+    fun rejectsTooManyTags() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(tagCount = EventLimits.MAX_TAG_COUNT + 1))
+            }
+        assertEquals(true, ex.message?.contains("tags"), ex.message)
+    }
+
+    @Test
+    fun rejectsTagWithTooManyElements() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(tagInnerCount = EventLimits.MAX_TAG_ELEMENTS_PER_TAG + 2))
+            }
+        assertEquals(true, ex.message?.contains("elements"), ex.message)
+    }
+
+    @Test
+    fun rejectsOversizedTagValue() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(tagValueLength = EventLimits.MAX_TAG_VALUE_LENGTH + 1))
+            }
+        assertEquals(true, ex.message?.contains("Tag value length"), ex.message)
+    }
+}

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTestSupport.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTestSupport.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.limits
+
+internal object EventLimitsTestSupport {
+    const val ID = "0000000000000000000000000000000000000000000000000000000000000001"
+    const val PUB_KEY = "0000000000000000000000000000000000000000000000000000000000000002"
+    val SIG = "0".repeat(128)
+
+    fun buildEventJson(
+        contentLength: Int = 10,
+        tagCount: Int = 1,
+        tagInnerCount: Int = 2,
+        tagValueLength: Int = 5,
+    ): String {
+        val content = "x".repeat(contentLength)
+        val tagValue = "v".repeat(tagValueLength)
+        // First element is a short tag key "t"; remaining (tagInnerCount - 1) are values of length tagValueLength.
+        val inner = "\"t\"" + ",\"$tagValue\"".repeat((tagInnerCount - 1).coerceAtLeast(0))
+        val tag = "[$inner]"
+        val tags = (1..tagCount).joinToString(",") { tag }
+        return """{"id":"$ID","pubkey":"$PUB_KEY","created_at":1,"kind":1,"tags":[$tags],"content":"$content","sig":"$SIG"}"""
+    }
+}

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/EventDeserializer.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/EventDeserializer.kt
@@ -78,7 +78,7 @@ class EventDeserializer : StdDeserializer<Event>(Event::class.java) {
             throw IllegalArgumentException("Event not found")
         }
 
-        EventLimits.validate(content, tags)
+        EventLimits.validateContent(content)
 
         return EventFactory.create(id, pubKey, createdAt, kind, tags, content, sig)
     }

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/EventDeserializer.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/EventDeserializer.kt
@@ -52,13 +52,23 @@ class EventDeserializer : StdDeserializer<Event>(Event::class.java) {
             p.nextToken()
 
             when (fieldName.hashCode()) {
-                3355 -> id = p.text.intern()
-                -977424830 -> pubKey = p.text.intern()
+                // Do not intern id/pubKey: each event ships a unique 64-char hex id, and a hostile
+                // relay could flood ids/pubkeys to grow the JVM StringTable without bound (security
+                // review 2026-04-24 §2.3).
+                3355 -> id = p.text
+
+                -977424830 -> pubKey = p.text
+
                 1369680106 -> createdAt = p.longValue
+
                 3292052 -> kind = p.intValue
+
                 3552281 -> tags = tagsDeserializer.deserialize(p, ctxt)
+
                 951530617 -> content = p.text
+
                 113873 -> sig = p.text
+
                 else -> p.skipChildren()
             }
         }

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/EventDeserializer.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/EventDeserializer.kt
@@ -28,6 +28,7 @@ import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.Kind
 import com.vitorpamplona.quartz.nip01Core.core.TagArray
+import com.vitorpamplona.quartz.nip01Core.limits.EventLimits
 import com.vitorpamplona.quartz.utils.EventFactory
 
 class EventDeserializer : StdDeserializer<Event>(Event::class.java) {
@@ -76,6 +77,8 @@ class EventDeserializer : StdDeserializer<Event>(Event::class.java) {
         if (pubKey.isEmpty()) {
             throw IllegalArgumentException("Event not found")
         }
+
+        EventLimits.validate(content, tags)
 
         return EventFactory.create(id, pubKey, createdAt, kind, tags, content, sig)
     }

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/TagArrayDeserializer.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/TagArrayDeserializer.kt
@@ -32,16 +32,21 @@ class TagArrayDeserializer : StdDeserializer<TagArray>(TagArray::class.java) {
         p: JsonParser,
         ctxt: DeserializationContext,
     ): TagArray {
-        // doesn't check for weird payloads on purpose.
         val outerList = ArrayList<Array<String>>()
         while (p.nextToken() != JsonToken.END_ARRAY) {
             val innerList = ArrayList<String>(5)
+            var index = 0
             while (p.nextToken() != JsonToken.END_ARRAY) {
                 if (p.currentToken == JsonToken.VALUE_NULL) {
                     innerList.add("")
                 } else {
-                    innerList.add(p.text.intern())
+                    // Intern only the tag key (index 0) — protocol-defined finite set ("p", "e", "a", …).
+                    // Tag values at index >= 1 are attacker-controlled (pubkeys, event ids, URLs, free text)
+                    // and must not be promoted to the JVM StringTable: hostile relays could flood unique
+                    // values to grow it without bound (security review 2026-04-24 §2.3).
+                    innerList.add(if (index == 0) p.text.intern() else p.text)
                 }
+                index++
             }
 
             outerList.add(innerList.toArray(arrayOfNulls<String>(innerList.size)))

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/TagArrayDeserializer.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/TagArrayDeserializer.kt
@@ -39,7 +39,6 @@ class TagArrayDeserializer : StdDeserializer<TagArray>(TagArray::class.java) {
                 "Event has more than ${EventLimits.MAX_TAG_COUNT} tags"
             }
             val innerList = ArrayList<String>(5)
-            var index = 0
             while (p.nextToken() != JsonToken.END_ARRAY) {
                 require(innerList.size < EventLimits.MAX_TAG_ELEMENTS_PER_TAG) {
                     "Tag has more than ${EventLimits.MAX_TAG_ELEMENTS_PER_TAG} elements"
@@ -51,13 +50,13 @@ class TagArrayDeserializer : StdDeserializer<TagArray>(TagArray::class.java) {
                     require(text.length <= EventLimits.MAX_TAG_VALUE_LENGTH) {
                         "Tag value length ${text.length} exceeds max ${EventLimits.MAX_TAG_VALUE_LENGTH}"
                     }
-                    // Intern only the tag key (index 0) — protocol-defined finite set ("p", "e", "a", …).
-                    // Tag values at index >= 1 are attacker-controlled (pubkeys, event ids, URLs, free text)
-                    // and must not be promoted to the JVM StringTable: hostile relays could flood unique
-                    // values to grow it without bound (security review 2026-04-24 §2.3).
-                    innerList.add(if (index == 0) text.intern() else text)
+                    // Intern only the tag key (the first element) — protocol-defined finite set
+                    // ("p", "e", "a", …). Tag values at later positions are attacker-controlled
+                    // (pubkeys, event ids, URLs, free text) and must not be promoted to the JVM
+                    // StringTable: hostile relays could flood unique values to grow it without
+                    // bound (security review 2026-04-24 §2.3).
+                    innerList.add(if (innerList.isEmpty()) text.intern() else text)
                 }
-                index++
             }
 
             outerList.add(innerList.toArray(arrayOfNulls<String>(innerList.size)))

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/TagArrayDeserializer.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/TagArrayDeserializer.kt
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.core.JsonToken
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.vitorpamplona.quartz.nip01Core.core.TagArray
+import com.vitorpamplona.quartz.nip01Core.limits.EventLimits
 
 class TagArrayDeserializer : StdDeserializer<TagArray>(TagArray::class.java) {
     // Needs to be very fast.
@@ -34,17 +35,27 @@ class TagArrayDeserializer : StdDeserializer<TagArray>(TagArray::class.java) {
     ): TagArray {
         val outerList = ArrayList<Array<String>>()
         while (p.nextToken() != JsonToken.END_ARRAY) {
+            require(outerList.size < EventLimits.MAX_TAG_COUNT) {
+                "Event has more than ${EventLimits.MAX_TAG_COUNT} tags"
+            }
             val innerList = ArrayList<String>(5)
             var index = 0
             while (p.nextToken() != JsonToken.END_ARRAY) {
+                require(innerList.size < EventLimits.MAX_TAG_ELEMENTS_PER_TAG) {
+                    "Tag has more than ${EventLimits.MAX_TAG_ELEMENTS_PER_TAG} elements"
+                }
                 if (p.currentToken == JsonToken.VALUE_NULL) {
                     innerList.add("")
                 } else {
+                    val text = p.text
+                    require(text.length <= EventLimits.MAX_TAG_VALUE_LENGTH) {
+                        "Tag value length ${text.length} exceeds max ${EventLimits.MAX_TAG_VALUE_LENGTH}"
+                    }
                     // Intern only the tag key (index 0) — protocol-defined finite set ("p", "e", "a", …).
                     // Tag values at index >= 1 are attacker-controlled (pubkeys, event ids, URLs, free text)
                     // and must not be promoted to the JVM StringTable: hostile relays could flood unique
                     // values to grow it without bound (security review 2026-04-24 §2.3).
-                    innerList.add(if (index == 0) p.text.intern() else p.text)
+                    innerList.add(if (index == 0) text.intern() else text)
                 }
                 index++
             }

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/relay/sockets/okhttp/BasicOkHttpWebSocket.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/relay/sockets/okhttp/BasicOkHttpWebSocket.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.quartz.nip01Core.relay.sockets.okhttp
 
+import com.vitorpamplona.quartz.nip01Core.limits.EventLimits
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.relay.sockets.WebSocket
 import com.vitorpamplona.quartz.nip01Core.relay.sockets.WebSocketListener
@@ -49,6 +50,10 @@ class BasicOkHttpWebSocket(
             CoroutineExceptionHandler { _, throwable ->
                 Log.e("BasicOkHttpWebSocket", "WebsocketListener Caught exception: ${throwable.message}", throwable)
             }
+
+        // RFC 6455 §7.4 close code 1009 — "Message Too Big". Used when a relay sends a frame
+        // exceeding EventLimits.MAX_RELAY_MESSAGE_LENGTH (security review 2026-04-24 §2.3 Layer 1).
+        const val CLOSE_MESSAGE_TOO_LARGE = 1009
     }
 
     private var socket: OkHttpWebSocket? = null
@@ -81,6 +86,7 @@ class BasicOkHttpWebSocket(
                     webSocket: OkHttpWebSocket,
                     text: String,
                 ) {
+                    if (!acceptIncoming(webSocket, text)) return
                     // Asynchronously send the received message to the channel.
                     // `trySendBlocking` is used here for simplicity within the callback,
                     // but it's important to understand potential thread blocking if the buffer is full.
@@ -123,6 +129,25 @@ class BasicOkHttpWebSocket(
     }
 
     override fun send(msg: String): Boolean = socket?.send(msg) ?: false
+
+    // Decides whether an incoming WebSocket text message should be forwarded to `out`.
+    // Drops messages exceeding EventLimits.MAX_RELAY_MESSAGE_LENGTH and closes the socket
+    // (security review 2026-04-24 §2.3 Layer 1: a hostile relay can otherwise OOM the
+    // client with one giant frame before the per-event caps in EventDeserializer fire).
+    // Returns true when the caller should forward the message; false when it should drop.
+    internal fun acceptIncoming(
+        webSocket: OkHttpWebSocket,
+        text: String,
+    ): Boolean {
+        if (text.length > EventLimits.MAX_RELAY_MESSAGE_LENGTH) {
+            Log.w("BasicOkHttpWebSocket") {
+                "Dropping ${text.length}-char message from $url; max is ${EventLimits.MAX_RELAY_MESSAGE_LENGTH}"
+            }
+            webSocket.close(CLOSE_MESSAGE_TOO_LARGE, "message too large")
+            return false
+        }
+        return true
+    }
 
     class Builder(
         val httpClient: (NormalizedRelayUrl) -> OkHttpClient,

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/relay/sockets/okhttp/BasicOkHttpWebSocket.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/relay/sockets/okhttp/BasicOkHttpWebSocket.kt
@@ -54,6 +54,7 @@ class BasicOkHttpWebSocket(
         // RFC 6455 §7.4 close code 1009 — "Message Too Big". Used when a relay sends a frame
         // exceeding EventLimits.MAX_RELAY_MESSAGE_LENGTH (security review 2026-04-24 §2.3 Layer 1).
         const val CLOSE_MESSAGE_TOO_LARGE = 1009
+        const val CLOSE_REASON_MESSAGE_TOO_LARGE = "message too large"
     }
 
     private var socket: OkHttpWebSocket? = null
@@ -86,7 +87,7 @@ class BasicOkHttpWebSocket(
                     webSocket: OkHttpWebSocket,
                     text: String,
                 ) {
-                    if (!acceptIncoming(webSocket, text)) return
+                    if (!acceptIncoming(text) { webSocket.close(CLOSE_MESSAGE_TOO_LARGE, CLOSE_REASON_MESSAGE_TOO_LARGE) }) return
                     // Asynchronously send the received message to the channel.
                     // `trySendBlocking` is used here for simplicity within the callback,
                     // but it's important to understand potential thread blocking if the buffer is full.
@@ -131,19 +132,21 @@ class BasicOkHttpWebSocket(
     override fun send(msg: String): Boolean = socket?.send(msg) ?: false
 
     // Decides whether an incoming WebSocket text message should be forwarded to `out`.
-    // Drops messages exceeding EventLimits.MAX_RELAY_MESSAGE_LENGTH and closes the socket
-    // (security review 2026-04-24 §2.3 Layer 1: a hostile relay can otherwise OOM the
-    // client with one giant frame before the per-event caps in EventDeserializer fire).
-    // Returns true when the caller should forward the message; false when it should drop.
+    // Drops messages exceeding EventLimits.MAX_RELAY_MESSAGE_LENGTH (security review
+    // 2026-04-24 §2.3 Layer 1: a hostile relay can otherwise OOM the client with one
+    // giant frame before the per-event caps in EventDeserializer fire). On overflow,
+    // invokes `closeOversized` (typically `webSocket.close(1009, "message too large")`)
+    // and returns false. The closer is supplied by the caller so this helper stays free
+    // of the `okhttp3.WebSocket` type and can be unit-tested without a fake.
     internal fun acceptIncoming(
-        webSocket: OkHttpWebSocket,
         text: String,
+        closeOversized: () -> Unit,
     ): Boolean {
         if (text.length > EventLimits.MAX_RELAY_MESSAGE_LENGTH) {
             Log.w("BasicOkHttpWebSocket") {
                 "Dropping ${text.length}-char message from $url; max is ${EventLimits.MAX_RELAY_MESSAGE_LENGTH}"
             }
-            webSocket.close(CLOSE_MESSAGE_TOO_LARGE, "message too large")
+            closeOversized()
             return false
         }
         return true

--- a/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/sockets/okhttp/BasicOkHttpWebSocketAcceptIncomingTest.kt
+++ b/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/sockets/okhttp/BasicOkHttpWebSocketAcceptIncomingTest.kt
@@ -24,14 +24,10 @@ import com.vitorpamplona.quartz.nip01Core.limits.EventLimits
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.relay.sockets.WebSocketListener
 import okhttp3.OkHttpClient
-import okhttp3.Request
-import okio.ByteString
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import okhttp3.WebSocket as OkHttpWebSocket
 
 // Layer 1 of security review 2026-04-24 §2.3: a hostile relay must not be able to deliver
 // frames larger than EventLimits.MAX_RELAY_MESSAGE_LENGTH. Per-event caps in EventDeserializer
@@ -39,30 +35,6 @@ import okhttp3.WebSocket as OkHttpWebSocket
 // already have allocated 10 MB before parsing begins. Layer 1 closes the socket at the WS
 // boundary with RFC 6455 close code 1009 ("Message Too Big").
 class BasicOkHttpWebSocketAcceptIncomingTest {
-    private class RecordingWebSocket : OkHttpWebSocket {
-        var closedCode: Int? = null
-        var closedReason: String? = null
-
-        override fun request(): Request = throw NotImplementedError("not used in test")
-
-        override fun queueSize(): Long = 0
-
-        override fun send(text: String): Boolean = throw NotImplementedError("not used in test")
-
-        override fun send(bytes: ByteString): Boolean = throw NotImplementedError("not used in test")
-
-        override fun close(
-            code: Int,
-            reason: String?,
-        ): Boolean {
-            closedCode = code
-            closedReason = reason
-            return true
-        }
-
-        override fun cancel() = Unit
-    }
-
     private val noopListener =
         object : WebSocketListener {
             override fun onOpen(
@@ -95,31 +67,33 @@ class BasicOkHttpWebSocketAcceptIncomingTest {
     @Test
     fun acceptIncomingForwardsMessagesAtAndBelowTheCap() {
         val sut = newSubject()
-        val ws = RecordingWebSocket()
+        var closeCalls = 0
 
-        assertTrue(sut.acceptIncoming(ws, "x".repeat(EventLimits.MAX_RELAY_MESSAGE_LENGTH)))
-        assertNull(ws.closedCode, "must not close socket on within-limit message")
-
-        assertTrue(sut.acceptIncoming(ws, "x".repeat(1)))
-        assertNull(ws.closedCode)
+        assertTrue(sut.acceptIncoming("x".repeat(EventLimits.MAX_RELAY_MESSAGE_LENGTH)) { closeCalls++ })
+        assertTrue(sut.acceptIncoming("x") { closeCalls++ })
+        assertEquals(0, closeCalls, "closer must not be invoked on within-limit messages")
     }
 
     @Test
-    fun acceptIncomingDropsAndClosesOnOversizedMessage() {
+    fun acceptIncomingDropsAndInvokesCloserOnOversizedMessage() {
         val sut = newSubject()
-        val ws = RecordingWebSocket()
+        var closeCalls = 0
 
-        val accepted = sut.acceptIncoming(ws, "x".repeat(EventLimits.MAX_RELAY_MESSAGE_LENGTH + 1))
+        val accepted = sut.acceptIncoming("x".repeat(EventLimits.MAX_RELAY_MESSAGE_LENGTH + 1)) { closeCalls++ }
 
         assertFalse(accepted, "oversized message must not be forwarded")
-        assertEquals(BasicOkHttpWebSocket.CLOSE_MESSAGE_TOO_LARGE, ws.closedCode)
-        assertEquals("message too large", ws.closedReason)
+        assertEquals(1, closeCalls, "closer must be invoked exactly once on overflow")
     }
 
     @Test
     fun closeCodeIsRfc6455MessageTooBig() {
-        // RFC 6455 §7.4.1 reserves 1009 for "Message Too Big". This guards against the
-        // constant accidentally drifting and silencing the wrong category of error.
+        // RFC 6455 §7.4.1 reserves 1009 for "Message Too Big". The listener wires this code
+        // to webSocket.close(...); pinning the constant guards against silent drift.
         assertEquals(1009, BasicOkHttpWebSocket.CLOSE_MESSAGE_TOO_LARGE)
+    }
+
+    @Test
+    fun closeReasonIsMessageTooLarge() {
+        assertEquals("message too large", BasicOkHttpWebSocket.CLOSE_REASON_MESSAGE_TOO_LARGE)
     }
 }

--- a/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/sockets/okhttp/BasicOkHttpWebSocketAcceptIncomingTest.kt
+++ b/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/sockets/okhttp/BasicOkHttpWebSocketAcceptIncomingTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.relay.sockets.okhttp
+
+import com.vitorpamplona.quartz.nip01Core.limits.EventLimits
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip01Core.relay.sockets.WebSocketListener
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okio.ByteString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import okhttp3.WebSocket as OkHttpWebSocket
+
+// Layer 1 of security review 2026-04-24 §2.3: a hostile relay must not be able to deliver
+// frames larger than EventLimits.MAX_RELAY_MESSAGE_LENGTH. Per-event caps in EventDeserializer
+// (Layer 2) only fire after the JSON has reached the parser, so a 10 MB JSON message would
+// already have allocated 10 MB before parsing begins. Layer 1 closes the socket at the WS
+// boundary with RFC 6455 close code 1009 ("Message Too Big").
+class BasicOkHttpWebSocketAcceptIncomingTest {
+    private class RecordingWebSocket : OkHttpWebSocket {
+        var closedCode: Int? = null
+        var closedReason: String? = null
+
+        override fun request(): Request = throw NotImplementedError("not used in test")
+
+        override fun queueSize(): Long = 0
+
+        override fun send(text: String): Boolean = throw NotImplementedError("not used in test")
+
+        override fun send(bytes: ByteString): Boolean = throw NotImplementedError("not used in test")
+
+        override fun close(
+            code: Int,
+            reason: String?,
+        ): Boolean {
+            closedCode = code
+            closedReason = reason
+            return true
+        }
+
+        override fun cancel() = Unit
+    }
+
+    private val noopListener =
+        object : WebSocketListener {
+            override fun onOpen(
+                pingMillis: Int,
+                compression: Boolean,
+            ) = Unit
+
+            override fun onMessage(text: String) = Unit
+
+            override fun onClosed(
+                code: Int,
+                reason: String,
+            ) = Unit
+
+            override fun onFailure(
+                t: Throwable,
+                code: Int?,
+                response: String?,
+            ) = Unit
+        }
+
+    private fun newSubject(): BasicOkHttpWebSocket =
+        // httpClient and url providers are never invoked because we never call connect().
+        BasicOkHttpWebSocket(
+            url = NormalizedRelayUrl("wss://example.invalid/"),
+            httpClient = { _: NormalizedRelayUrl -> OkHttpClient() },
+            out = noopListener,
+        )
+
+    @Test
+    fun acceptIncomingForwardsMessagesAtAndBelowTheCap() {
+        val sut = newSubject()
+        val ws = RecordingWebSocket()
+
+        assertTrue(sut.acceptIncoming(ws, "x".repeat(EventLimits.MAX_RELAY_MESSAGE_LENGTH)))
+        assertNull(ws.closedCode, "must not close socket on within-limit message")
+
+        assertTrue(sut.acceptIncoming(ws, "x".repeat(1)))
+        assertNull(ws.closedCode)
+    }
+
+    @Test
+    fun acceptIncomingDropsAndClosesOnOversizedMessage() {
+        val sut = newSubject()
+        val ws = RecordingWebSocket()
+
+        val accepted = sut.acceptIncoming(ws, "x".repeat(EventLimits.MAX_RELAY_MESSAGE_LENGTH + 1))
+
+        assertFalse(accepted, "oversized message must not be forwarded")
+        assertEquals(BasicOkHttpWebSocket.CLOSE_MESSAGE_TOO_LARGE, ws.closedCode)
+        assertEquals("message too large", ws.closedReason)
+    }
+
+    @Test
+    fun closeCodeIsRfc6455MessageTooBig() {
+        // RFC 6455 §7.4.1 reserves 1009 for "Message Too Big". This guards against the
+        // constant accidentally drifting and silencing the wrong category of error.
+        assertEquals(1009, BasicOkHttpWebSocket.CLOSE_MESSAGE_TOO_LARGE)
+    }
+}

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/JacksonEventDeserializerLimitsTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/JacksonEventDeserializerLimitsTest.kt
@@ -23,6 +23,7 @@ package com.vitorpamplona.quartz.nip01Core.jackson
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.limits.EventLimits
+import com.vitorpamplona.quartz.nip01Core.limits.EventLimitsTestSupport.buildEventJson
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -32,25 +33,7 @@ import kotlin.test.assertFailsWith
 // streaming Jackson deserializers (EventDeserializer + TagArrayDeserializer) which terminate
 // the parse early on cap overflow.
 class JacksonEventDeserializerLimitsTest {
-    private val id = "0".repeat(63) + "1"
-    private val pubKey = "0".repeat(63) + "2"
-    private val sig = "0".repeat(128)
-
     private fun parse(json: String): Event = JacksonMapper.mapper.readValue(json)
-
-    private fun buildEventJson(
-        contentLength: Int = 10,
-        tagCount: Int = 1,
-        tagInnerCount: Int = 2,
-        tagValueLength: Int = 5,
-    ): String {
-        val content = "x".repeat(contentLength)
-        val tagValue = "v".repeat(tagValueLength)
-        val inner = "\"t\"" + ",\"$tagValue\"".repeat((tagInnerCount - 1).coerceAtLeast(0))
-        val tag = "[$inner]"
-        val tags = (1..tagCount).joinToString(",") { tag }
-        return """{"id":"$id","pubkey":"$pubKey","created_at":1,"kind":1,"tags":[$tags],"content":"$content","sig":"$sig"}"""
-    }
 
     @Test
     fun acceptsEventWithinLimits() {

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/JacksonEventDeserializerLimitsTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/JacksonEventDeserializerLimitsTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.jackson
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.limits.EventLimits
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+// Jackson-path coverage for security review 2026-04-24 §2.3 / Finding #5.
+// The kotlinx path is exercised by EventLimitsTest in commonTest; this file targets the
+// streaming Jackson deserializers (EventDeserializer + TagArrayDeserializer) which terminate
+// the parse early on cap overflow.
+class JacksonEventDeserializerLimitsTest {
+    private val id = "0".repeat(63) + "1"
+    private val pubKey = "0".repeat(63) + "2"
+    private val sig = "0".repeat(128)
+
+    private fun parse(json: String): Event = JacksonMapper.mapper.readValue(json)
+
+    private fun buildEventJson(
+        contentLength: Int = 10,
+        tagCount: Int = 1,
+        tagInnerCount: Int = 2,
+        tagValueLength: Int = 5,
+    ): String {
+        val content = "x".repeat(contentLength)
+        val tagValue = "v".repeat(tagValueLength)
+        val inner = "\"t\"" + ",\"$tagValue\"".repeat((tagInnerCount - 1).coerceAtLeast(0))
+        val tag = "[$inner]"
+        val tags = (1..tagCount).joinToString(",") { tag }
+        return """{"id":"$id","pubkey":"$pubKey","created_at":1,"kind":1,"tags":[$tags],"content":"$content","sig":"$sig"}"""
+    }
+
+    @Test
+    fun acceptsEventWithinLimits() {
+        val event = parse(buildEventJson(contentLength = 100, tagCount = 5, tagInnerCount = 3, tagValueLength = 50))
+        assertEquals(5, event.tags.size)
+        assertEquals(100, event.content.length)
+    }
+
+    @Test
+    fun rejectsOversizedContent() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(contentLength = EventLimits.MAX_CONTENT_LENGTH + 1))
+            }
+        assertEquals(true, ex.message?.contains("content length"), ex.message)
+    }
+
+    @Test
+    fun rejectsTooManyTags() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(tagCount = EventLimits.MAX_TAG_COUNT + 1))
+            }
+        assertEquals(true, ex.message?.contains("tags"), ex.message)
+    }
+
+    @Test
+    fun rejectsTagWithTooManyElements() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(tagInnerCount = EventLimits.MAX_TAG_ELEMENTS_PER_TAG + 2))
+            }
+        assertEquals(true, ex.message?.contains("elements"), ex.message)
+    }
+
+    @Test
+    fun rejectsOversizedTagValue() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(tagValueLength = EventLimits.MAX_TAG_VALUE_LENGTH + 1))
+            }
+        assertEquals(true, ex.message?.contains("Tag value length"), ex.message)
+    }
+}

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/JacksonInternBehaviorTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/JacksonInternBehaviorTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.jackson
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+
+// Regression for security review 2026-04-24 §2.3 / Finding #5: the Jackson event/tag
+// deserializers used to call String.intern() on attacker-controlled fields (id, pubKey,
+// every tag value). Each interned string is permanently allocated in the JVM StringTable,
+// so a hostile relay could grow process memory without bound by flooding events with
+// unique ids / pubkeys / tag values.
+//
+// Post-fix: id, pubKey, and tag values (index >= 1) are stored as freshly-allocated
+// Strings; only the small protocol-defined set of tag keys (index 0: "p", "e", "a", …)
+// is still interned for hashmap performance.
+class JacksonInternBehaviorTest {
+    private val id = "0000000000000000000000000000000000000000000000000000000000000001"
+    private val pubKey = "0000000000000000000000000000000000000000000000000000000000000002"
+    private val sig = "0".repeat(128)
+
+    private fun jsonWithTagValue(tagValue: String): String = """{"id":"$id","pubkey":"$pubKey","created_at":1,"kind":1,"tags":[["t","$tagValue"]],"content":"","sig":"$sig"}"""
+
+    private fun parse(json: String): Event = JacksonMapper.mapper.readValue(json)
+
+    @Test
+    fun tagValuesAreNotInterned() {
+        // A unique-per-test value that no other code path is likely to have placed in the StringTable.
+        val unique = "anti-intern-tag-value-${System.nanoTime()}"
+        val a = parse(jsonWithTagValue(unique))
+        val b = parse(jsonWithTagValue(unique))
+
+        assertEquals(unique, a.tags[0][1])
+        assertEquals(unique, b.tags[0][1])
+        // Without intern, two parses produce distinct String references.
+        assertNotSame(
+            a.tags[0][1],
+            b.tags[0][1],
+            "tag values must not be interned (would let hostile relays grow the StringTable without bound)",
+        )
+    }
+
+    @Test
+    fun idAndPubKeyAreNotInterned() {
+        val a = parse(jsonWithTagValue("v"))
+        val b = parse(jsonWithTagValue("v"))
+
+        assertEquals(id, a.id)
+        assertEquals(pubKey, a.pubKey)
+        assertNotSame(a.id, b.id, "id must not be interned")
+        assertNotSame(a.pubKey, b.pubKey, "pubKey must not be interned")
+    }
+
+    @Test
+    fun tagKeysAreInterned() {
+        // Use a tag key unique to this test so no class-load literal pre-interns it.
+        val uniqueKey = "anti-intern-tag-key-${System.nanoTime()}"
+        val json =
+            """{"id":"$id","pubkey":"$pubKey","created_at":1,"kind":1,"tags":[["$uniqueKey","v1"]],"content":"","sig":"$sig"}"""
+        val a = parse(json)
+        val b = parse(json)
+
+        assertEquals(uniqueKey, a.tags[0][0])
+        // Tag keys remain interned for hashmap performance — finite protocol-defined set.
+        assertSame(
+            a.tags[0][0],
+            b.tags[0][0],
+            "tag keys (index 0) should still be interned",
+        )
+    }
+}


### PR DESCRIPTION
Implements §2.3 of the Quartz security review (Finding #5) in three layers, plus a follow-up code-review pass that simplified the patch.

## Layers

### Layer 3 — drop attacker-controlled `String.intern()`
Tag values, `id`, and `pubKey` are no longer interned. Each interned string is permanently allocated in the JVM StringTable, so a hostile relay could grow process memory without bound by flooding events with unique values. Tag *keys* (`"p"`, `"e"`, `"a"`, …) remain interned since they're a small protocol-defined set.

### Layer 2 — size / count / length caps
New `EventLimits` constants (defense-in-depth):

| Cap | Value | Real-world max in `LargeDBTests` fixture (248K events) |
|---|---|---|
| `MAX_CONTENT_LENGTH` | 64 KB | 47 KB |
| `MAX_TAG_COUNT` | 2 000 | 204 |
| `MAX_TAG_ELEMENTS_PER_TAG` | 256 | 104 |
| `MAX_TAG_VALUE_LENGTH` | 16 KB | ~10 KB |
| `MAX_RELAY_MESSAGE_LENGTH` | 256 KB | (used by Layer 1) |

Wired into both deserializer paths:
- **Jackson** (`EventDeserializer`, `TagArrayDeserializer`): early termination during streaming parse so a hostile relay can't grow allocations beyond the bound before being rejected.
- **kotlinx** (`EventKSerializer`, `TagArrayKSerializer`): inline checks during decoding from `JsonElement`, plus post-parse `validateContent`.

Throws `IllegalArgumentException` on overflow.

### Layer 1 — WebSocket message-size cap
`BasicOkHttpWebSocket` rejects any incoming message exceeding `MAX_RELAY_MESSAGE_LENGTH` and closes the socket with RFC 6455 close code 1009 ("Message Too Big"). Catches the giant-frame OOM class before the per-event caps fire.

## Why this PR

The original review labeled this finding as HIGH because, when paired with §2.1 (signature verification on receive), a single oversized event from a hostile relay could OOM the client; a slow drip of unique tag values could leak memory permanently via the StringTable.

## Test plan

- [x] `EventLimitsTest` (commonTest, kotlinx path) — 5 tests covering accepts-within-limits + 4 rejection cases
- [x] `JacksonEventDeserializerLimitsTest` (jvmTest, Jackson path) — same matrix
- [x] `JacksonInternBehaviorTest` (jvmTest) — 3 tests verifying tag values / id / pubKey not interned, tag keys still interned
- [x] `BasicOkHttpWebSocketAcceptIncomingTest` (jvmAndroidTest) — 4 tests: forward at-cap, drop+close at-cap+1, pin RFC code 1009, pin reason string
- [x] Full `:quartz:jvmTest` — **1881 tests / 188 suites all green** after rebase onto current `upstream/main`
- [x] `LargeDBTests` (real-world fixture, 248K events) — loads cleanly; cap headroom verified

## Commits

1. `f8577053b` — Layer 3: drop attacker-controlled intern
2. `af1bcfcdb` — Layer 2: event/tag/value caps
3. `dcd288018` — Layer 1: WS message-size cap
4. `e2fc88604` — Code review: simplify (single-pass validate, dedup test fixtures, lambda closer, drop redundant `index` counter, named close-reason constant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)