### PR TITLE
fix(quartz): bound Tlv.parse against malformed naddr/nevent/nprofile

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip19Bech32/tlv/Tlv.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip19Bech32/tlv/Tlv.kt
@@ -43,21 +43,17 @@ class Tlv(
     companion object {
         fun parse(data: ByteArray): Tlv {
             val result = mutableMapOf<Byte, MutableList<ByteArray>>()
-            var rest = data
-            // Need at least the 2-byte (type, length) header to read another tuple. A
-            // single trailing byte previously crashed at `rest[1]` (security review
-            // 2026-04-24 §2.5).
-            while (rest.size >= 2) {
-                val t = rest[0]
-                val l = rest[1].toUByte().toInt()
-                // Clamp so a declared length exceeding the remaining bytes is treated as
-                // a truncated entry to skip rather than an array-bounds throw.
-                val end = (2 + l).coerceAtMost(rest.size)
-                val v = rest.copyOfRange(2, end)
-                rest = rest.copyOfRange(end, rest.size)
-                if (v.size < l) continue
-
-                result.getOrPut(t) { mutableListOf() }.add(v)
+            var pos = 0
+            // Each tuple needs a 2-byte (type, length) header plus `length` value bytes.
+            // Stop on a single trailing byte or a declared length that exceeds the
+            // remaining bytes — both cases previously threw IndexOutOfBoundsException
+            // (security review 2026-04-24 §2.5).
+            while (pos + 2 <= data.size) {
+                val t = data[pos]
+                val l = data[pos + 1].toUByte().toInt()
+                if (pos + 2 + l > data.size) break
+                result.getOrPut(t) { mutableListOf() }.add(data.copyOfRange(pos + 2, pos + 2 + l))
+                pos += 2 + l
             }
             return Tlv(result)
         }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip19Bech32/tlv/Tlv.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip19Bech32/tlv/Tlv.kt
@@ -44,17 +44,20 @@ class Tlv(
         fun parse(data: ByteArray): Tlv {
             val result = mutableMapOf<Byte, MutableList<ByteArray>>()
             var rest = data
-            while (rest.isNotEmpty()) {
+            // Need at least the 2-byte (type, length) header to read another tuple. A
+            // single trailing byte previously crashed at `rest[1]` (security review
+            // 2026-04-24 §2.5).
+            while (rest.size >= 2) {
                 val t = rest[0]
                 val l = rest[1].toUByte().toInt()
-                val v = rest.sliceArray(IntRange(2, (2 + l) - 1))
-                rest = rest.sliceArray(IntRange(2 + l, rest.size - 1))
+                // Clamp so a declared length exceeding the remaining bytes is treated as
+                // a truncated entry to skip rather than an array-bounds throw.
+                val end = (2 + l).coerceAtMost(rest.size)
+                val v = rest.copyOfRange(2, end)
+                rest = rest.copyOfRange(end, rest.size)
                 if (v.size < l) continue
 
-                if (!result.containsKey(t)) {
-                    result[t] = mutableListOf()
-                }
-                result[t]?.add(v)
+                result.getOrPut(t) { mutableListOf() }.add(v)
             }
             return Tlv(result)
         }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip19Bech32/tlv/TlvParseTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip19Bech32/tlv/TlvParseTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip19Bech32.tlv
+
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+// Regression for security review 2026-04-24 §2.5 / Finding #10.
+// Pre-fix `Tlv.parse` threw `IndexOutOfBoundsException` whenever:
+//   - input had a trailing single byte (read `rest[1]` with size==1)
+//   - a TLV entry declared length > remaining bytes (slice walked off the end)
+// Both are reachable from a hostile naddr/nevent/nprofile/nrelay relay hint.
+class TlvParseTest {
+    private fun bytes(vararg ints: Int) = ByteArray(ints.size) { ints[it].toByte() }
+
+    @Test
+    fun parsesEmptyInput() {
+        val tlv = Tlv.parse(bytes())
+        assertEquals(null, tlv.firstAsString(0))
+    }
+
+    @Test
+    fun singleTrailingByteDoesNotThrow() {
+        // Pre-fix: rest[1] threw IndexOutOfBoundsException.
+        val tlv = Tlv.parse(bytes(0x05))
+        assertEquals(null, tlv.firstAsString(5))
+    }
+
+    @Test
+    fun parsesSingleEntry() {
+        // type=1, length=3, value=[0xa, 0xb, 0xc]
+        val tlv = Tlv.parse(bytes(1, 3, 0xa, 0xb, 0xc))
+        assertContentEquals(byteArrayOf(0xa, 0xb, 0xc), tlv.data[1.toByte()]?.first())
+    }
+
+    @Test
+    fun parsesEntryWithEmptyValue() {
+        // type=2, length=0
+        val tlv = Tlv.parse(bytes(2, 0))
+        assertContentEquals(byteArrayOf(), tlv.data[2.toByte()]?.first())
+    }
+
+    @Test
+    fun parsesMultipleEntries() {
+        // (1,2,[a,b]) (3,1,[c])
+        val tlv = Tlv.parse(bytes(1, 2, 0xa, 0xb, 3, 1, 0xc))
+        assertContentEquals(byteArrayOf(0xa, 0xb), tlv.data[1.toByte()]?.first())
+        assertContentEquals(byteArrayOf(0xc), tlv.data[3.toByte()]?.first())
+    }
+
+    @Test
+    fun groupsRepeatedTypes() {
+        // (5,1,[a]) (5,1,[b]) — two entries under the same type get appended
+        val tlv = Tlv.parse(bytes(5, 1, 0xa, 5, 1, 0xb))
+        val entries = tlv.data[5.toByte()]
+        assertEquals(2, entries?.size)
+        assertContentEquals(byteArrayOf(0xa), entries?.get(0))
+        assertContentEquals(byteArrayOf(0xb), entries?.get(1))
+    }
+
+    @Test
+    fun truncatedDeclaredLengthIsSkippedNotThrown() {
+        // type=1, length=5, but only 2 value bytes follow → truncated, must be skipped.
+        // Pre-fix: sliceArray(IntRange(2, 6)) on a 4-byte array threw.
+        val tlv = Tlv.parse(bytes(1, 5, 0xa, 0xb))
+        assertEquals(null, tlv.data[1.toByte()])
+    }
+
+    @Test
+    fun keepsValidPrefixWhenLaterTupleIsTruncated() {
+        // First (1,2,[a,b]) is well-formed, then (2,5,[c,d]) is truncated.
+        val tlv = Tlv.parse(bytes(1, 2, 0xa, 0xb, 2, 5, 0xc, 0xd))
+        assertContentEquals(byteArrayOf(0xa, 0xb), tlv.data[1.toByte()]?.first())
+        assertEquals(null, tlv.data[2.toByte()])
+    }
+
+    @Test
+    fun handlesUnsignedLengthByte() {
+        // length byte 0xFF must be treated as 255 (unsigned), not -1.
+        val payload = ByteArray(255) { 0x42 }
+        val tlv = Tlv.parse(byteArrayOf(7, 0xFF.toByte()) + payload)
+        assertContentEquals(payload, tlv.data[7.toByte()]?.first())
+    }
+
+    @Test
+    fun arbitraryFuzzInputDoesNotThrow() {
+        // 200 random byte sequences of varying lengths up to 64 bytes. Pre-fix this
+        // would have hit IndexOutOfBoundsException on a meaningful fraction of inputs.
+        val rng = Random(0xC0FFEE)
+        repeat(200) {
+            val len = rng.nextInt(0, 65)
+            val data = ByteArray(len) { rng.nextInt().toByte() }
+            val tlv = Tlv.parse(data)
+            assertTrue(tlv.data.size >= 0)
+        }
+    }
+}

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip19Bech32/tlv/TlvParseTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip19Bech32/tlv/TlvParseTest.kt
@@ -24,7 +24,6 @@ import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 // Regression for security review 2026-04-24 §2.5 / Finding #10.
 // Pre-fix `Tlv.parse` threw `IndexOutOfBoundsException` whenever:
@@ -107,12 +106,12 @@ class TlvParseTest {
     fun arbitraryFuzzInputDoesNotThrow() {
         // 200 random byte sequences of varying lengths up to 64 bytes. Pre-fix this
         // would have hit IndexOutOfBoundsException on a meaningful fraction of inputs.
+        // Implicit assertion: parse must not throw on any input.
         val rng = Random(0xC0FFEE)
         repeat(200) {
             val len = rng.nextInt(0, 65)
             val data = ByteArray(len) { rng.nextInt().toByte() }
-            val tlv = Tlv.parse(data)
-            assertTrue(tlv.data.size >= 0)
+            Tlv.parse(data)
         }
     }
 }


### PR DESCRIPTION
Implements §2.5 of the Quartz security review — `Tlv.parse` previously threw `IndexOutOfBoundsException` on malformed TLV input reachable from any hostile NIP-19 string (`naddr1…`, `nevent1…`, `nprofile1…`, `nrelay1…`).

**Independent of #2700 / #2701** (§2.3 / §2.4). Different module path (`nip19Bech32` vs `nip01Core`).

## Crash sites

Pre-fix `Tlv.parse(data: ByteArray)`:

```kotlin
while (rest.isNotEmpty()) {
    val t = rest[0]
    val l = rest[1].toUByte().toInt()                  // 1: rest.size==1 → IOOBE
    val v = rest.sliceArray(IntRange(2, (2 + l) - 1))  // 2: l > rest.size-2 → IOOBE
    ...
}
```

Both paths reachable from a hostile relay hint embedded in any received event tag. Outer `try { } catch (e: Throwable)` blocks in `Nip19Parser.parseComponents` masked the crash for events parsed via that entry point, but `NAddress.parse(ByteArray)`, `NEvent.parse(ByteArray)`, `NProfile.parse(ByteArray)`, `NRelay.parse(ByteArray)` propagate without a catch — defense-in-depth was missing.

## Fix

Per security review prescription:

```kotlin
while (pos + 2 <= data.size) {
    val t = data[pos]
    val l = data[pos + 1].toUByte().toInt()
    if (pos + 2 + l > data.size) break
    result.getOrPut(t) { mutableListOf() }.add(data.copyOfRange(pos + 2, pos + 2 + l))
    pos += 2 + l
}
```

- `while (pos + 2 <= data.size)` — single trailing byte stops the loop instead of crashing.
- `if (pos + 2 + l > data.size) break` — declared length exceeding remaining bytes treated as truncation.
- Integer-cursor pattern — one `copyOfRange` per accepted entry instead of two per loop iteration; idiomatic for fixed-format binary parsing.
- `getOrPut` replaces the prior `containsKey + add` pattern.

## Test plan

- [x] New `TlvParseTest` (commonTest, runs on every KMP target) — 10 cases: empty input, single trailing byte, single/multiple/empty-value entries, repeated-types grouping, truncated-length skip, valid-prefix-then-truncated, unsigned `0xFF` length, plus a 200-iteration deterministic fuzz with `Random(0xC0FFEE)`.
- [x] `:quartz:jvmTest` — full quartz suite **1874 / 1874 green**.
- [x] `:quartz:connectedAndroidDeviceTest` running on a connected device (mid-flight at submission; will update if it surfaces anything).
- [x] kotlin-reviewer: APPROVE (0 CRITICAL / 0 HIGH; 1 MEDIUM perf observation already incorporated in commit 3, 2 LOW notes).
- [x] /simplify pass: HIGH (loop control flow) + MEDIUM (tautological assertion) addressed in commit 2.

## Commits

1. `de46c7782` — fix: bound Tlv.parse — guard short input + clamp truncated lengths
2. `e52e799aa` — refactor: tighten loop + drop tautological fuzz assertion (post-/simplify)
3. `a90bb46a1` — refactor: switch Tlv.parse to integer cursor (post-kotlin-review MEDIUM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)