### PR TITLE
feat(electrumx): add relay.testls.bit endpoints (clearnet TLS + Tor)

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/namecoin/ElectrumXServer.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/namecoin/ElectrumXServer.kt
@@ -99,6 +99,12 @@ val DEFAULT_ELECTRUMX_SERVERS =
         ElectrumxServer("electrumx.testls.space", 50002, useSsl = true, usePinnedTrustStore = true),
         ElectrumxServer("nmc2.bitcoins.sk", 57002, useSsl = true, usePinnedTrustStore = true),
         ElectrumxServer("46.229.238.187", 57002, useSsl = true, usePinnedTrustStore = true),
+        // relay.testls.bit — second public Namecoin ElectrumX deployment, served
+        // alongside the Namecoin-anchored Nostr relay at wss://relay.testls.bit/.
+        // TLS endpoint pinned to a self-signed cert (see PINNED_ELECTRUMX_CERTS).
+        // Also exposed as wss://relay.testls.bit/electrumx (browser-viable, future
+        // WS transport — see N1 §"Browser / WebSocket transport" in mstrofnone/nips).
+        ElectrumxServer("relay.testls.bit", 50002, useSsl = true, usePinnedTrustStore = true),
     )
 
 /** Tor-preferred server list: onion primary, clearnet fallback. */
@@ -110,6 +116,16 @@ val TOR_ELECTRUMX_SERVERS =
             useSsl = true,
             usePinnedTrustStore = true,
         ),
+        // relay.testls.bit — hidden service shared with the Nostr relay's onion.
+        // Plaintext over Tor (port 50001) since the onion key already authenticates
+        // the endpoint; TLS-on-Tor would only add round-trips with no security gain.
+        ElectrumxServer(
+            "6cbn4rskfdr647otej7gpqlmpqcmj723vg2eoeuu7ljbwu6cpdebozyd.onion",
+            50001,
+            useSsl = false,
+            usePinnedTrustStore = false,
+        ),
         ElectrumxServer("electrumx.testls.space", 50002, useSsl = true, usePinnedTrustStore = true),
         ElectrumxServer("nmc2.bitcoins.sk", 57002, useSsl = true, usePinnedTrustStore = true),
+        ElectrumxServer("relay.testls.bit", 50002, useSsl = true, usePinnedTrustStore = true),
     )

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/namecoin/ElectrumXClient.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/namecoin/ElectrumXClient.kt
@@ -890,6 +890,31 @@ bK2N2smrHUOQnFijuiFw3WOrjERi0eMhjVNfVu9W9ZYa/Wd6SdIzV55LbG+NpmSf
 5W7ix41hRvdT6cTAJA==
 -----END CERTIFICATE-----
                 """.trimIndent(),
+                // relay.testls.bit:50002 — expires 2036-04-30
+                // Self-signed RSA-2048 cert (CN=relay.testls.bit) served by
+                // ElectrumX-NMC alongside the Namecoin-anchored Nostr relay.
+                // SHA-256 (DER): BB:0B:35:E6:42:35:A7:94:E1:57:B6:9A:CD:72:DA:4C:CC:16:A4:D8:1D:0F:F6:B1:D8:F7:FD:FC:6C:CA:6C:BA
+                """
+-----BEGIN CERTIFICATE-----
+MIIDFzCCAf+gAwIBAgIUAz+Ky5Lu2u1QchHKTwQIStWD8fQwDQYJKoZIhvcNAQEL
+BQAwGzEZMBcGA1UEAwwQcmVsYXkudGVzdGxzLmJpdDAeFw0yNjA1MDMwNjEyNDBa
+Fw0zNjA0MzAwNjEyNDBaMBsxGTAXBgNVBAMMEHJlbGF5LnRlc3Rscy5iaXQwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCngMim0wilCdclMyIIBRAeFBjE
+HWA0l5n3ebCtyepYmyXUrbth2TDdyMHiUNVvE3f7RSAUFtE+Tjb9+xzmLf04qlbC
+i3b2DV3xdVOZpRCI4kybmraYG6lRLQJ5I/N8NWgPsFgcy2mZF3q0yMVEkzGAKqUT
+QGZd2eBs/OVicbCWKmgyhXlnqGeHIs4iKOqenHKSZ8QE5bhAKaMn+Q116QEdBg12
+svGNoSZSlX8hDNUf5N5pOcsK8vj0Yb0ypJOd0J5eVpYS/KA0oMMwALnEs0H17hfO
+IIaWqrbfaqmdR67uzUfci2EoiwQJrXSy7WkNiVX0ikN02VlUPCb2OaSABmwjAgMB
+AAGjUzBRMB0GA1UdDgQWBBSgnHYFU93wufP131xk5w843VWhATAfBgNVHSMEGDAW
+gBSgnHYFU93wufP131xk5w843VWhATAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3
+DQEBCwUAA4IBAQAiVC5RJj/Y3S5uNYraPmRLQrgPui9eGlWDh6LeZvjftACA3WiN
+XabJtTmHxOFFwxmBtzGVCWKR6udETHyfqaq0me/XoYLjGstYTd14GfoV9Klx7Glh
+gLOgqC3Do04o2xnXxhPh00c0jUggKdI05KLVAc4dLfU/XDrOfxBl4XHZY4lYz4CF
+bn+n5Q1cqqcGqoJIHl2cgDdrxSMigIpsunjk8cJXO+hsteA/Pd1UUY5plvE9nbNv
+hy4QgfNqjy36b0Nbm7Fc9Te9W6zgXjHM+q7KhuQvTfKh2sHbCJzRcy7Chgwqyrfq
+NsK0JcBkyRPB+fXmEoE/Xmj/UnOD0fZCCanD
+-----END CERTIFICATE-----
+                """.trimIndent(),
             )
     }
 


### PR DESCRIPTION
## Summary

Adds the `relay.testls.bit` ElectrumX-NMC deployment as a second public Namecoin name resolver in the default server lists. The same physical box runs the Namecoin-anchored Nostr relay at `wss://relay.testls.bit/`, so a single TLSA record on `d/testls` anchors the trust chain for both services — proving out the cypherpunk "no CA, no DNS" stack end-to-end.

## What changed

### `DEFAULT_ELECTRUMX_SERVERS` (clearnet)

| New entry | Transport | Auth |
|-----------|-----------|------|
| `relay.testls.bit:50002` | TLS | Self-signed cert pinned (added to `PINNED_ELECTRUMX_CERTS`) |

### `TOR_ELECTRUMX_SERVERS` (onion-first)

| New entry | Transport | Auth |
|-----------|-----------|------|
| `6cbn4rskfdr647otej7gpqlmpqcmj723vg2eoeuu7ljbwu6cpdebozyd.onion:50001` | Plaintext over Tor | Onion v3 key |
| `relay.testls.bit:50002` | TLS | Same pinned cert as above |

The onion entry uses `useSsl = false` because the v3 hidden service key already authenticates the endpoint; layering TLS on top would only add round-trips with no security gain. The same onion is shared with the `wss://relay.testls.bit/` Nostr relay (one hidden service, two ports).

### Cert pin

```
SHA-256 (DER): bb0b35e64235a794e157b69acd72da4ccc16a4d81d0ff6b1d8f7fdfc6cca6cba
Subject: CN=relay.testls.bit
Validity: 2026-05-03 → 2036-04-30 (10y, RSA-2048)
```

Appended to `PINNED_ELECTRUMX_CERTS` so strict-TLS Android devices (Samsung One UI 7, GrapheneOS) accept the handshake without falling back to a trust-all `X509TrustManager` (regression covered by PR #1937).

## Out of scope (tracked separately)

The reference deployment also exposes `wss://relay.testls.bit/electrumx` — a WebSocket-framed JSON-RPC endpoint that browser-based Nostr clients (Jumble, nostrudel, Snort, Iris) can reach without raw TCP. The current `ElectrumXClient` JVM implementation only speaks TCP+TLS; adding a WS variant is a larger change and is not part of this PR. Spec backing for the WS transport is in [mstrofnone/nips N1 §"Browser / WebSocket transport"](https://github.com/mstrofnone/nips/blob/master/N1.md).

## Test plan

- [x] `./gradlew :quartz:jvmTest` — clean (full quartz suite)
- [x] `./gradlew :amethyst:compilePlayDebugKotlin` — clean
- [x] `./gradlew :quartz:spotlessApply` / `:quartz:spotlessCheck` — clean
- [x] Smoke-test from outside the box: `node tls` JSON-RPC roundtrip → `ElectrumX 1.16.0` reply, cert pin verified
- [x] Smoke-test via Tor SOCKS5: `node socks5 → onion:50001` → `ElectrumX 1.16.0` reply

## Related

- PR #2612 (`.bit` relay client work, currently open against this same fork)
- PR #1937 (Samsung One UI 7 strict-TLS — established the `usePinnedTrustStore` pattern this PR uses)
- Spec context: [mstrofnone/nips N1](https://github.com/mstrofnone/nips/blob/master/N1.md) "ElectrumX server set" + "Browser / WebSocket transport"

## Risk

Purely additive. Existing entries (`electrumx.testls.space`, `nmc2.bitcoins.sk`, `46.229.238.187`, the existing onion) are untouched. Failover behaviour falls back to them on any error per the existing client logic.