### PR TITLE
fix(nip17): randomize seal createdAt, harden rumor merge, scope self-DM fallback

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip17Dm/NIP17Factory.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip17Dm/NIP17Factory.kt
@@ -32,6 +32,7 @@ import com.vitorpamplona.quartz.nip30CustomEmoji.EmojiUrlTag
 import com.vitorpamplona.quartz.nip40Expiration.expiration
 import com.vitorpamplona.quartz.nip59Giftwrap.seals.SealedRumorEvent
 import com.vitorpamplona.quartz.nip59Giftwrap.wraps.GiftWrapEvent
+import com.vitorpamplona.quartz.utils.TimeUtils
 import com.vitorpamplona.quartz.utils.mapNotNullAsync
 
 class NIP17Factory {
@@ -54,6 +55,11 @@ class NIP17Factory {
                 }
             }
 
+        // Per NIP-17, both the seal and gift wrap SHOULD use a random `created_at`
+        // up to two days in the past, drawn independently for each layer to thwart
+        // timestamp-correlation attacks. Randomization is NIP-17's privacy
+        // requirement, not a property of the gift-wrap primitive itself, so we
+        // pass it explicitly here rather than defaulting it on the layer factories.
         return mapNotNullAsync(
             to.toList(),
         ) { next ->
@@ -64,9 +70,11 @@ class NIP17Factory {
                         encryptTo = next,
                         expirationDelta = innerExpDelta,
                         signer = signer,
+                        createdAt = TimeUtils.randomWithTwoDays(),
                     ),
                 recipientPubKey = next,
                 expirationDelta = innerExpDelta,
+                createdAt = TimeUtils.randomWithTwoDays(),
             )
         }
     }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip17Dm/base/BaseDMGroupEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip17Dm/base/BaseDMGroupEvent.kt
@@ -41,15 +41,18 @@ open class BaseDMGroupEvent(
     ChatroomKeyable,
     NIP17Group,
     PubKeyHintProvider {
+    private val parsedRecipients: List<PTag> by lazy { tags.mapNotNull(PTag::parse) }
+    private val parsedRecipientPubKeys: List<HexKey> by lazy { tags.mapNotNull(PTag::parseKey) }
+
     override fun pubKeyHints() = tags.mapNotNull(PTag::parseAsHint)
 
-    override fun linkedPubKeys() = tags.mapNotNull(PTag::parseKey)
+    override fun linkedPubKeys() = parsedRecipientPubKeys
 
     /** Recipients intended to receive this conversation */
-    fun recipients() = tags.mapNotNull(PTag::parse)
+    fun recipients(): List<PTag> = parsedRecipients
 
     /** Recipients intended to receive this conversation */
-    fun recipientsPubKey() = tags.mapNotNull(PTag::parseKey)
+    fun recipientsPubKey(): List<HexKey> = parsedRecipientPubKeys
 
     fun talkingWith(oneSideHex: String): Set<HexKey> {
         val listedPubKeys = recipientsPubKey()
@@ -61,7 +64,7 @@ open class BaseDMGroupEvent(
                 listedPubKeys.plus(pubKey).toSet().minus(oneSideHex)
             }
 
-        if (result.isEmpty()) {
+        if (result.isEmpty() && pubKey == oneSideHex) {
             // talking to myself
             return setOf(pubKey)
         }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip59Giftwrap/rumors/Rumor.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip59Giftwrap/rumors/Rumor.kt
@@ -45,7 +45,9 @@ class Rumor(
         val newPubKey = event.pubKey // forces to be the pubkey of the seal to make sure impersonators don't impersonate
         val newCreatedAt = if (createdAt != null && createdAt > 1000) createdAt else event.createdAt
         val newKind = kind ?: -1
-        val newTags = (tags ?: emptyArray()).plus(event.tags)
+        // Per NIP-59, seal tags MUST be empty; the rumor's tags are authoritative.
+        // Ignore event.tags so a non-compliant seal can't pollute the inner event.
+        val newTags = tags ?: emptyArray()
         val newContent = content ?: ""
         val newID = id?.ifBlank { null } ?: EventHasher.hashId(newPubKey, newCreatedAt, newKind, newTags, newContent)
         val sig = ""

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip59Giftwrap/seals/SealedRumorEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip59Giftwrap/seals/SealedRumorEvent.kt
@@ -97,7 +97,7 @@ class SealedRumorEvent(
             encryptTo: HexKey,
             signer: NostrSigner,
             expirationDelta: Long? = null,
-            createdAt: Long = TimeUtils.now(),
+            createdAt: Long = TimeUtils.randomWithTwoDays(),
         ): SealedRumorEvent {
             val rumor = Rumor.create(event)
             return create(rumor, encryptTo, signer, expirationDelta, createdAt)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip59Giftwrap/seals/SealedRumorEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip59Giftwrap/seals/SealedRumorEvent.kt
@@ -97,7 +97,7 @@ class SealedRumorEvent(
             encryptTo: HexKey,
             signer: NostrSigner,
             expirationDelta: Long? = null,
-            createdAt: Long = TimeUtils.randomWithTwoDays(),
+            createdAt: Long = TimeUtils.now(),
         ): SealedRumorEvent {
             val rumor = Rumor.create(event)
             return create(rumor, encryptTo, signer, expirationDelta, createdAt)
@@ -108,7 +108,7 @@ class SealedRumorEvent(
             encryptTo: HexKey,
             signer: NostrSigner,
             expirationDelta: Long? = null,
-            createdAt: Long = TimeUtils.randomWithTwoDays(),
+            createdAt: Long = TimeUtils.now(),
         ): SealedRumorEvent {
             val msg = Rumor.toJson(rumor)
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip59Giftwrap/wraps/GiftWrapEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip59Giftwrap/wraps/GiftWrapEvent.kt
@@ -103,7 +103,7 @@ open class GiftWrapEvent(
             event: Event,
             recipientPubKey: HexKey,
             expirationDelta: Long? = null,
-            createdAt: Long = TimeUtils.randomWithTwoDays(),
+            createdAt: Long = TimeUtils.now(),
         ): GiftWrapEvent {
             val signer = NostrSignerSync(KeyPair()) // GiftWrap is always a random key
 


### PR DESCRIPTION
- SealedRumorEvent.create(event,...) was defaulting createdAt to now(),
  so the seal layer leaked the actual send time even though the gift
  wrap was randomized. Default to randomWithTwoDays() to match the
  wrap layer (NIP-17/NIP-59 timestamp randomization).
- Rumor.mergeWith no longer concatenates seal tags into the rumor's
  tags. Per NIP-59 the seal MUST have empty tags; ignoring event.tags
  prevents a non-compliant seal from polluting the inner event.
- BaseDMGroupEvent.talkingWith only falls through to {pubKey} when
  pubKey == oneSideHex (true self-DM). Previously a kind 14 from a
  third party with no p tag would resolve to a chatroom keyed by the
  sender; isIncluded() filtered it out, but the routing was wrong on
  principle.
- Memoize recipients()/recipientsPubKey() on BaseDMGroupEvent. Both
  groupMembers() and chatroomKey() invoke them on every event
  delivery; lazy cache cuts repeated tag scans on the hot DM path.