### PR TITLE
Add grace period to lifecycle-aware subscriptions

### DIFF
--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/subscriptions/LifecycleAwareKeyDataSourceSubscription.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/subscriptions/LifecycleAwareKeyDataSourceSubscription.kt
@@ -22,23 +22,33 @@ package com.vitorpamplona.amethyst.commons.relayClient.subscriptions
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.vitorpamplona.amethyst.commons.relayClient.composeSubscriptionManagers.ComposeSubscriptionManager
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+private const val UNSUBSCRIBE_GRACE_MILLIS = 30_000L
 
 /**
  * A lifecycle-aware version of [KeyDataSourceSubscription] that subscribes
- * when the lifecycle reaches STARTED and unsubscribes when it reaches STOPPED.
+ * when the lifecycle reaches STARTED and unsubscribes 30 seconds after it
+ * reaches STOPPED. If the lifecycle returns to STARTED before the grace
+ * period elapses, the pending unsubscribe is cancelled and the subscription
+ * keeps running uninterrupted.
+ *
+ * The grace window absorbs short app switches (copy a snippet from another
+ * app, dismiss a notification, glance at recents) without tearing down and
+ * rebuilding the relay REQ — which would otherwise lose EOSE state and
+ * trigger a refetch on return.
  *
  * Use this for heavy feed subscriptions (home, video, discovery, chatroom list)
- * that should NOT run when the app is in the background. When an always-on
- * notification service keeps the relay client connected, these subscriptions
- * would otherwise leak bandwidth on feeds nobody is viewing.
+ * that should NOT run when the app is truly in the background. When an
+ * always-on notification service keeps the relay client connected, these
+ * subscriptions would otherwise leak bandwidth on feeds nobody is viewing.
  *
  * Lightweight subscriptions that should always run (account metadata, notifications,
  * gift wraps) should continue using the regular [KeyDataSourceSubscription].
@@ -49,24 +59,43 @@ fun <T> LifecycleAwareKeyDataSourceSubscription(
     dataSource: ComposeSubscriptionManager<T>,
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
-    var isStarted by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
 
     DisposableEffect(state, lifecycleOwner) {
+        var isSubscribed = false
+        var pendingUnsubscribe: Job? = null
+
+        fun subscribeNow() {
+            pendingUnsubscribe?.cancel()
+            pendingUnsubscribe = null
+            if (!isSubscribed) {
+                dataSource.subscribe(state)
+                isSubscribed = true
+            }
+        }
+
+        fun scheduleUnsubscribe() {
+            if (!isSubscribed || pendingUnsubscribe != null) return
+            pendingUnsubscribe =
+                scope.launch {
+                    delay(UNSUBSCRIBE_GRACE_MILLIS)
+                    if (isSubscribed) {
+                        dataSource.unsubscribe(state)
+                        isSubscribed = false
+                    }
+                    pendingUnsubscribe = null
+                }
+        }
+
         val observer =
             LifecycleEventObserver { _, event ->
                 when (event) {
                     Lifecycle.Event.ON_START -> {
-                        if (!isStarted) {
-                            dataSource.subscribe(state)
-                            isStarted = true
-                        }
+                        subscribeNow()
                     }
 
                     Lifecycle.Event.ON_STOP -> {
-                        if (isStarted) {
-                            dataSource.unsubscribe(state)
-                            isStarted = false
-                        }
+                        scheduleUnsubscribe()
                     }
 
                     else -> {}
@@ -75,17 +104,17 @@ fun <T> LifecycleAwareKeyDataSourceSubscription(
 
         lifecycleOwner.lifecycle.addObserver(observer)
 
-        // If already started (e.g., recomposition while visible), subscribe immediately
         if (lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
-            dataSource.subscribe(state)
-            isStarted = true
+            subscribeNow()
         }
 
         onDispose {
             lifecycleOwner.lifecycle.removeObserver(observer)
-            if (isStarted) {
+            pendingUnsubscribe?.cancel()
+            pendingUnsubscribe = null
+            if (isSubscribed) {
                 dataSource.unsubscribe(state)
-                isStarted = false
+                isSubscribed = false
             }
         }
     }


### PR DESCRIPTION
## Summary
Refactored `LifecycleAwareKeyDataSourceSubscription` to introduce a 30-second grace period before unsubscribing when the app lifecycle reaches STOPPED. This prevents unnecessary subscription teardown and rebuilding during brief app switches.

## Key Changes
- **Grace period mechanism**: Added a 30-second delay before unsubscribing when the app moves to background. If the app returns to foreground before the grace period expires, the pending unsubscribe is cancelled and the subscription continues uninterrupted.
- **State management refactor**: Replaced Compose `mutableStateOf` with local variables (`isSubscribed` and `pendingUnsubscribe`) within the `DisposableEffect`, eliminating unnecessary recompositions.
- **Coroutine-based delays**: Integrated `rememberCoroutineScope` to handle the grace period using `delay()` and `launch()`, allowing cancellation of pending unsubscribes.
- **Helper functions**: Extracted `subscribeNow()` and `scheduleUnsubscribe()` functions for clearer logic and to centralize subscription state management.
- **Improved cleanup**: Enhanced the `onDispose` block to properly cancel any pending unsubscribe jobs before final cleanup.

## Implementation Details
- The grace period (30 seconds) is defined as a module-level constant `UNSUBSCRIBE_GRACE_MILLIS`.
- The `subscribeNow()` function cancels any pending unsubscribe before subscribing, ensuring the subscription is always active when needed.
- The `scheduleUnsubscribe()` function only schedules a new unsubscribe if one isn't already pending, preventing duplicate jobs.
- Updated documentation to explain the grace period behavior and its benefits for heavy feed subscriptions during brief interruptions.

https://claude.ai/code/session_01W3RY9Rf4gc4eEkL4v1v8Bg