### PR TITLE
feat(electrumx): add bare IP peer for relay.testls.bit (23.158.233.10)

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/namecoin/ElectrumXServer.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/namecoin/ElectrumXServer.kt
@@ -99,6 +99,12 @@ val DEFAULT_ELECTRUMX_SERVERS =
         ElectrumxServer("electrumx.testls.space", 50002, useSsl = true, usePinnedTrustStore = true),
         ElectrumxServer("nmc2.bitcoins.sk", 57002, useSsl = true, usePinnedTrustStore = true),
         ElectrumxServer("46.229.238.187", 57002, useSsl = true, usePinnedTrustStore = true),
+        // relay.testls.bit — second public Namecoin ElectrumX deployment, served
+        // alongside the Namecoin-anchored Nostr relay at wss://relay.testls.bit/.
+        // TLS endpoint pinned to a self-signed cert (see PINNED_ELECTRUMX_CERTS).
+        // Also exposed as wss://relay.testls.bit/electrumx (browser-viable, future
+        // WS transport — see N1 §"Browser / WebSocket transport" in mstrofnone/nips).
+        ElectrumxServer("relay.testls.bit", 50002, useSsl = true, usePinnedTrustStore = true),
     )
 
 /** Tor-preferred server list: onion primary, clearnet fallback. */
@@ -110,6 +116,16 @@ val TOR_ELECTRUMX_SERVERS =
             useSsl = true,
             usePinnedTrustStore = true,
         ),
+        // relay.testls.bit — hidden service shared with the Nostr relay's onion.
+        // Plaintext over Tor (port 50001) since the onion key already authenticates
+        // the endpoint; TLS-on-Tor would only add round-trips with no security gain.
+        ElectrumxServer(
+            "6cbn4rskfdr647otej7gpqlmpqcmj723vg2eoeuu7ljbwu6cpdebozyd.onion",
+            50001,
+            useSsl = false,
+            usePinnedTrustStore = false,
+        ),
         ElectrumxServer("electrumx.testls.space", 50002, useSsl = true, usePinnedTrustStore = true),
         ElectrumxServer("nmc2.bitcoins.sk", 57002, useSsl = true, usePinnedTrustStore = true),
+        ElectrumxServer("relay.testls.bit", 50002, useSsl = true, usePinnedTrustStore = true),
     )

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/namecoin/ElectrumXServer.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/namecoin/ElectrumXServer.kt
@@ -105,6 +105,11 @@ val DEFAULT_ELECTRUMX_SERVERS =
         // Also exposed as wss://relay.testls.bit/electrumx (browser-viable, future
         // WS transport — see N1 §"Browser / WebSocket transport" in mstrofnone/nips).
         ElectrumxServer("relay.testls.bit", 50002, useSsl = true, usePinnedTrustStore = true),
+        // Bare IP peer of relay.testls.bit — same operator, same cert, same box.
+        // Listed as a separate entry (mirrors how 46.229.238.187 sits beside
+        // nmc2.bitcoins.sk) so resolvers that have an unhealthy DNS path can
+        // still reach the server. Cert pin works by SHA-256 of DER, no SNI required.
+        ElectrumxServer("23.158.233.10", 50002, useSsl = true, usePinnedTrustStore = true),
     )
 
 /** Tor-preferred server list: onion primary, clearnet fallback. */
@@ -128,4 +133,6 @@ val TOR_ELECTRUMX_SERVERS =
         ElectrumxServer("electrumx.testls.space", 50002, useSsl = true, usePinnedTrustStore = true),
         ElectrumxServer("nmc2.bitcoins.sk", 57002, useSsl = true, usePinnedTrustStore = true),
         ElectrumxServer("relay.testls.bit", 50002, useSsl = true, usePinnedTrustStore = true),
+        // Bare IP peer (same operator/cert/box). See clearnet list above.
+        ElectrumxServer("23.158.233.10", 50002, useSsl = true, usePinnedTrustStore = true),
     )

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/namecoin/ElectrumXClient.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/namecoin/ElectrumXClient.kt
@@ -890,6 +890,31 @@ bK2N2smrHUOQnFijuiFw3WOrjERi0eMhjVNfVu9W9ZYa/Wd6SdIzV55LbG+NpmSf
 5W7ix41hRvdT6cTAJA==
 -----END CERTIFICATE-----
                 """.trimIndent(),
+                // relay.testls.bit:50002 — expires 2036-04-30
+                // Self-signed RSA-2048 cert (CN=relay.testls.bit) served by
+                // ElectrumX-NMC alongside the Namecoin-anchored Nostr relay.
+                // SHA-256 (DER): BB:0B:35:E6:42:35:A7:94:E1:57:B6:9A:CD:72:DA:4C:CC:16:A4:D8:1D:0F:F6:B1:D8:F7:FD:FC:6C:CA:6C:BA
+                """
+-----BEGIN CERTIFICATE-----
+MIIDFzCCAf+gAwIBAgIUAz+Ky5Lu2u1QchHKTwQIStWD8fQwDQYJKoZIhvcNAQEL
+BQAwGzEZMBcGA1UEAwwQcmVsYXkudGVzdGxzLmJpdDAeFw0yNjA1MDMwNjEyNDBa
+Fw0zNjA0MzAwNjEyNDBaMBsxGTAXBgNVBAMMEHJlbGF5LnRlc3Rscy5iaXQwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCngMim0wilCdclMyIIBRAeFBjE
+HWA0l5n3ebCtyepYmyXUrbth2TDdyMHiUNVvE3f7RSAUFtE+Tjb9+xzmLf04qlbC
+i3b2DV3xdVOZpRCI4kybmraYG6lRLQJ5I/N8NWgPsFgcy2mZF3q0yMVEkzGAKqUT
+QGZd2eBs/OVicbCWKmgyhXlnqGeHIs4iKOqenHKSZ8QE5bhAKaMn+Q116QEdBg12
+svGNoSZSlX8hDNUf5N5pOcsK8vj0Yb0ypJOd0J5eVpYS/KA0oMMwALnEs0H17hfO
+IIaWqrbfaqmdR67uzUfci2EoiwQJrXSy7WkNiVX0ikN02VlUPCb2OaSABmwjAgMB
+AAGjUzBRMB0GA1UdDgQWBBSgnHYFU93wufP131xk5w843VWhATAfBgNVHSMEGDAW
+gBSgnHYFU93wufP131xk5w843VWhATAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3
+DQEBCwUAA4IBAQAiVC5RJj/Y3S5uNYraPmRLQrgPui9eGlWDh6LeZvjftACA3WiN
+XabJtTmHxOFFwxmBtzGVCWKR6udETHyfqaq0me/XoYLjGstYTd14GfoV9Klx7Glh
+gLOgqC3Do04o2xnXxhPh00c0jUggKdI05KLVAc4dLfU/XDrOfxBl4XHZY4lYz4CF
+bn+n5Q1cqqcGqoJIHl2cgDdrxSMigIpsunjk8cJXO+hsteA/Pd1UUY5plvE9nbNv
+hy4QgfNqjy36b0Nbm7Fc9Te9W6zgXjHM+q7KhuQvTfKh2sHbCJzRcy7Chgwqyrfq
+NsK0JcBkyRPB+fXmEoE/Xmj/UnOD0fZCCanD
+-----END CERTIFICATE-----
+                """.trimIndent(),
             )
     }
 


### PR DESCRIPTION
## Summary

Stacked on top of #2708. Adds the underlying IP literal `23.158.233.10:50002` as a separate default ElectrumX entry alongside the `relay.testls.bit:50002` hostname entry — mirrors how `46.229.238.187:57002` sits beside `nmc2.bitcoins.sk:57002` in the existing list.

## Why a bare IP next to a hostname?

Robustness against unhealthy DNS paths. `relay.testls.bit` resolves via Namecoin (.bit), which most clients fetch through ElectrumX itself — a chicken-and-egg if every listed server requires `.bit` resolution to reach. A bare IP gives the resolver pool a completely-DNS-free anchor.

Same operator, same physical box, same self-signed cert, same SHA-256 (DER) pin `bb0b35e6…6cba` already added in #2708's `PINNED_ELECTRUMX_CERTS` entry — no new cert needed. The pinned-trust-store path matches by cert fingerprint (`SHA-256(DER)`), not by SNI/CN, so connecting bare-IP works identically.

The `.onion` entry already added in #2708 covers the equivalent DNS-free anchor for the Tor list; this PR handles the clearnet side.

## Diff

```kotlin
DEFAULT_ELECTRUMX_SERVERS:
  + ElectrumxServer("23.158.233.10", 50002, useSsl = true, usePinnedTrustStore = true)

TOR_ELECTRUMX_SERVERS:
  + ElectrumxServer("23.158.233.10", 50002, useSsl = true, usePinnedTrustStore = true)
```

## Test plan

- [x] `./gradlew :quartz:jvmTest --tests "*namecoin*"` — clean
- [x] `./gradlew :quartz:spotlessApply` / `:quartz:spotlessCheck` — clean
- [x] Direct `node tls` connect to `23.158.233.10:50002` (no SNI) → `ElectrumX 1.16.0` reply, cert SHA-256 matches the pin from #2708 exactly:
  ```
  $ node ... 23.158.233.10:50002
  cert SHA-256 (DER): bb0b35e64235a794e157b69acd72da4ccc16a4d81d0ff6b1d8f7fdfc6cca6cba
  REPLY: {"jsonrpc":"2.0","result":["ElectrumX 1.16.0","1.4"],"id":1}
  ```

## Depends on

#2708 (provides the pinned cert this entry validates against)