### PR TITLE
Handle Android 12+ ForegroundServiceStartNotAllowedException gracefully

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationRelayService.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationRelayService.kt
@@ -89,7 +89,20 @@ class NotificationRelayService : Service() {
             try {
                 ContextCompat.startForegroundService(context, intent)
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to start foreground service", e)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+                    e is ForegroundServiceStartNotAllowedException
+                ) {
+                    // Android 12+ blocks startForegroundService() from the background unless
+                    // the caller has a temporary FGS exemption (e.g. broadcast receiver,
+                    // exact alarm, high-priority FCM). Cold-start triggered by a flow emission
+                    // from AlwaysOnNotificationServiceManager hits this path. The other
+                    // notification layers (BootCompletedReceiver, ServiceWatchdogManager,
+                    // NotificationCatchUpWorker) plus MainActivity.onResume retry from
+                    // contexts that are allowed.
+                    Log.w(TAG) { "Foreground service start not allowed from background; will retry from another layer" }
+                } else {
+                    Log.e(TAG, "Failed to start foreground service", e)
+                }
             }
         }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/MainActivity.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/MainActivity.kt
@@ -31,6 +31,7 @@ import com.vitorpamplona.amethyst.debugState
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.service.lang.LanguageTranslatorService
+import com.vitorpamplona.amethyst.service.notifications.NotificationRelayService
 import com.vitorpamplona.amethyst.service.playback.composable.DEFAULT_MUTED_SETTING
 import com.vitorpamplona.amethyst.service.playback.pip.BackgroundMedia
 import com.vitorpamplona.amethyst.ui.navigation.findParameterValue
@@ -89,6 +90,13 @@ class MainActivity : AppCompatActivity() {
 
         // starts muted every time
         DEFAULT_MUTED_SETTING.value = true
+
+        // If always-on notifications are enabled but the foreground service couldn't be
+        // started from the background during cold-start (Android 12+ restriction), retry
+        // now that the activity is in the foreground.
+        if (NotificationRelayService.isEnabled(this)) {
+            NotificationRelayService.start(this)
+        }
     }
 
     override fun onPause() {


### PR DESCRIPTION
## Summary
This PR improves handling of Android 12+ restrictions on starting foreground services from the background by gracefully catching `ForegroundServiceStartNotAllowedException` and retrying from the foreground context when the app is resumed.

## Key Changes
- **NotificationRelayService.kt**: Enhanced exception handling to distinguish between `ForegroundServiceStartNotAllowedException` (expected on Android 12+ when called from background) and other failures. The specific exception is now logged as a warning with context about retry mechanisms, while other exceptions continue to be logged as errors.
- **MainActivity.kt**: Added retry logic in `onCreate()` to attempt starting the notification relay service when the activity comes to the foreground, providing a valid context for the foreground service start that bypasses Android 12+ background restrictions.

## Implementation Details
- The fix leverages the fact that starting a foreground service from an activity's `onCreate()` is allowed on Android 12+, unlike background cold-starts triggered by flow emissions
- Multiple notification layers (BootCompletedReceiver, ServiceWatchdogManager, NotificationCatchUpWorker, and now MainActivity) provide fallback retry paths to ensure the service eventually starts
- The solution maintains backward compatibility by only applying the specific exception handling on Android 12 (API 31) and above

https://claude.ai/code/session_01Ket2hK9aMrqos5Jxf88jsX