### PR TITLE
Add option to disable NIP-89 client tag in published events

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
@@ -95,6 +95,7 @@ private object PrefKeys {
     const val LOCAL_RELAY_SERVERS = "localRelayServers"
     const val DEFAULT_FILE_SERVER = "defaultFileServer"
     const val STRIP_LOCATION_ON_UPLOAD = "stripLocationOnUpload"
+    const val DISABLE_CLIENT_TAG = "disableClientTag"
     const val DEFAULT_HOME_FOLLOW_LIST = "defaultHomeFollowList"
     const val DEFAULT_STORIES_FOLLOW_LIST = "defaultStoriesFollowList"
     const val DEFAULT_NOTIFICATION_FOLLOW_LIST = "defaultNotificationFollowList"
@@ -346,6 +347,7 @@ object LocalPreferences {
                     )
 
                     putBoolean(PrefKeys.STRIP_LOCATION_ON_UPLOAD, settings.stripLocationOnUpload)
+                    putBoolean(PrefKeys.DISABLE_CLIENT_TAG, settings.disableClientTag)
 
                     putString(PrefKeys.DEFAULT_HOME_FOLLOW_LIST, JsonMapper.toJson(settings.defaultHomeFollowList.value))
                     putString(PrefKeys.DEFAULT_STORIES_FOLLOW_LIST, JsonMapper.toJson(settings.defaultStoriesFollowList.value))
@@ -513,6 +515,7 @@ object LocalPreferences {
                     Log.d("LocalPreferences") { "Load account from file $npub - keys ready" }
 
                     val stripLocationOnUpload = getBoolean(PrefKeys.STRIP_LOCATION_ON_UPLOAD, true)
+                    val disableClientTag = getBoolean(PrefKeys.DISABLE_CLIENT_TAG, false)
                     val hideDeleteRequestDialog = getBoolean(PrefKeys.HIDE_DELETE_REQUEST_DIALOG, false)
                     val hideBlockAlertDialog = getBoolean(PrefKeys.HIDE_BLOCK_ALERT_DIALOG, false)
                     val hideNIP17WarningDialog = getBoolean(PrefKeys.HIDE_NIP_17_WARNING_DIALOG, false)
@@ -620,6 +623,7 @@ object LocalPreferences {
                         localRelayServers = MutableStateFlow(localRelayServers),
                         defaultFileServer = defaultFileServer.await(),
                         stripLocationOnUpload = stripLocationOnUpload,
+                        disableClientTag = disableClientTag,
                         defaultHomeFollowList = MutableStateFlow(followListPrefs.home),
                         defaultStoriesFollowList = MutableStateFlow(followListPrefs.stories),
                         defaultNotificationFollowList = MutableStateFlow(followListPrefs.notification),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
@@ -95,7 +95,6 @@ private object PrefKeys {
     const val LOCAL_RELAY_SERVERS = "localRelayServers"
     const val DEFAULT_FILE_SERVER = "defaultFileServer"
     const val STRIP_LOCATION_ON_UPLOAD = "stripLocationOnUpload"
-    const val DISABLE_CLIENT_TAG = "disableClientTag"
     const val DEFAULT_HOME_FOLLOW_LIST = "defaultHomeFollowList"
     const val DEFAULT_STORIES_FOLLOW_LIST = "defaultStoriesFollowList"
     const val DEFAULT_NOTIFICATION_FOLLOW_LIST = "defaultNotificationFollowList"
@@ -347,7 +346,6 @@ object LocalPreferences {
                     )
 
                     putBoolean(PrefKeys.STRIP_LOCATION_ON_UPLOAD, settings.stripLocationOnUpload)
-                    putBoolean(PrefKeys.DISABLE_CLIENT_TAG, settings.disableClientTag)
 
                     putString(PrefKeys.DEFAULT_HOME_FOLLOW_LIST, JsonMapper.toJson(settings.defaultHomeFollowList.value))
                     putString(PrefKeys.DEFAULT_STORIES_FOLLOW_LIST, JsonMapper.toJson(settings.defaultStoriesFollowList.value))
@@ -515,7 +513,6 @@ object LocalPreferences {
                     Log.d("LocalPreferences") { "Load account from file $npub - keys ready" }
 
                     val stripLocationOnUpload = getBoolean(PrefKeys.STRIP_LOCATION_ON_UPLOAD, true)
-                    val disableClientTag = getBoolean(PrefKeys.DISABLE_CLIENT_TAG, false)
                     val hideDeleteRequestDialog = getBoolean(PrefKeys.HIDE_DELETE_REQUEST_DIALOG, false)
                     val hideBlockAlertDialog = getBoolean(PrefKeys.HIDE_BLOCK_ALERT_DIALOG, false)
                     val hideNIP17WarningDialog = getBoolean(PrefKeys.HIDE_NIP_17_WARNING_DIALOG, false)
@@ -623,7 +620,6 @@ object LocalPreferences {
                         localRelayServers = MutableStateFlow(localRelayServers),
                         defaultFileServer = defaultFileServer.await(),
                         stripLocationOnUpload = stripLocationOnUpload,
-                        disableClientTag = disableClientTag,
                         defaultHomeFollowList = MutableStateFlow(followListPrefs.home),
                         defaultStoriesFollowList = MutableStateFlow(followListPrefs.stories),
                         defaultNotificationFollowList = MutableStateFlow(followListPrefs.notification),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -529,6 +529,14 @@ class Account(
         return false
     }
 
+    suspend fun updateDisableClientTag(disable: Boolean): Boolean {
+        if (settings.updateDisableClientTag(disable)) {
+            sendNewAppSpecificData()
+            return true
+        }
+        return false
+    }
+
     suspend fun updateFilterSpam(filterSpam: Boolean): Boolean {
         if (settings.updateFilterSpam(filterSpam)) {
             if (!settings.syncedSettings.security.filterSpamFromStrangers.value) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -149,6 +149,7 @@ class AccountSettings(
     var localRelayServers: MutableStateFlow<Set<String>> = MutableStateFlow(setOf()),
     var defaultFileServer: ServerName = DEFAULT_MEDIA_SERVERS[0],
     var stripLocationOnUpload: Boolean = true,
+    var disableClientTag: Boolean = false,
     val defaultHomeFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.AllFollows),
     val defaultStoriesFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.Global),
     val defaultNotificationFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.Global),
@@ -399,6 +400,13 @@ class AccountSettings(
     fun changeStripLocationOnUpload(strip: Boolean) {
         if (stripLocationOnUpload != strip) {
             stripLocationOnUpload = strip
+            saveAccountSettings()
+        }
+    }
+
+    fun changeDisableClientTag(disable: Boolean) {
+        if (disableClientTag != disable) {
+            disableClientTag = disable
             saveAccountSettings()
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -149,7 +149,6 @@ class AccountSettings(
     var localRelayServers: MutableStateFlow<Set<String>> = MutableStateFlow(setOf()),
     var defaultFileServer: ServerName = DEFAULT_MEDIA_SERVERS[0],
     var stripLocationOnUpload: Boolean = true,
-    var disableClientTag: Boolean = false,
     val defaultHomeFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.AllFollows),
     val defaultStoriesFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.Global),
     val defaultNotificationFollowList: MutableStateFlow<TopFilter> = MutableStateFlow(TopFilter.Global),
@@ -404,12 +403,13 @@ class AccountSettings(
         }
     }
 
-    fun changeDisableClientTag(disable: Boolean) {
-        if (disableClientTag != disable) {
-            disableClientTag = disable
+    fun updateDisableClientTag(disable: Boolean): Boolean =
+        if (syncedSettings.security.updateDisableClientTag(disable)) {
             saveAccountSettings()
+            true
+        } else {
+            false
         }
-    }
 
     // ---
     // list names

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettings.kt
@@ -55,6 +55,7 @@ class AccountSyncedSettings(
             MutableStateFlow(internalSettings.security.filterSpamFromStrangers),
             MutableStateFlow(internalSettings.security.maxHashtagLimit),
             MutableStateFlow(internalSettings.security.sendKind0EventsToLocalRelay),
+            MutableStateFlow(internalSettings.security.disableClientTag),
         )
     val videoPlayer =
         AccountVideoPlayerPreferences(
@@ -82,6 +83,7 @@ class AccountSyncedSettings(
                     security.filterSpamFromStrangers.value,
                     security.maxHashtagLimit.value,
                     security.sendKind0EventsToLocalRelay.value,
+                    security.disableClientTag.value,
                 ),
             videoPlayer = AccountVideoPlayerPreferencesInternal(videoPlayer.buttonItems.value),
         )
@@ -136,6 +138,10 @@ class AccountSyncedSettings(
 
         if (security.sendKind0EventsToLocalRelay.value != syncedSettingsInternal.security.sendKind0EventsToLocalRelay) {
             security.sendKind0EventsToLocalRelay.tryEmit(syncedSettingsInternal.security.sendKind0EventsToLocalRelay)
+        }
+
+        if (security.disableClientTag.value != syncedSettingsInternal.security.disableClientTag) {
+            security.disableClientTag.tryEmit(syncedSettingsInternal.security.disableClientTag)
         }
 
         val newVideoPlayerButtonItems = syncedSettingsInternal.videoPlayer.buttonItems.toImmutableList()
@@ -233,6 +239,7 @@ class AccountSecurityPreferences(
     var filterSpamFromStrangers: MutableStateFlow<Boolean> = MutableStateFlow(true),
     val maxHashtagLimit: MutableStateFlow<Int> = MutableStateFlow(5),
     var sendKind0EventsToLocalRelay: MutableStateFlow<Boolean> = MutableStateFlow(false),
+    val disableClientTag: MutableStateFlow<Boolean> = MutableStateFlow(false),
 ) {
     fun updateShowSensitiveContent(show: Boolean?): Boolean {
         if (showSensitiveContent.value != show) {
@@ -269,6 +276,14 @@ class AccountSecurityPreferences(
     fun updateSendKind0EventsToLocalRelay(send: Boolean): Boolean =
         if (send != sendKind0EventsToLocalRelay.value) {
             sendKind0EventsToLocalRelay.tryEmit(send)
+            true
+        } else {
+            false
+        }
+
+    fun updateDisableClientTag(disable: Boolean): Boolean =
+        if (disable != disableClientTag.value) {
+            disableClientTag.tryEmit(disable)
             true
         } else {
             false

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettingsInternal.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettingsInternal.kt
@@ -147,4 +147,5 @@ class AccountSecurityPreferencesInternal(
     var filterSpamFromStrangers: Boolean = true,
     val maxHashtagLimit: Int = 5,
     var sendKind0EventsToLocalRelay: Boolean = false,
+    var disableClientTag: Boolean = false,
 )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/accountsCache/AccountCacheState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/accountsCache/AccountCacheState.kt
@@ -135,7 +135,12 @@ class AccountCacheState(
         val cached = accounts.value[signer.pubKey]
         if (cached != null) return cached
 
-        val signerWithClientTag = NostrSignerWithClientTag(signer, CLIENT_TAG_NAME)
+        val signerWithClientTag =
+            NostrSignerWithClientTag(
+                inner = signer,
+                clientName = CLIENT_TAG_NAME,
+                disabled = { accountSettings.disableClientTag },
+            )
 
         val accountDir = File(rootFilesDir(), "accounts/${signer.pubKey}").apply { mkdirs() }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/accountsCache/AccountCacheState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/accountsCache/AccountCacheState.kt
@@ -139,7 +139,7 @@ class AccountCacheState(
             NostrSignerWithClientTag(
                 inner = signer,
                 clientName = CLIENT_TAG_NAME,
-                disabled = { accountSettings.disableClientTag },
+                disabled = { accountSettings.syncedSettings.security.disableClientTag.value },
             )
 
         val accountDir = File(rootFilesDir(), "accounts/${signer.pubKey}").apply { mkdirs() }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -1112,6 +1112,8 @@ class AccountViewModel(
 
     fun updateWarnReports(warnReports: Boolean) = launchSigner { account.updateWarnReports(warnReports) }
 
+    fun updateDisableClientTag(disable: Boolean) = launchSigner { account.updateDisableClientTag(disable) }
+
     fun updateFilterSpam(filterSpam: Boolean) =
         launchSigner {
             if (account.updateFilterSpam(filterSpam)) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/SecurityFiltersScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/SecurityFiltersScreen.kt
@@ -375,13 +375,13 @@ private fun HeaderOptions(accountViewModel: AccountViewModel) {
             R.string.disable_client_tag_title,
             R.string.disable_client_tag_explainer,
         ) {
-            var disableClientTag by remember { mutableStateOf(accountViewModel.account.settings.disableClientTag) }
+            var disableClientTag by remember { mutableStateOf(accountViewModel.account.settings.syncedSettings.security.disableClientTag.value) }
 
             Switch(
                 checked = disableClientTag,
                 onCheckedChange = {
                     disableClientTag = it
-                    accountViewModel.account.settings.changeDisableClientTag(it)
+                    accountViewModel.updateDisableClientTag(disableClientTag)
                 },
             )
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/SecurityFiltersScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/SecurityFiltersScreen.kt
@@ -372,6 +372,21 @@ private fun HeaderOptions(accountViewModel: AccountViewModel) {
         }
 
         SettingsRow(
+            R.string.disable_client_tag_title,
+            R.string.disable_client_tag_explainer,
+        ) {
+            var disableClientTag by remember { mutableStateOf(accountViewModel.account.settings.disableClientTag) }
+
+            Switch(
+                checked = disableClientTag,
+                onCheckedChange = {
+                    disableClientTag = it
+                    accountViewModel.account.settings.changeDisableClientTag(it)
+                },
+            )
+        }
+
+        SettingsRow(
             R.string.show_sensitive_content_title,
             R.string.show_sensitive_content_explainer,
         ) {

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -1172,6 +1172,8 @@
 
     <string name="filter_spam_from_strangers_title">Filter spam</string>
     <string name="filter_spam_from_strangers_explainer">Hides posts from strangers that were exactly the same for 5 or more times</string>
+    <string name="disable_client_tag_title">Don\'t add client tag to my events</string>
+    <string name="disable_client_tag_explainer">When enabled, Amethyst will not append a NIP-89 client tag to events you publish.</string>
     <string name="warn_when_posts_have_reports_from_your_follows_title">Warn on reports</string>
     <string name="warn_when_posts_have_reports_from_your_follows_explainer">Shows a warning message when posts have 5 or more reports from your follows</string>
     <string name="show_sensitive_content_title">Show sensitive content</string>

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip89AppHandlers/clientTag/NostrSignerWithClientTag.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip89AppHandlers/clientTag/NostrSignerWithClientTag.kt
@@ -40,11 +40,18 @@ import com.vitorpamplona.quartz.nip57Zaps.LnZapRequestEvent
 class NostrSignerWithClientTag(
     val inner: NostrSigner,
     val clientTag: Array<String>,
+    val disabled: () -> Boolean = { false },
 ) : NostrSigner(inner.pubKey) {
     constructor(
         inner: NostrSigner,
         clientName: String,
     ) : this(inner, ClientTag.assemble(clientName))
+
+    constructor(
+        inner: NostrSigner,
+        clientName: String,
+        disabled: () -> Boolean,
+    ) : this(inner, ClientTag.assemble(clientName), disabled)
 
     constructor(
         inner: NostrSigner,
@@ -60,7 +67,12 @@ class NostrSignerWithClientTag(
         kind: Int,
         tags: Array<Array<String>>,
         content: String,
-    ): T = inner.sign(createdAt, kind, appendClientTag(tags), content)
+    ): T =
+        if (disabled()) {
+            inner.sign(createdAt, kind, tags, content)
+        } else {
+            inner.sign(createdAt, kind, appendClientTag(tags), content)
+        }
 
     override suspend fun nip04Encrypt(
         plaintext: String,


### PR DESCRIPTION
## Summary
This PR adds a new security setting that allows users to opt out of having the NIP-89 client tag appended to events they publish. The feature is fully integrated into the settings system with UI controls, persistence, and synchronization across the application.

## Key Changes
- **New Security Setting**: Added `disableClientTag` boolean preference to `AccountSecurityPreferences` and `AccountSecurityPreferencesInternal`
- **Settings UI**: Added a toggle switch in `SecurityFiltersScreen` to control the client tag behavior with user-friendly title and description
- **Signer Integration**: Modified `NostrSignerWithClientTag` to accept a `disabled` lambda function that conditionally skips appending the client tag based on the user's preference
- **Settings Persistence**: Integrated the new setting into the account settings synchronization flow, including:
  - State flow management in `AccountSyncedSettings`
  - Serialization/deserialization in `AccountSyncedSettingsInternal`
  - Update methods in `AccountSettings` and `Account` classes
- **ViewModel Support**: Added `updateDisableClientTag()` method to `AccountViewModel` to handle UI interactions
- **Localization**: Added English strings for the new setting title and explainer text

## Implementation Details
- The `NostrSignerWithClientTag` class now accepts an optional `disabled` lambda that is evaluated at signing time, allowing dynamic control without recreating the signer
- The setting is properly synced through the account's synced settings mechanism, ensuring consistency across app restarts
- The feature respects the existing settings architecture and follows established patterns for boolean security preferences

https://claude.ai/code/session_01KhNVTm8LLdVphqyxVkZtDS