### PR TITLE
Increase Gradle daemon JVM heap memory from 4GB to 6GB

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx6g -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
## Summary
Increased the maximum heap memory allocation for the Gradle daemon process to improve build performance and stability.

## Changes
- Updated `org.gradle.jvmargs` in `gradle.properties` to increase `-Xmx` from 4g to 6g

## Details
This change allocates an additional 2GB of heap memory to the Gradle daemon, which can help prevent out-of-memory errors during large builds and improve overall build performance, particularly for projects with many modules or complex dependency graphs.

https://claude.ai/code/session_01VeKrAVdaK5ArSB1ujr9sTq