### PR TITLE
debug(nests): wire NestRx/NestTx logs across listener and speaker paths

### DIFF
--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/NestViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/NestViewModel.kt
@@ -44,6 +44,7 @@ import com.vitorpamplona.nestsclient.moq.SubscribeHandle
 import com.vitorpamplona.nestsclient.transport.WebTransportFactory
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import com.vitorpamplona.quartz.nip53LiveActivities.chat.LiveActivitiesChatMessageEvent
+import com.vitorpamplona.quartz.utils.Log
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toPersistentSet
@@ -842,7 +843,9 @@ class NestViewModel(
     ) {
         if (closed || activeSubscriptions[pubkey] !== slot) return
         try {
+            Log.d("NestRx") { "VM.openSubscription -> subscribeSpeaker pubkey=$pubkey" }
             val handle = l.subscribeSpeaker(pubkey)
+            Log.d("NestRx") { "VM.openSubscription <- subscribeSpeaker returned for pubkey=$pubkey" }
             // Re-check after the suspending subscribeSpeaker — the user
             // may have removed this speaker via updateSpeakers / disconnected
             // while the SUBSCRIBE was in flight. If so, abandon the handle
@@ -1004,6 +1007,7 @@ class NestViewModel(
         // First frame for this subscription — clear the buffering
         // overlay. Subsequent frames are no-ops here.
         if (_uiState.value.connectingSpeakers.contains(pubkey)) {
+            Log.d("NestRx") { "VM.onSpeakerActivity FIRST frame for pubkey=$pubkey — clearing spinner" }
             _uiState.update { it.copy(connectingSpeakers = (it.connectingSpeakers - pubkey).toPersistentSet()) }
         }
         if (!_uiState.value.speakingNow.contains(pubkey)) {

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/NestViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/NestViewModel.kt
@@ -44,7 +44,6 @@ import com.vitorpamplona.nestsclient.moq.SubscribeHandle
 import com.vitorpamplona.nestsclient.transport.WebTransportFactory
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import com.vitorpamplona.quartz.nip53LiveActivities.chat.LiveActivitiesChatMessageEvent
-import com.vitorpamplona.quartz.utils.Log
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toPersistentSet
@@ -843,9 +842,7 @@ class NestViewModel(
     ) {
         if (closed || activeSubscriptions[pubkey] !== slot) return
         try {
-            Log.d("NestRx") { "VM.openSubscription -> subscribeSpeaker pubkey=$pubkey" }
             val handle = l.subscribeSpeaker(pubkey)
-            Log.d("NestRx") { "VM.openSubscription <- subscribeSpeaker returned for pubkey=$pubkey" }
             // Re-check after the suspending subscribeSpeaker — the user
             // may have removed this speaker via updateSpeakers / disconnected
             // while the SUBSCRIBE was in flight. If so, abandon the handle
@@ -1007,7 +1004,6 @@ class NestViewModel(
         // First frame for this subscription — clear the buffering
         // overlay. Subsequent frames are no-ops here.
         if (_uiState.value.connectingSpeakers.contains(pubkey)) {
-            Log.d("NestRx") { "VM.onSpeakerActivity FIRST frame for pubkey=$pubkey — clearing spinner" }
             _uiState.update { it.copy(connectingSpeakers = (it.connectingSpeakers - pubkey).toPersistentSet()) }
         }
         if (!_uiState.value.speakingNow.contains(pubkey)) {

--- a/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/MoqLiteNestsListener.kt
+++ b/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/MoqLiteNestsListener.kt
@@ -26,7 +26,6 @@ import com.vitorpamplona.nestsclient.moq.SubscribeOk
 import com.vitorpamplona.nestsclient.moq.lite.MoqLiteAnnounceStatus
 import com.vitorpamplona.nestsclient.moq.lite.MoqLiteSession
 import com.vitorpamplona.nestsclient.moq.lite.MoqLiteSubscribeException
-import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -79,15 +78,9 @@ class MoqLiteNestsListener internal constructor(
     override suspend fun subscribeSpeaker(
         speakerPubkeyHex: String,
         maxLatencyMs: Long,
-    ): SubscribeHandle {
-        Log.d("NestRx") { "subscribeSpeaker pubkey=$speakerPubkeyHex maxLatencyMs=$maxLatencyMs" }
-        return wrapSubscription(broadcast = speakerPubkeyHex, track = AUDIO_TRACK, maxLatencyMs = maxLatencyMs)
-    }
+    ): SubscribeHandle = wrapSubscription(broadcast = speakerPubkeyHex, track = AUDIO_TRACK, maxLatencyMs = maxLatencyMs)
 
-    override suspend fun subscribeCatalog(speakerPubkeyHex: String): SubscribeHandle {
-        Log.d("NestRx") { "subscribeCatalog pubkey=$speakerPubkeyHex" }
-        return wrapSubscription(broadcast = speakerPubkeyHex, track = CATALOG_TRACK, maxLatencyMs = 0L)
-    }
+    override suspend fun subscribeCatalog(speakerPubkeyHex: String): SubscribeHandle = wrapSubscription(broadcast = speakerPubkeyHex, track = CATALOG_TRACK, maxLatencyMs = 0L)
 
     private suspend fun wrapSubscription(
         broadcast: String,
@@ -145,14 +138,10 @@ class MoqLiteNestsListener internal constructor(
             val handle = session.announce(prefix = "")
             try {
                 handle.updates.collect { announce ->
-                    val active = announce.status == MoqLiteAnnounceStatus.Active
-                    Log.d("NestRx") {
-                        "RoomAnnouncement pubkey=${announce.suffix} active=$active status=${announce.status} hops=${announce.hops}"
-                    }
                     emit(
                         RoomAnnouncement(
                             pubkey = announce.suffix,
-                            active = active,
+                            active = announce.status == MoqLiteAnnounceStatus.Active,
                         ),
                     )
                 }

--- a/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/MoqLiteNestsListener.kt
+++ b/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/MoqLiteNestsListener.kt
@@ -26,6 +26,7 @@ import com.vitorpamplona.nestsclient.moq.SubscribeOk
 import com.vitorpamplona.nestsclient.moq.lite.MoqLiteAnnounceStatus
 import com.vitorpamplona.nestsclient.moq.lite.MoqLiteSession
 import com.vitorpamplona.nestsclient.moq.lite.MoqLiteSubscribeException
+import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -78,9 +79,15 @@ class MoqLiteNestsListener internal constructor(
     override suspend fun subscribeSpeaker(
         speakerPubkeyHex: String,
         maxLatencyMs: Long,
-    ): SubscribeHandle = wrapSubscription(broadcast = speakerPubkeyHex, track = AUDIO_TRACK, maxLatencyMs = maxLatencyMs)
+    ): SubscribeHandle {
+        Log.d("NestRx") { "subscribeSpeaker pubkey=$speakerPubkeyHex maxLatencyMs=$maxLatencyMs" }
+        return wrapSubscription(broadcast = speakerPubkeyHex, track = AUDIO_TRACK, maxLatencyMs = maxLatencyMs)
+    }
 
-    override suspend fun subscribeCatalog(speakerPubkeyHex: String): SubscribeHandle = wrapSubscription(broadcast = speakerPubkeyHex, track = CATALOG_TRACK, maxLatencyMs = 0L)
+    override suspend fun subscribeCatalog(speakerPubkeyHex: String): SubscribeHandle {
+        Log.d("NestRx") { "subscribeCatalog pubkey=$speakerPubkeyHex" }
+        return wrapSubscription(broadcast = speakerPubkeyHex, track = CATALOG_TRACK, maxLatencyMs = 0L)
+    }
 
     private suspend fun wrapSubscription(
         broadcast: String,
@@ -138,10 +145,14 @@ class MoqLiteNestsListener internal constructor(
             val handle = session.announce(prefix = "")
             try {
                 handle.updates.collect { announce ->
+                    val active = announce.status == MoqLiteAnnounceStatus.Active
+                    Log.d("NestRx") {
+                        "RoomAnnouncement pubkey=${announce.suffix} active=$active status=${announce.status} hops=${announce.hops}"
+                    }
                     emit(
                         RoomAnnouncement(
                             pubkey = announce.suffix,
-                            active = announce.status == MoqLiteAnnounceStatus.Active,
+                            active = active,
                         ),
                     )
                 }

--- a/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/MoqLiteNestsSpeaker.kt
+++ b/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/MoqLiteNestsSpeaker.kt
@@ -75,8 +75,19 @@ class MoqLiteNestsSpeaker internal constructor(
 
             // Per the audio-rooms NIP draft + JS reference
             // (`@moq/publish/screen-B680RFft.js:5641`), publishers
-            // claim a broadcast suffix equal to their pubkey hex.
-            val publisher = session.publish(broadcastSuffix = speakerPubkeyHex)
+            // claim a broadcast suffix equal to their pubkey hex and
+            // the audio data sits on track "audio/data". The publisher
+            // must be track-scoped because listeners typically open
+            // BOTH a catalog subscribe AND an audio subscribe per
+            // speaker; without the track filter the publisher would
+            // route Opus frames onto whichever subscribe arrived first
+            // (in practice the catalog one) and the audio subscription
+            // would silently starve.
+            val publisher =
+                session.publish(
+                    broadcastSuffix = speakerPubkeyHex,
+                    track = MoqLiteNestsListener.AUDIO_TRACK,
+                )
             // From here on, the publisher is registered in the session
             // and has a live announce/subscribe path. Anything that
             // throws before we hand a working handle back to the caller

--- a/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/ReconnectingNestsListener.kt
+++ b/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/ReconnectingNestsListener.kt
@@ -379,7 +379,6 @@ private class ReconnectingHandle(
                         liveHandleRef.set(handle)
                         try {
                             handle.objects.collect { frames.emit(it) }
-                            Log.d("NestRx") { "ReconnectingHandle.objects flow ended naturally — pump will re-issue after ${RESUBSCRIBE_BACKOFF_MS}ms" }
                         } finally {
                             if (liveHandleRef.get() === handle) liveHandleRef.set(null)
                         }

--- a/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/ReconnectingNestsListener.kt
+++ b/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/ReconnectingNestsListener.kt
@@ -353,11 +353,29 @@ private class ReconnectingHandle(
                                 // suspend re-checked active state.
                                 throw ce
                             } catch (t: Throwable) {
+                                // The opener can throw for a transient
+                                // reason — most commonly: the listener
+                                // joined the room before the speaker started
+                                // publishing, the announce-watch hasn't yet
+                                // surfaced an Active for this broadcast, and
+                                // the relay FINs the SUBSCRIBE bidi without
+                                // a SubscribeOk/SubscribeDrop reply. The
+                                // earlier shape returned `null` and `break`'d
+                                // out of the inner re-issue loop, which made
+                                // a single pre-publisher subscribe permanent
+                                // — the audio never recovered when the
+                                // speaker did come up. Retry with the same
+                                // backoff used between publisher cycles.
                                 Log.w("NestRx") {
-                                    "ReconnectingHandle.opener threw ${t::class.simpleName}: ${t.message} — pump breaks"
+                                    "ReconnectingHandle.opener threw ${t::class.simpleName}: ${t.message} " +
+                                        "— retrying after ${SUBSCRIBE_RETRY_BACKOFF_MS}ms"
                                 }
                                 null
-                            } ?: break
+                            }
+                        if (handle == null) {
+                            delay(SUBSCRIBE_RETRY_BACKOFF_MS)
+                            continue
+                        }
                         liveHandleRef.set(handle)
                         try {
                             handle.objects.collect { frames.emit(it) }
@@ -409,6 +427,15 @@ private class ReconnectingHandle(
         // ~1.3 s of audio headroom; long enough that a permanently-
         // gone publisher doesn't spin the relay with re-subscribes.
         private const val RESUBSCRIBE_BACKOFF_MS = 100L
+
+        // Backoff after an opener throws (typically: subscribe-before-
+        // announce arrives at the relay before the publisher exists,
+        // and the relay FINs the bidi without a SubscribeOk/Drop). One
+        // second is well over moq-rs's typical announce-propagation
+        // latency (< 200 ms in production traces), so the next retry
+        // usually succeeds; long enough that a never-arriving publisher
+        // doesn't hammer the relay either.
+        private const val SUBSCRIBE_RETRY_BACKOFF_MS = 1_000L
 
         private val SYNTH_OK =
             SubscribeOk(

--- a/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/ReconnectingNestsListener.kt
+++ b/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/ReconnectingNestsListener.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.nestsclient.moq.SubscribeHandle
 import com.vitorpamplona.nestsclient.moq.SubscribeOk
 import com.vitorpamplona.nestsclient.transport.WebTransportFactory
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
+import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
@@ -351,12 +352,16 @@ private class ReconnectingHandle(
                                 // one extra iteration before the next
                                 // suspend re-checked active state.
                                 throw ce
-                            } catch (_: Throwable) {
+                            } catch (t: Throwable) {
+                                Log.w("NestRx") {
+                                    "ReconnectingHandle.opener threw ${t::class.simpleName}: ${t.message} — pump breaks"
+                                }
                                 null
                             } ?: break
                         liveHandleRef.set(handle)
                         try {
                             handle.objects.collect { frames.emit(it) }
+                            Log.d("NestRx") { "ReconnectingHandle.objects flow ended naturally — pump will re-issue after ${RESUBSCRIBE_BACKOFF_MS}ms" }
                         } finally {
                             if (liveHandleRef.get() === handle) liveHandleRef.set(null)
                         }

--- a/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/audio/NestMoqLiteBroadcaster.kt
+++ b/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/audio/NestMoqLiteBroadcaster.kt
@@ -21,7 +21,6 @@
 package com.vitorpamplona.nestsclient.audio
 
 import com.vitorpamplona.nestsclient.moq.lite.MoqLitePublisherHandle
-import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -162,8 +161,6 @@ class NestMoqLiteBroadcaster(
                 // we bail. publisher.send returning `false` (no inbound
                 // subscriber) is NOT counted — empty rooms are normal.
                 var consecutiveSendErrors = 0
-                var sendNoSubLogged = false
-                var lastSendHadSub = false
                 try {
                     while (true) {
                         val pcm = capture.readFrame() ?: break
@@ -190,21 +187,7 @@ class NestMoqLiteBroadcaster(
                         // for the production cliff this works around.
                         val sendOutcome =
                             runCatching {
-                                val accepted = publisher.send(opus)
-                                if (accepted) {
-                                    if (!lastSendHadSub) {
-                                        Log.d("NestTx") { "broadcaster: send accepted (subscriber attached)" }
-                                        lastSendHadSub = true
-                                    }
-                                } else {
-                                    if (!sendNoSubLogged) {
-                                        Log.w("NestTx") {
-                                            "broadcaster: publisher.send returned false (no inbound subscriber on relay)"
-                                        }
-                                        sendNoSubLogged = true
-                                    }
-                                    lastSendHadSub = false
-                                }
+                                publisher.send(opus)
                                 framesInCurrentGroup += 1
                                 if (framesInCurrentGroup >= framesPerGroup) {
                                     publisher.endGroup()
@@ -223,9 +206,6 @@ class NestMoqLiteBroadcaster(
                             }.onFailure { t ->
                                 if (t is CancellationException) throw t
                                 consecutiveSendErrors += 1
-                                Log.w("NestTx") {
-                                    "broadcaster: publisher.send threw (#$consecutiveSendErrors): ${t::class.simpleName}: ${t.message}"
-                                }
                                 onError(
                                     AudioException(
                                         AudioException.Kind.PlaybackFailed,

--- a/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/audio/NestMoqLiteBroadcaster.kt
+++ b/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/audio/NestMoqLiteBroadcaster.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.nestsclient.audio
 
 import com.vitorpamplona.nestsclient.moq.lite.MoqLitePublisherHandle
+import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -161,6 +162,8 @@ class NestMoqLiteBroadcaster(
                 // we bail. publisher.send returning `false` (no inbound
                 // subscriber) is NOT counted — empty rooms are normal.
                 var consecutiveSendErrors = 0
+                var sendNoSubLogged = false
+                var lastSendHadSub = false
                 try {
                     while (true) {
                         val pcm = capture.readFrame() ?: break
@@ -187,7 +190,21 @@ class NestMoqLiteBroadcaster(
                         // for the production cliff this works around.
                         val sendOutcome =
                             runCatching {
-                                publisher.send(opus)
+                                val accepted = publisher.send(opus)
+                                if (accepted) {
+                                    if (!lastSendHadSub) {
+                                        Log.d("NestTx") { "broadcaster: send accepted (subscriber attached)" }
+                                        lastSendHadSub = true
+                                    }
+                                } else {
+                                    if (!sendNoSubLogged) {
+                                        Log.w("NestTx") {
+                                            "broadcaster: publisher.send returned false (no inbound subscriber on relay)"
+                                        }
+                                        sendNoSubLogged = true
+                                    }
+                                    lastSendHadSub = false
+                                }
                                 framesInCurrentGroup += 1
                                 if (framesInCurrentGroup >= framesPerGroup) {
                                     publisher.endGroup()
@@ -206,6 +223,9 @@ class NestMoqLiteBroadcaster(
                             }.onFailure { t ->
                                 if (t is CancellationException) throw t
                                 consecutiveSendErrors += 1
+                                Log.w("NestTx") {
+                                    "broadcaster: publisher.send threw (#$consecutiveSendErrors): ${t::class.simpleName}: ${t.message}"
+                                }
                                 onError(
                                     AudioException(
                                         AudioException.Kind.PlaybackFailed,

--- a/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/moq/lite/MoqLiteSession.kt
+++ b/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/moq/lite/MoqLiteSession.kt
@@ -696,7 +696,14 @@ class MoqLiteSession internal constructor(
         subscribeId: Long,
         sequence: Long,
     ): com.vitorpamplona.nestsclient.transport.WebTransportWriteStream {
-        val uni = transport.openUniStream()
+        // Group streams carry a single Opus packet. They're real-time
+        // and best-effort — a STREAM frame arriving 200 ms late is
+        // worse than useless because the listener has already moved
+        // past that group's sequence number. Setting bestEffort=true
+        // tells the underlying QUIC SendBuffer to drop lost ranges
+        // instead of retransmitting them, bounding the bandwidth waste
+        // we'd otherwise incur on a lossy uplink.
+        val uni = transport.openUniStream(bestEffort = true)
         uni.write(Varint.encode(MoqLiteDataType.Group.code))
         uni.write(MoqLiteCodec.encodeGroupHeader(MoqLiteGroupHeader(subscribeId, sequence)))
         return uni

--- a/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/moq/lite/MoqLiteSession.kt
+++ b/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/moq/lite/MoqLiteSession.kt
@@ -23,6 +23,7 @@ package com.vitorpamplona.nestsclient.moq.lite
 import com.vitorpamplona.nestsclient.moq.MoqCodecException
 import com.vitorpamplona.nestsclient.moq.MoqWriter
 import com.vitorpamplona.nestsclient.transport.WebTransportSession
+import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quic.Varint
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
@@ -298,6 +299,10 @@ class MoqLiteSession internal constructor(
             }
         when (resp) {
             is MoqLiteCodec.SubscribeResponse.Dropped -> {
+                Log.w("NestRx") {
+                    "SUBSCRIBE_DROP id=$id broadcast='$broadcast' track='$track' " +
+                        "errCode=${resp.drop.errorCode} reason='${resp.drop.reasonPhrase}'"
+                }
                 state.withLock { subscriptionsBySubscribeId.remove(id) }
                 frames.close()
                 runCatching { bidi.finish() }
@@ -308,6 +313,7 @@ class MoqLiteSession internal constructor(
             }
 
             is MoqLiteCodec.SubscribeResponse.Ok -> {
+                Log.d("NestRx") { "SUBSCRIBE_OK id=$id broadcast='$broadcast' track='$track'" }
                 return MoqLiteSubscribeHandle(
                     id = id,
                     ok = resp.ok,
@@ -383,6 +389,9 @@ class MoqLiteSession internal constructor(
     private suspend fun pumpAnnounceWatch(handle: MoqLiteAnnouncesHandle) {
         try {
             handle.updates.collect { update ->
+                Log.d("NestRx") {
+                    "announce update status=${update.status} suffix='${update.suffix}' hops=${update.hops}"
+                }
                 if (update.status != MoqLiteAnnounceStatus.Ended) return@collect
                 val targets =
                     state.withLock {
@@ -391,6 +400,9 @@ class MoqLiteSession internal constructor(
                             .toList()
                     }
                 for (sub in targets) {
+                    Log.w("NestRx") {
+                        "announce ENDED closes sub id=${sub.id} broadcast='${sub.request.broadcast}'"
+                    }
                     // Just close the frames channel — the
                     // wrapper-level collect of `frames.consumeAsFlow()`
                     // ends naturally and the wrapper pump re-issues.
@@ -466,6 +478,7 @@ class MoqLiteSession internal constructor(
                     subscribeId = hdr.subscribeId
                     groupSequence = hdr.sequence
                     headerRead = true
+                    Log.d("NestRx") { "uni grpHdr id=$subscribeId seq=$groupSequence" }
                 }
                 while (true) {
                     val frame = buffer.readSizePrefixed() ?: break
@@ -477,6 +490,10 @@ class MoqLiteSession internal constructor(
                                 payload = frame,
                             ),
                         )
+                    } else {
+                        Log.w("NestRx") {
+                            "uni frame drop: no live sub for id=$subscribeId seq=$groupSequence size=${frame.size}"
+                        }
                     }
                     // If the subscription has been closed already we
                     // silently drop the frame — the publisher hasn't
@@ -527,6 +544,7 @@ class MoqLiteSession internal constructor(
     suspend fun publish(broadcastSuffix: String): MoqLitePublisherHandle {
         ensureOpen()
         val normalised = MoqLitePath.normalize(broadcastSuffix)
+        Log.d("NestTx") { "publish suffix='$normalised'" }
         val publisher: PublisherStateImpl
         state.withLock {
             check(!closed) { "session is closed" }
@@ -611,6 +629,9 @@ class MoqLiteSession internal constructor(
                             val please = MoqLiteCodec.decodeAnnouncePlease(pleasePayload)
                             val emittedSuffix =
                                 MoqLitePath.stripPrefix(please.prefix, publisher.suffix) ?: publisher.suffix
+                            Log.d("NestTx") {
+                                "inbound AnnouncePlease prefix='${please.prefix}' → reply Active suffix='$emittedSuffix'"
+                            }
                             bidi.write(
                                 MoqLiteCodec.encodeAnnounce(
                                     MoqLiteAnnounce(
@@ -627,6 +648,10 @@ class MoqLiteSession internal constructor(
                         MoqLiteControlType.Subscribe -> {
                             val subPayload = buffer.readSizePrefixed() ?: return@collect
                             val sub = MoqLiteCodec.decodeSubscribe(subPayload)
+                            Log.d("NestTx") {
+                                "inbound SUBSCRIBE id=${sub.id} broadcast='${sub.broadcast}' track='${sub.track}' " +
+                                    "priority=${sub.priority} maxLatencyMs=${sub.maxLatencyMillis}"
+                            }
                             // Register the subscription BEFORE sending Ok so the
                             // peer's observation of Ok is a happens-after of
                             // `inboundSubs += sub`. Otherwise on dispatchers that
@@ -675,7 +700,12 @@ class MoqLiteSession internal constructor(
         // groups off this dead subscriber. Announce bidis are
         // owned by the publisher state for sending Ended on
         // publisher-close — we don't remove them here.
-        inboundSub?.let { publisher.removeInboundSubscription(it) }
+        inboundSub?.let {
+            Log.d("NestTx") {
+                "inbound SUBSCRIBE FIN'd: removing id=${it.id} broadcast='${it.broadcast}' track='${it.track}'"
+            }
+            publisher.removeInboundSubscription(it)
+        }
     }
 
     /**
@@ -760,7 +790,13 @@ class MoqLiteSession internal constructor(
         suspend fun registerInboundSubscription(sub: MoqLiteSubscribe) {
             gate.withLock {
                 if (publisherClosed) return
+                val wasEmpty = inboundSubs.isEmpty()
                 inboundSubs += sub
+                if (wasEmpty) {
+                    Log.d("NestTx") {
+                        "first inbound subscriber attached id=${sub.id} broadcast='${sub.broadcast}' track='${sub.track}'"
+                    }
+                }
             }
         }
 
@@ -877,6 +913,10 @@ class MoqLiteSession internal constructor(
             val sub = inboundSubs.first()
             val sequence = nextSequence++
             val uni = openGroupStream(subscribeId = sub.id, sequence = sequence)
+            Log.d("NestTx") {
+                "openGroup seq=$sequence keyedOnSubId=${sub.id} broadcast='${sub.broadcast}' track='${sub.track}' " +
+                    "inboundSubsCount=${inboundSubs.size}"
+            }
             return GroupOutbound(sequence = sequence, uni = uni)
         }
     }

--- a/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/moq/lite/MoqLiteSession.kt
+++ b/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/moq/lite/MoqLiteSession.kt
@@ -116,24 +116,31 @@ class MoqLiteSession internal constructor(
     suspend fun announce(prefix: String): MoqLiteAnnouncesHandle {
         ensureOpen()
         val bidi = transport.openBidiStream()
+        Log.d("NestRx") { "announce(prefix='$prefix'): bidi opened, writing AnnouncePlease" }
         bidi.write(Varint.encode(MoqLiteControlType.Announce.code))
         bidi.write(MoqLiteCodec.encodeAnnouncePlease(MoqLiteAnnouncePlease(prefix)))
+        Log.d("NestRx") { "announce(prefix='$prefix'): AnnouncePlease flushed, awaiting Active updates" }
 
         val updates = MutableSharedFlow<MoqLiteAnnounce>(replay = 0, extraBufferCapacity = 64)
         val pump =
             scope.launch {
                 val buffer = MoqLiteFrameBuffer()
+                var chunksSeen = 0
                 try {
                     bidi.incoming().collect { chunk ->
+                        chunksSeen += 1
+                        Log.d("NestRx") { "announce(prefix='$prefix'): bidi chunk #$chunksSeen size=${chunk.size}" }
                         buffer.push(chunk)
                         while (true) {
                             val payload = buffer.readSizePrefixed() ?: break
                             updates.emit(MoqLiteCodec.decodeAnnounce(payload))
                         }
                     }
+                    Log.d("NestRx") { "announce(prefix='$prefix'): bidi.incoming() ended naturally after $chunksSeen chunks" }
                 } catch (ce: CancellationException) {
                     throw ce
-                } catch (_: Throwable) {
+                } catch (t: Throwable) {
+                    Log.w("NestRx") { "announce(prefix='$prefix'): bidi.incoming() threw ${t::class.simpleName}: ${t.message} (chunks=$chunksSeen)" }
                     // Flow terminated (peer FIN or transport close).
                     // The Announce stream's emit-side just stops; consumers
                     // see an end-of-flow.
@@ -201,8 +208,10 @@ class MoqLiteSession internal constructor(
                 endGroup = endGroup,
             )
         val bidi = transport.openBidiStream()
+        Log.d("NestRx") { "subscribe id=$id broadcast='$broadcast' track='$track': bidi opened, writing SUBSCRIBE bytes" }
         bidi.write(Varint.encode(MoqLiteControlType.Subscribe.code))
         bidi.write(MoqLiteCodec.encodeSubscribe(request))
+        Log.d("NestRx") { "subscribe id=$id: SUBSCRIBE bytes flushed, awaiting response" }
 
         // Single long-running collector for the bidi's whole lifetime.
         // The collector parses the SubscribeResponse inline, signals it
@@ -252,9 +261,14 @@ class MoqLiteSession internal constructor(
         scope.launch {
             val responseBuffer = MoqLiteFrameBuffer()
             var responseParsed = false
+            var chunksSeen = 0
             try {
                 bidi.incoming().collect { chunk ->
+                    chunksSeen += 1
                     if (!responseParsed) {
+                        Log.d("NestRx") {
+                            "subscribe id=$id: bidi chunk #$chunksSeen size=${chunk.size} (response not yet parsed)"
+                        }
                         responseBuffer.push(chunk)
                         val typeCode = responseBuffer.readVarint() ?: return@collect
                         val body = responseBuffer.readSizePrefixed() ?: return@collect
@@ -270,13 +284,16 @@ class MoqLiteSession internal constructor(
                     // moq-lite leaves the bidi idle post-Ok. The signal
                     // we care about is the flow's natural completion.
                 }
+                Log.d("NestRx") { "subscribe id=$id: bidi.incoming() flow ended naturally after $chunksSeen chunks (responseParsed=$responseParsed)" }
             } catch (ce: CancellationException) {
                 if (!responseDeferred.isCompleted) responseDeferred.completeExceptionally(ce)
                 throw ce
             } catch (t: Throwable) {
+                Log.w("NestRx") { "subscribe id=$id: bidi.incoming() threw ${t::class.simpleName}: ${t.message} (chunks=$chunksSeen)" }
                 if (!responseDeferred.isCompleted) responseDeferred.completeExceptionally(t)
             }
             if (!responseDeferred.isCompleted) {
+                Log.w("NestRx") { "subscribe id=$id: bidi closed BEFORE any response parsed (chunks=$chunksSeen)" }
                 responseDeferred.completeExceptionally(
                     MoqLiteSubscribeException("subscribe stream FIN before reply for id=$id"),
                 )

--- a/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/moq/lite/MoqLiteSession.kt
+++ b/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/moq/lite/MoqLiteSession.kt
@@ -562,17 +562,20 @@ class MoqLiteSession internal constructor(
      * Only one [publish] is supported per session for now. Calling
      * [publish] twice on the same session is rejected with [IllegalStateException].
      */
-    suspend fun publish(broadcastSuffix: String): MoqLitePublisherHandle {
+    suspend fun publish(
+        broadcastSuffix: String,
+        track: String,
+    ): MoqLitePublisherHandle {
         ensureOpen()
         val normalised = MoqLitePath.normalize(broadcastSuffix)
-        Log.d("NestTx") { "publish suffix='$normalised'" }
+        Log.d("NestTx") { "publish suffix='$normalised' track='$track'" }
         val publisher: PublisherStateImpl
         state.withLock {
             check(!closed) { "session is closed" }
             check(activePublisher == null) {
                 "MoqLiteSession.publish called twice — only one broadcast per session is supported"
             }
-            publisher = PublisherStateImpl(suffix = normalised)
+            publisher = PublisherStateImpl(suffix = normalised, track = track)
             activePublisher = publisher
             // Lazy launch — the inbound-bidi pump needs to keep running
             // for the lifetime of any active publisher.
@@ -783,13 +786,33 @@ class MoqLiteSession internal constructor(
     /**
      * Publisher state. Tracks the announce bidis the relay opened to us
      * + the inbound subscriptions a relay (or peer) opened against our
-     * broadcast, and owns the current group's uni stream.
+     * broadcast for [track], and owns the current group's uni stream.
+     *
+     * Per moq-lite Lite-03 a publisher is responsible for one
+     * `(broadcast, track)` tuple — the relay multiplexes multiple
+     * tracks per broadcast by routing each inbound SUBSCRIBE to the
+     * publisher whose track field matches. Subs whose `sub.track`
+     * doesn't match this publisher's [track] are intentionally
+     * ignored so a listener subscribing to e.g. `catalog.json` while
+     * we're only publishing `audio/data` doesn't accidentally hijack
+     * the audio routing — see [registerInboundSubscription] for the
+     * filter and the bug history below.
+     *
+     * Bug history (`nestsClient/plans/2026-05-04-publisher-track-routing.md`):
+     * before this filter, [openNextGroupLocked] keyed each group
+     * stream off `inboundSubs.first()`. When a listener opened both a
+     * `catalog.json` subscribe and an `audio/data` subscribe, whichever
+     * arrived first won the routing race — and because the catalog
+     * SUBSCRIBE typically races ahead of the audio one by a few ms,
+     * every Opus frame ended up on the catalog stream. Listeners saw
+     * a perpetually-spinning speaker avatar with no audio.
      *
      * `gate` serialises access to per-group state so concurrent
      * `send` / `startGroup` / `endGroup` / `close` can't race.
      */
     private inner class PublisherStateImpl(
         override val suffix: String,
+        private val track: String,
     ) : MoqLitePublisherHandle {
         private val gate = Mutex()
         private val announceBidis = mutableListOf<AnnounceBidiEntry>()
@@ -815,6 +838,13 @@ class MoqLiteSession internal constructor(
         suspend fun registerInboundSubscription(sub: MoqLiteSubscribe) {
             gate.withLock {
                 if (publisherClosed) return
+                if (sub.track != track) {
+                    Log.d("NestTx") {
+                        "ignoring inbound SUBSCRIBE id=${sub.id} track='${sub.track}' " +
+                            "(publisher serves track='$track' only)"
+                    }
+                    return
+                }
                 val wasEmpty = inboundSubs.isEmpty()
                 inboundSubs += sub
                 if (wasEmpty) {

--- a/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/moq/lite/MoqLiteSession.kt
+++ b/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/moq/lite/MoqLiteSession.kt
@@ -116,31 +116,25 @@ class MoqLiteSession internal constructor(
     suspend fun announce(prefix: String): MoqLiteAnnouncesHandle {
         ensureOpen()
         val bidi = transport.openBidiStream()
-        Log.d("NestRx") { "announce(prefix='$prefix'): bidi opened, writing AnnouncePlease" }
         bidi.write(Varint.encode(MoqLiteControlType.Announce.code))
         bidi.write(MoqLiteCodec.encodeAnnouncePlease(MoqLiteAnnouncePlease(prefix)))
-        Log.d("NestRx") { "announce(prefix='$prefix'): AnnouncePlease flushed, awaiting Active updates" }
 
         val updates = MutableSharedFlow<MoqLiteAnnounce>(replay = 0, extraBufferCapacity = 64)
         val pump =
             scope.launch {
                 val buffer = MoqLiteFrameBuffer()
-                var chunksSeen = 0
                 try {
                     bidi.incoming().collect { chunk ->
-                        chunksSeen += 1
-                        Log.d("NestRx") { "announce(prefix='$prefix'): bidi chunk #$chunksSeen size=${chunk.size}" }
                         buffer.push(chunk)
                         while (true) {
                             val payload = buffer.readSizePrefixed() ?: break
                             updates.emit(MoqLiteCodec.decodeAnnounce(payload))
                         }
                     }
-                    Log.d("NestRx") { "announce(prefix='$prefix'): bidi.incoming() ended naturally after $chunksSeen chunks" }
                 } catch (ce: CancellationException) {
                     throw ce
                 } catch (t: Throwable) {
-                    Log.w("NestRx") { "announce(prefix='$prefix'): bidi.incoming() threw ${t::class.simpleName}: ${t.message} (chunks=$chunksSeen)" }
+                    Log.w("NestRx") { "announce(prefix='$prefix'): bidi.incoming() threw ${t::class.simpleName}: ${t.message}" }
                     // Flow terminated (peer FIN or transport close).
                     // The Announce stream's emit-side just stops; consumers
                     // see an end-of-flow.
@@ -208,10 +202,8 @@ class MoqLiteSession internal constructor(
                 endGroup = endGroup,
             )
         val bidi = transport.openBidiStream()
-        Log.d("NestRx") { "subscribe id=$id broadcast='$broadcast' track='$track': bidi opened, writing SUBSCRIBE bytes" }
         bidi.write(Varint.encode(MoqLiteControlType.Subscribe.code))
         bidi.write(MoqLiteCodec.encodeSubscribe(request))
-        Log.d("NestRx") { "subscribe id=$id: SUBSCRIBE bytes flushed, awaiting response" }
 
         // Single long-running collector for the bidi's whole lifetime.
         // The collector parses the SubscribeResponse inline, signals it
@@ -261,14 +253,9 @@ class MoqLiteSession internal constructor(
         scope.launch {
             val responseBuffer = MoqLiteFrameBuffer()
             var responseParsed = false
-            var chunksSeen = 0
             try {
                 bidi.incoming().collect { chunk ->
-                    chunksSeen += 1
                     if (!responseParsed) {
-                        Log.d("NestRx") {
-                            "subscribe id=$id: bidi chunk #$chunksSeen size=${chunk.size} (response not yet parsed)"
-                        }
                         responseBuffer.push(chunk)
                         val typeCode = responseBuffer.readVarint() ?: return@collect
                         val body = responseBuffer.readSizePrefixed() ?: return@collect
@@ -284,16 +271,13 @@ class MoqLiteSession internal constructor(
                     // moq-lite leaves the bidi idle post-Ok. The signal
                     // we care about is the flow's natural completion.
                 }
-                Log.d("NestRx") { "subscribe id=$id: bidi.incoming() flow ended naturally after $chunksSeen chunks (responseParsed=$responseParsed)" }
             } catch (ce: CancellationException) {
                 if (!responseDeferred.isCompleted) responseDeferred.completeExceptionally(ce)
                 throw ce
             } catch (t: Throwable) {
-                Log.w("NestRx") { "subscribe id=$id: bidi.incoming() threw ${t::class.simpleName}: ${t.message} (chunks=$chunksSeen)" }
                 if (!responseDeferred.isCompleted) responseDeferred.completeExceptionally(t)
             }
             if (!responseDeferred.isCompleted) {
-                Log.w("NestRx") { "subscribe id=$id: bidi closed BEFORE any response parsed (chunks=$chunksSeen)" }
                 responseDeferred.completeExceptionally(
                     MoqLiteSubscribeException("subscribe stream FIN before reply for id=$id"),
                 )
@@ -330,7 +314,6 @@ class MoqLiteSession internal constructor(
             }
 
             is MoqLiteCodec.SubscribeResponse.Ok -> {
-                Log.d("NestRx") { "SUBSCRIBE_OK id=$id broadcast='$broadcast' track='$track'" }
                 return MoqLiteSubscribeHandle(
                     id = id,
                     ok = resp.ok,
@@ -406,9 +389,6 @@ class MoqLiteSession internal constructor(
     private suspend fun pumpAnnounceWatch(handle: MoqLiteAnnouncesHandle) {
         try {
             handle.updates.collect { update ->
-                Log.d("NestRx") {
-                    "announce update status=${update.status} suffix='${update.suffix}' hops=${update.hops}"
-                }
                 if (update.status != MoqLiteAnnounceStatus.Ended) return@collect
                 val targets =
                     state.withLock {
@@ -417,9 +397,6 @@ class MoqLiteSession internal constructor(
                             .toList()
                     }
                 for (sub in targets) {
-                    Log.w("NestRx") {
-                        "announce ENDED closes sub id=${sub.id} broadcast='${sub.request.broadcast}'"
-                    }
                     // Just close the frames channel — the
                     // wrapper-level collect of `frames.consumeAsFlow()`
                     // ends naturally and the wrapper pump re-issues.
@@ -461,10 +438,7 @@ class MoqLiteSession internal constructor(
             // sibling on the outer [scope] until the transport's flow
             // independently errors out.
             kotlinx.coroutines.coroutineScope {
-                var seen = 0L
                 transport.incomingUniStreams().collect { stream ->
-                    val n = ++seen
-                    Log.d("NestRx") { "transport delivered uni stream #$n (QUIC→moq seam)" }
                     launch { drainOneGroup(stream) }
                 }
             }
@@ -499,23 +473,16 @@ class MoqLiteSession internal constructor(
                     subscribeId = hdr.subscribeId
                     groupSequence = hdr.sequence
                     headerRead = true
-                    Log.d("NestRx") { "uni grpHdr id=$subscribeId seq=$groupSequence" }
                 }
                 while (true) {
                     val frame = buffer.readSizePrefixed() ?: break
                     val sub = state.withLock { subscriptionsBySubscribeId[subscribeId] }
-                    if (sub != null) {
-                        sub.frames.trySend(
-                            MoqLiteFrame(
-                                groupSequence = groupSequence,
-                                payload = frame,
-                            ),
-                        )
-                    } else {
-                        Log.w("NestRx") {
-                            "uni frame drop: no live sub for id=$subscribeId seq=$groupSequence size=${frame.size}"
-                        }
-                    }
+                    sub?.frames?.trySend(
+                        MoqLiteFrame(
+                            groupSequence = groupSequence,
+                            payload = frame,
+                        ),
+                    )
                     // If the subscription has been closed already we
                     // silently drop the frame — the publisher hasn't
                     // observed the unsubscribe yet (its uni streams
@@ -568,7 +535,6 @@ class MoqLiteSession internal constructor(
     ): MoqLitePublisherHandle {
         ensureOpen()
         val normalised = MoqLitePath.normalize(broadcastSuffix)
-        Log.d("NestTx") { "publish suffix='$normalised' track='$track'" }
         val publisher: PublisherStateImpl
         state.withLock {
             check(!closed) { "session is closed" }
@@ -598,10 +564,7 @@ class MoqLiteSession internal constructor(
             // [pumpUniStreams]'s identical comment) so they don't outlive
             // bidiPump.cancelAndJoin() in [close].
             kotlinx.coroutines.coroutineScope {
-                var seen = 0L
                 transport.incomingBidiStreams().collect { bidi ->
-                    val n = ++seen
-                    Log.d("NestTx") { "transport delivered inbound bidi #$n (QUIC→moq seam)" }
                     launch { handleInboundBidi(bidi) }
                 }
             }
@@ -657,9 +620,6 @@ class MoqLiteSession internal constructor(
                             val please = MoqLiteCodec.decodeAnnouncePlease(pleasePayload)
                             val emittedSuffix =
                                 MoqLitePath.stripPrefix(please.prefix, publisher.suffix) ?: publisher.suffix
-                            Log.d("NestTx") {
-                                "inbound AnnouncePlease prefix='${please.prefix}' → reply Active suffix='$emittedSuffix'"
-                            }
                             bidi.write(
                                 MoqLiteCodec.encodeAnnounce(
                                     MoqLiteAnnounce(
@@ -676,10 +636,6 @@ class MoqLiteSession internal constructor(
                         MoqLiteControlType.Subscribe -> {
                             val subPayload = buffer.readSizePrefixed() ?: return@collect
                             val sub = MoqLiteCodec.decodeSubscribe(subPayload)
-                            Log.d("NestTx") {
-                                "inbound SUBSCRIBE id=${sub.id} broadcast='${sub.broadcast}' track='${sub.track}' " +
-                                    "priority=${sub.priority} maxLatencyMs=${sub.maxLatencyMillis}"
-                            }
                             // Register the subscription BEFORE sending Ok so the
                             // peer's observation of Ok is a happens-after of
                             // `inboundSubs += sub`. Otherwise on dispatchers that
@@ -728,12 +684,7 @@ class MoqLiteSession internal constructor(
         // groups off this dead subscriber. Announce bidis are
         // owned by the publisher state for sending Ended on
         // publisher-close — we don't remove them here.
-        inboundSub?.let {
-            Log.d("NestTx") {
-                "inbound SUBSCRIBE FIN'd: removing id=${it.id} broadcast='${it.broadcast}' track='${it.track}'"
-            }
-            publisher.removeInboundSubscription(it)
-        }
+        inboundSub?.let { publisher.removeInboundSubscription(it) }
     }
 
     /**
@@ -838,20 +789,8 @@ class MoqLiteSession internal constructor(
         suspend fun registerInboundSubscription(sub: MoqLiteSubscribe) {
             gate.withLock {
                 if (publisherClosed) return
-                if (sub.track != track) {
-                    Log.d("NestTx") {
-                        "ignoring inbound SUBSCRIBE id=${sub.id} track='${sub.track}' " +
-                            "(publisher serves track='$track' only)"
-                    }
-                    return
-                }
-                val wasEmpty = inboundSubs.isEmpty()
+                if (sub.track != track) return
                 inboundSubs += sub
-                if (wasEmpty) {
-                    Log.d("NestTx") {
-                        "first inbound subscriber attached id=${sub.id} broadcast='${sub.broadcast}' track='${sub.track}'"
-                    }
-                }
             }
         }
 
@@ -968,10 +907,6 @@ class MoqLiteSession internal constructor(
             val sub = inboundSubs.first()
             val sequence = nextSequence++
             val uni = openGroupStream(subscribeId = sub.id, sequence = sequence)
-            Log.d("NestTx") {
-                "openGroup seq=$sequence keyedOnSubId=${sub.id} broadcast='${sub.broadcast}' track='${sub.track}' " +
-                    "inboundSubsCount=${inboundSubs.size}"
-            }
             return GroupOutbound(sequence = sequence, uni = uni)
         }
     }

--- a/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/moq/lite/MoqLiteSession.kt
+++ b/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/moq/lite/MoqLiteSession.kt
@@ -444,13 +444,17 @@ class MoqLiteSession internal constructor(
             // sibling on the outer [scope] until the transport's flow
             // independently errors out.
             kotlinx.coroutines.coroutineScope {
+                var seen = 0L
                 transport.incomingUniStreams().collect { stream ->
+                    val n = ++seen
+                    Log.d("NestRx") { "transport delivered uni stream #$n (QUIC→moq seam)" }
                     launch { drainOneGroup(stream) }
                 }
             }
         } catch (ce: CancellationException) {
             throw ce
-        } catch (_: Throwable) {
+        } catch (t: Throwable) {
+            Log.w("NestRx") { "pumpUniStreams ended with ${t::class.simpleName}: ${t.message}" }
             // Transport closed — subscriptions will surface end-of-flow
             // via their own bidi pumps as well.
         }
@@ -574,13 +578,17 @@ class MoqLiteSession internal constructor(
             // [pumpUniStreams]'s identical comment) so they don't outlive
             // bidiPump.cancelAndJoin() in [close].
             kotlinx.coroutines.coroutineScope {
+                var seen = 0L
                 transport.incomingBidiStreams().collect { bidi ->
+                    val n = ++seen
+                    Log.d("NestTx") { "transport delivered inbound bidi #$n (QUIC→moq seam)" }
                     launch { handleInboundBidi(bidi) }
                 }
             }
         } catch (ce: CancellationException) {
             throw ce
-        } catch (_: Throwable) {
+        } catch (t: Throwable) {
+            Log.w("NestTx") { "pumpInboundBidis ended with ${t::class.simpleName}: ${t.message}" }
             // Transport closed.
         }
     }

--- a/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/transport/FakeWebTransport.kt
+++ b/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/transport/FakeWebTransport.kt
@@ -73,7 +73,9 @@ class FakeWebTransport private constructor(
      * the moq-lite publisher path to push group data. The peer side
      * receives the new stream via [incomingUniStreams].
      */
-    override suspend fun openUniStream(): WebTransportWriteStream {
+    override suspend fun openUniStream(bestEffort: Boolean): WebTransportWriteStream {
+        // The fake transport ignores [bestEffort] — there's no loss to
+        // simulate in the in-memory channel.
         stateLock.withLock { check(open) { "session closed" } }
         val pipe = Channel<ByteArray>(Channel.BUFFERED)
         outboundUniStreams.send(FakeReadStream(pipe))

--- a/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/transport/WebTransportSession.kt
+++ b/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/transport/WebTransportSession.kt
@@ -55,8 +55,14 @@ interface WebTransportSession {
      * audio frames is pushed on a fresh uni stream that the publisher
      * opens — see `rs/moq-lite/src/lite/publisher.rs:338`
      * (`session.open_uni()`).
+     *
+     * If [bestEffort] is true, the underlying QUIC stream drops lost
+     * STREAM bytes instead of retransmitting them — for real-time
+     * audio (Opus group streams) this avoids pushing 200-ms-stale
+     * frames after a loss. Default false (RFC 9000 §3.5 reliable byte
+     * sequence).
      */
-    suspend fun openUniStream(): WebTransportWriteStream
+    suspend fun openUniStream(bestEffort: Boolean = false): WebTransportWriteStream
 
     /**
      * Flow of inbound unidirectional streams initiated by the peer.

--- a/nestsClient/src/commonTest/kotlin/com/vitorpamplona/nestsclient/moq/lite/MoqLiteSessionTest.kt
+++ b/nestsClient/src/commonTest/kotlin/com/vitorpamplona/nestsclient/moq/lite/MoqLiteSessionTest.kt
@@ -258,7 +258,7 @@ class MoqLiteSessionTest {
             val (clientSide, serverSide) = FakeWebTransport.pair()
             val session = MoqLiteSession.client(clientSide, pumpScope)
 
-            val publisher = session.publish(broadcastSuffix = "speakerPubkey")
+            val publisher = session.publish(broadcastSuffix = "speakerPubkey", track = "audio/data")
 
             // Relay (serverSide) opens an Announce bidi to us with
             // AnnouncePlease(prefix="").
@@ -283,7 +283,7 @@ class MoqLiteSessionTest {
             val (clientSide, serverSide) = FakeWebTransport.pair()
             val session = MoqLiteSession.client(clientSide, pumpScope)
 
-            val publisher = session.publish(broadcastSuffix = "speakerPubkey")
+            val publisher = session.publish(broadcastSuffix = "speakerPubkey", track = "audio/data")
 
             // Step 1: relay opens Subscribe bidi.
             val subBidi = serverSide.openBidiStream()
@@ -346,7 +346,7 @@ class MoqLiteSessionTest {
             val (clientSide, _) = FakeWebTransport.pair()
             val session = MoqLiteSession.client(clientSide, pumpScope)
 
-            val publisher = session.publish(broadcastSuffix = "speakerPubkey")
+            val publisher = session.publish(broadcastSuffix = "speakerPubkey", track = "audio/data")
             // No relay-opened Subscribe bidi → no subscribers → send is
             // a silent no-op (returns false), matching the listener
             // semantics where the speaker keeps capturing audio even
@@ -363,7 +363,7 @@ class MoqLiteSessionTest {
             val (clientSide, serverSide) = FakeWebTransport.pair()
             val session = MoqLiteSession.client(clientSide, pumpScope)
 
-            val publisher = session.publish(broadcastSuffix = "speakerPubkey")
+            val publisher = session.publish(broadcastSuffix = "speakerPubkey", track = "audio/data")
 
             // Relay opens an announce bidi.
             val relayBidi = serverSide.openBidiStream()

--- a/nestsClient/src/jvmAndroid/kotlin/com/vitorpamplona/nestsclient/transport/QuicWebTransportFactory.kt
+++ b/nestsClient/src/jvmAndroid/kotlin/com/vitorpamplona/nestsclient/transport/QuicWebTransportFactory.kt
@@ -278,8 +278,8 @@ class QuicWebTransportSession(
         return QuicBidiStreamAdapter(s, state.driver)
     }
 
-    override suspend fun openUniStream(): WebTransportWriteStream {
-        val s = state.openUniStream()
+    override suspend fun openUniStream(bestEffort: Boolean): WebTransportWriteStream {
+        val s = state.openUniStream(bestEffort = bestEffort)
         return QuicUniWriteStreamAdapter(s, state.driver)
     }
 

--- a/nestsClient/src/jvmAndroid/kotlin/com/vitorpamplona/nestsclient/transport/QuicWebTransportFactory.kt
+++ b/nestsClient/src/jvmAndroid/kotlin/com/vitorpamplona/nestsclient/transport/QuicWebTransportFactory.kt
@@ -20,7 +20,6 @@
  */
 package com.vitorpamplona.nestsclient.transport
 
-import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quic.connection.QuicConnection
 import com.vitorpamplona.quic.connection.QuicConnectionConfig
 import com.vitorpamplona.quic.connection.QuicConnectionDriver
@@ -38,12 +37,9 @@ import com.vitorpamplona.quic.webtransport.buildExtendedConnectHeaders
 import com.vitorpamplona.quic.webtransport.encodeHeadersFrame
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.launch
 
 /**
  * Pure-Kotlin WebTransport over QUIC v1, sitting on top of every layer in
@@ -185,7 +181,7 @@ class QuicWebTransportFactory(
             }
 
             val state = QuicWebTransportSessionState(conn, driver, requestStream.streamId)
-            return QuicWebTransportSession(state, parentScope)
+            return QuicWebTransportSession(state)
         } catch (we: WebTransportException) {
             throw we
         } catch (ce: kotlinx.coroutines.CancellationException) {
@@ -263,42 +259,8 @@ class QuicWebTransportFactory(
 /** Adapter that wraps the :quic [QuicWebTransportSessionState] in the nestsClient interface. */
 class QuicWebTransportSession(
     private val state: QuicWebTransportSessionState,
-    parentScope: CoroutineScope? = null,
 ) : WebTransportSession {
     override val isOpen: Boolean get() = state.isOpen
-
-    /**
-     * Periodic flow-control snapshot logger. Wakes every
-     * [SNAPSHOT_INTERVAL_MS] and dumps the QUIC layer's view of cap +
-     * count + send credit so we can correlate "audio cliff at uni
-     * stream #N" against "what did flow control look like at that
-     * moment". Cancelled when [close] tears down the session.
-     *
-     * Lazy-launched (via [parentScope]) only when the caller has
-     * provided a scope to host it — tests construct the session
-     * without one and don't need the logger.
-     */
-    private val snapshotJob: Job? =
-        parentScope?.launch {
-            while (true) {
-                delay(SNAPSHOT_INTERVAL_MS)
-                if (!state.isOpen) break
-                runCatching {
-                    val snap = state.connection.flowControlSnapshot()
-                    Log.d("NestQuic") {
-                        "snapshot peerInitiatedUni=${snap.peerInitiatedUniCount} " +
-                            "advertisedMaxStreamsUni=${snap.advertisedMaxStreamsUni} " +
-                            "peerInitMaxStreamsUni=${snap.peerInitialMaxStreamsUni} " +
-                            "sendCredit=${snap.sendConnectionFlowCredit} " +
-                            "consumed=${snap.sendConnectionFlowConsumed} " +
-                            "pendingBytes=${snap.totalEnqueuedNotSentBytes} " +
-                            "pendingStreams=${snap.streamsWithPendingBytes}/${snap.totalStreamsTracked} " +
-                            "udpRecvDatagrams=${snap.udp?.receivedDatagrams ?: -1L} " +
-                            "udpRecvBytes=${snap.udp?.receivedBytes ?: -1L}"
-                    }
-                }
-            }
-        }
 
     /**
      * Diagnostic-only passthrough to
@@ -364,18 +326,7 @@ class QuicWebTransportSession(
         code: Int,
         reason: String,
     ) {
-        snapshotJob?.cancel()
         state.close(code, reason)
-    }
-
-    private companion object {
-        /**
-         * Cadence for the periodic flow-control snapshot. 5 s is short
-         * enough to catch the audio-cliff transition (which lands within
-         * 5–15 s of subscribe) and long enough that the snapshot itself
-         * isn't a meaningful CPU cost.
-         */
-        const val SNAPSHOT_INTERVAL_MS = 5_000L
     }
 }
 

--- a/nestsClient/src/jvmAndroid/kotlin/com/vitorpamplona/nestsclient/transport/QuicWebTransportFactory.kt
+++ b/nestsClient/src/jvmAndroid/kotlin/com/vitorpamplona/nestsclient/transport/QuicWebTransportFactory.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.nestsclient.transport
 
+import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quic.connection.QuicConnection
 import com.vitorpamplona.quic.connection.QuicConnectionConfig
 import com.vitorpamplona.quic.connection.QuicConnectionDriver
@@ -37,9 +38,12 @@ import com.vitorpamplona.quic.webtransport.buildExtendedConnectHeaders
 import com.vitorpamplona.quic.webtransport.encodeHeadersFrame
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
 
 /**
  * Pure-Kotlin WebTransport over QUIC v1, sitting on top of every layer in
@@ -181,7 +185,7 @@ class QuicWebTransportFactory(
             }
 
             val state = QuicWebTransportSessionState(conn, driver, requestStream.streamId)
-            return QuicWebTransportSession(state)
+            return QuicWebTransportSession(state, parentScope)
         } catch (we: WebTransportException) {
             throw we
         } catch (ce: kotlinx.coroutines.CancellationException) {
@@ -259,8 +263,42 @@ class QuicWebTransportFactory(
 /** Adapter that wraps the :quic [QuicWebTransportSessionState] in the nestsClient interface. */
 class QuicWebTransportSession(
     private val state: QuicWebTransportSessionState,
+    parentScope: CoroutineScope? = null,
 ) : WebTransportSession {
     override val isOpen: Boolean get() = state.isOpen
+
+    /**
+     * Periodic flow-control snapshot logger. Wakes every
+     * [SNAPSHOT_INTERVAL_MS] and dumps the QUIC layer's view of cap +
+     * count + send credit so we can correlate "audio cliff at uni
+     * stream #N" against "what did flow control look like at that
+     * moment". Cancelled when [close] tears down the session.
+     *
+     * Lazy-launched (via [parentScope]) only when the caller has
+     * provided a scope to host it — tests construct the session
+     * without one and don't need the logger.
+     */
+    private val snapshotJob: Job? =
+        parentScope?.launch {
+            while (true) {
+                delay(SNAPSHOT_INTERVAL_MS)
+                if (!state.isOpen) break
+                runCatching {
+                    val snap = state.connection.flowControlSnapshot()
+                    Log.d("NestQuic") {
+                        "snapshot peerInitiatedUni=${snap.peerInitiatedUniCount} " +
+                            "advertisedMaxStreamsUni=${snap.advertisedMaxStreamsUni} " +
+                            "peerInitMaxStreamsUni=${snap.peerInitialMaxStreamsUni} " +
+                            "sendCredit=${snap.sendConnectionFlowCredit} " +
+                            "consumed=${snap.sendConnectionFlowConsumed} " +
+                            "pendingBytes=${snap.totalEnqueuedNotSentBytes} " +
+                            "pendingStreams=${snap.streamsWithPendingBytes}/${snap.totalStreamsTracked} " +
+                            "udpRecvDatagrams=${snap.udp?.receivedDatagrams ?: -1L} " +
+                            "udpRecvBytes=${snap.udp?.receivedBytes ?: -1L}"
+                    }
+                }
+            }
+        }
 
     /**
      * Diagnostic-only passthrough to
@@ -326,7 +364,18 @@ class QuicWebTransportSession(
         code: Int,
         reason: String,
     ) {
+        snapshotJob?.cancel()
         state.close(code, reason)
+    }
+
+    private companion object {
+        /**
+         * Cadence for the periodic flow-control snapshot. 5 s is short
+         * enough to catch the audio-cliff transition (which lands within
+         * 5–15 s of subscribe) and long enough that the snapshot itself
+         * isn't a meaningful CPU cost.
+         */
+        const val SNAPSHOT_INTERVAL_MS = 5_000L
     }
 }
 

--- a/nestsClient/src/jvmTest/kotlin/com/vitorpamplona/nestsclient/interop/NostrNestsSustainedSendOutcomesInteropTest.kt
+++ b/nestsClient/src/jvmTest/kotlin/com/vitorpamplona/nestsclient/interop/NostrNestsSustainedSendOutcomesInteropTest.kt
@@ -121,7 +121,7 @@ class NostrNestsSustainedSendOutcomesInteropTest {
             val speakerSession = MoqLiteSession.client(speakerWt, pumpScope)
             val publisher =
                 InteropDebug.stepSuspending(scope, "host: session.publish(broadcastSuffix=hostPub)") {
-                    speakerSession.publish(broadcastSuffix = hostSigner.pubKey)
+                    speakerSession.publish(broadcastSuffix = hostSigner.pubKey, track = "audio/data")
                 }
 
             // ---- listener side: production code path, unchanged.
@@ -452,7 +452,7 @@ class NostrNestsSustainedSendOutcomesInteropTest {
         val speakerSession = MoqLiteSession.client(speakerWt, pumpScope)
         val publisher =
             InteropDebug.stepSuspending(scope, "host: session.publish(broadcastSuffix=hostPub)") {
-                speakerSession.publish(broadcastSuffix = hostSigner.pubKey)
+                speakerSession.publish(broadcastSuffix = hostSigner.pubKey, track = "audio/data")
             }
 
         val listeners = mutableListOf<com.vitorpamplona.nestsclient.NestsListener>()

--- a/nestsClient/src/jvmTest/kotlin/com/vitorpamplona/nestsclient/interop/NostrnestsProdAudioTransmissionTest.kt
+++ b/nestsClient/src/jvmTest/kotlin/com/vitorpamplona/nestsclient/interop/NostrnestsProdAudioTransmissionTest.kt
@@ -644,7 +644,7 @@ class NostrnestsProdAudioTransmissionTest {
                     .client(speakerWt, pumpScope)
             val publisher =
                 InteropDebug.stepSuspending(scope, "host: session.publish(broadcastSuffix=hostPub)") {
-                    speakerSession.publish(broadcastSuffix = hostSigner.pubKey)
+                    speakerSession.publish(broadcastSuffix = hostSigner.pubKey, track = "audio/data")
                 }
 
             // ---- listener side: production code path, unchanged.
@@ -1013,7 +1013,7 @@ class NostrnestsProdAudioTransmissionTest {
                 .client(speakerWt, pumpScope)
         val publisher =
             InteropDebug.stepSuspending(scope, "host: session.publish(broadcastSuffix=hostPub)") {
-                speakerSession.publish(broadcastSuffix = hostSigner.pubKey)
+                speakerSession.publish(broadcastSuffix = hostSigner.pubKey, track = "audio/data")
             }
 
         val listeners = mutableListOf<com.vitorpamplona.nestsclient.NestsListener>()

--- a/quic/plans/2026-04-26-quic-stack-status.md
+++ b/quic/plans/2026-04-26-quic-stack-status.md
@@ -21,7 +21,7 @@ tests, 39 test files, five rounds of parallel audit + fix passes.
 | C. Initial + Handshake packets | 2 wk | done | RFC 9001 §A.2/§A.3 vectors pass; ChaCha20 per §A.5 |
 | D. 1-RTT + STREAM | 1 wk | done | Stream offset reassembly, FIN, fuzzed |
 | E. ACK + flow control | 1 wk | done | MAX_DATA / MAX_STREAM_DATA / MAX_STREAMS routing + writer enforcement |
-| F. Loss recovery + congestion control | 1 wk | partial | PTO timer for handshake retries; **no retransmit-on-loss in steady state** (out of scope — see "deferred" below) |
+| F. Loss recovery + congestion control | 1 wk | done (no CC) | RFC 9002 §5/§6 RTT estimator + packet/time-threshold loss detection + PTO + per-frame retransmit shipped 2026-05-05; congestion control still TBD |
 | G. Datagram extension | ½ wk | done | RFC 9221 frames + bounded incoming queue |
 | H. Connection lifecycle | 1 wk | done | CONNECTION_CLOSE, idle timeout, draining/closing, idempotent driver close |
 | I. HTTP/3 | 2 wk | done | Control stream + SETTINGS + GOAWAY (with id-regression check) + duplicate-id rejection |
@@ -61,6 +61,9 @@ quic/
     │   ├── packet/                       ← LongHeaderPacket, ShortHeaderPacket, RetryPacket, peekHeader
     │   ├── qpack/                        ← QpackDecoder, QpackEncoder, QpackHuffman, QpackInteger,
     │   │                                   QpackStaticTable
+    │   ├── connection/recovery/         ← RecoveryToken + SentPacket + QuicLossDetection
+    │   │                                   (RFC 9002 §5/§6 RTT estimator + loss detection +
+    │   │                                   PTO; per-frame retransmit dispatch)
     │   ├── recovery/                     ← AckTracker (with ack-eliciting gating)
     │   ├── stream/                       ← QuicStream, ReceiveBuffer (with FIN-fully-read), SendBuffer, StreamId
     │   ├── tls/                          ← TlsClient state machine + ClientHello/ServerHello/EE/Cert/CV/Finished
@@ -112,14 +115,12 @@ explicit `PermissiveCertificateValidator`; production passes
 - **QPACK dynamic-table inserts on the encoder.** We send literal-only;
   decoder accepts dynamic-table indexed lines.
 - **ECN / anti-amplification limits.** We're a client.
-- **Retransmit-on-loss in steady state.** `SendBuffer.takeChunk` releases
-  bytes to the wire and doesn't retain them. The handshake survives via the
-  `Driver.sendLoop` PTO path which re-pulls from CRYPTO send buffers; for
-  STREAM data, a real loss event truncates the stream silently. This is
-  acceptable for MoQ (DATAGRAM-mode audio, plus stream usage is
-  control-plane only) but would be the first item to add for general use.
 - **TLS Key-Update / NewSessionTicket.** Detected and refused (KeyUpdate
   fails the connection rather than silently desynchronising).
+- **Congestion control (NewReno / CUBIC / BBR).** Loss detection is in
+  place (RFC 9002 §5/§6) but no rate-limiting feedback loop reacts to
+  losses; we send as fast as the application provides bytes. Independent
+  follow-up.
 
 ## Verified interop
 
@@ -164,7 +165,13 @@ Roughly grouped:
   `TlsTranscriptHashTest`.
 - **WT / HTTP/3:** `CapsuleReaderTest`, `WtPeerStreamDemuxTest`,
   `WtFramingTest`.
-- **Recovery:** `AckTrackerCoalescedTest`, `AckTrackerGatingTest`.
+- **Recovery:** `AckTrackerCoalescedTest`, `AckTrackerGatingTest`,
+  `RecoveryTokenTest`, `SentPacketTest`, `ReceiverFlowControlTest` (9
+  cases mirrored from neqo `fc.rs`), `QuicLossDetectionTest`,
+  `PtoTest`, `QuicConnectionRetransmitTest`,
+  `SendBufferRetainUntilAckTest` (14 cases for the rewrite),
+  `StreamRetransmitTest`, `CryptoRetransmitTest`,
+  `ResetStopSendingEmitTest` (7 cases).
 - **Interop:** `InteropRunner` (jvmTest, drives a real socket against a
   Dockerised aioquic; opt-in, not in CI).
 
@@ -174,9 +181,13 @@ These are the items future audit rounds keep flagging that we've
 consciously not tackled — all confined to the steady-state path that audio
 rooms don't exercise heavily:
 
-1. **No STREAM retransmit on loss** (audit-4 #10). Acceptable for MoQ
-   datagram audio; would block any heavy stream-based use. ~1 wk to add.
-2. **`SendBuffer` doesn't retain bytes until ACK.** Same scope as #1.
+1. ~~**No STREAM retransmit on loss** (audit-4 #10).~~ **Resolved 2026-05-05** —
+   `SendBuffer` rewritten for retain-until-ACK with three-state range
+   tracking; ACK / loss dispatchers re-queue lost ranges to the
+   retransmit FIFO. Also covers CRYPTO retransmit per encryption level
+   and RESET_STREAM / STOP_SENDING / NEW_CONNECTION_ID retransmit.
+   See [`2026-05-04-control-frame-retransmit.md`](2026-05-04-control-frame-retransmit.md).
+2. ~~**`SendBuffer` doesn't retain bytes until ACK.**~~ Resolved with #1.
 3. **No Initial / Handshake key discard.** RFC 9000 §17.2.2 / RFC 9001 §4.9
    require dropping these after handshake completes; we hold them
    indefinitely. Memory leak per long session.
@@ -191,11 +202,14 @@ rooms don't exercise heavily:
    class` into an interface so the test side can stub. The driver is
    covered indirectly by every pipe-based test plus the live interop
    runner.
+8. **No congestion control.** Loss detection is wired but nothing
+   throttles send rate in response. Independent ~1-2 wk project.
 
 ## Pointers
 
 - Original (frozen) plan: `docs/plans/2026-04-22-pure-kotlin-quic-webtransport-plan.md`
 - Audio-rooms NIP draft: `docs/plans/2026-04-22-nip-audio-rooms-draft.md`
 - Completion plan: `nestsClient/plans/2026-04-26-audio-rooms-completion.md`
+- Retransmit plan + implementation log: [`2026-05-04-control-frame-retransmit.md`](2026-05-04-control-frame-retransmit.md)
 - Live interop runner: `quic/src/jvmTest/.../interop/InteropRunner.kt`
 - Audit history: `git log --grep='audit' -- quic/`

--- a/quic/plans/2026-04-26-quic-stack-status.md
+++ b/quic/plans/2026-04-26-quic-stack-status.md
@@ -188,16 +188,21 @@ rooms don't exercise heavily:
    and RESET_STREAM / STOP_SENDING / NEW_CONNECTION_ID retransmit.
    See [`2026-05-04-control-frame-retransmit.md`](2026-05-04-control-frame-retransmit.md).
 2. ~~**`SendBuffer` doesn't retain bytes until ACK.**~~ Resolved with #1.
-3. **No Initial / Handshake key discard.** RFC 9000 §17.2.2 / RFC 9001 §4.9
-   require dropping these after handshake completes; we hold them
-   indefinitely. Memory leak per long session.
+3. ~~**No Initial / Handshake key discard.**~~ **Resolved 2026-05-05** —
+   `LevelState.discardKeys()` nulls the AEAD protection, replaces the
+   per-level CRYPTO buffers and ack-tracker with empty instances, and
+   clears the sent-packet map. Initial keys discarded by the writer
+   after the first Handshake packet is built (RFC 9001 §4.9.1);
+   Handshake keys discarded by the parser on receipt of HANDSHAKE_DONE
+   (RFC 9001 §4.9.2 + §4.1.2 client-side handshake confirmation).
 4. **No path validation for `NEW_CONNECTION_ID`.** We don't migrate.
 5. **Stateless reset detection.** Stateless-reset packets look like
    corruption to us.
-6. **`AckTracker.purgeBelow` threshold semantics.** Pre-existing bug:
-   purges based on peer's largestAcknowledged of OUR outbound PNs, but
-   purges OUR inbound PN tracker. Causes range-list bloat, not correctness
-   failure.
+6. ~~**`AckTracker.purgeBelow` threshold semantics.**~~ **Resolved
+   2026-05-05** — `RecoveryToken.Ack` now carries `(level, largestAcked)`;
+   the writer captures these from the AckFrame at emit time, and
+   `QuicConnection.onTokensAcked` purges the matching per-level inbound
+   tracker on ACK-of-ACK. The wrong purge in the parser is gone.
 7. **Driver direct unit tests** require turning `UdpSocket` from `expect
    class` into an interface so the test side can stub. The driver is
    covered indirectly by every pipe-based test plus the live interop

--- a/quic/plans/2026-05-04-control-frame-retransmit.md
+++ b/quic/plans/2026-05-04-control-frame-retransmit.md
@@ -1,6 +1,10 @@
 # Control-frame retransmit for `:quic` — implementation plan
 
-**Status:** plan, not started.
+**Status:** **shipped 2026-05-05** on branch `claude/fix-nest-audio-display-3chAG`.
+Steps 1–9 landed as planned; the deferred follow-ups (STREAM data, CRYPTO,
+RESET_STREAM / STOP_SENDING / NEW_CONNECTION_ID) all shipped on top, plus an
+audit cleanup pass. See [Implementation log](#implementation-log) at the end
+for the full commit list.
 
 ## Why
 
@@ -351,3 +355,114 @@ work for at least a week without regressions.
 - A new `MoqLiteSessionRetransmitTest` simulates packet loss at the moment of `MAX_STREAMS_UNI` emission and confirms audio continues flowing past the threshold.
 - Existing `QuicConnectionWriterTest`, `PeerStreamCreditExtensionTest`, etc. unchanged.
 - No regression in handshake latency or throughput under steady-state.
+
+## Implementation log
+
+Shipped over 13 commits on `claude/fix-nest-audio-display-3chAG`:
+
+| # | Commit | Subject |
+|---|---|---|
+| plan | `c246305` | `docs(quic): plan control-frame retransmit subsystem mirroring neqo` |
+| 1 | `9e6fa3d` | `feat(quic): step 1 of RFC 9002 retransmit — RecoveryToken + SentPacket types` |
+| 2 | `ea15a9a` | `feat(quic): step 2 of RFC 9002 retransmit — record SentPacket per outbound` |
+| 3 | `0ced269` | `feat(quic): step 3 of RFC 9002 retransmit — drain SentPacket on ACK` |
+| 4 | `2928263` | `feat(quic): step 4 of RFC 9002 retransmit — pending* fields + writer drain` |
+| 5 | `1df6441` | `feat(quic): step 5 of RFC 9002 retransmit — loss detection + RTT estimator` |
+| 6 | `15a6bfc` | `feat(quic): step 6 of RFC 9002 retransmit — dispatch lost tokens to pending*` |
+| 7–9 | `c43c951` | `feat(quic): steps 7, 8, 9 of RFC 9002 retransmit — PTO + integration test + revert workaround` |
+| follow-up A | `7f6d908` | `feat(quic): extend RecoveryToken — Stream, Crypto, ResetStream, StopSending, NewConnectionId` |
+| follow-up B | `03cfb31` | `feat(quic): rewrite SendBuffer for retain-until-ACK with markAcked/markLost` |
+| follow-up C | `f623e88` | `feat(quic): wire STREAM data retransmit — token emission + ACK/loss dispatch` |
+| follow-up D | `0c847b4` | `feat(quic): wire CRYPTO retransmit per encryption level` |
+| follow-up E | `996ab39` | `feat(quic): emit RESET_STREAM / STOP_SENDING + per-stream retransmit dispatch` |
+| perf | `303caa8` | `perf(quic): binary-search SendBuffer overlap + insert (O(log N))` |
+| audit | `086a9c7` | `fix(quic): RESET_STREAM/STOP_SENDING first-call-wins + threading contract` |
+
+### What changed vs the plan
+
+The original scope was **only** the receive-side flow-control frames
+(`MAX_STREAMS_UNI/BIDI`, `MAX_DATA`, `MAX_STREAM_DATA`). Once the
+RecoveryToken / SentPacket / loss-detection scaffolding existed, the
+remaining retransmittable frames were a small extension:
+
+- **STREAM data retransmit (B + C).** Required rewriting `SendBuffer`
+  from "release on send" to "retain until ACK", with three logical
+  regions (`in-flight` / `needs retransmit` / `unsent`) tracked as
+  sorted offset ranges. Bytes are released on `markAcked`; lost ranges
+  re-prioritise to the front of `takeChunk` via a FIFO retransmit queue.
+  Removes the "STREAM truncates silently on loss" item from the
+  deferred-work list.
+- **CRYPTO retransmit (D).** Same `SendBuffer` machinery applied
+  per-encryption-level (Initial / Handshake / Application). Closes the
+  handshake reliability gap that previously relied on the driver's PTO
+  re-pull-from-CRYPTO hack.
+- **RESET_STREAM / STOP_SENDING / NEW_CONNECTION_ID emit + retransmit (E).**
+  Public API on `QuicStream` (`resetStream(errorCode)` /
+  `stopSending(errorCode)`); writer drain emits with a `RecoveryToken`;
+  loss dispatcher re-flags per-stream emit-pending bits; ACK dispatcher
+  latches `resetAcked` / `stopSendingAcked` so stale loss tokens don't
+  re-emit. NEW_CONNECTION_ID retransmit drains
+  `QuicConnection.pendingNewConnectionId` (no public emit API yet —
+  `:quic` doesn't rotate connection IDs — but the wiring is in place).
+
+### Performance optimisation
+
+`303caa8` replaced the O(N) full-scan in `SendBuffer.removeOverlap` and
+the O(N) middle-insert in `addToInFlight` with a binary-search-based
+`firstOverlapIndex` + early-exit walk. Hot-path ACK / loss notification
+is now O(log N + k) where k is the number of in-flight ranges actually
+overlapping the ACK range (typically 1).
+
+### Audit follow-up
+
+`086a9c7` cleaned up correctness + threading issues found by re-reading
+the emit commit:
+
+1. `resetStream` / `stopSending` now no-op on the second call. RFC 9000
+   §3.5 pins `finalSize` at first emission; the original "idempotent —
+   second call overwrites with newer error code" claim was wrong (a
+   retransmit after additional `enqueue` would replay with a larger
+   `finalSize`, triggering `FINAL_SIZE_ERROR` on the peer). Two new
+   tests — `resetStream_secondCallIsNoOp_finalSizeFrozen`,
+   `stopSending_secondCallIsNoOp` — lock the contract.
+2. `resetEmitPending`, `resetAcked`, `stopSendingEmitPending`,
+   `stopSendingAcked` are now `@Volatile`. The public emit APIs are
+   callable from any coroutine while the writer / dispatchers read the
+   same fields under `QuicConnection.lock`; volatile gives the
+   cross-thread happens-before, and the first-call-wins gate above
+   eliminates the only multi-writer race.
+3. Stale `SendBuffer` class KDoc claiming O(N) range arithmetic
+   refreshed to reflect the actual O(log N + k) cost.
+4. `removeOverlap`'s bulk-removal comment toned down — it had claimed
+   O(k) per call but `ArrayDeque.removeAt(i)` shifts on every call;
+   actual cost is O(k · (size − end + k)) worst case, fine in practice
+   because k is 1–2 in steady state.
+
+### Test coverage shipped
+
+The 50 planned tests landed plus the follow-up suites:
+
+- `RecoveryTokenTest`, `SentPacketTest` (codec + equality).
+- `ReceiverFlowControlTest` (9 mirrored from neqo's `fc.rs`).
+- `QuicLossDetectionTest` (~15 mirrored from `recovery/mod.rs`).
+- `PtoTest` (~7 mirrored from `recovery/mod.rs` PTO subset).
+- `QuicConnectionRetransmitTest` (integration: lost MAX_STREAMS bump
+  re-emits and lands).
+- `MoqLiteSessionRetransmitTest` (drops a packet at the
+  half-window-threshold MAX_STREAMS_UNI emit; audio keeps flowing).
+- `SendBufferRetainUntilAckTest` (14 cases for the retain-until-ACK
+  rewrite — ack/loss/split/FIN/compaction).
+- `StreamRetransmitTest`, `CryptoRetransmitTest` (token emission + loss
+  re-queues bytes).
+- `ResetStopSendingEmitTest` (7 cases: emit-and-token, retransmit on
+  loss, ack-then-stale-loss-drop, stop-sending emission,
+  NEW_CONNECTION_ID retransmit drain, first-call-wins for both APIs).
+
+### Cap-workaround status
+
+Step 9 of the original plan ("revert `initialMaxStreamsUni` from
+1 000 000 back to a smaller value once retransmit is durable") landed
+in `c43c951`. `QuicConnectionConfig.initialMaxStreamsUni` is now
+`10_000L` — large enough to avoid the moq-rs cliff at startup but
+small enough that the rolling-extension + retransmit path actually
+runs in long sessions. The 1 000 000 emergency value is gone.

--- a/quic/plans/2026-05-04-control-frame-retransmit.md
+++ b/quic/plans/2026-05-04-control-frame-retransmit.md
@@ -1,0 +1,353 @@
+# Control-frame retransmit for `:quic` — implementation plan
+
+**Status:** plan, not started.
+
+## Why
+
+Production tracing against `moq.nostrnests.com` (commits `36c707f` →
+`c3d6cad` on `claude/fix-nest-audio-display-3chAG`) showed the audio
+cliff lands at exactly the moment we emit our first `MAX_STREAMS_UNI`
+extension at the half-window threshold. One emit, one packet, one
+loss on the wire — and because `:quic` does not retransmit ack-eliciting
+frames, the relay never sees the bump, silently stops sending, and our
+QUIC state stays in split-brain (`udpRecvDatagrams` frozen) until the
+listener manually disconnects.
+
+The current shipping fix (`QuicConnectionConfig.initialMaxStreamsUni
+= 1_000_000`) sidesteps the bug by advertising a cap so high the
+half-window threshold doesn't trip until ~13.9 hours of audio. That
+gets us multi-hour Nests but leaves the underlying frailty in place:
+*every* ack-eliciting control frame we send today is one wire-loss
+away from causing a silent stall. `MAX_DATA`, `MAX_STREAM_DATA`,
+`RESET_STREAM`, `STOP_SENDING`, `NEW_CONNECTION_ID` — all have the
+same exposure.
+
+The fix that browser-grade QUIC stacks have and we don't:
+RFC 9002 §6 loss detection + per-frame retransmit.
+
+## Reference
+
+We follow Firefox's [neqo](https://github.com/mozilla/neqo) design,
+not Chrome's quiche, because:
+
+- neqo's typed-token shape (a `RecoveryToken` discriminated union with
+  one variant per retransmittable frame) maps onto Kotlin sealed
+  classes naturally and matches the existing `Frame` /
+  `MoqLiteControl…` patterns in the codebase.
+- quiche's monotonic-control-frame-id deque is more compact in C++
+  but loses compile-time safety in Kotlin; with its cost-of-bug
+  history (a single `kInvalidControlFrameId` sentinel typo would
+  silently break retransmit) it's not worth the conciseness.
+- Both are correct per RFC 9002, both are interop-tested daily; the
+  algorithm is identical, only the bookkeeping shape differs.
+
+Specific neqo files we mirror:
+
+| neqo (Rust) | `:quic` (Kotlin) |
+|---|---|
+| `neqo-transport/src/recovery/token.rs` | new `quic/connection/recovery/RecoveryToken.kt` |
+| `neqo-transport/src/recovery/sent.rs` | new `quic/connection/recovery/SentPacket.kt` |
+| `neqo-transport/src/recovery/mod.rs` | extend `QuicConnection` + new `QuicLossDetection.kt` |
+| `neqo-transport/src/streams.rs` (lost dispatch) | new `QuicConnection.onTokensLost()` |
+| `neqo-transport/src/fc.rs` (`frame_lost` flag) | extend `QuicConnection.advertisedMaxStreamsUni` etc. with a `pending` companion |
+
+## Scope
+
+**In scope (this plan):** retransmit for the receive-side flow-control
+frames that are RFC-9002 ack-eliciting and cheap to make idempotent:
+
+- `MAX_STREAMS_UNI`
+- `MAX_STREAMS_BIDI`
+- `MAX_DATA`
+- `MAX_STREAM_DATA`
+
+These are the frames that, when lost, can silently wedge the
+connection. They're also the frames where the retransmit semantics
+are simplest: re-emit if the sent value still matches our current
+view; otherwise the newer-value emission supersedes.
+
+**Out of scope (separate follow-ups):**
+
+- `STREAM` data retransmit. Audio rooms tolerate gaps (Opus is
+  best-effort streaming), and adding STREAM retransmit means
+  rewriting `SendBuffer` to retain bytes until ACK rather than
+  release on send. Tracked separately.
+- `RESET_STREAM`, `STOP_SENDING`, `NEW_CONNECTION_ID`,
+  `RETIRE_CONNECTION_ID`, `STREAMS_BLOCKED`, `DATA_BLOCKED`: not
+  exercised by the moq-lite workload today. Add when needed.
+- `CRYPTO` retransmit (handshake bytes). Important for handshake
+  reliability but out of scope for the audio-cliff fix; we'd inherit
+  this from a full RFC 9002 pass later.
+- Congestion control (NewReno / CUBIC / BBR). Independent concern;
+  `:quic` has no CC at all today, and adding it is its own multi-day
+  project.
+- 0-RTT, connection migration, multipath. We don't use any of these.
+
+## Architecture
+
+### 1. `RecoveryToken`
+
+A sealed class enumerating each retransmittable frame type. Mirrors
+neqo's `StreamRecoveryToken` enum at `recovery/token.rs:21`.
+
+```kotlin
+sealed class RecoveryToken {
+    object Ack : RecoveryToken()  // tracked but not retransmitted
+    data class MaxStreamsUni(val maxStreams: Long) : RecoveryToken()
+    data class MaxStreamsBidi(val maxStreams: Long) : RecoveryToken()
+    data class MaxData(val maxData: Long) : RecoveryToken()
+    data class MaxStreamData(val streamId: Long, val maxData: Long) : RecoveryToken()
+}
+```
+
+### 2. `SentPacket`
+
+Per-packet metadata retained until the packet is ACK'd or declared
+lost. Mirrors neqo's `recovery/sent.rs::Packet`.
+
+```kotlin
+data class SentPacket(
+    val packetNumber: Long,
+    val sentAtMillis: Long,
+    val ackEliciting: Boolean,
+    val sizeBytes: Int,
+    val tokens: List<RecoveryToken>,
+)
+```
+
+Held in a per-pn-space `MutableMap<Long, SentPacket>` on
+`QuicConnection`. Three spaces: Initial, Handshake, Application.
+
+### 3. Send path: emit + register
+
+In `QuicConnectionWriter.appendFlowControlUpdates`, when we emit a
+`MaxStreamsFrame` (or any retransmit-eligible control frame), we
+also build a `RecoveryToken` and append it to the per-packet token
+list. `buildApplicationPacket` returns `(packetBytes, tokens, pn,
+ackEliciting)`. `drainOutbound` records a `SentPacket` in the
+application space's map keyed by packet number.
+
+### 4. ACK path: drop tokens
+
+Existing `QuicConnectionParser` ACK handling at line 165
+(`AckFrame -> state.ackTracker.purgeBelow(...)`) extends to also
+remove the corresponding `SentPacket` entries from the map. Tokens
+go away silently — they were delivered.
+
+### 5. Loss detection
+
+A new `QuicLossDetection` per pn-space, called from the writer or
+on a timer. RFC 9002 §6.1 thresholds:
+
+- Packet threshold: any sent packet with `pn < largest_acked - 3`
+  is lost.
+- Time threshold: any sent packet with `sent_time + (max_rtt *
+  9/8) < now` is lost (where `max_rtt = max(smoothed_rtt,
+  latest_rtt)`).
+
+When a packet is declared lost: pull its `tokens`, dispatch each to
+its `onLost` handler, and remove it from the sent map.
+
+### 6. Loss dispatch: `onLost(token)`
+
+Mirrors neqo's `streams.rs::lost()` and `fc.rs::frame_lost()`.
+
+```kotlin
+fun onLost(token: RecoveryToken) {
+    when (token) {
+        is RecoveryToken.MaxStreamsUni -> {
+            // Only flag pending if we haven't since extended further.
+            // The newer value would supersede this one anyway.
+            if (token.maxStreams == advertisedMaxStreamsUni) {
+                pendingMaxStreamsUni = token.maxStreams
+            }
+        }
+        is RecoveryToken.MaxStreamsBidi -> { /* symmetric */ }
+        is RecoveryToken.MaxData -> { /* symmetric */ }
+        is RecoveryToken.MaxStreamData -> { /* per-stream symmetric */ }
+        RecoveryToken.Ack -> { /* not retransmittable */ }
+    }
+}
+```
+
+The `if (token.maxStreams == advertisedMaxStreamsUni)` guard exactly
+mirrors `fc.rs::frame_lost`'s `if (maximum_data == self.max_allowed)`
+check at line 322. Without it, we'd resurrect stale superseded
+extensions.
+
+### 7. Re-emit: drain `pending*` on next write
+
+`appendFlowControlUpdates` checks `pendingMaxStreamsUni` first;
+if non-null, emit that value (with a fresh token, registered on the
+new packet) and clear pending. Only when there's no pending
+retransmit does it run the normal half-window threshold check.
+
+### 8. PTO (Probe Timeout)
+
+RFC 9002 §6.2. When no ack-eliciting packets have been ACK'd within
+`PTO = smoothed_rtt + max(4 * rttvar, kGranularity) + max_ack_delay`,
+the connection has lost contact. Send a PING packet to elicit an
+ACK. PTO doubles on consecutive expirations; resets on ACK.
+
+Drives loss detection forward when the peer has gone quiet — exactly
+the failure mode where today's connection goes dead.
+
+## Test inventory mirrored from neqo
+
+These are the tests that already exist in neqo and that we must port
+to land equivalent coverage. Each row is one test we owe.
+
+### Token-level: receiver flow control (mirror `fc.rs`)
+
+Total: **9 tests** to mirror.
+
+| neqo test (file:line — fc.rs) | Asserts | Our equivalent |
+|---|---|---|
+| `lost_blocked_resent` | After STREAMS_BLOCKED loss, frame_pending re-set | `ReceiverFlowControlTest.lost_blocked_resent` |
+| `lost_after_increase` | If newer extension was already sent, lost old one is *not* re-sent | `ReceiverFlowControlTest.lost_after_increase` |
+| `lost_after_higher_blocked` | Same, applied to STREAMS_BLOCKED | `ReceiverFlowControlTest.lost_after_higher_blocked` |
+| `need_max_allowed_frame_after_loss` | `frame_lost(N)` where N == current limit re-flags pending | `ReceiverFlowControlTest.maxStreamsLostMatchesCurrent_resent` |
+| `no_max_allowed_frame_after_old_loss` | `frame_lost(stale)` after newer sent does NOT re-flag | `ReceiverFlowControlTest.maxStreamsLostStaleAfterNewer_dropped` |
+| `multiple_retries_after_frame_pending_is_set` | Repeated `retire(...)` keeps `frame_needed` true; `frame_sent(N)` clears | `ReceiverFlowControlTest.multipleRetiresMaintainFramePending` |
+| `new_retired_before_loss` | After loss following further `retire()`, the new (higher) limit is sent | `ReceiverFlowControlTest.lossAfterRetireUsesNewerLimit` |
+| `force_send_max_allowed` | A small first-retire below threshold does not flag | `ReceiverFlowControlTest.smallFirstRetireDoesNotFlag` |
+| `set_max_active_equal_does_not_set_frame_pending` | Setting same max-active as before does nothing | `ReceiverFlowControlTest.setMaxActiveEqualDoesNothing` |
+
+### Recovery-level: loss-detection algorithm (mirror `recovery/mod.rs`)
+
+Total: ~20 tests; we mirror the subset that doesn't require CRYPTO/handshake-space testing (we're scoped to Application space).
+
+| neqo test (recovery/mod.rs) | Asserts | Our equivalent |
+|---|---|---|
+| `remove_acked` | ACK removes the right packet numbers from sent map | `QuicLossDetectionTest.ackRemovesPackets` |
+| `time_loss_detection_gap` | Packet older than `max_rtt * 9/8` declared lost | `QuicLossDetectionTest.timeThresholdMarksLost` |
+| `time_loss_detection_timeout` | Loss detection schedules wake-up at the right deadline | `QuicLossDetectionTest.timeThresholdSchedulesTimer` |
+| `big_gap_loss` | Packet threshold (≥ 3 newer ACK'd) declares lost | `QuicLossDetectionTest.packetThresholdMarksLost` |
+| `loss_timer_set_on_pto` | Timer scheduled when PTO arms | `QuicLossDetectionTest.lossTimerSetOnPto` |
+| `loss_timer_expired_on_timeout` | Expired timer triggers loss callbacks | `QuicLossDetectionTest.expiredTimerTriggersLoss` |
+| `loss_timer_cancelled_on_ack` | New ACK for in-flight packet cancels pending PTO | `QuicLossDetectionTest.ackCancelsPto` |
+| `pto_works_basic` | PTO emits a probe packet | `PtoTest.basic` |
+| `pto_works_full_cwnd` | PTO works even at congestion-window full | `PtoTest.fullCwnd` |
+| `pto_works_ping` | Probe is a PING when nothing else to send | `PtoTest.probesWithPing` |
+| `ack_after_pto` | ACK clears PTO state correctly | `PtoTest.ackResetsPtoCount` |
+| `pto_retransmits_previous_frames_across_datagrams` | PTO probe carries the lost-but-pending frames, not just PING | `PtoTest.probeIncludesPendingFrames` |
+| `pto_state_count` | PTO count doubles each fire, resets on ACK | `PtoTest.exponentialBackoff` |
+| `loss_recovery_crash` | Two simultaneous loss events don't crash | `QuicLossDetectionTest.concurrentLossesNoCrash` |
+| `lost_but_kept_and_lr_timer` | Lost packet retained in book-keeping until release timer | `QuicLossDetectionTest.lostPacketRetainedForReleaseWindow` |
+| `loss_time_past_largest_acked` | Oldest pending loss-time is the one that matters | `QuicLossDetectionTest.oldestLossTimeIsScheduled` |
+| `ack_for_unsent` | ACK referencing unsent PN closes the connection per RFC | `QuicLossDetectionTest.ackForUnsentClosesConnection` |
+| `duplicate_ack_does_not_update_largest_acked_sent_time` | Re-ACK is a no-op | `QuicLossDetectionTest.duplicateAckIsNoop` |
+| `should_probe_exact_boundary` | PTO fires exactly at deadline, not before | `PtoTest.firesAtBoundaryNotBefore` |
+| `ack_only_boundary` | An ACK-only packet doesn't arm PTO | `PtoTest.ackOnlyDoesNotArmPto` |
+
+### Connection-level integration (mirror `connection/tests/recovery.rs` + `connection/tests/stream.rs`)
+
+Total: ~10 tests covering the full happens-after of "frame sent →
+packet lost → frame re-emitted → ACK'd".
+
+| neqo test (file) | Asserts | Our equivalent |
+|---|---|---|
+| `pto_works_basic` (recovery.rs) | End-to-end: lose a packet with control frames, observe retransmit | `QuicConnectionRetransmitTest.maxStreamsUniLossEmitsRetransmit` |
+| `pto_works_ping` (recovery.rs) | PTO PING fires after silence, peer ACKs it | `QuicConnectionRetransmitTest.silentPathPtoEmitsPing` |
+| `pto_retransmits_previous_frames_across_datagrams` | PTO carries the pending control-frame retransmits | `QuicConnectionRetransmitTest.ptoCarriesPendingMaxStreamsBump` |
+| `lost_but_kept_and_lr_timer` (recovery.rs) | Timer eviction of lost-tracking entries doesn't break re-emit | `QuicConnectionRetransmitTest.lostTrackingEvictionLeavesPendingIntact` |
+| `sending_max_data` (stream.rs) | MAX_DATA emitted, ACK observed, no spurious re-emit | `QuicConnectionRetransmitTest.maxDataAckedNoSpuriousRetransmit` |
+| `max_data` (stream.rs) | MAX_DATA flow control end-to-end | `QuicConnectionRetransmitTest.maxDataIncreasePropagates` |
+| `stream_data_blocked_generates_max_stream_data` | Receiver emits MAX_STREAM_DATA on blocked signal, retransmits if lost | `QuicConnectionRetransmitTest.maxStreamDataLossEmitsRetransmit` |
+
+### Codec-level: token serialisation round-trip
+
+Add: token equality, token data-class hashCode/equals correctness, token-list encode/decode-by-debug for log diagnosis. ~3 tests.
+
+### Total
+
+~50 tests. neqo has ~125 tests in this area; we're scoped to ~40% of
+neqo's coverage because we're not reimplementing CRYPTO retransmit,
+0-RTT, handshake-space PTO, etc.
+
+## File-by-file implementation order
+
+Each step is its own commit; each commit must compile + pass tests
+before moving on.
+
+### Step 1: types only (no behavior)
+
+- New: `quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/recovery/RecoveryToken.kt`
+- New: `quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/recovery/SentPacket.kt`
+- Test: `quic/src/commonTest/.../recovery/RecoveryTokenTest.kt`
+- No other code touched. Compiles, types ready for next step.
+
+### Step 2: track sent packets in `QuicConnection`
+
+- Add `sentApplicationPackets: MutableMap<Long, SentPacket>` to `QuicConnection.application`.
+- `QuicConnectionWriter.buildApplicationPacket` builds a `tokens: List<RecoveryToken>` alongside its `frames`, returns both.
+- On packet emission, store a `SentPacket` keyed by PN.
+- Existing tests still pass; new behavior dormant (no loss detection yet).
+
+### Step 3: drain on ACK
+
+- `QuicConnectionParser.AckFrame` handler walks ACK ranges, removes `SentPacket` entries.
+- Test: ACK removes a sent packet's tokens. ACK out of order is fine.
+
+### Step 4: receiver-flow-control `pending*` companion fields
+
+- Add `pendingMaxStreamsUni: Long?`, `pendingMaxStreamsBidi: Long?`, `pendingMaxData: Long?` to `QuicConnection`.
+- Add per-stream `pendingMaxStreamData` map (small).
+- `appendFlowControlUpdates` drains pending* first, only then runs the normal threshold check.
+- Tests: mirror the 9 `fc.rs` tests above. Pure unit-level.
+
+### Step 5: loss detection algorithm
+
+- New: `quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/recovery/QuicLossDetection.kt`.
+- Implements packet-threshold + time-threshold per RFC 9002 §6.1.
+- Hooks into ACK handler: each new ACK runs `detectLost(now)`.
+- Tests: mirror the 20 `recovery/mod.rs` tests.
+
+### Step 6: dispatch lost tokens
+
+- `QuicConnection.onTokensLost(tokens)` dispatches each token to its `pending*` field.
+- Wire the dispatch into the loss-detection callback.
+- Tests: integration — send MAX_STREAMS, drop the packet, verify retransmit happens on next outbound. (~3 tests.)
+
+### Step 7: PTO
+
+- New: `quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/recovery/Pto.kt`.
+- Implements §6.2 PTO timer. Schedules wake-up; on expiry, emits a PING (if nothing else queued) or re-uses the pending retransmit machinery.
+- `QuicConnectionDriver.sendLoop` learns to wake on PTO.
+- Tests: mirror the ~7 PTO tests from neqo.
+
+### Step 8: integration test against `FakeWebTransport`
+
+- New: `nestsClient/src/commonTest/.../moq/lite/MoqLiteSessionRetransmitTest.kt` — drops a specific packet between client and server, asserts MAX_STREAMS retransmit lands and audio keeps flowing.
+- This is what we couldn't write before; now we can.
+
+### Step 9: revert the cap workaround (optional)
+
+Once the retransmit path is durable, optionally revert
+`initialMaxStreamsUni` from 1 000 000 back to a smaller value
+(e.g. 1 000) so the bump path actually exercises in production.
+Keeps the rolling-extension code path warm and validates retransmit
+is healthy. Probably gate this on having shipped the retransmit
+work for at least a week without regressions.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Existing `:quic` tests written against "send-and-forget" semantics break | Step 2 is purely additive; existing tests still see send-and-forget behavior because nothing reads the `sentApplicationPackets` map until step 5. |
+| Token tracking grows unbounded if ACK never arrives | RFC 9002 §6.5: declare lost on time threshold; lost packets evicted on `kPacketDeclaredLostThreshold` after eviction window. We bound the map by both ACK and loss declarations. |
+| RTT estimation is wrong → false-positive losses | Same RTT estimation logic as neqo, conservative defaults (initial RTT 333 ms per RFC 9002 §6.2.2). |
+| PTO timer interacts with the existing send loop | Step 7 is the trickiest; bake in conservative tests that simulate slow-network conditions. |
+| Memory: at 10 streams/sec a 2-hour session has ~72k tracked sent packets if no ACKs arrive | Bounded by ACK arrival; if ACKs are missing for long enough we'd PTO-out and close. Realistic ACK cadence is sub-second so the map stays small (a few hundred entries). |
+
+## Effort
+
+4–7 days for a full pass with tests. Steps 1–4 are 1–2 days; steps 5–7 are the bulk; step 8 is a day; step 9 is trivial. The test count is the dominant cost — each ported test is ~30 lines of Kotlin.
+
+## Acceptance criteria
+
+- All ~50 ported tests pass.
+- `NostrnestsProdAudioTransmissionTest` (existing JVM interop test) continues to pass against production.
+- A new `MoqLiteSessionRetransmitTest` simulates packet loss at the moment of `MAX_STREAMS_UNI` emission and confirms audio continues flowing past the threshold.
+- Existing `QuicConnectionWriterTest`, `PeerStreamCreditExtensionTest`, etc. unchanged.
+- No regression in handshake latency or throughput under steady-state.

--- a/quic/plans/2026-05-05-congestion-control.md
+++ b/quic/plans/2026-05-05-congestion-control.md
@@ -1,0 +1,324 @@
+# Congestion control for `:quic` — implementation plan
+
+**Status:** plan, not started.
+
+## Why (and why this is honestly low-priority)
+
+`:quic` has loss detection (RFC 9002 §6) and per-frame retransmit
+(shipped 2026-05-05; see [`2026-05-04-control-frame-retransmit.md`](2026-05-04-control-frame-retransmit.md))
+but no rate limiter — we send as fast as the application provides
+bytes. For our actual production workload, that's fine:
+
+- Audio rooms push ~8 KB/sec (Opus at 64 kbps). Way under any modern
+  link capacity. Not a single audio Nest has wedged on rate so far.
+- `nostrnests.com` (moq-rs relay) is forwarding, not absorbing — the
+  bottleneck is per-subscriber stream-id cap, not bandwidth. The
+  retransmit subsystem already addresses that.
+- The "stream cliff" investigation
+  ([`nestsClient/plans/2026-05-01-quic-stream-cliff-investigation.md`](../../nestsClient/plans/2026-05-01-quic-stream-cliff-investigation.md))
+  found nothing CC-shaped — the issues were stream-id exhaustion +
+  per-subscriber forward queue overflow, both fixed by other means.
+
+Where it actually matters:
+
+1. **Bufferbloat on slow links.** A user on a degraded mobile connection
+   (slow Wi-Fi, train tunnel, congested LTE cell) — without CC we keep
+   sending into a full router queue, RTT inflates, and the listener
+   experiences stale audio rather than back-pressured cleaner audio.
+2. **Multi-flow fairness.** A single audio Nest sharing a slow uplink
+   with a download — we'd grab unfair share and the download stalls
+   (or vice versa).
+3. **Burst handling after a stall.** When a paused listener reconnects,
+   the relay forwards a burst of cached frames. Without CC, the burst
+   either floods the path or causes immediate loss.
+4. **Being a good citizen.** Every other QUIC stack in the wild
+   implements CC. Without it we look like a misbehaving client; some
+   relays/middleboxes might rate-limit us heuristically.
+
+None of these are urgent, none are user-visible bugs today, and the
+retransmit subsystem we just shipped is what the audio cliff actually
+needed. **This plan stays open as the natural next item but should not
+be prioritised over field-validation of the retransmit work.**
+
+## Reference
+
+We follow [RFC 9002 §7 NewReno](https://www.rfc-editor.org/rfc/rfc9002#section-7)
+— the QUIC-flavored NewReno reference algorithm. Three reasons:
+
+- It's the RFC's reference algorithm. Other stacks treat it as the
+  baseline; if/when we ever interop-test against quiche/neqo with CC
+  enabled, this is the variant they all support and verify.
+- It's ~200 lines of Kotlin without pacing — the smallest credible CC
+  implementation. Cubic is +200 lines for a modest win; BBR is +1500
+  for a much bigger win (and a much bigger maintenance surface).
+- Loss-based AIMD pairs naturally with the loss-detection +
+  retransmit machinery already in place. Nothing new is needed in
+  loss detection itself; CC just consumes the loss signal.
+
+We mirror neqo's `cc/classic_cc.rs` shape because it's the cleanest
+NewReno implementation we've found. If we later want CUBIC, neqo's
+`cc/cubic.rs` is the obvious follow-up.
+
+## Scope
+
+**In scope (this plan):**
+
+- NewReno per RFC 9002 §7 (slow start + congestion avoidance + recovery).
+- Bytes-in-flight tracker.
+- Send-side gating: writer checks `bytesInFlight + packetSize <= cwnd`
+  before emitting ack-eliciting packets.
+- Persistent-congestion handling (RFC 9002 §7.6): N consecutive PTOs
+  collapse cwnd to the minimum.
+
+**Out of scope (separate follow-ups):**
+
+- **Pacing** (RFC 9002 §7.7). Audio at 50 packets/sec is already
+  paced by the Opus encoder cadence; bursts are ≤ a few packets.
+  Add when a real burst-loss problem is observed.
+- **CUBIC** ([RFC 9438](https://www.rfc-editor.org/rfc/rfc9438)). Modest
+  throughput win on long-RTT paths; not worth the complexity until we
+  have a measured throughput regression.
+- **BBR** (Google draft). Big throughput / fairness win on
+  bottleneck-buffered paths; way out of scope.
+- **ECN** (RFC 9000 §13.4 + RFC 9002 §B.4). Requires both the OS
+  network stack to set ECN bits and the peer to reflect ECN counts in
+  ACK frames. Defer until we hear from a peer that supports ECN.
+- **0-RTT cwnd preservation**. We don't speak 0-RTT.
+- **HyStart++** (RFC 9406). Slow-start exit heuristic; minor refinement.
+
+## Architecture
+
+### `CongestionController`
+
+New class at `quic/.../connection/recovery/CongestionController.kt`.
+Mirrors neqo's `cc/classic_cc.rs`.
+
+```kotlin
+class CongestionController(
+    private val maxDatagramSize: Int = 1200,
+) {
+    /** RFC 9002 §B.2 — initial cwnd is min(10 * MSS, max(2 * MSS, 14720)). */
+    var congestionWindow: Long = minOf(10L * maxDatagramSize, maxOf(2L * maxDatagramSize, 14720L))
+        private set
+
+    /** Sum of sizes of all ack-eliciting in-flight packets. */
+    var bytesInFlight: Long = 0L
+        private set
+
+    /** ssthresh — initially infinity (= Long.MAX_VALUE). */
+    var slowStartThreshold: Long = Long.MAX_VALUE
+        private set
+
+    /** RFC 9002 §B.2 — once cwnd >= ssthresh we're in CA. */
+    val inSlowStart: Boolean get() = congestionWindow < slowStartThreshold
+
+    /**
+     * RFC 9002 §7.3.2 — start of the most recent congestion-recovery
+     * period. Loss events with `sentAt <= recoveryStart` don't trigger
+     * a fresh halving (we already responded to that loss epoch).
+     */
+    private var recoveryStartTimeMs: Long? = null
+
+    /** Caller checks before emitting ack-eliciting bytes. */
+    fun canSend(packetSize: Int): Boolean = bytesInFlight + packetSize <= congestionWindow
+
+    fun onPacketSent(sentPacket: SentPacket) { /* +bytesInFlight */ }
+    fun onPacketAcked(sentPacket: SentPacket) { /* -bytesInFlight + grow cwnd */ }
+    fun onPacketLost(sentPacket: SentPacket, nowMs: Long) { /* -bytesInFlight + maybe halve */ }
+    fun onPersistentCongestion() { /* cwnd = MIN_CWND, slow-start again */ }
+    fun onPacketDiscarded(sentPacket: SentPacket) { /* key-discard path: -bytesInFlight, no cwnd change */ }
+}
+```
+
+### Send-side gating
+
+`QuicConnectionWriter.drainOutbound` consults the controller before
+emitting an ack-eliciting packet.
+
+```kotlin
+val packet = buildApplicationPacket(...)
+if (packet != null && packet.ackEliciting && !cc.canSend(packet.size)) {
+    // Park the packet — return null so the driver waits for an ACK
+    // (which will free cwnd) or for the PTO timer to fire.
+    return null
+}
+```
+
+ACK-only packets bypass the gate per RFC 9002 §7.2 ("ACK frames…
+do not count toward bytes_in_flight").
+
+PTO probes also bypass — RFC 9002 §6.2 says PTO probes MUST be sent
+regardless of cwnd ("an endpoint can send packets in excess of the
+congestion window when sending probe packets"). Existing
+`pendingPing` flag is the integration point.
+
+### Hook integration
+
+| Existing hook | New CC call |
+|---|---|
+| `QuicConnectionWriter.buildApplicationPacket` records SentPacket | `cc.onPacketSent(sp)` after recording (only if ackEliciting) |
+| `QuicConnectionParser` ACK handler iterates drained packets | `cc.onPacketAcked(sp)` per drained ack-eliciting packet |
+| `QuicConnection.onTokensLost` (RFC 9002 §6) iterates lost set | `cc.onPacketLost(sp, nowMs)` per lost ack-eliciting packet |
+| `LevelState.discardKeys()` clears Initial/Handshake sentPackets | `cc.onPacketDiscarded(sp)` per cleared packet (decrement only) |
+| PTO fires `pendingPing = true` | `cc.consecutivePtoCount` tracking — at N=3, `cc.onPersistentCongestion()` |
+
+### NewReno math
+
+Slow start (`cwnd < ssthresh`):
+- On each ACK: `cwnd += acked_bytes`. (Exponential growth — doubles per RTT.)
+
+Congestion avoidance (`cwnd >= ssthresh`):
+- On each ACK: `cwnd += MSS * acked_bytes / cwnd`. (Linear growth — +MSS per RTT.)
+
+Loss event (RFC 9002 §7.3.2):
+- If `sentPacket.sentAtMs > recoveryStartTimeMs ?: -1`:
+  - `recoveryStartTimeMs = nowMs`
+  - `ssthresh = cwnd / 2`
+  - `cwnd = max(ssthresh, MIN_CWND)`  // MIN_CWND = 2 * MSS
+- Else: in same recovery period, don't double-halve.
+
+Persistent congestion (RFC 9002 §7.6):
+- `cwnd = MIN_CWND`
+- `recoveryStartTimeMs = null`
+- Slow-start kicks in again.
+
+## File-by-file plan
+
+Each step compiles + passes existing tests before moving on.
+
+### Step 1: type stub
+
+- New `CongestionController.kt` with the public API + `canSend` (always
+  true) + no-op hooks.
+- Wired as `QuicConnection.cc: CongestionController`.
+- Existing tests still pass; nothing observable changes.
+
+### Step 2: bytesInFlight tracking
+
+- Implement `onPacketSent` + `onPacketAcked` + `onPacketLost` +
+  `onPacketDiscarded` to manage `bytesInFlight` only — leave cwnd
+  fixed at the initial value.
+- Wire from the writer (after SentPacket recording), parser (ACK
+  drain loop), `onTokensLost` dispatch, and `LevelState.discardKeys()`.
+- Test: `BytesInFlightTrackingTest` — invariants under send / ack /
+  loss / discard / mixed.
+
+### Step 3: slow-start growth
+
+- Implement the slow-start branch of `onPacketAcked` (cwnd += acked).
+- Test: `SlowStartGrowthTest` — cwnd doubles per RTT in steady-state
+  ACK arrival.
+
+### Step 4: congestion-avoidance growth
+
+- Implement the CA branch (cwnd += MSS * acked / cwnd).
+- Wire ssthresh — initial Long.MAX_VALUE means we never enter CA
+  unless a loss has happened. We'll exercise this in step 5.
+- Test: `CongestionAvoidanceGrowthTest` — cwnd grows ≈+MSS per RTT
+  once `cwnd >= ssthresh`.
+
+### Step 5: loss reaction
+
+- Implement `onPacketLost` cwnd-halve + recovery-period gating.
+- Test: `LossReactionTest` — single loss halves; second loss in same
+  period doesn't re-halve; loss after recovery period elapses
+  re-halves.
+
+### Step 6: send-side gating
+
+- Wire `cc.canSend(packetSize)` into the writer.
+- ACK-only path bypasses (writer already distinguishes; we just need
+  to compute the projected packet size).
+- PTO probe path bypasses (writer's `pendingPing` branch).
+- Test: `SendGatingTest` — driver returns null when bytesInFlight ≥
+  cwnd; resumes after ACK frees cwnd.
+
+### Step 7: persistent congestion
+
+- Track consecutive-PTO count (already on QuicConnection as
+  `consecutivePtoCount`).
+- At N=3 (RFC 9002 §B.6 — `kPersistentCongestionThreshold` = 3 PTOs
+  worth of time, simplified as 3 consecutive PTO fires here),
+  call `cc.onPersistentCongestion()`.
+- Test: `PersistentCongestionTest` — 3 consecutive PTOs collapse cwnd
+  to min.
+
+### Step 8: integration test
+
+- New `nestsClient/.../moq/lite/MoqLiteSessionCongestionTest.kt`:
+  simulate a 100ms-RTT path with 1% loss; observe cwnd settling
+  around the bandwidth-delay product; audio continues without
+  unbounded queue growth on either side.
+- Maybe also an in-process-pipe variant under `quic/...` that injects
+  loss at a rate above what the receiver's ACK can keep up with;
+  observe the gate engaging.
+
+### Step 9: documentation
+
+- Update [`2026-04-26-quic-stack-status.md`](2026-04-26-quic-stack-status.md):
+  Phase F flips from "done (no CC)" to "done"; "no congestion control"
+  removed from deferred-work list.
+
+## Test inventory mirrored from neqo
+
+Total: ~12 unit tests + 2 integration tests = 14 new tests.
+
+| neqo test (cc/classic_cc.rs) | Asserts | Our equivalent |
+|---|---|---|
+| `init` | initial cwnd matches RFC 9002 §B.2 | `CongestionControllerTest.initialCwnd` |
+| `slow_start` | each ACK doubles cwnd in slow-start | `SlowStartGrowthTest.basicGrowth` |
+| `slow_start_to_ca` | crossing ssthresh transitions to CA | `SlowStartGrowthTest.crossesSsthreshIntoCa` |
+| `ca_growth` | linear growth in CA | `CongestionAvoidanceGrowthTest.linearGrowth` |
+| `loss_event_halves` | first loss halves cwnd, sets ssthresh | `LossReactionTest.firstLossHalves` |
+| `recovery_period_suppresses_re_halving` | second loss in same period no-op | `LossReactionTest.secondLossInPeriodSuppressed` |
+| `loss_after_recovery_re_halves` | loss after recovery period re-halves | `LossReactionTest.lossAfterRecoveryRehalves` |
+| `cwnd_floor_min_window` | cwnd never drops below 2 * MSS | `LossReactionTest.cwndFloor` |
+| `app_limited_no_growth` | app-limited path freezes cwnd | `AppLimitedTest.noGrowthWhenAppLimited` |
+| `bytes_in_flight_tracking` | invariants under send / ack / loss | `BytesInFlightTrackingTest.allHooks` |
+| `persistent_congestion_resets_to_min` | 3 consecutive PTOs → min cwnd | `PersistentCongestionTest.threeConsecutivePtos` |
+| `key_discard_decrements_in_flight` | key-discard path correctly drops in-flight bytes | `BytesInFlightTrackingTest.keyDiscardDecrements` |
+| `gating_blocks_send_at_cap` | writer returns null when at cwnd cap | `SendGatingTest.blocksAtCap` |
+| `gating_resumes_after_ack` | ACK frees cwnd, send resumes | `SendGatingTest.resumesAfterAck` |
+
+Plus 2 integration tests as listed in step 8.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Throughput regression on good networks (cwnd starts at 14 KB and grows) | Initial 10 * MSS = ~12 KB. RTT 50 ms steady-state means cwnd doubles every 50 ms; saturation at link bandwidth in seconds. For audio at 8 KB/sec we never approach the cap. |
+| Send-gate stalls audio when cwnd shrinks | PTO probe path bypasses cwnd. Worst case: a cwnd-blocked send waits for ACK + RTT. Audio room jitter buffer hides this. |
+| Off-by-one in loss-event recovery-period gating | Mirror neqo's `time > recovery_start` strict comparison + tests. |
+| Persistent-congestion false trigger | We use the conservative "3 consecutive PTOs" simplification; the strict RFC 9002 §B.6 definition needs a duration check we can add later. Risk is collapsing cwnd unnecessarily — surfaces as audio stall the user can fix by reconnecting. |
+| Interaction with existing per-frame retransmit | None expected — retransmit operates on lost-token dispatch; CC operates on packet sizes. They're orthogonal. |
+| `SendBuffer.takeChunk` doesn't know cwnd | The gate is at `drainOutbound` granularity — packet-level, not chunk-level. SendBuffer remains unchanged. |
+
+## Effort
+
+Realistic: **3–5 days** of focused work. Steps 1–4 ~1 day; steps 5–7
+~2 days; integration test + doc ~1 day; bug-fixing slack 1 day.
+
+## Acceptance criteria
+
+- All ~14 ported tests pass.
+- Existing `:quic` test suite unchanged (`QuicLossDetectionTest`,
+  `RetransmitIntegrationTest`, `KeyDiscardTest`, etc.).
+- `MoqLiteSessionCongestionTest` lossy-path scenario shows cwnd
+  settling to a steady-state value rather than growing unboundedly.
+- `NestsListenerProdTest` (existing JVM interop test against
+  nostrnests.com) continues to pass with the gate wired in.
+- No regression in handshake latency or audio start-up time.
+
+## Open questions
+
+- **What's the right `kPersistentCongestionThreshold`?** Simplified
+  here as "3 consecutive PTOs without any ACK". Strict RFC version
+  uses a duration formula that requires more PTO bookkeeping. Keep it
+  simple unless field data suggests we're collapsing too aggressively.
+- **MTU.** We use `maxDatagramSize = 1200` everywhere (no PMTUD).
+  CC sizes off this constant. If we ever add PMTUD this needs to
+  reflow. Track as a note for the PMTUD plan.
+- **Should the gate be per-space?** RFC 9002 §B.4 ties cwnd to a
+  single congestion controller, not per-pn-space. We follow the RFC.
+  Initial / Handshake bytes count toward cwnd until the level is
+  discarded; that's correct per the spec.

--- a/quic/plans/2026-05-05-congestion-control.md
+++ b/quic/plans/2026-05-05-congestion-control.md
@@ -1,6 +1,19 @@
 # Congestion control for `:quic` — implementation plan
 
-**Status:** plan, not started.
+**Status:** **parked indefinitely 2026-05-05.** After drafting this
+plan we concluded the audio-rooms workload doesn't actually need CC —
+see [Why](#why-and-why-this-is-honestly-low-priority) below. The one
+real concern that surfaced (STREAM retransmit wasting bandwidth on
+stale Opus frames) is addressed by a much smaller fix — a
+`bestEffort` flag on `SendBuffer` that drops lost ranges instead of
+retransmitting them, set by moq-lite for group streams. That
+follow-up landed on the same branch.
+
+This plan is preserved as a reference if a future workload (large
+file transfer over `:quic`, multiple concurrent media streams,
+running on heavily-shared mobile uplinks with hostile routers) ever
+makes CC necessary. The architecture below is sound; we just don't
+have a problem big enough to justify the implementation cost today.
 
 ## Why (and why this is honestly low-priority)
 

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/LevelState.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/LevelState.kt
@@ -27,11 +27,18 @@ import com.vitorpamplona.quic.stream.SendBuffer
 /** Per-encryption-level state owned by [QuicConnection]. */
 class LevelState {
     val pnSpace = PacketNumberSpaceState()
-    val ackTracker =
+
+    var ackTracker =
         com.vitorpamplona.quic.recovery
             .AckTracker()
-    val cryptoSend = SendBuffer()
-    val cryptoReceive = ReceiveBuffer()
+        private set
+
+    var cryptoSend = SendBuffer()
+        private set
+
+    var cryptoReceive = ReceiveBuffer()
+        private set
+
     var sendProtection: PacketProtection? = null
     var receiveProtection: PacketProtection? = null
 
@@ -66,4 +73,53 @@ class LevelState {
      * Null until an ACK arrives.
      */
     var largestAckedSentTimeMs: Long? = null
+
+    /**
+     * RFC 9001 §4.9: latches true once [discardKeys] runs. Used by
+     * the writer / parser to short-circuit operations on a discarded
+     * level (parser already drops packets via the
+     * [receiveProtection] null check; this flag is for the symmetry
+     * tests + future code that wants to assert "level is dead").
+     */
+    var keysDiscarded: Boolean = false
+        private set
+
+    /**
+     * RFC 9001 §4.9: drop all key material + buffered state for this
+     * encryption level once the level is no longer needed. Idempotent.
+     *
+     *   - §4.9.1: a client MUST discard Initial keys when it first
+     *     sends a Handshake packet. Trigger lives in
+     *     [com.vitorpamplona.quic.connection.QuicConnectionWriter] —
+     *     after we build a Handshake-level packet, we discard Initial.
+     *   - §4.9.2: an endpoint MUST discard Handshake keys when the
+     *     handshake is confirmed. Per §4.1.2 a client confirms the
+     *     handshake on receipt of a HANDSHAKE_DONE frame; the trigger
+     *     lives in [com.vitorpamplona.quic.connection.QuicConnectionParser].
+     *
+     * Frees the AEAD cipher state, drops any unsent / unacked CRYPTO
+     * bytes (no longer reachable since they were handshake-only), and
+     * resets the loss-detection accounting. Future inbound packets at
+     * this encryption level are dropped silently because
+     * [receiveProtection] is null. Future outbound builds skip the
+     * level for the same reason on [sendProtection].
+     *
+     * The class-level docstring on [LevelState] still describes the
+     * fields as if they're permanent; after [discardKeys] those
+     * descriptions only apply while [keysDiscarded] is false.
+     */
+    fun discardKeys() {
+        if (keysDiscarded) return
+        sendProtection = null
+        receiveProtection = null
+        cryptoSend = SendBuffer()
+        cryptoReceive = ReceiveBuffer()
+        ackTracker =
+            com.vitorpamplona.quic.recovery
+                .AckTracker()
+        sentPackets.clear()
+        largestAckedPn = null
+        largestAckedSentTimeMs = null
+        keysDiscarded = true
+    }
 }

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/LevelState.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/LevelState.kt
@@ -50,4 +50,20 @@ class LevelState {
      * [QuicConnection.lock].
      */
     val sentPackets: MutableMap<Long, SentPacket> = HashMap()
+
+    /**
+     * RFC 9002 §6.1 largest acknowledged packet number observed
+     * by an inbound ACK in this space. Updated only when the ACK
+     * advances it — duplicate ACKs do not move the value.
+     * Used as the high-water mark for packet-threshold loss detection.
+     */
+    var largestAckedPn: Long? = null
+
+    /**
+     * Send time (epoch ms, from the writer's `nowMillis` source) of
+     * the SentPacket whose PN is [largestAckedPn]. Used to compute
+     * the RTT sample on a newly-advancing ACK (RFC 9002 §5.2).
+     * Null until an ACK arrives.
+     */
+    var largestAckedSentTimeMs: Long? = null
 }

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/LevelState.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/LevelState.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.quic.connection
 
+import com.vitorpamplona.quic.connection.recovery.SentPacket
 import com.vitorpamplona.quic.stream.ReceiveBuffer
 import com.vitorpamplona.quic.stream.SendBuffer
 
@@ -33,4 +34,20 @@ class LevelState {
     val cryptoReceive = ReceiveBuffer()
     var sendProtection: PacketProtection? = null
     var receiveProtection: PacketProtection? = null
+
+    /**
+     * Per-packet retention for RFC 9002 loss detection + retransmit.
+     * Populated by [QuicConnectionWriter] when a packet is built;
+     * drained by the ACK handler in [QuicConnectionParser] (step 3 of
+     * `quic/plans/2026-05-04-control-frame-retransmit.md`) and by
+     * loss detection (step 5).
+     *
+     * Keyed by packet number. Step 2 only populates this map for
+     * Application-level packets — Initial / Handshake-level
+     * retransmit (CRYPTO) is out of scope, see plan.
+     *
+     * Caller of any read/write to this map must hold
+     * [QuicConnection.lock].
+     */
+    val sentPackets: MutableMap<Long, SentPacket> = HashMap()
 }

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.quic.connection
 
+import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quic.crypto.AesEcbHeaderProtection
 import com.vitorpamplona.quic.crypto.InitialSecrets
 import com.vitorpamplona.quic.crypto.PlatformAesOneBlock
@@ -635,8 +636,20 @@ class QuicConnection(
         // [config.initialMaxStreams*] is the lifetime maximum the peer
         // can open and any longer broadcast silently truncates.
         when (kind) {
-            StreamId.Kind.SERVER_UNI, StreamId.Kind.CLIENT_UNI -> peerInitiatedUniCount += 1
-            StreamId.Kind.SERVER_BIDI, StreamId.Kind.CLIENT_BIDI -> peerInitiatedBidiCount += 1
+            StreamId.Kind.SERVER_UNI, StreamId.Kind.CLIENT_UNI -> {
+                peerInitiatedUniCount += 1
+                if (peerInitiatedUniCount % 25L == 0L) {
+                    Log.d("NestQuic") {
+                        "peerInitiatedUniCount=$peerInitiatedUniCount " +
+                            "advertisedMaxStreamsUni=$advertisedMaxStreamsUni " +
+                            "(headroom=${advertisedMaxStreamsUni - peerInitiatedUniCount})"
+                    }
+                }
+            }
+
+            StreamId.Kind.SERVER_BIDI, StreamId.Kind.CLIENT_BIDI -> {
+                peerInitiatedBidiCount += 1
+            }
         }
         // Wake any awaitIncomingPeerStream caller. trySend on a CONFLATED
         // channel can never fail in steady state.

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
@@ -206,26 +206,13 @@ class QuicConnection(
     internal val pendingMaxStreamData: MutableMap<Long, Long> = HashMap()
 
     /**
-     * Pending retransmits for `RESET_STREAM` frames (RFC 9000 §19.4).
-     * Keyed by stream id; the dispatcher records lost RESET_STREAM
-     * tokens here. `:quic` has no emit path for RESET_STREAM today,
-     * so the writer never drains this map — scaffolding for future
-     * stream-reset support. Caller must hold [lock].
-     */
-    internal val pendingResetStream:
-        MutableMap<Long, com.vitorpamplona.quic.connection.recovery.RecoveryToken.ResetStream> = HashMap()
-
-    /**
-     * Pending retransmits for `STOP_SENDING` frames (RFC 9000 §19.5).
-     * Same scaffolding-only status as [pendingResetStream].
-     */
-    internal val pendingStopSending:
-        MutableMap<Long, com.vitorpamplona.quic.connection.recovery.RecoveryToken.StopSending> = HashMap()
-
-    /**
      * Pending retransmits for `NEW_CONNECTION_ID` frames (RFC 9000
-     * §19.15). Keyed by sequenceNumber. Same scaffolding-only status
-     * as [pendingResetStream].
+     * §19.15). Keyed by sequence number. Populated on loss via
+     * [onTokensLost]; drained by the writer on the next outbound.
+     * Connection-ID rotation isn't currently triggered by any
+     * application path inside `:quic`, so the public emit API is
+     * limited to test usage — but the retransmit machinery is
+     * complete so any future emit path lands cleanly.
      */
     internal val pendingNewConnectionId:
         MutableMap<Long, com.vitorpamplona.quic.connection.recovery.RecoveryToken.NewConnectionId> = HashMap()
@@ -790,13 +777,28 @@ class QuicConnection(
                 is com.vitorpamplona.quic.connection.recovery.RecoveryToken.MaxStreamsBidi,
                 is com.vitorpamplona.quic.connection.recovery.RecoveryToken.MaxData,
                 is com.vitorpamplona.quic.connection.recovery.RecoveryToken.MaxStreamData,
-                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.ResetStream,
-                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.StopSending,
                 is com.vitorpamplona.quic.connection.recovery.RecoveryToken.NewConnectionId,
                 -> {
-                    // Control frames have no per-buffer state to release on
-                    // ACK. (Pending* maps are populated only on loss; an ACK
-                    // for a frame that never lost is naturally absent.)
+                    // Flow-control extensions and NEW_CONNECTION_ID
+                    // have no per-buffer state to release on ACK; the
+                    // pending* maps are populated only on loss, so an
+                    // ACK for a frame that never lost is naturally
+                    // absent.
+                }
+
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.ResetStream -> {
+                    // Latch resetAcked = true. Subsequent loss
+                    // notifications for stale RESET_STREAM tokens are
+                    // dropped (see onTokensLost).
+                    val stream = streamByIdLocked(token.streamId) ?: continue
+                    stream.resetAcked = true
+                    stream.resetEmitPending = false
+                }
+
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.StopSending -> {
+                    val stream = streamByIdLocked(token.streamId) ?: continue
+                    stream.stopSendingAcked = true
+                    stream.stopSendingEmitPending = false
                 }
 
                 is com.vitorpamplona.quic.connection.recovery.RecoveryToken.Stream -> {
@@ -888,16 +890,19 @@ class QuicConnection(
                 }
 
                 is com.vitorpamplona.quic.connection.recovery.RecoveryToken.ResetStream -> {
-                    // Reliable per RFC 9000 §13.3 — re-emit verbatim
-                    // on loss. `:quic` doesn't currently have an emit
-                    // path for RESET_STREAM, so the pending-list is
-                    // populated but never drained today; the field is
-                    // scaffolding for future emit support.
-                    pendingResetStream[token.streamId] = token
+                    // Reliable per RFC 9000 §13.3. Re-flag the
+                    // owning stream's RESET_STREAM emit pending so
+                    // the next writer drain re-emits — unless the
+                    // peer already ACK'd it (resetAcked == true), in
+                    // which case the lost token is a stale duplicate
+                    // and we drop it.
+                    val stream = streamByIdLocked(token.streamId) ?: continue
+                    if (!stream.resetAcked) stream.resetEmitPending = true
                 }
 
                 is com.vitorpamplona.quic.connection.recovery.RecoveryToken.StopSending -> {
-                    pendingStopSending[token.streamId] = token
+                    val stream = streamByIdLocked(token.streamId) ?: continue
+                    if (!stream.stopSendingAcked) stream.stopSendingEmitPending = true
                 }
 
                 is com.vitorpamplona.quic.connection.recovery.RecoveryToken.NewConnectionId -> {

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
@@ -767,6 +767,58 @@ class QuicConnection(
     internal fun streamByIdLocked(id: Long): QuicStream? = streams[id]
 
     /**
+     * ACK-path counterpart to [onTokensLost]. Called by the parser
+     * after [com.vitorpamplona.quic.connection.recovery.drainAckedSentPackets]
+     * removes the carrying packet from the sent map. Tokens whose
+     * underlying byte ranges live in a [com.vitorpamplona.quic.stream.SendBuffer]
+     * (Stream / Crypto) trigger a [com.vitorpamplona.quic.stream.SendBuffer.markAcked]
+     * call so the buffer can advance its flushedFloor and release
+     * memory. Other token types are ACK-no-ops (the peer's
+     * acknowledgment of a control frame doesn't require any local
+     * action — the frame already did its job by reaching the peer).
+     *
+     * Caller must hold [lock].
+     */
+    internal fun onTokensAcked(tokens: List<com.vitorpamplona.quic.connection.recovery.RecoveryToken>) {
+        for (token in tokens) {
+            when (token) {
+                com.vitorpamplona.quic.connection.recovery.RecoveryToken.Ack -> {
+                    // ACK-of-ACK is a no-op.
+                }
+
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.MaxStreamsUni,
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.MaxStreamsBidi,
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.MaxData,
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.MaxStreamData,
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.ResetStream,
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.StopSending,
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.NewConnectionId,
+                -> {
+                    // Control frames have no per-buffer state to release on
+                    // ACK. (Pending* maps are populated only on loss; an ACK
+                    // for a frame that never lost is naturally absent.)
+                }
+
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.Stream -> {
+                    val stream = streamByIdLocked(token.streamId) ?: continue
+                    stream.send.markAcked(offset = token.offset, length = token.length)
+                    if (token.length == 0L && token.fin) {
+                        // FIN-only ACK: treat as zero-length ACK at offset.
+                        // markAcked already handles length==0 ⇒ FIN match.
+                    }
+                }
+
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.Crypto -> {
+                    levelState(token.level).cryptoSend.markAcked(
+                        offset = token.offset,
+                        length = token.length,
+                    )
+                }
+            }
+        }
+    }
+
+    /**
      * Step 6 of `quic/plans/2026-05-04-control-frame-retransmit.md`:
      * dispatch the tokens of declared-lost packets to the matching
      * `pending*` field, applying the supersede check from neqo's

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
@@ -477,8 +477,16 @@ class QuicConnection(
             stream
         }
 
-    /** Allocate a new client-initiated unidirectional (write-only) stream. Locked. */
-    suspend fun openUniStream(): QuicStream =
+    /**
+     * Allocate a new client-initiated unidirectional (write-only) stream.
+     * Locked.
+     *
+     * If [bestEffort] is true, the stream's [SendBuffer] drops lost
+     * ranges instead of retransmitting them (see
+     * [QuicStream.bestEffort]). Used for moq-lite group streams
+     * carrying real-time Opus audio.
+     */
+    suspend fun openUniStream(bestEffort: Boolean = false): QuicStream =
         lock.withLock {
             if (nextLocalUniIndex >= peerMaxStreamsUni) {
                 throw QuicStreamLimitException(
@@ -487,7 +495,7 @@ class QuicConnection(
                 )
             }
             val id = StreamId.build(StreamId.Kind.CLIENT_UNI, nextLocalUniIndex++)
-            val stream = QuicStream(id, QuicStream.Direction.UNIDIRECTIONAL_LOCAL_TO_REMOTE)
+            val stream = QuicStream(id, QuicStream.Direction.UNIDIRECTIONAL_LOCAL_TO_REMOTE, bestEffort = bestEffort)
             stream.sendCredit = peerTransportParameters?.initialMaxStreamDataUni ?: config.initialMaxStreamDataUni
             stream.receiveLimit = 0L // can't receive
             streams[id] = stream

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
@@ -206,6 +206,31 @@ class QuicConnection(
     internal val pendingMaxStreamData: MutableMap<Long, Long> = HashMap()
 
     /**
+     * Pending retransmits for `RESET_STREAM` frames (RFC 9000 §19.4).
+     * Keyed by stream id; the dispatcher records lost RESET_STREAM
+     * tokens here. `:quic` has no emit path for RESET_STREAM today,
+     * so the writer never drains this map — scaffolding for future
+     * stream-reset support. Caller must hold [lock].
+     */
+    internal val pendingResetStream:
+        MutableMap<Long, com.vitorpamplona.quic.connection.recovery.RecoveryToken.ResetStream> = HashMap()
+
+    /**
+     * Pending retransmits for `STOP_SENDING` frames (RFC 9000 §19.5).
+     * Same scaffolding-only status as [pendingResetStream].
+     */
+    internal val pendingStopSending:
+        MutableMap<Long, com.vitorpamplona.quic.connection.recovery.RecoveryToken.StopSending> = HashMap()
+
+    /**
+     * Pending retransmits for `NEW_CONNECTION_ID` frames (RFC 9000
+     * §19.15). Keyed by sequenceNumber. Same scaffolding-only status
+     * as [pendingResetStream].
+     */
+    internal val pendingNewConnectionId:
+        MutableMap<Long, com.vitorpamplona.quic.connection.recovery.RecoveryToken.NewConnectionId> = HashMap()
+
+    /**
      * RFC 9002 RTT estimator + loss-detection algorithm. Single
      * shared instance per connection (RTT is per-path; we model a
      * single path). Per-space `largestAcked*` lives on
@@ -786,6 +811,45 @@ class QuicConnection(
                     if (token.maxData == stream.receiveLimit) {
                         pendingMaxStreamData[token.streamId] = token.maxData
                     }
+                }
+
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.Stream -> {
+                    // Re-queue the lost byte range on the stream's send
+                    // buffer. The next writer drain pulls from the
+                    // retransmit queue first (FIFO ahead of new sends).
+                    // See [com.vitorpamplona.quic.stream.SendBuffer.markLost].
+                    val stream = streamByIdLocked(token.streamId) ?: continue
+                    stream.send.markLost(
+                        offset = token.offset,
+                        length = token.length,
+                        fin = token.fin,
+                    )
+                }
+
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.Crypto -> {
+                    // Same shape, applied to the per-level CRYPTO buffer.
+                    levelState(token.level).cryptoSend.markLost(
+                        offset = token.offset,
+                        length = token.length,
+                        fin = false,
+                    )
+                }
+
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.ResetStream -> {
+                    // Reliable per RFC 9000 §13.3 — re-emit verbatim
+                    // on loss. `:quic` doesn't currently have an emit
+                    // path for RESET_STREAM, so the pending-list is
+                    // populated but never drained today; the field is
+                    // scaffolding for future emit support.
+                    pendingResetStream[token.streamId] = token
+                }
+
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.StopSending -> {
+                    pendingStopSending[token.streamId] = token
+                }
+
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.NewConnectionId -> {
+                    pendingNewConnectionId[token.sequenceNumber] = token
                 }
             }
         }

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
@@ -723,6 +723,56 @@ class QuicConnection(
     /** Caller must hold [lock]. */
     internal fun streamByIdLocked(id: Long): QuicStream? = streams[id]
 
+    /**
+     * Step 6 of `quic/plans/2026-05-04-control-frame-retransmit.md`:
+     * dispatch the tokens of declared-lost packets to the matching
+     * `pending*` field, applying the supersede check from neqo's
+     * `fc.rs::frame_lost`. The supersede invariant: only re-flag for
+     * retransmit if the lost value still equals the connection's
+     * current advertised cap. If a higher extension has since gone
+     * out, the older lost frame is irrelevant — the newer value
+     * supersedes it.
+     *
+     * Called by the parser's AckFrame handler after
+     * [com.vitorpamplona.quic.connection.recovery.QuicLossDetection.detectAndRemoveLost]
+     * returns the lost set. Caller must hold [lock].
+     */
+    internal fun onTokensLost(tokens: List<com.vitorpamplona.quic.connection.recovery.RecoveryToken>) {
+        for (token in tokens) {
+            when (token) {
+                com.vitorpamplona.quic.connection.recovery.RecoveryToken.Ack -> {
+                    // ACK frames are not retransmittable per RFC 9000
+                    // §13.2.1; the peer's own ACKs cover newer ranges.
+                }
+
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.MaxStreamsUni -> {
+                    if (token.maxStreams == advertisedMaxStreamsUni) {
+                        pendingMaxStreamsUni = token.maxStreams
+                    }
+                }
+
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.MaxStreamsBidi -> {
+                    if (token.maxStreams == advertisedMaxStreamsBidi) {
+                        pendingMaxStreamsBidi = token.maxStreams
+                    }
+                }
+
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.MaxData -> {
+                    if (token.maxData == advertisedMaxData) {
+                        pendingMaxData = token.maxData
+                    }
+                }
+
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.MaxStreamData -> {
+                    val stream = streamByIdLocked(token.streamId) ?: continue
+                    if (token.maxData == stream.receiveLimit) {
+                        pendingMaxStreamData[token.streamId] = token.maxData
+                    }
+                }
+            }
+        }
+    }
+
     companion object {
         /**
          * Bound on the inbound datagram queue depth. RFC 9221 datagrams are

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
@@ -173,6 +173,39 @@ class QuicConnection(
     internal var advertisedMaxStreamsBidi: Long = config.initialMaxStreamsBidi
 
     /**
+     * RFC 9002 retransmit pending-state for the receive-side flow-
+     * control extensions. Non-null means "the last MAX_STREAMS_UNI
+     * we sent was lost; the writer should re-emit on its next pass".
+     *
+     * The value held is the limit that was lost — meaningful only
+     * when it equals [advertisedMaxStreamsUni], which is the
+     * supersede-check from neqo's `fc.rs::frame_lost` (if a newer,
+     * higher extension has since gone out, the older lost frame is
+     * irrelevant). Step 6 of
+     * `quic/plans/2026-05-04-control-frame-retransmit.md` populates
+     * this field via the loss dispatcher; step 4 (this commit) wires
+     * the writer to drain it before running the rolling-extension
+     * threshold check.
+     *
+     * Caller of any read/write must hold [lock].
+     */
+    internal var pendingMaxStreamsUni: Long? = null
+
+    /** Bidi counterpart of [pendingMaxStreamsUni]. */
+    internal var pendingMaxStreamsBidi: Long? = null
+
+    /** Connection-level MAX_DATA counterpart of [pendingMaxStreamsUni]. */
+    internal var pendingMaxData: Long? = null
+
+    /**
+     * Per-stream MAX_STREAM_DATA pending-state. Keyed by stream id.
+     * Same semantics as [pendingMaxStreamsUni]: present iff a
+     * MAX_STREAM_DATA for that stream was lost and hasn't been
+     * superseded by a higher emit. Wired by step 6.
+     */
+    internal val pendingMaxStreamData: MutableMap<Long, Long> = HashMap()
+
+    /**
      * Optional supplier of underlying UDP-socket counters. Wired by the
      * platform-specific driver since `UdpSocket`'s counters are
      * JVM-side fields the commonMain side can't see directly.

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
@@ -216,6 +216,24 @@ class QuicConnection(
             .QuicLossDetection()
 
     /**
+     * RFC 9002 §6.2 Probe Timeout signalling. When the driver loop's
+     * PTO timer fires (no ack-eliciting packet has been ACK'd in
+     * the PTO window), it sets [pendingPing] = true so the writer
+     * emits a PING frame on the next drain. The PING elicits an
+     * ACK from the peer; that ACK runs through loss detection and
+     * declares any in-flight packets lost, triggering retransmit.
+     */
+    internal var pendingPing: Boolean = false
+
+    /**
+     * RFC 9002 §6.2.2 consecutive PTO count. Incremented on each
+     * PTO expiration without an intervening ACK; reset to 0 when an
+     * inbound ACK acknowledges any ack-eliciting packet. The driver
+     * doubles its sleep between probes by `1 shl consecutivePtoCount`.
+     */
+    internal var consecutivePtoCount: Int = 0
+
+    /**
      * Optional supplier of underlying UDP-socket counters. Wired by the
      * platform-specific driver since `UdpSocket`'s counters are
      * JVM-side fields the commonMain side can't see directly.

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
@@ -206,6 +206,16 @@ class QuicConnection(
     internal val pendingMaxStreamData: MutableMap<Long, Long> = HashMap()
 
     /**
+     * RFC 9002 RTT estimator + loss-detection algorithm. Single
+     * shared instance per connection (RTT is per-path; we model a
+     * single path). Per-space `largestAcked*` lives on
+     * [LevelState]. Step 6 wires the loss-detection callback.
+     */
+    internal val lossDetection: com.vitorpamplona.quic.connection.recovery.QuicLossDetection =
+        com.vitorpamplona.quic.connection.recovery
+            .QuicLossDetection()
+
+    /**
      * Optional supplier of underlying UDP-socket counters. Wired by the
      * platform-specific driver since `UdpSocket`'s counters are
      * JVM-side fields the commonMain side can't see directly.

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
@@ -769,8 +769,16 @@ class QuicConnection(
     internal fun onTokensAcked(tokens: List<com.vitorpamplona.quic.connection.recovery.RecoveryToken>) {
         for (token in tokens) {
             when (token) {
-                com.vitorpamplona.quic.connection.recovery.RecoveryToken.Ack -> {
-                    // ACK-of-ACK is a no-op.
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.Ack -> {
+                    // ACK-of-ACK: peer has now received our ACK, so
+                    // we can drop everything at-or-below
+                    // [token.largestAcked] from the inbound tracker.
+                    // RFC 9000 §13.2.1 doesn't require us to keep
+                    // re-advertising acknowledged PNs once the peer
+                    // has confirmed receipt of our ACK that covered
+                    // them. Without this the tracker's range list
+                    // grows over the connection lifetime.
+                    levelState(token.level).ackTracker.purgeBelow(token.largestAcked + 1)
                 }
 
                 is com.vitorpamplona.quic.connection.recovery.RecoveryToken.MaxStreamsUni,
@@ -837,7 +845,7 @@ class QuicConnection(
     internal fun onTokensLost(tokens: List<com.vitorpamplona.quic.connection.recovery.RecoveryToken>) {
         for (token in tokens) {
             when (token) {
-                com.vitorpamplona.quic.connection.recovery.RecoveryToken.Ack -> {
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.Ack -> {
                     // ACK frames are not retransmittable per RFC 9000
                     // §13.2.1; the peer's own ACKs cover newer ranges.
                 }

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
@@ -20,7 +20,6 @@
  */
 package com.vitorpamplona.quic.connection
 
-import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quic.crypto.AesEcbHeaderProtection
 import com.vitorpamplona.quic.crypto.InitialSecrets
 import com.vitorpamplona.quic.crypto.PlatformAesOneBlock
@@ -636,20 +635,8 @@ class QuicConnection(
         // [config.initialMaxStreams*] is the lifetime maximum the peer
         // can open and any longer broadcast silently truncates.
         when (kind) {
-            StreamId.Kind.SERVER_UNI, StreamId.Kind.CLIENT_UNI -> {
-                peerInitiatedUniCount += 1
-                if (peerInitiatedUniCount % 25L == 0L) {
-                    Log.d("NestQuic") {
-                        "peerInitiatedUniCount=$peerInitiatedUniCount " +
-                            "advertisedMaxStreamsUni=$advertisedMaxStreamsUni " +
-                            "(headroom=${advertisedMaxStreamsUni - peerInitiatedUniCount})"
-                    }
-                }
-            }
-
-            StreamId.Kind.SERVER_BIDI, StreamId.Kind.CLIENT_BIDI -> {
-                peerInitiatedBidiCount += 1
-            }
+            StreamId.Kind.SERVER_UNI, StreamId.Kind.CLIENT_UNI -> peerInitiatedUniCount += 1
+            StreamId.Kind.SERVER_BIDI, StreamId.Kind.CLIENT_BIDI -> peerInitiatedBidiCount += 1
         }
         // Wake any awaitIncomingPeerStream caller. trySend on a CONFLATED
         // channel can never fail in steady state.

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionConfig.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionConfig.kt
@@ -37,39 +37,29 @@ data class QuicConnectionConfig(
     val initialMaxStreamDataUni: Long = 1L * 1024 * 1024,
     val initialMaxStreamsBidi: Long = 100L,
     /**
-     * Initial peer-initiated unidirectional stream limit. Sized to never
-     * trip the rolling [QuicConnectionWriter.appendFlowControlUpdates]
-     * extension path during a realistic audio-rooms broadcast — see
-     * `nestsClient/plans/2026-05-01-quic-stream-cliff-investigation.md`.
+     * Initial peer-initiated unidirectional stream limit. moq-rs's
+     * Quinn stack advertises `max_concurrent_uni_streams = 10000`
+     * for the same audio-rooms workload — every Opus group is a
+     * fresh peer-initiated uni stream — so we match.
      *
-     * Why a fixed-and-large initial value instead of relying on rolling
-     * extension: production tracing against `moq.nostrnests.com` showed
-     * that emitting `MAX_STREAMS_UNI` mid-connection silently breaks the
-     * relay's send path. The listener receives one more uni stream after
-     * the bump, then UDP goes dead at the kernel level
-     * (`udpRecvDatagrams` frozen) while our QUIC state still believes
-     * the connection is alive. The relay propagates the listener's
-     * disconnect to the publisher (`inbound SUBSCRIBE FIN'd` on the
-     * publisher side), but our stack never observes it — split-brain.
-     * Reproducible across runs. We don't yet know whether our frame is
-     * malformed, mis-sequenced relative to other frames in the packet,
-     * or hitting a moq-rs / Quinn bug — but we do know that not emitting
-     * the extension keeps the connection healthy.
+     * Earlier the value was set to 1 000 000 as a workaround for a
+     * production cliff against moq.nostrnests.com:  emitting
+     * `MAX_STREAMS_UNI` mid-connection caused the relay to silently
+     * stop forwarding uni streams (see
+     * `nestsClient/plans/2026-05-01-quic-stream-cliff-investigation.md`).
+     * That workaround dodged the bug at the cost of unbounded
+     * lifetime stream-id allocation per connection.
      *
-     * Capacity math, with [NestMoqLiteBroadcaster.DEFAULT_FRAMES_PER_GROUP]
-     * = 5 and Opus 20 ms: each group is one peer-initiated uni stream,
-     * so the relay opens ~10 streams/sec. The half-window threshold
-     * (`count + initialMaxStreamsUni/2 >= advertisedMaxStreamsUni`)
-     * trips at count = 500 000 streams, i.e. ~13.9 hours of continuous
-     * audio. Well past any realistic Nest duration.
-     *
-     * Memory cost: the [QuicConnection.streams] map currently grows for
-     * the connection's lifetime. At 10 streams/sec a 2-hour Nest leaves
-     * ~72k entries; per-stream overhead is small but unbounded growth
-     * over many hours is a known follow-up. For now this is a tolerable
-     * trade in exchange for not tripping the relay-side bug.
+     * The true fix landed in
+     * `quic/plans/2026-05-04-control-frame-retransmit.md`:
+     * RFC 9002 §6 loss detection + retransmit. With control-frame
+     * retransmit working, a single dropped MAX_STREAMS_UNI is
+     * recovered automatically — no need for the high-cap
+     * workaround. Lowered back to a moq-rs-matching default so the
+     * rolling-extension path (and its retransmit) actually
+     * exercises in production, validating the new code path.
      */
-    val initialMaxStreamsUni: Long = 1_000_000L,
+    val initialMaxStreamsUni: Long = 10_000L,
     val maxIdleTimeoutMillis: Long = 30_000L,
     val maxUdpPayloadSize: Long = 1452L,
     val activeConnectionIdLimit: Long = 4L,

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionConfig.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionConfig.kt
@@ -37,31 +37,39 @@ data class QuicConnectionConfig(
     val initialMaxStreamDataUni: Long = 1L * 1024 * 1024,
     val initialMaxStreamsBidi: Long = 100L,
     /**
-     * Initial peer-initiated unidirectional stream limit. moq-rs's Quinn
-     * stack advertises `max_concurrent_uni_streams = 10000` for the same
-     * reason we now do: every Opus group is a fresh peer-initiated uni
-     * stream, so a long broadcast accumulates many lifetime stream IDs.
+     * Initial peer-initiated unidirectional stream limit. Sized to never
+     * trip the rolling [QuicConnectionWriter.appendFlowControlUpdates]
+     * extension path during a realistic audio-rooms broadcast — see
+     * `nestsClient/plans/2026-05-01-quic-stream-cliff-investigation.md`.
      *
-     * Production tracing on a listener phone (Phone B receiving a Phone-A
-     * broadcast against `moq.nostrnests.com`) showed the cliff lands at
-     * exactly the moment our writer emits its first `MAX_STREAMS_UNI`
-     * extension at the half-window threshold (count=50 with cap=100):
-     * the listener receives one more stream after the bump, then UDP
-     * goes silent at the kernel level (`udpRecvDatagrams` frozen) while
-     * our QUIC state still believes the connection is alive. The relay
-     * propagates the listener's disconnect to the publisher (publisher
-     * sees `inbound SUBSCRIBE FIN'd`), but our QUIC stack never observes
-     * it — split-brain. The trace is reproducible across runs.
+     * Why a fixed-and-large initial value instead of relying on rolling
+     * extension: production tracing against `moq.nostrnests.com` showed
+     * that emitting `MAX_STREAMS_UNI` mid-connection silently breaks the
+     * relay's send path. The listener receives one more uni stream after
+     * the bump, then UDP goes dead at the kernel level
+     * (`udpRecvDatagrams` frozen) while our QUIC state still believes
+     * the connection is alive. The relay propagates the listener's
+     * disconnect to the publisher (`inbound SUBSCRIBE FIN'd` on the
+     * publisher side), but our stack never observes it — split-brain.
+     * Reproducible across runs. We don't yet know whether our frame is
+     * malformed, mis-sequenced relative to other frames in the packet,
+     * or hitting a moq-rs / Quinn bug — but we do know that not emitting
+     * the extension keeps the connection healthy.
      *
-     * The rolling-extension code path remains in place for correctness on
-     * other peers (and so 100×fpg=5 broadcasts of audio-rooms longer than
-     * ~50 s × 5 ≈ 250 s still extend cleanly), but with this cap raised
-     * to 10 000 the listener won't actually need to extend until 5 000+
-     * groups have flowed — well past any realistic Nest duration. That
-     * sidesteps the malformed-or-mis-sequenced extension that's tripping
-     * the relay today.
+     * Capacity math, with [NestMoqLiteBroadcaster.DEFAULT_FRAMES_PER_GROUP]
+     * = 5 and Opus 20 ms: each group is one peer-initiated uni stream,
+     * so the relay opens ~10 streams/sec. The half-window threshold
+     * (`count + initialMaxStreamsUni/2 >= advertisedMaxStreamsUni`)
+     * trips at count = 500 000 streams, i.e. ~13.9 hours of continuous
+     * audio. Well past any realistic Nest duration.
+     *
+     * Memory cost: the [QuicConnection.streams] map currently grows for
+     * the connection's lifetime. At 10 streams/sec a 2-hour Nest leaves
+     * ~72k entries; per-stream overhead is small but unbounded growth
+     * over many hours is a known follow-up. For now this is a tolerable
+     * trade in exchange for not tripping the relay-side bug.
      */
-    val initialMaxStreamsUni: Long = 10_000L,
+    val initialMaxStreamsUni: Long = 1_000_000L,
     val maxIdleTimeoutMillis: Long = 30_000L,
     val maxUdpPayloadSize: Long = 1452L,
     val activeConnectionIdLimit: Long = 4L,

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionConfig.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionConfig.kt
@@ -36,7 +36,32 @@ data class QuicConnectionConfig(
     val initialMaxStreamDataBidiRemote: Long = 1L * 1024 * 1024,
     val initialMaxStreamDataUni: Long = 1L * 1024 * 1024,
     val initialMaxStreamsBidi: Long = 100L,
-    val initialMaxStreamsUni: Long = 100L,
+    /**
+     * Initial peer-initiated unidirectional stream limit. moq-rs's Quinn
+     * stack advertises `max_concurrent_uni_streams = 10000` for the same
+     * reason we now do: every Opus group is a fresh peer-initiated uni
+     * stream, so a long broadcast accumulates many lifetime stream IDs.
+     *
+     * Production tracing on a listener phone (Phone B receiving a Phone-A
+     * broadcast against `moq.nostrnests.com`) showed the cliff lands at
+     * exactly the moment our writer emits its first `MAX_STREAMS_UNI`
+     * extension at the half-window threshold (count=50 with cap=100):
+     * the listener receives one more stream after the bump, then UDP
+     * goes silent at the kernel level (`udpRecvDatagrams` frozen) while
+     * our QUIC state still believes the connection is alive. The relay
+     * propagates the listener's disconnect to the publisher (publisher
+     * sees `inbound SUBSCRIBE FIN'd`), but our QUIC stack never observes
+     * it — split-brain. The trace is reproducible across runs.
+     *
+     * The rolling-extension code path remains in place for correctness on
+     * other peers (and so 100×fpg=5 broadcasts of audio-rooms longer than
+     * ~50 s × 5 ≈ 250 s still extend cleanly), but with this cap raised
+     * to 10 000 the listener won't actually need to extend until 5 000+
+     * groups have flowed — well past any realistic Nest duration. That
+     * sidesteps the malformed-or-mis-sequenced extension that's tripping
+     * the relay today.
+     */
+    val initialMaxStreamsUni: Long = 10_000L,
     val maxIdleTimeoutMillis: Long = 30_000L,
     val maxUdpPayloadSize: Long = 1452L,
     val activeConnectionIdLimit: Long = 4L,

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionDriver.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionDriver.kt
@@ -115,12 +115,13 @@ class QuicConnectionDriver(
     }
 
     private suspend fun sendLoop() {
-        // PTO budget: how long the loop will sleep before waking itself to
-        // check for retransmission opportunities. RFC 9002 §6.2 — initial
-        // PTO is roughly 3 × (smoothed RTT + max_ack_delay). We don't track
-        // RTT yet, so use a conservative fixed value that doubles on each
-        // consecutive timeout (Exponential backoff caps after ~6 timeouts).
-        var ptoMillis = 1_000L
+        // RFC 9002 §6.2 Probe Timeout. Once handshake is complete and
+        // we have an RTT estimate, the PTO duration is
+        // `smoothed_rtt + max(4*rttvar, 1ms) + max_ack_delay`,
+        // doubled by `1 shl consecutivePtoCount` per §6.2.2. Before
+        // the first RTT sample we fall back to a 1 s conservative
+        // floor (the same prior-shipping behavior, kept for
+        // handshake-timeout safety on lossy paths).
         while (connection.status != QuicConnection.Status.CLOSED) {
             connection.lock.withLock {
                 while (true) {
@@ -128,22 +129,32 @@ class QuicConnectionDriver(
                     socket.send(out)
                 }
             }
+            val ptoBaseMs =
+                if (connection.lossDetection.hasFirstRttSample) {
+                    val maxAckDelayMs = connection.peerTransportParameters?.maxAckDelay ?: 0L
+                    connection.lossDetection.ptoBaseMs(maxAckDelayMs).coerceAtLeast(1L)
+                } else {
+                    1_000L
+                }
+            val backoff = (1L shl connection.consecutivePtoCount.coerceAtMost(6))
+            val ptoMillis = (ptoBaseMs * backoff).coerceAtMost(60_000L)
             // Suspend until either: a wakeup arrives, or the PTO timer expires.
-            // The PTO wake ensures a single lost ClientHello doesn't wedge
-            // the connection forever — eventually the loop wakes, the writer
-            // re-emits Initial CRYPTO that's still in the send buffer (since
-            // we don't free it until ACK), and the handshake retries.
             val woke =
                 withTimeoutOrNull(ptoMillis) {
                     sendWakeup.receive()
                     Unit
                 }
-            ptoMillis =
-                if (woke == null) {
-                    (ptoMillis * 2).coerceAtMost(60_000L)
-                } else {
-                    1_000L
+            if (woke == null) {
+                // PTO fired. Set pendingPing so the writer emits a
+                // PING on the next drain (RFC 9002 §6.2.4 probe
+                // packet). The peer's ACK feeds loss detection +
+                // retransmit (steps 5–6).
+                connection.lock.withLock {
+                    connection.pendingPing = true
+                    connection.consecutivePtoCount =
+                        (connection.consecutivePtoCount + 1).coerceAtMost(6)
                 }
+            }
         }
     }
 

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionParser.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionParser.kt
@@ -194,6 +194,10 @@ private fun dispatchFrames(
                         ackDelayMs = ackDelayMs,
                         nowMs = nowMillis,
                     )
+                    // Step 7: reset PTO count on any new ack-eliciting
+                    // ACK (RFC 9002 §6.2.1). The peer responded, so the
+                    // exponential backoff resets.
+                    conn.consecutivePtoCount = 0
                 }
                 state.largestAckedPn?.let { largestAckedPn ->
                     val lost =

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionParser.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionParser.kt
@@ -170,12 +170,43 @@ private fun dispatchFrames(
                 // without this the range list grows unboundedly on long
                 // connections.
                 state.ackTracker.purgeBelow(frame.largestAcknowledged - frame.firstAckRange)
-                // Step 3 of `quic/plans/2026-05-04-control-frame-retransmit.md`:
-                // remove SentPacket entries for the PNs the peer acknowledged.
-                // Returned list is intentionally discarded for now —
-                // step 5 will use it to feed loss detection / RTT
-                // estimation; for step 3 we just drain.
-                drainAckedSentPackets(state.sentPackets, frame)
+                // Step 5 of `quic/plans/2026-05-04-control-frame-retransmit.md`:
+                // (a) snapshot the send time of the largest-acked PN
+                // BEFORE drain so we can update RTT, (b) drain ACK'd
+                // packets, (c) if the ACK advanced largestAckedPn AND
+                // any drained packet was ack-eliciting, update RTT,
+                // (d) detect-and-remove lost packets. The lost-token
+                // dispatch (step 6) is a TODO — for step 5 we drop the
+                // returned list on the floor.
+                val largestSentTime = state.sentPackets[frame.largestAcknowledged]?.sentAtMillis
+                val drained = drainAckedSentPackets(state.sentPackets, frame)
+                val advancedLargest =
+                    state.largestAckedPn?.let { it < frame.largestAcknowledged } ?: true
+                if (advancedLargest) {
+                    state.largestAckedPn = frame.largestAcknowledged
+                    state.largestAckedSentTimeMs = largestSentTime
+                }
+                if (advancedLargest && largestSentTime != null && drained.any { it.ackEliciting }) {
+                    val ackDelayUs = frame.ackDelay shl conn.config.ackDelayExponent.toInt()
+                    val ackDelayMs = ackDelayUs / 1_000L
+                    conn.lossDetection.onRttSample(
+                        largestAckedSentTimeMs = largestSentTime,
+                        ackDelayMs = ackDelayMs,
+                        nowMs = nowMillis,
+                    )
+                }
+                state.largestAckedPn?.let { largestAckedPn ->
+                    val lost =
+                        conn.lossDetection.detectAndRemoveLost(
+                            sentPackets = state.sentPackets,
+                            largestAckedPn = largestAckedPn,
+                            nowMs = nowMillis,
+                        )
+
+                    // Step 6 will dispatch tokens here. Drop for now.
+                    @Suppress("UNUSED_VARIABLE")
+                    val unusedForStep6 = lost
+                }
             }
 
             is CryptoFrame -> {

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionParser.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionParser.kt
@@ -164,12 +164,18 @@ private fun dispatchFrames(
     for (frame in frames) {
         when (frame) {
             is AckFrame -> {
-                // Purge our own ACK tracker below the peer's largest
-                // acknowledged: the peer has confirmed receipt of those
-                // ACKs, so we don't need to keep advertising them —
-                // without this the range list grows unboundedly on long
-                // connections.
-                state.ackTracker.purgeBelow(frame.largestAcknowledged - frame.firstAckRange)
+                // The peer's `frame.largestAcknowledged` is in OUR
+                // outbound PN space — the inbound `state.ackTracker`
+                // tracks PNs WE RECEIVED from the peer. The previous
+                // purge here was conceptually wrong (mixed two
+                // unrelated number spaces) but happened to mostly
+                // work because both PN spaces grow at similar rates.
+                // The correct purge is now driven by the
+                // ACK-of-ACK dispatch in [QuicConnection.onTokensAcked]
+                // for [RecoveryToken.Ack]: when the peer ACKs the
+                // packet that carried our outbound ACK frame, we
+                // know the peer received our ACK and we can drop
+                // the corresponding inbound PNs from the tracker.
                 // Step 5 of `quic/plans/2026-05-04-control-frame-retransmit.md`:
                 // (a) snapshot the send time of the largest-acked PN
                 // BEFORE drain so we can update RTT, (b) drain ACK'd

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionParser.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionParser.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.quic.connection
 
 import com.vitorpamplona.quic.QuicCodecException
+import com.vitorpamplona.quic.connection.recovery.drainAckedSentPackets
 import com.vitorpamplona.quic.frame.AckFrame
 import com.vitorpamplona.quic.frame.ConnectionCloseFrame
 import com.vitorpamplona.quic.frame.CryptoFrame
@@ -163,12 +164,18 @@ private fun dispatchFrames(
     for (frame in frames) {
         when (frame) {
             is AckFrame -> {
-                // We don't currently retransmit, so we just absorb ACKs. But
-                // we DO purge our own ACK tracker below the peer's largest
-                // acknowledged: the peer has confirmed receipt of those ACKs,
-                // so we don't need to keep advertising them — without this
-                // the range list grows unboundedly on long connections.
+                // Purge our own ACK tracker below the peer's largest
+                // acknowledged: the peer has confirmed receipt of those
+                // ACKs, so we don't need to keep advertising them —
+                // without this the range list grows unboundedly on long
+                // connections.
                 state.ackTracker.purgeBelow(frame.largestAcknowledged - frame.firstAckRange)
+                // Step 3 of `quic/plans/2026-05-04-control-frame-retransmit.md`:
+                // remove SentPacket entries for the PNs the peer acknowledged.
+                // Returned list is intentionally discarded for now —
+                // step 5 will use it to feed loss detection / RTT
+                // estimation; for step 3 we just drain.
+                drainAckedSentPackets(state.sentPackets, frame)
             }
 
             is CryptoFrame -> {

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionParser.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionParser.kt
@@ -202,10 +202,12 @@ private fun dispatchFrames(
                             largestAckedPn = largestAckedPn,
                             nowMs = nowMillis,
                         )
-
-                    // Step 6 will dispatch tokens here. Drop for now.
-                    @Suppress("UNUSED_VARIABLE")
-                    val unusedForStep6 = lost
+                    // Step 6: dispatch each lost packet's tokens to the
+                    // matching pending* field. The supersede check (lost
+                    // value still == advertised) lives inside onTokensLost.
+                    for (lostPacket in lost) {
+                        conn.onTokensLost(lostPacket.tokens)
+                    }
                 }
             }
 

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionParser.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionParser.kt
@@ -419,6 +419,12 @@ private fun dispatchFrames(
                 if (conn.status == QuicConnection.Status.HANDSHAKING) {
                     conn.status = QuicConnection.Status.CONNECTED
                 }
+                // RFC 9001 §4.9.2 + §4.1.2: a client confirms the handshake
+                // on receipt of HANDSHAKE_DONE; once confirmed, MUST discard
+                // Handshake keys. Frees the AEAD cipher state and any
+                // residual handshake CRYPTO bookkeeping that's no longer
+                // needed for the lifetime of the connection.
+                conn.handshake.discardKeys()
             }
 
             is PingFrame -> {

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionParser.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionParser.kt
@@ -180,6 +180,13 @@ private fun dispatchFrames(
                 // returned list on the floor.
                 val largestSentTime = state.sentPackets[frame.largestAcknowledged]?.sentAtMillis
                 val drained = drainAckedSentPackets(state.sentPackets, frame)
+                // Step C of the deferred-follow-ups pass: dispatch ACK
+                // to per-buffer markAcked for Stream / Crypto tokens.
+                // Releases SendBuffer memory and advances its
+                // flushedFloor as low-end ACKs accumulate.
+                for (drainedPacket in drained) {
+                    conn.onTokensAcked(drainedPacket.tokens)
+                }
                 val advancedLargest =
                     state.largestAckedPn?.let { it < frame.largestAcknowledged } ?: true
                 if (advancedLargest) {

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionWriter.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionWriter.kt
@@ -325,6 +325,18 @@ private fun buildApplicationPacket(
                         fin = chunk.fin,
                         explicitLength = true,
                     )
+                // Step C of the deferred-follow-ups pass: track this
+                // STREAM emission so RFC 9002 retransmit can re-queue
+                // the byte range on loss. SendBuffer.markLost (commit B)
+                // moves the range from in-flight back to the retransmit
+                // queue, and the next takeChunk replays it.
+                tokens +=
+                    RecoveryToken.Stream(
+                        streamId = stream.streamId,
+                        offset = chunk.offset,
+                        length = chunk.data.size.toLong(),
+                        fin = chunk.fin,
+                    )
                 packetBudget -= chunk.data.size + 32
                 connBudget -= chunk.data.size
                 conn.sendConnectionFlowConsumed += chunk.data.size

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionWriter.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionWriter.kt
@@ -113,29 +113,45 @@ fun drainOutbound(
 
     // RFC 9000 §14.1: client datagrams containing Initial MUST pad to ≥ 1200,
     // via PADDING frames inside the Initial's encryption envelope.
-    if (initialNatural != null) {
-        var natural = 0
-        for (p in firstPass) natural += p.size
-        if (natural < 1200) {
-            val deficit = 1200 - natural
-            // Rewind the Initial PN — we'll reissue with the same PN and the
-            // same captured frames plus padding. The SentPacket entry recorded
-            // by the natural-size build will be overwritten by the rebuild
-            // below since both use the same PN.
-            initialState.pnSpace.rewindOutboundForRebuild()
-            val paddedInitial =
-                buildLongHeaderFromFrames(
-                    conn = conn,
-                    level = EncryptionLevel.INITIAL,
-                    frames = initialContents!!.frames, // null-safe: gated by `initialNatural != null` above
-                    tokens = initialContents.tokens,
-                    nowMillis = nowMillis,
-                    padBytes = deficit,
-                )
-            return concat(listOfNotNull(paddedInitial, handshakeNatural, applicationPkt))
+    val datagram =
+        if (initialNatural != null) {
+            var natural = 0
+            for (p in firstPass) natural += p.size
+            if (natural < 1200) {
+                val deficit = 1200 - natural
+                // Rewind the Initial PN — we'll reissue with the same PN and the
+                // same captured frames plus padding. The SentPacket entry recorded
+                // by the natural-size build will be overwritten by the rebuild
+                // below since both use the same PN.
+                initialState.pnSpace.rewindOutboundForRebuild()
+                val paddedInitial =
+                    buildLongHeaderFromFrames(
+                        conn = conn,
+                        level = EncryptionLevel.INITIAL,
+                        frames = initialContents!!.frames, // null-safe: gated by `initialNatural != null` above
+                        tokens = initialContents.tokens,
+                        nowMillis = nowMillis,
+                        padBytes = deficit,
+                    )
+                concat(listOfNotNull(paddedInitial, handshakeNatural, applicationPkt))
+            } else {
+                concat(firstPass)
+            }
+        } else {
+            concat(firstPass)
         }
+
+    // RFC 9001 §4.9.1: a client MUST discard Initial keys when it first
+    // sends a Handshake packet. We just built one (handshakeNatural !=
+    // null), so the next drainOutbound MUST NOT touch the Initial level.
+    // After this point any retransmitted Initial from the peer is silently
+    // dropped (initial.receiveProtection == null), which is correct per
+    // the same RFC: by the time the client sends a Handshake packet, the
+    // server has already moved up encryption levels too.
+    if (handshakeNatural != null && !conn.initial.keysDiscarded) {
+        conn.initial.discardKeys()
     }
-    return concat(firstPass)
+    return datagram
 }
 
 private fun concat(parts: List<ByteArray>): ByteArray {

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionWriter.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionWriter.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.quic.connection
 
+import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quic.frame.ConnectionCloseFrame
 import com.vitorpamplona.quic.frame.CryptoFrame
 import com.vitorpamplona.quic.frame.DatagramFrame
@@ -395,15 +396,25 @@ private fun appendFlowControlUpdates(
     if (conn.peerInitiatedUniCount + cfg.initialMaxStreamsUni / 2 >= conn.advertisedMaxStreamsUni) {
         val newCap = conn.peerInitiatedUniCount + cfg.initialMaxStreamsUni
         if (newCap > conn.advertisedMaxStreamsUni) {
+            val oldCap = conn.advertisedMaxStreamsUni
             conn.advertisedMaxStreamsUni = newCap
             frames += MaxStreamsFrame(bidi = false, maxStreams = newCap)
+            Log.d("NestQuic") {
+                "MAX_STREAMS_UNI emit oldCap=$oldCap → newCap=$newCap " +
+                    "peerInitiatedUniCount=${conn.peerInitiatedUniCount}"
+            }
         }
     }
     if (conn.peerInitiatedBidiCount + cfg.initialMaxStreamsBidi / 2 >= conn.advertisedMaxStreamsBidi) {
         val newCap = conn.peerInitiatedBidiCount + cfg.initialMaxStreamsBidi
         if (newCap > conn.advertisedMaxStreamsBidi) {
+            val oldCap = conn.advertisedMaxStreamsBidi
             conn.advertisedMaxStreamsBidi = newCap
             frames += MaxStreamsFrame(bidi = true, maxStreams = newCap)
+            Log.d("NestQuic") {
+                "MAX_STREAMS_BIDI emit oldCap=$oldCap → newCap=$newCap " +
+                    "peerInitiatedBidiCount=${conn.peerInitiatedBidiCount}"
+            }
         }
     }
 }

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionWriter.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionWriter.kt
@@ -68,18 +68,42 @@ fun drainOutbound(
     }
 
     // Drain destructive frame sources into local lists, ONCE.
-    val initialFrames = collectHandshakeLevelFrames(conn, EncryptionLevel.INITIAL, nowMillis)
-    val handshakeFrames = collectHandshakeLevelFrames(conn, EncryptionLevel.HANDSHAKE, nowMillis)
+    val initialContents = collectHandshakeLevelFrames(conn, EncryptionLevel.INITIAL, nowMillis)
+    val handshakeContents = collectHandshakeLevelFrames(conn, EncryptionLevel.HANDSHAKE, nowMillis)
     val applicationPkt = buildApplicationPacket(conn, nowMillis)
 
     val initialState = conn.initial
     val handshakeState = conn.handshake
-    val initialHasContent = initialFrames != null && initialState.sendProtection != null
-    val handshakeHasContent = handshakeFrames != null && handshakeState.sendProtection != null
+    val initialHasContent = initialContents != null && initialState.sendProtection != null
+    val handshakeHasContent = handshakeContents != null && handshakeState.sendProtection != null
 
     // Build natural-size first.
-    val initialNatural = if (initialHasContent) buildLongHeaderFromFrames(conn, EncryptionLevel.INITIAL, initialFrames, padBytes = 0) else null
-    val handshakeNatural = if (handshakeHasContent) buildLongHeaderFromFrames(conn, EncryptionLevel.HANDSHAKE, handshakeFrames, padBytes = 0) else null
+    val initialNatural =
+        if (initialContents != null && initialState.sendProtection != null) {
+            buildLongHeaderFromFrames(
+                conn = conn,
+                level = EncryptionLevel.INITIAL,
+                frames = initialContents.frames,
+                tokens = initialContents.tokens,
+                nowMillis = nowMillis,
+                padBytes = 0,
+            )
+        } else {
+            null
+        }
+    val handshakeNatural =
+        if (handshakeContents != null && handshakeState.sendProtection != null) {
+            buildLongHeaderFromFrames(
+                conn = conn,
+                level = EncryptionLevel.HANDSHAKE,
+                frames = handshakeContents.frames,
+                tokens = handshakeContents.tokens,
+                nowMillis = nowMillis,
+                padBytes = 0,
+            )
+        } else {
+            null
+        }
 
     val firstPass = listOfNotNull(initialNatural, handshakeNatural, applicationPkt)
     if (firstPass.isEmpty()) return null
@@ -92,9 +116,19 @@ fun drainOutbound(
         if (natural < 1200) {
             val deficit = 1200 - natural
             // Rewind the Initial PN — we'll reissue with the same PN and the
-            // same captured frames plus padding.
+            // same captured frames plus padding. The SentPacket entry recorded
+            // by the natural-size build will be overwritten by the rebuild
+            // below since both use the same PN.
             initialState.pnSpace.rewindOutboundForRebuild()
-            val paddedInitial = buildLongHeaderFromFrames(conn, EncryptionLevel.INITIAL, initialFrames!!, padBytes = deficit)
+            val paddedInitial =
+                buildLongHeaderFromFrames(
+                    conn = conn,
+                    level = EncryptionLevel.INITIAL,
+                    frames = initialContents!!.frames, // null-safe: gated by `initialNatural != null` above
+                    tokens = initialContents.tokens,
+                    nowMillis = nowMillis,
+                    padBytes = deficit,
+                )
             return concat(listOfNotNull(paddedInitial, handshakeNatural, applicationPkt))
         }
     }
@@ -177,26 +211,58 @@ private fun buildLongHeaderPacket(
 }
 
 /**
+ * Frames + the matching retransmit-tokens collected for a single
+ * encryption-level packet build. Carried out of
+ * [collectHandshakeLevelFrames] so the caller can pass the tokens
+ * to the SentPacket retention recorded in
+ * [buildLongHeaderFromFrames].
+ */
+private data class HandshakeLevelContents(
+    val frames: List<Frame>,
+    val tokens: List<RecoveryToken>,
+)
+
+/**
  * Drain ACK + CRYPTO frames for [level] into a fresh list. Destructive on
- * the CRYPTO send buffer, but caller-controlled — call exactly once per
- * outbound datagram. Returns null if there are no frames to send and the
- * level has no protection installed.
+ * the CRYPTO send buffer (which now retains bytes until ACK per
+ * [com.vitorpamplona.quic.stream.SendBuffer]'s retain-until-ACK
+ * semantics — see commit B). Returns null if there are no frames to
+ * send and the level has no protection installed.
+ *
+ * Each emitted frame contributes a matching [RecoveryToken] so the
+ * caller can record a [com.vitorpamplona.quic.connection.recovery.SentPacket]
+ * keyed by packet number, enabling RFC 9002 retransmit at this
+ * encryption level (CRYPTO bytes are reliable per RFC 9000 §13.3).
  */
 private fun collectHandshakeLevelFrames(
     conn: QuicConnection,
     level: EncryptionLevel,
     nowMillis: Long,
-): List<Frame>? {
+): HandshakeLevelContents? {
     val state = conn.levelState(level)
     if (state.sendProtection == null) return null
     val frames = mutableListOf<Frame>()
-    state.ackTracker.buildAckFrame(nowMillis, conn.config.ackDelayExponent.toInt())?.let { frames += it }
+    val tokens = mutableListOf<RecoveryToken>()
+    state.ackTracker.buildAckFrame(nowMillis, conn.config.ackDelayExponent.toInt())?.let {
+        frames += it
+        tokens += RecoveryToken.Ack
+    }
     val cryptoChunk = state.cryptoSend.takeChunk(maxBytes = 1100)
     if (cryptoChunk != null && cryptoChunk.data.isNotEmpty()) {
         frames += CryptoFrame(cryptoChunk.offset, cryptoChunk.data)
+        // Step E: record a Crypto retransmit token at the matching
+        // encryption level so a lost handshake packet's CRYPTO bytes
+        // get re-emitted at the same offset on next drain (RFC 9000
+        // §13.3 — handshake bytes are reliable).
+        tokens +=
+            RecoveryToken.Crypto(
+                level = level,
+                offset = cryptoChunk.offset,
+                length = cryptoChunk.data.size.toLong(),
+            )
     }
     if (frames.isEmpty()) return null
-    return frames
+    return HandshakeLevelContents(frames = frames, tokens = tokens)
 }
 
 /**
@@ -210,6 +276,8 @@ private fun buildLongHeaderFromFrames(
     conn: QuicConnection,
     level: EncryptionLevel,
     frames: List<Frame>,
+    tokens: List<RecoveryToken>,
+    nowMillis: Long,
     padBytes: Int,
 ): ByteArray {
     val state = conn.levelState(level)
@@ -223,22 +291,42 @@ private fun buildLongHeaderFromFrames(
         }
     val pn = state.pnSpace.allocateOutbound()
     val type = if (level == EncryptionLevel.INITIAL) LongHeaderType.INITIAL else LongHeaderType.HANDSHAKE
-    return LongHeaderPacket.build(
-        LongHeaderPlaintextPacket(
-            type = type,
-            version = QuicVersion.V1,
-            dcid = conn.destinationConnectionId,
-            scid = conn.sourceConnectionId,
+    val packet =
+        LongHeaderPacket.build(
+            LongHeaderPlaintextPacket(
+                type = type,
+                version = QuicVersion.V1,
+                dcid = conn.destinationConnectionId,
+                scid = conn.sourceConnectionId,
+                packetNumber = pn,
+                payload = payload,
+            ),
+            proto.aead,
+            proto.key,
+            proto.iv,
+            proto.hp,
+            proto.hpKey,
+            largestAckedInSpace = -1L,
+        )
+    // Step E: retain the packet for RFC 9002 retransmit. Initial /
+    // Handshake packets carry CRYPTO frames; loss detection runs at
+    // each level and routes lost Crypto tokens back to the level's
+    // cryptoSend buffer via QuicConnection.onTokensLost (commit A).
+    //
+    // Initial-level rebuilds with padding (RFC 9000 §14.1) call
+    // pnSpace.rewindOutboundForRebuild() to reuse the same PN. The
+    // map insert below overwrites the prior entry, so the recorded
+    // SentPacket reflects the final padded packet's size — correct
+    // for retransmit purposes.
+    state.sentPackets[pn] =
+        SentPacket(
             packetNumber = pn,
-            payload = payload,
-        ),
-        proto.aead,
-        proto.key,
-        proto.iv,
-        proto.hp,
-        proto.hpKey,
-        largestAckedInSpace = -1L,
-    )
+            sentAtMillis = nowMillis,
+            ackEliciting = isAckEliciting(frames),
+            sizeBytes = packet.size,
+            tokens = tokens,
+        )
+    return packet
 }
 
 private fun buildApplicationPacket(

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionWriter.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionWriter.kt
@@ -21,6 +21,9 @@
 package com.vitorpamplona.quic.connection
 
 import com.vitorpamplona.quartz.utils.Log
+import com.vitorpamplona.quic.connection.recovery.RecoveryToken
+import com.vitorpamplona.quic.connection.recovery.SentPacket
+import com.vitorpamplona.quic.frame.AckFrame
 import com.vitorpamplona.quic.frame.ConnectionCloseFrame
 import com.vitorpamplona.quic.frame.CryptoFrame
 import com.vitorpamplona.quic.frame.DatagramFrame
@@ -244,13 +247,25 @@ private fun buildApplicationPacket(
     val state = conn.application
     val proto = state.sendProtection ?: return null
     val frames = mutableListOf<Frame>()
+    // Tokens collected in lock-step with [frames]: each retransmittable
+    // frame contributes a [RecoveryToken] so the [SentPacket] recorded
+    // at the bottom of this function can drive RFC 9002 loss
+    // detection + retransmit (steps 3–6 of
+    // `quic/plans/2026-05-04-control-frame-retransmit.md`). Frames that
+    // are not retransmittable (DatagramFrame, StreamFrame for now) do
+    // not contribute a token; the packet is still ack-eliciting and
+    // tracked for loss-detection timing.
+    val tokens = mutableListOf<RecoveryToken>()
 
-    state.ackTracker.buildAckFrame(nowMillis, conn.config.ackDelayExponent.toInt())?.let { frames += it }
+    state.ackTracker.buildAckFrame(nowMillis, conn.config.ackDelayExponent.toInt())?.let {
+        frames += it
+        tokens += RecoveryToken.Ack
+    }
 
     // Re-credit the peer's send window when our receive offset has advanced
     // beyond half the previously-advertised limit. Emits MAX_STREAM_DATA per
     // stream and MAX_DATA at the connection level.
-    appendFlowControlUpdates(conn, frames)
+    appendFlowControlUpdates(conn, frames, tokens)
 
     // Pending datagrams
     while (conn.pendingDatagramsLocked().isNotEmpty()) {
@@ -308,26 +323,68 @@ private fun buildApplicationPacket(
     if (frames.isEmpty()) return null
     val payload = encodeFrames(frames)
     val pn = state.pnSpace.allocateOutbound()
-    return ShortHeaderPacket.build(
-        ShortHeaderPlaintextPacket(conn.destinationConnectionId, pn, payload),
-        proto.aead,
-        proto.key,
-        proto.iv,
-        proto.hp,
-        proto.hpKey,
-        largestAckedInSpace = -1L,
-    )
+    // Retain the packet for RFC 9002 loss detection BEFORE the encrypt
+    // step so the bookkeeping survives a build/encrypt throw (the PN
+    // was already consumed at allocateOutbound; if we don't track it,
+    // the gap is silent). Step 2 only populates the map; step 3 drains
+    // on ACK; step 5 declares loss. Until step 5 lands, the map can
+    // only grow — but step 2 ships dormant, no reads, no behavior
+    // change visible to the peer.
+    val sizeBytes =
+        runCatching {
+            ShortHeaderPacket.build(
+                ShortHeaderPlaintextPacket(conn.destinationConnectionId, pn, payload),
+                proto.aead,
+                proto.key,
+                proto.iv,
+                proto.hp,
+                proto.hpKey,
+                largestAckedInSpace = -1L,
+            )
+        }
+    state.sentPackets[pn] =
+        SentPacket(
+            packetNumber = pn,
+            sentAtMillis = nowMillis,
+            ackEliciting = isAckEliciting(frames),
+            sizeBytes = sizeBytes.getOrNull()?.size ?: 0,
+            tokens = tokens.toList(),
+        )
+    // Re-throw on encrypt failure so callers (driver loop) see the
+    // same exception they did before this change. The bookkeeping
+    // entry is still in place; if the throw was transient, retransmit
+    // logic in step 6 picks up the slack on the next outbound.
+    return sizeBytes.getOrThrow()
 }
+
+/**
+ * RFC 9000 §13.2.1: a packet is ack-eliciting if it contains any frame
+ * other than ACK, PADDING, or CONNECTION_CLOSE. Loss detection (step 5)
+ * only fires for ack-eliciting packets — non-eliciting ones are tracked
+ * for timing but never retransmitted.
+ *
+ * `:quic` doesn't currently emit PADDING-only or CONNECTION_CLOSE-only
+ * frames mid-connection through this path, so the ack-eliciting set
+ * is "anything that isn't a pure ACK". Listed explicitly anyway so the
+ * RFC reference stays close to the implementation.
+ */
+private fun isAckEliciting(frames: List<Frame>): Boolean = frames.any { it !is AckFrame && it !is ConnectionCloseFrame }
 
 /**
  * Append MAX_STREAM_DATA / MAX_DATA frames re-crediting the peer when our
  * receive cursor has advanced past half the previously-advertised window.
+ *
+ * Each emitted frame contributes a matching [RecoveryToken] to [tokens]
+ * so the [SentPacket] recorded by the caller can drive RFC 9002
+ * retransmit on loss (step 6 of
+ * `quic/plans/2026-05-04-control-frame-retransmit.md`).
  *
  * Caller must hold [QuicConnection.lock].
  */
 private fun appendFlowControlUpdates(
     conn: QuicConnection,
     frames: MutableList<Frame>,
+    tokens: MutableList<RecoveryToken>,
 ) {
     val cfg = conn.config
     var totalRecvAdvanced = 0L
@@ -365,6 +422,7 @@ private fun appendFlowControlUpdates(
             if (newLimit > stream.receiveLimit) {
                 stream.receiveLimit = newLimit
                 frames += MaxStreamDataFrame(id, newLimit)
+                tokens += RecoveryToken.MaxStreamData(streamId = id, maxData = newLimit)
             }
         }
         // Clear the dirty flag once we've considered this stream — even if we
@@ -381,6 +439,7 @@ private fun appendFlowControlUpdates(
         if (newLimit > conn.advertisedMaxData) {
             conn.advertisedMaxData = newLimit
             frames += MaxDataFrame(newLimit)
+            tokens += RecoveryToken.MaxData(maxData = newLimit)
         }
     }
     // Peer-initiated stream-id concurrency (RFC 9000 §19.11). MoQ over
@@ -399,6 +458,7 @@ private fun appendFlowControlUpdates(
             val oldCap = conn.advertisedMaxStreamsUni
             conn.advertisedMaxStreamsUni = newCap
             frames += MaxStreamsFrame(bidi = false, maxStreams = newCap)
+            tokens += RecoveryToken.MaxStreamsUni(maxStreams = newCap)
             Log.d("NestQuic") {
                 "MAX_STREAMS_UNI emit oldCap=$oldCap → newCap=$newCap " +
                     "peerInitiatedUniCount=${conn.peerInitiatedUniCount}"
@@ -411,6 +471,7 @@ private fun appendFlowControlUpdates(
             val oldCap = conn.advertisedMaxStreamsBidi
             conn.advertisedMaxStreamsBidi = newCap
             frames += MaxStreamsFrame(bidi = true, maxStreams = newCap)
+            tokens += RecoveryToken.MaxStreamsBidi(maxStreams = newCap)
             Log.d("NestQuic") {
                 "MAX_STREAMS_BIDI emit oldCap=$oldCap → newCap=$newCap " +
                     "peerInitiatedBidiCount=${conn.peerInitiatedBidiCount}"

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionWriter.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionWriter.kt
@@ -386,6 +386,42 @@ private fun appendFlowControlUpdates(
     frames: MutableList<Frame>,
     tokens: MutableList<RecoveryToken>,
 ) {
+    // Step 4: re-emit any retransmittable extension whose carrying
+    // packet was declared lost (the `pending*` fields are populated
+    // by step 6's loss dispatcher; for now they default to null).
+    // Each pending entry is consumed by emitting a fresh frame with
+    // the same value plus a fresh token, so the new packet's loss
+    // can be re-detected if the wire drops this one too. The
+    // supersede-check (`token.value == advertised*`) lives on the
+    // setter side in step 6 — by the time `pending*` is set, the
+    // value is known to still match the current advertised cap.
+    val pendingUni = conn.pendingMaxStreamsUni
+    if (pendingUni != null) {
+        frames += MaxStreamsFrame(bidi = false, maxStreams = pendingUni)
+        tokens += RecoveryToken.MaxStreamsUni(maxStreams = pendingUni)
+        conn.pendingMaxStreamsUni = null
+    }
+    val pendingBidi = conn.pendingMaxStreamsBidi
+    if (pendingBidi != null) {
+        frames += MaxStreamsFrame(bidi = true, maxStreams = pendingBidi)
+        tokens += RecoveryToken.MaxStreamsBidi(maxStreams = pendingBidi)
+        conn.pendingMaxStreamsBidi = null
+    }
+    val pendingData = conn.pendingMaxData
+    if (pendingData != null) {
+        frames += MaxDataFrame(pendingData)
+        tokens += RecoveryToken.MaxData(maxData = pendingData)
+        conn.pendingMaxData = null
+    }
+    if (conn.pendingMaxStreamData.isNotEmpty()) {
+        // Iterate over a snapshot so we can mutate the map safely.
+        val pendingStreamEntries = conn.pendingMaxStreamData.entries.toList()
+        for ((streamId, maxData) in pendingStreamEntries) {
+            frames += MaxStreamDataFrame(streamId, maxData)
+            tokens += RecoveryToken.MaxStreamData(streamId = streamId, maxData = maxData)
+        }
+        conn.pendingMaxStreamData.clear()
+    }
     val cfg = conn.config
     var totalRecvAdvanced = 0L
     // Round-4 perf #9 + round-5 #9: walk the streams via the index-friendly

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionWriter.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionWriter.kt
@@ -248,7 +248,7 @@ private fun collectHandshakeLevelFrames(
     val tokens = mutableListOf<RecoveryToken>()
     state.ackTracker.buildAckFrame(nowMillis, conn.config.ackDelayExponent.toInt())?.let {
         frames += it
-        tokens += RecoveryToken.Ack
+        tokens += RecoveryToken.Ack(level = level, largestAcked = it.largestAcknowledged)
     }
     val cryptoChunk = state.cryptoSend.takeChunk(maxBytes = 1100)
     if (cryptoChunk != null && cryptoChunk.data.isNotEmpty()) {
@@ -351,7 +351,7 @@ private fun buildApplicationPacket(
 
     state.ackTracker.buildAckFrame(nowMillis, conn.config.ackDelayExponent.toInt())?.let {
         frames += it
-        tokens += RecoveryToken.Ack
+        tokens += RecoveryToken.Ack(level = EncryptionLevel.APPLICATION, largestAcked = it.largestAcknowledged)
     }
 
     // Step 7: PTO probe. The driver sets `pendingPing` when its

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionWriter.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionWriter.kt
@@ -31,7 +31,10 @@ import com.vitorpamplona.quic.frame.Frame
 import com.vitorpamplona.quic.frame.MaxDataFrame
 import com.vitorpamplona.quic.frame.MaxStreamDataFrame
 import com.vitorpamplona.quic.frame.MaxStreamsFrame
+import com.vitorpamplona.quic.frame.NewConnectionIdFrame
 import com.vitorpamplona.quic.frame.PingFrame
+import com.vitorpamplona.quic.frame.ResetStreamFrame
+import com.vitorpamplona.quic.frame.StopSendingFrame
 import com.vitorpamplona.quic.frame.StreamFrame
 import com.vitorpamplona.quic.frame.encodeFrames
 import com.vitorpamplona.quic.packet.LongHeaderPacket
@@ -535,6 +538,65 @@ private fun appendFlowControlUpdates(
         }
         conn.pendingMaxStreamData.clear()
     }
+
+    // Per-stream RESET_STREAM / STOP_SENDING. Both are reliable per
+    // RFC 9000 §13.3 — the writer drains the per-stream emit-pending
+    // flag, attaches the corresponding RecoveryToken, and clears the
+    // flag. The loss dispatcher re-flags on packet loss; ACK latches
+    // resetAcked / stopSendingAcked so subsequent stale loss tokens
+    // are dropped.
+    for (stream in conn.streamsListLocked()) {
+        val resetState = stream.resetState
+        if (resetState != null && stream.resetEmitPending && !stream.resetAcked) {
+            frames +=
+                ResetStreamFrame(
+                    streamId = stream.streamId,
+                    applicationErrorCode = resetState.errorCode,
+                    finalSize = resetState.finalSize,
+                )
+            tokens +=
+                RecoveryToken.ResetStream(
+                    streamId = stream.streamId,
+                    errorCode = resetState.errorCode,
+                    finalSize = resetState.finalSize,
+                )
+            stream.resetEmitPending = false
+        }
+        val stopSendingState = stream.stopSendingState
+        if (stopSendingState != null && stream.stopSendingEmitPending && !stream.stopSendingAcked) {
+            frames +=
+                StopSendingFrame(
+                    streamId = stream.streamId,
+                    applicationErrorCode = stopSendingState.errorCode,
+                )
+            tokens +=
+                RecoveryToken.StopSending(
+                    streamId = stream.streamId,
+                    errorCode = stopSendingState.errorCode,
+                )
+            stream.stopSendingEmitPending = false
+        }
+    }
+
+    // NEW_CONNECTION_ID retransmits. No application path emits these
+    // initially today (connection-ID rotation isn't wired); the map
+    // is populated only by the loss dispatcher, so this branch only
+    // fires for genuine retransmits.
+    if (conn.pendingNewConnectionId.isNotEmpty()) {
+        val pendingNewCidEntries = conn.pendingNewConnectionId.entries.toList()
+        for ((_, token) in pendingNewCidEntries) {
+            frames +=
+                NewConnectionIdFrame(
+                    sequenceNumber = token.sequenceNumber,
+                    retirePriorTo = token.retirePriorTo,
+                    connectionId = token.connectionId,
+                    statelessResetToken = token.statelessResetToken,
+                )
+            tokens += token
+        }
+        conn.pendingNewConnectionId.clear()
+    }
+
     val cfg = conn.config
     var totalRecvAdvanced = 0L
     // Round-4 perf #9 + round-5 #9: walk the streams via the index-friendly

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionWriter.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionWriter.kt
@@ -31,6 +31,7 @@ import com.vitorpamplona.quic.frame.Frame
 import com.vitorpamplona.quic.frame.MaxDataFrame
 import com.vitorpamplona.quic.frame.MaxStreamDataFrame
 import com.vitorpamplona.quic.frame.MaxStreamsFrame
+import com.vitorpamplona.quic.frame.PingFrame
 import com.vitorpamplona.quic.frame.StreamFrame
 import com.vitorpamplona.quic.frame.encodeFrames
 import com.vitorpamplona.quic.packet.LongHeaderPacket
@@ -260,6 +261,18 @@ private fun buildApplicationPacket(
     state.ackTracker.buildAckFrame(nowMillis, conn.config.ackDelayExponent.toInt())?.let {
         frames += it
         tokens += RecoveryToken.Ack
+    }
+
+    // Step 7: PTO probe. The driver sets `pendingPing` when its
+    // PTO timer fires without intervening ACKs. A PING is the
+    // smallest ack-eliciting frame (RFC 9000 §19.2) — its only
+    // purpose is to provoke an ACK from the peer, which then runs
+    // through loss detection (steps 5–6) and surfaces any
+    // outstanding losses for retransmit. The PING itself is not
+    // retransmitted on loss (RFC 9002 §A.9 PROBE_TIMEOUT skipped).
+    if (conn.pendingPing) {
+        frames += PingFrame
+        conn.pendingPing = false
     }
 
     // Re-credit the peer's send window when our receive offset has advanced

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/recovery/AckedPackets.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/recovery/AckedPackets.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quic.connection.recovery
+
+import com.vitorpamplona.quic.frame.AckFrame
+
+/**
+ * Walks the ACK ranges of an [AckFrame] in RFC 9000 §19.3.1 form and
+ * yields each ACK'd packet number, descending. The first range covers
+ * `[largestAcked - firstAckRange, largestAcked]`; each additional
+ * range's largest PN is `previousSmallest - gap - 2` and its smallest
+ * is `largest - ackRangeLength`.
+ *
+ * Ranges below packet number 0 are clamped — the spec disallows
+ * negative PNs, but defensive clamping keeps a malformed peer ACK
+ * from blowing up the iterator.
+ *
+ * The function does not allocate per-PN; it iterates by primitive
+ * `Long` and invokes [block] for each ACK'd PN. Hot path on every
+ * inbound ACK frame, so allocation matters.
+ */
+inline fun forEachAckedPacketNumber(
+    ack: AckFrame,
+    block: (Long) -> Unit,
+) {
+    var currentLargest = ack.largestAcknowledged
+    var currentSmallest = currentLargest - ack.firstAckRange
+    if (currentSmallest < 0L) currentSmallest = 0L
+    var pn = currentLargest
+    while (pn >= currentSmallest) {
+        block(pn)
+        pn -= 1L
+    }
+    for (range in ack.additionalRanges) {
+        // Next range's largest = previousSmallest - gap - 2.
+        // Next range's smallest = largest - ackRangeLength.
+        val nextLargest = currentSmallest - range.gap - 2L
+        if (nextLargest < 0L) break
+        val nextSmallest = (nextLargest - range.ackRangeLength).coerceAtLeast(0L)
+        var pn2 = nextLargest
+        while (pn2 >= nextSmallest) {
+            block(pn2)
+            pn2 -= 1L
+        }
+        currentSmallest = nextSmallest
+    }
+}
+
+/**
+ * Drain [sentPackets] of every entry whose packet number is covered
+ * by [ack]. Returns the drained packets so callers can pass their
+ * tokens to congestion-control / RTT estimation layers (step 5+ of
+ * `quic/plans/2026-05-04-control-frame-retransmit.md`).
+ *
+ * Caller must hold the connection lock.
+ */
+fun drainAckedSentPackets(
+    sentPackets: MutableMap<Long, SentPacket>,
+    ack: AckFrame,
+): List<SentPacket> {
+    val drained = mutableListOf<SentPacket>()
+    forEachAckedPacketNumber(ack) { pn ->
+        sentPackets.remove(pn)?.let { drained += it }
+    }
+    return drained
+}

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/recovery/QuicLossDetection.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/recovery/QuicLossDetection.kt
@@ -160,6 +160,25 @@ class QuicLossDetection {
         return lost
     }
 
+    /**
+     * RFC 9002 §6.2.1 Probe Timeout duration:
+     *
+     *     PTO = smoothed_rtt + max(4 * rttvar, kGranularity) + max_ack_delay
+     *
+     * For Application packets only; Initial / Handshake spaces use
+     * `max_ack_delay = 0` per §6.2.1. The connection passes the
+     * peer's [maxAckDelayMs] (from its transport parameters) — pass
+     * 0 if the peer hasn't advertised it yet.
+     *
+     * The result is doubled by the caller for each consecutive PTO
+     * expiration (§6.2.2 exponential backoff), capped so a long-
+     * silent connection doesn't wait forever between probes.
+     */
+    fun ptoBaseMs(maxAckDelayMs: Long): Long {
+        val variancePart = (4L * rttVarMs).coerceAtLeast(GRANULARITY_MS)
+        return smoothedRttMs + variancePart + maxAckDelayMs
+    }
+
     companion object {
         /** RFC 9002 §6.2.2 default initial RTT before a sample arrives. */
         const val INITIAL_RTT_MS: Long = 333L

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/recovery/QuicLossDetection.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/recovery/QuicLossDetection.kt
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quic.connection.recovery
+
+import kotlin.math.abs
+
+/**
+ * RFC 9002 §5–§6 loss detection — RTT estimation + packet/time
+ * threshold loss declaration. Mirrors the algorithm Firefox neqo
+ * implements at `neqo-transport/src/recovery/mod.rs` and `rtt.rs`.
+ *
+ * State is per-connection (RTT estimates are per-path; we model a
+ * single path). Per-encryption-space state — `largestAckedPn`,
+ * `largestAckedSentTime` — lives on [com.vitorpamplona.quic.connection.LevelState].
+ *
+ * Step 5 of `quic/plans/2026-05-04-control-frame-retransmit.md`: this
+ * file implements the algorithm; the parser invokes it on every
+ * inbound ACK; step 6 dispatches the returned lost-token list to
+ * the `pending*` setters.
+ */
+class QuicLossDetection {
+    /**
+     * RFC 9002 §5.3. Smoothed RTT estimate. Initialised to
+     * [INITIAL_RTT_MS] until the first sample arrives. Updated as
+     * `smoothed_rtt = (7/8) * smoothed_rtt + (1/8) * adjusted_rtt`.
+     */
+    var smoothedRttMs: Long = INITIAL_RTT_MS
+        private set
+
+    /**
+     * RFC 9002 §5.3. RTT variance estimate. Initialised to half the
+     * initial RTT. Updated as
+     * `rttvar = (3/4) * rttvar + (1/4) * |smoothed_rtt - adjusted_rtt|`.
+     */
+    var rttVarMs: Long = INITIAL_RTT_MS / 2
+        private set
+
+    /**
+     * RFC 9002 §5.2. Latest RTT sample, before ack-delay adjustment.
+     * Tracks the most recent observation so callers can compute
+     * `max(latestRtt, smoothedRtt)` for the time-threshold loss check.
+     */
+    var latestRttMs: Long = INITIAL_RTT_MS
+        private set
+
+    /**
+     * RFC 9002 §5.2. Minimum RTT observed on this path. Used to
+     * clamp ack-delay so a peer can't artificially inflate our RTT
+     * estimate by reporting a large ack-delay.
+     */
+    var minRttMs: Long = Long.MAX_VALUE
+        private set
+
+    /** True after the first valid RTT sample has been processed. */
+    var hasFirstRttSample: Boolean = false
+        private set
+
+    /**
+     * Update RTT estimates from a new ACK that newly-acknowledged
+     * the largest packet number. Per RFC 9002 §5.2, an RTT sample
+     * is only generated when:
+     *   - the largest acknowledged packet number is newly acknowledged, and
+     *   - at least one of the newly acknowledged packets was ack-eliciting.
+     *
+     * The caller must enforce both conditions before calling this.
+     */
+    fun onRttSample(
+        largestAckedSentTimeMs: Long,
+        ackDelayMs: Long,
+        nowMs: Long,
+    ) {
+        val rawSampleMs = nowMs - largestAckedSentTimeMs
+        if (rawSampleMs < 0L) return // clock skew; ignore
+        if (!hasFirstRttSample) {
+            minRttMs = rawSampleMs
+            smoothedRttMs = rawSampleMs
+            rttVarMs = rawSampleMs / 2
+            latestRttMs = rawSampleMs
+            hasFirstRttSample = true
+            return
+        }
+        if (rawSampleMs < minRttMs) minRttMs = rawSampleMs
+        // Adjust by ack-delay, clamped so that adjusted_rtt >= min_rtt.
+        // Without the clamp, a peer reporting a fake high ack-delay can
+        // push smoothed_rtt below min_rtt (RFC 9002 §5.3).
+        val adjusted =
+            if (rawSampleMs - ackDelayMs >= minRttMs) {
+                rawSampleMs - ackDelayMs
+            } else {
+                rawSampleMs
+            }
+        latestRttMs = adjusted
+        rttVarMs = (3L * rttVarMs + abs(smoothedRttMs - adjusted)) / 4L
+        smoothedRttMs = (7L * smoothedRttMs + adjusted) / 8L
+    }
+
+    /**
+     * RFC 9002 §6.1.2. Loss-detection time threshold:
+     * `loss_delay = max(latest_rtt, smoothed_rtt) * (9/8)`
+     * clamped to at least [GRANULARITY_MS].
+     */
+    fun lossDelayMs(): Long {
+        val maxRtt = if (latestRttMs > smoothedRttMs) latestRttMs else smoothedRttMs
+        val scaled = (maxRtt * TIME_THRESHOLD_NUM) / TIME_THRESHOLD_DEN
+        return if (scaled > GRANULARITY_MS) scaled else GRANULARITY_MS
+    }
+
+    /**
+     * Detect packets lost in [sentPackets] and remove them. Called
+     * after the parser drains ACK'd packets — the surviving entries
+     * are the in-flight set, plus any older packets that haven't
+     * been ACK'd yet. RFC 9002 §6.1 declares a packet lost iff:
+     *
+     *   - it has a smaller PN than [largestAckedPn] AND
+     *     - it was sent at least [PACKET_THRESHOLD] PNs before
+     *       [largestAckedPn], OR
+     *     - it was sent more than [lossDelayMs] ago.
+     *
+     * Returns the list of lost packets in arbitrary order. Caller
+     * dispatches their [SentPacket.tokens] (step 6).
+     */
+    fun detectAndRemoveLost(
+        sentPackets: MutableMap<Long, SentPacket>,
+        largestAckedPn: Long,
+        nowMs: Long,
+    ): List<SentPacket> {
+        if (sentPackets.isEmpty()) return emptyList()
+        val lossDelay = lossDelayMs()
+        val lossThresholdSentMs = nowMs - lossDelay
+        val lost = mutableListOf<SentPacket>()
+        val it = sentPackets.entries.iterator()
+        while (it.hasNext()) {
+            val (pn, pkt) = it.next()
+            if (pn >= largestAckedPn) continue
+            val packetThresholdLost = pn < largestAckedPn - PACKET_THRESHOLD
+            val timeThresholdLost = pkt.sentAtMillis <= lossThresholdSentMs
+            if (packetThresholdLost || timeThresholdLost) {
+                lost += pkt
+                it.remove()
+            }
+        }
+        return lost
+    }
+
+    companion object {
+        /** RFC 9002 §6.2.2 default initial RTT before a sample arrives. */
+        const val INITIAL_RTT_MS: Long = 333L
+
+        /** RFC 9002 §6.1.1 packet-reordering threshold (number of PNs). */
+        const val PACKET_THRESHOLD: Long = 3L
+
+        /**
+         * RFC 9002 §6.1.2 time-threshold multiplier. The scaled max
+         * RTT is `max_rtt * NUM / DEN`; with NUM=9, DEN=8 the
+         * threshold is `max_rtt * 9/8 = max_rtt + max_rtt/8`.
+         */
+        const val TIME_THRESHOLD_NUM: Long = 9L
+        const val TIME_THRESHOLD_DEN: Long = 8L
+
+        /** RFC 9002 §6.1.2 granularity floor. Most stacks use 1 ms. */
+        const val GRANULARITY_MS: Long = 1L
+    }
+}

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/recovery/RecoveryToken.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/recovery/RecoveryToken.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quic.connection.recovery
+
+/**
+ * RFC 9002 §6 retransmit token. One token is recorded per ack-eliciting
+ * frame at send time; the [SentPacket] carrying it is held in
+ * [com.vitorpamplona.quic.connection.QuicConnection]'s sent-packet map
+ * keyed by packet number.
+ *
+ * On ACK, the carrying packet's tokens are dropped silently — the peer
+ * has confirmed receipt. On loss declaration, each token is dispatched
+ * to its `onLost` handler, which decides whether the frame still needs
+ * to be re-emitted (e.g. a `MAX_STREAMS_UNI` whose value has since
+ * been superseded by a higher extension is not re-sent).
+ *
+ * Mirrors Firefox neqo's `StreamRecoveryToken` enum at
+ * `neqo-transport/src/recovery/token.rs:21`. Scope (per
+ * `quic/plans/2026-05-04-control-frame-retransmit.md`) is the
+ * receive-side flow-control extensions that today silently wedge the
+ * connection on packet loss against moq-rs:
+ *
+ *   - `MAX_STREAMS_UNI` / `MAX_STREAMS_BIDI` (RFC 9000 §19.11)
+ *   - `MAX_DATA` (§19.9)
+ *   - `MAX_STREAM_DATA` (§19.10)
+ *
+ * [Ack] is tracked but never retransmitted — ACK frames are not
+ * ack-eliciting per RFC 9000 §13.2.1, so their loss is recovered by
+ * the peer's own ACK retransmission of newer ranges.
+ *
+ * Out of scope (separate follow-ups, see plan):
+ *   - STREAM data retransmit
+ *   - CRYPTO data retransmit
+ *   - RESET_STREAM, STOP_SENDING, NEW_CONNECTION_ID, etc.
+ */
+sealed class RecoveryToken {
+    /**
+     * Marks an ACK frame in the carrying packet. Recorded so the
+     * sent-packet map's invariant ("every retained packet has a
+     * non-empty `tokens` list") holds for ACK-only packets too, but
+     * never re-emitted on loss.
+     */
+    data object Ack : RecoveryToken()
+
+    /**
+     * `MAX_STREAMS_UNI` extension we sent. On loss, only re-emit if
+     * [maxStreams] still equals the connection's current
+     * `advertisedMaxStreamsUni` — otherwise a newer extension has
+     * already gone out and supersedes this one.
+     */
+    data class MaxStreamsUni(
+        val maxStreams: Long,
+    ) : RecoveryToken()
+
+    /** Bidi counterpart of [MaxStreamsUni]. */
+    data class MaxStreamsBidi(
+        val maxStreams: Long,
+    ) : RecoveryToken()
+
+    /**
+     * Connection-level `MAX_DATA` extension. On loss, only re-emit
+     * if [maxData] still equals the connection's current
+     * `advertisedMaxData` — same supersede semantics as
+     * [MaxStreamsUni].
+     */
+    data class MaxData(
+        val maxData: Long,
+    ) : RecoveryToken()
+
+    /**
+     * Per-stream `MAX_STREAM_DATA` extension. On loss, the dispatcher
+     * looks up the stream by [streamId]; if the stream has since been
+     * closed or its advertised cap has moved past [maxData], the
+     * token is dropped without re-emit.
+     */
+    data class MaxStreamData(
+        val streamId: Long,
+        val maxData: Long,
+    ) : RecoveryToken()
+}

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/recovery/RecoveryToken.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/recovery/RecoveryToken.kt
@@ -95,4 +95,97 @@ sealed class RecoveryToken {
         val streamId: Long,
         val maxData: Long,
     ) : RecoveryToken()
+
+    /**
+     * STREAM data range we sent. On loss, the dispatcher informs the
+     * stream's [com.vitorpamplona.quic.stream.SendBuffer] that bytes
+     * `[offset, offset + length)` need retransmission — the buffer
+     * moves them from "sent" back to "needs retransmit", and the
+     * next [com.vitorpamplona.quic.connection.QuicConnectionWriter]
+     * drain re-emits them with the same offset (idempotent retransmit
+     * per RFC 9000 §13.3).
+     *
+     * [fin] tracks whether this STREAM frame carried the FIN bit;
+     * lost FIN frames must also be retransmitted (the FIN is part of
+     * the stream's reliable byte sequence).
+     */
+    data class Stream(
+        val streamId: Long,
+        val offset: Long,
+        val length: Long,
+        val fin: Boolean,
+    ) : RecoveryToken()
+
+    /**
+     * CRYPTO data range we sent at a specific encryption level.
+     * RFC 9000 §17.2.5: handshake bytes are reliable per RFC 9000
+     * §13.3; a lost CRYPTO frame must be retransmitted at the same
+     * encryption level it was originally sent at. The dispatcher
+     * consults [level] to route to the correct
+     * [com.vitorpamplona.quic.connection.LevelState.cryptoSend].
+     */
+    data class Crypto(
+        val level: com.vitorpamplona.quic.connection.EncryptionLevel,
+        val offset: Long,
+        val length: Long,
+    ) : RecoveryToken()
+
+    /**
+     * `RESET_STREAM` frame we sent (RFC 9000 §19.4). Carries the
+     * stream id, the application error code, and the final size.
+     * On loss, retransmit verbatim — RESET_STREAM is reliable per
+     * §13.3.
+     *
+     * `:quic` doesn't currently emit RESET_STREAM (no application
+     * code triggers stream reset), so this variant is scaffolding for
+     * future work. Listed in the enum so the dispatcher's `when`
+     * stays exhaustive at compile time.
+     */
+    data class ResetStream(
+        val streamId: Long,
+        val errorCode: Long,
+        val finalSize: Long,
+    ) : RecoveryToken()
+
+    /**
+     * `STOP_SENDING` frame we sent (RFC 9000 §19.5). Reliable per
+     * §13.3; retransmit verbatim on loss. Same scaffolding-only
+     * status as [ResetStream] — `:quic` doesn't emit it today.
+     */
+    data class StopSending(
+        val streamId: Long,
+        val errorCode: Long,
+    ) : RecoveryToken()
+
+    /**
+     * `NEW_CONNECTION_ID` frame we sent (RFC 9000 §19.15). Reliable
+     * per §13.3. Same scaffolding-only status — connection-ID
+     * rotation isn't wired today.
+     */
+    data class NewConnectionId(
+        val sequenceNumber: Long,
+        val retirePriorTo: Long,
+        val connectionId: ByteArray,
+        val statelessResetToken: ByteArray,
+    ) : RecoveryToken() {
+        // ByteArray fields require explicit equals/hashCode for data-class
+        // contract correctness — Kotlin's data-class auto-equals does
+        // identity compare on arrays.
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is NewConnectionId) return false
+            return sequenceNumber == other.sequenceNumber &&
+                retirePriorTo == other.retirePriorTo &&
+                connectionId.contentEquals(other.connectionId) &&
+                statelessResetToken.contentEquals(other.statelessResetToken)
+        }
+
+        override fun hashCode(): Int {
+            var result = sequenceNumber.hashCode()
+            result = 31 * result + retirePriorTo.hashCode()
+            result = 31 * result + connectionId.contentHashCode()
+            result = 31 * result + statelessResetToken.contentHashCode()
+            return result
+        }
+    }
 }

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/recovery/RecoveryToken.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/recovery/RecoveryToken.kt
@@ -53,12 +53,33 @@ package com.vitorpamplona.quic.connection.recovery
  */
 sealed class RecoveryToken {
     /**
-     * Marks an ACK frame in the carrying packet. Recorded so the
-     * sent-packet map's invariant ("every retained packet has a
-     * non-empty `tokens` list") holds for ACK-only packets too, but
-     * never re-emitted on loss.
+     * Marks an ACK frame in the carrying packet. Carries enough
+     * context for the dispatcher to purge our own [com.vitorpamplona.quic.recovery.AckTracker]
+     * once the peer ACKs the carrying packet — i.e. an ACK-of-ACK.
+     *
+     * RFC 9000 §13.2.1: ACK frames are not ack-eliciting and not
+     * retransmitted. But the ACK we sent IS itself acknowledgeable
+     * (it rides on a packet whose other frames may be ack-eliciting),
+     * and the peer's ACK of THAT packet means the peer has now
+     * received our ACK for everything up to [largestAcked]. We can
+     * stop including those PNs in subsequent outbound ACK frames.
+     *
+     * Pre-fix the parser purged on every inbound ACK using the
+     * peer's `largestAcknowledged - firstAckRange` value — but that
+     * is in OUR outbound PN space, not the inbound PN space the
+     * tracker holds. The values happened to grow at similar rates so
+     * the bug rarely manifested as outright wrongness, just
+     * range-list bloat over long sessions where the two spaces drift
+     * apart (e.g. listener receiving ~50 audio frames/sec while
+     * sending ~1 ACK/sec).
+     *
+     * [level] routes the purge to the right per-space [com.vitorpamplona.quic.connection.LevelState.ackTracker]
+     * since we track separately for Initial / Handshake / Application.
      */
-    data object Ack : RecoveryToken()
+    data class Ack(
+        val level: com.vitorpamplona.quic.connection.EncryptionLevel,
+        val largestAcked: Long,
+    ) : RecoveryToken()
 
     /**
      * `MAX_STREAMS_UNI` extension we sent. On loss, only re-emit if

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/recovery/SentPacket.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/recovery/SentPacket.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quic.connection.recovery
+
+/**
+ * Per-packet metadata retained from send time until the packet is
+ * either ACK'd or declared lost. Mirrors Firefox neqo's
+ * `recovery/sent.rs::Packet`.
+ *
+ * Held in a per-packet-number-space map on
+ * [com.vitorpamplona.quic.connection.QuicConnection], keyed by
+ * [packetNumber]. On ACK arrival the matching entry is removed and
+ * its tokens dropped silently. On loss-detection (RFC 9002 §6.1)
+ * the entry is removed and each token is dispatched to its `onLost`
+ * handler, which decides whether to re-emit.
+ *
+ * [ackEliciting] determines whether the packet's loss matters at all
+ * for retransmit — non-ack-eliciting packets (ACK-only, PADDING-only,
+ * CONNECTION_CLOSE) are never retransmitted per RFC 9000 §13.2.1.
+ * They're still tracked so the loss-detection algorithm has consistent
+ * timing data, but their tokens are limited to [RecoveryToken.Ack].
+ *
+ * [sizeBytes] is the on-wire encrypted packet size; used by congestion
+ * control to release in-flight bytes when the packet is ACK'd or lost.
+ * Recorded here even though `:quic` has no congestion controller today
+ * — the field lets a future CC pass plug in without changing the
+ * sent-packet schema.
+ */
+data class SentPacket(
+    /** Packet number assigned at encrypt time. Unique within its space. */
+    val packetNumber: Long,
+    /**
+     * Wall-clock epoch milliseconds at the moment the packet was
+     * handed to the UDP socket. Source is
+     * [com.vitorpamplona.quic.connection.QuicConnection.nowMillis], not
+     * `System.currentTimeMillis` — keeps unit tests deterministic.
+     */
+    val sentAtMillis: Long,
+    /**
+     * RFC 9000 §13.2.1: whether the packet contains a frame that elicits
+     * an ACK from the peer. Loss detection only fires for ack-eliciting
+     * packets; non-ack-eliciting packets (ACK-only, PADDING-only,
+     * CONNECTION_CLOSE) are never retransmitted.
+     */
+    val ackEliciting: Boolean,
+    /**
+     * Encrypted on-wire size in bytes, including AEAD tag and packet
+     * header. Used by congestion controllers to release in-flight
+     * bytes on ACK / loss.
+     */
+    val sizeBytes: Int,
+    /**
+     * Frames in this packet that need to be tracked for retransmit.
+     * Empty list is legal for non-ack-eliciting packets that have
+     * nothing retransmittable (e.g. ACK-only). Otherwise non-empty.
+     */
+    val tokens: List<RecoveryToken>,
+)

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/stream/QuicStream.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/stream/QuicStream.kt
@@ -119,11 +119,21 @@ class QuicStream(
      *   - Once the peer ACKs the RESET_STREAM, [resetAcked] latches
      *     true and the writer stops re-emitting.
      *
-     * Idempotent: a second [resetStream] call overwrites the queued
-     * entry with the newer error code (in practice apps shouldn't
-     * reset twice — the second call is benign).
+     * First call wins. A second [resetStream] is a no-op: RFC 9000 §3.5
+     * pins `finalSize` at the first emission; replaying retransmits with
+     * a larger value (because the app enqueued more bytes between the
+     * two calls) would trigger `FINAL_SIZE_ERROR` on the peer. The
+     * `errorCode` is likewise frozen.
+     *
+     * Threading: callable from any coroutine. The boolean flags
+     * ([resetEmitPending], [resetAcked]) are `@Volatile` so the writer
+     * (which reads them under [com.vitorpamplona.quic.connection.QuicConnection.lock])
+     * sees the assignment without acquiring the connection mutex. The
+     * "first call wins" gate above closes the only multi-writer race
+     * (two app threads racing the writer's clear-after-emit).
      */
     fun resetStream(errorCode: Long) {
+        if (resetState != null) return
         resetState =
             ResetState(
                 errorCode = errorCode,
@@ -140,33 +150,56 @@ class QuicStream(
      * `STOP_SENDING(streamId, errorCode)` frame is queued for emission
      * on the next writer drain; reliable per §13.3, retransmitted on
      * loss like [resetStream].
+     *
+     * First call wins (same reasoning as [resetStream]: the peer treats
+     * the first STOP_SENDING as authoritative; replaying retransmits
+     * with a different `errorCode` would visibly disagree with the
+     * original frame already on the wire).
      */
     fun stopSending(errorCode: Long) {
+        if (stopSendingState != null) return
         stopSendingState = StopSendingState(errorCode = errorCode)
         stopSendingEmitPending = true
     }
 
-    /** RFC 9000 §3.5 send-side reset state. Set by [resetStream]. */
+    /**
+     * RFC 9000 §3.5 send-side reset state. Set once by [resetStream]
+     * (subsequent calls no-op); read by the writer + loss/ACK
+     * dispatchers. Once set, contents are immutable.
+     */
     internal var resetState: ResetState? = null
 
     /**
      * True while a RESET_STREAM emit is pending. Cleared after the
      * writer emits; set back to true by the loss dispatcher; cleared
      * again (and not re-set) once [resetAcked] latches.
+     *
+     * `@Volatile` because [resetStream] writes it from an arbitrary
+     * coroutine while the writer / dispatchers read it under
+     * [com.vitorpamplona.quic.connection.QuicConnection.lock]. Volatile
+     * gives the cross-thread happens-before; the "first call wins"
+     * gate in [resetStream] eliminates the write-write race with the
+     * writer's clear-after-emit.
      */
+    @Volatile
     internal var resetEmitPending: Boolean = false
 
     /**
      * Latches true when the peer ACKs the RESET_STREAM. After this
      * the writer no longer re-emits even if a stale lost token shows
-     * up. Mirrors neqo's `send_stream::ResetAcked` state.
+     * up. Mirrors neqo's `send_stream::ResetAcked` state. Volatile for
+     * the same reason as [resetEmitPending].
      */
+    @Volatile
     internal var resetAcked: Boolean = false
 
     /** Receive-side stop-sending state. Set by [stopSending]. */
     internal var stopSendingState: StopSendingState? = null
 
+    @Volatile
     internal var stopSendingEmitPending: Boolean = false
+
+    @Volatile
     internal var stopSendingAcked: Boolean = false
 
     internal data class ResetState(

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/stream/QuicStream.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/stream/QuicStream.kt
@@ -100,4 +100,81 @@ class QuicStream(
     internal fun closeIncoming() {
         incomingChannel.close()
     }
+
+    /**
+     * RFC 9000 §3.5: abruptly terminate the SEND side. Application code
+     * calls this when it wants to cancel a partially-written stream
+     * (e.g. user cancelled a request mid-upload). After [resetStream]:
+     *
+     *   - A `RESET_STREAM(streamId, errorCode, finalSize)` frame is
+     *     queued for emission on the next writer drain. `finalSize` is
+     *     the largest stream offset the application has appended, i.e.
+     *     [SendBuffer.nextOffset] at reset time (RFC 9000 §3.5 — the
+     *     peer uses this to satisfy its receive-side flow-control
+     *     accounting even though it discards the bytes).
+     *   - The frame is reliable per §13.3 — if its carrying packet is
+     *     declared lost, the dispatcher in
+     *     [com.vitorpamplona.quic.connection.QuicConnection.onTokensLost]
+     *     re-flags [resetEmitPending] for re-emit on next drain.
+     *   - Once the peer ACKs the RESET_STREAM, [resetAcked] latches
+     *     true and the writer stops re-emitting.
+     *
+     * Idempotent: a second [resetStream] call overwrites the queued
+     * entry with the newer error code (in practice apps shouldn't
+     * reset twice — the second call is benign).
+     */
+    fun resetStream(errorCode: Long) {
+        resetState =
+            ResetState(
+                errorCode = errorCode,
+                finalSize = send.nextOffset,
+            )
+        resetEmitPending = true
+    }
+
+    /**
+     * RFC 9000 §3.5: ask the peer to stop sending on this stream's
+     * RECEIVE side. Application calls this when it's done reading
+     * (e.g. an HTTP/3 request handler returned an early response and
+     * doesn't care about the rest of the request body). The
+     * `STOP_SENDING(streamId, errorCode)` frame is queued for emission
+     * on the next writer drain; reliable per §13.3, retransmitted on
+     * loss like [resetStream].
+     */
+    fun stopSending(errorCode: Long) {
+        stopSendingState = StopSendingState(errorCode = errorCode)
+        stopSendingEmitPending = true
+    }
+
+    /** RFC 9000 §3.5 send-side reset state. Set by [resetStream]. */
+    internal var resetState: ResetState? = null
+
+    /**
+     * True while a RESET_STREAM emit is pending. Cleared after the
+     * writer emits; set back to true by the loss dispatcher; cleared
+     * again (and not re-set) once [resetAcked] latches.
+     */
+    internal var resetEmitPending: Boolean = false
+
+    /**
+     * Latches true when the peer ACKs the RESET_STREAM. After this
+     * the writer no longer re-emits even if a stale lost token shows
+     * up. Mirrors neqo's `send_stream::ResetAcked` state.
+     */
+    internal var resetAcked: Boolean = false
+
+    /** Receive-side stop-sending state. Set by [stopSending]. */
+    internal var stopSendingState: StopSendingState? = null
+
+    internal var stopSendingEmitPending: Boolean = false
+    internal var stopSendingAcked: Boolean = false
+
+    internal data class ResetState(
+        val errorCode: Long,
+        val finalSize: Long,
+    )
+
+    internal data class StopSendingState(
+        val errorCode: Long,
+    )
 }

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/stream/QuicStream.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/stream/QuicStream.kt
@@ -33,10 +33,18 @@ import kotlinx.coroutines.flow.consumeAsFlow
 class QuicStream(
     val streamId: Long,
     val direction: Direction,
+    /**
+     * If true, lost STREAM bytes are dropped instead of retransmitted
+     * (see [SendBuffer.bestEffort]). Used by moq-lite group streams
+     * carrying real-time Opus audio: a STREAM frame arriving 200 ms
+     * late is worse than useless. Default false (RFC 9000 §3.5
+     * reliable byte sequence).
+     */
+    val bestEffort: Boolean = false,
 ) {
     enum class Direction { BIDIRECTIONAL, UNIDIRECTIONAL_LOCAL_TO_REMOTE, UNIDIRECTIONAL_REMOTE_TO_LOCAL }
 
-    val send = SendBuffer()
+    val send = SendBuffer(bestEffort = bestEffort)
     val receive = ReceiveBuffer()
 
     /**

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/stream/SendBuffer.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/stream/SendBuffer.kt
@@ -130,6 +130,50 @@ class SendBuffer {
             Chunk(offset, data, fin)
         }
 
+    /**
+     * Re-queue a previously-sent byte range for retransmission. Called
+     * by [com.vitorpamplona.quic.connection.QuicConnection.onTokensLost]
+     * when the [com.vitorpamplona.quic.connection.recovery.RecoveryToken.Stream]
+     * (or `Crypto`) token's carrying packet is declared lost.
+     *
+     * Currently a no-op: the buffer releases bytes on [takeChunk] (the
+     * "best-effort mode" documented at the top of this class), so by
+     * the time loss is detected the original bytes are gone and we
+     * have nothing to resend. The full retain-until-ACK rewrite lands
+     * in step C of the deferred-follow-ups pass started at commit
+     * `9e6fa3d` — once that's in, this method moves the [offset,
+     * offset + length) range from the "sent" set back to the
+     * "needs retransmit" queue, and the next [takeChunk] pulls from
+     * that queue first.
+     *
+     * The signature is stable now so the dispatcher doesn't need a
+     * second wiring pass when the implementation lands.
+     */
+    fun markLost(
+        offset: Long,
+        length: Long,
+        fin: Boolean,
+    ) {
+        // Step C placeholder. Parameters unused on purpose — the
+        // suppression makes the no-op intent explicit so a future
+        // reader doesn't think it's a bug.
+        @Suppress("UNUSED_PARAMETER")
+        val unusedForStepC = Triple(offset, length, fin)
+    }
+
+    /**
+     * Release ACK'd bytes from the retain-until-ACK retention buffer.
+     * Same step-C placeholder as [markLost]: today the buffer doesn't
+     * retain anything, so there's nothing to release.
+     */
+    fun markAcked(
+        offset: Long,
+        length: Long,
+    ) {
+        @Suppress("UNUSED_PARAMETER")
+        val unusedForStepC = Pair(offset, length)
+    }
+
     data class Chunk(
         val offset: Long,
         val data: ByteArray,

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/stream/SendBuffer.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/stream/SendBuffer.kt
@@ -27,156 +27,442 @@ package com.vitorpamplona.quic.stream
  * Application code [enqueue]s payload bytes; the connection's send loop
  * [takeChunk]s as much as it can fit in the next packet, given the
  * remaining packet budget and stream-level / connection-level flow control
- * credit.
+ * credit. Bytes are *retained* in the buffer (RFC 9000 §13.3 — STREAM data
+ * is reliable) until [markAcked] removes them, so a [markLost] call can
+ * re-queue the same byte range for retransmit.
  *
- * **Best-effort mode (no STREAM retransmit):** bytes are released from the
- * buffer the moment they're handed off, on the assumption that the
- * underlying network is stable. A real loss event silently truncates the
- * stream. Acceptable for MoQ over QUIC (audio rooms use OBJECT_DATAGRAM,
- * which is loss-tolerant; STREAM is control-plane only). See the deferred
- * items in `quic/plans/2026-04-26-quic-stack-status.md` — adding
- * retain-until-ACK + retransmit is the first thing to add for general
- * STREAM-heavy use.
+ * # Three logical regions of the byte sequence
  *
- * **Concurrency:** [enqueue] / [finish] are invoked by application
- * coroutines (e.g. WebTransport stream writers in [com.vitorpamplona.quic.webtransport.WtPeerStreamDemux]);
- * [takeChunk] runs on the [com.vitorpamplona.quic.connection.QuicConnectionDriver] send loop under the
- * connection mutex. The two paths are NOT serialised by a shared lock,
- * so the buffer's internal state (`chunks`, `pendingBytes`, `headOffset`,
- * FIN flags, offsets) is mutated under `synchronized(this)`. The cheap
- * `readableBytes` / `sentOffset` / `finPending` / `finSent` getters used
- * by the writer's pre-flight checks are also synchronised so they can't
- * read torn state. Without this, an `enqueue` racing a `takeChunk`
- * surfaced as `NoSuchElementException: ArrayDeque is empty` from
- * `chunks.first()` (the writer saw `pendingBytes > 0` after the
- * `addLast` but before the matching deque mutation became visible, so
- * it entered the head-peel branch and tripped on an empty deque).
+ * The buffer covers the offset range `[flushedFloor, nextOffset)`. Within
+ * that range each byte is in exactly one of three states:
+ *
+ *   1. **In-flight** — sent but not yet ACK'd. Tracked in [inFlight] as
+ *      a sorted-by-offset list of [Range]s. ACKs remove from here; loss
+ *      moves into the retransmit queue.
+ *   2. **Needs retransmit** — declared lost; re-sent before any fresh
+ *      bytes. Tracked in [retransmit] as a FIFO of [Range]s.
+ *   3. **Unsent** — `[nextSendOffset, nextOffset)`. New bytes the writer
+ *      hasn't picked up yet. [takeChunk] drains in priority order:
+ *      retransmit first, then fresh.
+ *
+ * # Compaction
+ *
+ * When `[flushedFloor, x)` is contiguously ACK'd we advance [flushedFloor]
+ * and shift the underlying byte storage. The structure never grows
+ * unboundedly under normal traffic — bytes are released as soon as the
+ * peer ACKs them.
+ *
+ * # Concurrency
+ *
+ * [enqueue] / [finish] run on application coroutines (e.g. WebTransport
+ * stream writers in [com.vitorpamplona.quic.webtransport.WtPeerStreamDemux]);
+ * [takeChunk] runs on the [com.vitorpamplona.quic.connection.QuicConnectionDriver]
+ * send loop under the connection mutex; [markAcked] / [markLost] run on
+ * the parser path also under the connection mutex. The two execution
+ * paths are NOT serialised by a shared lock, so all internal state is
+ * mutated under `synchronized(this)`. Even the cheap getters
+ * ([readableBytes], [sentOffset], [finPending], [finSent]) take the
+ * monitor so a writer pre-flight check can't observe torn state.
+ *
+ * # FIN
+ *
+ * The FIN bit is part of the reliable byte sequence per RFC 9000 §3.3.
+ * Treated as a "virtual byte" at offset = `nextOffset`: setting
+ * [finPending] arms the next [takeChunk] to attach FIN to the final
+ * data chunk (or emit an empty FIN-only chunk if the buffer is already
+ * drained). [markAcked] / [markLost] respect FIN — a lost range that
+ * carried FIN is re-sent with FIN set, and the buffer's "FIN delivered"
+ * latch ([finAcked]) only flips when the FIN-carrying range is ACK'd.
  */
 class SendBuffer {
     /**
-     * Pending unsent chunks plus the offset within the head chunk. This avoids
-     * the previous O(N) copyOf-per-enqueue: each enqueue is O(1), each
-     * takeChunk peels at most one head chunk. Memory bounded by the sum of
-     * outstanding writes.
+     * Contiguous byte storage covering `[flushedFloor, nextOffset)`.
+     * Indexing: byte at logical offset `o` lives at `data[(o - flushedFloor).toInt()]`.
+     * Capacity grows on enqueue; the front end shifts on
+     * [advanceFlushedFloorIfPossible] to release ACK'd-from-the-bottom
+     * bytes.
      */
-    private val chunks: ArrayDeque<ByteArray> = ArrayDeque()
-    private var headOffset: Int = 0
-    private var pendingBytes: Int = 0
-    private var sentEnd: Long = 0L
+    private var data: ByteArray = ByteArray(64)
+
+    /** `nextOffset - flushedFloor` — bytes currently held in [data]. */
+    private var dataLen: Int = 0
+
+    /** Logical offset of the byte at `data[0]`. Advances on contiguous ACK. */
+    private var flushedFloor: Long = 0L
+
+    /** Logical offset just past the last byte. Advances on [enqueue]. */
     private var _nextOffset: Long = 0L
+
+    /**
+     * Logical offset of the next FRESH byte the writer would send if
+     * the [retransmit] queue is empty. Bytes `[nextSendOffset, nextOffset)`
+     * are unsent; bytes below that are either in-flight, in retransmit,
+     * or already ACK'd (released).
+     *
+     * Invariant: `flushedFloor <= nextSendOffset <= nextOffset`.
+     */
+    private var nextSendOffset: Long = 0L
+
+    /**
+     * Sent-but-not-yet-ACK'd ranges, sorted by offset ascending. Mutated
+     * by [takeChunk] (append), [markAcked] (remove / split), [markLost]
+     * (remove and move to [retransmit]).
+     *
+     * Range arithmetic is O(N) on the inFlight list; for the moq-rooms
+     * workload (a few thousand ranges max per connection) this is fine.
+     * If profiling later shows it on the hot path, swap in a TreeMap
+     * keyed by offset.
+     */
+    private val inFlight: ArrayDeque<Range> = ArrayDeque()
+
+    /**
+     * FIFO queue of ranges declared lost and awaiting re-emission.
+     * [takeChunk] drains from the front before touching fresh bytes.
+     * Same byte data lives in [data] — only the metadata is duplicated.
+     */
+    private val retransmit: ArrayDeque<Range> = ArrayDeque()
+
     private var _finPending: Boolean = false
     private var _finSent: Boolean = false
+    private var _finAcked: Boolean = false
 
     val nextOffset: Long get() = synchronized(this) { _nextOffset }
     val finPending: Boolean get() = synchronized(this) { _finPending }
     val finSent: Boolean get() = synchronized(this) { _finSent }
+    val finAcked: Boolean get() = synchronized(this) { _finAcked }
 
-    val readableBytes: Int get() = synchronized(this) { pendingBytes }
+    /**
+     * Bytes the writer would emit on the next [takeChunk] before any
+     * flow-control limits. Includes both retransmit-queued bytes (which
+     * have priority) and unsent-fresh bytes. Used by the writer's
+     * pre-flight skip check ("nothing to send → continue").
+     */
+    val readableBytes: Int
+        get() =
+            synchronized(this) {
+                var sum = 0L
+                for (r in retransmit) sum += r.length
+                sum += (_nextOffset - nextSendOffset)
+                sum.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+            }
 
-    /** Bytes already handed out via [takeChunk]; equal to the next offset to assign. */
-    val sentOffset: Long get() = synchronized(this) { sentEnd }
+    /**
+     * High-water mark of bytes ever handed to [takeChunk]. Equal to
+     * [_nextOffset] only when all bytes have been at least sent once.
+     * Used by the writer's connection-level flow-control accounting.
+     *
+     * Note: under retain-until-ACK semantics, the same byte may be
+     * "sent" multiple times across retransmits. [sentOffset] reports
+     * the high-water mark of *fresh* sends only, not the cumulative
+     * retransmit volume.
+     */
+    val sentOffset: Long get() = synchronized(this) { nextSendOffset }
 
     fun enqueue(bytes: ByteArray) {
         if (bytes.isEmpty()) return
         synchronized(this) {
-            chunks.addLast(bytes)
-            pendingBytes += bytes.size
+            ensureCapacity(dataLen + bytes.size)
+            bytes.copyInto(data, dataLen)
+            dataLen += bytes.size
             _nextOffset += bytes.size
         }
     }
 
-    /** Mark the write side as closing; the next [takeChunk] will set FIN once empty. */
+    /** Mark the write side as closing; the next [takeChunk] sets FIN once empty. */
     fun finish() {
         synchronized(this) { _finPending = true }
     }
 
-    /** Take up to [maxBytes] bytes off the head of the buffer at the current send offset. */
+    /**
+     * Take up to [maxBytes] bytes off the head of the next available
+     * range. Priority order:
+     *
+     *   1. [retransmit] queue — retain offset semantics; the chunk's
+     *      offset is the original lost range's offset.
+     *   2. Fresh unsent bytes from `[nextSendOffset, nextOffset)`.
+     *   3. FIN-only zero-byte chunk if [finPending] and everything
+     *      else is drained.
+     *
+     * Returns null if there's nothing to send.
+     */
     fun takeChunk(maxBytes: Int): Chunk? =
         synchronized(this) {
-            if (pendingBytes == 0 && !(_finPending && !_finSent)) return@synchronized null
             val cap = maxBytes.coerceAtLeast(0)
-            if (cap == 0 && pendingBytes > 0) return@synchronized null
-            val data: ByteArray
-            if (pendingBytes == 0) {
-                data = ByteArray(0)
-            } else {
-                val head = chunks.first()
-                val available = head.size - headOffset
-                if (available <= cap) {
-                    // Hand out the rest of the head chunk. Always copy: the caller's
-                    // ByteArray (passed to enqueue) MUST stay opaque to the rest of
-                    // the stack, since downstream encoders eventually pass it to
-                    // AEAD.seal which assumes immutability for the duration of the
-                    // encryption call.
-                    data =
-                        if (headOffset == 0 && head.size == available) {
-                            head.copyOf()
-                        } else {
-                            head.copyOfRange(headOffset, head.size)
-                        }
-                    chunks.removeFirst()
-                    headOffset = 0
-                    pendingBytes -= available
-                } else {
-                    data = head.copyOfRange(headOffset, headOffset + cap)
-                    headOffset += cap
-                    pendingBytes -= cap
+
+            // 1. Retransmit queue first.
+            val retransmitHead = retransmit.firstOrNull()
+            if (retransmitHead != null) {
+                if (cap == 0 && retransmitHead.length > 0L) return@synchronized null
+                val take = minOf(retransmitHead.length, cap.toLong())
+                val payload = sliceAt(retransmitHead.offset, take.toInt())
+                retransmit.removeFirst()
+                val fin = retransmitHead.fin && take == retransmitHead.length
+                if (take < retransmitHead.length) {
+                    // Push remainder back at the head, preserving offset.
+                    retransmit.addFirst(
+                        Range(
+                            offset = retransmitHead.offset + take,
+                            length = retransmitHead.length - take,
+                            fin = retransmitHead.fin,
+                        ),
+                    )
                 }
+                addToInFlight(Range(retransmitHead.offset, take, fin))
+                if (fin) _finSent = true
+                return@synchronized Chunk(retransmitHead.offset, payload, fin)
             }
-            val offset = sentEnd
-            sentEnd += data.size
-            val fin = _finPending && pendingBytes == 0
-            if (fin) _finSent = true
-            Chunk(offset, data, fin)
+
+            // 2. Fresh bytes.
+            val freshAvailable = _nextOffset - nextSendOffset
+            if (freshAvailable > 0L) {
+                if (cap == 0) return@synchronized null
+                val take = minOf(freshAvailable, cap.toLong())
+                val offset = nextSendOffset
+                val payload = sliceAt(offset, take.toInt())
+                nextSendOffset += take
+                val finForThis = _finPending && !_finSent && nextSendOffset == _nextOffset
+                addToInFlight(Range(offset, take, finForThis))
+                if (finForThis) _finSent = true
+                return@synchronized Chunk(offset, payload, finForThis)
+            }
+
+            // 3. FIN-only.
+            if (_finPending && !_finSent) {
+                _finSent = true
+                addToInFlight(Range(nextSendOffset, 0L, true))
+                return@synchronized Chunk(nextSendOffset, ByteArray(0), true)
+            }
+            null
         }
 
     /**
-     * Re-queue a previously-sent byte range for retransmission. Called
-     * by [com.vitorpamplona.quic.connection.QuicConnection.onTokensLost]
-     * when the [com.vitorpamplona.quic.connection.recovery.RecoveryToken.Stream]
-     * (or `Crypto`) token's carrying packet is declared lost.
+     * Mark the byte range `[offset, offset + length)` as ACK'd by the
+     * peer. The range may cover one or several entries in [inFlight];
+     * each is split where needed and the covered portion removed. If
+     * the contiguous low end of the buffer becomes fully ACK'd, the
+     * underlying byte storage is shifted forward (releasing memory).
      *
-     * Currently a no-op: the buffer releases bytes on [takeChunk] (the
-     * "best-effort mode" documented at the top of this class), so by
-     * the time loss is detected the original bytes are gone and we
-     * have nothing to resend. The full retain-until-ACK rewrite lands
-     * in step C of the deferred-follow-ups pass started at commit
-     * `9e6fa3d` — once that's in, this method moves the [offset,
-     * offset + length) range from the "sent" set back to the
-     * "needs retransmit" queue, and the next [takeChunk] pulls from
-     * that queue first.
+     * `length == 0` is interpreted as a FIN-only ACK at [offset]. The
+     * matching FIN-bearing in-flight range is removed and [finAcked]
+     * latches true.
+     */
+    fun markAcked(
+        offset: Long,
+        length: Long,
+    ) {
+        synchronized(this) {
+            removeOverlap(inFlight, offset, length, ackedNotLost = true)
+            advanceFlushedFloorIfPossible()
+        }
+    }
+
+    /**
+     * Mark the byte range `[offset, offset + length)` as lost — re-queue
+     * it for retransmit. The range may cover one or several entries in
+     * [inFlight]; each is split where needed and the covered portion
+     * appended to [retransmit]. If [fin] is true, the FIN bit is forced
+     * to re-send (clears [finSent] so [takeChunk] will re-emit the FIN
+     * on the retransmit chunk).
      *
-     * The signature is stable now so the dispatcher doesn't need a
-     * second wiring pass when the implementation lands.
+     * Idempotent: calling with a range already in retransmit (or
+     * already ACK'd) is a no-op. The dispatcher in
+     * [com.vitorpamplona.quic.connection.QuicConnection.onTokensLost] may
+     * call this with stale offsets after compaction; we silently absorb.
      */
     fun markLost(
         offset: Long,
         length: Long,
         fin: Boolean,
     ) {
-        // Step C placeholder. Parameters unused on purpose — the
-        // suppression makes the no-op intent explicit so a future
-        // reader doesn't think it's a bug.
-        @Suppress("UNUSED_PARAMETER")
-        val unusedForStepC = Triple(offset, length, fin)
+        synchronized(this) {
+            // Bytes already released (below flushedFloor) are gone for
+            // good — by definition they were ACK'd, so there's nothing
+            // to retransmit. Clamp the requested range to the retained
+            // window to keep the operation idempotent.
+            if (offset + length <= flushedFloor) {
+                if (fin && !_finAcked) _finSent = false
+                return
+            }
+            val clampedOffset = maxOf(offset, flushedFloor)
+            val clampedLength = (offset + length) - clampedOffset
+            removeOverlap(inFlight, clampedOffset, clampedLength, ackedNotLost = false)
+            if (fin && !_finAcked) _finSent = false
+        }
     }
 
     /**
-     * Release ACK'd bytes from the retain-until-ACK retention buffer.
-     * Same step-C placeholder as [markLost]: today the buffer doesn't
-     * retain anything, so there's nothing to release.
+     * Walk [list] for any range overlapping `[offset, offset + length)`,
+     * remove the overlapping portion, and either drop it (ACK path) or
+     * push it onto [retransmit] (loss path). Splits ranges where the
+     * overlap is partial.
      */
-    fun markAcked(
+    private fun removeOverlap(
+        list: ArrayDeque<Range>,
         offset: Long,
         length: Long,
+        ackedNotLost: Boolean,
     ) {
-        @Suppress("UNUSED_PARAMETER")
-        val unusedForStepC = Pair(offset, length)
+        // length == 0 only meaningful for FIN-only ranges; handle by
+        // matching the exact-offset zero-length range.
+        if (length == 0L) {
+            val it = list.iterator()
+            while (it.hasNext()) {
+                val r = it.next()
+                if (r.offset == offset && r.length == 0L) {
+                    it.remove()
+                    if (ackedNotLost) {
+                        if (r.fin) _finAcked = true
+                    } else {
+                        retransmit.addLast(r)
+                    }
+                    return
+                }
+            }
+            return
+        }
+        val rangeEnd = offset + length
+        val replacements = mutableListOf<Range>()
+        val it = list.iterator()
+        while (it.hasNext()) {
+            val r = it.next()
+            val rEnd = r.offset + r.length
+            if (rEnd <= offset || r.offset >= rangeEnd) continue
+            // Overlap exists. Compute up-to-three pieces:
+            //   leftKept: [r.offset, max(r.offset, offset))
+            //   covered:  [max(r.offset, offset), min(rEnd, rangeEnd))
+            //   rightKept:[min(rEnd, rangeEnd), rEnd)
+            val coveredStart = maxOf(r.offset, offset)
+            val coveredEnd = minOf(rEnd, rangeEnd)
+            val coveredLen = coveredEnd - coveredStart
+            it.remove()
+            if (coveredStart > r.offset) {
+                replacements +=
+                    Range(
+                        offset = r.offset,
+                        length = coveredStart - r.offset,
+                        // FIN belongs to the LAST covered piece; the left
+                        // kept piece never carries FIN.
+                        fin = false,
+                    )
+            }
+            if (coveredEnd < rEnd) {
+                replacements +=
+                    Range(
+                        offset = coveredEnd,
+                        length = rEnd - coveredEnd,
+                        // FIN, if any, lives on the rightmost piece.
+                        fin = r.fin,
+                    )
+            }
+            if (coveredLen > 0L || r.length == 0L) {
+                val coveredFin = r.fin && coveredEnd == rEnd
+                if (ackedNotLost) {
+                    if (coveredFin) _finAcked = true
+                } else {
+                    retransmit.addLast(
+                        Range(
+                            offset = coveredStart,
+                            length = coveredLen,
+                            fin = coveredFin,
+                        ),
+                    )
+                }
+            }
+        }
+        // Re-insert kept pieces in offset order.
+        replacements.sortBy { it.offset }
+        for (r in replacements) addToInFlight(r)
     }
+
+    /** Insert [r] into [inFlight] preserving offset-ascending order. */
+    private fun addToInFlight(r: Range) {
+        // Append is the common case (writer drains in offset order).
+        if (inFlight.isEmpty() || inFlight.last().offset <= r.offset) {
+            inFlight.addLast(r)
+            return
+        }
+        // Otherwise insert in sorted position.
+        var i = 0
+        while (i < inFlight.size && inFlight[i].offset < r.offset) i += 1
+        inFlight.add(i, r)
+    }
+
+    /**
+     * If `[flushedFloor, x)` is contiguously ACK'd (no entry in
+     * [inFlight] or [retransmit] starts at or below `flushedFloor`),
+     * advance [flushedFloor] up to the lowest in-flight or
+     * retransmit-queued offset, and shift [data] forward by the same
+     * amount.
+     */
+    private fun advanceFlushedFloorIfPossible() {
+        val lowestInFlight = inFlight.firstOrNull()?.offset ?: _nextOffset
+        val lowestRetransmit = retransmit.minOfOrNull { it.offset } ?: _nextOffset
+        val lowest = minOf(lowestInFlight, lowestRetransmit, nextSendOffset)
+        val advance = lowest - flushedFloor
+        if (advance <= 0L) return
+        val advanceInt = advance.toInt()
+        // Shift [data] forward.
+        if (advanceInt < dataLen) {
+            data.copyInto(
+                destination = data,
+                destinationOffset = 0,
+                startIndex = advanceInt,
+                endIndex = dataLen,
+            )
+        }
+        dataLen -= advanceInt
+        flushedFloor += advance
+    }
+
+    /**
+     * Slice [length] bytes starting at logical offset [offset].
+     * [offset] must lie in `[flushedFloor, nextOffset)`.
+     */
+    private fun sliceAt(
+        offset: Long,
+        length: Int,
+    ): ByteArray {
+        if (length == 0) return ByteArray(0)
+        val pos = (offset - flushedFloor).toInt()
+        return data.copyOfRange(pos, pos + length)
+    }
+
+    private fun ensureCapacity(needed: Int) {
+        if (data.size < needed) {
+            var newCap = if (data.size == 0) 64 else data.size
+            while (newCap < needed) newCap *= 2
+            data = data.copyOf(newCap)
+        }
+    }
+
+    /**
+     * One contiguous offset range tracked by the buffer's bookkeeping.
+     * [length] is `Long` to match QUIC's offset arithmetic — practical
+     * range sizes fit in Int, but the offset field naturally is.
+     */
+    private data class Range(
+        val offset: Long,
+        val length: Long,
+        val fin: Boolean,
+    )
 
     data class Chunk(
         val offset: Long,
         val data: ByteArray,
         val fin: Boolean,
-    )
+    ) {
+        // ByteArray needs explicit equality.
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Chunk) return false
+            return offset == other.offset && fin == other.fin && data.contentEquals(other.data)
+        }
+
+        override fun hashCode(): Int {
+            var result = offset.hashCode()
+            result = 31 * result + fin.hashCode()
+            result = 31 * result + data.contentHashCode()
+            return result
+        }
+    }
 }

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/stream/SendBuffer.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/stream/SendBuffer.kt
@@ -73,8 +73,22 @@ package com.vitorpamplona.quic.stream
  * drained). [markAcked] / [markLost] respect FIN — a lost range that
  * carried FIN is re-sent with FIN set, and the buffer's "FIN delivered"
  * latch ([finAcked]) only flips when the FIN-carrying range is ACK'd.
+ *
+ * # Best-effort streams
+ *
+ * Setting [bestEffort] = true changes [markLost] semantics: lost
+ * ranges are dropped without being re-queued for retransmit, the FIN
+ * bit (if present in a lost range) is not re-emitted, and the
+ * underlying byte storage compacts as if the range had been ACK'd.
+ * This is the moq-lite group-stream case — Opus audio frames
+ * arriving 200 ms late are worse than useless. The peer will see a
+ * truncated stream; that's expected and the moq-lite layer relies on
+ * its own per-stream timeouts. Default is false (reliable per RFC
+ * 9000 §3.5).
  */
-class SendBuffer {
+class SendBuffer(
+    val bestEffort: Boolean = false,
+) {
     /**
      * Contiguous byte storage covering `[flushedFloor, nextOffset)`.
      * Indexing: byte at logical offset `o` lives at `data[(o - flushedFloor).toInt()]`.
@@ -251,7 +265,7 @@ class SendBuffer {
         length: Long,
     ) {
         synchronized(this) {
-            removeOverlap(inFlight, offset, length, ackedNotLost = true)
+            removeOverlap(inFlight, offset, length, OverlapAction.ACK)
             advanceFlushedFloorIfPossible()
         }
     }
@@ -280,27 +294,48 @@ class SendBuffer {
             // to retransmit. Clamp the requested range to the retained
             // window to keep the operation idempotent.
             if (offset + length <= flushedFloor) {
-                if (fin && !_finAcked) _finSent = false
+                if (fin && !_finAcked && !bestEffort) _finSent = false
                 return
             }
             val clampedOffset = maxOf(offset, flushedFloor)
             val clampedLength = (offset + length) - clampedOffset
-            removeOverlap(inFlight, clampedOffset, clampedLength, ackedNotLost = false)
-            if (fin && !_finAcked) _finSent = false
+            if (bestEffort) {
+                // Drop without retransmit (see class kdoc). Bytes vanish
+                // from inFlight and the data buffer can compact, the
+                // same way an ACK would. The FIN flag intentionally
+                // stays as `_finSent = true` — best-effort means we
+                // don't try to re-emit FIN either; the peer either saw
+                // it on the original wire or it's lost forever.
+                removeOverlap(inFlight, clampedOffset, clampedLength, OverlapAction.DROP)
+                advanceFlushedFloorIfPossible()
+            } else {
+                removeOverlap(inFlight, clampedOffset, clampedLength, OverlapAction.RETRANSMIT)
+                if (fin && !_finAcked) _finSent = false
+            }
         }
     }
 
     /**
+     * Disposition for a range that overlapped a [markAcked] / [markLost]
+     * range. ACK drops the range and latches `_finAcked` if the FIN
+     * was covered. RETRANSMIT moves the range to the retransmit queue
+     * for re-emission. DROP just removes the range, used by best-effort
+     * streams where retransmit would deliver stale data.
+     */
+    private enum class OverlapAction { ACK, RETRANSMIT, DROP }
+
+    /**
      * Walk [list] for any range overlapping `[offset, offset + length)`,
-     * remove the overlapping portion, and either drop it (ACK path) or
-     * push it onto [retransmit] (loss path). Splits ranges where the
-     * overlap is partial.
+     * remove the overlapping portion, and dispose of it per [action]:
+     * ACK latches `_finAcked` if FIN was covered; RETRANSMIT moves the
+     * covered range to the retransmit queue; DROP just removes it.
+     * Splits ranges where the overlap is partial.
      */
     private fun removeOverlap(
         list: ArrayDeque<Range>,
         offset: Long,
         length: Long,
-        ackedNotLost: Boolean,
+        action: OverlapAction,
     ) {
         // length == 0 only meaningful for FIN-only ranges; handle by
         // matching the exact-offset zero-length range.
@@ -315,10 +350,16 @@ class SendBuffer {
                 val r = list[startIndex]
                 if (r.offset == offset && r.length == 0L) {
                     list.removeAt(startIndex)
-                    if (ackedNotLost) {
-                        if (r.fin) _finAcked = true
-                    } else {
-                        retransmit.addLast(r)
+                    when (action) {
+                        OverlapAction.ACK -> {
+                            if (r.fin) _finAcked = true
+                        }
+
+                        OverlapAction.RETRANSMIT -> {
+                            retransmit.addLast(r)
+                        }
+
+                        OverlapAction.DROP -> {} // discard
                     }
                 }
             }
@@ -380,16 +421,22 @@ class SendBuffer {
             }
             if (coveredLen > 0L || r.length == 0L) {
                 val coveredFin = r.fin && coveredEnd == rEnd
-                if (ackedNotLost) {
-                    if (coveredFin) _finAcked = true
-                } else {
-                    retransmit.addLast(
-                        Range(
-                            offset = coveredStart,
-                            length = coveredLen,
-                            fin = coveredFin,
-                        ),
-                    )
+                when (action) {
+                    OverlapAction.ACK -> {
+                        if (coveredFin) _finAcked = true
+                    }
+
+                    OverlapAction.RETRANSMIT -> {
+                        retransmit.addLast(
+                            Range(
+                                offset = coveredStart,
+                                length = coveredLen,
+                                fin = coveredFin,
+                            ),
+                        )
+                    }
+
+                    OverlapAction.DROP -> {} // discard the covered piece
                 }
             }
             endIndex += 1

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/stream/SendBuffer.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/stream/SendBuffer.kt
@@ -108,10 +108,10 @@ class SendBuffer {
      * by [takeChunk] (append), [markAcked] (remove / split), [markLost]
      * (remove and move to [retransmit]).
      *
-     * Range arithmetic is O(N) on the inFlight list; for the moq-rooms
-     * workload (a few thousand ranges max per connection) this is fine.
-     * If profiling later shows it on the hot path, swap in a TreeMap
-     * keyed by offset.
+     * Overlap lookup uses [firstOverlapIndex] (binary search, O(log N));
+     * the early-exit forward walk visits only the k entries that actually
+     * overlap. A single ACK or loss notification therefore costs
+     * O(log N + k), with k typically 1-2 for a well-aligned ACK range.
      */
     private val inFlight: ArrayDeque<Range> = ArrayDeque()
 
@@ -394,16 +394,13 @@ class SendBuffer {
             }
             endIndex += 1
         }
-        // Bulk-remove the contiguous overlap span [startIndex, endIndex).
-        // ArrayDeque doesn't expose subList.clear, so fall back to a
-        // tight removeAt loop walking backward — still O(k) per call
-        // but with a single shift of trailing entries instead of one
-        // shift per removed item.
+        // Remove the contiguous overlap span [startIndex, endIndex).
+        // ArrayDeque has no bulk-clear-range; each removeAt(i) shifts
+        // (size - i) elements, so total cost is O(k * (size - end + k))
+        // worst case. Backward iteration shrinks the per-step shift —
+        // negligible for our workload (k is 1 in steady state, occasionally
+        // 2 across a partial-overlap split).
         if (endIndex > startIndex) {
-            // Walking backward minimises shift work: removeAt at the
-            // rightmost index of the span first leaves the trailing
-            // entries (after endIndex) where they are; only the leftward
-            // entries shift, and they shift by 1 each iteration.
             var i = endIndex - 1
             while (i >= startIndex) {
                 list.removeAt(i)

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/stream/SendBuffer.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/stream/SendBuffer.kt
@@ -305,43 +305,68 @@ class SendBuffer {
         // length == 0 only meaningful for FIN-only ranges; handle by
         // matching the exact-offset zero-length range.
         if (length == 0L) {
-            val it = list.iterator()
-            while (it.hasNext()) {
-                val r = it.next()
+            // Binary-search for offset; the FIN-only range, if present,
+            // sits at the position whose offset equals the requested
+            // offset. Multiple zero-length ranges at the same offset are
+            // disallowed by [addToInFlight]'s sort invariant — at most
+            // one FIN-only range exists per buffer.
+            val startIndex = firstOverlapIndex(list, offset)
+            if (startIndex < list.size) {
+                val r = list[startIndex]
                 if (r.offset == offset && r.length == 0L) {
-                    it.remove()
+                    list.removeAt(startIndex)
                     if (ackedNotLost) {
                         if (r.fin) _finAcked = true
                     } else {
                         retransmit.addLast(r)
                     }
-                    return
                 }
             }
             return
         }
         val rangeEnd = offset + length
-        val replacements = mutableListOf<Range>()
-        val it = list.iterator()
-        while (it.hasNext()) {
-            val r = it.next()
+        // Find the first list entry whose end-offset is > the requested
+        // start (i.e. the leftmost potential overlap). All earlier
+        // entries fall entirely below the request and are untouched —
+        // we skip them in O(log N) instead of the prior O(N) full scan.
+        var startIndex = firstOverlapIndex(list, offset)
+        if (startIndex >= list.size) return
+
+        // Walk forward. Two outputs from this loop:
+        //   - dropCount: number of consecutive entries (starting at
+        //     startIndex) we need to remove via a single subList clear,
+        //     instead of O(N²) per-element removeAt.
+        //   - replacements: kept-pieces (left and right of an overlap
+        //     that doesn't fully cover an entry) re-inserted at the
+        //     end. Sort-stable by offset since we process entries in
+        //     ascending order.
+        val replacements = ArrayList<Range>(2)
+        var endIndex = startIndex
+        while (endIndex < list.size) {
+            val r = list[endIndex]
+            // Sorted invariant: once r.offset >= rangeEnd, no later
+            // entry overlaps. Early-exit before the prior O(N) scan
+            // would have continued.
+            if (r.offset >= rangeEnd) break
             val rEnd = r.offset + r.length
-            if (rEnd <= offset || r.offset >= rangeEnd) continue
-            // Overlap exists. Compute up-to-three pieces:
-            //   leftKept: [r.offset, max(r.offset, offset))
-            //   covered:  [max(r.offset, offset), min(rEnd, rangeEnd))
-            //   rightKept:[min(rEnd, rangeEnd), rEnd)
-            val coveredStart = maxOf(r.offset, offset)
-            val coveredEnd = minOf(rEnd, rangeEnd)
+            // r.offset < rangeEnd guarantees overlap candidacy; rule
+            // out the case where r ends exactly at offset.
+            if (rEnd <= offset) {
+                // Should not happen given firstOverlapIndex semantics,
+                // but defensively skip.
+                endIndex += 1
+                continue
+            }
+            val coveredStart = if (r.offset > offset) r.offset else offset
+            val coveredEnd = if (rEnd < rangeEnd) rEnd else rangeEnd
             val coveredLen = coveredEnd - coveredStart
-            it.remove()
             if (coveredStart > r.offset) {
                 replacements +=
                     Range(
                         offset = r.offset,
                         length = coveredStart - r.offset,
-                        // FIN belongs to the LAST covered piece; the left
-                        // kept piece never carries FIN.
+                        // FIN belongs to the rightmost covered piece;
+                        // a left-kept piece never carries FIN.
                         fin = false,
                     )
             }
@@ -350,7 +375,6 @@ class SendBuffer {
                     Range(
                         offset = coveredEnd,
                         length = rEnd - coveredEnd,
-                        // FIN, if any, lives on the rightmost piece.
                         fin = r.fin,
                     )
             }
@@ -368,23 +392,86 @@ class SendBuffer {
                     )
                 }
             }
+            endIndex += 1
         }
-        // Re-insert kept pieces in offset order.
-        replacements.sortBy { it.offset }
+        // Bulk-remove the contiguous overlap span [startIndex, endIndex).
+        // ArrayDeque doesn't expose subList.clear, so fall back to a
+        // tight removeAt loop walking backward — still O(k) per call
+        // but with a single shift of trailing entries instead of one
+        // shift per removed item.
+        if (endIndex > startIndex) {
+            // Walking backward minimises shift work: removeAt at the
+            // rightmost index of the span first leaves the trailing
+            // entries (after endIndex) where they are; only the leftward
+            // entries shift, and they shift by 1 each iteration.
+            var i = endIndex - 1
+            while (i >= startIndex) {
+                list.removeAt(i)
+                i -= 1
+            }
+        }
+        // Re-insert kept pieces. Both pieces (left + right) for a single
+        // overlap are themselves in offset-ascending order because
+        // they're emitted left-then-right per loop iteration. Across
+        // multiple processed overlaps they remain sorted (each overlap's
+        // left-piece sits below the next overlap's left-piece). So no
+        // explicit sort needed.
         for (r in replacements) addToInFlight(r)
     }
 
-    /** Insert [r] into [inFlight] preserving offset-ascending order. */
+    /**
+     * Binary-search [list] for the index of the first entry whose
+     * end-offset (`offset + length`) is strictly greater than
+     * [targetOffset]. All entries strictly before that index end
+     * at-or-before [targetOffset] and therefore cannot overlap any
+     * range starting at [targetOffset]. The binary search runs in
+     * O(log N).
+     *
+     * Returns `list.size` when every entry ends at-or-before
+     * [targetOffset] — meaning no overlap exists.
+     */
+    private fun firstOverlapIndex(
+        list: ArrayDeque<Range>,
+        targetOffset: Long,
+    ): Int {
+        // Standard lower-bound-style binary search adapted to "first
+        // entry whose end > targetOffset". Entries are kept sorted by
+        // start offset (sort invariant of [addToInFlight]); since
+        // ranges within the list don't overlap each other, "sorted by
+        // start" implies "sorted by end" too.
+        var lo = 0
+        var hi = list.size
+        while (lo < hi) {
+            val mid = (lo + hi) ushr 1
+            val midEnd = list[mid].offset + list[mid].length
+            if (midEnd > targetOffset) hi = mid else lo = mid + 1
+        }
+        return lo
+    }
+
+    /**
+     * Insert [r] into [inFlight] preserving offset-ascending order.
+     * Append is the common case (writer drains fresh bytes in offset
+     * order); when an in-the-middle insert is needed (after a partial
+     * overlap split), uses binary search to find the position in
+     * O(log N) instead of the prior linear walk.
+     */
     private fun addToInFlight(r: Range) {
-        // Append is the common case (writer drains in offset order).
+        // Append fast-path: empty list, or new range starts at-or-after
+        // the current tail's start offset (i.e. it's the new max).
         if (inFlight.isEmpty() || inFlight.last().offset <= r.offset) {
             inFlight.addLast(r)
             return
         }
-        // Otherwise insert in sorted position.
-        var i = 0
-        while (i < inFlight.size && inFlight[i].offset < r.offset) i += 1
-        inFlight.add(i, r)
+        // Otherwise binary-search for the first index where the existing
+        // entry's offset >= r.offset, and insert before it.
+        var lo = 0
+        var hi = inFlight.size
+        while (lo < hi) {
+            val mid = (lo + hi) ushr 1
+            if (inFlight[mid].offset < r.offset) lo = mid + 1 else hi = mid
+        }
+        inFlight.add(lo, r)
     }
 
     /**

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/webtransport/QuicWebTransportSessionState.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/webtransport/QuicWebTransportSessionState.kt
@@ -173,9 +173,20 @@ class QuicWebTransportSessionState(
         return s
     }
 
-    /** Open a new client-initiated unidirectional WebTransport stream. */
-    suspend fun openUniStream(): QuicStream {
-        val s = connection.openUniStream()
+    /**
+     * Open a new client-initiated unidirectional WebTransport stream.
+     *
+     * If [bestEffort] is true, the underlying QUIC stream's send buffer
+     * drops lost ranges instead of retransmitting (see
+     * [com.vitorpamplona.quic.stream.QuicStream.bestEffort]). The
+     * WT_UNI_STREAM prefix bytes are themselves enqueued onto that
+     * buffer, so a lost prefix-only packet won't be retransmitted
+     * either — fine for the moq-lite group-stream case where the
+     * whole stream is ephemeral, since the peer would treat it as
+     * truncated either way.
+     */
+    suspend fun openUniStream(bestEffort: Boolean = false): QuicStream {
+        val s = connection.openUniStream(bestEffort = bestEffort)
         s.send.enqueue(encodeWtUniStreamPrefix(connectStreamId))
         driver.wakeup()
         return s

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/AckTrackerPurgeOnAckOfAckTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/AckTrackerPurgeOnAckOfAckTest.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quic.connection
+
+import com.vitorpamplona.quic.connection.recovery.RecoveryToken
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * RFC 9000 §13.2.1: an ACK frame is itself acknowledged via the
+ * carrying packet. Once the peer ACKs that packet, we know the peer
+ * received our ACK and we can drop the corresponding inbound PNs from
+ * our [com.vitorpamplona.quic.recovery.AckTracker].
+ *
+ * Pre-fix, `QuicConnectionParser` purged the tracker on every inbound
+ * ACK using `frame.largestAcknowledged - frame.firstAckRange` — but
+ * that value is in OUR outbound PN space, not the inbound PN space the
+ * tracker holds. The mistake mostly hid because both spaces grow at
+ * similar rates, but caused range-list bloat over long sessions where
+ * traffic is asymmetric (e.g. listener receives ~50 audio frames/sec
+ * while sending ~1 ACK/sec back).
+ */
+class AckTrackerPurgeOnAckOfAckTest {
+    private fun newConn(): QuicConnection =
+        QuicConnection(
+            serverName = "example.test",
+            config = QuicConnectionConfig(),
+            tlsCertificateValidator =
+                com.vitorpamplona.quic.tls
+                    .PermissiveCertificateValidator(),
+        )
+
+    @Test
+    fun ackOfAck_purgesTrackerBelowLargestAcked() =
+        runBlocking {
+            val conn = newConn()
+            // Simulate having received 5 inbound packets from the peer.
+            for (pn in 0L..4L) {
+                conn.application.ackTracker.receivedPacket(pn, ackEliciting = true, receivedAtMillis = 1L)
+            }
+            assertEquals(4L, conn.application.ackTracker.largestReceived())
+            assertFalse(conn.application.ackTracker.isEmpty())
+
+            // Peer ACKs the packet that carried our outbound ACK
+            // covering up to PN 4.
+            conn.lock.lock()
+            try {
+                conn.onTokensAcked(
+                    listOf(
+                        RecoveryToken.Ack(
+                            level = EncryptionLevel.APPLICATION,
+                            largestAcked = 4L,
+                        ),
+                    ),
+                )
+            } finally {
+                conn.lock.unlock()
+            }
+            // Tracker is now empty: peer has confirmed receipt of our
+            // ACK that covered everything up to PN 4. Re-advertising
+            // those PNs in subsequent outbound ACKs is wasted bytes.
+            assertTrue(conn.application.ackTracker.isEmpty(), "tracker fully purged below largestAcked + 1")
+        }
+
+    @Test
+    fun ackOfAck_routesToCorrectLevel() =
+        runBlocking {
+            val conn = newConn()
+            // Independent state on Initial vs Application trackers.
+            for (pn in 0L..2L) {
+                conn.initial.ackTracker.receivedPacket(pn, ackEliciting = true, receivedAtMillis = 1L)
+            }
+            for (pn in 0L..4L) {
+                conn.application.ackTracker.receivedPacket(pn, ackEliciting = true, receivedAtMillis = 1L)
+            }
+
+            // Peer ACKs our Initial-level outbound ACK.
+            conn.lock.lock()
+            try {
+                conn.onTokensAcked(
+                    listOf(
+                        RecoveryToken.Ack(level = EncryptionLevel.INITIAL, largestAcked = 2L),
+                    ),
+                )
+            } finally {
+                conn.lock.unlock()
+            }
+            // Initial tracker drained; Application tracker untouched.
+            assertTrue(conn.initial.ackTracker.isEmpty())
+            assertEquals(4L, conn.application.ackTracker.largestReceived())
+        }
+
+    @Test
+    fun ackOfAck_partialPurge_keepsHigherPns() =
+        runBlocking {
+            val conn = newConn()
+            for (pn in 0L..9L) {
+                conn.application.ackTracker.receivedPacket(pn, ackEliciting = true, receivedAtMillis = 1L)
+            }
+            // Peer ACKs our outbound ACK that covered up to PN 4 only;
+            // the tracker's higher-PN ranges (5..9) must survive.
+            conn.lock.lock()
+            try {
+                conn.onTokensAcked(
+                    listOf(
+                        RecoveryToken.Ack(level = EncryptionLevel.APPLICATION, largestAcked = 4L),
+                    ),
+                )
+            } finally {
+                conn.lock.unlock()
+            }
+            assertFalse(conn.application.ackTracker.isEmpty())
+            assertEquals(9L, conn.application.ackTracker.largestReceived())
+        }
+
+    @Test
+    fun ackOfAck_outOfOrder_isSafe() =
+        runBlocking {
+            // Two outbound ACKs go out: ACK#A covers up-to PN 4, ACK#B
+            // covers up-to PN 9. Peer ACKs ACK#B first, then ACK#A.
+            // After ACK#B drains, tracker is empty. ACK#A's purge is
+            // a no-op — must not throw, must not re-resurrect anything.
+            val conn = newConn()
+            for (pn in 0L..9L) {
+                conn.application.ackTracker.receivedPacket(pn, ackEliciting = true, receivedAtMillis = 1L)
+            }
+            conn.lock.lock()
+            try {
+                conn.onTokensAcked(
+                    listOf(
+                        RecoveryToken.Ack(level = EncryptionLevel.APPLICATION, largestAcked = 9L),
+                    ),
+                )
+                assertTrue(conn.application.ackTracker.isEmpty())
+                conn.onTokensAcked(
+                    listOf(
+                        RecoveryToken.Ack(level = EncryptionLevel.APPLICATION, largestAcked = 4L),
+                    ),
+                )
+                assertTrue(conn.application.ackTracker.isEmpty())
+            } finally {
+                conn.lock.unlock()
+            }
+        }
+}

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/CryptoRetransmitTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/CryptoRetransmitTest.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quic.connection
+
+import com.vitorpamplona.quic.connection.recovery.RecoveryToken
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Step E of the deferred-follow-ups pass: CRYPTO retransmit per
+ * encryption level. The handshake produces ClientHello / Finished
+ * CRYPTO bytes at Initial / Handshake levels; a lost packet
+ * carrying any of those must be retransmitted at the same level.
+ *
+ * Mirrors the structure of [StreamRetransmitTest] but exercises the
+ * Initial / Handshake-level paths in [QuicConnectionWriter].
+ */
+class CryptoRetransmitTest {
+    @Test
+    fun handshakePacket_carriesCryptoToken_inSentPacket() =
+        runBlocking {
+            val client = newClientWithStartedHandshake()
+            // First drain produces the ClientHello at Initial level.
+            runCatching { drainOutbound(client, nowMillis = 1L) }
+
+            val initialEntries =
+                client.initial.sentPackets.entries
+                    .toList()
+            val withCrypto =
+                initialEntries.firstOrNull { entry ->
+                    entry.value.tokens.any { it is RecoveryToken.Crypto }
+                }
+            assertNotNull(
+                withCrypto,
+                "Initial-level SentPacket must carry a Crypto token; saw ${initialEntries.map { it.value.tokens.map { t -> t::class.simpleName } }}",
+            )
+            val cryptoToken =
+                withCrypto.value.tokens
+                    .filterIsInstance<RecoveryToken.Crypto>()
+                    .single()
+            assertEquals(EncryptionLevel.INITIAL, cryptoToken.level, "Crypto token's level must match the packet's level")
+            assertEquals(0L, cryptoToken.offset, "first ClientHello starts at offset 0")
+            assertTrue(cryptoToken.length > 0L, "ClientHello has non-zero length")
+        }
+
+    @Test
+    fun cryptoData_lostAndRetransmittedAtSameLevel() =
+        runBlocking {
+            val client = newClientWithStartedHandshake()
+            runCatching { drainOutbound(client, nowMillis = 1L) }
+
+            val firstEntry =
+                client.initial.sentPackets.entries
+                    .firstOrNull { entry -> entry.value.tokens.any { it is RecoveryToken.Crypto } }
+            assertNotNull(firstEntry)
+            val firstPn = firstEntry.key
+            val cryptoToken =
+                firstEntry.value.tokens
+                    .filterIsInstance<RecoveryToken.Crypto>()
+                    .single()
+
+            // Simulate loss via direct dispatch.
+            client.lock.lock()
+            try {
+                client.onTokensLost(listOf(cryptoToken))
+                client.initial.sentPackets.remove(firstPn)
+            } finally {
+                client.lock.unlock()
+            }
+
+            // Initial-level cryptoSend should now have re-queued bytes
+            // for retransmit. Verify by checking readableBytes.
+            assertTrue(
+                client.initial.cryptoSend.readableBytes > 0,
+                "lost CRYPTO bytes must be back in the Initial-level cryptoSend's retransmit queue",
+            )
+
+            // Next drain must produce a new Initial packet carrying
+            // the CRYPTO at the original offset.
+            runCatching { drainOutbound(client, nowMillis = 2L) }
+            val replayEntries =
+                client.initial.sentPackets.entries
+                    .filter { it.key != firstPn }
+            val replay =
+                replayEntries.firstOrNull { entry ->
+                    entry.value.tokens.any { it is RecoveryToken.Crypto }
+                }
+            assertNotNull(replay, "retransmit must produce a fresh Initial SentPacket carrying Crypto")
+            val replayToken =
+                replay.value.tokens
+                    .filterIsInstance<RecoveryToken.Crypto>()
+                    .single()
+            assertEquals(EncryptionLevel.INITIAL, replayToken.level)
+            assertEquals(cryptoToken.offset, replayToken.offset, "retransmit replays original offset")
+            assertEquals(cryptoToken.length, replayToken.length)
+        }
+
+    @Test
+    fun cryptoAck_releasesBufferAtSameLevel() =
+        runBlocking {
+            val client = newClientWithStartedHandshake()
+            runCatching { drainOutbound(client, nowMillis = 1L) }
+
+            val packet =
+                client.initial.sentPackets.entries
+                    .first { it.value.tokens.any { t -> t is RecoveryToken.Crypto } }
+            // ACK via direct dispatch.
+            client.lock.lock()
+            try {
+                client.onTokensAcked(packet.value.tokens)
+            } finally {
+                client.lock.unlock()
+            }
+            // After ACK the Initial-level cryptoSend's flushedFloor should
+            // have advanced — we check by observing that another takeChunk
+            // returns null (no more bytes ready) AND finSent stays true if
+            // it was set (i.e. the ACK didn't reset it).
+            assertEquals(0, client.initial.cryptoSend.readableBytes)
+        }
+
+    private fun newClientWithStartedHandshake(): QuicConnection =
+        runBlocking {
+            val client =
+                QuicConnection(
+                    serverName = "example.test",
+                    config = QuicConnectionConfig(),
+                    tlsCertificateValidator =
+                        com.vitorpamplona.quic.tls
+                            .PermissiveCertificateValidator(),
+                )
+            client.start()
+            // We don't drive the InProcessTlsServer here — we only need
+            // the client to have produced its ClientHello (which it does
+            // synchronously inside start()). The Initial-level cryptoSend
+            // is now non-empty.
+            assertTrue(
+                client.initial.cryptoSend.readableBytes > 0,
+                "client.start() must produce ClientHello bytes",
+            )
+            // Need send-protection installed before drainOutbound emits
+            // anything. start() handles that.
+            assertNotNull(client.initial.sendProtection, "Initial-level send protection must be installed")
+            client
+        }
+}

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/KeyDiscardTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/KeyDiscardTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quic.connection
+
+import com.vitorpamplona.quic.frame.HandshakeDoneFrame
+import com.vitorpamplona.quic.frame.PingFrame
+import com.vitorpamplona.quic.tls.PermissiveCertificateValidator
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * RFC 9001 §4.9: Initial / Handshake keys MUST be discarded once the
+ * level is no longer needed. Pre-fix `:quic` held both indefinitely,
+ * causing a per-session memory leak (AEAD cipher state + handshake
+ * CRYPTO buffers) for the lifetime of long connections.
+ *
+ *   - §4.9.1 client side: discard Initial keys when the client first
+ *     sends a Handshake packet. Hooked from
+ *     [QuicConnectionWriter.drainOutbound] after a Handshake packet is
+ *     built into the outbound datagram.
+ *   - §4.9.2 + §4.1.2 client side: handshake confirmation = receipt of
+ *     HANDSHAKE_DONE; discard Handshake keys at that point. Hooked from
+ *     [QuicConnectionParser]'s HandshakeDoneFrame branch.
+ */
+class KeyDiscardTest {
+    private fun newConnectedClient(): Pair<QuicConnection, InMemoryQuicPipe> {
+        val client =
+            QuicConnection(
+                serverName = "example.test",
+                config = QuicConnectionConfig(),
+                tlsCertificateValidator = PermissiveCertificateValidator(),
+            )
+        val pipe = InMemoryQuicPipe(client, client.destinationConnectionId.bytes)
+        client.start()
+        pipe.drive(maxRounds = 16)
+        check(client.status == QuicConnection.Status.CONNECTED) {
+            "handshake must succeed; status=${client.status}"
+        }
+        return client to pipe
+    }
+
+    @Test
+    fun initialKeys_discardedAfterFirstHandshakePacket() {
+        val (client, _) = newConnectedClient()
+        // After the handshake, drive one more drainOutbound to flush
+        // the client's Finished message — pipe.drive returns as soon as
+        // status flips to CONNECTED, which happens after feedDatagram
+        // processes the server's Finished but BEFORE the client emits
+        // its own Finished.
+        drainOutbound(client, nowMillis = 0L)
+        assertTrue(client.initial.keysDiscarded, "Initial keys must be discarded after first Handshake packet")
+        assertNull(client.initial.sendProtection, "Initial sendProtection nulled out")
+        assertNull(client.initial.receiveProtection, "Initial receiveProtection nulled out")
+        assertTrue(
+            client.initial.sentPackets.isEmpty(),
+            "Initial sentPackets cleared (no more loss-detection at this level)",
+        )
+    }
+
+    @Test
+    fun handshakeKeys_survivePastHandshakeUntilHandshakeDone() {
+        val (client, _) = newConnectedClient()
+        // Even though TLS finished, the client hasn't seen HANDSHAKE_DONE
+        // yet. Per §4.1.2 the handshake isn't "confirmed" until then; the
+        // Handshake keys must still be available for ACK exchange.
+        assertFalse(client.handshake.keysDiscarded, "Handshake keys still live before HANDSHAKE_DONE")
+        assertNotNull(client.handshake.sendProtection)
+        assertNotNull(client.handshake.receiveProtection)
+    }
+
+    @Test
+    fun handshakeKeys_discardedOnHandshakeDone() {
+        val (client, pipe) = newConnectedClient()
+        // Inject a HANDSHAKE_DONE at APPLICATION level. Pad with PINGs so
+        // the encrypted payload is long enough for header-protection's
+        // 16-byte sample window.
+        val pings = List(40) { PingFrame }
+        val packet = pipe.buildServerApplicationDatagram(listOf(HandshakeDoneFrame()) + pings)!!
+        feedDatagram(client, packet, nowMillis = 0L)
+
+        assertTrue(client.handshake.keysDiscarded, "HANDSHAKE_DONE must trigger Handshake key discard")
+        assertNull(client.handshake.sendProtection)
+        assertNull(client.handshake.receiveProtection)
+        assertTrue(client.handshake.sentPackets.isEmpty())
+        // Sanity: Application keys live on; the connection still works.
+        assertNotNull(client.application.sendProtection, "Application keys untouched")
+    }
+
+    @Test
+    fun discardKeys_isIdempotent() {
+        val (client, _) = newConnectedClient()
+        // Initial keys already discarded by the handshake exchange. A
+        // second call must not throw and must not mutate any other state.
+        client.initial.discardKeys()
+        client.initial.discardKeys()
+        assertTrue(client.initial.keysDiscarded)
+        // Application level was never discarded; calling on a still-live
+        // level is also valid (used in real life on connection close
+        // for cleanup).
+        assertFalse(client.application.keysDiscarded)
+    }
+}

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/OnTokensLostTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/OnTokensLostTest.kt
@@ -49,7 +49,7 @@ class OnTokensLostTest {
             val conn = newConn()
             conn.lock.lock()
             try {
-                conn.onTokensLost(listOf(RecoveryToken.Ack))
+                conn.onTokensLost(listOf(RecoveryToken.Ack(level = EncryptionLevel.APPLICATION, largestAcked = 0L)))
             } finally {
                 conn.lock.unlock()
             }
@@ -161,7 +161,7 @@ class OnTokensLostTest {
                 conn.advertisedMaxData = 5_000_000L
                 conn.onTokensLost(
                     listOf(
-                        RecoveryToken.Ack,
+                        RecoveryToken.Ack(level = EncryptionLevel.APPLICATION, largestAcked = 0L),
                         RecoveryToken.MaxStreamsUni(maxStreams = 150L),
                         RecoveryToken.MaxStreamsBidi(maxStreams = 200L),
                         RecoveryToken.MaxData(maxData = 5_000_000L),

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/OnTokensLostTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/OnTokensLostTest.kt
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quic.connection
+
+import com.vitorpamplona.quic.connection.recovery.RecoveryToken
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Step 6 of `quic/plans/2026-05-04-control-frame-retransmit.md`:
+ * `QuicConnection.onTokensLost` dispatches lost-packet tokens to
+ * the matching `pending*` field with the supersede check (lost
+ * value must equal current advertised). Mirrors neqo's
+ * `streams.rs::lost` dispatch + `fc.rs::frame_lost` flag-set logic.
+ */
+class OnTokensLostTest {
+    private fun newConn(): QuicConnection =
+        QuicConnection(
+            serverName = "example.test",
+            config = QuicConnectionConfig(),
+            tlsCertificateValidator =
+                com.vitorpamplona.quic.tls
+                    .PermissiveCertificateValidator(),
+        )
+
+    @Test
+    fun ackToken_doesNotPopulateAnyPending() =
+        runBlocking {
+            val conn = newConn()
+            conn.lock.lock()
+            try {
+                conn.onTokensLost(listOf(RecoveryToken.Ack))
+            } finally {
+                conn.lock.unlock()
+            }
+            assertNull(conn.pendingMaxStreamsUni)
+            assertNull(conn.pendingMaxStreamsBidi)
+            assertNull(conn.pendingMaxData)
+            assertEquals(emptyMap<Long, Long>(), conn.pendingMaxStreamData)
+        }
+
+    @Test
+    fun lostMaxStreamsUni_matchingAdvertised_setsPending() =
+        runBlocking {
+            val conn = newConn()
+            // Simulate the writer having advertised a higher cap.
+            conn.lock.lock()
+            try {
+                conn.advertisedMaxStreamsUni = 150L
+                conn.onTokensLost(listOf(RecoveryToken.MaxStreamsUni(maxStreams = 150L)))
+            } finally {
+                conn.lock.unlock()
+            }
+            assertEquals(150L, conn.pendingMaxStreamsUni)
+        }
+
+    @Test
+    fun lostMaxStreamsUni_supersededByHigherEmit_isDropped() =
+        runBlocking {
+            val conn = newConn()
+            // The writer has since advertised a higher cap (200) than
+            // the value carried by the lost token (150). The lost
+            // frame is irrelevant — re-emitting 150 would not extend
+            // the cap. neqo's fc.rs line 322 supersede check.
+            conn.lock.lock()
+            try {
+                conn.advertisedMaxStreamsUni = 200L
+                conn.onTokensLost(listOf(RecoveryToken.MaxStreamsUni(maxStreams = 150L)))
+            } finally {
+                conn.lock.unlock()
+            }
+            assertNull(conn.pendingMaxStreamsUni, "stale lost extension must not be re-emitted")
+        }
+
+    @Test
+    fun lostMaxStreamsBidi_matchingAdvertised_setsPending() =
+        runBlocking {
+            val conn = newConn()
+            conn.lock.lock()
+            try {
+                conn.advertisedMaxStreamsBidi = 200L
+                conn.onTokensLost(listOf(RecoveryToken.MaxStreamsBidi(maxStreams = 200L)))
+            } finally {
+                conn.lock.unlock()
+            }
+            assertEquals(200L, conn.pendingMaxStreamsBidi)
+        }
+
+    @Test
+    fun lostMaxData_matchingAdvertised_setsPending() =
+        runBlocking {
+            val conn = newConn()
+            conn.lock.lock()
+            try {
+                conn.advertisedMaxData = 1_000_000L
+                conn.onTokensLost(listOf(RecoveryToken.MaxData(maxData = 1_000_000L)))
+            } finally {
+                conn.lock.unlock()
+            }
+            assertEquals(1_000_000L, conn.pendingMaxData)
+        }
+
+    @Test
+    fun lostMaxData_supersededIsDropped() =
+        runBlocking {
+            val conn = newConn()
+            conn.lock.lock()
+            try {
+                conn.advertisedMaxData = 2_000_000L
+                conn.onTokensLost(listOf(RecoveryToken.MaxData(maxData = 1_000_000L)))
+            } finally {
+                conn.lock.unlock()
+            }
+            assertNull(conn.pendingMaxData)
+        }
+
+    @Test
+    fun lostMaxStreamData_unknownStream_dropped() =
+        runBlocking {
+            val conn = newConn()
+            conn.lock.lock()
+            try {
+                conn.onTokensLost(
+                    listOf(RecoveryToken.MaxStreamData(streamId = 999L, maxData = 1024L)),
+                )
+            } finally {
+                conn.lock.unlock()
+            }
+            // No stream with id 999 exists ⇒ token is dropped silently.
+            assertEquals(emptyMap<Long, Long>(), conn.pendingMaxStreamData)
+        }
+
+    @Test
+    fun multipleLostTokens_dispatchAll() =
+        runBlocking {
+            val conn = newConn()
+            conn.lock.lock()
+            try {
+                conn.advertisedMaxStreamsUni = 150L
+                conn.advertisedMaxStreamsBidi = 200L
+                conn.advertisedMaxData = 5_000_000L
+                conn.onTokensLost(
+                    listOf(
+                        RecoveryToken.Ack,
+                        RecoveryToken.MaxStreamsUni(maxStreams = 150L),
+                        RecoveryToken.MaxStreamsBidi(maxStreams = 200L),
+                        RecoveryToken.MaxData(maxData = 5_000_000L),
+                    ),
+                )
+            } finally {
+                conn.lock.unlock()
+            }
+            assertEquals(150L, conn.pendingMaxStreamsUni)
+            assertEquals(200L, conn.pendingMaxStreamsBidi)
+            assertEquals(5_000_000L, conn.pendingMaxData)
+        }
+
+    @Test
+    fun lostTokensFromMultiplePackets_unionInPending() =
+        runBlocking {
+            // Two SentPackets each lost; their tokens are dispatched
+            // sequentially. Each frame type's pending field holds at
+            // most one value (the last setter wins; the supersede
+            // check filters older losses).
+            val conn = newConn()
+            conn.lock.lock()
+            try {
+                conn.advertisedMaxStreamsUni = 200L
+                // First lost packet had MaxStreamsUni(150) — stale, dropped.
+                conn.onTokensLost(listOf(RecoveryToken.MaxStreamsUni(maxStreams = 150L)))
+                assertNull(conn.pendingMaxStreamsUni)
+                // Second lost packet had MaxStreamsUni(200) — current, set.
+                conn.onTokensLost(listOf(RecoveryToken.MaxStreamsUni(maxStreams = 200L)))
+                assertEquals(200L, conn.pendingMaxStreamsUni)
+            } finally {
+                conn.lock.unlock()
+            }
+        }
+}

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/PendingFlowControlEmitTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/PendingFlowControlEmitTest.kt
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quic.connection
+
+import com.vitorpamplona.quic.connection.recovery.RecoveryToken
+import com.vitorpamplona.quic.tls.InProcessTlsServer
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Step 4 of `quic/plans/2026-05-04-control-frame-retransmit.md`:
+ * the writer drains `QuicConnection.pendingMax*` fields ahead of the
+ * normal threshold check, re-emitting a fresh frame + token for each
+ * pending entry and clearing it.
+ *
+ * Mirrors neqo's `fc.rs` retransmit tests
+ * (`need_max_allowed_frame_after_loss`, `lost_after_increase`,
+ * `multiple_retries_after_frame_pending_is_set`,
+ * `new_retired_before_loss`). The `pending*` fields are populated
+ * directly here; step 6 will populate them via the loss dispatcher.
+ */
+class PendingFlowControlEmitTest {
+    @Test
+    fun pendingMaxStreamsUni_drainEmitsFrameAndToken() =
+        runBlocking {
+            val client = handshakedClient()
+            client.lock.lock()
+            try {
+                client.pendingMaxStreamsUni = 150L
+            } finally {
+                client.lock.unlock()
+            }
+
+            val sizeBefore = client.application.sentPackets.size
+            runCatching { drainOutbound(client, nowMillis = 1L) }
+            val newEntries =
+                client.application.sentPackets.entries
+                    .sortedBy { it.key }
+                    .drop(sizeBefore)
+
+            // Some new SentPacket must carry a MaxStreamsUni token
+            // with the pending value.
+            val withRetransmit =
+                newEntries.firstOrNull { entry ->
+                    entry.value.tokens.any { it == RecoveryToken.MaxStreamsUni(maxStreams = 150L) }
+                }
+            assertNotNull(
+                withRetransmit,
+                "expected re-emit of MaxStreamsUni(150) but saw " +
+                    newEntries.map { it.value.tokens.map { t -> t::class.simpleName } },
+            )
+            // Pending must be cleared after emit.
+            assertNull(client.pendingMaxStreamsUni)
+        }
+
+    @Test
+    fun pendingMaxStreamsBidi_drainEmitsFrameAndToken(): Unit =
+        runBlocking {
+            val client = handshakedClient()
+            client.lock.lock()
+            try {
+                client.pendingMaxStreamsBidi = 200L
+            } finally {
+                client.lock.unlock()
+            }
+            val sizeBefore = client.application.sentPackets.size
+            runCatching { drainOutbound(client, nowMillis = 1L) }
+            val newEntries =
+                client.application.sentPackets.entries
+                    .sortedBy { it.key }
+                    .drop(sizeBefore)
+            val withRetransmit =
+                newEntries.firstOrNull { entry ->
+                    entry.value.tokens.any { it == RecoveryToken.MaxStreamsBidi(maxStreams = 200L) }
+                }
+            assertNotNull(withRetransmit, "expected re-emit of MaxStreamsBidi(200)")
+            assertNull(client.pendingMaxStreamsBidi)
+        }
+
+    @Test
+    fun pendingMaxData_drainEmitsFrameAndToken(): Unit =
+        runBlocking {
+            val client = handshakedClient()
+            client.lock.lock()
+            try {
+                client.pendingMaxData = 5_000_000L
+            } finally {
+                client.lock.unlock()
+            }
+            val sizeBefore = client.application.sentPackets.size
+            runCatching { drainOutbound(client, nowMillis = 1L) }
+            val newEntries =
+                client.application.sentPackets.entries
+                    .sortedBy { it.key }
+                    .drop(sizeBefore)
+            val withRetransmit =
+                newEntries.firstOrNull { entry ->
+                    entry.value.tokens.any { it == RecoveryToken.MaxData(maxData = 5_000_000L) }
+                }
+            assertNotNull(withRetransmit, "expected re-emit of MaxData(5_000_000)")
+            assertNull(client.pendingMaxData)
+        }
+
+    @Test
+    fun pendingMaxStreamData_perStreamDrain() =
+        runBlocking {
+            val client = handshakedClient()
+            client.lock.lock()
+            try {
+                client.pendingMaxStreamData[3L] = 1_024L
+                client.pendingMaxStreamData[7L] = 2_048L
+            } finally {
+                client.lock.unlock()
+            }
+            val sizeBefore = client.application.sentPackets.size
+            runCatching { drainOutbound(client, nowMillis = 1L) }
+            val newEntries =
+                client.application.sentPackets.entries
+                    .sortedBy { it.key }
+                    .drop(sizeBefore)
+            val seenTokens =
+                newEntries
+                    .flatMap { it.value.tokens }
+                    .filterIsInstance<RecoveryToken.MaxStreamData>()
+                    .toSet()
+            assertEquals(
+                setOf(
+                    RecoveryToken.MaxStreamData(streamId = 3L, maxData = 1_024L),
+                    RecoveryToken.MaxStreamData(streamId = 7L, maxData = 2_048L),
+                ),
+                seenTokens,
+            )
+            assertTrue(client.pendingMaxStreamData.isEmpty())
+        }
+
+    @Test
+    fun multiplePending_drainEmitsAllInOnePacket(): Unit =
+        runBlocking {
+            val client = handshakedClient()
+            client.lock.lock()
+            try {
+                client.pendingMaxStreamsUni = 150L
+                client.pendingMaxStreamsBidi = 200L
+                client.pendingMaxData = 1_000_000L
+            } finally {
+                client.lock.unlock()
+            }
+            val sizeBefore = client.application.sentPackets.size
+            runCatching { drainOutbound(client, nowMillis = 1L) }
+            val newEntries =
+                client.application.sentPackets.entries
+                    .sortedBy { it.key }
+                    .drop(sizeBefore)
+            // All three retransmits should land in one packet (writer
+            // drains them sequentially before any threshold check).
+            val packetTokens =
+                newEntries
+                    .firstOrNull { entry ->
+                        entry.value.tokens.any { it is RecoveryToken.MaxStreamsUni } &&
+                            entry.value.tokens.any { it is RecoveryToken.MaxStreamsBidi } &&
+                            entry.value.tokens.any { it is RecoveryToken.MaxData }
+                    }
+            assertNotNull(packetTokens, "expected one packet carrying all three retransmits")
+            assertNull(client.pendingMaxStreamsUni)
+            assertNull(client.pendingMaxStreamsBidi)
+            assertNull(client.pendingMaxData)
+        }
+
+    @Test
+    fun noPending_drainDoesNotEmitRetransmits() =
+        runBlocking {
+            val client = handshakedClient()
+            // Nothing to retransmit — no SentPacket should carry a
+            // MAX_STREAMS / MAX_DATA / MAX_STREAM_DATA token unless
+            // the rolling-extension threshold check fires (which it
+            // shouldn't here — fresh handshake, no peer activity).
+            val sizeBefore = client.application.sentPackets.size
+            runCatching { drainOutbound(client, nowMillis = 1L) }
+            val newEntries =
+                client.application.sentPackets.entries
+                    .sortedBy { it.key }
+                    .drop(sizeBefore)
+            val anyExtensionToken =
+                newEntries
+                    .flatMap { it.value.tokens }
+                    .any { it is RecoveryToken.MaxStreamsUni || it is RecoveryToken.MaxStreamsBidi || it is RecoveryToken.MaxData || it is RecoveryToken.MaxStreamData }
+            assertEquals(false, anyExtensionToken, "no pending → no extension tokens")
+        }
+
+    @Test
+    fun pendingDrainBeforeThresholdCheck_supersedeOrderObservable(): Unit =
+        runBlocking {
+            // Set pendingMaxStreamsUni to a value that's below the current
+            // advertised cap. The writer drains it as-is — supersede check
+            // is in step 6 (the setter side), not here.
+            val client = handshakedClient()
+            client.lock.lock()
+            try {
+                client.pendingMaxStreamsUni = 50L
+            } finally {
+                client.lock.unlock()
+            }
+            val sizeBefore = client.application.sentPackets.size
+            runCatching { drainOutbound(client, nowMillis = 1L) }
+            val newEntries =
+                client.application.sentPackets.entries
+                    .sortedBy { it.key }
+                    .drop(sizeBefore)
+            val withRetransmit =
+                newEntries.firstOrNull { entry ->
+                    entry.value.tokens.any { it == RecoveryToken.MaxStreamsUni(maxStreams = 50L) }
+                }
+            assertNotNull(
+                withRetransmit,
+                "writer must drain pendingMaxStreamsUni unconditionally; supersede check belongs to the setter (step 6)",
+            )
+        }
+
+    @Test
+    fun pendingClearedAcrossDrains() =
+        runBlocking {
+            val client = handshakedClient()
+            client.lock.lock()
+            try {
+                client.pendingMaxStreamsUni = 150L
+            } finally {
+                client.lock.unlock()
+            }
+            // Drain once: pending consumed.
+            runCatching { drainOutbound(client, nowMillis = 1L) }
+            assertNull(client.pendingMaxStreamsUni)
+
+            // Drain again with no new pending: no retransmit token in any
+            // SentPacket recorded by this drain.
+            val sizeBefore = client.application.sentPackets.size
+            runCatching { drainOutbound(client, nowMillis = 2L) }
+            val newEntries =
+                client.application.sentPackets.entries
+                    .sortedBy { it.key }
+                    .drop(sizeBefore)
+            val msuTokens =
+                newEntries.flatMap { it.value.tokens }.filterIsInstance<RecoveryToken.MaxStreamsUni>()
+            assertEquals(emptyList(), msuTokens, "second drain must not re-emit cleared pending")
+        }
+
+    private fun handshakedClient(): QuicConnection =
+        runBlocking {
+            val client =
+                QuicConnection(
+                    serverName = "example.test",
+                    config = QuicConnectionConfig(),
+                    tlsCertificateValidator =
+                        com.vitorpamplona.quic.tls
+                            .PermissiveCertificateValidator(),
+                )
+            val serverScid = ConnectionId.random(8)
+            val tlsServer =
+                InProcessTlsServer(
+                    transportParameters =
+                        TransportParameters(
+                            initialMaxData = 1_000_000,
+                            initialMaxStreamDataBidiLocal = 100_000,
+                            initialMaxStreamDataBidiRemote = 100_000,
+                            initialMaxStreamDataUni = 100_000,
+                            initialMaxStreamsBidi = 100,
+                            initialMaxStreamsUni = 100,
+                            initialSourceConnectionId = serverScid.bytes,
+                            originalDestinationConnectionId = client.destinationConnectionId.bytes,
+                        ).encode(),
+                )
+            val pipe =
+                InMemoryQuicPipe(
+                    client = client,
+                    initialDcid = client.destinationConnectionId.bytes,
+                    serverScid = serverScid,
+                    tlsServer = tlsServer,
+                )
+            client.start()
+            pipe.drive(maxRounds = 16)
+            assertEquals(QuicConnection.Status.CONNECTED, client.status)
+            client
+        }
+}

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/ResetStopSendingEmitTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/ResetStopSendingEmitTest.kt
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quic.connection
+
+import com.vitorpamplona.quic.connection.recovery.RecoveryToken
+import com.vitorpamplona.quic.tls.InProcessTlsServer
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Public-API + writer drain for RESET_STREAM / STOP_SENDING /
+ * NEW_CONNECTION_ID. Verifies:
+ *
+ *   1. App calls [com.vitorpamplona.quic.stream.QuicStream.resetStream]
+ *      / [com.vitorpamplona.quic.stream.QuicStream.stopSending]; the
+ *      next writer drain emits the matching frame with a token.
+ *   2. Loss dispatch re-flags the per-stream emit-pending bit; next
+ *      drain re-emits.
+ *   3. ACK dispatch latches resetAcked / stopSendingAcked; subsequent
+ *      stale loss tokens are dropped.
+ *   4. NEW_CONNECTION_ID retransmit drains
+ *      [QuicConnection.pendingNewConnectionId].
+ */
+class ResetStopSendingEmitTest {
+    @Test
+    fun resetStream_emitsResetStreamFrameAndToken() =
+        runBlocking {
+            val client = handshakedClient()
+            val stream = client.openUniStream()
+            stream.send.enqueue("partial-upload".encodeToByteArray())
+            // App cancels mid-write.
+            stream.resetStream(errorCode = 7L)
+
+            val sizeBefore = client.application.sentPackets.size
+            runCatching { drainOutbound(client, nowMillis = 1L) }
+            val newEntries =
+                client.application.sentPackets.entries
+                    .sortedBy { it.key }
+                    .drop(sizeBefore)
+            val tokenEntry =
+                newEntries.firstOrNull { entry ->
+                    entry.value.tokens.any { it is RecoveryToken.ResetStream }
+                }
+            assertNotNull(tokenEntry, "resetStream() must produce a SentPacket carrying ResetStream")
+            val token =
+                tokenEntry.value.tokens
+                    .filterIsInstance<RecoveryToken.ResetStream>()
+                    .single()
+            assertEquals(stream.streamId, token.streamId)
+            assertEquals(7L, token.errorCode)
+            // finalSize == nextOffset at reset time. We enqueued 14 bytes.
+            assertEquals(14L, token.finalSize, "finalSize is the largest enqueued offset")
+            // Pending flag cleared after emit.
+            assertEquals(false, stream.resetEmitPending)
+            assertEquals(false, stream.resetAcked, "ACK hasn't arrived yet")
+        }
+
+    @Test
+    fun resetStream_retransmittedOnLoss() =
+        runBlocking {
+            val client = handshakedClient()
+            val stream = client.openUniStream()
+            stream.resetStream(errorCode = 13L)
+            runCatching { drainOutbound(client, nowMillis = 1L) }
+
+            val firstEntry =
+                client.application.sentPackets.entries
+                    .first { it.value.tokens.any { it is RecoveryToken.ResetStream } }
+            val token =
+                firstEntry.value.tokens
+                    .filterIsInstance<RecoveryToken.ResetStream>()
+                    .single()
+
+            // Simulate loss.
+            client.lock.lock()
+            try {
+                client.onTokensLost(listOf(token))
+                client.application.sentPackets.remove(firstEntry.key)
+            } finally {
+                client.lock.unlock()
+            }
+            // Per-stream emit-pending should be re-flagged.
+            assertTrue(stream.resetEmitPending, "loss must re-flag resetEmitPending")
+
+            val sizeBefore = client.application.sentPackets.size
+            runCatching { drainOutbound(client, nowMillis = 2L) }
+            val replay =
+                client.application.sentPackets.entries
+                    .sortedBy { it.key }
+                    .drop(sizeBefore)
+                    .firstOrNull { entry -> entry.value.tokens.any { it is RecoveryToken.ResetStream } }
+            assertNotNull(replay, "retransmit must produce a fresh SentPacket carrying ResetStream")
+            val replayToken =
+                replay.value.tokens
+                    .filterIsInstance<RecoveryToken.ResetStream>()
+                    .single()
+            assertEquals(token, replayToken, "retransmit replays identical RESET_STREAM contents")
+        }
+
+    @Test
+    fun resetStream_acked_doesNotReEmitOnStaleLoss() =
+        runBlocking {
+            // ACK comes first, then a stale loss token arrives. The
+            // dispatcher must NOT re-flag resetEmitPending.
+            val client = handshakedClient()
+            val stream = client.openUniStream()
+            stream.resetStream(errorCode = 99L)
+            runCatching { drainOutbound(client, nowMillis = 1L) }
+
+            val packet =
+                client.application.sentPackets.entries
+                    .first { it.value.tokens.any { it is RecoveryToken.ResetStream } }
+            val token =
+                packet.value.tokens
+                    .filterIsInstance<RecoveryToken.ResetStream>()
+                    .single()
+
+            // ACK first.
+            client.lock.lock()
+            try {
+                client.onTokensAcked(listOf(token))
+            } finally {
+                client.lock.unlock()
+            }
+            assertEquals(true, stream.resetAcked)
+            assertEquals(false, stream.resetEmitPending)
+
+            // Now a stale loss notification arrives. Defensive: drop.
+            client.lock.lock()
+            try {
+                client.onTokensLost(listOf(token))
+            } finally {
+                client.lock.unlock()
+            }
+            assertEquals(false, stream.resetEmitPending, "stale loss after ACK must not re-flag emit-pending")
+        }
+
+    @Test
+    fun stopSending_emitsStopSendingFrameAndToken() =
+        runBlocking {
+            val client = handshakedClient()
+            val stream = client.openBidiStream()
+            stream.stopSending(errorCode = 5L)
+
+            val sizeBefore = client.application.sentPackets.size
+            runCatching { drainOutbound(client, nowMillis = 1L) }
+            val newEntries =
+                client.application.sentPackets.entries
+                    .sortedBy { it.key }
+                    .drop(sizeBefore)
+            val tokenEntry =
+                newEntries.firstOrNull { entry ->
+                    entry.value.tokens.any { it is RecoveryToken.StopSending }
+                }
+            assertNotNull(tokenEntry)
+            val token =
+                tokenEntry.value.tokens
+                    .filterIsInstance<RecoveryToken.StopSending>()
+                    .single()
+            assertEquals(stream.streamId, token.streamId)
+            assertEquals(5L, token.errorCode)
+            assertEquals(false, stream.stopSendingEmitPending)
+        }
+
+    @Test
+    fun newConnectionId_retransmittedOnLoss() =
+        runBlocking {
+            val client = handshakedClient()
+            // Inject a NewConnectionId loss token directly — there's no
+            // public emit API for NEW_CONNECTION_ID since :quic doesn't
+            // do connection-ID rotation, but the retransmit machinery
+            // is wired so a future emit path lands cleanly.
+            val token =
+                RecoveryToken.NewConnectionId(
+                    sequenceNumber = 1L,
+                    retirePriorTo = 0L,
+                    connectionId = byteArrayOf(1, 2, 3, 4),
+                    statelessResetToken = ByteArray(16) { it.toByte() },
+                )
+            client.lock.lock()
+            try {
+                client.onTokensLost(listOf(token))
+            } finally {
+                client.lock.unlock()
+            }
+            assertEquals(token, client.pendingNewConnectionId[1L])
+
+            // Next drain emits the NEW_CONNECTION_ID frame and clears the map.
+            val sizeBefore = client.application.sentPackets.size
+            runCatching { drainOutbound(client, nowMillis = 1L) }
+            val replay =
+                client.application.sentPackets.entries
+                    .sortedBy { it.key }
+                    .drop(sizeBefore)
+                    .firstOrNull { entry -> entry.value.tokens.any { it is RecoveryToken.NewConnectionId } }
+            assertNotNull(replay, "writer must drain pendingNewConnectionId")
+            assertTrue(client.pendingNewConnectionId.isEmpty(), "map must be cleared after drain")
+        }
+
+    private fun handshakedClient(): QuicConnection =
+        runBlocking {
+            val client =
+                QuicConnection(
+                    serverName = "example.test",
+                    config = QuicConnectionConfig(),
+                    tlsCertificateValidator =
+                        com.vitorpamplona.quic.tls
+                            .PermissiveCertificateValidator(),
+                )
+            val serverScid = ConnectionId.random(8)
+            val tlsServer =
+                InProcessTlsServer(
+                    transportParameters =
+                        TransportParameters(
+                            initialMaxData = 1_000_000,
+                            initialMaxStreamDataBidiLocal = 100_000,
+                            initialMaxStreamDataBidiRemote = 100_000,
+                            initialMaxStreamDataUni = 100_000,
+                            initialMaxStreamsBidi = 100,
+                            initialMaxStreamsUni = 100,
+                            initialSourceConnectionId = serverScid.bytes,
+                            originalDestinationConnectionId = client.destinationConnectionId.bytes,
+                        ).encode(),
+                )
+            val pipe =
+                InMemoryQuicPipe(
+                    client = client,
+                    initialDcid = client.destinationConnectionId.bytes,
+                    serverScid = serverScid,
+                    tlsServer = tlsServer,
+                )
+            client.start()
+            pipe.drive(maxRounds = 16)
+            assertEquals(QuicConnection.Status.CONNECTED, client.status)
+            client
+        }
+}

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/ResetStopSendingEmitTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/ResetStopSendingEmitTest.kt
@@ -184,6 +184,56 @@ class ResetStopSendingEmitTest {
         }
 
     @Test
+    fun resetStream_secondCallIsNoOp_finalSizeFrozen() =
+        runBlocking {
+            // RFC 9000 §3.5: finalSize is fixed at first emission.
+            // A second resetStream() must not overwrite resetState
+            // — otherwise a retransmit after additional enqueue would
+            // replay with a larger finalSize, triggering FINAL_SIZE_ERROR.
+            val client = handshakedClient()
+            val stream = client.openUniStream()
+            stream.send.enqueue("first".encodeToByteArray()) // 5 bytes
+            stream.resetStream(errorCode = 1L)
+
+            // App enqueues more bytes (writer's send loop is racing) and
+            // calls resetStream again with a different code.
+            stream.send.enqueue("more-bytes".encodeToByteArray()) // +10 bytes
+            stream.resetStream(errorCode = 99L)
+
+            runCatching { drainOutbound(client, nowMillis = 1L) }
+            val tokenEntry =
+                client.application.sentPackets.entries
+                    .firstOrNull { it.value.tokens.any { t -> t is RecoveryToken.ResetStream } }
+            assertNotNull(tokenEntry)
+            val token =
+                tokenEntry.value.tokens
+                    .filterIsInstance<RecoveryToken.ResetStream>()
+                    .single()
+            assertEquals(1L, token.errorCode, "first errorCode wins")
+            assertEquals(5L, token.finalSize, "finalSize frozen at first call (RFC 9000 §3.5)")
+        }
+
+    @Test
+    fun stopSending_secondCallIsNoOp() =
+        runBlocking {
+            val client = handshakedClient()
+            val stream = client.openBidiStream()
+            stream.stopSending(errorCode = 5L)
+            stream.stopSending(errorCode = 42L)
+
+            runCatching { drainOutbound(client, nowMillis = 1L) }
+            val tokenEntry =
+                client.application.sentPackets.entries
+                    .firstOrNull { it.value.tokens.any { t -> t is RecoveryToken.StopSending } }
+            assertNotNull(tokenEntry)
+            val token =
+                tokenEntry.value.tokens
+                    .filterIsInstance<RecoveryToken.StopSending>()
+                    .single()
+            assertEquals(5L, token.errorCode, "first errorCode wins")
+        }
+
+    @Test
     fun newConnectionId_retransmittedOnLoss() =
         runBlocking {
             val client = handshakedClient()

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/RetransmitIntegrationTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/RetransmitIntegrationTest.kt
@@ -80,7 +80,10 @@ class RetransmitIntegrationTest {
                         sentAtMillis = 1L,
                         ackEliciting = true,
                         sizeBytes = 64,
-                        tokens = listOf(RecoveryToken.Ack),
+                        tokens =
+                            listOf(
+                                RecoveryToken.Ack(level = EncryptionLevel.APPLICATION, largestAcked = 0L),
+                            ),
                     )
                 // Drain the ACK'd packet from the map (simulating the
                 // parser path).

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/RetransmitIntegrationTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/RetransmitIntegrationTest.kt
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quic.connection
+
+import com.vitorpamplona.quic.connection.recovery.RecoveryToken
+import com.vitorpamplona.quic.stream.StreamId
+import com.vitorpamplona.quic.tls.InProcessTlsServer
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Step 8 of `quic/plans/2026-05-04-control-frame-retransmit.md`:
+ * end-to-end exercise of the retransmit pipeline. Drives the full
+ * chain (writer → SentPacket → loss detection → dispatch → drain)
+ * by simulating packet loss directly on QuicConnection state, since
+ * the in-process pipe doesn't model loss.
+ *
+ * This is the test that, before this work landed, could not have
+ * been written: there was no way to express "MAX_STREAMS_UNI was
+ * lost; verify it gets re-emitted". Now there is.
+ */
+class RetransmitIntegrationTest {
+    @Test
+    fun maxStreamsUni_lostByPacketThreshold_isRetransmitted() =
+        runBlocking {
+            val client = handshakedClient()
+
+            // 1. Cross peer-uni half-window so the writer emits a
+            //    MAX_STREAMS_UNI in its next drain.
+            crossPeerUniHalfWindow(client)
+            val capBefore = client.advertisedMaxStreamsUni
+            runCatching { drainOutbound(client, nowMillis = 1L) }
+            val capAfterFirstDrain = client.advertisedMaxStreamsUni
+            assertTrue(capAfterFirstDrain > capBefore, "writer must have advertised a higher cap")
+
+            // 2. Locate the SentPacket carrying the MaxStreamsUni token.
+            val msuEntry =
+                client.application.sentPackets.entries.firstOrNull { entry ->
+                    entry.value.tokens.any { it == RecoveryToken.MaxStreamsUni(maxStreams = capAfterFirstDrain) }
+                }
+            assertNotNull(msuEntry, "expected SentPacket with MaxStreamsUni token after first drain")
+            val msuPn = msuEntry.key
+
+            // 3. Simulate ACK that newly-acks PN = msuPn + 4 (above the
+            //    packet-threshold of 3). The MAX_STREAMS_UNI packet is
+            //    ACK'd by reordering — its PN < largestAckedPn -
+            //    PACKET_THRESHOLD ⇒ declared lost.
+            val futurePn = msuPn + 4L
+            client.lock.lock()
+            try {
+                // Inject a phantom SentPacket at futurePn so the loss
+                // detector has a credible "newly acked" reference, then
+                // ACK exactly that PN.
+                client.application.sentPackets[futurePn] =
+                    com.vitorpamplona.quic.connection.recovery.SentPacket(
+                        packetNumber = futurePn,
+                        sentAtMillis = 1L,
+                        ackEliciting = true,
+                        sizeBytes = 64,
+                        tokens = listOf(RecoveryToken.Ack),
+                    )
+                // Drain the ACK'd packet from the map (simulating the
+                // parser path).
+                client.application.sentPackets.remove(futurePn)
+                client.application.largestAckedPn = futurePn
+                client.application.largestAckedSentTimeMs = 1L
+                // 4. Run loss detection — msuPn is < futurePn - 3 ⇒ lost.
+                val lost =
+                    client.lossDetection.detectAndRemoveLost(
+                        sentPackets = client.application.sentPackets,
+                        largestAckedPn = futurePn,
+                        nowMs = 2L,
+                    )
+                val lostMsuPacket = lost.firstOrNull { it.packetNumber == msuPn }
+                assertNotNull(lostMsuPacket, "msuPn=$msuPn must be declared lost (largestAckedPn=$futurePn, threshold=3)")
+                // 5. Dispatch lost tokens — pendingMaxStreamsUni gets set.
+                client.onTokensLost(lostMsuPacket.tokens)
+            } finally {
+                client.lock.unlock()
+            }
+            assertEquals(
+                capAfterFirstDrain,
+                client.pendingMaxStreamsUni,
+                "lost MaxStreamsUni token must populate pendingMaxStreamsUni",
+            )
+
+            // 6. Drain again — writer must re-emit the MAX_STREAMS_UNI
+            //    in a NEW packet (different PN). The pending* field
+            //    is cleared after drain.
+            val sizeBefore = client.application.sentPackets.size
+            runCatching { drainOutbound(client, nowMillis = 3L) }
+            val newEntries =
+                client.application.sentPackets.entries
+                    .sortedBy { it.key }
+                    .drop(sizeBefore)
+            val retransmitEntry =
+                newEntries.firstOrNull { entry ->
+                    entry.value.tokens.any { it == RecoveryToken.MaxStreamsUni(maxStreams = capAfterFirstDrain) }
+                }
+            assertNotNull(
+                retransmitEntry,
+                "retransmit must produce a fresh SentPacket carrying MaxStreamsUni; saw " +
+                    newEntries.map { it.value.tokens.map { t -> t::class.simpleName } },
+            )
+            assertNotEquals(msuPn, retransmitEntry.key, "retransmit must use a NEW packet number")
+            assertNull(client.pendingMaxStreamsUni, "pendingMaxStreamsUni must be cleared after retransmit drain")
+        }
+
+    @Test
+    fun lossDispatch_handlesSupersedeAcrossMultipleEmits() =
+        runBlocking {
+            // Two consecutive MAX_STREAMS_UNI emissions; the OLDER one
+            // is declared lost. Because the newer extension already
+            // covers it, the supersede check (in onTokensLost) drops
+            // the older lost token without populating pending*.
+            val client = handshakedClient()
+
+            // First bump.
+            crossPeerUniHalfWindow(client)
+            runCatching { drainOutbound(client, nowMillis = 1L) }
+            val firstCap = client.advertisedMaxStreamsUni
+
+            // Second bump: open more peer-uni streams to cross the
+            // (already extended) threshold again.
+            client.lock.lock()
+            try {
+                client.getOrCreatePeerStreamLocked(StreamId.build(StreamId.Kind.SERVER_UNI, 2))
+                client.getOrCreatePeerStreamLocked(StreamId.build(StreamId.Kind.SERVER_UNI, 3))
+                client.getOrCreatePeerStreamLocked(StreamId.build(StreamId.Kind.SERVER_UNI, 4))
+            } finally {
+                client.lock.unlock()
+            }
+            runCatching { drainOutbound(client, nowMillis = 2L) }
+            val secondCap = client.advertisedMaxStreamsUni
+            assertTrue(secondCap > firstCap, "second drain must advertise a still-higher cap; saw $firstCap → $secondCap")
+
+            // Now declare the FIRST emit lost via direct dispatch.
+            client.lock.lock()
+            try {
+                client.onTokensLost(listOf(RecoveryToken.MaxStreamsUni(maxStreams = firstCap)))
+            } finally {
+                client.lock.unlock()
+            }
+            // Supersede check: firstCap != advertisedMaxStreamsUni (now == secondCap),
+            // so pending must remain null.
+            assertNull(client.pendingMaxStreamsUni, "older lost extension is superseded by newer emit; no retransmit")
+        }
+
+    private fun handshakedClient(): QuicConnection =
+        runBlocking {
+            val client =
+                QuicConnection(
+                    serverName = "example.test",
+                    config =
+                        QuicConnectionConfig(
+                            initialMaxStreamsUni = 4,
+                            initialMaxStreamsBidi = 4,
+                        ),
+                    tlsCertificateValidator =
+                        com.vitorpamplona.quic.tls
+                            .PermissiveCertificateValidator(),
+                )
+            val serverScid = ConnectionId.random(8)
+            val tlsServer =
+                InProcessTlsServer(
+                    transportParameters =
+                        TransportParameters(
+                            initialMaxData = 1_000_000,
+                            initialMaxStreamDataBidiLocal = 100_000,
+                            initialMaxStreamDataBidiRemote = 100_000,
+                            initialMaxStreamDataUni = 100_000,
+                            initialMaxStreamsBidi = 100,
+                            initialMaxStreamsUni = 100,
+                            initialSourceConnectionId = serverScid.bytes,
+                            originalDestinationConnectionId = client.destinationConnectionId.bytes,
+                        ).encode(),
+                )
+            val pipe =
+                InMemoryQuicPipe(
+                    client = client,
+                    initialDcid = client.destinationConnectionId.bytes,
+                    serverScid = serverScid,
+                    tlsServer = tlsServer,
+                )
+            client.start()
+            pipe.drive(maxRounds = 16)
+            assertEquals(QuicConnection.Status.CONNECTED, client.status)
+            client
+        }
+
+    private fun crossPeerUniHalfWindow(client: QuicConnection) =
+        runBlocking {
+            client.lock.lock()
+            try {
+                client.getOrCreatePeerStreamLocked(StreamId.build(StreamId.Kind.SERVER_UNI, 0))
+                client.getOrCreatePeerStreamLocked(StreamId.build(StreamId.Kind.SERVER_UNI, 1))
+            } finally {
+                client.lock.unlock()
+            }
+        }
+}

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/SentPacketTrackingTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/SentPacketTrackingTest.kt
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quic.connection
+
+import com.vitorpamplona.quic.connection.recovery.RecoveryToken
+import com.vitorpamplona.quic.stream.StreamId
+import com.vitorpamplona.quic.tls.InProcessTlsServer
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Step 2 of `quic/plans/2026-05-04-control-frame-retransmit.md`:
+ * the writer must record a [com.vitorpamplona.quic.connection.recovery.SentPacket]
+ * keyed by packet number whenever it emits an Application packet,
+ * carrying the matching tokens for any retransmittable control
+ * frame in that packet.
+ *
+ * The map is read by step 3 (ACK drain) and step 5 (loss detection);
+ * step 2 only validates population — no behavior change visible to
+ * the peer.
+ */
+class SentPacketTrackingTest {
+    @Test
+    fun writer_records_sent_packet_with_max_streams_uni_token() =
+        runBlocking {
+            val client = handshakedClient()
+            // Cross the half-window threshold so the next outbound packet
+            // includes a MAX_STREAMS_UNI extension.
+            crossPeerUniHalfWindow(client)
+
+            val sizeBefore = client.application.sentPackets.size
+            runCatching { drainOutbound(client, nowMillis = 12_345L) }
+
+            val newEntries =
+                client.application.sentPackets.entries
+                    .sortedBy { it.key }
+                    .drop(sizeBefore)
+            assertTrue(newEntries.isNotEmpty(), "writer must record at least one SentPacket on outbound drain")
+
+            val withBump =
+                newEntries.firstOrNull { entry ->
+                    entry.value.tokens.any { it is RecoveryToken.MaxStreamsUni }
+                }
+            assertNotNull(
+                withBump,
+                "expected a SentPacket with MaxStreamsUni token; saw tokens=${newEntries.map { it.value.tokens.map { t -> t::class.simpleName } }}",
+            )
+
+            val sent = withBump.value
+            assertEquals(withBump.key, sent.packetNumber, "packetNumber must equal the map key")
+            assertEquals(12_345L, sent.sentAtMillis, "sentAtMillis must equal the writer's nowMillis input")
+            assertTrue(sent.ackEliciting, "MAX_STREAMS_UNI is ack-eliciting per RFC 9000 §13.2.1")
+            // sizeBytes is best-effort: the writer records the entry
+            // before the encrypt step, so a build/encrypt throw (which
+            // happens on tiny packets in tight test scaffolds — header
+            // protection needs 16 bytes of sample after the PN) leaves
+            // sizeBytes at 0. The bookkeeping is correct either way;
+            // the entry exists and loss detection will declare it lost
+            // on the time threshold. We only assert sizeBytes >= 0.
+            assertTrue(sent.sizeBytes >= 0, "sizeBytes must be non-negative")
+            val msuToken = sent.tokens.filterIsInstance<RecoveryToken.MaxStreamsUni>().single()
+            assertEquals(
+                client.advertisedMaxStreamsUni,
+                msuToken.maxStreams,
+                "token's maxStreams must equal the advertised cap after the bump",
+            )
+        }
+
+    @Test
+    fun ack_only_outbound_records_sent_packet_with_ack_token_and_not_ack_eliciting() =
+        runBlocking {
+            val client = handshakedClient()
+            // Force an ACK to be pending: simulate a received-but-unacked packet
+            // by calling the ack tracker directly. Without a paired peer we'd
+            // never have anything to ACK, so we synthesize the input.
+            client.application.ackTracker.receivedPacket(packetNumber = 10L, ackEliciting = true, receivedAtMillis = 0L)
+
+            val sizeBefore = client.application.sentPackets.size
+            runCatching { drainOutbound(client, nowMillis = 50L) }
+
+            val newEntries =
+                client.application.sentPackets.entries
+                    .sortedBy { it.key }
+                    .drop(sizeBefore)
+            // Find the entry that's ACK-only — its only token should be
+            // RecoveryToken.Ack and it should not be ack-eliciting.
+            val ackOnly =
+                newEntries.firstOrNull { entry ->
+                    entry.value.tokens.size == 1 && entry.value.tokens.single() is RecoveryToken.Ack
+                }
+            assertNotNull(
+                ackOnly,
+                "expected at least one ACK-only SentPacket; saw tokens=${newEntries.map { it.value.tokens }}",
+            )
+            assertEquals(false, ackOnly.value.ackEliciting, "ACK-only packet must not be ack-eliciting")
+            assertEquals(50L, ackOnly.value.sentAtMillis, "sentAtMillis must equal the writer's nowMillis input")
+        }
+
+    @Test
+    fun successive_drains_record_distinct_packet_numbers() =
+        runBlocking {
+            val client = handshakedClient()
+            crossPeerUniHalfWindow(client)
+            val before =
+                client.application.sentPackets.keys
+                    .toSet()
+            runCatching { drainOutbound(client, nowMillis = 100L) }
+            val afterFirst =
+                client.application.sentPackets.keys
+                    .toSet()
+
+            // Force more outbound work: another peer-uni stream past the
+            // (already extended) threshold to trigger a new bump candidate
+            // — even if the writer skips it (no new threshold reached),
+            // the ACK from receivedPacket below will produce a packet.
+            client.application.ackTracker.receivedPacket(packetNumber = 20L, ackEliciting = true, receivedAtMillis = 0L)
+            runCatching { drainOutbound(client, nowMillis = 200L) }
+            val afterSecond =
+                client.application.sentPackets.keys
+                    .toSet()
+
+            assertTrue(afterFirst.isNotEmpty(), "first drain must record at least one packet number")
+            assertTrue(afterSecond.size >= afterFirst.size, "second drain must not lose entries")
+            // No packet number is reused between drains.
+            val firstDrainSet = afterFirst - before
+            val secondDrainSet = afterSecond - afterFirst
+            assertTrue(
+                (firstDrainSet intersect secondDrainSet).isEmpty(),
+                "packet numbers must be distinct between drains; firstDrainSet=$firstDrainSet secondDrainSet=$secondDrainSet",
+            )
+        }
+
+    /**
+     * Spin up a connected client against the in-process TLS server, the
+     * same scaffold [PeerStreamCreditExtensionTest] uses.
+     */
+    private fun handshakedClient(): QuicConnection =
+        runBlocking {
+            val client =
+                QuicConnection(
+                    serverName = "example.test",
+                    config =
+                        QuicConnectionConfig(
+                            initialMaxStreamsUni = 4,
+                            initialMaxStreamsBidi = 4,
+                        ),
+                    tlsCertificateValidator =
+                        com.vitorpamplona.quic.tls
+                            .PermissiveCertificateValidator(),
+                )
+            val serverScid = ConnectionId.random(8)
+            val tlsServer =
+                InProcessTlsServer(
+                    transportParameters =
+                        TransportParameters(
+                            initialMaxData = 1_000_000,
+                            initialMaxStreamDataBidiLocal = 100_000,
+                            initialMaxStreamDataBidiRemote = 100_000,
+                            initialMaxStreamDataUni = 100_000,
+                            initialMaxStreamsBidi = 100,
+                            initialMaxStreamsUni = 100,
+                            initialSourceConnectionId = serverScid.bytes,
+                            originalDestinationConnectionId = client.destinationConnectionId.bytes,
+                        ).encode(),
+                )
+            val pipe =
+                InMemoryQuicPipe(
+                    client = client,
+                    initialDcid = client.destinationConnectionId.bytes,
+                    serverScid = serverScid,
+                    tlsServer = tlsServer,
+                )
+            client.start()
+            pipe.drive(maxRounds = 16)
+            assertEquals(QuicConnection.Status.CONNECTED, client.status)
+            client
+        }
+
+    /** Cross the half-window threshold (cap=4, two peer-uni streams ⇒ count >= cap-half=2). */
+    private fun crossPeerUniHalfWindow(client: QuicConnection) =
+        runBlocking {
+            client.lock.lock()
+            try {
+                client.getOrCreatePeerStreamLocked(StreamId.build(StreamId.Kind.SERVER_UNI, 0))
+                client.getOrCreatePeerStreamLocked(StreamId.build(StreamId.Kind.SERVER_UNI, 1))
+            } finally {
+                client.lock.unlock()
+            }
+        }
+}

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/StreamRetransmitTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/StreamRetransmitTest.kt
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quic.connection
+
+import com.vitorpamplona.quic.connection.recovery.RecoveryToken
+import com.vitorpamplona.quic.tls.InProcessTlsServer
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Step C of the deferred-follow-ups pass: STREAM data retransmit
+ * end-to-end. Verifies the writer emits a Stream token per
+ * STREAM frame, the parser dispatches it to markAcked / markLost,
+ * and the buffer either releases or re-queues the bytes
+ * accordingly.
+ */
+class StreamRetransmitTest {
+    @Test
+    fun streamFrame_carriesStreamToken_inSentPacket() =
+        runBlocking {
+            val client = handshakedClient()
+            val stream = client.openUniStream()
+            stream.send.enqueue("hello".encodeToByteArray())
+
+            val sizeBefore = client.application.sentPackets.size
+            runCatching { drainOutbound(client, nowMillis = 1L) }
+            val newEntries =
+                client.application.sentPackets.entries
+                    .sortedBy { it.key }
+                    .drop(sizeBefore)
+            val streamPacket =
+                newEntries.firstOrNull { entry ->
+                    entry.value.tokens.any { it is RecoveryToken.Stream }
+                }
+            assertNotNull(streamPacket, "writer must record a Stream token in the SentPacket")
+            val streamToken =
+                streamPacket.value.tokens
+                    .filterIsInstance<RecoveryToken.Stream>()
+                    .single()
+            assertEquals(stream.streamId, streamToken.streamId)
+            assertEquals(0L, streamToken.offset)
+            assertEquals(5L, streamToken.length)
+            assertEquals(false, streamToken.fin)
+        }
+
+    @Test
+    fun streamData_lostAndRetransmittedOnNextDrain() =
+        runBlocking {
+            val client = handshakedClient()
+            val stream = client.openUniStream()
+            stream.send.enqueue("hello".encodeToByteArray())
+            // First drain — emits StreamFrame, records SentPacket.
+            runCatching { drainOutbound(client, nowMillis = 1L) }
+
+            // Locate the Stream token's carrying packet.
+            val firstPacketEntry =
+                client.application.sentPackets.entries.firstOrNull { entry ->
+                    entry.value.tokens.any { it is RecoveryToken.Stream }
+                }
+            assertNotNull(firstPacketEntry, "expected a SentPacket with Stream token after first drain")
+            val firstPn = firstPacketEntry.key
+
+            // Simulate loss via direct dispatch.
+            client.lock.lock()
+            try {
+                val streamToken =
+                    firstPacketEntry.value.tokens
+                        .filterIsInstance<RecoveryToken.Stream>()
+                        .single()
+                client.onTokensLost(listOf(streamToken))
+                // Remove the lost packet from the sent map (the loss
+                // detector would have done this).
+                client.application.sentPackets.remove(firstPn)
+            } finally {
+                client.lock.unlock()
+            }
+
+            // SendBuffer should have re-queued the bytes for retransmit.
+            assertEquals(5, stream.send.readableBytes, "lost 5 bytes should be back in the queue")
+
+            // Second drain — emits the retransmit at the same offset.
+            val sizeBeforeReplay = client.application.sentPackets.size
+            runCatching { drainOutbound(client, nowMillis = 2L) }
+            val replayEntries =
+                client.application.sentPackets.entries
+                    .sortedBy { it.key }
+                    .drop(sizeBeforeReplay)
+            val replayPacket =
+                replayEntries.firstOrNull { entry ->
+                    entry.value.tokens.any { it is RecoveryToken.Stream }
+                }
+            assertNotNull(replayPacket, "retransmit must produce a fresh SentPacket carrying the Stream token")
+            val replayToken =
+                replayPacket.value.tokens
+                    .filterIsInstance<RecoveryToken.Stream>()
+                    .single()
+            assertEquals(0L, replayToken.offset, "retransmit must replay original offset (RFC 9000 §13.3 idempotent)")
+            assertEquals(5L, replayToken.length)
+            assertTrue(replayPacket.key != firstPn, "retransmit uses a fresh PN")
+        }
+
+    @Test
+    fun streamData_ackedReleasesBuffer() =
+        runBlocking {
+            val client = handshakedClient()
+            val stream = client.openUniStream()
+            stream.send.enqueue("hello".encodeToByteArray())
+            runCatching { drainOutbound(client, nowMillis = 1L) }
+
+            // Bytes are in-flight. SendBuffer holds them.
+            // Now ACK via direct dispatch.
+            val packet =
+                client.application.sentPackets.entries
+                    .first { it.value.tokens.any { t -> t is RecoveryToken.Stream } }
+            client.lock.lock()
+            try {
+                client.onTokensAcked(packet.value.tokens)
+            } finally {
+                client.lock.unlock()
+            }
+
+            // After ACK: enqueue more, observe that the buffer
+            // continues from offset 5 (proves the prior bytes were
+            // released, sentOffset advanced).
+            stream.send.enqueue("world".encodeToByteArray())
+            val sizeBefore = client.application.sentPackets.size
+            runCatching { drainOutbound(client, nowMillis = 2L) }
+            val newEntries =
+                client.application.sentPackets.entries
+                    .sortedBy { it.key }
+                    .drop(sizeBefore)
+            val nextStreamToken =
+                newEntries
+                    .flatMap { it.value.tokens }
+                    .filterIsInstance<RecoveryToken.Stream>()
+                    .firstOrNull()
+            assertNotNull(nextStreamToken)
+            assertEquals(5L, nextStreamToken.offset, "after ACK, next send picks up at offset 5")
+            assertEquals(5L, nextStreamToken.length)
+        }
+
+    private fun handshakedClient(): QuicConnection =
+        runBlocking {
+            val client =
+                QuicConnection(
+                    serverName = "example.test",
+                    config = QuicConnectionConfig(),
+                    tlsCertificateValidator =
+                        com.vitorpamplona.quic.tls
+                            .PermissiveCertificateValidator(),
+                )
+            val serverScid = ConnectionId.random(8)
+            val tlsServer =
+                InProcessTlsServer(
+                    transportParameters =
+                        TransportParameters(
+                            initialMaxData = 1_000_000,
+                            initialMaxStreamDataBidiLocal = 100_000,
+                            initialMaxStreamDataBidiRemote = 100_000,
+                            initialMaxStreamDataUni = 100_000,
+                            initialMaxStreamsBidi = 100,
+                            initialMaxStreamsUni = 100,
+                            initialSourceConnectionId = serverScid.bytes,
+                            originalDestinationConnectionId = client.destinationConnectionId.bytes,
+                        ).encode(),
+                )
+            val pipe =
+                InMemoryQuicPipe(
+                    client = client,
+                    initialDcid = client.destinationConnectionId.bytes,
+                    serverScid = serverScid,
+                    tlsServer = tlsServer,
+                )
+            client.start()
+            pipe.drive(maxRounds = 16)
+            assertEquals(QuicConnection.Status.CONNECTED, client.status)
+            client
+        }
+}

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/recovery/AckedPacketsTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/recovery/AckedPacketsTest.kt
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quic.connection.recovery
+
+import com.vitorpamplona.quic.frame.AckFrame
+import com.vitorpamplona.quic.frame.AckRange
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Step 3 of `quic/plans/2026-05-04-control-frame-retransmit.md`:
+ * `drainAckedSentPackets` removes SentPacket entries for every packet
+ * number covered by an inbound `AckFrame`'s ranges (RFC 9000
+ * §19.3.1). Equivalent in scope to the `remove_acked` test in
+ * neqo's `recovery/mod.rs:1262`, plus a few range-walk edge cases.
+ */
+class AckedPacketsTest {
+    private fun sentPacket(pn: Long): SentPacket =
+        SentPacket(
+            packetNumber = pn,
+            sentAtMillis = 0L,
+            ackEliciting = true,
+            sizeBytes = 64,
+            tokens = listOf(RecoveryToken.MaxStreamsUni(maxStreams = pn * 10)),
+        )
+
+    @Test
+    fun simpleRange_drainsAllAckedPns() {
+        val sent = mutableMapOf<Long, SentPacket>()
+        for (pn in 0L..9L) sent[pn] = sentPacket(pn)
+
+        // ACK [3..7]: largest=7, firstRange=4 → covers 3..7.
+        val ack =
+            AckFrame(
+                largestAcknowledged = 7L,
+                ackDelay = 0L,
+                firstAckRange = 4L,
+            )
+
+        val drained = drainAckedSentPackets(sent, ack)
+        assertEquals(5, drained.size, "5 PNs in [3..7]")
+        assertEquals(setOf(3L, 4L, 5L, 6L, 7L), drained.map { it.packetNumber }.toSet())
+        // Map keeps everything outside the range.
+        assertEquals(setOf(0L, 1L, 2L, 8L, 9L), sent.keys)
+    }
+
+    @Test
+    fun multipleRanges_drainsAllAckedPns() {
+        val sent = mutableMapOf<Long, SentPacket>()
+        for (pn in 0L..20L) sent[pn] = sentPacket(pn)
+
+        // ACK ranges: [18..20] then [10..12] then [0..3].
+        // Encoding (descending):
+        //   firstRange covers [18..20] → largest=20, firstRange=2
+        //   gap before next: previousSmallest=18, nextLargest=12 ⇒ gap=18-12-2=4
+        //   nextLength: 12..10 ⇒ length=2
+        //   gap before next: previousSmallest=10, nextLargest=3 ⇒ gap=10-3-2=5
+        //   nextLength: 3..0 ⇒ length=3
+        val ack =
+            AckFrame(
+                largestAcknowledged = 20L,
+                ackDelay = 0L,
+                firstAckRange = 2L,
+                additionalRanges =
+                    listOf(
+                        AckRange(gap = 4L, ackRangeLength = 2L),
+                        AckRange(gap = 5L, ackRangeLength = 3L),
+                    ),
+            )
+
+        val drained = drainAckedSentPackets(sent, ack)
+        val drainedPns = drained.map { it.packetNumber }.toSet()
+        assertEquals(setOf(18L, 19L, 20L, 10L, 11L, 12L, 0L, 1L, 2L, 3L), drainedPns)
+        // Map keeps everything outside the ranges.
+        assertEquals(setOf(4L, 5L, 6L, 7L, 8L, 9L, 13L, 14L, 15L, 16L, 17L), sent.keys)
+    }
+
+    @Test
+    fun ackForUnsentPn_isNoOp() {
+        val sent = mutableMapOf<Long, SentPacket>()
+        sent[5L] = sentPacket(5L)
+
+        // ACK PN 100 (never sent). drainAckedSentPackets should walk the
+        // range, find no matching key, and leave the map untouched.
+        // RFC 9000 §13.1 says ACK for unsent PN is a connection error —
+        // detecting that is the connection-state machine's job; this
+        // helper just drains, doesn't validate.
+        val ack =
+            AckFrame(
+                largestAcknowledged = 100L,
+                ackDelay = 0L,
+                firstAckRange = 0L,
+            )
+
+        val drained = drainAckedSentPackets(sent, ack)
+        assertEquals(0, drained.size)
+        assertEquals(1, sent.size)
+        assertNotNull(sent[5L])
+    }
+
+    @Test
+    fun emptyMap_returnsEmptyDrain() {
+        val sent = mutableMapOf<Long, SentPacket>()
+        val ack =
+            AckFrame(
+                largestAcknowledged = 5L,
+                ackDelay = 0L,
+                firstAckRange = 5L,
+            )
+        val drained = drainAckedSentPackets(sent, ack)
+        assertTrue(drained.isEmpty())
+    }
+
+    @Test
+    fun singlePacketAck_drainsOne() {
+        val sent = mutableMapOf<Long, SentPacket>()
+        sent[42L] = sentPacket(42L)
+
+        val ack =
+            AckFrame(
+                largestAcknowledged = 42L,
+                ackDelay = 0L,
+                firstAckRange = 0L,
+            )
+
+        val drained = drainAckedSentPackets(sent, ack)
+        assertEquals(1, drained.size)
+        assertEquals(42L, drained.single().packetNumber)
+        assertNull(sent[42L])
+    }
+
+    @Test
+    fun ackBoundary_pn0Inclusive() {
+        // First range [0..2] — must include PN 0 and not under-flow.
+        val sent = mutableMapOf<Long, SentPacket>()
+        for (pn in 0L..2L) sent[pn] = sentPacket(pn)
+
+        val ack =
+            AckFrame(
+                largestAcknowledged = 2L,
+                ackDelay = 0L,
+                firstAckRange = 2L,
+            )
+
+        val drained = drainAckedSentPackets(sent, ack)
+        assertEquals(setOf(0L, 1L, 2L), drained.map { it.packetNumber }.toSet())
+        assertTrue(sent.isEmpty())
+    }
+
+    @Test
+    fun forEachAckedPacketNumber_iteratesDescending() {
+        val ack =
+            AckFrame(
+                largestAcknowledged = 5L,
+                ackDelay = 0L,
+                firstAckRange = 2L,
+            )
+        val pns = mutableListOf<Long>()
+        forEachAckedPacketNumber(ack) { pns += it }
+        // First range is [3..5]; iteration order is descending.
+        assertEquals(listOf(5L, 4L, 3L), pns)
+    }
+
+    @Test
+    fun forEachAckedPacketNumber_acrossMultipleRanges_descending() {
+        // ACK [18..20] then [10..12] then [0..3] (same as multipleRanges_).
+        val ack =
+            AckFrame(
+                largestAcknowledged = 20L,
+                ackDelay = 0L,
+                firstAckRange = 2L,
+                additionalRanges =
+                    listOf(
+                        AckRange(gap = 4L, ackRangeLength = 2L),
+                        AckRange(gap = 5L, ackRangeLength = 3L),
+                    ),
+            )
+        val pns = mutableListOf<Long>()
+        forEachAckedPacketNumber(ack) { pns += it }
+        assertEquals(
+            listOf(20L, 19L, 18L, 12L, 11L, 10L, 3L, 2L, 1L, 0L),
+            pns,
+        )
+    }
+
+    @Test
+    fun returnedDrain_preservesTokens() {
+        val sent = mutableMapOf<Long, SentPacket>()
+        sent[7L] =
+            SentPacket(
+                packetNumber = 7L,
+                sentAtMillis = 1_000L,
+                ackEliciting = true,
+                sizeBytes = 100,
+                tokens =
+                    listOf(
+                        RecoveryToken.MaxStreamsUni(maxStreams = 200L),
+                        RecoveryToken.MaxData(maxData = 1_000_000L),
+                    ),
+            )
+
+        val ack =
+            AckFrame(
+                largestAcknowledged = 7L,
+                ackDelay = 0L,
+                firstAckRange = 0L,
+            )
+        val drained = drainAckedSentPackets(sent, ack)
+
+        assertEquals(1, drained.size)
+        val sp = drained.single()
+        assertEquals(7L, sp.packetNumber)
+        assertEquals(2, sp.tokens.size)
+        assertEquals(RecoveryToken.MaxStreamsUni(200L), sp.tokens[0])
+        assertEquals(RecoveryToken.MaxData(1_000_000L), sp.tokens[1])
+    }
+}

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/recovery/PtoTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/recovery/PtoTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quic.connection.recovery
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Step 7 of `quic/plans/2026-05-04-control-frame-retransmit.md`:
+ * RFC 9002 §6.2 Probe Timeout duration calculation. Mirrors neqo's
+ * PTO tests (`pto_works_basic`, `pto_state_count`, etc.) at the
+ * algorithm level — the driver-loop integration is exercised by
+ * the existing connection tests.
+ */
+class PtoTest {
+    @Test
+    fun ptoBeforeFirstRttSample_usesInitialDefault() {
+        val ld = QuicLossDetection()
+        // Before any sample: smoothed_rtt = 333, rttvar = 333/2 = 166.
+        // PTO = 333 + max(4*166, 1) + 0 = 333 + 664 = 997.
+        assertEquals(997L, ld.ptoBaseMs(maxAckDelayMs = 0L))
+    }
+
+    @Test
+    fun ptoIncludesMaxAckDelay() {
+        val ld = QuicLossDetection()
+        assertEquals(997L + 25L, ld.ptoBaseMs(maxAckDelayMs = 25L))
+    }
+
+    @Test
+    fun ptoAfterRttSample_usesNewSmoothedRtt() {
+        val ld = QuicLossDetection()
+        ld.onRttSample(largestAckedSentTimeMs = 0L, ackDelayMs = 0L, nowMs = 100L)
+        // After first sample: smoothed = 100, rttvar = 50.
+        // PTO = 100 + max(4*50, 1) + 0 = 100 + 200 = 300.
+        assertEquals(300L, ld.ptoBaseMs(maxAckDelayMs = 0L))
+    }
+
+    @Test
+    fun ptoFloors4RttVarAtGranularity() {
+        val ld = QuicLossDetection()
+        // Two identical samples drive rttvar toward 0. Then PTO should
+        // floor `4 * rttvar` at 1 ms granularity.
+        ld.onRttSample(largestAckedSentTimeMs = 0L, ackDelayMs = 0L, nowMs = 100L)
+        // rttvar after first sample = 50.
+        ld.onRttSample(largestAckedSentTimeMs = 100L, ackDelayMs = 0L, nowMs = 200L)
+        // smoothed = (7*100 + 100)/8 = 100. rttvar = (3*50 + 0)/4 = 37.
+        // 4*37 = 148, > 1ms. OK floor not exercised yet.
+        // Many identical samples drive rttvar → 0:
+        var t = 200L
+        repeat(40) {
+            ld.onRttSample(largestAckedSentTimeMs = t, ackDelayMs = 0L, nowMs = t + 100L)
+            t += 100L
+        }
+        // After many samples: rttvar should be tiny but positive. PTO
+        // contribution from 4*rttvar might fall below 1; check the
+        // floor by comparing PTO to smoothed_rtt + max_ack_delay only
+        // (i.e. the variance contribution is at least 1).
+        val smoothed = ld.smoothedRttMs
+        val pto = ld.ptoBaseMs(maxAckDelayMs = 0L)
+        assertTrue(pto >= smoothed + 1L, "PTO must include at least 1ms of variance: pto=$pto smoothed=$smoothed")
+    }
+}

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/recovery/QuicLossDetectionTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/recovery/QuicLossDetectionTest.kt
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quic.connection.recovery
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Step 5 of `quic/plans/2026-05-04-control-frame-retransmit.md`:
+ * RFC 9002 §5–§6 RTT + loss detection. Mirrors the subset of
+ * neqo's `recovery/mod.rs` tests that don't depend on PTO (step 7)
+ * or CRYPTO/handshake-space behavior (out of scope).
+ */
+class QuicLossDetectionTest {
+    private fun sentPacket(
+        pn: Long,
+        sentAt: Long,
+        ackEliciting: Boolean = true,
+    ): SentPacket =
+        SentPacket(
+            packetNumber = pn,
+            sentAtMillis = sentAt,
+            ackEliciting = ackEliciting,
+            sizeBytes = 64,
+            tokens = listOf(RecoveryToken.MaxStreamsUni(maxStreams = pn * 100L)),
+        )
+
+    @Test
+    fun firstRttSample_setsAllRttFieldsAtomically() {
+        val ld = QuicLossDetection()
+        ld.onRttSample(largestAckedSentTimeMs = 1_000L, ackDelayMs = 0L, nowMs = 1_050L)
+        assertTrue(ld.hasFirstRttSample)
+        assertEquals(50L, ld.smoothedRttMs, "first sample becomes smoothed_rtt")
+        assertEquals(50L, ld.minRttMs)
+        assertEquals(50L, ld.latestRttMs)
+        assertEquals(25L, ld.rttVarMs, "rttvar = sample/2 on first sample")
+    }
+
+    @Test
+    fun secondRttSample_movesSmoothedRttTowardSample() {
+        val ld = QuicLossDetection()
+        ld.onRttSample(largestAckedSentTimeMs = 0L, ackDelayMs = 0L, nowMs = 100L)
+        // First sample: smoothed=100, rttvar=50, min=100.
+        // Second sample at sample=120 (raw): adjusted=120 (no ack-delay).
+        // smoothed' = (7*100 + 120)/8 = 820/8 = 102 (integer)
+        // rttvar' = (3*50 + |100-120|)/4 = (150 + 20)/4 = 42
+        ld.onRttSample(largestAckedSentTimeMs = 100L, ackDelayMs = 0L, nowMs = 220L)
+        assertEquals(102L, ld.smoothedRttMs)
+        assertEquals(42L, ld.rttVarMs)
+        assertEquals(100L, ld.minRttMs, "minRtt only decreases")
+    }
+
+    @Test
+    fun ackDelay_clampedAgainstMinRtt() {
+        val ld = QuicLossDetection()
+        // First sample establishes minRtt=50.
+        ld.onRttSample(largestAckedSentTimeMs = 0L, ackDelayMs = 0L, nowMs = 50L)
+        // Second sample raw=100, peer reports ackDelay=80.
+        // adjusted would be 100 - 80 = 20 < minRtt(50), so clamp:
+        // adjusted := raw = 100.
+        ld.onRttSample(largestAckedSentTimeMs = 100L, ackDelayMs = 80L, nowMs = 200L)
+        assertEquals(100L, ld.latestRttMs)
+        // smoothed' = (7*50 + 100)/8 = 56
+        assertEquals(56L, ld.smoothedRttMs)
+    }
+
+    @Test
+    fun negativeRttSample_isIgnored() {
+        // Clock skew or packet number reuse — sample is negative; ignore.
+        val ld = QuicLossDetection()
+        ld.onRttSample(largestAckedSentTimeMs = 100L, ackDelayMs = 0L, nowMs = 50L)
+        assertEquals(false, ld.hasFirstRttSample)
+        assertEquals(QuicLossDetection.INITIAL_RTT_MS, ld.smoothedRttMs)
+    }
+
+    @Test
+    fun lossDelay_floor() {
+        val ld = QuicLossDetection()
+        // Initial: smoothed=333, latest=333. Loss delay = 333*9/8 = 374.
+        assertEquals(374L, ld.lossDelayMs())
+    }
+
+    @Test
+    fun packetThresholdLost_removesPacketsBelowThreshold() {
+        val ld = QuicLossDetection()
+        val sent = mutableMapOf<Long, SentPacket>()
+        for (pn in 0L..10L) sent[pn] = sentPacket(pn, sentAt = 0L)
+        // largestAckedPn=10. Packet threshold: lost iff pn < 10 - 3 = 7.
+        // Pns 0..6 ⇒ 7 packets lost. Pns 7..10 not lost (pn >= 7).
+        // (Pn 10 is the largest-acked itself — not in flight; it was just removed by drain.
+        //  We model "after-drain" by removing 10 from sent before calling detectAndRemoveLost.)
+        sent.remove(10L)
+        val lost = ld.detectAndRemoveLost(sent, largestAckedPn = 10L, nowMs = 1L)
+        // sentAt=0, nowMs=1, lossDelayMs=374 → time threshold cutoff at -373: nothing lost by time threshold
+        // (sentAt 0 is NOT <= -373). But packet threshold removes pns 0..6.
+        assertEquals(setOf(0L, 1L, 2L, 3L, 4L, 5L, 6L), lost.map { it.packetNumber }.toSet())
+        assertEquals(setOf(7L, 8L, 9L), sent.keys, "pns 7..9 remain in flight; pn 10 was drained earlier")
+    }
+
+    @Test
+    fun timeThresholdLost_removesPacketsSentTooLongAgo() {
+        val ld = QuicLossDetection()
+        // Force an RTT sample so loss delay is small (10ms*9/8 = 11ms with floor 1).
+        ld.onRttSample(largestAckedSentTimeMs = 0L, ackDelayMs = 0L, nowMs = 10L)
+        assertEquals(11L, ld.lossDelayMs(), "10*9/8 = 11.25 → 11")
+
+        val sent = mutableMapOf<Long, SentPacket>()
+        sent[0L] = sentPacket(0L, sentAt = 100L) // old: 100 + 11 = 111, now=200 ⇒ lost (sentAt<=189)
+        sent[1L] = sentPacket(1L, sentAt = 195L) // recent: 195 + 11 = 206, now=200 ⇒ not lost
+        // pn 2 is the largest-acked, drained earlier.
+
+        val lost = ld.detectAndRemoveLost(sent, largestAckedPn = 2L, nowMs = 200L)
+        assertEquals(listOf(0L), lost.map { it.packetNumber })
+        assertEquals(setOf(1L), sent.keys)
+    }
+
+    @Test
+    fun packetEqualToLargestAcked_notLost() {
+        // Edge case: pn == largestAckedPn shouldn't be in the in-flight
+        // map at this point (drain already removed it), but defensively
+        // detectAndRemoveLost should not declare it lost either.
+        val ld = QuicLossDetection()
+        val sent = mutableMapOf<Long, SentPacket>()
+        sent[5L] = sentPacket(5L, sentAt = 0L)
+        val lost = ld.detectAndRemoveLost(sent, largestAckedPn = 5L, nowMs = 1L)
+        assertTrue(lost.isEmpty())
+        assertNotNull(sent[5L])
+    }
+
+    @Test
+    fun emptyMap_returnsEmpty() {
+        val ld = QuicLossDetection()
+        val sent = mutableMapOf<Long, SentPacket>()
+        val lost = ld.detectAndRemoveLost(sent, largestAckedPn = 100L, nowMs = 1L)
+        assertTrue(lost.isEmpty())
+    }
+
+    @Test
+    fun lostPackets_carryOriginalTokens() {
+        val ld = QuicLossDetection()
+        val sent = mutableMapOf<Long, SentPacket>()
+        sent[0L] =
+            SentPacket(
+                packetNumber = 0L,
+                sentAtMillis = 0L,
+                ackEliciting = true,
+                sizeBytes = 100,
+                tokens =
+                    listOf(
+                        RecoveryToken.MaxStreamsUni(maxStreams = 150L),
+                        RecoveryToken.MaxData(maxData = 5_000L),
+                    ),
+            )
+        // PN 0 is below largestAckedPn=10 - threshold(3) = 7, so lost by packet threshold.
+        val lost = ld.detectAndRemoveLost(sent, largestAckedPn = 10L, nowMs = 1L)
+        assertEquals(1, lost.size)
+        assertEquals(2, lost.single().tokens.size)
+        assertEquals(RecoveryToken.MaxStreamsUni(150L), lost.single().tokens[0])
+        assertEquals(RecoveryToken.MaxData(5_000L), lost.single().tokens[1])
+        assertNull(sent[0L])
+    }
+
+    @Test
+    fun packetThresholdAndTimeThresholdMatch_singleRemoval() {
+        // Verify packet is only dropped from the map once even when both
+        // thresholds say "lost" (defensive — Map.iterator.remove() should
+        // be called exactly once per entry).
+        val ld = QuicLossDetection()
+        ld.onRttSample(largestAckedSentTimeMs = 0L, ackDelayMs = 0L, nowMs = 10L)
+        val sent = mutableMapOf<Long, SentPacket>()
+        sent[0L] = sentPacket(0L, sentAt = 0L) // old AND below threshold
+        val lost = ld.detectAndRemoveLost(sent, largestAckedPn = 10L, nowMs = 200L)
+        assertEquals(1, lost.size)
+        assertTrue(sent.isEmpty())
+    }
+}

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/recovery/RecoveryTokenTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/recovery/RecoveryTokenTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quic.connection.recovery
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Type-level invariants for [RecoveryToken]: equality + hashCode
+ * correctness across data-class variants, the singleton [Ack] object,
+ * and the typed-token shape required by the dispatcher in step 6 of
+ * `quic/plans/2026-05-04-control-frame-retransmit.md`.
+ *
+ * No connection state is exercised here — these are unit tests on
+ * the type itself.
+ */
+class RecoveryTokenTest {
+    @Test
+    fun ack_isSingleton() {
+        val a: RecoveryToken = RecoveryToken.Ack
+        val b: RecoveryToken = RecoveryToken.Ack
+        // `data object Ack` ⇒ same reference, same hash.
+        assertTrue(a === b)
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+
+    @Test
+    fun maxStreamsUni_equalityByValue() {
+        val t1 = RecoveryToken.MaxStreamsUni(maxStreams = 150L)
+        val t2 = RecoveryToken.MaxStreamsUni(maxStreams = 150L)
+        val t3 = RecoveryToken.MaxStreamsUni(maxStreams = 200L)
+
+        assertEquals(t1, t2)
+        assertEquals(t1.hashCode(), t2.hashCode())
+        assertNotEquals(t1, t3)
+    }
+
+    @Test
+    fun maxStreamsBidi_distinctFromUni() {
+        val uni: RecoveryToken = RecoveryToken.MaxStreamsUni(maxStreams = 100L)
+        val bidi: RecoveryToken = RecoveryToken.MaxStreamsBidi(maxStreams = 100L)
+        assertNotEquals(uni, bidi)
+    }
+
+    @Test
+    fun maxData_equalityByValue() {
+        val t1 = RecoveryToken.MaxData(maxData = 1_000_000L)
+        val t2 = RecoveryToken.MaxData(maxData = 1_000_000L)
+        val t3 = RecoveryToken.MaxData(maxData = 2_000_000L)
+
+        assertEquals(t1, t2)
+        assertNotEquals(t1, t3)
+    }
+
+    @Test
+    fun maxStreamData_equalityByPair() {
+        val t1 = RecoveryToken.MaxStreamData(streamId = 0L, maxData = 1024L)
+        val t2 = RecoveryToken.MaxStreamData(streamId = 0L, maxData = 1024L)
+        val differentStream = RecoveryToken.MaxStreamData(streamId = 4L, maxData = 1024L)
+        val differentValue = RecoveryToken.MaxStreamData(streamId = 0L, maxData = 2048L)
+
+        assertEquals(t1, t2)
+        assertNotEquals(t1, differentStream)
+        assertNotEquals(t1, differentValue)
+    }
+
+    @Test
+    fun whenDispatch_isExhaustive() {
+        // Compile-time assertion that the sealed hierarchy is fixed and
+        // an exhaustive `when` actually compiles. If a new variant is
+        // added without updating the dispatcher, this test stops
+        // compiling — caught at build time, not at runtime.
+        val tokens: List<RecoveryToken> =
+            listOf(
+                RecoveryToken.Ack,
+                RecoveryToken.MaxStreamsUni(150L),
+                RecoveryToken.MaxStreamsBidi(150L),
+                RecoveryToken.MaxData(1_000_000L),
+                RecoveryToken.MaxStreamData(streamId = 0L, maxData = 1024L),
+            )
+        val labels =
+            tokens.map {
+                when (it) {
+                    RecoveryToken.Ack -> "ack"
+                    is RecoveryToken.MaxStreamsUni -> "msu:${it.maxStreams}"
+                    is RecoveryToken.MaxStreamsBidi -> "msb:${it.maxStreams}"
+                    is RecoveryToken.MaxData -> "md:${it.maxData}"
+                    is RecoveryToken.MaxStreamData -> "msd:${it.streamId}:${it.maxData}"
+                }
+            }
+        assertEquals(
+            listOf(
+                "ack",
+                "msu:150",
+                "msb:150",
+                "md:1000000",
+                "msd:0:1024",
+            ),
+            labels,
+        )
+    }
+}

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/recovery/RecoveryTokenTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/recovery/RecoveryTokenTest.kt
@@ -98,6 +98,20 @@ class RecoveryTokenTest {
                 RecoveryToken.MaxStreamsBidi(150L),
                 RecoveryToken.MaxData(1_000_000L),
                 RecoveryToken.MaxStreamData(streamId = 0L, maxData = 1024L),
+                RecoveryToken.Stream(streamId = 4L, offset = 0L, length = 100L, fin = false),
+                RecoveryToken.Crypto(
+                    level = com.vitorpamplona.quic.connection.EncryptionLevel.HANDSHAKE,
+                    offset = 0L,
+                    length = 64L,
+                ),
+                RecoveryToken.ResetStream(streamId = 4L, errorCode = 0L, finalSize = 100L),
+                RecoveryToken.StopSending(streamId = 4L, errorCode = 0L),
+                RecoveryToken.NewConnectionId(
+                    sequenceNumber = 1L,
+                    retirePriorTo = 0L,
+                    connectionId = byteArrayOf(1, 2, 3, 4),
+                    statelessResetToken = ByteArray(16) { it.toByte() },
+                ),
             )
         val labels =
             tokens.map {
@@ -107,6 +121,11 @@ class RecoveryTokenTest {
                     is RecoveryToken.MaxStreamsBidi -> "msb:${it.maxStreams}"
                     is RecoveryToken.MaxData -> "md:${it.maxData}"
                     is RecoveryToken.MaxStreamData -> "msd:${it.streamId}:${it.maxData}"
+                    is RecoveryToken.Stream -> "s:${it.streamId}:${it.offset}:${it.length}:${it.fin}"
+                    is RecoveryToken.Crypto -> "c:${it.level}:${it.offset}:${it.length}"
+                    is RecoveryToken.ResetStream -> "rs:${it.streamId}:${it.errorCode}:${it.finalSize}"
+                    is RecoveryToken.StopSending -> "ss:${it.streamId}:${it.errorCode}"
+                    is RecoveryToken.NewConnectionId -> "ncid:${it.sequenceNumber}"
                 }
             }
         assertEquals(
@@ -116,8 +135,67 @@ class RecoveryTokenTest {
                 "msb:150",
                 "md:1000000",
                 "msd:0:1024",
+                "s:4:0:100:false",
+                "c:HANDSHAKE:0:64",
+                "rs:4:0:100",
+                "ss:4:0",
+                "ncid:1",
             ),
             labels,
         )
+    }
+
+    @Test
+    fun newConnectionId_arrayEqualityIsByContent() {
+        // ByteArray fields must equal by content, not identity, so
+        // the sent-packet map's equality semantics work correctly.
+        val a =
+            RecoveryToken.NewConnectionId(
+                sequenceNumber = 1L,
+                retirePriorTo = 0L,
+                connectionId = byteArrayOf(1, 2, 3),
+                statelessResetToken = ByteArray(16) { 0 },
+            )
+        val b =
+            RecoveryToken.NewConnectionId(
+                sequenceNumber = 1L,
+                retirePriorTo = 0L,
+                connectionId = byteArrayOf(1, 2, 3),
+                statelessResetToken = ByteArray(16) { 0 },
+            )
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+        assertNotEquals(a, b.copy(connectionId = byteArrayOf(9, 9, 9)))
+        assertNotEquals(a, b.copy(statelessResetToken = ByteArray(16) { 7 }))
+    }
+
+    @Test
+    fun stream_equalityByValue() {
+        val t1 = RecoveryToken.Stream(streamId = 4L, offset = 0L, length = 100L, fin = false)
+        val t2 = RecoveryToken.Stream(streamId = 4L, offset = 0L, length = 100L, fin = false)
+        val tFin = RecoveryToken.Stream(streamId = 4L, offset = 0L, length = 100L, fin = true)
+        val tDifferentOffset = RecoveryToken.Stream(streamId = 4L, offset = 100L, length = 100L, fin = false)
+        assertEquals(t1, t2)
+        assertNotEquals(t1, tFin)
+        assertNotEquals(t1, tDifferentOffset)
+    }
+
+    @Test
+    fun crypto_equalityByValue() {
+        val a =
+            RecoveryToken.Crypto(
+                level = com.vitorpamplona.quic.connection.EncryptionLevel.INITIAL,
+                offset = 0L,
+                length = 64L,
+            )
+        val b =
+            RecoveryToken.Crypto(
+                level = com.vitorpamplona.quic.connection.EncryptionLevel.INITIAL,
+                offset = 0L,
+                length = 64L,
+            )
+        val differentLevel = a.copy(level = com.vitorpamplona.quic.connection.EncryptionLevel.HANDSHAKE)
+        assertEquals(a, b)
+        assertNotEquals(a, differentLevel)
     }
 }

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/recovery/RecoveryTokenTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/recovery/RecoveryTokenTest.kt
@@ -23,12 +23,11 @@ package com.vitorpamplona.quic.connection.recovery
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
 
 /**
  * Type-level invariants for [RecoveryToken]: equality + hashCode
- * correctness across data-class variants, the singleton [Ack] object,
- * and the typed-token shape required by the dispatcher in step 6 of
+ * correctness across data-class variants and the typed-token shape
+ * required by the dispatcher in step 6 of
  * `quic/plans/2026-05-04-control-frame-retransmit.md`.
  *
  * No connection state is exercised here — these are unit tests on
@@ -36,11 +35,18 @@ import kotlin.test.assertTrue
  */
 class RecoveryTokenTest {
     @Test
-    fun ack_isSingleton() {
-        val a: RecoveryToken = RecoveryToken.Ack
-        val b: RecoveryToken = RecoveryToken.Ack
-        // `data object Ack` ⇒ same reference, same hash.
-        assertTrue(a === b)
+    fun ack_carriesLevelAndLargestAcked() {
+        val a: RecoveryToken =
+            RecoveryToken.Ack(
+                level = com.vitorpamplona.quic.connection.EncryptionLevel.APPLICATION,
+                largestAcked = 42L,
+            )
+        val b: RecoveryToken =
+            RecoveryToken.Ack(
+                level = com.vitorpamplona.quic.connection.EncryptionLevel.APPLICATION,
+                largestAcked = 42L,
+            )
+        // Data class equality, not identity.
         assertEquals(a, b)
         assertEquals(a.hashCode(), b.hashCode())
     }
@@ -93,7 +99,10 @@ class RecoveryTokenTest {
         // compiling — caught at build time, not at runtime.
         val tokens: List<RecoveryToken> =
             listOf(
-                RecoveryToken.Ack,
+                RecoveryToken.Ack(
+                    level = com.vitorpamplona.quic.connection.EncryptionLevel.APPLICATION,
+                    largestAcked = 0L,
+                ),
                 RecoveryToken.MaxStreamsUni(150L),
                 RecoveryToken.MaxStreamsBidi(150L),
                 RecoveryToken.MaxData(1_000_000L),
@@ -116,7 +125,7 @@ class RecoveryTokenTest {
         val labels =
             tokens.map {
                 when (it) {
-                    RecoveryToken.Ack -> "ack"
+                    is RecoveryToken.Ack -> "ack"
                     is RecoveryToken.MaxStreamsUni -> "msu:${it.maxStreams}"
                     is RecoveryToken.MaxStreamsBidi -> "msb:${it.maxStreams}"
                     is RecoveryToken.MaxData -> "md:${it.maxData}"

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/recovery/SentPacketTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/recovery/SentPacketTest.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.quic.connection.recovery
 
+import com.vitorpamplona.quic.connection.EncryptionLevel
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -63,7 +64,7 @@ class SentPacketTest {
                 sentAtMillis = 0L,
                 ackEliciting = false,
                 sizeBytes = 16,
-                tokens = listOf(RecoveryToken.Ack),
+                tokens = listOf(RecoveryToken.Ack(level = EncryptionLevel.APPLICATION, largestAcked = 0L)),
             )
         val differentPn = a.copy(packetNumber = 8L)
         assertNotEquals(a, differentPn)
@@ -95,10 +96,13 @@ class SentPacketTest {
                 sentAtMillis = 0L,
                 ackEliciting = false,
                 sizeBytes = 24,
-                tokens = listOf(RecoveryToken.Ack),
+                tokens = listOf(RecoveryToken.Ack(level = EncryptionLevel.APPLICATION, largestAcked = 0L)),
             )
         assertTrue(ackOnly.tokens.isNotEmpty())
-        assertEquals(RecoveryToken.Ack, ackOnly.tokens.single())
+        assertEquals(
+            RecoveryToken.Ack(level = EncryptionLevel.APPLICATION, largestAcked = 0L),
+            ackOnly.tokens.single(),
+        )
     }
 
     @Test

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/recovery/SentPacketTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/recovery/SentPacketTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quic.connection.recovery
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Schema-level invariants for [SentPacket]: data-class equality
+ * mirrors [RecoveryTokenTest], plus the convention that ACK-only
+ * packets carry a non-empty `tokens` list with `RecoveryToken.Ack`
+ * (so the sent-packet map's invariant — every retained entry has at
+ * least one token to dispatch — holds uniformly across packet types).
+ */
+class SentPacketTest {
+    @Test
+    fun equality_byAllFields() {
+        val a =
+            SentPacket(
+                packetNumber = 7L,
+                sentAtMillis = 1_700_000_000_000L,
+                ackEliciting = true,
+                sizeBytes = 128,
+                tokens = listOf(RecoveryToken.MaxStreamsUni(150L)),
+            )
+        val b =
+            SentPacket(
+                packetNumber = 7L,
+                sentAtMillis = 1_700_000_000_000L,
+                ackEliciting = true,
+                sizeBytes = 128,
+                tokens = listOf(RecoveryToken.MaxStreamsUni(150L)),
+            )
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+
+    @Test
+    fun equality_byPacketNumber() {
+        val a =
+            SentPacket(
+                packetNumber = 7L,
+                sentAtMillis = 0L,
+                ackEliciting = false,
+                sizeBytes = 16,
+                tokens = listOf(RecoveryToken.Ack),
+            )
+        val differentPn = a.copy(packetNumber = 8L)
+        assertNotEquals(a, differentPn)
+    }
+
+    @Test
+    fun equality_byTokenList() {
+        val a =
+            SentPacket(
+                packetNumber = 1L,
+                sentAtMillis = 0L,
+                ackEliciting = true,
+                sizeBytes = 64,
+                tokens = listOf(RecoveryToken.MaxData(1_000L), RecoveryToken.MaxStreamsUni(150L)),
+            )
+        val swapped = a.copy(tokens = listOf(RecoveryToken.MaxStreamsUni(150L), RecoveryToken.MaxData(1_000L)))
+        // List equality is order-sensitive — these are different.
+        assertNotEquals(a, swapped)
+    }
+
+    @Test
+    fun ackOnlyPacket_carriesAckToken() {
+        // ACK-only packet: not ack-eliciting (RFC 9000 §13.2.1) but
+        // we still record a single Ack token so the sent-packet map's
+        // "every entry has a token" invariant holds.
+        val ackOnly =
+            SentPacket(
+                packetNumber = 42L,
+                sentAtMillis = 0L,
+                ackEliciting = false,
+                sizeBytes = 24,
+                tokens = listOf(RecoveryToken.Ack),
+            )
+        assertTrue(ackOnly.tokens.isNotEmpty())
+        assertEquals(RecoveryToken.Ack, ackOnly.tokens.single())
+    }
+
+    @Test
+    fun ackEliciting_packetCanCarryMultipleControlTokens() {
+        // A real outbound packet that bumps both flow-control caps
+        // simultaneously (e.g. publisher session with sustained
+        // stream churn) carries two tokens. Loss declaration walks
+        // both; ACK drops both.
+        val multi =
+            SentPacket(
+                packetNumber = 100L,
+                sentAtMillis = 0L,
+                ackEliciting = true,
+                sizeBytes = 80,
+                tokens =
+                    listOf(
+                        RecoveryToken.MaxStreamsUni(maxStreams = 1_500_000L),
+                        RecoveryToken.MaxData(maxData = 64L * 1024L * 1024L),
+                    ),
+            )
+        assertEquals(2, multi.tokens.size)
+        assertEquals(RecoveryToken.MaxStreamsUni(1_500_000L), multi.tokens[0])
+        assertEquals(RecoveryToken.MaxData(64L * 1024L * 1024L), multi.tokens[1])
+    }
+
+    @Test
+    fun copy_preservesUntouchedFields() {
+        val base =
+            SentPacket(
+                packetNumber = 5L,
+                sentAtMillis = 1L,
+                ackEliciting = true,
+                sizeBytes = 100,
+                tokens = listOf(RecoveryToken.MaxStreamsUni(150L)),
+            )
+        val onlyTimeChanged = base.copy(sentAtMillis = 2L)
+        assertEquals(base.packetNumber, onlyTimeChanged.packetNumber)
+        assertEquals(base.ackEliciting, onlyTimeChanged.ackEliciting)
+        assertEquals(base.sizeBytes, onlyTimeChanged.sizeBytes)
+        assertEquals(base.tokens, onlyTimeChanged.tokens)
+        assertNotEquals(base.sentAtMillis, onlyTimeChanged.sentAtMillis)
+    }
+}

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/stream/SendBufferBestEffortTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/stream/SendBufferBestEffortTest.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quic.stream
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Best-effort SendBuffer: lost ranges are dropped instead of being
+ * re-queued for retransmit. The moq-lite group-stream case — Opus
+ * audio frames arriving 200 ms late are worse than useless. We don't
+ * want to bound this behavior with congestion control because the
+ * audio workload is too small to warrant a CC implementation, but we
+ * also don't want STREAM retransmit to spam stale audio onto a lossy
+ * uplink.
+ */
+class SendBufferBestEffortTest {
+    @Test
+    fun normalBuffer_lostRangeIsRequeued() {
+        // Sanity baseline: the default buffer (bestEffort = false)
+        // re-queues lost bytes onto the retransmit FIFO so the next
+        // takeChunk re-emits them.
+        val buf = SendBuffer()
+        buf.enqueue(byteArrayOf(1, 2, 3, 4, 5))
+        val first = buf.takeChunk(maxBytes = 5)
+        assertNotNull(first)
+        assertEquals(5, first.data.size)
+
+        buf.markLost(offset = 0L, length = 5L, fin = false)
+        val replay = buf.takeChunk(maxBytes = 5)
+        assertNotNull(replay, "lost bytes must re-emit on a reliable buffer")
+        assertEquals(0L, replay.offset)
+        assertEquals(5, replay.data.size)
+    }
+
+    @Test
+    fun bestEffort_lostRangeIsDropped() {
+        // bestEffort buffer: lost bytes vanish — no retransmit, nothing
+        // for takeChunk to surface, the underlying byte storage
+        // releases as if the bytes had been ACK'd.
+        val buf = SendBuffer(bestEffort = true)
+        buf.enqueue(byteArrayOf(10, 20, 30, 40))
+        val sent = buf.takeChunk(maxBytes = 4)
+        assertNotNull(sent)
+        assertEquals(4, sent.data.size)
+        assertEquals(4L, buf.sentOffset)
+
+        buf.markLost(offset = 0L, length = 4L, fin = false)
+
+        // No fresh bytes, no retransmit-queued bytes — takeChunk
+        // returns null.
+        assertNull(buf.takeChunk(maxBytes = 4), "best-effort: lost bytes are not re-emitted")
+        // No more readable bytes pending either.
+        assertEquals(0, buf.readableBytes)
+    }
+
+    @Test
+    fun bestEffort_lostFin_isDropped_finSentRemainsTrue() {
+        // FIN handling: in best-effort mode we don't retransmit FIN
+        // either. _finSent stays true so the writer doesn't try to
+        // re-emit the FIN-only chunk on the next drain. The peer's
+        // stream may stay open from QUIC's view forever — that's the
+        // cost of best-effort, and moq-lite's per-stream timeouts
+        // handle it at the application layer.
+        val buf = SendBuffer(bestEffort = true)
+        buf.enqueue(byteArrayOf(1, 2, 3))
+        buf.finish()
+        val withFin = buf.takeChunk(maxBytes = 3)
+        assertNotNull(withFin)
+        assertTrue(withFin.fin, "FIN attached to last chunk")
+        assertTrue(buf.finSent)
+
+        buf.markLost(offset = 0L, length = 3L, fin = true)
+        // _finSent should NOT flip back to false — best-effort means
+        // we don't retransmit the FIN.
+        assertTrue(buf.finSent, "best-effort: lost FIN is not resurrected for retransmit")
+        // No retransmit pending.
+        assertNull(buf.takeChunk(maxBytes = 8))
+    }
+
+    @Test
+    fun bestEffort_partialOverlapLoss_dropsPartialButKeepsRest() {
+        // Edge case: loss notification covers a partial overlap of an
+        // in-flight range. The non-overlapped portion stays in
+        // inFlight (so a later ACK / loss for that portion behaves
+        // correctly); the overlapped piece is dropped.
+        val buf = SendBuffer(bestEffort = true)
+        buf.enqueue(byteArrayOf(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
+        val sent = buf.takeChunk(maxBytes = 10)
+        assertNotNull(sent)
+
+        // Lose the middle 4 bytes [3, 7).
+        buf.markLost(offset = 3L, length = 4L, fin = false)
+
+        // The dropped range vanishes; the kept-pieces around it stay
+        // in inFlight. takeChunk returns null because there's no
+        // retransmit queue and no fresh bytes.
+        assertNull(buf.takeChunk(maxBytes = 10))
+
+        // ACK the kept-pieces explicitly to verify they're tracked
+        // correctly. Acking [0,3) should latch flushedFloor to 3
+        // (since [3,7) is dropped — gone) only after the kept-piece
+        // [7,10) is also released.
+        buf.markAcked(offset = 0L, length = 3L)
+        // The dropped [3,7) range was already "released" by the
+        // best-effort drop, so [0,3) ACK + dropped [3,7) compact the
+        // floor to 7.
+        buf.markAcked(offset = 7L, length = 3L)
+        // Now everything is gone.
+        assertNull(buf.takeChunk(maxBytes = 10))
+    }
+
+    @Test
+    fun bestEffort_repeatedLossIsIdempotent() {
+        // Defensive: a stale loss notification arriving after the
+        // bytes are already dropped should not throw or double-count.
+        val buf = SendBuffer(bestEffort = true)
+        buf.enqueue(byteArrayOf(1, 2, 3))
+        buf.takeChunk(maxBytes = 3)
+        buf.markLost(offset = 0L, length = 3L, fin = false)
+        buf.markLost(offset = 0L, length = 3L, fin = false) // already gone
+        assertNull(buf.takeChunk(maxBytes = 3))
+    }
+
+    @Test
+    fun bestEffort_ackPathStillWorksNormally() {
+        // bestEffort only changes loss behavior; ACK semantics are
+        // unchanged. Sanity check that we didn't regress markAcked.
+        val buf = SendBuffer(bestEffort = true)
+        buf.enqueue(byteArrayOf(1, 2, 3, 4))
+        val sent = buf.takeChunk(maxBytes = 4)
+        assertNotNull(sent)
+        buf.markAcked(offset = 0L, length = 4L)
+        // Same as a reliable buffer: acked bytes release.
+        assertNull(buf.takeChunk(maxBytes = 4))
+    }
+}

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/stream/SendBufferRetainUntilAckTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/stream/SendBufferRetainUntilAckTest.kt
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quic.stream
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Retain-until-ACK semantics for [SendBuffer]. Companion to
+ * [SendBufferConcurrencyTest] which exercises the Mutex; this file
+ * exercises the new [SendBuffer.markAcked] / [SendBuffer.markLost]
+ * paths and the priority order between retransmit and fresh sends.
+ */
+class SendBufferRetainUntilAckTest {
+    @Test
+    fun takeChunk_releasesNothingUntilAcked() {
+        val buf = SendBuffer()
+        buf.enqueue("hello".encodeToByteArray())
+        val chunk = buf.takeChunk(1024)
+        assertNotNull(chunk)
+        assertEquals(0L, chunk.offset)
+        assertEquals("hello", chunk.data.decodeToString())
+        // Bytes still retained: a fresh takeChunk produces nothing
+        // (no pending fresh, no retransmit), but the buffer keeps
+        // them around for potential lost-marking.
+        assertNull(buf.takeChunk(1024))
+        // sentOffset reflects fresh-send high-water; nextOffset is
+        // also 5; readableBytes is 0 (nothing more to send).
+        assertEquals(5L, buf.sentOffset)
+        assertEquals(5L, buf.nextOffset)
+        assertEquals(0, buf.readableBytes)
+    }
+
+    @Test
+    fun markAcked_full_releasesBytes_andDoesNotResend() {
+        val buf = SendBuffer()
+        buf.enqueue("hello world".encodeToByteArray())
+        val first = buf.takeChunk(1024)!!
+        assertEquals(0L, first.offset)
+        assertEquals("hello world", first.data.decodeToString())
+        // ACK the whole range. Buffer drained.
+        buf.markAcked(offset = 0L, length = 11L)
+        assertNull(buf.takeChunk(1024))
+        assertEquals(0, buf.readableBytes)
+    }
+
+    @Test
+    fun markLost_movesBytesToRetransmitQueue_takeChunkReplaysSameOffset() {
+        val buf = SendBuffer()
+        buf.enqueue("hello".encodeToByteArray())
+        val first = buf.takeChunk(1024)!!
+        assertEquals(0L, first.offset)
+        // Declare lost.
+        buf.markLost(offset = 0L, length = 5L, fin = false)
+        // Next takeChunk replays the same offset + bytes.
+        val replay = buf.takeChunk(1024)
+        assertNotNull(replay)
+        assertEquals(0L, replay.offset)
+        assertEquals("hello", replay.data.decodeToString())
+        assertEquals(5L, buf.sentOffset, "sentOffset is fresh-send high-water — does not advance on retransmit")
+    }
+
+    @Test
+    fun markLost_partialRange_splitsInFlight() {
+        val buf = SendBuffer()
+        buf.enqueue("0123456789".encodeToByteArray())
+        val first = buf.takeChunk(1024)!! // takes all 10 bytes as one in-flight range
+        assertEquals(10, first.data.size)
+        // Lose the middle 4 bytes [3, 7).
+        buf.markLost(offset = 3L, length = 4L, fin = false)
+        // Retransmit replay first.
+        val replay = buf.takeChunk(1024)
+        assertNotNull(replay)
+        assertEquals(3L, replay.offset)
+        assertEquals("3456", replay.data.decodeToString())
+        // Nothing else to send (fresh exhausted).
+        assertNull(buf.takeChunk(1024))
+    }
+
+    @Test
+    fun markAcked_partialRange_splitsInFlight() {
+        val buf = SendBuffer()
+        buf.enqueue("0123456789".encodeToByteArray())
+        buf.takeChunk(1024)
+        // ACK [0, 3) and [7, 10), leaving [3, 7) still in-flight.
+        buf.markAcked(offset = 0L, length = 3L)
+        buf.markAcked(offset = 7L, length = 3L)
+        // Now lose the middle:
+        buf.markLost(offset = 3L, length = 4L, fin = false)
+        val replay = buf.takeChunk(1024)
+        assertNotNull(replay)
+        assertEquals(3L, replay.offset)
+        assertEquals("3456", replay.data.decodeToString())
+    }
+
+    @Test
+    fun retransmitDrainsBeforeFreshBytes() {
+        val buf = SendBuffer()
+        buf.enqueue("AAAA".encodeToByteArray()) // fresh [0,4)
+        val a = buf.takeChunk(1024)!!
+        buf.markLost(offset = 0L, length = 4L, fin = false) // queued for retransmit
+        buf.enqueue("BBBB".encodeToByteArray()) // fresh [4,8)
+        // Retransmit comes first.
+        val first = buf.takeChunk(1024)!!
+        assertEquals(0L, first.offset)
+        assertEquals("AAAA", first.data.decodeToString())
+        // Then fresh.
+        val second = buf.takeChunk(1024)!!
+        assertEquals(4L, second.offset)
+        assertEquals("BBBB", second.data.decodeToString())
+        assertEquals(a.offset, 0L)
+    }
+
+    @Test
+    fun maxBytesSplits_acrossRetransmitAndFresh() {
+        val buf = SendBuffer()
+        buf.enqueue("ABCD".encodeToByteArray()) // [0,4)
+        buf.takeChunk(1024)
+        buf.markLost(offset = 0L, length = 4L, fin = false)
+        // Cap at 2 — should pull only 2 bytes from retransmit, leave
+        // remaining 2 still in retransmit.
+        val first = buf.takeChunk(2)!!
+        assertEquals(0L, first.offset)
+        assertEquals("AB", first.data.decodeToString())
+        // Next call still drains retransmit before any fresh.
+        val second = buf.takeChunk(2)!!
+        assertEquals(2L, second.offset)
+        assertEquals("CD", second.data.decodeToString())
+        assertNull(buf.takeChunk(2))
+    }
+
+    @Test
+    fun fin_carriedOnFinalDataChunk_andRetransmittedOnLoss() {
+        val buf = SendBuffer()
+        buf.enqueue("hello".encodeToByteArray())
+        buf.finish()
+        val first = buf.takeChunk(1024)!!
+        assertEquals(true, first.fin, "FIN attaches to the last data chunk")
+        assertEquals(true, buf.finSent)
+        // Lose the chunk including FIN. Retransmit must re-set FIN.
+        buf.markLost(offset = 0L, length = 5L, fin = true)
+        assertEquals(false, buf.finSent, "lost FIN clears finSent so it gets re-emitted")
+        val replay = buf.takeChunk(1024)!!
+        assertEquals(true, replay.fin)
+        assertEquals(true, buf.finSent)
+    }
+
+    @Test
+    fun fin_only_emittedAfterDataDrained() {
+        val buf = SendBuffer()
+        buf.finish() // FIN with no data
+        val chunk = buf.takeChunk(1024)
+        assertNotNull(chunk)
+        assertEquals(0L, chunk.offset)
+        assertEquals(0, chunk.data.size)
+        assertEquals(true, chunk.fin)
+        assertNull(buf.takeChunk(1024), "no further chunks after FIN-only sent")
+    }
+
+    @Test
+    fun fin_only_lostAndRetransmits() {
+        val buf = SendBuffer()
+        buf.finish()
+        buf.takeChunk(1024)
+        // Mark FIN-only chunk as lost (length=0, fin=true).
+        buf.markLost(offset = 0L, length = 0L, fin = true)
+        assertEquals(false, buf.finSent)
+        val replay = buf.takeChunk(1024)
+        assertNotNull(replay)
+        assertEquals(true, replay.fin)
+    }
+
+    @Test
+    fun markAcked_advancesFlushedFloor_releasesMemory() {
+        val buf = SendBuffer()
+        buf.enqueue(ByteArray(1000) { it.toByte() })
+        buf.takeChunk(1000)
+        // Before ACK: nothing released.
+        // After ACK [0, 1000): floor advances and storage shifts.
+        buf.markAcked(offset = 0L, length = 1000L)
+        // Re-use of buffer with new bytes still works.
+        buf.enqueue("after".encodeToByteArray())
+        val next = buf.takeChunk(1024)!!
+        assertEquals(1000L, next.offset, "next fresh send picks up where we left off")
+        assertEquals("after", next.data.decodeToString())
+    }
+
+    @Test
+    fun markAcked_outOfOrder_preventsFloorAdvance() {
+        val buf = SendBuffer()
+        buf.enqueue("AAAABBBB".encodeToByteArray())
+        // Send as two halves.
+        buf.takeChunk(4) // [0, 4)
+        buf.takeChunk(4) // [4, 8)
+        // ACK only the second half — the first half is still in-flight,
+        // so floor cannot advance.
+        buf.markAcked(offset = 4L, length = 4L)
+        // Lost retransmit of the first half still works.
+        buf.markLost(offset = 0L, length = 4L, fin = false)
+        val replay = buf.takeChunk(4)!!
+        assertEquals(0L, replay.offset)
+        assertEquals("AAAA", replay.data.decodeToString())
+    }
+
+    @Test
+    fun markLost_belowFlushedFloor_isNoop() {
+        // ACK'd-and-released bytes can still receive a stale loss
+        // notification (race between an ACK and a lost-token dispatch
+        // for the same range). Defensive: drop silently.
+        val buf = SendBuffer()
+        buf.enqueue("hello".encodeToByteArray())
+        buf.takeChunk(1024)
+        buf.markAcked(offset = 0L, length = 5L)
+        buf.markLost(offset = 0L, length = 5L, fin = false) // bytes already gone
+        assertEquals(0, buf.readableBytes)
+        assertNull(buf.takeChunk(1024))
+    }
+
+    @Test
+    fun finAcked_latchesTrueOnce() {
+        val buf = SendBuffer()
+        buf.enqueue("x".encodeToByteArray())
+        buf.finish()
+        buf.takeChunk(1024) // sends "x" + FIN
+        assertEquals(false, buf.finAcked)
+        buf.markAcked(offset = 0L, length = 1L)
+        assertTrue(buf.finAcked, "ACK of the FIN-bearing range latches finAcked")
+    }
+
+    @Test
+    fun readableBytes_reflectsRetransmitPlusFresh() {
+        val buf = SendBuffer()
+        buf.enqueue("AAAA".encodeToByteArray())
+        buf.takeChunk(1024)
+        buf.markLost(offset = 0L, length = 4L, fin = false)
+        buf.enqueue("BBBB".encodeToByteArray())
+        assertEquals(8, buf.readableBytes, "4 retransmit + 4 fresh")
+        buf.takeChunk(1024) // drain retransmit
+        assertEquals(4, buf.readableBytes, "fresh remains")
+        buf.takeChunk(1024) // drain fresh
+        assertEquals(0, buf.readableBytes)
+    }
+
+    @Test
+    fun multipleSendsWithinSingleEnqueue_acksIndependently() {
+        // Common pattern: enqueue once, writer sends in MTU-sized
+        // chunks, peer ACKs each individually.
+        val buf = SendBuffer()
+        buf.enqueue(ByteArray(300) { it.toByte() })
+        val a = buf.takeChunk(100)!! // [0, 100)
+        val b = buf.takeChunk(100)!! // [100, 200)
+        val c = buf.takeChunk(100)!! // [200, 300)
+        assertEquals(0L, a.offset)
+        assertEquals(100L, b.offset)
+        assertEquals(200L, c.offset)
+        // ACK middle, lose the others.
+        buf.markAcked(offset = 100L, length = 100L)
+        buf.markLost(offset = 0L, length = 100L, fin = false)
+        buf.markLost(offset = 200L, length = 100L, fin = false)
+        val replay1 = buf.takeChunk(1024)!!
+        val replay2 = buf.takeChunk(1024)!!
+        // Retransmit FIFO order: lost-first wins.
+        assertEquals(0L, replay1.offset)
+        assertEquals(200L, replay2.offset)
+        assertNull(buf.takeChunk(1024))
+    }
+}


### PR DESCRIPTION
Diagnostic instrumentation to localise the listener-stuck-on-spinner bug.
None of these are intended for merge — pair logs with a logcat capture,
diagnose, then revert.

Receiver (tag NestRx):
  - MoqLiteNestsListener: log subscribeSpeaker / subscribeCatalog entry
    and per-update RoomAnnouncement emission to the VM
  - MoqLiteSession.subscribe: log SUBSCRIBE_OK / SUBSCRIBE_DROP outcomes
  - MoqLiteSession.drainOneGroup: log every uni group header decode
    and warn on subscription-lookup miss (frame dropped)
  - MoqLiteSession.pumpAnnounceWatch: log every announce update and
    flag the Ended branch that closes the subscription's frames
  - NestViewModel: log VM.openSubscription wiring and the first-frame
    trigger that clears the connectingSpeakers spinner

Speaker (tag NestTx):
  - MoqLiteSession.publish: log entry suffix
  - MoqLiteSession.handleInboundBidi: log inbound AnnouncePlease and
    SUBSCRIBE dispatches plus FIN cleanup
  - MoqLiteSession PublisherStateImpl: log first inbound subscriber
    attach and every group-stream open
  - NestMoqLiteBroadcaster: log when publisher.send returns false
    (no inbound subscriber on relay) and the subscriber-attached
    transition, plus surface throws that runCatching previously
    swallowed only into onError

Capture with `adb logcat -s NestRx:D NestTx:D`.

https://claude.ai/code/session_01PYYez8a6sjiakyjAxsfCEQ