### PR TITLE
fix(quartz): validate event id, pubKey, sig hex/length and kind range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,7 @@ TASKS.md
 
 # Claude Code local settings
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Downloaded VLC binaries (vlc-setup plugin)
 desktopApp/src/jvmMain/appResources/linux/

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/EventKSerializer.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/EventKSerializer.kt
@@ -101,10 +101,6 @@ object EventKSerializer : KSerializer<Event> {
             }
         }
 
-        if (pubKey.isEmpty()) {
-            throw IllegalArgumentException("Event not found")
-        }
-
         EventLimits.validateFields(id, pubKey, sig, kind)
         EventLimits.validateContent(content)
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/EventKSerializer.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/EventKSerializer.kt
@@ -105,6 +105,7 @@ object EventKSerializer : KSerializer<Event> {
             throw IllegalArgumentException("Event not found")
         }
 
+        EventLimits.validateFields(id, pubKey, sig, kind)
         EventLimits.validateContent(content)
 
         return EventFactory.create(id, pubKey, createdAt, kind, tags, content, sig)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/EventKSerializer.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/EventKSerializer.kt
@@ -105,7 +105,7 @@ object EventKSerializer : KSerializer<Event> {
             throw IllegalArgumentException("Event not found")
         }
 
-        EventLimits.validate(content, tags)
+        EventLimits.validateContent(content)
 
         return EventFactory.create(id, pubKey, createdAt, kind, tags, content, sig)
     }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/EventKSerializer.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/EventKSerializer.kt
@@ -24,6 +24,7 @@ import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.Kind
 import com.vitorpamplona.quartz.nip01Core.core.TagArray
+import com.vitorpamplona.quartz.nip01Core.limits.EventLimits
 import com.vitorpamplona.quartz.utils.EventFactory
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -103,6 +104,8 @@ object EventKSerializer : KSerializer<Event> {
         if (pubKey.isEmpty()) {
             throw IllegalArgumentException("Event not found")
         }
+
+        EventLimits.validate(content, tags)
 
         return EventFactory.create(id, pubKey, createdAt, kind, tags, content, sig)
     }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/TagArrayKSerializer.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/TagArrayKSerializer.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.quartz.nip01Core.kotlinSerialization
 
 import com.vitorpamplona.quartz.nip01Core.core.TagArray
+import com.vitorpamplona.quartz.nip01Core.limits.EventLimits
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
@@ -68,15 +69,25 @@ object TagArrayKSerializer : KSerializer<TagArray> {
 
     fun deserializeFromElement(element: JsonElement): TagArray {
         val array = element.jsonArray
+        require(array.size <= EventLimits.MAX_TAG_COUNT) {
+            "Event has ${array.size} tags; max is ${EventLimits.MAX_TAG_COUNT}"
+        }
         val outerList = ArrayList<Array<String>>(array.size)
         for (inner in array) {
             val innerArray = inner.jsonArray
+            require(innerArray.size <= EventLimits.MAX_TAG_ELEMENTS_PER_TAG) {
+                "Tag has ${innerArray.size} elements; max is ${EventLimits.MAX_TAG_ELEMENTS_PER_TAG}"
+            }
             val innerList = ArrayList<String>(innerArray.size.coerceAtLeast(5))
             for (s in innerArray) {
                 if (s is JsonNull) {
                     innerList.add("")
                 } else {
-                    innerList.add(s.jsonPrimitive.content)
+                    val text = s.jsonPrimitive.content
+                    require(text.length <= EventLimits.MAX_TAG_VALUE_LENGTH) {
+                        "Tag value length ${text.length} exceeds max ${EventLimits.MAX_TAG_VALUE_LENGTH}"
+                    }
+                    innerList.add(text)
                 }
             }
             outerList.add(innerList.toTypedArray())

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimits.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimits.kt
@@ -37,13 +37,17 @@ object EventLimits {
     const val MAX_CONTENT_LENGTH = 64 * 1024
     const val MAX_RELAY_MESSAGE_LENGTH = 256 * 1024
 
-    fun validate(
-        content: String,
-        tags: TagArray,
-    ) {
+    fun validateContent(content: String) {
         require(content.length <= MAX_CONTENT_LENGTH) {
             "Event content length ${content.length} exceeds max $MAX_CONTENT_LENGTH"
         }
+    }
+
+    // Used by callers that have a TagArray in hand (e.g. constructed without going through
+    // a tag deserializer). The streaming Jackson and kotlinx tag deserializers already
+    // enforce these caps inline during parse, so the deserializer hot path does not call
+    // this helper.
+    fun validateTags(tags: TagArray) {
         require(tags.size <= MAX_TAG_COUNT) {
             "Event has ${tags.size} tags; max is $MAX_TAG_COUNT"
         }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimits.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimits.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.quartz.nip01Core.limits
 
 import com.vitorpamplona.quartz.nip01Core.core.TagArray
+import com.vitorpamplona.quartz.utils.Hex
 
 // Defense-in-depth caps on relay-supplied event payloads.
 // A hostile relay can otherwise OOM the client with one giant event or a flood of large tags
@@ -37,9 +38,47 @@ object EventLimits {
     const val MAX_CONTENT_LENGTH = 64 * 1024
     const val MAX_RELAY_MESSAGE_LENGTH = 256 * 1024
 
+    // NIP-01 declares `kind` as an unsigned 16-bit integer (0..65 535).
+    const val MAX_KIND = 65_535
+
     fun validateContent(content: String) {
         require(content.length <= MAX_CONTENT_LENGTH) {
             "Event content length ${content.length} exceeds max $MAX_CONTENT_LENGTH"
+        }
+    }
+
+    // Validates structural fields of an Event after deserialization (security review
+    // 2026-04-24 §2.4 / Finding #11). Without this, malformed events sit in the cache
+    // permanently and only blow up later inside Hex.decode if signature verification
+    // ever runs.
+    //
+    // - `id`/`pubKey`: required 64-char hex (32-byte hashes / x-only pubkeys).
+    // - `sig`: 128-char hex (64-byte Schnorr signature) when present, OR empty.
+    //   NIP-17 (kind:14 DMs) and NIP-37 drafts are stored as Event with sig="" because
+    //   the inner-event rumor is unsigned per NIP-59; we'd reject ~5 K real DMs from
+    //   any production cache otherwise. Signature verification (security review §2.1)
+    //   handles the "must be signed if non-empty" semantic.
+    // - `kind`: NIP-01 u16 range.
+    //
+    // `createdAt` is intentionally not bounded here: it's a UI / feed-sort concern, and
+    // archive replay legitimately produces events with timestamps from years ago.
+    fun validateFields(
+        id: String,
+        pubKey: String,
+        sig: String,
+        kind: Int,
+    ) {
+        require(id.length == 64 && Hex.isHex64(id)) {
+            "Event id must be 64-char hex; got length=${id.length}"
+        }
+        require(pubKey.length == 64 && Hex.isHex64(pubKey)) {
+            "Event pubKey must be 64-char hex; got length=${pubKey.length}"
+        }
+        require(sig.isEmpty() || (sig.length == 128 && Hex.isHex(sig))) {
+            "Event sig must be empty or 128-char hex; got length=${sig.length}"
+        }
+        require(kind in 0..MAX_KIND) {
+            "Event kind $kind out of range [0, $MAX_KIND]"
         }
     }
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimits.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimits.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.limits
+
+import com.vitorpamplona.quartz.nip01Core.core.TagArray
+
+// Defense-in-depth caps on relay-supplied event payloads.
+// A hostile relay can otherwise OOM the client with one giant event or a flood of large tags
+// (security review 2026-04-24 §2.3). Numbers are conservative: well above any legitimate
+// real-world event seen in production, well below sizes that would meaningfully impact memory.
+object EventLimits {
+    const val MAX_TAG_COUNT = 2_000
+
+    // Sized to accommodate observed real-world events (max ~104 inner elements in Vitor's
+    // startup-data fixture) with ~2.5x headroom; still small enough that an attacker can't
+    // amplify a single tag into a meaningful allocation.
+    const val MAX_TAG_ELEMENTS_PER_TAG = 256
+    const val MAX_TAG_VALUE_LENGTH = 16 * 1024
+    const val MAX_CONTENT_LENGTH = 64 * 1024
+    const val MAX_RELAY_MESSAGE_LENGTH = 256 * 1024
+
+    fun validate(
+        content: String,
+        tags: TagArray,
+    ) {
+        require(content.length <= MAX_CONTENT_LENGTH) {
+            "Event content length ${content.length} exceeds max $MAX_CONTENT_LENGTH"
+        }
+        require(tags.size <= MAX_TAG_COUNT) {
+            "Event has ${tags.size} tags; max is $MAX_TAG_COUNT"
+        }
+        for (tag in tags) {
+            require(tag.size <= MAX_TAG_ELEMENTS_PER_TAG) {
+                "Tag has ${tag.size} elements; max is $MAX_TAG_ELEMENTS_PER_TAG"
+            }
+            for (value in tag) {
+                require(value.length <= MAX_TAG_VALUE_LENGTH) {
+                    "Tag value length ${value.length} exceeds max $MAX_TAG_VALUE_LENGTH"
+                }
+            }
+        }
+    }
+}

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTest.kt
@@ -24,115 +24,60 @@ import com.vitorpamplona.quartz.nip01Core.kotlinSerialization.KotlinSerializatio
 import com.vitorpamplona.quartz.nip01Core.limits.EventLimitsTestSupport.buildEventJson
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 
-// Regression for security review 2026-04-24 §2.3 / Finding #5: the deserializers used to
-// materialize whole events with no upper bound. A hostile relay could OOM the client with
-// one giant event or a flood of large tags. Caps are enforced inline by the tag deserializers
-// and post-parse by EventLimits.validateContent.
+// Regression for security review 2026-04-24 §2.3 / Finding #5 + §2.4 / Finding #11.
+// Exercises the kotlinx path; JacksonEventDeserializerLimitsTest mirrors this against the
+// streaming Jackson parser.
 class EventLimitsTest {
     private fun parse(json: String) = KotlinSerializationMapper.fromJson(json)
 
     @Test
     fun acceptsEventWithinLimits() {
-        val event =
-            parse(buildEventJson(contentLength = 100, tagCount = 5, tagInnerCount = 3, tagValueLength = 50))
+        val event = parse(buildEventJson(contentLength = 100, tagCount = 5, tagInnerCount = 3, tagValueLength = 50))
         assertEquals(5, event.tags.size)
         assertEquals(100, event.content.length)
         assertEquals(3, event.tags[0].size)
     }
 
-    @Test
-    fun rejectsOversizedContent() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(contentLength = EventLimits.MAX_CONTENT_LENGTH + 1))
-            }
-        assertEquals(true, ex.message?.contains("content length"), ex.message)
-    }
+    // --- §2.3: size / count / length caps ---
 
     @Test
-    fun rejectsTooManyTags() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(tagCount = EventLimits.MAX_TAG_COUNT + 1))
-            }
-        assertEquals(true, ex.message?.contains("tags"), ex.message)
-    }
+    fun rejectsOversizedContent() = assertRejectsBecause(::parse, buildEventJson(contentLength = EventLimits.MAX_CONTENT_LENGTH + 1), "content length")
 
     @Test
-    fun rejectsTagWithTooManyElements() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(tagInnerCount = EventLimits.MAX_TAG_ELEMENTS_PER_TAG + 2))
-            }
-        assertEquals(true, ex.message?.contains("elements"), ex.message)
-    }
+    fun rejectsTooManyTags() = assertRejectsBecause(::parse, buildEventJson(tagCount = EventLimits.MAX_TAG_COUNT + 1), "tags")
 
     @Test
-    fun rejectsOversizedTagValue() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(tagValueLength = EventLimits.MAX_TAG_VALUE_LENGTH + 1))
-            }
-        assertEquals(true, ex.message?.contains("Tag value length"), ex.message)
-    }
-
-    // --- §2.4: id / pubKey / sig / kind / createdAt validation ---
+    fun rejectsTagWithTooManyElements() = assertRejectsBecause(::parse, buildEventJson(tagInnerCount = EventLimits.MAX_TAG_ELEMENTS_PER_TAG + 2), "elements")
 
     @Test
-    fun rejectsIdWithWrongLength() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(id = "0".repeat(63)))
-            }
-        assertEquals(true, ex.message?.contains("id must be 64-char hex"), ex.message)
-    }
+    fun rejectsOversizedTagValue() = assertRejectsBecause(::parse, buildEventJson(tagValueLength = EventLimits.MAX_TAG_VALUE_LENGTH + 1), "Tag value length")
+
+    // --- §2.4: id / pubKey / sig / kind validation ---
 
     @Test
-    fun rejectsIdWithNonHex() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(id = "z".repeat(64)))
-            }
-        assertEquals(true, ex.message?.contains("id must be 64-char hex"), ex.message)
-    }
+    fun rejectsIdWithWrongLength() = assertRejectsBecause(::parse, buildEventJson(id = "0".repeat(63)), "id must be 64-char hex")
 
     @Test
-    fun rejectsPubKeyWithWrongLength() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(pubKey = "0".repeat(65)))
-            }
-        assertEquals(true, ex.message?.contains("pubKey must be 64-char hex"), ex.message)
-    }
+    fun rejectsIdWithNonHex() = assertRejectsBecause(::parse, buildEventJson(id = "z".repeat(64)), "id must be 64-char hex")
 
     @Test
-    fun rejectsPubKeyWithNonHex() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(pubKey = "g".repeat(64)))
-            }
-        assertEquals(true, ex.message?.contains("pubKey must be 64-char hex"), ex.message)
-    }
+    fun rejectsPubKeyWithWrongLength() = assertRejectsBecause(::parse, buildEventJson(pubKey = "0".repeat(65)), "pubKey must be 64-char hex")
 
     @Test
-    fun rejectsSigWithWrongNonZeroLength() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(sig = "0".repeat(127)))
-            }
-        assertEquals(true, ex.message?.contains("sig must be empty or 128-char hex"), ex.message)
-    }
+    fun rejectsPubKeyWithNonHex() = assertRejectsBecause(::parse, buildEventJson(pubKey = "g".repeat(64)), "pubKey must be 64-char hex")
 
     @Test
-    fun rejectsSigWithNonHex() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(sig = "z".repeat(128)))
-            }
-        assertEquals(true, ex.message?.contains("sig must be empty or 128-char hex"), ex.message)
-    }
+    fun rejectsSigWithWrongNonZeroLength() = assertRejectsBecause(::parse, buildEventJson(sig = "0".repeat(127)), "sig must be empty or 128-char hex")
+
+    @Test
+    fun rejectsSigWithNonHex() = assertRejectsBecause(::parse, buildEventJson(sig = "z".repeat(128)), "sig must be empty or 128-char hex")
+
+    @Test
+    fun rejectsKindAboveMax() = assertRejectsBecause(::parse, buildEventJson(kind = EventLimits.MAX_KIND + 1), "kind")
+
+    @Test
+    fun rejectsKindBelowZero() = assertRejectsBecause(::parse, buildEventJson(kind = -1), "kind")
 
     @Test
     fun acceptsEmptySig() {
@@ -144,27 +89,9 @@ class EventLimitsTest {
     }
 
     @Test
-    fun rejectsKindAboveMax() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(kind = EventLimits.MAX_KIND + 1))
-            }
-        assertEquals(true, ex.message?.contains("kind"), ex.message)
-    }
-
-    @Test
-    fun rejectsKindBelowZero() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(kind = -1))
-            }
-        assertEquals(true, ex.message?.contains("kind"), ex.message)
-    }
-
-    @Test
     fun acceptsAncientCreatedAt() {
         // Archive replay legitimately produces events with timestamps from years ago.
-        // The deserializer doesn't bound createdAt; UI / feed-sort code can apply policy.
+        // The deserializer doesn't bound createdAt; UI / feed-sort code applies policy.
         val event = parse(buildEventJson(createdAt = 100L))
         assertEquals(100L, event.createdAt)
     }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTest.kt
@@ -77,4 +77,95 @@ class EventLimitsTest {
             }
         assertEquals(true, ex.message?.contains("Tag value length"), ex.message)
     }
+
+    // --- §2.4: id / pubKey / sig / kind / createdAt validation ---
+
+    @Test
+    fun rejectsIdWithWrongLength() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(id = "0".repeat(63)))
+            }
+        assertEquals(true, ex.message?.contains("id must be 64-char hex"), ex.message)
+    }
+
+    @Test
+    fun rejectsIdWithNonHex() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(id = "z".repeat(64)))
+            }
+        assertEquals(true, ex.message?.contains("id must be 64-char hex"), ex.message)
+    }
+
+    @Test
+    fun rejectsPubKeyWithWrongLength() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(pubKey = "0".repeat(65)))
+            }
+        assertEquals(true, ex.message?.contains("pubKey must be 64-char hex"), ex.message)
+    }
+
+    @Test
+    fun rejectsPubKeyWithNonHex() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(pubKey = "g".repeat(64)))
+            }
+        assertEquals(true, ex.message?.contains("pubKey must be 64-char hex"), ex.message)
+    }
+
+    @Test
+    fun rejectsSigWithWrongNonZeroLength() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(sig = "0".repeat(127)))
+            }
+        assertEquals(true, ex.message?.contains("sig must be empty or 128-char hex"), ex.message)
+    }
+
+    @Test
+    fun rejectsSigWithNonHex() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(sig = "z".repeat(128)))
+            }
+        assertEquals(true, ex.message?.contains("sig must be empty or 128-char hex"), ex.message)
+    }
+
+    @Test
+    fun acceptsEmptySig() {
+        // NIP-17 (kind:14 DMs) and NIP-37 drafts are stored as Event with sig="" because
+        // the inner-event rumor is unsigned per NIP-59. Production caches contain ~5 K
+        // such events; the deserializer must accept them.
+        val event = parse(buildEventJson(sig = ""))
+        assertEquals("", event.sig)
+    }
+
+    @Test
+    fun rejectsKindAboveMax() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(kind = EventLimits.MAX_KIND + 1))
+            }
+        assertEquals(true, ex.message?.contains("kind"), ex.message)
+    }
+
+    @Test
+    fun rejectsKindBelowZero() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(kind = -1))
+            }
+        assertEquals(true, ex.message?.contains("kind"), ex.message)
+    }
+
+    @Test
+    fun acceptsAncientCreatedAt() {
+        // Archive replay legitimately produces events with timestamps from years ago.
+        // The deserializer doesn't bound createdAt; UI / feed-sort code can apply policy.
+        val event = parse(buildEventJson(createdAt = 100L))
+        assertEquals(100L, event.createdAt)
+    }
 }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTest.kt
@@ -21,35 +21,17 @@
 package com.vitorpamplona.quartz.nip01Core.limits
 
 import com.vitorpamplona.quartz.nip01Core.kotlinSerialization.KotlinSerializationMapper
+import com.vitorpamplona.quartz.nip01Core.limits.EventLimitsTestSupport.buildEventJson
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 // Regression for security review 2026-04-24 §2.3 / Finding #5: the deserializers used to
 // materialize whole events with no upper bound. A hostile relay could OOM the client with
-// one giant event or a flood of large tags. Caps are now enforced via EventLimits.validate()
-// and inside TagArrayKSerializer.
+// one giant event or a flood of large tags. Caps are enforced inline by the tag deserializers
+// and post-parse by EventLimits.validateContent.
 class EventLimitsTest {
-    private val id = "0".repeat(63) + "1"
-    private val pubKey = "0".repeat(63) + "2"
-    private val sig = "0".repeat(128)
-
     private fun parse(json: String) = KotlinSerializationMapper.fromJson(json)
-
-    private fun buildEventJson(
-        contentLength: Int = 10,
-        tagCount: Int = 1,
-        tagInnerCount: Int = 2,
-        tagValueLength: Int = 5,
-    ): String {
-        val content = "x".repeat(contentLength)
-        val tagValue = "v".repeat(tagValueLength)
-        // First element is a short tag key "t"; remaining (tagInnerCount - 1) are values of length tagValueLength.
-        val inner = "\"t\"" + ",\"$tagValue\"".repeat((tagInnerCount - 1).coerceAtLeast(0))
-        val tag = "[$inner]"
-        val tags = (1..tagCount).joinToString(",") { tag }
-        return """{"id":"$id","pubkey":"$pubKey","created_at":1,"kind":1,"tags":[$tags],"content":"$content","sig":"$sig"}"""
-    }
 
     @Test
     fun acceptsEventWithinLimits() {

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.limits
+
+import com.vitorpamplona.quartz.nip01Core.kotlinSerialization.KotlinSerializationMapper
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+// Regression for security review 2026-04-24 §2.3 / Finding #5: the deserializers used to
+// materialize whole events with no upper bound. A hostile relay could OOM the client with
+// one giant event or a flood of large tags. Caps are now enforced via EventLimits.validate()
+// and inside TagArrayKSerializer.
+class EventLimitsTest {
+    private val id = "0".repeat(63) + "1"
+    private val pubKey = "0".repeat(63) + "2"
+    private val sig = "0".repeat(128)
+
+    private fun parse(json: String) = KotlinSerializationMapper.fromJson(json)
+
+    private fun buildEventJson(
+        contentLength: Int = 10,
+        tagCount: Int = 1,
+        tagInnerCount: Int = 2,
+        tagValueLength: Int = 5,
+    ): String {
+        val content = "x".repeat(contentLength)
+        val tagValue = "v".repeat(tagValueLength)
+        // First element is a short tag key "t"; remaining (tagInnerCount - 1) are values of length tagValueLength.
+        val inner = "\"t\"" + ",\"$tagValue\"".repeat((tagInnerCount - 1).coerceAtLeast(0))
+        val tag = "[$inner]"
+        val tags = (1..tagCount).joinToString(",") { tag }
+        return """{"id":"$id","pubkey":"$pubKey","created_at":1,"kind":1,"tags":[$tags],"content":"$content","sig":"$sig"}"""
+    }
+
+    @Test
+    fun acceptsEventWithinLimits() {
+        val event =
+            parse(buildEventJson(contentLength = 100, tagCount = 5, tagInnerCount = 3, tagValueLength = 50))
+        assertEquals(5, event.tags.size)
+        assertEquals(100, event.content.length)
+        assertEquals(3, event.tags[0].size)
+    }
+
+    @Test
+    fun rejectsOversizedContent() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(contentLength = EventLimits.MAX_CONTENT_LENGTH + 1))
+            }
+        assertEquals(true, ex.message?.contains("content length"), ex.message)
+    }
+
+    @Test
+    fun rejectsTooManyTags() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(tagCount = EventLimits.MAX_TAG_COUNT + 1))
+            }
+        assertEquals(true, ex.message?.contains("tags"), ex.message)
+    }
+
+    @Test
+    fun rejectsTagWithTooManyElements() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(tagInnerCount = EventLimits.MAX_TAG_ELEMENTS_PER_TAG + 2))
+            }
+        assertEquals(true, ex.message?.contains("elements"), ex.message)
+    }
+
+    @Test
+    fun rejectsOversizedTagValue() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(tagValueLength = EventLimits.MAX_TAG_VALUE_LENGTH + 1))
+            }
+        assertEquals(true, ex.message?.contains("Tag value length"), ex.message)
+    }
+}

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTestSupport.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTestSupport.kt
@@ -20,7 +20,19 @@
  */
 package com.vitorpamplona.quartz.nip01Core.limits
 
+import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.utils.TimeUtils
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+internal fun assertRejectsBecause(
+    parse: (String) -> Event,
+    json: String,
+    expectedMessageFragment: String,
+) {
+    val ex = assertFailsWith<IllegalArgumentException> { parse(json) }
+    assertEquals(true, ex.message?.contains(expectedMessageFragment), ex.message)
+}
 
 internal object EventLimitsTestSupport {
     const val ID = "0000000000000000000000000000000000000000000000000000000000000001"

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTestSupport.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTestSupport.kt
@@ -20,12 +20,19 @@
  */
 package com.vitorpamplona.quartz.nip01Core.limits
 
+import com.vitorpamplona.quartz.utils.TimeUtils
+
 internal object EventLimitsTestSupport {
     const val ID = "0000000000000000000000000000000000000000000000000000000000000001"
     const val PUB_KEY = "0000000000000000000000000000000000000000000000000000000000000002"
     val SIG = "0".repeat(128)
 
     fun buildEventJson(
+        id: String = ID,
+        pubKey: String = PUB_KEY,
+        sig: String = SIG,
+        kind: Int = 1,
+        createdAt: Long = TimeUtils.now(),
         contentLength: Int = 10,
         tagCount: Int = 1,
         tagInnerCount: Int = 2,
@@ -37,6 +44,6 @@ internal object EventLimitsTestSupport {
         val inner = "\"t\"" + ",\"$tagValue\"".repeat((tagInnerCount - 1).coerceAtLeast(0))
         val tag = "[$inner]"
         val tags = (1..tagCount).joinToString(",") { tag }
-        return """{"id":"$ID","pubkey":"$PUB_KEY","created_at":1,"kind":1,"tags":[$tags],"content":"$content","sig":"$SIG"}"""
+        return """{"id":"$id","pubkey":"$pubKey","created_at":$createdAt,"kind":$kind,"tags":[$tags],"content":"$content","sig":"$sig"}"""
     }
 }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTestSupport.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/limits/EventLimitsTestSupport.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.limits
+
+internal object EventLimitsTestSupport {
+    const val ID = "0000000000000000000000000000000000000000000000000000000000000001"
+    const val PUB_KEY = "0000000000000000000000000000000000000000000000000000000000000002"
+    val SIG = "0".repeat(128)
+
+    fun buildEventJson(
+        contentLength: Int = 10,
+        tagCount: Int = 1,
+        tagInnerCount: Int = 2,
+        tagValueLength: Int = 5,
+    ): String {
+        val content = "x".repeat(contentLength)
+        val tagValue = "v".repeat(tagValueLength)
+        // First element is a short tag key "t"; remaining (tagInnerCount - 1) are values of length tagValueLength.
+        val inner = "\"t\"" + ",\"$tagValue\"".repeat((tagInnerCount - 1).coerceAtLeast(0))
+        val tag = "[$inner]"
+        val tags = (1..tagCount).joinToString(",") { tag }
+        return """{"id":"$ID","pubkey":"$PUB_KEY","created_at":1,"kind":1,"tags":[$tags],"content":"$content","sig":"$SIG"}"""
+    }
+}

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/EventDeserializer.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/EventDeserializer.kt
@@ -78,7 +78,7 @@ class EventDeserializer : StdDeserializer<Event>(Event::class.java) {
             throw IllegalArgumentException("Event not found")
         }
 
-        EventLimits.validate(content, tags)
+        EventLimits.validateContent(content)
 
         return EventFactory.create(id, pubKey, createdAt, kind, tags, content, sig)
     }

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/EventDeserializer.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/EventDeserializer.kt
@@ -74,10 +74,6 @@ class EventDeserializer : StdDeserializer<Event>(Event::class.java) {
             }
         }
 
-        if (pubKey.isEmpty()) {
-            throw IllegalArgumentException("Event not found")
-        }
-
         EventLimits.validateFields(id, pubKey, sig, kind)
         EventLimits.validateContent(content)
 

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/EventDeserializer.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/EventDeserializer.kt
@@ -52,13 +52,23 @@ class EventDeserializer : StdDeserializer<Event>(Event::class.java) {
             p.nextToken()
 
             when (fieldName.hashCode()) {
-                3355 -> id = p.text.intern()
-                -977424830 -> pubKey = p.text.intern()
+                // Do not intern id/pubKey: each event ships a unique 64-char hex id, and a hostile
+                // relay could flood ids/pubkeys to grow the JVM StringTable without bound (security
+                // review 2026-04-24 §2.3).
+                3355 -> id = p.text
+
+                -977424830 -> pubKey = p.text
+
                 1369680106 -> createdAt = p.longValue
+
                 3292052 -> kind = p.intValue
+
                 3552281 -> tags = tagsDeserializer.deserialize(p, ctxt)
+
                 951530617 -> content = p.text
+
                 113873 -> sig = p.text
+
                 else -> p.skipChildren()
             }
         }

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/EventDeserializer.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/EventDeserializer.kt
@@ -28,6 +28,7 @@ import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.Kind
 import com.vitorpamplona.quartz.nip01Core.core.TagArray
+import com.vitorpamplona.quartz.nip01Core.limits.EventLimits
 import com.vitorpamplona.quartz.utils.EventFactory
 
 class EventDeserializer : StdDeserializer<Event>(Event::class.java) {
@@ -76,6 +77,8 @@ class EventDeserializer : StdDeserializer<Event>(Event::class.java) {
         if (pubKey.isEmpty()) {
             throw IllegalArgumentException("Event not found")
         }
+
+        EventLimits.validate(content, tags)
 
         return EventFactory.create(id, pubKey, createdAt, kind, tags, content, sig)
     }

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/EventDeserializer.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/EventDeserializer.kt
@@ -78,6 +78,7 @@ class EventDeserializer : StdDeserializer<Event>(Event::class.java) {
             throw IllegalArgumentException("Event not found")
         }
 
+        EventLimits.validateFields(id, pubKey, sig, kind)
         EventLimits.validateContent(content)
 
         return EventFactory.create(id, pubKey, createdAt, kind, tags, content, sig)

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/TagArrayDeserializer.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/TagArrayDeserializer.kt
@@ -32,16 +32,21 @@ class TagArrayDeserializer : StdDeserializer<TagArray>(TagArray::class.java) {
         p: JsonParser,
         ctxt: DeserializationContext,
     ): TagArray {
-        // doesn't check for weird payloads on purpose.
         val outerList = ArrayList<Array<String>>()
         while (p.nextToken() != JsonToken.END_ARRAY) {
             val innerList = ArrayList<String>(5)
+            var index = 0
             while (p.nextToken() != JsonToken.END_ARRAY) {
                 if (p.currentToken == JsonToken.VALUE_NULL) {
                     innerList.add("")
                 } else {
-                    innerList.add(p.text.intern())
+                    // Intern only the tag key (index 0) — protocol-defined finite set ("p", "e", "a", …).
+                    // Tag values at index >= 1 are attacker-controlled (pubkeys, event ids, URLs, free text)
+                    // and must not be promoted to the JVM StringTable: hostile relays could flood unique
+                    // values to grow it without bound (security review 2026-04-24 §2.3).
+                    innerList.add(if (index == 0) p.text.intern() else p.text)
                 }
+                index++
             }
 
             outerList.add(innerList.toArray(arrayOfNulls<String>(innerList.size)))

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/TagArrayDeserializer.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/TagArrayDeserializer.kt
@@ -39,7 +39,6 @@ class TagArrayDeserializer : StdDeserializer<TagArray>(TagArray::class.java) {
                 "Event has more than ${EventLimits.MAX_TAG_COUNT} tags"
             }
             val innerList = ArrayList<String>(5)
-            var index = 0
             while (p.nextToken() != JsonToken.END_ARRAY) {
                 require(innerList.size < EventLimits.MAX_TAG_ELEMENTS_PER_TAG) {
                     "Tag has more than ${EventLimits.MAX_TAG_ELEMENTS_PER_TAG} elements"
@@ -51,13 +50,13 @@ class TagArrayDeserializer : StdDeserializer<TagArray>(TagArray::class.java) {
                     require(text.length <= EventLimits.MAX_TAG_VALUE_LENGTH) {
                         "Tag value length ${text.length} exceeds max ${EventLimits.MAX_TAG_VALUE_LENGTH}"
                     }
-                    // Intern only the tag key (index 0) — protocol-defined finite set ("p", "e", "a", …).
-                    // Tag values at index >= 1 are attacker-controlled (pubkeys, event ids, URLs, free text)
-                    // and must not be promoted to the JVM StringTable: hostile relays could flood unique
-                    // values to grow it without bound (security review 2026-04-24 §2.3).
-                    innerList.add(if (index == 0) text.intern() else text)
+                    // Intern only the tag key (the first element) — protocol-defined finite set
+                    // ("p", "e", "a", …). Tag values at later positions are attacker-controlled
+                    // (pubkeys, event ids, URLs, free text) and must not be promoted to the JVM
+                    // StringTable: hostile relays could flood unique values to grow it without
+                    // bound (security review 2026-04-24 §2.3).
+                    innerList.add(if (innerList.isEmpty()) text.intern() else text)
                 }
-                index++
             }
 
             outerList.add(innerList.toArray(arrayOfNulls<String>(innerList.size)))

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/TagArrayDeserializer.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/TagArrayDeserializer.kt
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.core.JsonToken
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.vitorpamplona.quartz.nip01Core.core.TagArray
+import com.vitorpamplona.quartz.nip01Core.limits.EventLimits
 
 class TagArrayDeserializer : StdDeserializer<TagArray>(TagArray::class.java) {
     // Needs to be very fast.
@@ -34,17 +35,27 @@ class TagArrayDeserializer : StdDeserializer<TagArray>(TagArray::class.java) {
     ): TagArray {
         val outerList = ArrayList<Array<String>>()
         while (p.nextToken() != JsonToken.END_ARRAY) {
+            require(outerList.size < EventLimits.MAX_TAG_COUNT) {
+                "Event has more than ${EventLimits.MAX_TAG_COUNT} tags"
+            }
             val innerList = ArrayList<String>(5)
             var index = 0
             while (p.nextToken() != JsonToken.END_ARRAY) {
+                require(innerList.size < EventLimits.MAX_TAG_ELEMENTS_PER_TAG) {
+                    "Tag has more than ${EventLimits.MAX_TAG_ELEMENTS_PER_TAG} elements"
+                }
                 if (p.currentToken == JsonToken.VALUE_NULL) {
                     innerList.add("")
                 } else {
+                    val text = p.text
+                    require(text.length <= EventLimits.MAX_TAG_VALUE_LENGTH) {
+                        "Tag value length ${text.length} exceeds max ${EventLimits.MAX_TAG_VALUE_LENGTH}"
+                    }
                     // Intern only the tag key (index 0) — protocol-defined finite set ("p", "e", "a", …).
                     // Tag values at index >= 1 are attacker-controlled (pubkeys, event ids, URLs, free text)
                     // and must not be promoted to the JVM StringTable: hostile relays could flood unique
                     // values to grow it without bound (security review 2026-04-24 §2.3).
-                    innerList.add(if (index == 0) p.text.intern() else p.text)
+                    innerList.add(if (index == 0) text.intern() else text)
                 }
                 index++
             }

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/relay/sockets/okhttp/BasicOkHttpWebSocket.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/relay/sockets/okhttp/BasicOkHttpWebSocket.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.quartz.nip01Core.relay.sockets.okhttp
 
+import com.vitorpamplona.quartz.nip01Core.limits.EventLimits
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.relay.sockets.WebSocket
 import com.vitorpamplona.quartz.nip01Core.relay.sockets.WebSocketListener
@@ -49,6 +50,10 @@ class BasicOkHttpWebSocket(
             CoroutineExceptionHandler { _, throwable ->
                 Log.e("BasicOkHttpWebSocket", "WebsocketListener Caught exception: ${throwable.message}", throwable)
             }
+
+        // RFC 6455 §7.4 close code 1009 — "Message Too Big". Used when a relay sends a frame
+        // exceeding EventLimits.MAX_RELAY_MESSAGE_LENGTH (security review 2026-04-24 §2.3 Layer 1).
+        const val CLOSE_MESSAGE_TOO_LARGE = 1009
     }
 
     private var socket: OkHttpWebSocket? = null
@@ -81,6 +86,7 @@ class BasicOkHttpWebSocket(
                     webSocket: OkHttpWebSocket,
                     text: String,
                 ) {
+                    if (!acceptIncoming(webSocket, text)) return
                     // Asynchronously send the received message to the channel.
                     // `trySendBlocking` is used here for simplicity within the callback,
                     // but it's important to understand potential thread blocking if the buffer is full.
@@ -123,6 +129,25 @@ class BasicOkHttpWebSocket(
     }
 
     override fun send(msg: String): Boolean = socket?.send(msg) ?: false
+
+    // Decides whether an incoming WebSocket text message should be forwarded to `out`.
+    // Drops messages exceeding EventLimits.MAX_RELAY_MESSAGE_LENGTH and closes the socket
+    // (security review 2026-04-24 §2.3 Layer 1: a hostile relay can otherwise OOM the
+    // client with one giant frame before the per-event caps in EventDeserializer fire).
+    // Returns true when the caller should forward the message; false when it should drop.
+    internal fun acceptIncoming(
+        webSocket: OkHttpWebSocket,
+        text: String,
+    ): Boolean {
+        if (text.length > EventLimits.MAX_RELAY_MESSAGE_LENGTH) {
+            Log.w("BasicOkHttpWebSocket") {
+                "Dropping ${text.length}-char message from $url; max is ${EventLimits.MAX_RELAY_MESSAGE_LENGTH}"
+            }
+            webSocket.close(CLOSE_MESSAGE_TOO_LARGE, "message too large")
+            return false
+        }
+        return true
+    }
 
     class Builder(
         val httpClient: (NormalizedRelayUrl) -> OkHttpClient,

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/relay/sockets/okhttp/BasicOkHttpWebSocket.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/relay/sockets/okhttp/BasicOkHttpWebSocket.kt
@@ -54,6 +54,7 @@ class BasicOkHttpWebSocket(
         // RFC 6455 §7.4 close code 1009 — "Message Too Big". Used when a relay sends a frame
         // exceeding EventLimits.MAX_RELAY_MESSAGE_LENGTH (security review 2026-04-24 §2.3 Layer 1).
         const val CLOSE_MESSAGE_TOO_LARGE = 1009
+        const val CLOSE_REASON_MESSAGE_TOO_LARGE = "message too large"
     }
 
     private var socket: OkHttpWebSocket? = null
@@ -86,7 +87,7 @@ class BasicOkHttpWebSocket(
                     webSocket: OkHttpWebSocket,
                     text: String,
                 ) {
-                    if (!acceptIncoming(webSocket, text)) return
+                    if (!acceptIncoming(text) { webSocket.close(CLOSE_MESSAGE_TOO_LARGE, CLOSE_REASON_MESSAGE_TOO_LARGE) }) return
                     // Asynchronously send the received message to the channel.
                     // `trySendBlocking` is used here for simplicity within the callback,
                     // but it's important to understand potential thread blocking if the buffer is full.
@@ -131,19 +132,21 @@ class BasicOkHttpWebSocket(
     override fun send(msg: String): Boolean = socket?.send(msg) ?: false
 
     // Decides whether an incoming WebSocket text message should be forwarded to `out`.
-    // Drops messages exceeding EventLimits.MAX_RELAY_MESSAGE_LENGTH and closes the socket
-    // (security review 2026-04-24 §2.3 Layer 1: a hostile relay can otherwise OOM the
-    // client with one giant frame before the per-event caps in EventDeserializer fire).
-    // Returns true when the caller should forward the message; false when it should drop.
+    // Drops messages exceeding EventLimits.MAX_RELAY_MESSAGE_LENGTH (security review
+    // 2026-04-24 §2.3 Layer 1: a hostile relay can otherwise OOM the client with one
+    // giant frame before the per-event caps in EventDeserializer fire). On overflow,
+    // invokes `closeOversized` (typically `webSocket.close(1009, "message too large")`)
+    // and returns false. The closer is supplied by the caller so this helper stays free
+    // of the `okhttp3.WebSocket` type and can be unit-tested without a fake.
     internal fun acceptIncoming(
-        webSocket: OkHttpWebSocket,
         text: String,
+        closeOversized: () -> Unit,
     ): Boolean {
         if (text.length > EventLimits.MAX_RELAY_MESSAGE_LENGTH) {
             Log.w("BasicOkHttpWebSocket") {
                 "Dropping ${text.length}-char message from $url; max is ${EventLimits.MAX_RELAY_MESSAGE_LENGTH}"
             }
-            webSocket.close(CLOSE_MESSAGE_TOO_LARGE, "message too large")
+            closeOversized()
             return false
         }
         return true

--- a/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/KotlinSerializationMapperTest.kt
+++ b/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/kotlinSerialization/KotlinSerializationMapperTest.kt
@@ -180,12 +180,15 @@ class KotlinSerializationMapperTest {
 
     @Test
     fun deserializeEventWithUnknownFields() {
+        val id = "a".repeat(64)
+        val pubKey = "b".repeat(64)
+        val sig = "c".repeat(128)
         val json =
-            """{"id":"abc123","pubkey":"def456","created_at":12345,"kind":1,"tags":[],"content":"test","sig":"sig123","unknown_field":"ignored"}"""
+            """{"id":"$id","pubkey":"$pubKey","created_at":12345,"kind":1,"tags":[],"content":"test","sig":"$sig","unknown_field":"ignored"}"""
         // Should not throw with unknown fields, should be ignored
         val deserialized = KotlinSerializationMapper.fromJson(json)
-        assertEquals("abc123", deserialized.id)
-        assertEquals("def456", deserialized.pubKey)
+        assertEquals(id, deserialized.id)
+        assertEquals(pubKey, deserialized.pubKey)
         assertEquals("test", deserialized.content)
     }
 
@@ -194,12 +197,12 @@ class KotlinSerializationMapperTest {
         val content = "Hello \"world\" \n\ttab\\backslash"
         val event =
             FollowListEvent(
-                id = "abc",
-                pubKey = "def",
+                id = "a".repeat(64),
+                pubKey = "b".repeat(64),
                 createdAt = 1000,
                 tags = emptyArray(),
                 content = content,
-                sig = "sig",
+                sig = "c".repeat(128),
             )
         val json = KotlinSerializationMapper.toJson(event)
         val deserialized = KotlinSerializationMapper.fromJson(json)
@@ -684,7 +687,7 @@ class KotlinSerializationMapperTest {
                 createdAt = 0,
                 tags = emptyArray(),
                 content = "",
-                sig = "c".repeat(64),
+                sig = "c".repeat(128),
             )
         val json = KotlinSerializationMapper.toJson(event)
         val deserialized = KotlinSerializationMapper.fromJson(json)
@@ -711,7 +714,7 @@ class KotlinSerializationMapperTest {
                 createdAt = 1000,
                 tags = emptyArray(),
                 content = content,
-                sig = "c".repeat(64),
+                sig = "c".repeat(128),
             )
         val json = KotlinSerializationMapper.toJson(event)
         val deserialized = KotlinSerializationMapper.fromJson(json)

--- a/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/sockets/okhttp/BasicOkHttpWebSocketAcceptIncomingTest.kt
+++ b/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/sockets/okhttp/BasicOkHttpWebSocketAcceptIncomingTest.kt
@@ -24,14 +24,10 @@ import com.vitorpamplona.quartz.nip01Core.limits.EventLimits
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.relay.sockets.WebSocketListener
 import okhttp3.OkHttpClient
-import okhttp3.Request
-import okio.ByteString
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import okhttp3.WebSocket as OkHttpWebSocket
 
 // Layer 1 of security review 2026-04-24 §2.3: a hostile relay must not be able to deliver
 // frames larger than EventLimits.MAX_RELAY_MESSAGE_LENGTH. Per-event caps in EventDeserializer
@@ -39,30 +35,6 @@ import okhttp3.WebSocket as OkHttpWebSocket
 // already have allocated 10 MB before parsing begins. Layer 1 closes the socket at the WS
 // boundary with RFC 6455 close code 1009 ("Message Too Big").
 class BasicOkHttpWebSocketAcceptIncomingTest {
-    private class RecordingWebSocket : OkHttpWebSocket {
-        var closedCode: Int? = null
-        var closedReason: String? = null
-
-        override fun request(): Request = throw NotImplementedError("not used in test")
-
-        override fun queueSize(): Long = 0
-
-        override fun send(text: String): Boolean = throw NotImplementedError("not used in test")
-
-        override fun send(bytes: ByteString): Boolean = throw NotImplementedError("not used in test")
-
-        override fun close(
-            code: Int,
-            reason: String?,
-        ): Boolean {
-            closedCode = code
-            closedReason = reason
-            return true
-        }
-
-        override fun cancel() = Unit
-    }
-
     private val noopListener =
         object : WebSocketListener {
             override fun onOpen(
@@ -95,31 +67,33 @@ class BasicOkHttpWebSocketAcceptIncomingTest {
     @Test
     fun acceptIncomingForwardsMessagesAtAndBelowTheCap() {
         val sut = newSubject()
-        val ws = RecordingWebSocket()
+        var closeCalls = 0
 
-        assertTrue(sut.acceptIncoming(ws, "x".repeat(EventLimits.MAX_RELAY_MESSAGE_LENGTH)))
-        assertNull(ws.closedCode, "must not close socket on within-limit message")
-
-        assertTrue(sut.acceptIncoming(ws, "x".repeat(1)))
-        assertNull(ws.closedCode)
+        assertTrue(sut.acceptIncoming("x".repeat(EventLimits.MAX_RELAY_MESSAGE_LENGTH)) { closeCalls++ })
+        assertTrue(sut.acceptIncoming("x") { closeCalls++ })
+        assertEquals(0, closeCalls, "closer must not be invoked on within-limit messages")
     }
 
     @Test
-    fun acceptIncomingDropsAndClosesOnOversizedMessage() {
+    fun acceptIncomingDropsAndInvokesCloserOnOversizedMessage() {
         val sut = newSubject()
-        val ws = RecordingWebSocket()
+        var closeCalls = 0
 
-        val accepted = sut.acceptIncoming(ws, "x".repeat(EventLimits.MAX_RELAY_MESSAGE_LENGTH + 1))
+        val accepted = sut.acceptIncoming("x".repeat(EventLimits.MAX_RELAY_MESSAGE_LENGTH + 1)) { closeCalls++ }
 
         assertFalse(accepted, "oversized message must not be forwarded")
-        assertEquals(BasicOkHttpWebSocket.CLOSE_MESSAGE_TOO_LARGE, ws.closedCode)
-        assertEquals("message too large", ws.closedReason)
+        assertEquals(1, closeCalls, "closer must be invoked exactly once on overflow")
     }
 
     @Test
     fun closeCodeIsRfc6455MessageTooBig() {
-        // RFC 6455 §7.4.1 reserves 1009 for "Message Too Big". This guards against the
-        // constant accidentally drifting and silencing the wrong category of error.
+        // RFC 6455 §7.4.1 reserves 1009 for "Message Too Big". The listener wires this code
+        // to webSocket.close(...); pinning the constant guards against silent drift.
         assertEquals(1009, BasicOkHttpWebSocket.CLOSE_MESSAGE_TOO_LARGE)
+    }
+
+    @Test
+    fun closeReasonIsMessageTooLarge() {
+        assertEquals("message too large", BasicOkHttpWebSocket.CLOSE_REASON_MESSAGE_TOO_LARGE)
     }
 }

--- a/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/sockets/okhttp/BasicOkHttpWebSocketAcceptIncomingTest.kt
+++ b/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/sockets/okhttp/BasicOkHttpWebSocketAcceptIncomingTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.relay.sockets.okhttp
+
+import com.vitorpamplona.quartz.nip01Core.limits.EventLimits
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip01Core.relay.sockets.WebSocketListener
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okio.ByteString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import okhttp3.WebSocket as OkHttpWebSocket
+
+// Layer 1 of security review 2026-04-24 §2.3: a hostile relay must not be able to deliver
+// frames larger than EventLimits.MAX_RELAY_MESSAGE_LENGTH. Per-event caps in EventDeserializer
+// (Layer 2) only fire after the JSON has reached the parser, so a 10 MB JSON message would
+// already have allocated 10 MB before parsing begins. Layer 1 closes the socket at the WS
+// boundary with RFC 6455 close code 1009 ("Message Too Big").
+class BasicOkHttpWebSocketAcceptIncomingTest {
+    private class RecordingWebSocket : OkHttpWebSocket {
+        var closedCode: Int? = null
+        var closedReason: String? = null
+
+        override fun request(): Request = throw NotImplementedError("not used in test")
+
+        override fun queueSize(): Long = 0
+
+        override fun send(text: String): Boolean = throw NotImplementedError("not used in test")
+
+        override fun send(bytes: ByteString): Boolean = throw NotImplementedError("not used in test")
+
+        override fun close(
+            code: Int,
+            reason: String?,
+        ): Boolean {
+            closedCode = code
+            closedReason = reason
+            return true
+        }
+
+        override fun cancel() = Unit
+    }
+
+    private val noopListener =
+        object : WebSocketListener {
+            override fun onOpen(
+                pingMillis: Int,
+                compression: Boolean,
+            ) = Unit
+
+            override fun onMessage(text: String) = Unit
+
+            override fun onClosed(
+                code: Int,
+                reason: String,
+            ) = Unit
+
+            override fun onFailure(
+                t: Throwable,
+                code: Int?,
+                response: String?,
+            ) = Unit
+        }
+
+    private fun newSubject(): BasicOkHttpWebSocket =
+        // httpClient and url providers are never invoked because we never call connect().
+        BasicOkHttpWebSocket(
+            url = NormalizedRelayUrl("wss://example.invalid/"),
+            httpClient = { _: NormalizedRelayUrl -> OkHttpClient() },
+            out = noopListener,
+        )
+
+    @Test
+    fun acceptIncomingForwardsMessagesAtAndBelowTheCap() {
+        val sut = newSubject()
+        val ws = RecordingWebSocket()
+
+        assertTrue(sut.acceptIncoming(ws, "x".repeat(EventLimits.MAX_RELAY_MESSAGE_LENGTH)))
+        assertNull(ws.closedCode, "must not close socket on within-limit message")
+
+        assertTrue(sut.acceptIncoming(ws, "x".repeat(1)))
+        assertNull(ws.closedCode)
+    }
+
+    @Test
+    fun acceptIncomingDropsAndClosesOnOversizedMessage() {
+        val sut = newSubject()
+        val ws = RecordingWebSocket()
+
+        val accepted = sut.acceptIncoming(ws, "x".repeat(EventLimits.MAX_RELAY_MESSAGE_LENGTH + 1))
+
+        assertFalse(accepted, "oversized message must not be forwarded")
+        assertEquals(BasicOkHttpWebSocket.CLOSE_MESSAGE_TOO_LARGE, ws.closedCode)
+        assertEquals("message too large", ws.closedReason)
+    }
+
+    @Test
+    fun closeCodeIsRfc6455MessageTooBig() {
+        // RFC 6455 §7.4.1 reserves 1009 for "Message Too Big". This guards against the
+        // constant accidentally drifting and silencing the wrong category of error.
+        assertEquals(1009, BasicOkHttpWebSocket.CLOSE_MESSAGE_TOO_LARGE)
+    }
+}

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/JacksonEventDeserializerLimitsTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/JacksonEventDeserializerLimitsTest.kt
@@ -24,14 +24,12 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.limits.EventLimits
 import com.vitorpamplona.quartz.nip01Core.limits.EventLimitsTestSupport.buildEventJson
+import com.vitorpamplona.quartz.nip01Core.limits.assertRejectsBecause
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 
-// Jackson-path coverage for security review 2026-04-24 §2.3 / Finding #5.
-// The kotlinx path is exercised by EventLimitsTest in commonTest; this file targets the
-// streaming Jackson deserializers (EventDeserializer + TagArrayDeserializer) which terminate
-// the parse early on cap overflow.
+// Jackson-path mirror of EventLimitsTest (commonTest, kotlinx path). Shared assertion helper
+// from EventLimitsTestSupport keeps the two classes aligned.
 class JacksonEventDeserializerLimitsTest {
     private fun parse(json: String): Event = JacksonMapper.mapper.readValue(json)
 
@@ -42,121 +40,50 @@ class JacksonEventDeserializerLimitsTest {
         assertEquals(100, event.content.length)
     }
 
-    @Test
-    fun rejectsOversizedContent() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(contentLength = EventLimits.MAX_CONTENT_LENGTH + 1))
-            }
-        assertEquals(true, ex.message?.contains("content length"), ex.message)
-    }
+    // --- §2.3: size / count / length caps ---
 
     @Test
-    fun rejectsTooManyTags() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(tagCount = EventLimits.MAX_TAG_COUNT + 1))
-            }
-        assertEquals(true, ex.message?.contains("tags"), ex.message)
-    }
+    fun rejectsOversizedContent() = assertRejectsBecause(::parse, buildEventJson(contentLength = EventLimits.MAX_CONTENT_LENGTH + 1), "content length")
 
     @Test
-    fun rejectsTagWithTooManyElements() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(tagInnerCount = EventLimits.MAX_TAG_ELEMENTS_PER_TAG + 2))
-            }
-        assertEquals(true, ex.message?.contains("elements"), ex.message)
-    }
+    fun rejectsTooManyTags() = assertRejectsBecause(::parse, buildEventJson(tagCount = EventLimits.MAX_TAG_COUNT + 1), "tags")
 
     @Test
-    fun rejectsOversizedTagValue() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(tagValueLength = EventLimits.MAX_TAG_VALUE_LENGTH + 1))
-            }
-        assertEquals(true, ex.message?.contains("Tag value length"), ex.message)
-    }
-
-    // --- §2.4: id / pubKey / sig / kind / createdAt validation ---
+    fun rejectsTagWithTooManyElements() = assertRejectsBecause(::parse, buildEventJson(tagInnerCount = EventLimits.MAX_TAG_ELEMENTS_PER_TAG + 2), "elements")
 
     @Test
-    fun rejectsIdWithWrongLength() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(id = "0".repeat(63)))
-            }
-        assertEquals(true, ex.message?.contains("id must be 64-char hex"), ex.message)
-    }
+    fun rejectsOversizedTagValue() = assertRejectsBecause(::parse, buildEventJson(tagValueLength = EventLimits.MAX_TAG_VALUE_LENGTH + 1), "Tag value length")
+
+    // --- §2.4: id / pubKey / sig / kind validation ---
 
     @Test
-    fun rejectsIdWithNonHex() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(id = "z".repeat(64)))
-            }
-        assertEquals(true, ex.message?.contains("id must be 64-char hex"), ex.message)
-    }
+    fun rejectsIdWithWrongLength() = assertRejectsBecause(::parse, buildEventJson(id = "0".repeat(63)), "id must be 64-char hex")
 
     @Test
-    fun rejectsPubKeyWithWrongLength() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(pubKey = "0".repeat(65)))
-            }
-        assertEquals(true, ex.message?.contains("pubKey must be 64-char hex"), ex.message)
-    }
+    fun rejectsIdWithNonHex() = assertRejectsBecause(::parse, buildEventJson(id = "z".repeat(64)), "id must be 64-char hex")
 
     @Test
-    fun rejectsPubKeyWithNonHex() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(pubKey = "g".repeat(64)))
-            }
-        assertEquals(true, ex.message?.contains("pubKey must be 64-char hex"), ex.message)
-    }
+    fun rejectsPubKeyWithWrongLength() = assertRejectsBecause(::parse, buildEventJson(pubKey = "0".repeat(65)), "pubKey must be 64-char hex")
 
     @Test
-    fun rejectsSigWithWrongNonZeroLength() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(sig = "0".repeat(127)))
-            }
-        assertEquals(true, ex.message?.contains("sig must be empty or 128-char hex"), ex.message)
-    }
+    fun rejectsPubKeyWithNonHex() = assertRejectsBecause(::parse, buildEventJson(pubKey = "g".repeat(64)), "pubKey must be 64-char hex")
 
     @Test
-    fun rejectsSigWithNonHex() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(sig = "z".repeat(128)))
-            }
-        assertEquals(true, ex.message?.contains("sig must be empty or 128-char hex"), ex.message)
-    }
+    fun rejectsSigWithWrongNonZeroLength() = assertRejectsBecause(::parse, buildEventJson(sig = "0".repeat(127)), "sig must be empty or 128-char hex")
+
+    @Test
+    fun rejectsSigWithNonHex() = assertRejectsBecause(::parse, buildEventJson(sig = "z".repeat(128)), "sig must be empty or 128-char hex")
+
+    @Test
+    fun rejectsKindAboveMax() = assertRejectsBecause(::parse, buildEventJson(kind = EventLimits.MAX_KIND + 1), "kind")
+
+    @Test
+    fun rejectsKindBelowZero() = assertRejectsBecause(::parse, buildEventJson(kind = -1), "kind")
 
     @Test
     fun acceptsEmptySig() {
-        // NIP-17 (kind:14 DMs) and NIP-37 drafts are stored as Event with sig="".
         val event = parse(buildEventJson(sig = ""))
         assertEquals("", event.sig)
-    }
-
-    @Test
-    fun rejectsKindAboveMax() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(kind = EventLimits.MAX_KIND + 1))
-            }
-        assertEquals(true, ex.message?.contains("kind"), ex.message)
-    }
-
-    @Test
-    fun rejectsKindBelowZero() {
-        val ex =
-            assertFailsWith<IllegalArgumentException> {
-                parse(buildEventJson(kind = -1))
-            }
-        assertEquals(true, ex.message?.contains("kind"), ex.message)
     }
 
     @Test

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/JacksonEventDeserializerLimitsTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/JacksonEventDeserializerLimitsTest.kt
@@ -77,4 +77,91 @@ class JacksonEventDeserializerLimitsTest {
             }
         assertEquals(true, ex.message?.contains("Tag value length"), ex.message)
     }
+
+    // --- §2.4: id / pubKey / sig / kind / createdAt validation ---
+
+    @Test
+    fun rejectsIdWithWrongLength() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(id = "0".repeat(63)))
+            }
+        assertEquals(true, ex.message?.contains("id must be 64-char hex"), ex.message)
+    }
+
+    @Test
+    fun rejectsIdWithNonHex() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(id = "z".repeat(64)))
+            }
+        assertEquals(true, ex.message?.contains("id must be 64-char hex"), ex.message)
+    }
+
+    @Test
+    fun rejectsPubKeyWithWrongLength() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(pubKey = "0".repeat(65)))
+            }
+        assertEquals(true, ex.message?.contains("pubKey must be 64-char hex"), ex.message)
+    }
+
+    @Test
+    fun rejectsPubKeyWithNonHex() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(pubKey = "g".repeat(64)))
+            }
+        assertEquals(true, ex.message?.contains("pubKey must be 64-char hex"), ex.message)
+    }
+
+    @Test
+    fun rejectsSigWithWrongNonZeroLength() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(sig = "0".repeat(127)))
+            }
+        assertEquals(true, ex.message?.contains("sig must be empty or 128-char hex"), ex.message)
+    }
+
+    @Test
+    fun rejectsSigWithNonHex() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(sig = "z".repeat(128)))
+            }
+        assertEquals(true, ex.message?.contains("sig must be empty or 128-char hex"), ex.message)
+    }
+
+    @Test
+    fun acceptsEmptySig() {
+        // NIP-17 (kind:14 DMs) and NIP-37 drafts are stored as Event with sig="".
+        val event = parse(buildEventJson(sig = ""))
+        assertEquals("", event.sig)
+    }
+
+    @Test
+    fun rejectsKindAboveMax() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(kind = EventLimits.MAX_KIND + 1))
+            }
+        assertEquals(true, ex.message?.contains("kind"), ex.message)
+    }
+
+    @Test
+    fun rejectsKindBelowZero() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(kind = -1))
+            }
+        assertEquals(true, ex.message?.contains("kind"), ex.message)
+    }
+
+    @Test
+    fun acceptsAncientCreatedAt() {
+        val event = parse(buildEventJson(createdAt = 100L))
+        assertEquals(100L, event.createdAt)
+    }
 }

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/JacksonEventDeserializerLimitsTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/JacksonEventDeserializerLimitsTest.kt
@@ -23,6 +23,7 @@ package com.vitorpamplona.quartz.nip01Core.jackson
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.limits.EventLimits
+import com.vitorpamplona.quartz.nip01Core.limits.EventLimitsTestSupport.buildEventJson
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -32,25 +33,7 @@ import kotlin.test.assertFailsWith
 // streaming Jackson deserializers (EventDeserializer + TagArrayDeserializer) which terminate
 // the parse early on cap overflow.
 class JacksonEventDeserializerLimitsTest {
-    private val id = "0".repeat(63) + "1"
-    private val pubKey = "0".repeat(63) + "2"
-    private val sig = "0".repeat(128)
-
     private fun parse(json: String): Event = JacksonMapper.mapper.readValue(json)
-
-    private fun buildEventJson(
-        contentLength: Int = 10,
-        tagCount: Int = 1,
-        tagInnerCount: Int = 2,
-        tagValueLength: Int = 5,
-    ): String {
-        val content = "x".repeat(contentLength)
-        val tagValue = "v".repeat(tagValueLength)
-        val inner = "\"t\"" + ",\"$tagValue\"".repeat((tagInnerCount - 1).coerceAtLeast(0))
-        val tag = "[$inner]"
-        val tags = (1..tagCount).joinToString(",") { tag }
-        return """{"id":"$id","pubkey":"$pubKey","created_at":1,"kind":1,"tags":[$tags],"content":"$content","sig":"$sig"}"""
-    }
 
     @Test
     fun acceptsEventWithinLimits() {

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/JacksonEventDeserializerLimitsTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/JacksonEventDeserializerLimitsTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.jackson
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.limits.EventLimits
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+// Jackson-path coverage for security review 2026-04-24 §2.3 / Finding #5.
+// The kotlinx path is exercised by EventLimitsTest in commonTest; this file targets the
+// streaming Jackson deserializers (EventDeserializer + TagArrayDeserializer) which terminate
+// the parse early on cap overflow.
+class JacksonEventDeserializerLimitsTest {
+    private val id = "0".repeat(63) + "1"
+    private val pubKey = "0".repeat(63) + "2"
+    private val sig = "0".repeat(128)
+
+    private fun parse(json: String): Event = JacksonMapper.mapper.readValue(json)
+
+    private fun buildEventJson(
+        contentLength: Int = 10,
+        tagCount: Int = 1,
+        tagInnerCount: Int = 2,
+        tagValueLength: Int = 5,
+    ): String {
+        val content = "x".repeat(contentLength)
+        val tagValue = "v".repeat(tagValueLength)
+        val inner = "\"t\"" + ",\"$tagValue\"".repeat((tagInnerCount - 1).coerceAtLeast(0))
+        val tag = "[$inner]"
+        val tags = (1..tagCount).joinToString(",") { tag }
+        return """{"id":"$id","pubkey":"$pubKey","created_at":1,"kind":1,"tags":[$tags],"content":"$content","sig":"$sig"}"""
+    }
+
+    @Test
+    fun acceptsEventWithinLimits() {
+        val event = parse(buildEventJson(contentLength = 100, tagCount = 5, tagInnerCount = 3, tagValueLength = 50))
+        assertEquals(5, event.tags.size)
+        assertEquals(100, event.content.length)
+    }
+
+    @Test
+    fun rejectsOversizedContent() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(contentLength = EventLimits.MAX_CONTENT_LENGTH + 1))
+            }
+        assertEquals(true, ex.message?.contains("content length"), ex.message)
+    }
+
+    @Test
+    fun rejectsTooManyTags() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(tagCount = EventLimits.MAX_TAG_COUNT + 1))
+            }
+        assertEquals(true, ex.message?.contains("tags"), ex.message)
+    }
+
+    @Test
+    fun rejectsTagWithTooManyElements() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(tagInnerCount = EventLimits.MAX_TAG_ELEMENTS_PER_TAG + 2))
+            }
+        assertEquals(true, ex.message?.contains("elements"), ex.message)
+    }
+
+    @Test
+    fun rejectsOversizedTagValue() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                parse(buildEventJson(tagValueLength = EventLimits.MAX_TAG_VALUE_LENGTH + 1))
+            }
+        assertEquals(true, ex.message?.contains("Tag value length"), ex.message)
+    }
+}

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/JacksonInternBehaviorTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/jackson/JacksonInternBehaviorTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.jackson
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+
+// Regression for security review 2026-04-24 §2.3 / Finding #5: the Jackson event/tag
+// deserializers used to call String.intern() on attacker-controlled fields (id, pubKey,
+// every tag value). Each interned string is permanently allocated in the JVM StringTable,
+// so a hostile relay could grow process memory without bound by flooding events with
+// unique ids / pubkeys / tag values.
+//
+// Post-fix: id, pubKey, and tag values (index >= 1) are stored as freshly-allocated
+// Strings; only the small protocol-defined set of tag keys (index 0: "p", "e", "a", …)
+// is still interned for hashmap performance.
+class JacksonInternBehaviorTest {
+    private val id = "0000000000000000000000000000000000000000000000000000000000000001"
+    private val pubKey = "0000000000000000000000000000000000000000000000000000000000000002"
+    private val sig = "0".repeat(128)
+
+    private fun jsonWithTagValue(tagValue: String): String = """{"id":"$id","pubkey":"$pubKey","created_at":1,"kind":1,"tags":[["t","$tagValue"]],"content":"","sig":"$sig"}"""
+
+    private fun parse(json: String): Event = JacksonMapper.mapper.readValue(json)
+
+    @Test
+    fun tagValuesAreNotInterned() {
+        // A unique-per-test value that no other code path is likely to have placed in the StringTable.
+        val unique = "anti-intern-tag-value-${System.nanoTime()}"
+        val a = parse(jsonWithTagValue(unique))
+        val b = parse(jsonWithTagValue(unique))
+
+        assertEquals(unique, a.tags[0][1])
+        assertEquals(unique, b.tags[0][1])
+        // Without intern, two parses produce distinct String references.
+        assertNotSame(
+            a.tags[0][1],
+            b.tags[0][1],
+            "tag values must not be interned (would let hostile relays grow the StringTable without bound)",
+        )
+    }
+
+    @Test
+    fun idAndPubKeyAreNotInterned() {
+        val a = parse(jsonWithTagValue("v"))
+        val b = parse(jsonWithTagValue("v"))
+
+        assertEquals(id, a.id)
+        assertEquals(pubKey, a.pubKey)
+        assertNotSame(a.id, b.id, "id must not be interned")
+        assertNotSame(a.pubKey, b.pubKey, "pubKey must not be interned")
+    }
+
+    @Test
+    fun tagKeysAreInterned() {
+        // Use a tag key unique to this test so no class-load literal pre-interns it.
+        val uniqueKey = "anti-intern-tag-key-${System.nanoTime()}"
+        val json =
+            """{"id":"$id","pubkey":"$pubKey","created_at":1,"kind":1,"tags":[["$uniqueKey","v1"]],"content":"","sig":"$sig"}"""
+        val a = parse(json)
+        val b = parse(json)
+
+        assertEquals(uniqueKey, a.tags[0][0])
+        // Tag keys remain interned for hashmap performance — finite protocol-defined set.
+        assertSame(
+            a.tags[0][0],
+            b.tags[0][0],
+            "tag keys (index 0) should still be interned",
+        )
+    }
+}


### PR DESCRIPTION
**Stacked on top of #2700.** Until that PR merges, this PR's diff includes the 4 §2.3 commits (`f8577053b`, `af1bcfcdb`, `dcd288018`, `e2fc88604`); they will auto-collapse from the diff once #2700 lands. The 3 commits in scope for review **here** are the §2.4 commits at the top of the list.

Implements §2.4 of the Quartz security review (Finding #11) — post-parse hex/length/range validation of `Event` structural fields.

## Validation rules

`EventLimits.validateFields(id, pubKey, sig, kind)` is called post-parse from both Jackson `EventDeserializer` and kotlinx `EventKSerializer`:

| Field | Rule | Why |
|---|---|---|
| `id` | 64-char hex | 32-byte SHA-256 of the canonical event |
| `pubKey` | 64-char hex | x-only secp256k1 pubkey |
| `sig` | empty OR 128-char hex | NIP-17 (kind:14 DMs) and NIP-37 drafts are stored as `Event` with `sig=""` because the inner-event rumor is unsigned per NIP-59; ~5 K such events exist in production caches |
| `kind` | `0..65535` | NIP-01 unsigned 16-bit |
| `createdAt` | **not bounded** | Nostr legitimately uses ancient and future timestamps (scheduled posts, archive replay, NIP-23 backdated long-form, NIP-03/1040 OpenTimestamp attestations). The id pre-image binds `created_at` to the signature, so `verify()` detects tampering; sort-order manipulation is a feed/UI concern |

Without this, malformed events sat in the cache permanently and only blew up later inside `Hex.decode` if signature verification ran.

## Implementation

- New: `EventLimits.validateFields(...)` + `MAX_KIND` constant.
- Wired into both deserializers post-parse. The new (more informative) length check supplants the old empty-pubKey early-throw.
- Test helper `EventLimitsTestSupport` extended with id/pubKey/sig/kind/createdAt overrides + new `assertRejectsBecause(parse, json, fragment)` helper shared by both test classes.

## Test plan

- [x] `EventLimitsTest` (commonTest, kotlinx path) — 14 tests including 4 §2.3 carries and all §2.4 rejection cases + accepts-empty-sig + accepts-ancient-createdAt
- [x] `JacksonEventDeserializerLimitsTest` (jvmTest, Jackson path) — same matrix
- [x] Updated 4 fixtures in `KotlinSerializationMapperTest` from synthetic short hex to realistic 64/128-char hex
- [x] Full `:quartz:jvmTest` — **1901 / 188 suites all green** including `LargeDBTests` (248 K real events) and `JacksonInternBehaviorTest` from §2.3
- [x] kotlin-reviewer: APPROVE (0 CRITICAL / 0 HIGH; 1 MEDIUM cosmetic, 3 LOW notes)

## Commits in this PR (top three)

1. `91f0122aa` — fix: validate event id, pubKey, sig hex/length and kind range
2. `d854f91e2` — chore: gitignore .claude/scheduled_tasks.lock
3. `b7f0c62ef` — refactor: drop redundant pubKey-empty check + dedup limits tests (post-/simplify cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)