### PR TITLE
Add notifications for Marmot group messages (kind:445)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
@@ -505,18 +505,17 @@ class EventNotificationConsumer(
      * decrypted the outer ChaCha20-Poly1305 layer and verified the inner
      * MLS-signed payload.
      *
-     * Only kind:9 chat messages produce a notification — reactions, control
-     * messages, and deletions stay silent, mirroring how NIP-17 (kind:14)
-     * is the only DM kind we notify.
+     * Typed to [ChatEvent] so the caller has to narrow first — reactions,
+     * control messages, and deletions stay silent at the type level,
+     * mirroring how NIP-17 (kind:14) is the only DM kind we notify.
      */
     suspend fun notifyGroupMessage(
-        innerEvent: Event,
+        innerEvent: ChatEvent,
         nostrGroupId: String,
         account: Account,
     ) = withWakeLock {
         Log.d(TAG, "New Marmot Group Message to Notify")
 
-        if (innerEvent.kind != ChatEvent.KIND) return@withWakeLock
         if (!notificationManager().areNotificationsEnabled()) return@withWakeLock
         if (MainActivity.isResumed) return@withWakeLock
 
@@ -530,8 +529,9 @@ class EventNotificationConsumer(
         val sender = LocalCache.getOrCreateUser(innerEvent.pubKey)
         val senderName = sender.toBestDisplayName()
         val senderPicture = sender.profilePicture()
-        // Show the message body when present; reactions/empty payloads fall
-        // back to a generic prompt so the popup is still actionable.
+        // Defensive fallback for the rare empty-content ChatEvent so the
+        // popup is still actionable. Non-chat inner kinds were filtered
+        // out at the call site by the ChatEvent type narrowing.
         val body = innerEvent.content.takeIf { it.isNotBlank() } ?: "New message"
 
         val accountNpub =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
@@ -83,6 +83,7 @@ import com.vitorpamplona.quartz.nip71Video.VideoVerticalEvent
 import com.vitorpamplona.quartz.nip84Highlights.HighlightEvent
 import com.vitorpamplona.quartz.nip88Polls.poll.PollEvent
 import com.vitorpamplona.quartz.nipACWebRtcCalls.events.CallOfferEvent
+import com.vitorpamplona.quartz.nipC7Chats.ChatEvent
 import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.TimeoutCancellationException
@@ -487,6 +488,67 @@ class EventNotificationConsumer(
                 senderName = inviterName,
                 time = event.createdAt,
                 pictureUrl = inviterPicture,
+                uri = noteUri,
+                applicationContext = applicationContext,
+                accountNpub = accountNpub,
+                accountPictureUrl = account.userProfile().profilePicture(),
+                chatroomMembers = null,
+            )
+    }
+
+    /**
+     * Marmot kind:445 group messages have no `p` tag (recipients are routed
+     * by the `h` tag carrying the nostr_group_id), so the cache-observer path
+     * in [NotificationDispatcher] can't match them to an account. They're
+     * dispatched here directly from [com.vitorpamplona.amethyst.ui.screen.loggedIn.GroupEventHandler]
+     * once [com.vitorpamplona.quartz.marmot.MarmotInboundProcessor] has
+     * decrypted the outer ChaCha20-Poly1305 layer and verified the inner
+     * MLS-signed payload.
+     *
+     * Only kind:9 chat messages produce a notification — reactions, control
+     * messages, and deletions stay silent, mirroring how NIP-17 (kind:14)
+     * is the only DM kind we notify.
+     */
+    suspend fun notifyGroupMessage(
+        innerEvent: Event,
+        nostrGroupId: String,
+        account: Account,
+    ) = withWakeLock {
+        Log.d(TAG, "New Marmot Group Message to Notify")
+
+        if (innerEvent.kind != ChatEvent.KIND) return@withWakeLock
+        if (!notificationManager().areNotificationsEnabled()) return@withWakeLock
+        if (MainActivity.isResumed) return@withWakeLock
+
+        // old event being re-broadcast
+        if (innerEvent.createdAt < TimeUtils.fifteenMinutesAgo()) return@withWakeLock
+        // a message we ourselves sent
+        if (innerEvent.pubKey == account.signer.pubKey) return@withWakeLock
+
+        val chatroom = account.marmotGroupList.getOrCreateGroup(nostrGroupId)
+        val groupName = chatroom.displayName.value?.takeIf { it.isNotBlank() } ?: "Private group"
+        val sender = LocalCache.getOrCreateUser(innerEvent.pubKey)
+        val senderName = sender.toBestDisplayName()
+        val senderPicture = sender.profilePicture()
+        // Show the message body when present; reactions/empty payloads fall
+        // back to a generic prompt so the popup is still actionable.
+        val body = innerEvent.content.takeIf { it.isNotBlank() } ?: "New message"
+
+        val accountNpub =
+            account.signer.pubKey
+                .hexToByteArray()
+                .toNpub()
+        // marmot:<groupHex>?account=<npub> — same scheme as notifyWelcome,
+        // taps deep-link straight to the group's chatroom.
+        val noteUri = "marmot:$nostrGroupId$ACCOUNT_QUERY_PARAM$accountNpub"
+
+        notificationManager()
+            .sendDMNotification(
+                id = innerEvent.id,
+                messageBody = "$senderName: $body",
+                senderName = groupName,
+                time = innerEvent.createdAt,
+                pictureUrl = senderPicture,
                 uri = noteUri,
                 applicationContext = applicationContext,
                 accountNpub = accountNpub,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationDispatcher.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationDispatcher.kt
@@ -222,4 +222,24 @@ class NotificationDispatcher(
             Log.e(TAG, "Failed to dispatch Welcome notification ${event.id}", e)
         }
     }
+
+    /**
+     * Direct-invocation entry point for Marmot kind:445 group messages.
+     * Bypasses the cache-observer path because GroupEvents are routed by
+     * the `h` tag (nostr_group_id), not by `p` tag. Called from
+     * [com.vitorpamplona.amethyst.ui.screen.loggedIn.GroupEventHandler]
+     * once the MLS-decrypted inner event has been parsed and indexed.
+     */
+    suspend fun notifyGroupMessage(
+        innerEvent: Event,
+        nostrGroupId: String,
+        account: Account,
+    ) {
+        try {
+            consumer.notifyGroupMessage(innerEvent, nostrGroupId, account)
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Log.e(TAG, "Failed to dispatch Group Message notification ${innerEvent.id}", e)
+        }
+    }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationDispatcher.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/NotificationDispatcher.kt
@@ -51,6 +51,7 @@ import com.vitorpamplona.quartz.nip71Video.VideoVerticalEvent
 import com.vitorpamplona.quartz.nip84Highlights.HighlightEvent
 import com.vitorpamplona.quartz.nip88Polls.poll.PollEvent
 import com.vitorpamplona.quartz.nipACWebRtcCalls.events.CallOfferEvent
+import com.vitorpamplona.quartz.nipC7Chats.ChatEvent
 import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.CancellationException
@@ -231,7 +232,7 @@ class NotificationDispatcher(
      * once the MLS-decrypted inner event has been parsed and indexed.
      */
     suspend fun notifyGroupMessage(
-        innerEvent: Event,
+        innerEvent: ChatEvent,
         nostrGroupId: String,
         account: Account,
     ) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/DecryptAndIndexProcessor.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/DecryptAndIndexProcessor.kt
@@ -660,6 +660,18 @@ class GroupEventHandler(
                     // re-persist would silently grow the on-disk log).
                     if (isNew) {
                         manager.persistDecryptedMessage(result.groupId, result.innerEventJson)
+
+                        // GroupEvents have no `p` tag, so the cache-observer
+                        // notification path can't route them. Fire the popup
+                        // directly here — only on first-time decryption, so
+                        // a relay re-broadcast or persist-replay doesn't
+                        // double-notify. The notifier itself filters by
+                        // inner kind (chat only) and freshness.
+                        Amethyst.instance.notificationDispatcher.notifyGroupMessage(
+                            innerEvent,
+                            result.groupId,
+                            account,
+                        )
                     }
                 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/DecryptAndIndexProcessor.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/DecryptAndIndexProcessor.kt
@@ -49,6 +49,7 @@ import com.vitorpamplona.quartz.nipACWebRtcCalls.events.CallIceCandidateEvent
 import com.vitorpamplona.quartz.nipACWebRtcCalls.events.CallOfferEvent
 import com.vitorpamplona.quartz.nipACWebRtcCalls.events.CallRejectEvent
 import com.vitorpamplona.quartz.nipACWebRtcCalls.events.CallRenegotiateEvent
+import com.vitorpamplona.quartz.nipC7Chats.ChatEvent
 import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.sync.Mutex
@@ -665,13 +666,16 @@ class GroupEventHandler(
                         // notification path can't route them. Fire the popup
                         // directly here — only on first-time decryption, so
                         // a relay re-broadcast or persist-replay doesn't
-                        // double-notify. The notifier itself filters by
-                        // inner kind (chat only) and freshness.
-                        Amethyst.instance.notificationDispatcher.notifyGroupMessage(
-                            innerEvent,
-                            result.groupId,
-                            account,
-                        )
+                        // double-notify. Restrict to ChatEvent (kind:9) so
+                        // reactions, deletions, and control messages stay
+                        // silent.
+                        if (innerEvent is ChatEvent) {
+                            Amethyst.instance.notificationDispatcher.notifyGroupMessage(
+                                innerEvent,
+                                result.groupId,
+                                account,
+                            )
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary
Implements notification support for Marmot group messages (kind:445) by adding a direct invocation path that bypasses the standard cache-observer notification mechanism. Since group messages are routed by the `h` tag (nostr_group_id) rather than `p` tags, they require special handling to trigger notifications.

## Key Changes
- **EventNotificationConsumer**: Added `notifyGroupMessage()` method to handle notifications for decrypted Marmot group messages. Includes checks for:
  - Notification settings enabled
  - App not in foreground
  - Message not older than 15 minutes
  - Message not sent by the current user
  - Constructs deep-link URI using `marmot:<groupHex>?account=<npub>` scheme

- **NotificationDispatcher**: Added `notifyGroupMessage()` wrapper method that delegates to the consumer with proper error handling and logging

- **GroupEventHandler** (DecryptAndIndexProcessor): Integrated notification trigger in the MLS decryption flow:
  - Fires notification only on first-time decryption (not on re-broadcasts or replays)
  - Type-narrowed to `ChatEvent` to keep reactions, deletions, and control messages silent
  - Called after message is persisted to disk

## Implementation Details
- Notifications are only sent for `ChatEvent` (kind:9) inner events, filtering out other event types at the type level
- Uses existing `sendDMNotification()` infrastructure with group-specific parameters (group name, sender info, deep-link URI)
- Defensive fallback for empty-content messages ensures notifications remain actionable
- Follows the same pattern as NIP-17 (kind:14) DM notifications

https://claude.ai/code/session_01W5hshEBsrbCBFSVcXuMFAD