### PR TITLE
Add animated outer ring indicator for speaking participants

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/stage/ParticipantsGrid.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/stage/ParticipantsGrid.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -92,6 +93,16 @@ private val MAX_RING_WIDTH = 7.dp
 // avatar via drawBehind so it doesn't change layout bounds; alpha
 // fades to 0 when not speaking.
 private val MAX_GLOW_RADIUS = 12.dp
+
+// Detached green ring drawn around a speaking avatar with a clear
+// gap to the profile picture, so the "is talking" signal reads from
+// across the room without overpowering the face. Only rendered while
+// `isSpeaking` is true; pulses with the live audio level. Drawn via
+// drawBehind to avoid affecting layout bounds — the gap + ring fit
+// inside the GRID_SPACING between cells.
+private val OUTER_RING_GAP = 5.dp
+private val OUTER_RING_WIDTH = 2.5.dp
+private val OUTER_RING_MAX_WIDTH = 4.dp
 
 // Cap badge sizes so they stay legible without dominating the avatar
 // at 100.dp. The 0.42 ratio was tuned for ~48.dp avatars (giving
@@ -392,16 +403,44 @@ private fun MemberCell(
         targetValue = if (isSpeaking) (clampedLevel * 0.45f) else 0f,
         label = "speaker-ring-glow-alpha",
     )
+    // Detached outer ring: stays at full opacity while speaking so the
+    // signal is unmistakable, fades out when speech stops. Stroke width
+    // tracks audio level for an extra liveness cue on top of the inner
+    // border ring.
+    val animatedOuterRingAlpha by animateFloatAsState(
+        targetValue = if (isSpeaking) 1f else 0f,
+        label = "speaker-outer-ring-alpha",
+    )
+    val animatedOuterRingWidth by animateDpAsState(
+        targetValue =
+            if (isSpeaking) {
+                OUTER_RING_WIDTH + (clampedLevel * (OUTER_RING_MAX_WIDTH - OUTER_RING_WIDTH).value).dp
+            } else {
+                0.dp
+            },
+        label = "speaker-outer-ring-width",
+    )
     val avatarModifier =
         Modifier
             .drawBehind {
-                if (animatedGlowAlpha <= 0.001f) return@drawBehind
-                val baseRadius = size.minDimension / 2f
-                val extra = MAX_GLOW_RADIUS.toPx() * clampedLevel
-                drawCircle(
-                    color = NEST_SPEAKING_COLOR.copy(alpha = animatedGlowAlpha),
-                    radius = baseRadius + extra,
-                )
+                if (animatedGlowAlpha > 0.001f) {
+                    val baseRadius = size.minDimension / 2f
+                    val extra = MAX_GLOW_RADIUS.toPx() * clampedLevel
+                    drawCircle(
+                        color = NEST_SPEAKING_COLOR.copy(alpha = animatedGlowAlpha),
+                        radius = baseRadius + extra,
+                    )
+                }
+                if (animatedOuterRingAlpha > 0.001f && animatedOuterRingWidth > 0.dp) {
+                    val baseRadius = size.minDimension / 2f
+                    val strokePx = animatedOuterRingWidth.toPx()
+                    val ringRadius = baseRadius + OUTER_RING_GAP.toPx() + strokePx / 2f
+                    drawCircle(
+                        color = NEST_SPEAKING_COLOR.copy(alpha = animatedOuterRingAlpha),
+                        radius = ringRadius,
+                        style = Stroke(width = strokePx),
+                    )
+                }
             }.border(animatedRingWidth, animatedRingColor, CircleShape)
             .let { if (member.absent) it.alpha(0.5f) else it }
     val user =


### PR DESCRIPTION
## Summary
Enhanced the speaking participant visual indicator in the participants grid by adding a detached outer ring that provides a clearer "is talking" signal visible from across the room without overpowering the participant's face.

## Key Changes
- Added import for `Stroke` from `androidx.compose.ui.graphics.drawscope`
- Introduced three new constants for the outer ring styling:
  - `OUTER_RING_GAP`: 5.dp gap between avatar and ring
  - `OUTER_RING_WIDTH`: 2.5.dp base stroke width
  - `OUTER_RING_MAX_WIDTH`: 4.dp maximum stroke width
- Implemented animated outer ring that:
  - Renders only while `isSpeaking` is true
  - Maintains full opacity (1f) while speaking for unmistakable signal
  - Fades out when speech stops
  - Stroke width pulses with live audio level for additional liveness cue
- Refactored the `drawBehind` block to:
  - Wrap the existing glow circle in a conditional check
  - Add new outer ring drawing logic with proper radius calculation accounting for gap and stroke width
  - Use `Stroke` style for the ring to create a hollow circle effect

## Implementation Details
The outer ring is drawn via `drawBehind` to avoid affecting layout bounds, ensuring the gap and ring fit within the existing `GRID_SPACING` between cells. The ring radius is calculated as: `baseRadius + OUTER_RING_GAP + strokeWidth/2`, positioning it precisely outside the avatar with the specified gap. The stroke width dynamically scales between `OUTER_RING_WIDTH` and `OUTER_RING_MAX_WIDTH` based on the audio level, providing visual feedback of speech intensity.

https://claude.ai/code/session_01GwkFUWWi7kjWY7EbPN83YX