### PR TITLE
Fix race condition in ReconnectingNestsListenerTest frame delivery

### DIFF
--- a/nestsClient/src/commonTest/kotlin/com/vitorpamplona/nestsclient/ReconnectingNestsListenerTest.kt
+++ b/nestsClient/src/commonTest/kotlin/com/vitorpamplona/nestsclient/ReconnectingNestsListenerTest.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
@@ -189,6 +190,18 @@ class ReconnectingNestsListenerTest {
                 // before the test thread races into the first emit.
                 val consumerSubscribed = CompletableDeferred<Unit>()
 
+                // Counter for frames the consumer has actually observed.
+                // Needed to break the FRAME1-delivery race: emit() into
+                // first.frames is non-suspending and just enqueues into
+                // the pump's slot. If we trigger a session swap before
+                // the pump's collect lambda runs (`frames.emit(it)` to
+                // the wrapper), collectLatest cancels iteration 1 mid-
+                // resume and FRAME1 is lost — consumer ends with 1/2
+                // frames and the async's withTimeout fires. The
+                // collector is single-coroutine so a plain StateFlow
+                // update is safe; the test thread reads it via .first.
+                val consumerProgress = MutableStateFlow(0)
+
                 // The wrapper backs handle.objects with a SharedFlow
                 // (frames.asSharedFlow); the cast lets us use
                 // SharedFlow.onSubscription, which fires AFTER the
@@ -201,6 +214,7 @@ class ReconnectingNestsListenerTest {
                             objectsAsShared
                                 .onSubscription { consumerSubscribed.complete(Unit) }
                                 .take(2)
+                                .onEach { consumerProgress.value += 1 }
                                 .toList()
                         }
                     }
@@ -219,6 +233,19 @@ class ReconnectingNestsListenerTest {
                 }
 
                 first.frames.emit(frame(byteArrayOf(0x01)))
+
+                // Wait for FRAME1 to traverse pump → wrapper.frames →
+                // consumer collector. Without this sync the next
+                // `first.fail(...)` can race ahead and trigger
+                // collectLatest cancellation of pump-iteration-1 while
+                // FRAME1 is still queued in first.frames; the cancel
+                // interrupts the pump's resume before its lambda runs
+                // and FRAME1 never reaches the wrapper. Consumer then
+                // observes only FRAME2 (1 frame ≠ take(2)) and the
+                // async's withTimeout fires after 5 s.
+                withTimeout(5_000L) {
+                    consumerProgress.first { it >= 1 }
+                }
 
                 // Force a reconnect: fail the first listener, the
                 // orchestrator opens the next one.


### PR DESCRIPTION
## Summary
Fixes a race condition in `ReconnectingNestsListenerTest` where emitted frames could be lost during session reconnection, causing test timeouts. The issue occurred when a session swap was triggered before the first frame was fully delivered through the pump to the consumer.

## Key Changes
- Added `consumerProgress` StateFlow to track frames actually observed by the consumer
- Imported `onEach` operator from `kotlinx.coroutines.flow`
- Added `onEach { consumerProgress.value += 1 }` to the consumer's collection pipeline to increment progress counter
- Added explicit synchronization point with `withTimeout(5_000L) { consumerProgress.first { it >= 1 } }` after emitting FRAME1 to ensure it traverses through the pump and wrapper before triggering reconnection

## Implementation Details
The race condition occurred because `emit()` into the pump's slot is non-suspending and just enqueues the frame. If the session swap was triggered before the pump's collect lambda executed, `collectLatest` would cancel the iteration mid-resume, causing FRAME1 to be lost. The consumer would then observe only 1 frame instead of the expected 2, triggering the async's withTimeout.

The fix ensures the first frame is fully delivered to the consumer before proceeding with the reconnection test by waiting for the consumer's progress counter to reach at least 1.

https://claude.ai/code/session_019bgyL5SviEZkf8NCpD1f2a