### PR TITLE
Correct '_@' display in profile header + centralise wildcard rule  

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NIP05VerificationDisplay.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NIP05VerificationDisplay.kt
@@ -378,7 +378,7 @@ fun ObserveAndDisplayNIP05(
 ) {
     val uri = LocalUriHandler.current
 
-    if (nip05State.nip05.name != "_") {
+    if (nip05State.nip05.hasLocalPart()) {
         Text(
             text = remember(nip05State) { AnnotatedString(nip05State.nip05.name) },
             fontSize = Font14SP,
@@ -407,7 +407,7 @@ fun DisplayNIP05(
 ) {
     val uri = LocalUriHandler.current
 
-    if (nip05State.nip05.name != "_") {
+    if (nip05State.nip05.hasLocalPart()) {
         Text(
             text = remember(nip05State) { AnnotatedString(nip05State.nip05.name) },
             fontSize = Font14SP,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/userSuggestions/ShowUserSuggestionList.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/userSuggestions/ShowUserSuggestionList.kt
@@ -188,7 +188,7 @@ private fun NonClickableObserveAndDisplayNIP05(
     nip05State: Nip05State.Exists,
     accountViewModel: AccountViewModel,
 ) {
-    if (nip05State.nip05.name != "_") {
+    if (nip05State.nip05.hasLocalPart()) {
         Text(
             text = remember(nip05State) { AnnotatedString(nip05State.nip05.name) },
             fontSize = Font14SP,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/badges/award/AwardBadgeScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/badges/award/AwardBadgeScreen.kt
@@ -48,10 +48,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.commons.model.nip05DnsIdentifiers.Nip05State
+import com.vitorpamplona.amethyst.commons.ui.components.Nip05OrPubkeyLine
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.SavingTopBar
@@ -231,35 +230,10 @@ private fun SelectedUserRow(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
-            UserSecondaryLine(user)
+            Nip05OrPubkeyLine(user)
         }
         TextButton(onClick = onClear) {
             Text(stringRes(R.string.award_badge_remove_recipient))
         }
     }
-}
-
-@Composable
-private fun UserSecondaryLine(user: User) {
-    val nip05StateMetadata by user.nip05State().flow.collectAsStateWithLifecycle()
-
-    val text =
-        when (val state = nip05StateMetadata) {
-            is Nip05State.Exists -> {
-                val name = state.nip05.name
-                if (name == "_") state.nip05.domain else "$name@${state.nip05.domain}"
-            }
-
-            else -> {
-                user.pubkeyDisplayHex()
-            }
-        }
-
-    Text(
-        text = text,
-        style = MaterialTheme.typography.bodySmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
-    )
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/communities/newCommunity/NewCommunityScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/communities/newCommunity/NewCommunityScreen.kt
@@ -65,14 +65,13 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
-import com.vitorpamplona.amethyst.commons.model.nip05DnsIdentifiers.Nip05State
+import com.vitorpamplona.amethyst.commons.ui.components.Nip05OrPubkeyLine
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.ui.actions.StrippingFailureDialog
@@ -497,7 +496,7 @@ private fun SelectedModeratorRow(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
-            ModeratorSecondaryLine(user)
+            Nip05OrPubkeyLine(user)
         }
 
         if (isOwner) {
@@ -520,31 +519,6 @@ private fun SelectedModeratorRow(
             }
         }
     }
-}
-
-@Composable
-private fun ModeratorSecondaryLine(user: User) {
-    val nip05StateMetadata by user.nip05State().flow.collectAsStateWithLifecycle()
-
-    val text =
-        when (val state = nip05StateMetadata) {
-            is Nip05State.Exists -> {
-                val name = state.nip05.name
-                if (name == "_") state.nip05.domain else "$name@${state.nip05.domain}"
-            }
-
-            else -> {
-                user.pubkeyDisplayHex()
-            }
-        }
-
-    Text(
-        text = text,
-        style = MaterialTheme.typography.bodySmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
-    )
 }
 
 // --- Relays ------------------------------------------------------------------------------------

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/DrawAdditionalInfo.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/DrawAdditionalInfo.kt
@@ -338,10 +338,8 @@ fun DisplayNip05ProfileStatus(
                 Text(
                     text =
                         remember(nip05State) {
-                            val name = nip05State.nip05.name
-                            val display = if (name == "_") nip05State.nip05.domain else "$name@${nip05State.nip05.domain}"
                             buildAnnotatedString {
-                                appendLink(display, color) {
+                                appendLink(nip05State.nip05.toDisplayValue(), color) {
                                     runCatching { uri.openUri("https://${nip05State.nip05.domain}") }
                                 }
                             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/DrawAdditionalInfo.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/DrawAdditionalInfo.kt
@@ -338,8 +338,10 @@ fun DisplayNip05ProfileStatus(
                 Text(
                     text =
                         remember(nip05State) {
+                            val name = nip05State.nip05.name
+                            val display = if (name == "_") nip05State.nip05.domain else "$name@${nip05State.nip05.domain}"
                             buildAnnotatedString {
-                                appendLink(nip05State.nip05.toValue(), color) {
+                                appendLink(display, color) {
                                     runCatching { uri.openUri("https://${nip05State.nip05.domain}") }
                                 }
                             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip86/RelayManagementScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/nip86/RelayManagementScreen.kt
@@ -490,7 +490,7 @@ private fun PubkeyNip05Row(
 
     when (val nip05State = nip05StateMetadata) {
         is Nip05State.Exists -> {
-            if (nip05State.nip05.name != "_") {
+            if (nip05State.nip05.hasLocalPart()) {
                 Text(
                     text = remember(nip05State) { AnnotatedString(nip05State.nip05.name) },
                     fontSize = Font14SP,

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/Nip05OrPubkeyLine.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/Nip05OrPubkeyLine.kt
@@ -24,24 +24,22 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.commons.model.User
 import com.vitorpamplona.amethyst.commons.model.nip05DnsIdentifiers.Nip05State
 
-/**
- * Single-line bodySmall label for a user secondary identifier: shows the
- * verified NIP-05 (formatted via [com.vitorpamplona.quartz.nip05DnsIdentifiers.Nip05Id.toDisplayValue])
- * when present, otherwise a shortened pubkey.
- */
+/** Shows the verified NIP-05 if present, otherwise a shortened pubkey. */
 @Composable
 fun Nip05OrPubkeyLine(user: User) {
     val nip05StateMetadata by user.nip05State().flow.collectAsStateWithLifecycle()
+    val pubkeyShort = remember(user.pubkeyHex) { user.pubkeyDisplayHex() }
 
     val text =
         when (val state = nip05StateMetadata) {
             is Nip05State.Exists -> state.nip05.toDisplayValue()
-            else -> user.pubkeyDisplayHex()
+            is Nip05State.NotFound -> pubkeyShort
         }
 
     Text(

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/Nip05OrPubkeyLine.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/Nip05OrPubkeyLine.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.components
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.nip05DnsIdentifiers.Nip05State
+
+/**
+ * Single-line bodySmall label for a user secondary identifier: shows the
+ * verified NIP-05 (formatted via [com.vitorpamplona.quartz.nip05DnsIdentifiers.Nip05Id.toDisplayValue])
+ * when present, otherwise a shortened pubkey.
+ */
+@Composable
+fun Nip05OrPubkeyLine(user: User) {
+    val nip05StateMetadata by user.nip05State().flow.collectAsStateWithLifecycle()
+
+    val text =
+        when (val state = nip05StateMetadata) {
+            is Nip05State.Exists -> state.nip05.toDisplayValue()
+            else -> user.pubkeyDisplayHex()
+        }
+
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+    )
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/Nip05Id.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/Nip05Id.kt
@@ -36,6 +36,12 @@ data class Nip05Id(
      */
     fun toDisplayValue(): String = if (name == "_") domain else assemble(name, domain)
 
+    /**
+     * False when [name] is the NIP-05 wildcard `"_"`; use to gate rendering of
+     * the local part when name and domain are shown as separate widgets.
+     */
+    fun hasLocalPart(): Boolean = name != "_"
+
     fun toUserUrl(): String = userUrl(name, domain)
 
     fun toDomainUrl(): String = domainUrl(domain)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/Nip05Id.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/Nip05Id.kt
@@ -29,6 +29,13 @@ data class Nip05Id(
 ) {
     fun toValue(): String = assemble(name, domain)
 
+    /**
+     * Renders the address for users to read. When [name] is `"_"`, NIP-05
+     * specifies the address should display as just the domain. Use this in UI;
+     * use [toValue] for network lookups and storage.
+     */
+    fun toDisplayValue(): String = if (name == "_") domain else assemble(name, domain)
+
     fun toUserUrl(): String = userUrl(name, domain)
 
     fun toDomainUrl(): String = domainUrl(domain)

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/Nip05Test.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/Nip05Test.kt
@@ -124,6 +124,20 @@ class Nip05Test {
     }
 
     @Test
+    fun `hasLocalPart is true for regular name`() {
+        val nip05 = Nip05Id.parse("alice@example.com")
+        assertNotNull(nip05)
+        assertEquals(true, nip05.hasLocalPart())
+    }
+
+    @Test
+    fun `hasLocalPart is false for underscore name`() {
+        val nip05 = Nip05Id.parse("_@example.com")
+        assertNotNull(nip05)
+        assertEquals(false, nip05.hasLocalPart())
+    }
+
+    @Test
     fun `test json parsing with relays`() {
         val parsedNip05 = Nip05Id.parse("bob@test.com")
         assertNotNull(parsedNip05)

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/Nip05Test.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/Nip05Test.kt
@@ -110,6 +110,20 @@ class Nip05Test {
     }
 
     @Test
+    fun `toDisplayValue with regular name returns name@domain`() {
+        val nip05 = Nip05Id.parse("alice@example.com")
+        assertNotNull(nip05)
+        assertEquals("alice@example.com", nip05.toDisplayValue())
+    }
+
+    @Test
+    fun `toDisplayValue with underscore name returns domain only`() {
+        val nip05 = Nip05Id.parse("_@example.com")
+        assertNotNull(nip05)
+        assertEquals("example.com", nip05.toDisplayValue())
+    }
+
+    @Test
     fun `test json parsing with relays`() {
         val parsedNip05 = Nip05Id.parse("bob@test.com")
         assertNotNull(parsedNip05)


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                    
                                     
  - **Bug fix:** profile header for users with NIP-05 `_@<domain>` was rendering as `_@<domain>` instead of just `<domain>`. NIP-05 specifies that when the local part is `_`, the address should display as the domain alone.  
  - Two more sites (Award Badge → selected user, New Community → moderator row) were rendering the same way and are corrected by the same helper.
  - **`Nip05Id.toDisplayValue()`** added to `quartz` so the rule lives in one place; three single-string display sites now call it.                                                                                             
  - **`Nip05Id.hasLocalPart()`** added for the four multi-widget sites that render name and domain as separate composables (NIP-05 verification badge in posts, user-suggestion dropdown, QR screen, NIP-86 relay management).
  Pure refactor — same output, just no longer re-spelling `name != "_"` inline.                                                                                                                                                 
  - Extracted **`Nip05OrPubkeyLine`** shared composable to `commons/` — replaced two byte-identical private composables (`UserSecondaryLine`, `ModeratorSecondaryLine`).
                                                                                                                                                                                                                                
  Regression in `76598c30` ("Improvements to profile page") collapsed a correctly-guarded two-widget render into a single `Nip05Id.toValue()` call, which always returns `name@domain`.                                      
                                                                                                                                                                                                                                
  ## Test plan                                                                                                                                                                                                                  
                                          
  - [x] **Profile header** — open profile of a user with `_@<domain>` NIP-05 → shows only `<domain>` (was `_@<domain>` on 1.08.0).                                                                                              
  - [x] **Profile header** — regular `name@<domain>` user unchanged.                                                                                                                                                          
  - [x] **Award Badge → Add recipient** — pick a user, secondary line correct for both `_` and regular NIP-05.                                                                                                                  
  - [x] **New Community → Add moderator** — same.                                                                                                                                                                               
  - [x] **@-mention dropdown** in any composer — unchanged for both cases.
  - [x] **QR screen / NIP-86 relay management** — unchanged for both cases.                                                                                                                                                     
  - [x] `:quartz:jvmTest` green (4 new tests cover both helpers).
  - [x] `:amethyst:assembleDebug` green (Play + F-Droid). 