### PR TITLE
fix: don't broadcast non-DM events to DM-inbox-only relays (kind 10050)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -886,12 +886,19 @@ class Account(
                 existingRelays + replyAuthorRelays
             } ?: emptySet()
 
-        return reactionOutBoxRelays +
-            inboxRelaysOfTheAuthorOfTheOriginalNote +
-            taggedUserInboxRelays +
-            channelRelays +
-            replyRelays +
-            relaysItCameFrom
+        val combined =
+            reactionOutBoxRelays +
+                inboxRelaysOfTheAuthorOfTheOriginalNote +
+                taggedUserInboxRelays +
+                channelRelays +
+                replyRelays +
+                relaysItCameFrom
+
+        // Relays declared in kind 10050 are DM-inbox and reject reactions.
+        // Subtract the full DM list so a relay declared as DM inbox is excluded
+        // even if it also appears in the user's outbox composition.
+        val dmRelays = dmRelayList.flow.value
+        return if (dmRelays.isNotEmpty()) combined - dmRelays else combined
     }
 
     private fun computeRelayListForLinkedUser(user: User): Set<NormalizedRelayUrl> =
@@ -1026,6 +1033,15 @@ class Account(
         }
 
         relayList.addAll(computeRelaysForChannels(event))
+
+        // Relays declared in kind 10050 are DM-inbox and reject non-DM kinds.
+        // Subtract the full DM list so a relay declared as DM inbox is excluded
+        // even if it also appears in the user's outbox composition. GiftWrap /
+        // WrappedEvent paths return earlier and never reach this filter.
+        val dmRelays = dmRelayList.flow.value
+        if (dmRelays.isNotEmpty()) {
+            relayList.removeAll(dmRelays)
+        }
 
         return relayList
     }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                    
                                                                                                                                                                                                                              
  Filter `dmRelayList.flow.value` (kind 10050) out of the broadcast set in                                                                                                                                                      
  `Account.computeRelayListToBroadcast` and `Account.computeMyReactionToNote`.
  Relays declared as DM-inbox reject non-DM kinds with                                                                                                                                                                          
  `blocked kind N reason: this relay is for…`, which surfaces as failed                                                                                                                                                         
  entries in the Broadcast Results sheet for kind 1, kind 7, and similar.                                                                                                                                                       
                                                                                                                                                                                                                                
  ## Why DM relays were leaking in                                                                                                                                                                                              
                                                                                                                                                                                                                                
  Two paths, both confirmed on device:                                                                                                                                                                                          
                                      
  1. **`privateStorageRelayList` (kind 10013) is folded into the outbox flow**                                                                                                                                                  
     by `AccountOutboxRelayState`. Many users configure the same auth-required
     relay for both DM inbox and private storage, so it rides every public                                                                                                                                                      
     broadcast as `self-outbox`.                                                                                                                                                                                                
  2. **`User.allUsedRelays()` records every relay where any of a user's                                                                                                                                                         
     events were observed**, including their own kind 1059 GiftWraps delivered                                                                                                                                                  
     to the recipient's DM inbox. When a reply / mention links such a user,                                                                                                                                                     
     `computeRelayListForLinkedUser` falls back to `allUsedRelays()` and                                                                                                                                                        
     reintroduces the recipient's DM-inbox relay.                                                                                                                                                                               
                                                                                                                                                                                                                                
  ## Scope of this PR (defensive) vs. the larger fix                                                                                                                                                                            
                                         
  This PR is the **defensive filter only** — it treats kind 10050 as the                                                                                                                                                        
  authoritative declaration of relay role and strips DM relays at the end of                                                                                                                                                  
  each broadcast-set computation. Minimal blast radius, two functions touched.                                                                                                                                                  
                                                                                                                                                                                                                                
  A **root-cause fix** would also stop folding `privateStorageRelayList` into                                                                                                                                                   
  `AccountOutboxRelayState`, since the UI explainer for that list says                                                                                                                                                          
  *"events no one else can see, like Drafts and/or app settings"* — i.e. it                                                                                                                                                     
  should not carry public events. That change touches all ~14 consumers of                                                                                                                                                      
  `outboxRelays.flow.value` (deletions, reactions, zaps, kind 3, bounties,                                                                                                                                                      
  …) and is intentionally out of scope here. The defensive filter is enough                                                                                                                                                     
  to stop the user-visible rejections; the composition cleanup can land                                                                                                                                                         
  separately if maintainers agree on the contract reading.                                                                                                                                                                      
                                                                                                                                                                                                                                
  ## Test plan                                                                                                                                                                                                                  
                                                                                                                                                                                                                                
  - [x] Own kind 1: `auth.nostr1.com` leak via `self-outbox` stripped.                                                                                                                                                          
  - [x] Own kind 7: same, stripped.                                                                                                                                                                                           
  - [x] Reply/reaction to a contact: `nos.lol` leak via the                                                                                                                                                                     
    `computeRelayListForLinkedUser` `allUsedRelays()` fallback also stripped.                                                                                                                                                   
  - [x] DM send/receive (kind 1059), draft save/delete (kind 31234), profile