### PR TITLE
Save downloads: validate Content-Type & support PDF downloads

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
@@ -31,7 +31,7 @@ import android.webkit.MimeTypeMap
 import androidx.annotation.RequiresApi
 import androidx.core.net.toFile
 import androidx.core.net.toUri
-import com.vitorpamplona.amethyst.ui.actions.MediaSaverToDisk.PICTURES_SUBDIRECTORY
+import com.vitorpamplona.amethyst.ui.actions.MediaSaverToDisk.AMETHYST_SUBDIRECTORY
 import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -87,7 +87,7 @@ object MediaSaverToDisk {
     /**
      * Saves the image to the gallery. May require a storage permission.
      *
-     * @see PICTURES_SUBDIRECTORY
+     * @see AMETHYST_SUBDIRECTORY
      */
     suspend fun downloadAndSave(
         url: String,
@@ -120,9 +120,9 @@ object MediaSaverToDisk {
                                 ?.trim()
 
                         val realType =
-                            headerType?.takeIf(::isMediaMimeType)
-                                ?: mimeType?.takeIf(::isMediaMimeType)
-                                ?: getMimeTypeFromExtension(trimmedUrl).takeIf(::isMediaMimeType)
+                            headerType?.takeIf(::isSaveableMimeType)
+                                ?: mimeType?.takeIf(::isSaveableMimeType)
+                                ?: getMimeTypeFromExtension(trimmedUrl).takeIf(::isSaveableMimeType)
                                 ?: ""
                         check(realType.isNotBlank()) { "Can't find out the content type" }
 
@@ -154,12 +154,13 @@ object MediaSaverToDisk {
             MimeTypeMap.getSingleton().getMimeTypeFromExtension(it).orEmpty()
         }
 
-    private fun isMediaMimeType(type: String): Boolean =
+    private fun isSaveableMimeType(type: String): Boolean =
         type.isNotBlank() &&
             (
                 type.startsWith("image/", ignoreCase = true) ||
                     type.startsWith("video/", ignoreCase = true) ||
-                    type.startsWith("audio/", ignoreCase = true)
+                    type.startsWith("audio/", ignoreCase = true) ||
+                    type.equals(PDF_MIME_TYPE, ignoreCase = true)
             )
 
     @OptIn(ExperimentalUuidApi::class)
@@ -205,20 +206,30 @@ object MediaSaverToDisk {
         contentResolver: ContentResolver,
     ) {
         val cleanMimeType = contentType.substringBefore(";").trim()
+
+        val (masterUri, baseDir) =
+            when {
+                cleanMimeType.startsWith("image/", ignoreCase = true) -> {
+                    MediaStore.Images.Media.EXTERNAL_CONTENT_URI to Environment.DIRECTORY_PICTURES
+                }
+
+                cleanMimeType.equals(PDF_MIME_TYPE, ignoreCase = true) -> {
+                    MediaStore.Downloads.EXTERNAL_CONTENT_URI to Environment.DIRECTORY_DOWNLOADS
+                }
+
+                else -> {
+                    MediaStore.Video.Media.EXTERNAL_CONTENT_URI to Environment.DIRECTORY_PICTURES
+                }
+            }
+
         val contentValues =
             ContentValues().apply {
                 put(MediaStore.MediaColumns.DISPLAY_NAME, displayName)
                 put(MediaStore.MediaColumns.MIME_TYPE, cleanMimeType)
                 put(
                     MediaStore.MediaColumns.RELATIVE_PATH,
-                    Environment.DIRECTORY_PICTURES + File.separatorChar + PICTURES_SUBDIRECTORY,
+                    baseDir + File.separatorChar + AMETHYST_SUBDIRECTORY,
                 )
-            }
-
-        val masterUri =
-            when {
-                contentType.startsWith("image") -> MediaStore.Images.Media.EXTERNAL_CONTENT_URI
-                else -> MediaStore.Video.Media.EXTERNAL_CONTENT_URI
             }
 
         val uri = contentResolver.insert(masterUri, contentValues)
@@ -244,7 +255,7 @@ object MediaSaverToDisk {
         val subdirectory =
             File(
                 Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES),
-                PICTURES_SUBDIRECTORY,
+                AMETHYST_SUBDIRECTORY,
             ).apply {
                 if (!exists()) mkdirs()
             }
@@ -260,5 +271,6 @@ object MediaSaverToDisk {
 
     private fun trimInlineMetaData(url: String): String = url.substringBefore("#")
 
-    private const val PICTURES_SUBDIRECTORY = "Amethyst"
+    private const val AMETHYST_SUBDIRECTORY = "Amethyst"
+    private const val PDF_MIME_TYPE = "application/pdf"
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
@@ -111,26 +111,30 @@ object MediaSaverToDisk {
                 withContext(Dispatchers.IO) {
                     check(response.isSuccessful)
 
+                    val trimmedUrl = trimInlineMetaData(url)
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                        val contentType = response.header("Content-Type") ?: getMimeTypeFromExtension(trimInlineMetaData(url))
-                        check(contentType.isNotBlank()) { "Can't find out the content type" }
+                        val headerType =
+                            response
+                                .header("Content-Type")
+                                ?.substringBefore(";")
+                                ?.trim()
 
                         val realType =
-                            if (contentType == "application/octet-stream") {
-                                mimeType ?: getMimeTypeFromExtension(url)
-                            } else {
-                                contentType
-                            }
+                            headerType?.takeIf(::isMediaMimeType)
+                                ?: mimeType?.takeIf(::isMediaMimeType)
+                                ?: getMimeTypeFromExtension(trimmedUrl).takeIf(::isMediaMimeType)
+                                ?: ""
+                        check(realType.isNotBlank()) { "Can't find out the content type" }
 
                         saveContentQ(
-                            displayName = File(trimInlineMetaData(url)).nameWithoutExtension,
+                            displayName = File(trimmedUrl).nameWithoutExtension,
                             contentType = realType,
                             contentSource = response.body.source(),
                             contentResolver = context.contentResolver,
                         )
                     } else {
                         saveContentDefault(
-                            fileName = File(trimInlineMetaData(url)).name,
+                            fileName = File(trimmedUrl).name,
                             contentSource = response.body.source(),
                             context = context,
                         )
@@ -149,6 +153,14 @@ object MediaSaverToDisk {
         fileName.substringAfterLast('.', "").lowercase().let {
             MimeTypeMap.getSingleton().getMimeTypeFromExtension(it).orEmpty()
         }
+
+    private fun isMediaMimeType(type: String): Boolean =
+        type.isNotBlank() &&
+            (
+                type.startsWith("image/", ignoreCase = true) ||
+                    type.startsWith("video/", ignoreCase = true) ||
+                    type.startsWith("audio/", ignoreCase = true)
+            )
 
     @OptIn(ExperimentalUuidApi::class)
     fun save(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
@@ -87,6 +87,7 @@ import com.vitorpamplona.amethyst.commons.richtext.MediaLocalVideo
 import com.vitorpamplona.amethyst.commons.richtext.MediaPreloadedContent
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlContent
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlImage
+import com.vitorpamplona.amethyst.commons.richtext.MediaUrlPdf
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlVideo
 import com.vitorpamplona.amethyst.model.MediaAspectRatioCache
 import com.vitorpamplona.amethyst.service.playback.composable.VideoViewInner
@@ -377,7 +378,9 @@ private fun DialogContent(
 
                             ShareMediaAction(accountViewModel = accountViewModel, popupExpanded = sharePopupExpanded, myContent, onDismiss = { sharePopupExpanded.value = false })
                         }
+                    }
 
+                    if (myContent is MediaUrlImage || myContent is MediaLocalImage || myContent is MediaUrlPdf) {
                         if (myContent !is MediaUrlContent || !isLiveStreaming(myContent.url)) {
                             val localContext = LocalContext.current
 
@@ -447,22 +450,33 @@ private fun showToastOnMain(
     }
 }
 
-private suspend fun saveMediaToGallery(
+internal suspend fun saveMediaToGallery(
     content: BaseMediaContent,
     localContext: Context,
     accountViewModel: AccountViewModel,
 ) {
     val isImage = content is MediaUrlImage || content is MediaLocalImage
+    val isPdf = content is MediaUrlPdf
 
-    val success = if (isImage) R.string.image_saved_to_the_gallery else R.string.video_saved_to_the_gallery
-    val failure = if (isImage) R.string.failed_to_save_the_image else R.string.failed_to_save_the_video
+    val success =
+        when {
+            isImage -> R.string.image_saved_to_the_gallery
+            isPdf -> R.string.pdf_saved_to_the_gallery
+            else -> R.string.video_saved_to_the_gallery
+        }
+    val failure =
+        when {
+            isImage -> R.string.failed_to_save_the_image
+            isPdf -> R.string.failed_to_save_the_pdf
+            else -> R.string.failed_to_save_the_video
+        }
 
     if (content is MediaUrlContent) {
         MediaSaverToDisk.downloadAndSave(
             content.url,
             mimeType = content.mimeType,
             okHttpClient = {
-                if (isImage) {
+                if (isImage || isPdf) {
                     accountViewModel.httpClientBuilder.okHttpClientForImage(it)
                 } else {
                     accountViewModel.httpClientBuilder.okHttpClientForVideo(it)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
@@ -914,6 +914,21 @@ fun ShareMediaAction(
                             onDismiss()
                         }
                     }
+                    if (content is MediaUrlPdf && videoUri != null && !videoUri.startsWith("file")) {
+                        val appContext = LocalContext.current.applicationContext
+                        M3ActionRow(icon = MaterialSymbols.Download, text = stringRes(R.string.download_to_phone)) {
+                            accountViewModel.viewModelScope.launch(Dispatchers.IO) {
+                                saveMediaToGallery(content, appContext, accountViewModel)
+                            }
+                            Toast
+                                .makeText(
+                                    appContext,
+                                    stringRes(appContext, R.string.media_download_has_started_toast),
+                                    Toast.LENGTH_SHORT,
+                                ).show()
+                            onDismiss()
+                        }
+                    }
                     postNostrUri?.let {
                         M3ActionRow(icon = MaterialSymbols.ContentCopy, text = stringRes(R.string.copy_the_note_id_to_the_clipboard)) {
                             scope.launch {

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -176,6 +176,8 @@
     <string name="failed_to_save_the_image">Failed to save the image</string>
     <string name="video_saved_to_the_gallery">Video saved to the phone\'s video gallery</string>
     <string name="failed_to_save_the_video">Failed to save the video</string>
+    <string name="pdf_saved_to_the_gallery">PDF saved to Downloads/Amethyst</string>
+    <string name="failed_to_save_the_pdf">Failed to save the PDF</string>
     <string name="upload_image">Upload Image</string>
     <string name="upload_file">Upload File</string>
     <string name="take_a_picture">Take a picture</string>


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                    
                                                                                                                                                                                                                                
  - **Bug fix**: reject bogus `Content-Type` headers (e.g. `inode/x-empty` returned by some Blossom servers) before passing them to `MediaStore`. The downloader now validates the header is `image/*`, `video/*`, `audio/*`, or
   `application/pdf`; otherwise falls back to the caller-supplied `mimeType`, then to the URL extension.                                                                                                                        
  - **New**: PDFs viewed in `PdfViewerDialog` / `PdfPreviewCard` can now be saved to disk. A "Save to Phone" row is added to the `ShareMediaAction` bottom sheet (gated to `MediaUrlPdf`), and the existing Download icon in    
  `ZoomableContentDialog` is opened to PDFs as well. Files land in `Downloads/Amethyst/<name>.pdf` via `MediaStore.Downloads`.
                                                                                                                                                                                                                                
  ## Why                                                                                                                                                                                                                        
                                                                                                                                                                                                                              
  Users on Blossom servers that hand back `Content-Type: inode/x-empty` (literal output of `file --mime-type`) were unable to save images to the phone — `MediaStore` rejects the insert with `Unsupported MIME type inode/x-empty` even though the URL extension and caller-supplied `mimeType` both indicate a valid image. While in this code path, also unblocked PDF saving, which the viewer rendered but the save action filtered out.    
                                                                                                                                                                                                                                
  ## Notable subtleties                                                                                                                                                                                                       
                                                                                                                                                                                                                                
  - The download is launched in `accountViewModel.viewModelScope`, **not** the dialog's `rememberCoroutineScope()`. The dialog disposes on `onDismiss()` and would otherwise cancel the in-flight download. (Initial symptom was
   "starts but never finishes".)                                                                                                                                                                                              
  - The new row captures `LocalContext.current.applicationContext`, not the Activity context, so the long-running download doesn't pin the Activity past dialog dismiss.                                                        
  - `saveContentQ`'s routing now uses a single destructured `when` for `(masterUri, baseDir)` so the URI and the directory can't drift apart.
  - Pre-Q (`API < 29`) `saveContentDefault` still hardcodes `Pictures/Amethyst` for all types including PDFs — known limitation, < 5% device share, deferred.                                                                   
  - The bottom-sheet "Add Media to Gallery" row is **not** touched — that's the Nostr profile gallery feature.                                                                                                                  
                                                                                                                                                                                                                                
  ## Test plan                                                                                                                                                                                                                  
                                                                                                                                                                                                                                
  - [x] On Pixel 9a (API 36, debug variant), save a Blossom image where the server returns `Content-Type: inode/x-empty` — lands in `Pictures/Amethyst/<name>.<ext>`.                                                           
  - [x] On the same device, open a PDF, tap the new **Save to Phone** row → toast "PDF saved to Downloads/Amethyst", file appears in `Downloads/Amethyst/<name>.pdf`.                                                           
  - [x] Spotless + Kotlin compile pass; pre-commit hook clean.                                                                                                                                                                  
  - [x] Reviewed by `simplify` (3× rounds) and `kotlin-review` (3× rounds): all approved, no CRITICAL or HIGH findings; addressed all MEDIUM findings worth in-scope action.                                                  
                                                                                                                                                                                                                                
  ## Out of scope (follow-ups)                                                                                                                                                                                                  
                                                                                                                                                                                                                                
  - Centralizing `application/pdf` / `isPdfMimeType` checks across `RichTextParser`, `LoadUrlPreview`, `SelectFromGallery`, etc.                                                                                                
  - Pre-Q `saveContentDefault` MIME-type routing.                                                                                                                                                                               
  - Audio downloads landing in `MediaStore.Video` (preexisting; not introduced here).                                                                                                                                           
  - Separate Share branch for PDFs in `ShareMediaAction` (currently no Share row for PDFs; only Save).   