### PR TITLE
Add IME padding to MessagesTwoPane Scaffold

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/twopane/MessagesTwoPane.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/twopane/MessagesTwoPane.kt
@@ -22,6 +22,7 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.twopane
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
@@ -73,6 +74,7 @@ fun MessagesTwoPane(
     val displayFeatures = calculateDisplayFeatures(act)
 
     Scaffold(
+        modifier = Modifier.imePadding(),
         topBar = {
             UserDrawerSearchTopBar(accountViewModel, nav) { AmethystClickableIcon() }
         },


### PR DESCRIPTION
## Summary
This change adds IME (Input Method Editor) padding to the Scaffold composable in the MessagesTwoPane screen to ensure proper layout adjustment when the on-screen keyboard is displayed.

## Key Changes
- Added `androidx.compose.foundation.layout.imePadding` import
- Applied `Modifier.imePadding()` to the Scaffold composable in MessagesTwoPane

## Implementation Details
The `imePadding()` modifier automatically adjusts the padding of the Scaffold to account for the space occupied by the IME (soft keyboard) when it's displayed. This prevents UI elements from being hidden behind the keyboard and ensures a better user experience when typing messages in the two-pane chat layout.

https://claude.ai/code/session_012sPZ9KbbkTzdPL2KTn29ak