### PR TITLE
Downgrade VLC version to 3.0.20 due to Maven artifact availability

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,11 +111,14 @@ jobs:
       # populating the cache for the next run.
       #
       # Versions are pinned to match desktopApp/build.gradle.kts (vlcVersion
-      # = 3.0.21) and the vlc-setup extension default (upxVersion = 4.2.4).
+      # = 3.0.20) and the vlc-setup extension default (upxVersion = 4.2.4).
+      # NOTE: vlcVersion lags behind upstream VLC because the Linux plugins on
+      # Maven Central (ir.mahozad:vlc-plugins-linux) are only published for
+      # 3.0.20 / 3.0.20-2. Bump only after the Maven artifact is republished.
       # macOS does not download UPX — UPX cannot compress .dylib files.
       - name: Pre-fetch VLC + UPX archives
         env:
-          VLC_VERSION: "3.0.21"
+          VLC_VERSION: "3.0.20"
           UPX_VERSION: "4.2.4"
         run: |
           set -euo pipefail

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -133,7 +133,10 @@ compose.desktop {
 }
 
 vlcSetup {
-    vlcVersion.set("3.0.21")
+    // Pinned to 3.0.20 because the Linux VLC plugins on Maven Central
+    // (ir.mahozad:vlc-plugins-linux) have not been republished for 3.0.21 — the
+    // latest there is 3.0.20-2. Using 3.0.21 makes vlcDownload 404 on Linux CI.
+    vlcVersion.set("3.0.20")
     shouldCompressVlcFiles.set(true)
     shouldIncludeAllVlcFiles.set(true)
     pathToCopyVlcLinuxFilesTo.set(file("src/jvmMain/appResources/linux/vlc"))


### PR DESCRIPTION
## Summary
Downgrade VLC version from 3.0.21 to 3.0.20 to resolve Linux CI build failures caused by unavailable Maven artifacts for the Linux VLC plugins.

## Changes
- Updated VLC version from 3.0.21 to 3.0.20 in both the GitHub Actions workflow and Gradle build configuration
- Added explanatory comments documenting the constraint: the Linux VLC plugins on Maven Central (`ir.mahozad:vlc-plugins-linux`) are only published for version 3.0.20-2, causing 404 errors on Linux CI when attempting to use 3.0.21
- Documented that this version should only be bumped after the Maven artifact is republished upstream

## Implementation Details
The VLC version is pinned in two locations:
1. `.github/workflows/build.yml` - Pre-fetch step environment variable
2. `desktopApp/build.gradle.kts` - vlcSetup configuration

Both locations now reference 3.0.20 with clear comments explaining the Maven artifact availability constraint, preventing future maintainers from upgrading without understanding the dependency issue.

https://claude.ai/code/session_01GrZLMi3sdp6frwREmQ9cUi