### PR TITLE
Generate poster JPEGs and fix HLS video rendering in profile gallery

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -135,6 +135,7 @@ import com.vitorpamplona.quartz.experimental.profileGallery.blurhash
 import com.vitorpamplona.quartz.experimental.profileGallery.dimension
 import com.vitorpamplona.quartz.experimental.profileGallery.fromEvent
 import com.vitorpamplona.quartz.experimental.profileGallery.hash
+import com.vitorpamplona.quartz.experimental.profileGallery.image
 import com.vitorpamplona.quartz.experimental.profileGallery.mimeType
 import com.vitorpamplona.quartz.marmot.mip00KeyPackages.KeyPackageEvent
 import com.vitorpamplona.quartz.marmot.mls.group.MlsGroupStateStore
@@ -2547,6 +2548,7 @@ class Account(
         hash: String?,
         mimeType: String?,
         thumbhash: String? = null,
+        image: String? = null,
     ) {
         val template =
             ProfileGalleryEntryEvent.build(url) {
@@ -2556,6 +2558,7 @@ class Account(
                 dim?.let { dimension(it) }
                 blurhash?.let { blurhash(it) }
                 thumbhash?.let { galleryThumbhash(it) }
+                image?.let { image(it) }
             }
 
         val event = signer.sign(template)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/hls/HlsVideoEventBuilder.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/hls/HlsVideoEventBuilder.kt
@@ -49,6 +49,11 @@ data class HlsVideoPublishInput(
     val contentWarning: String? = null,
     val dTag: String? = null,
     val createdAt: Long? = null,
+    // Poster JPEG URL (e.g. a frame extracted from the source video and uploaded alongside the
+    // HLS segments). Threaded into every imeta's `image` property so HLS-unaware UI surfaces
+    // (gallery thumbnails, previews) have a still to render — the .m3u8 playlist itself is a
+    // text manifest that can't be decoded as an image frame.
+    val posterUrl: String? = null,
 )
 
 sealed class HlsVideoEventTemplate {
@@ -82,6 +87,7 @@ object HlsVideoEventBuilder {
 
         val largest = input.renditions.maxByOrNull { it.width * it.height }
         val masterDimension = largest?.let { DimensionTag(it.width, it.height) }
+        val posterImage = input.posterUrl?.let { listOf(it) } ?: emptyList()
         val masterVideoMeta =
             VideoMeta(
                 url = input.masterUrl,
@@ -89,6 +95,7 @@ object HlsVideoEventBuilder {
                 hash = input.masterSha256,
                 dimension = masterDimension,
                 alt = input.alt,
+                image = posterImage,
             )
 
         val renditionMetas =
@@ -107,6 +114,7 @@ object HlsVideoEventBuilder {
                     hash = combinedMetadata?.sha256,
                     size = combinedMetadata?.size?.toInt(),
                     dimension = DimensionTag(summary.width, summary.height),
+                    image = posterImage,
                 )
             }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
@@ -940,10 +940,9 @@ fun ShareMediaAction(
                             if (videoUri != null) {
                                 val n19 = Nip19Parser.uriToRoute(postNostrUri)?.entity as? NEvent
                                 if (n19 != null) {
-                                    // Forward the imeta poster (only MediaUrlVideo carries it) so HLS
-                                    // gallery entries have a still to render — without this, a video
-                                    // event whose imeta only contains a .m3u8 URL renders as a black
-                                    // play-icon tile in the gallery.
+                                    // Forward the imeta poster so HLS gallery entries have a decodable
+                                    // still — the .m3u8 URL itself is a text manifest. Only
+                                    // MediaUrlVideo carries an artworkUri.
                                     val posterUrl = (content as? MediaUrlVideo)?.artworkUri
                                     accountViewModel.addMediaToGallery(n19.hex, videoUri, n19.relay.getOrNull(0), blurhash, dim, hash, mimeType, image = posterUrl)
                                     accountViewModel.toastManager.toast(R.string.media_added, R.string.media_added_to_profile_gallery)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
@@ -940,7 +940,12 @@ fun ShareMediaAction(
                             if (videoUri != null) {
                                 val n19 = Nip19Parser.uriToRoute(postNostrUri)?.entity as? NEvent
                                 if (n19 != null) {
-                                    accountViewModel.addMediaToGallery(n19.hex, videoUri, n19.relay.getOrNull(0), blurhash, dim, hash, mimeType)
+                                    // Forward the imeta poster (only MediaUrlVideo carries it) so HLS
+                                    // gallery entries have a still to render — without this, a video
+                                    // event whose imeta only contains a .m3u8 URL renders as a black
+                                    // play-icon tile in the gallery.
+                                    val posterUrl = (content as? MediaUrlVideo)?.artworkUri
+                                    accountViewModel.addMediaToGallery(n19.hex, videoUri, n19.relay.getOrNull(0), blurhash, dim, hash, mimeType, image = posterUrl)
                                     accountViewModel.toastManager.toast(R.string.media_added, R.string.media_added_to_profile_gallery)
                                 }
                             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -856,7 +856,8 @@ class AccountViewModel(
         dim: DimensionTag?,
         hash: String?,
         mimeType: String?,
-    ) = launchSigner { account.addToGallery(hex, url, relay, blurhash, dim, hash, mimeType) }
+        image: String? = null,
+    ) = launchSigner { account.addToGallery(hex, url, relay, blurhash, dim, hash, mimeType, image = image) }
 
     fun removeFromMediaGallery(note: Note) = launchSigner { account.removeFromGallery(note) }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/gallery/GalleryThumb.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/gallery/GalleryThumb.kt
@@ -47,6 +47,7 @@ import com.vitorpamplona.amethyst.commons.richtext.MediaUrlImage
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlVideo
 import com.vitorpamplona.amethyst.commons.richtext.RichTextParser.Companion.isVideoUrl
 import com.vitorpamplona.amethyst.model.Note
+import com.vitorpamplona.amethyst.service.playback.diskCache.isLiveStreaming
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.observeNote
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
 import com.vitorpamplona.amethyst.ui.components.AutoNonlazyGrid
@@ -87,6 +88,7 @@ fun GalleryThumbnail(
                         uri = null,
                         mimeType = noteEvent.mimeType(),
                         thumbhash = noteEvent.thumbhash(),
+                        artworkUri = noteEvent.image()?.imageUrl ?: noteEvent.thumb()?.imageUrl,
                     )
                 } else {
                     MediaUrlImage(
@@ -128,6 +130,7 @@ fun GalleryThumbnail(
                     uri = null,
                     mimeType = imeta.mimeType,
                     thumbhash = imeta.thumbhash,
+                    artworkUri = imeta.image.firstOrNull(),
                 )
             }
         } else if (noteEvent is LiveActivitiesClipEvent) {
@@ -217,10 +220,19 @@ fun UrlImageView(
             )
         }
 
+    val isVideo = content is MediaUrlVideo
+    val artworkUri = (content as? MediaUrlVideo)?.artworkUri
+    // Coil's VideoFrameDecoder can extract a frame from .mp4/.webm but not from an HLS .m3u8
+    // playlist (it's a text manifest). For an HLS video without a separate artwork URL, sending
+    // the playlist to SubcomposeAsyncImage just produces an Error state and a stand-in icon.
+    // Skip the fetch in that case and render blurhash + play overlay directly.
+    val imageModelUrl = artworkUri ?: content.url
+    val canLoadAsImage = !isVideo || artworkUri != null || !isLiveStreaming(content.url)
+
     CrossfadeIfEnabled(targetState = showImage.value, contentAlignment = Alignment.Center, accountViewModel = accountViewModel) {
-        if (it) {
+        if (it && canLoadAsImage) {
             SubcomposeAsyncImage(
-                model = content.url,
+                model = imageModelUrl,
                 contentDescription = content.description,
                 contentScale = ContentScale.Crop,
                 modifier = Modifier.fillMaxSize(),
@@ -245,23 +257,26 @@ fun UrlImageView(
                     }
 
                     is AsyncImagePainter.State.Error -> {
-                        Box(defaultModifier, contentAlignment = Alignment.Center) {
-                            Icon(
-                                symbol = MaterialSymbols.PlayCircleOutline,
-                                contentDescription = stringRes(id = R.string.play),
-                                modifier = Size50Modifier,
-                                tint = MaterialTheme.colorScheme.onBackground,
-                            )
-                        }
+                        VideoPlaceholder(content, defaultModifier)
                     }
 
                     is AsyncImagePainter.State.Success -> {
                         SubcomposeAsyncImageContent(defaultModifier)
+                        if (isVideo) {
+                            Icon(
+                                symbol = MaterialSymbols.PlayCircleOutline,
+                                contentDescription = stringRes(id = R.string.play),
+                                modifier = Size50Modifier,
+                                tint = Color.White,
+                            )
+                        }
                     }
 
                     else -> {}
                 }
             }
+        } else if (it && isVideo) {
+            VideoPlaceholder(content, defaultModifier)
         } else {
             if (content.blurhash != null || content.thumbhash != null) {
                 DisplayBlurHash(
@@ -286,5 +301,29 @@ fun UrlImageView(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun VideoPlaceholder(
+    content: MediaUrlContent,
+    defaultModifier: Modifier,
+) {
+    if (content.blurhash != null || content.thumbhash != null) {
+        DisplayBlurHash(
+            content.blurhash,
+            content.description,
+            ContentScale.Crop,
+            defaultModifier,
+            thumbhash = content.thumbhash,
+        )
+    }
+    Box(defaultModifier, contentAlignment = Alignment.Center) {
+        Icon(
+            symbol = MaterialSymbols.PlayCircleOutline,
+            contentDescription = stringRes(id = R.string.play),
+            modifier = Size50Modifier,
+            tint = if (content.blurhash != null || content.thumbhash != null) Color.White else MaterialTheme.colorScheme.onBackground,
+        )
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/gallery/GalleryThumb.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/gallery/GalleryThumb.kt
@@ -66,6 +66,19 @@ import com.vitorpamplona.quartz.nip53LiveActivities.clip.LiveActivitiesClipEvent
 import com.vitorpamplona.quartz.nip68Picture.PictureEvent
 import com.vitorpamplona.quartz.nip71Video.VideoEvent
 
+// HLS playlist mime types as published in NIP-71 imeta tags. Mirrors the canonical list used in
+// MediaItemCache.toExoPlayerMimeType. Kept inline to avoid creating a one-off helper module.
+private fun isHlsMimeType(mimeType: String?): Boolean =
+    when (mimeType?.lowercase()) {
+        "application/vnd.apple.mpegurl",
+        "application/x-mpegurl",
+        "audio/x-mpegurl",
+        "audio/mpegurl",
+        -> true
+
+        else -> false
+    }
+
 @Composable
 fun GalleryThumbnail(
     baseNote: Note,
@@ -119,7 +132,28 @@ fun GalleryThumbnail(
                 )
             }
         } else if (noteEvent is VideoEvent) {
-            noteEvent.imetaTags().map { imeta ->
+            // An HLS publish writes one imeta per rendition (master + each variant) on the same
+            // NIP-71 event. Rendering them all expands a single video into a sub-grid of black
+            // tiles inside one gallery card — the .m3u8 playlist is a text manifest Coil can't
+            // decode. Collapse to a single tile when every imeta is an HLS playlist; prefer an
+            // imeta that carries a poster image, breaking ties by smallest dimensions so we
+            // pick the lowest-resolution variant. Non-HLS multi-imeta videos keep the existing
+            // per-imeta layout.
+            val imetas = noteEvent.imetaTags()
+            val isAllHls = imetas.isNotEmpty() && imetas.all { isHlsMimeType(it.mimeType) }
+            val toRender =
+                if (isAllHls) {
+                    val withPoster = imetas.filter { it.image.isNotEmpty() }
+                    val pick =
+                        (withPoster.ifEmpty { imetas })
+                            .minByOrNull {
+                                it.dimension?.let { d -> d.width * d.height } ?: Int.MAX_VALUE
+                            } ?: imetas.first()
+                    listOf(pick)
+                } else {
+                    imetas
+                }
+            toRender.map { imeta ->
                 MediaUrlVideo(
                     url = imeta.url,
                     description = noteEvent.content,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/gallery/GalleryThumb.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/gallery/GalleryThumb.kt
@@ -39,6 +39,7 @@ import androidx.media3.common.util.UnstableApi
 import coil3.compose.AsyncImagePainter
 import coil3.compose.SubcomposeAsyncImage
 import coil3.compose.SubcomposeAsyncImageContent
+import com.davotoula.lightcompressor.hls.HlsContentTypes
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
@@ -66,11 +67,11 @@ import com.vitorpamplona.quartz.nip53LiveActivities.clip.LiveActivitiesClipEvent
 import com.vitorpamplona.quartz.nip68Picture.PictureEvent
 import com.vitorpamplona.quartz.nip71Video.VideoEvent
 
-// HLS playlist mime types as published in NIP-71 imeta tags. Mirrors the canonical list used in
-// MediaItemCache.toExoPlayerMimeType. Kept inline to avoid creating a one-off helper module.
+// Mirrors the canonical HLS-playlist mime list used in MediaItemCache.toExoPlayerMimeType.
+// Kept inline rather than extracting a shared helper for one read-side caller.
 private fun isHlsMimeType(mimeType: String?): Boolean =
     when (mimeType?.lowercase()) {
-        "application/vnd.apple.mpegurl",
+        HlsContentTypes.HLS_PLAYLIST,
         "application/x-mpegurl",
         "audio/x-mpegurl",
         "audio/mpegurl",

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/gallery/GalleryThumb.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/gallery/GalleryThumb.kt
@@ -146,10 +146,9 @@ fun GalleryThumbnail(
                 if (isAllHls) {
                     val withPoster = imetas.filter { it.image.isNotEmpty() }
                     val pick =
-                        (withPoster.ifEmpty { imetas })
-                            .minByOrNull {
-                                it.dimension?.let { d -> d.width * d.height } ?: Int.MAX_VALUE
-                            } ?: imetas.first()
+                        withPoster.ifEmpty { imetas }.minBy {
+                            it.dimension?.let { d -> d.width * d.height } ?: Int.MAX_VALUE
+                        }
                     listOf(pick)
                 } else {
                     imetas

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/hls/HlsPublishOrchestrator.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/hls/HlsPublishOrchestrator.kt
@@ -35,11 +35,14 @@ import com.vitorpamplona.amethyst.service.uploads.hls.HlsVideoEventBuilder
 import com.vitorpamplona.amethyst.service.uploads.hls.HlsVideoEventTemplate
 import com.vitorpamplona.amethyst.service.uploads.hls.HlsVideoPublishInput
 import com.vitorpamplona.amethyst.ui.actions.mediaServers.ServerName
+import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import java.io.File
+
+private const val TAG = "HlsPublishOrchestrator"
 
 data class HlsPublishRequest(
     val title: String,
@@ -74,6 +77,11 @@ class HlsPublishOrchestrator(
     private val buildUploader: (ServerName) -> HlsBlobUploader,
     private val uploadMaster: suspend (HlsBlobUploader, String) -> MediaUploadResult,
     private val signAndPublish: suspend (HlsVideoEventTemplate) -> String,
+    // Generates a poster JPEG from the picked source video and uploads it via the supplied
+    // uploader, returning the public URL. Returns null if poster generation isn't possible
+    // (unsupported source, decode failure, no readable frame). Failures here must NOT fail
+    // the whole publish — the orchestrator catches and continues without a poster.
+    private val uploadPoster: suspend (HlsBlobUploader) -> String? = { _ -> null },
 ) {
     val state: StateFlow<HlsPublishState> = _state
 
@@ -196,6 +204,20 @@ class HlsPublishOrchestrator(
             val masterUrl =
                 masterUpload.url ?: error("Uploader returned null URL for master playlist")
 
+            // Generate + upload a poster JPEG so HLS-unaware UI surfaces (gallery thumbnails,
+            // previews) have a still to render. Tolerate failure: skip the poster rather than
+            // failing the entire publish, since the user has already paid the cost of the long
+            // segment uploads.
+            val posterUrl =
+                try {
+                    uploadPoster(uploader)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    Log.w(TAG) { "Poster generation/upload failed: ${e.message}" }
+                    null
+                }
+
             _state.value = HlsPublishState.Publishing
             val template =
                 HlsVideoEventBuilder.build(
@@ -208,6 +230,7 @@ class HlsPublishOrchestrator(
                         description = request.description,
                         durationSeconds = request.durationSeconds,
                         contentWarning = contentWarningOrNull(request),
+                        posterUrl = posterUrl,
                     ),
                 )
             val eventId = signAndPublish(template)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/hls/HlsPublishOrchestratorFactory.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/hls/HlsPublishOrchestratorFactory.kt
@@ -21,18 +21,28 @@
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.video.hls
 
 import android.content.Context
+import android.graphics.Bitmap
+import android.media.MediaMetadataRetriever
 import android.net.Uri
 import com.davotoula.lightcompressor.hls.HlsContentTypes
 import com.davotoula.lightcompressor.hls.HlsUploadHelper
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.service.uploads.MediaUploadResult
+import com.vitorpamplona.amethyst.service.uploads.getThumbnail
+import com.vitorpamplona.amethyst.service.uploads.hls.HlsBlobUploader
 import com.vitorpamplona.amethyst.service.uploads.hls.HlsBlobUploaderFactory
 import com.vitorpamplona.amethyst.service.uploads.hls.HlsVideoEventTemplate
 import com.vitorpamplona.quartz.utils.Log
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.withContext
 import java.io.File
+import java.io.FileOutputStream
 
 private const val TAG = "HlsPublishOrchestratorFactory"
+
+private const val POSTER_JPEG_QUALITY = 85
+private const val POSTER_CONTENT_TYPE = "image/jpeg"
 
 /**
  * Production wiring for [HlsPublishOrchestrator]. Binds the upload closure to
@@ -87,4 +97,74 @@ fun createProductionHlsPublishOrchestrator(
             account.sendAutomatic(signed)
             signed.id
         },
+        uploadPoster = { uploader ->
+            val uri = uriProvider()
+            if (uri == null) {
+                null
+            } else {
+                generateAndUploadPoster(context, uri, uploader)
+            }
+        },
     )
+
+/**
+ * Extracts a still frame from the source video at [uri], encodes it as JPEG, and uploads it
+ * via [uploader]. Returns the public URL on success or null if any step fails (unsupported
+ * source, no readable frame, encode/upload error). The orchestrator treats null as "publish
+ * without a poster" — failure here must never abort the publish.
+ */
+private suspend fun generateAndUploadPoster(
+    context: Context,
+    uri: Uri,
+    uploader: HlsBlobUploader,
+): String? {
+    val posterFile = extractPosterToTempFile(context, uri) ?: return null
+    return try {
+        val result = uploader.upload(posterFile, POSTER_CONTENT_TYPE) { _, _ -> }
+        result.url
+    } finally {
+        if (!posterFile.delete()) {
+            Log.w(TAG) { "uploadPoster: failed to delete temp file ${posterFile.absolutePath}" }
+        }
+    }
+}
+
+private suspend fun extractPosterToTempFile(
+    context: Context,
+    uri: Uri,
+): File? =
+    withContext(Dispatchers.IO) {
+        val retriever = MediaMetadataRetriever()
+        var bitmap: Bitmap? = null
+        try {
+            retriever.setDataSource(context, uri)
+            bitmap = retriever.getThumbnail()
+            if (bitmap == null) {
+                Log.w(TAG) { "extractPosterToTempFile: getThumbnail returned null for $uri" }
+                return@withContext null
+            }
+            val outFile = File.createTempFile("hls-poster-", ".jpg", context.cacheDir)
+            try {
+                FileOutputStream(outFile).use { stream ->
+                    bitmap.compress(Bitmap.CompressFormat.JPEG, POSTER_JPEG_QUALITY, stream)
+                }
+                outFile
+            } catch (e: Exception) {
+                if (!outFile.delete()) {
+                    Log.w(TAG) { "extractPosterToTempFile: failed to delete temp file ${outFile.absolutePath}" }
+                }
+                throw e
+            }
+        } catch (e: Exception) {
+            Log.w(TAG) { "extractPosterToTempFile: failed for $uri — ${e.message}" }
+            null
+        } finally {
+            bitmap?.recycle()
+            try {
+                retriever.release()
+            } catch (_: Exception) {
+                // release() can throw RuntimeException on some devices; swallow — the temp
+                // file (if any) is already cleaned up and the bitmap recycled.
+            }
+        }
+    }

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/service/uploads/hls/HlsPublishOrchestratorTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/service/uploads/hls/HlsPublishOrchestratorTest.kt
@@ -374,6 +374,64 @@ class HlsPublishOrchestratorTest {
     }
 
     @Test
+    fun posterUrlFromUploadPosterClosureLandsOnEveryImeta() {
+        val captured = mutableListOf<HlsVideoEventTemplate>()
+        val canned = CannedUploader()
+        val orchestrator =
+            HlsPublishOrchestrator(
+                _state = MutableStateFlow(HlsPublishState.Idle),
+                runUpload = fakeRunUpload(),
+                buildUploader = { canned },
+                uploadMaster = fakeUploadMaster(canned),
+                signAndPublish = { tpl ->
+                    captured += tpl
+                    "event-id"
+                },
+                uploadPoster = { _ -> "https://cdn.test/poster.jpg" },
+            )
+
+        runBlocking { orchestrator.publish(newRequest()) }
+
+        val template = (captured.single() as HlsVideoEventTemplate.Horizontal).template
+        val imetas = template.tags.filter { it.isNotEmpty() && it[0] == "imeta" }
+        assertTrue("expected at least one imeta", imetas.isNotEmpty())
+        imetas.forEach { imeta ->
+            val flat = imeta.joinToString("|")
+            assertTrue("imeta missing poster: $flat", flat.contains("image https://cdn.test/poster.jpg"))
+        }
+    }
+
+    @Test
+    fun posterFailureDoesNotAbortPublish() {
+        val captured = mutableListOf<HlsVideoEventTemplate>()
+        val canned = CannedUploader()
+        val orchestrator =
+            HlsPublishOrchestrator(
+                _state = MutableStateFlow(HlsPublishState.Idle),
+                runUpload = fakeRunUpload(),
+                buildUploader = { canned },
+                uploadMaster = fakeUploadMaster(canned),
+                signAndPublish = { tpl ->
+                    captured += tpl
+                    "event-id"
+                },
+                uploadPoster = { _ -> throw RuntimeException("decode failed") },
+            )
+
+        runBlocking { orchestrator.publish(newRequest()) }
+
+        // Publish still succeeded despite poster failure
+        assertTrue(orchestrator.state.value is HlsPublishState.Success)
+        // And the imetas have no `image ` property
+        val template = (captured.single() as HlsVideoEventTemplate.Horizontal).template
+        val imetas = template.tags.filter { it.isNotEmpty() && it[0] == "imeta" }
+        imetas.forEach { imeta ->
+            val flat = imeta.joinToString("|")
+            assertTrue("imeta unexpectedly carries image after poster failure: $flat", !flat.contains("image "))
+        }
+    }
+
+    @Test
     fun resetRestoresIdleState() {
         val orchestrator =
             HlsPublishOrchestrator(

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/service/uploads/hls/HlsVideoEventBuilderTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/service/uploads/hls/HlsVideoEventBuilderTest.kt
@@ -95,6 +95,7 @@ class HlsVideoEventBuilderTest {
         duration: Int? = null,
         contentWarning: String? = null,
         dTag: String? = "fixed-d-tag",
+        posterUrl: String? = null,
     ): HlsVideoPublishInput =
         HlsVideoPublishInput(
             renditions = renditions,
@@ -108,6 +109,7 @@ class HlsVideoEventBuilderTest {
             contentWarning = contentWarning,
             dTag = dTag,
             createdAt = 1_700_000_000L,
+            posterUrl = posterUrl,
         )
 
     private fun Array<Array<String>>.findTag(name: String): Array<String>? = firstOrNull { it.isNotEmpty() && it[0] == name }
@@ -229,5 +231,34 @@ class HlsVideoEventBuilderTest {
         val alt = tags.findTag("alt")
         assertNotNull(alt)
         assertEquals(VideoVerticalEvent.ALT_DESCRIPTION, alt!![1])
+    }
+
+    @Test
+    fun posterUrlIsPropagatedToEveryImetaImage() {
+        val result =
+            HlsVideoEventBuilder.build(
+                input(landscapeRenditions, posterUrl = "https://cdn.test/poster.jpg"),
+            )
+        val tags = (result as HlsVideoEventTemplate.Horizontal).template.tags
+
+        val imetas = tags.findAllTags("imeta")
+        // 1 master + 2 renditions, each must carry image <posterUrl>
+        assertEquals(3, imetas.size)
+        imetas.forEach { imeta ->
+            val flat = imeta.joinToString("|")
+            assertTrue("imeta missing poster image: $flat", flat.contains("image https://cdn.test/poster.jpg"))
+        }
+    }
+
+    @Test
+    fun noPosterUrlMeansNoImagePropertyOnImetas() {
+        val result = HlsVideoEventBuilder.build(input(landscapeRenditions))
+        val tags = (result as HlsVideoEventTemplate.Horizontal).template.tags
+
+        val imetas = tags.findAllTags("imeta")
+        imetas.forEach { imeta ->
+            val flat = imeta.joinToString("|")
+            assertTrue("imeta unexpectedly carries image: $flat", !flat.contains("image "))
+        }
     }
 }


### PR DESCRIPTION
## Summary                              
                                                                                                                                                                                                                                
  NIP-71 HLS publishes were rendering badly in the profile gallery: each rendition (master + every variant) became its own black play-icon tile inside a single gallery card, and there was no still image to fall back to since
   `.m3u8` is a text manifest Coil can't decode. This PR fixes both halves.                                                                                                                                                     
                                                                                                                                                                                                                                
  **Publish side (HLS poster pipeline)**                                                                                                                                                                                        
  - `HlsPublishOrchestrator` gains an `uploadPoster` step — the production factory extracts a frame from the source video via `MediaMetadataRetriever`, encodes JPEG, uploads it to the same Blossom/NIP-96 server as the
  segments, and `HlsVideoEventBuilder` threads the URL into every imeta's `image` field. Failures are swallowed (publish proceeds without a poster) so the user never loses a long upload over a poster glitch.          
  - New `HlsPublishOrchestratorTest` and `HlsVideoEventBuilderTest` coverage for the poster path.                                                                                                                               
                                                                                                 
  **Read side (gallery)**                                                                                                                                                                                                       
  - `GalleryThumb` now collapses HLS-only multi-imeta `VideoEvent`s to a single tile, picking the imeta carrying a poster `image` (tied by smallest dimensions, so the lowest-res variant wins). Non-HLS multi-imeta videos are 
  untouched to avoid regressing authors who publish alternate-format renditions side by side.                                                                                                                                   
  - `Account.addToGallery` and `AccountViewModel.addMediaToGallery` accept a new optional `image: String?` parameter. The `ZoomableContentView` "Add Media to Gallery" action now forwards the imeta poster (`(content as?      
  MediaUrlVideo)?.artworkUri`), so manual gallery entries created from a NIP-71 video event get a still.                                                                                                                      
                                                                                                                                                                                                                                
  A short follow-up note about an unrelated pre-existing `thumbhash` plumbing gap is parked outside this PR.
                                                                                                                                                                                                                                
  ## Test plan                            
                                                                                                                                                                                                                                
  - [x] `:amethyst:spotlessApply` clean                                                                                                                                                                                       
  - [x] `:amethyst:compilePlayBenchmarkKotlin` builds without errors                                                                                                                                                            
  - [x] Local install on Pixel 9a — manually verified that a multi-rendition HLS gallery card now collapses to a single tile (no more 3×2 sub-grid)                                                                           
  - [x] Upload a fresh HLS clip from this build and confirm the new poster lands in the imeta `image` and renders in the gallery                                                                                                
  - [ ] Verify non-HLS NIP-71 video events still render their existing per-imeta layout (no regression)                                                                                                                         
  - [x] Add a NIP-71 video event to gallery via the zoomable Add-Media menu and confirm the poster appears