### PR TITLE
Add copy-to-clipboard functionality for payment targets

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
@@ -82,6 +82,7 @@ import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
@@ -128,6 +129,7 @@ import com.vitorpamplona.amethyst.ui.components.M3ActionDialog
 import com.vitorpamplona.amethyst.ui.components.M3ActionRow
 import com.vitorpamplona.amethyst.ui.components.M3ActionSection
 import com.vitorpamplona.amethyst.ui.components.toasts.multiline.UserBasedErrorMessage
+import com.vitorpamplona.amethyst.ui.components.util.setText
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.navigation.routes.routeReplyTo
@@ -346,6 +348,8 @@ fun PayReaction(
     val authorPubkey = baseNote.author?.pubkeyHex ?: return
     val address = remember(authorPubkey) { PaymentTargetsEvent.createAddress(authorPubkey) }
     val context = LocalContext.current
+    val clipboardManager = LocalClipboard.current
+    val scope = rememberCoroutineScope()
 
     LoadAddressableNote(address, accountViewModel) { note ->
         val targets = remember(note) { (note?.event as? PaymentTargetsEvent)?.paymentTargets() ?: emptyList() }
@@ -392,6 +396,16 @@ fun PayReaction(
                                     } catch (e: Exception) {
                                         if (e is kotlinx.coroutines.CancellationException) throw e
                                         errorMessage = stringRes(context, R.string.no_payment_app_found)
+                                    }
+                                },
+                            )
+                            M3ActionRow(
+                                icon = MaterialSymbols.ContentCopy,
+                                text = stringRes(R.string.copy_to_clipboard),
+                                onClick = {
+                                    expanded = false
+                                    scope.launch {
+                                        clipboardManager.setText(target.authority)
                                     }
                                 },
                             )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/PaymentButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/PaymentButton.kt
@@ -28,8 +28,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
@@ -40,6 +42,7 @@ import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.ui.components.M3ActionDialog
 import com.vitorpamplona.amethyst.ui.components.M3ActionRow
 import com.vitorpamplona.amethyst.ui.components.M3ActionSection
+import com.vitorpamplona.amethyst.ui.components.util.setText
 import com.vitorpamplona.amethyst.ui.note.ErrorMessageDialog
 import com.vitorpamplona.amethyst.ui.note.LoadAddressableNote
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -47,6 +50,7 @@ import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.ZeroPadding
 import com.vitorpamplona.quartz.experimental.nipA3.PaymentTarget
 import com.vitorpamplona.quartz.experimental.nipA3.PaymentTargetsEvent
+import kotlinx.coroutines.launch
 
 @Composable
 fun PaymentButton(
@@ -72,6 +76,8 @@ fun PaymentButton(
 @Composable
 fun PaymentButtonWithTargets(targets: List<PaymentTarget>) {
     val context = LocalContext.current
+    val clipboardManager = LocalClipboard.current
+    val scope = rememberCoroutineScope()
     var expanded by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
 
@@ -108,6 +114,16 @@ fun PaymentButtonWithTargets(targets: List<PaymentTarget>) {
                             } catch (e: Exception) {
                                 if (e is kotlinx.coroutines.CancellationException) throw e
                                 errorMessage = stringRes(context, R.string.no_payment_app_found)
+                            }
+                        },
+                    )
+                    M3ActionRow(
+                        icon = MaterialSymbols.ContentCopy,
+                        text = stringRes(R.string.copy_to_clipboard),
+                        onClick = {
+                            expanded = false
+                            scope.launch {
+                                clipboardManager.setText(target.authority)
                             }
                         },
                     )


### PR DESCRIPTION
## Summary
Added the ability to copy payment target addresses to the clipboard in two locations where payment options are displayed to users.

## Key Changes
- **PaymentButton.kt**: Added a "Copy to Clipboard" action row in the payment targets menu that copies the target's authority to the clipboard
- **ReactionsRow.kt**: Added the same "Copy to Clipboard" functionality in the PayReaction composable for payment targets
- Both implementations use Compose's `LocalClipboard` API with coroutine scope to handle the clipboard operation asynchronously
- Imported necessary dependencies: `rememberCoroutineScope`, `LocalClipboard`, `setText` utility, and `kotlinx.coroutines.launch`

## Implementation Details
- Used `clipboardManager.setText()` utility function to copy the `target.authority` value
- Wrapped clipboard operations in `scope.launch {}` to execute asynchronously without blocking the UI
- Followed existing UI patterns by using `M3ActionRow` with `MaterialSymbols.ContentCopy` icon
- Closes the expanded menu after copying to provide user feedback

https://claude.ai/code/session_01D6vNkPHpBegjqDQzMwgkeE