### PR TITLE
Fix plural string formatting in Brazilian Portuguese translations

### DIFF
--- a/amethyst/src/main/res/values-pt-rBR/strings.xml
+++ b/amethyst/src/main/res/values-pt-rBR/strings.xml
@@ -441,11 +441,11 @@
         <item quantity="other">%d na fila</item>
     </plurals>
     <plurals name="scheduled_posts_subtitle_due_suffix">
-        <item quantity="one"> · 1 em 1h</item>
+        <item quantity="one"> · %d em 1h</item>
         <item quantity="other"> · %d em 1h</item>
     </plurals>
     <plurals name="scheduled_posts_relay_count">
-        <item quantity="one">para 1 relay</item>
+        <item quantity="one">para %d relay</item>
         <item quantity="other">para %d relays</item>
     </plurals>
     <string name="scheduled_posts_event_id_copied">ID do post copiado</string>


### PR DESCRIPTION
## Summary
Fixed incorrect plural string formatting in the Brazilian Portuguese (pt-BR) translation file for scheduled posts-related strings.

## Key Changes
- Updated `scheduled_posts_subtitle_due_suffix` plural form: Changed hardcoded "1" to `%d` placeholder to properly support dynamic values
- Updated `scheduled_posts_relay_count` plural form: Changed hardcoded "1" to `%d` placeholder to properly support dynamic values

## Details
These changes ensure that the plural string resources correctly use format placeholders (`%d`) instead of hardcoded values. This allows the application to properly substitute the actual count values at runtime, making the strings work correctly for all plural cases rather than only displaying "1" in the singular form.

https://claude.ai/code/session_01UmYZfFy8QqaDaXbcXguu8f