### PR TITLE
Add keep-alive mechanism to reconnect disconnected relays

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/NostrClient.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/NostrClient.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
@@ -156,6 +157,27 @@ class NostrClient(
                 SharingStarted.Eagerly,
                 false,
             )
+
+    /**
+     * Periodically wakes up disconnected relays. Without this, a relay
+     * that hit a long backoff (5 min, e.g. host unreachable or a server
+     * error code) would stay disconnected forever in the absence of any
+     * subscription change. The per-relay [BasicRelayClient] backoff still
+     * gates the actual reconnect attempt, so dead relays are not hammered.
+     */
+    private val keepAliveJob =
+        scope.launch {
+            while (true) {
+                delay(KEEP_ALIVE_INTERVAL_MS)
+                if (this@NostrClient.isActive) {
+                    relayPool.reconnectIfNeedsTo(ignoreRetryDelays = false)
+                }
+            }
+        }
+
+    companion object {
+        private const val KEEP_ALIVE_INTERVAL_MS = 60_000L
+    }
 
     override fun reconnect(
         onlyIfChanged: Boolean,

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/NostrClient.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/NostrClient.kt
@@ -295,6 +295,18 @@ class NostrClient(
     override fun onDisconnected(relay: IRelayClient) {
         activeRequests.onDisconnected(relay.url)
         listeners.forEach { it.onDisconnected(relay) }
+
+        // If the client is still active and the relay is still in the
+        // desired set (i.e. there are subscriptions, counts or pending
+        // outbox events that want it), reconnect it. Without this, a
+        // server-initiated close leaves the relay disconnected until a
+        // subscription change or an explicit reconnect() arrives.
+        // The reconnect path is debounced and goes through
+        // reconnectIfNeedsTo, which respects each relay's exponential
+        // backoff so we don't hammer dead relays.
+        if (isActive && relay.url in allRelays.value) {
+            reconnect(onlyIfChanged = true)
+        }
     }
 
     override fun onCannotConnect(


### PR DESCRIPTION
## Summary
This PR adds a keep-alive mechanism to the NostrClient that periodically attempts to reconnect relays that have been disconnected, preventing them from staying offline indefinitely due to long backoff periods.

## Key Changes
- **Keep-alive job**: Added a background coroutine job that wakes up every 60 seconds to check and reconnect disconnected relays via `relayPool.reconnectIfNeedsTo()`
- **Disconnect handler enhancement**: Modified `onDisconnected()` callback to immediately attempt reconnection when a relay is still in the desired set (has active subscriptions, counts, or pending events)
- **Backoff respect**: Both mechanisms respect each relay's exponential backoff strategy to avoid hammering dead relays

## Implementation Details
- The keep-alive job runs continuously while the NostrClient is active, using a 60-second interval (`KEEP_ALIVE_INTERVAL_MS`)
- The `onDisconnected()` handler now checks if the relay is still needed (`relay.url in allRelays.value`) before attempting reconnection
- Both reconnection paths use `reconnectIfNeedsTo()` which is debounced and respects per-relay backoff, ensuring graceful handling of unavailable relays
- This solves the issue where relays hitting long backoffs (e.g., 5 minutes for host unreachable or server errors) would remain disconnected without explicit user action

https://claude.ai/code/session_01GgBHhcKRSfEpwELJ5c9FEU