### PR TITLE
Implement RFC 9000 §9 client-initiated path validation and DCID rotation

### DIFF
--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/PathValidator.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/PathValidator.kt
@@ -83,7 +83,7 @@ sealed class PathValidationState {
     data class Validating(
         val challengeData: ByteArray,
         val newCidSequence: Long,
-        val newCidBytes: ByteArray,
+        val newConnectionId: ByteArray,
         val priorCidSequence: Long,
         val startedAtMillis: Long,
         val priorPtoMillis: Long,
@@ -93,7 +93,7 @@ sealed class PathValidationState {
             if (other !is Validating) return false
             return challengeData.contentEquals(other.challengeData) &&
                 newCidSequence == other.newCidSequence &&
-                newCidBytes.contentEquals(other.newCidBytes) &&
+                newConnectionId.contentEquals(other.newConnectionId) &&
                 priorCidSequence == other.priorCidSequence &&
                 startedAtMillis == other.startedAtMillis &&
                 priorPtoMillis == other.priorPtoMillis
@@ -102,7 +102,7 @@ sealed class PathValidationState {
         override fun hashCode(): Int {
             var h = challengeData.contentHashCode()
             h = 31 * h + newCidSequence.hashCode()
-            h = 31 * h + newCidBytes.contentHashCode()
+            h = 31 * h + newConnectionId.contentHashCode()
             h = 31 * h + priorCidSequence.hashCode()
             h = 31 * h + startedAtMillis.hashCode()
             h = 31 * h + priorPtoMillis.hashCode()
@@ -137,6 +137,14 @@ enum class PathMigrationResult {
      * pool. Caller should wait for fresh peer offers.
      */
     NoSpareCid,
+
+    /**
+     * Connection is not yet in CONNECTED state — RFC 9000 §9.1
+     * forbids initiating migration before the handshake is
+     * confirmed. Caller should drop the trigger; a fresh handshake
+     * doesn't need migration.
+     */
+    NotConnected,
 }
 
 /**
@@ -171,15 +179,6 @@ enum class PathMigrationResult {
  * are plain mutable collections.
  */
 class PathValidator(
-    /**
-     * Sequence number of the CID the writer is currently stamping
-     * into outbound short-header packets. Initial value 0 per RFC
-     * 9000 §5.1.1 — the DCID negotiated at handshake. After a
-     * successful validation [activeCidSequence] is the new
-     * sequence; the prior sequence is in `pendingRetireSequences`
-     * waiting to ride out as a RETIRE_CONNECTION_ID.
-     */
-    initialActiveCidSequence: Long = 0L,
     /**
      * Cap on the number of unused CIDs we'll buffer. Defaults to
      * the peer's `active_connection_id_limit` transport parameter,
@@ -222,7 +221,15 @@ class PathValidator(
     var retirePriorToWatermark: Long = 0L
         private set
 
-    var activeCidSequence: Long = initialActiveCidSequence
+    /**
+     * Sequence number of the CID the writer is currently stamping
+     * into outbound short-header packets. Starts at 0 per RFC 9000
+     * §5.1.1 — the DCID negotiated at handshake is implicitly
+     * sequence 0. Bumped to the new sequence after a successful
+     * [applyPathResponse]; the prior sequence is queued for
+     * RETIRE_CONNECTION_ID via [pendingRetireSequences].
+     */
+    var activeCidSequence: Long = 0L
         private set
 
     /**
@@ -231,7 +238,7 @@ class PathValidator(
      * next outbound application packet. Re-populated by the loss
      * dispatcher if our RETIRE_CONNECTION_ID was lost.
      */
-    val pendingRetireSequences: ArrayDeque<Long> = ArrayDeque()
+    internal val pendingRetireSequences: ArrayDeque<Long> = ArrayDeque()
 
     /**
      * Outbound `PATH_CHALLENGE` payloads the writer should drain on
@@ -240,7 +247,7 @@ class PathValidator(
      * (the writer also records a [com.vitorpamplona.quic.connection.recovery.RecoveryToken.PathChallenge]
      * so the loss dispatcher can decide to retransmit or abandon).
      */
-    val pendingChallenges: ArrayDeque<ByteArray> = ArrayDeque()
+    internal val pendingChallenges: ArrayDeque<ByteArray> = ArrayDeque()
 
     var state: PathValidationState = PathValidationState.Idle
         private set
@@ -276,25 +283,31 @@ class PathValidator(
      *
      * The semantics:
      *  - If [retirePriorTo] is greater than [sequenceNumber], that's
-     *    a §19.15 violation (the peer can't tell us to retire its
-     *    own brand-new CID).
-     *  - If [retirePriorTo] decreased, that's a §5.1.2 violation.
+     *    a §19.15 frame-encoding error (the peer can't tell us to
+     *    retire its own brand-new CID).
+     *  - If [retirePriorTo] is smaller than the current
+     *    [retirePriorToWatermark], it's clamped to the watermark
+     *    per §19.15 ("MUST be treated as the largest one it has
+     *    seen") — common with reordered NEW_CONNECTION_ID arrivals,
+     *    not a peer error.
      *  - If the new entry would push the pool past [maxUnusedCids],
-     *    return [Result.PoolFull] — the peer over-issued.
+     *    return [RecordResult.PoolFull] — the peer over-issued.
      *  - If [sequenceNumber] is below the current
-     *    [retirePriorToWatermark], the offer is already-retired and
-     *    we silently drop it (the caller MUST still queue a
-     *    RETIRE_CONNECTION_ID for it per §5.1.2).
+     *    [retirePriorToWatermark] (after clamp), the offer is
+     *    already-retired and we drop it after queuing a
+     *    RETIRE_CONNECTION_ID for it (§5.1.2).
      *  - Duplicate sequence number with matching CID/token is
-     *    idempotent ([Result.Duplicate]); a duplicate sequence with
-     *    DIFFERENT bytes is a §19.15 violation.
+     *    idempotent ([RecordResult.Duplicate]); a duplicate sequence
+     *    with DIFFERENT bytes is a §19.15 violation.
      *
      * Side effect on success: any cached entry whose sequence
-     * number is now below the new [retirePriorTo] is moved into
-     * [pendingRetireSequences] (we owe the peer a retire) and
-     * dropped from [unusedCids]. If the active CID itself is
-     * forced-retired, the active sequence is bumped (the caller
-     * must rotate the active CID — see [forceRetireActiveIfNeeded]).
+     * number is now below the new [retirePriorToWatermark] is moved
+     * into [pendingRetireSequences] and dropped from [unusedCids].
+     * Note that this routine does NOT force-retire the active CID
+     * if the watermark moves past [activeCidSequence] — that's the
+     * caller's responsibility (it requires picking a replacement
+     * from the pool and rotating the writer's DCID). See
+     * [QuicConnection.applyPeerNewConnectionIdLocked].
      */
     fun recordPeerNewConnectionId(
         sequenceNumber: Long,
@@ -385,15 +398,23 @@ class PathValidator(
     }
 
     /**
-     * Begin a fresh path-validation attempt. Picks the lowest-sequence
-     * unused CID, generates a random 8-byte challenge, queues both,
-     * and transitions [state] to [PathValidationState.Validating].
+     * Begin a fresh path-validation attempt. Picks the lowest-
+     * sequence unused CID, generates a random 8-byte challenge,
+     * queues the challenge in [pendingChallenges], and transitions
+     * [state] to [PathValidationState.Validating]. The selected
+     * CID is removed from the unused pool; on validation success
+     * [applyPathResponse] commits it (callers swap the writer's
+     * DCID), and on timeout [checkValidationTimeout] queues it
+     * for RETIRE_CONNECTION_ID so the peer can drop the routing
+     * entry.
      *
-     * Caller is responsible for waking the writer so the challenge
-     * actually goes out. The writer also stamps the new DCID into
-     * the next outbound short-header packet — see
-     * [QuicConnection.activatePendingValidatedCid] for the post-
-     * response promotion path.
+     * Caller is responsible for two follow-ups when this returns
+     * [PathMigrationResult.Started]:
+     *  1. Rotate the connection's `destinationConnectionId` to
+     *     [PathValidationState.Validating.newConnectionId] so the
+     *     PATH_CHALLENGE packet (and subsequent traffic, per the
+     *     abrupt-migration model) goes out on the new path.
+     *  2. Wake the send loop so the challenge actually leaves.
      */
     fun tryStartValidation(
         nowMillis: Long,
@@ -411,7 +432,7 @@ class PathValidator(
             PathValidationState.Validating(
                 challengeData = payload,
                 newCidSequence = seq,
-                newCidBytes = entry.connectionId,
+                newConnectionId = entry.connectionId,
                 priorCidSequence = activeCidSequence,
                 startedAtMillis = nowMillis,
                 priorPtoMillis = currentPtoMillis,
@@ -442,7 +463,7 @@ class PathValidator(
         successfulValidations += 1
         return ValidationOutcome.Validated(
             newSequence = current.newCidSequence,
-            newConnectionIdBytes = current.newCidBytes,
+            connectionId = current.newConnectionId,
             retiredSequence = priorSeq,
         )
     }
@@ -454,20 +475,20 @@ class PathValidator(
 
         data class Validated(
             val newSequence: Long,
-            val newConnectionIdBytes: ByteArray,
+            val connectionId: ByteArray,
             val retiredSequence: Long,
         ) : ValidationOutcome() {
             override fun equals(other: Any?): Boolean {
                 if (this === other) return true
                 if (other !is Validated) return false
                 return newSequence == other.newSequence &&
-                    newConnectionIdBytes.contentEquals(other.newConnectionIdBytes) &&
+                    connectionId.contentEquals(other.connectionId) &&
                     retiredSequence == other.retiredSequence
             }
 
             override fun hashCode(): Int {
                 var h = newSequence.hashCode()
-                h = 31 * h + newConnectionIdBytes.contentHashCode()
+                h = 31 * h + connectionId.contentHashCode()
                 h = 31 * h + retiredSequence.hashCode()
                 return h
             }
@@ -481,12 +502,21 @@ class PathValidator(
      * surface a qlog event / decide whether to attempt another
      * rotation), or null if no validation is in progress / the
      * timer hasn't fired yet.
+     *
+     * On abandonment the new CID's sequence is queued for
+     * RETIRE_CONNECTION_ID. We probed with that CID — even though
+     * the peer never echoed our challenge, our challenge packet
+     * may have reached them and they've stamped routing state
+     * against the CID. Retiring it tells them they can drop that
+     * state. RFC 9000 §5.1.2: a connection ID that was used and
+     * then abandoned MUST be retired.
      */
     fun checkValidationTimeout(nowMillis: Long): PathValidationState.Validating? {
         val current = state as? PathValidationState.Validating ?: return null
         val elapsed = nowMillis - current.startedAtMillis
         val budget = (current.priorPtoMillis * VALIDATION_PTO_BUDGET_MULTIPLIER).coerceAtLeast(MIN_VALIDATION_BUDGET_MS)
         if (elapsed < budget) return null
+        queueRetireSequence(current.newCidSequence)
         state = PathValidationState.Failed
         failedValidations += 1
         return current

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/PathValidator.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/PathValidator.kt
@@ -116,8 +116,12 @@ sealed class PathValidationState {
 }
 
 /**
- * Outcome of [PathValidator.tryStartValidation], used by the caller
- * (driver / test) to know whether a probe was actually issued.
+ * Outcome of attempting to start a client-initiated path
+ * migration. Produced by [PathValidator.tryStartValidation] (which
+ * never returns [NotConnected]) and the connection-level wrapper
+ * [QuicConnection.triggerPathMigrationLocked] (which adds the
+ * pre-handshake gate). Used by the driver / application code that
+ * fires the trigger to decide whether to retry later.
  */
 enum class PathMigrationResult {
     /** A `PATH_CHALLENGE` was queued; state is [PathValidationState.Validating]. */
@@ -402,11 +406,16 @@ class PathValidator(
      * sequence unused CID, generates a random 8-byte challenge,
      * queues the challenge in [pendingChallenges], and transitions
      * [state] to [PathValidationState.Validating]. The selected
-     * CID is removed from the unused pool; on validation success
-     * [applyPathResponse] commits it (callers swap the writer's
-     * DCID), and on timeout [checkValidationTimeout] queues it
-     * for RETIRE_CONNECTION_ID so the peer can drop the routing
-     * entry.
+     * CID is removed from the unused pool. The prior CID's
+     * sequence is queued for RETIRE_CONNECTION_ID immediately —
+     * we're abandoning that path and the peer can drop the
+     * routing entry now (RFC 9000 §5.1.2). [activeCidSequence]
+     * is bumped to the new sequence so it tracks what the writer
+     * is putting on the wire.
+     *
+     * On success the writer just promotes [PathValidationState] to
+     * [PathValidationState.Succeeded]; on timeout the failed CID
+     * is also queued for retire (see [checkValidationTimeout]).
      *
      * Caller is responsible for two follow-ups when this returns
      * [PathMigrationResult.Started]:
@@ -428,12 +437,25 @@ class PathValidator(
                 require(it.size == 8) { "challenge payload supplier must return 8 bytes" }
             }
         pendingChallenges.addLast(payload)
+        val priorSeq = activeCidSequence
+        // Bug-B fix: retire the prior sequence at trigger time.
+        // Abrupt migration means we won't use the old DCID again,
+        // so the peer's routing entry for it is dead state. Without
+        // this, two consecutive failed validations leave the
+        // initial seq=0 unretired indefinitely.
+        if (priorSeq != seq) queueRetireSequence(priorSeq)
+        // [activeCidSequence] tracks "the seq the writer is currently
+        // stamping on the wire", so it advances at trigger time
+        // alongside `destinationConnectionId`. The
+        // [PathValidationState.Validating.priorCidSequence] field
+        // preserves the value for diagnostic / qlog purposes.
+        activeCidSequence = seq
         state =
             PathValidationState.Validating(
                 challengeData = payload,
                 newCidSequence = seq,
                 newConnectionId = entry.connectionId,
-                priorCidSequence = activeCidSequence,
+                priorCidSequence = priorSeq,
                 startedAtMillis = nowMillis,
                 priorPtoMillis = currentPtoMillis,
             )
@@ -441,30 +463,33 @@ class PathValidator(
     }
 
     /**
-     * Process an inbound `PATH_RESPONSE` payload. Returns true when
-     * it matched the outstanding challenge and the migration just
-     * completed; false if there's no outstanding challenge or the
-     * payload doesn't match (an attacker echoing random bytes).
+     * Process an inbound `PATH_RESPONSE` payload. Confirms the
+     * outstanding challenge: state transitions to
+     * [PathValidationState.Succeeded] and a [ValidationOutcome.Validated]
+     * is returned with the new sequence + connection-id bytes for
+     * the connection-level wrapper to surface in qlog.
      *
-     * Side effects on success:
-     *  - [state] transitions to [PathValidationState.Succeeded].
-     *  - [activeCidSequence] is bumped to the validated sequence.
-     *  - The prior sequence is queued for RETIRE_CONNECTION_ID.
-     *  - Returns the new entry so the connection can swap its
-     *    `destinationConnectionId` field.
+     * Note that [activeCidSequence] and the retire-queue entry for
+     * the prior sequence were already mutated at challenge-issue
+     * time (see [tryStartValidation]) — under the abrupt-migration
+     * model the prior CID is abandoned the moment we rotate, not
+     * when the response arrives. So this method has no further
+     * cleanup work beyond marking the state as Succeeded.
+     *
+     * Returns [ValidationOutcome.NotValidating] if no challenge
+     * is outstanding, or [ValidationOutcome.PayloadMismatch] if
+     * the bytes don't match. Both are silently dropped at the
+     * caller per RFC 9000 §8.2.2.
      */
     fun applyPathResponse(payload: ByteArray): ValidationOutcome {
         val current = state as? PathValidationState.Validating ?: return ValidationOutcome.NotValidating
         if (!payload.contentEquals(current.challengeData)) return ValidationOutcome.PayloadMismatch
-        val priorSeq = activeCidSequence
-        activeCidSequence = current.newCidSequence
-        if (priorSeq != current.newCidSequence) queueRetireSequence(priorSeq)
         state = PathValidationState.Succeeded
         successfulValidations += 1
         return ValidationOutcome.Validated(
             newSequence = current.newCidSequence,
             connectionId = current.newConnectionId,
-            retiredSequence = priorSeq,
+            retiredSequence = current.priorCidSequence,
         )
     }
 
@@ -531,6 +556,77 @@ class PathValidator(
     fun acknowledgeTerminal() {
         if (state is PathValidationState.Succeeded || state is PathValidationState.Failed) {
             state = PathValidationState.Idle
+        }
+    }
+
+    /**
+     * RFC 9000 §5.1.2: "If the active connection ID's sequence
+     * number is less than the Retire Prior To value, the endpoint
+     * MUST retire the active connection ID and adopt one with a
+     * higher sequence number."
+     *
+     * Server-forced retirement does NOT require path validation —
+     * it's the same 4-tuple, just a different CID. Pick the
+     * lowest-sequence entry from the pool, swap it in, queue the
+     * old active sequence for RETIRE_CONNECTION_ID. If no spare
+     * is available, returns null and the caller should close the
+     * connection (we have no CID to use that satisfies the peer's
+     * watermark).
+     *
+     * If a path validation happens to be in progress when this
+     * fires, the in-flight challenge's CID may itself fall under
+     * the watermark — abandon the validation and queue the failed
+     * sequence for retire alongside the swap.
+     */
+    fun forceRotateToHigherSequence(): ForcedRotationResult? {
+        if (activeCidSequence >= retirePriorToWatermark) return null
+        val (seq, entry) = unusedCids.entries.firstOrNull() ?: return ForcedRotationResult.NoSpareCid
+        unusedCids.remove(seq)
+        val priorSeq = activeCidSequence
+        queueRetireSequence(priorSeq)
+        activeCidSequence = seq
+
+        // If we were mid-validation, the challenge we issued is
+        // for a CID that may now be retired (priorSeq could be
+        // the seq we were trying to validate). Abandon it.
+        val s = state
+        if (s is PathValidationState.Validating) {
+            queueRetireSequence(s.newCidSequence)
+            pendingChallenges.removeAll { it.contentEquals(s.challengeData) }
+            state = PathValidationState.Failed
+            failedValidations += 1
+        }
+        return ForcedRotationResult.Rotated(newSequence = seq, connectionId = entry.connectionId, retiredSequence = priorSeq)
+    }
+
+    sealed class ForcedRotationResult {
+        /**
+         * Watermark moved past active CID but the pool was empty —
+         * the caller cannot satisfy the spec MUST. RFC 9000 §5.1.2
+         * leaves the recovery to the caller; closing the connection
+         * with CONNECTION_ID_LIMIT_ERROR is the safe default.
+         */
+        object NoSpareCid : ForcedRotationResult()
+
+        data class Rotated(
+            val newSequence: Long,
+            val connectionId: ByteArray,
+            val retiredSequence: Long,
+        ) : ForcedRotationResult() {
+            override fun equals(other: Any?): Boolean {
+                if (this === other) return true
+                if (other !is Rotated) return false
+                return newSequence == other.newSequence &&
+                    connectionId.contentEquals(other.connectionId) &&
+                    retiredSequence == other.retiredSequence
+            }
+
+            override fun hashCode(): Int {
+                var h = newSequence.hashCode()
+                h = 31 * h + connectionId.contentHashCode()
+                h = 31 * h + retiredSequence.hashCode()
+                return h
+            }
         }
     }
 

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/PathValidator.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/PathValidator.kt
@@ -1,0 +1,534 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quic.connection
+
+import com.vitorpamplona.quartz.utils.RandomInstance
+
+/**
+ * Single connection ID the peer (server) has issued to us via a
+ * `NEW_CONNECTION_ID` frame (RFC 9000 §19.15) and we have NOT yet
+ * retired. The initial DCID negotiated during the handshake is
+ * implicitly sequence number 0 (RFC 9000 §5.1.1).
+ *
+ * `connectionId` is the bytes the writer would stamp into outbound
+ * short-header packets; `statelessResetToken` is the 16-byte token
+ * we'd compare against an incoming stateless reset.
+ */
+data class PeerConnectionIdEntry(
+    val sequenceNumber: Long,
+    val connectionId: ByteArray,
+    val statelessResetToken: ByteArray,
+) {
+    init {
+        require(connectionId.isNotEmpty()) { "connection id must not be empty" }
+        require(statelessResetToken.size == 16) { "stateless reset token must be 16 bytes" }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PeerConnectionIdEntry) return false
+        return sequenceNumber == other.sequenceNumber &&
+            connectionId.contentEquals(other.connectionId) &&
+            statelessResetToken.contentEquals(other.statelessResetToken)
+    }
+
+    override fun hashCode(): Int {
+        var h = sequenceNumber.hashCode()
+        h = 31 * h + connectionId.contentHashCode()
+        h = 31 * h + statelessResetToken.contentHashCode()
+        return h
+    }
+}
+
+/**
+ * Where the path validation state machine currently sits (RFC 9000
+ * §8.2 / §9). Most installations spend their entire life in [Idle];
+ * the transition to [Validating] happens when the driver detects the
+ * current path looks dead (consecutive PTOs without ACKs) and asks
+ * the connection to migrate to a fresh DCID.
+ *
+ *  - [Idle]: nothing in flight; the writer is happily using the
+ *    current DCID.
+ *  - [Validating]: a `PATH_CHALLENGE` is on the wire (or queued for
+ *    the next outbound) and we're waiting for a matching
+ *    `PATH_RESPONSE` with the SAME 8-byte payload.
+ *  - [Succeeded]: the peer echoed the payload; the writer has
+ *    switched to the new DCID and a `RETIRE_CONNECTION_ID` for the
+ *    old sequence number is queued.
+ *  - [Failed]: validation didn't complete inside the 3*PTO window
+ *    (RFC 9000 §8.2.4) — caller may retry with a different CID, or
+ *    surface the failure as a connection close.
+ */
+sealed class PathValidationState {
+    object Idle : PathValidationState()
+
+    data class Validating(
+        val challengeData: ByteArray,
+        val newCidSequence: Long,
+        val newCidBytes: ByteArray,
+        val priorCidSequence: Long,
+        val startedAtMillis: Long,
+        val priorPtoMillis: Long,
+    ) : PathValidationState() {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Validating) return false
+            return challengeData.contentEquals(other.challengeData) &&
+                newCidSequence == other.newCidSequence &&
+                newCidBytes.contentEquals(other.newCidBytes) &&
+                priorCidSequence == other.priorCidSequence &&
+                startedAtMillis == other.startedAtMillis &&
+                priorPtoMillis == other.priorPtoMillis
+        }
+
+        override fun hashCode(): Int {
+            var h = challengeData.contentHashCode()
+            h = 31 * h + newCidSequence.hashCode()
+            h = 31 * h + newCidBytes.contentHashCode()
+            h = 31 * h + priorCidSequence.hashCode()
+            h = 31 * h + startedAtMillis.hashCode()
+            h = 31 * h + priorPtoMillis.hashCode()
+            return h
+        }
+    }
+
+    object Succeeded : PathValidationState()
+
+    object Failed : PathValidationState()
+}
+
+/**
+ * Outcome of [PathValidator.tryStartValidation], used by the caller
+ * (driver / test) to know whether a probe was actually issued.
+ */
+enum class PathMigrationResult {
+    /** A `PATH_CHALLENGE` was queued; state is [PathValidationState.Validating]. */
+    Started,
+
+    /**
+     * Already in [PathValidationState.Validating] — the previous
+     * attempt hasn't resolved yet. Caller should not pile on; the
+     * existing challenge will resolve via PATH_RESPONSE or fail
+     * via [PathValidator.checkValidationTimeout].
+     */
+    AlreadyInProgress,
+
+    /**
+     * No spare CID in the pool. The peer hasn't yet issued a
+     * NEW_CONNECTION_ID we can use, or we've already drained the
+     * pool. Caller should wait for fresh peer offers.
+     */
+    NoSpareCid,
+}
+
+/**
+ * Per-connection state for client-initiated path validation + DCID
+ * rotation (RFC 9000 §9). Owned by [QuicConnection]; the parser and
+ * writer call into it under `streamsLock`.
+ *
+ * Spec mapping:
+ *   - **§5.1.1** initial DCID is sequence number 0.
+ *   - **§5.1.2** at most `active_connection_id_limit` CIDs
+ *     simultaneously usable; the limit is the PEER's transport
+ *     parameter telling us how many of OUR source CIDs they'll
+ *     hold, but reciprocally we cap the peer's pool the same way
+ *     so a buggy server can't pin arbitrary memory by spamming
+ *     NEW_CONNECTION_ID frames.
+ *   - **§5.1.2** `retire_prior_to` in a NEW_CONNECTION_ID frame
+ *     forces us to retire every previously-issued CID with a
+ *     smaller sequence number (and queue RETIRE_CONNECTION_ID for
+ *     each). The `retire_prior_to` value MUST NOT decrease across
+ *     successive frames; we treat a regression as a peer protocol
+ *     violation and abort the connection upstream.
+ *   - **§8.2 / §9** path validation: pick a spare CID, issue
+ *     PATH_CHALLENGE with a cryptographically random 8-byte
+ *     payload, await a PATH_RESPONSE that echoes the payload byte
+ *     for byte. RFC 9000 §8.2.4: validation MUST be abandoned after
+ *     `3 * PTO` of inactivity.
+ *   - **§19.16** RETIRE_CONNECTION_ID is reliable; the dispatcher
+ *     re-queues on loss until ACK'd.
+ *
+ * Thread safety: every method here assumes the caller holds the
+ * connection's `streamsLock`. The pool / outstanding-challenge maps
+ * are plain mutable collections.
+ */
+class PathValidator(
+    /**
+     * Sequence number of the CID the writer is currently stamping
+     * into outbound short-header packets. Initial value 0 per RFC
+     * 9000 §5.1.1 — the DCID negotiated at handshake. After a
+     * successful validation [activeCidSequence] is the new
+     * sequence; the prior sequence is in `pendingRetireSequences`
+     * waiting to ride out as a RETIRE_CONNECTION_ID.
+     */
+    initialActiveCidSequence: Long = 0L,
+    /**
+     * Cap on the number of unused CIDs we'll buffer. Defaults to
+     * the peer's `active_connection_id_limit` transport parameter,
+     * but the connection caller may pass a tighter cap. Excess
+     * NEW_CONNECTION_ID offers past this cap are silently dropped
+     * — the peer is in violation of the limit it asked us to
+     * advertise (or never advertised one) and we don't owe it
+     * indefinite buffering.
+     */
+    private val maxUnusedCids: Int = DEFAULT_MAX_UNUSED_CIDS,
+    /**
+     * Cryptographically random 8-byte payload generator used for
+     * outbound PATH_CHALLENGE. Default uses [RandomInstance]; tests
+     * can substitute a deterministic supplier so assertions can
+     * compare the on-wire payload against a known value.
+     */
+    private val challengePayloadFactory: () -> ByteArray = { RandomInstance.bytes(8) },
+) {
+    /**
+     * Sequence number → entry. Holds CIDs the peer has issued and
+     * we have NOT yet retired or activated. The active CID itself
+     * is NOT in this map (it's held by the connection's
+     * `destinationConnectionId` field); only the spare pool lives
+     * here.
+     *
+     * LinkedHashMap so iteration order matches issuance order — when
+     * we pick a CID for a fresh validation we prefer the lowest
+     * sequence number for FIFO fairness.
+     */
+    private val unusedCids: LinkedHashMap<Long, PeerConnectionIdEntry> = LinkedHashMap()
+
+    /**
+     * Highest `retire_prior_to` value the peer has ever advertised.
+     * Per RFC 9000 §5.1.2 this MUST NOT decrease; a decrease is a
+     * peer protocol violation. Used to decide whether a
+     * just-arrived NEW_CONNECTION_ID with a sequence number ≤
+     * [retirePriorToWatermark] is stale (drop it) or whether a
+     * previously-cached entry has now been forced into retirement.
+     */
+    var retirePriorToWatermark: Long = 0L
+        private set
+
+    var activeCidSequence: Long = initialActiveCidSequence
+        private set
+
+    /**
+     * Sequence numbers of CIDs we owe the peer a
+     * `RETIRE_CONNECTION_ID` for. Drained by the writer on the
+     * next outbound application packet. Re-populated by the loss
+     * dispatcher if our RETIRE_CONNECTION_ID was lost.
+     */
+    val pendingRetireSequences: ArrayDeque<Long> = ArrayDeque()
+
+    /**
+     * Outbound `PATH_CHALLENGE` payloads the writer should drain on
+     * the next application-level packet. Populated by
+     * [tryStartValidation]; emptied by the writer after encoding
+     * (the writer also records a [com.vitorpamplona.quic.connection.recovery.RecoveryToken.PathChallenge]
+     * so the loss dispatcher can decide to retransmit or abandon).
+     */
+    val pendingChallenges: ArrayDeque<ByteArray> = ArrayDeque()
+
+    var state: PathValidationState = PathValidationState.Idle
+        private set
+
+    /**
+     * Total number of validations that have completed successfully
+     * over the lifetime of this connection. Diagnostic only — used
+     * by tests and qlog to assert "exactly one rotation happened".
+     */
+    var successfulValidations: Long = 0L
+        private set
+
+    /**
+     * Total number of validations that timed out / were abandoned.
+     * Counter-part of [successfulValidations].
+     */
+    var failedValidations: Long = 0L
+        private set
+
+    /**
+     * Number of unused CIDs currently in the pool. Used by tests
+     * (and the connection's diagnostic surface) to assert the peer
+     * actually offered new CIDs we can rotate to.
+     */
+    fun unusedCount(): Int = unusedCids.size
+
+    fun unusedSequences(): List<Long> = unusedCids.keys.toList()
+
+    /**
+     * Record a peer-issued `NEW_CONNECTION_ID` (RFC 9000 §19.15).
+     * Returns the result code so the caller (parser) can decide
+     * whether to close the connection on a peer protocol violation.
+     *
+     * The semantics:
+     *  - If [retirePriorTo] is greater than [sequenceNumber], that's
+     *    a §19.15 violation (the peer can't tell us to retire its
+     *    own brand-new CID).
+     *  - If [retirePriorTo] decreased, that's a §5.1.2 violation.
+     *  - If the new entry would push the pool past [maxUnusedCids],
+     *    return [Result.PoolFull] — the peer over-issued.
+     *  - If [sequenceNumber] is below the current
+     *    [retirePriorToWatermark], the offer is already-retired and
+     *    we silently drop it (the caller MUST still queue a
+     *    RETIRE_CONNECTION_ID for it per §5.1.2).
+     *  - Duplicate sequence number with matching CID/token is
+     *    idempotent ([Result.Duplicate]); a duplicate sequence with
+     *    DIFFERENT bytes is a §19.15 violation.
+     *
+     * Side effect on success: any cached entry whose sequence
+     * number is now below the new [retirePriorTo] is moved into
+     * [pendingRetireSequences] (we owe the peer a retire) and
+     * dropped from [unusedCids]. If the active CID itself is
+     * forced-retired, the active sequence is bumped (the caller
+     * must rotate the active CID — see [forceRetireActiveIfNeeded]).
+     */
+    fun recordPeerNewConnectionId(
+        sequenceNumber: Long,
+        retirePriorTo: Long,
+        connectionId: ByteArray,
+        statelessResetToken: ByteArray,
+    ): RecordResult {
+        if (retirePriorTo > sequenceNumber) return RecordResult.RetirePriorToExceedsSequence
+        if (connectionId.isEmpty() || connectionId.size > 20) return RecordResult.InvalidCidLength
+        if (statelessResetToken.size != 16) return RecordResult.InvalidStatelessResetToken
+
+        // RFC 9000 §19.15: a smaller `retire_prior_to` than what we
+        // previously saw "MUST be treated as the largest one it has
+        // seen". This handles reordered NEW_CONNECTION_ID arrivals
+        // — not a protocol violation, just clamp.
+        val effectiveRetirePriorTo = if (retirePriorTo < retirePriorToWatermark) retirePriorToWatermark else retirePriorTo
+
+        // §5.1.2: bump the watermark and force-retire any cached
+        // entries that fall under it. This step happens BEFORE the
+        // duplicate check so a sequence number that's just been
+        // dropped doesn't survive on a stale entry.
+        if (effectiveRetirePriorTo > retirePriorToWatermark) {
+            retirePriorToWatermark = effectiveRetirePriorTo
+            val it = unusedCids.entries.iterator()
+            while (it.hasNext()) {
+                val (seq, _) = it.next()
+                if (seq < retirePriorToWatermark) {
+                    queueRetireSequence(seq)
+                    it.remove()
+                }
+            }
+        }
+
+        // Stale offer: the peer is pushing a sequence number we've
+        // already retired. Per §5.1.2 we owe a RETIRE_CONNECTION_ID
+        // back; queue it but don't add the entry to the pool.
+        if (sequenceNumber < retirePriorToWatermark) {
+            queueRetireSequence(sequenceNumber)
+            return RecordResult.AlreadyRetired
+        }
+
+        // Duplicate handling.
+        val existing = unusedCids[sequenceNumber]
+        if (existing != null) {
+            if (!existing.connectionId.contentEquals(connectionId) ||
+                !existing.statelessResetToken.contentEquals(statelessResetToken)
+            ) {
+                return RecordResult.DuplicateSequenceMismatch
+            }
+            return RecordResult.Duplicate
+        }
+
+        if (unusedCids.size >= maxUnusedCids) return RecordResult.PoolFull
+
+        unusedCids[sequenceNumber] =
+            PeerConnectionIdEntry(
+                sequenceNumber = sequenceNumber,
+                connectionId = connectionId.copyOf(),
+                statelessResetToken = statelessResetToken.copyOf(),
+            )
+        return RecordResult.Stored
+    }
+
+    /**
+     * Result of [recordPeerNewConnectionId].
+     */
+    enum class RecordResult {
+        Stored,
+        Duplicate,
+        DuplicateSequenceMismatch,
+        AlreadyRetired,
+        PoolFull,
+        RetirePriorToExceedsSequence,
+        InvalidCidLength,
+        InvalidStatelessResetToken,
+    }
+
+    /**
+     * Append [sequenceNumber] to [pendingRetireSequences] iff it
+     * isn't already queued. Idempotent — a duplicate request from
+     * the loss dispatcher (re-queue on loss) finds the entry
+     * already there and is a no-op.
+     */
+    fun queueRetireSequence(sequenceNumber: Long) {
+        if (!pendingRetireSequences.contains(sequenceNumber)) {
+            pendingRetireSequences.addLast(sequenceNumber)
+        }
+    }
+
+    /**
+     * Begin a fresh path-validation attempt. Picks the lowest-sequence
+     * unused CID, generates a random 8-byte challenge, queues both,
+     * and transitions [state] to [PathValidationState.Validating].
+     *
+     * Caller is responsible for waking the writer so the challenge
+     * actually goes out. The writer also stamps the new DCID into
+     * the next outbound short-header packet — see
+     * [QuicConnection.activatePendingValidatedCid] for the post-
+     * response promotion path.
+     */
+    fun tryStartValidation(
+        nowMillis: Long,
+        currentPtoMillis: Long,
+    ): PathMigrationResult {
+        if (state is PathValidationState.Validating) return PathMigrationResult.AlreadyInProgress
+        val (seq, entry) = unusedCids.entries.firstOrNull() ?: return PathMigrationResult.NoSpareCid
+        unusedCids.remove(seq)
+        val payload =
+            challengePayloadFactory().also {
+                require(it.size == 8) { "challenge payload supplier must return 8 bytes" }
+            }
+        pendingChallenges.addLast(payload)
+        state =
+            PathValidationState.Validating(
+                challengeData = payload,
+                newCidSequence = seq,
+                newCidBytes = entry.connectionId,
+                priorCidSequence = activeCidSequence,
+                startedAtMillis = nowMillis,
+                priorPtoMillis = currentPtoMillis,
+            )
+        return PathMigrationResult.Started
+    }
+
+    /**
+     * Process an inbound `PATH_RESPONSE` payload. Returns true when
+     * it matched the outstanding challenge and the migration just
+     * completed; false if there's no outstanding challenge or the
+     * payload doesn't match (an attacker echoing random bytes).
+     *
+     * Side effects on success:
+     *  - [state] transitions to [PathValidationState.Succeeded].
+     *  - [activeCidSequence] is bumped to the validated sequence.
+     *  - The prior sequence is queued for RETIRE_CONNECTION_ID.
+     *  - Returns the new entry so the connection can swap its
+     *    `destinationConnectionId` field.
+     */
+    fun applyPathResponse(payload: ByteArray): ValidationOutcome {
+        val current = state as? PathValidationState.Validating ?: return ValidationOutcome.NotValidating
+        if (!payload.contentEquals(current.challengeData)) return ValidationOutcome.PayloadMismatch
+        val priorSeq = activeCidSequence
+        activeCidSequence = current.newCidSequence
+        if (priorSeq != current.newCidSequence) queueRetireSequence(priorSeq)
+        state = PathValidationState.Succeeded
+        successfulValidations += 1
+        return ValidationOutcome.Validated(
+            newSequence = current.newCidSequence,
+            newConnectionIdBytes = current.newCidBytes,
+            retiredSequence = priorSeq,
+        )
+    }
+
+    sealed class ValidationOutcome {
+        object NotValidating : ValidationOutcome()
+
+        object PayloadMismatch : ValidationOutcome()
+
+        data class Validated(
+            val newSequence: Long,
+            val newConnectionIdBytes: ByteArray,
+            val retiredSequence: Long,
+        ) : ValidationOutcome() {
+            override fun equals(other: Any?): Boolean {
+                if (this === other) return true
+                if (other !is Validated) return false
+                return newSequence == other.newSequence &&
+                    newConnectionIdBytes.contentEquals(other.newConnectionIdBytes) &&
+                    retiredSequence == other.retiredSequence
+            }
+
+            override fun hashCode(): Int {
+                var h = newSequence.hashCode()
+                h = 31 * h + newConnectionIdBytes.contentHashCode()
+                h = 31 * h + retiredSequence.hashCode()
+                return h
+            }
+        }
+    }
+
+    /**
+     * RFC 9000 §8.2.4: abandon validation if more than 3 * PTO has
+     * elapsed since the challenge went out without a matching
+     * response. Returns the abandoned context (so the caller can
+     * surface a qlog event / decide whether to attempt another
+     * rotation), or null if no validation is in progress / the
+     * timer hasn't fired yet.
+     */
+    fun checkValidationTimeout(nowMillis: Long): PathValidationState.Validating? {
+        val current = state as? PathValidationState.Validating ?: return null
+        val elapsed = nowMillis - current.startedAtMillis
+        val budget = (current.priorPtoMillis * VALIDATION_PTO_BUDGET_MULTIPLIER).coerceAtLeast(MIN_VALIDATION_BUDGET_MS)
+        if (elapsed < budget) return null
+        state = PathValidationState.Failed
+        failedValidations += 1
+        return current
+    }
+
+    /**
+     * Reset to [PathValidationState.Idle] after the caller has
+     * surfaced a Succeeded / Failed transition. Allows the next
+     * trigger to start a fresh attempt without leaking the
+     * previous terminal state.
+     */
+    fun acknowledgeTerminal() {
+        if (state is PathValidationState.Succeeded || state is PathValidationState.Failed) {
+            state = PathValidationState.Idle
+        }
+    }
+
+    companion object {
+        /**
+         * Default cap on the unused-CID pool. RFC 9000 §18.2 default
+         * for `active_connection_id_limit` is 2, and the spec
+         * lower-bounds it at 2. A peer that issues more than its
+         * own advertised limit is misbehaving but harmless — we
+         * just cap at 8 here so a buggy server can't pin memory.
+         */
+        const val DEFAULT_MAX_UNUSED_CIDS: Int = 8
+
+        /**
+         * RFC 9000 §8.2.4: validation MUST be abandoned after
+         * 3 * PTO. We use 3.0 exactly; a slightly looser value
+         * (e.g. 4) wouldn't change correctness but might mask peer
+         * misbehavior in tests.
+         */
+        const val VALIDATION_PTO_BUDGET_MULTIPLIER: Long = 3L
+
+        /**
+         * Floor on the validation budget. PTO during the first RTT
+         * sample is ~300 ms (see [com.vitorpamplona.quic.connection.recovery.QuicLossDetection.INITIAL_RTT_MS]),
+         * so 3*PTO ≈ 900 ms. We add a generous floor so test paths
+         * with an artificially-tiny RTT still get a real chance to
+         * complete validation before the timer fires.
+         */
+        const val MIN_VALIDATION_BUDGET_MS: Long = 250L
+    }
+}

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
@@ -560,7 +560,17 @@ class QuicConnection(
      * PTO expiration without an intervening ACK; reset to 0 when an
      * inbound ACK acknowledges any ack-eliciting packet. The driver
      * doubles its sleep between probes by `1 shl consecutivePtoCount`.
+     *
+     * `@Volatile` because the driver's send-loop reads this without
+     * holding `streamsLock` (in the backoff calculation in
+     * [QuicConnectionDriver.sendLoopBody]), while three writers
+     * mutate it: the driver's PTO firing path, the parser's ACK
+     * handler resetting on inbound ACK, and the
+     * [applyPeerPathResponseLocked] reset on successful migration.
+     * Without volatility the JIT can cache a stale value
+     * indefinitely and the backoff multiplier grows unbounded.
      */
+    @Volatile
     internal var consecutivePtoCount: Int = 0
 
     /**
@@ -1911,13 +1921,15 @@ class QuicConnection(
      * RFC 9000 §19.15: store a peer-issued connection ID into the
      * [pathValidator] pool, enforcing `retire_prior_to` semantics
      * and capping pool size. On a peer protocol violation
-     * ([PathValidator.RecordResult.RetirePriorToExceedsSequence] /
-     * [PathValidator.RecordResult.RetirePriorToRegressed] /
-     * [PathValidator.RecordResult.DuplicateSequenceMismatch] /
-     * [PathValidator.RecordResult.InvalidCidLength] /
-     * [PathValidator.RecordResult.InvalidStatelessResetToken]) the
-     * connection is closed with FRAME_ENCODING_ERROR — these are
-     * MUSTs in the spec.
+     * the connection is closed with FRAME_ENCODING_ERROR /
+     * PROTOCOL_VIOLATION — these are MUSTs in the spec.
+     *
+     * After a successful store, if the peer's `retire_prior_to`
+     * has advanced past our currently-active CID sequence,
+     * RFC 9000 §5.1.2 obligates us to "retire the active
+     * connection ID and adopt one with a higher sequence number."
+     * That's a server-forced rotation on the same path — no
+     * PATH_CHALLENGE needed (Bug-C fix).
      *
      * Caller must hold [streamsLock].
      */
@@ -1927,23 +1939,18 @@ class QuicConnection(
         connectionId: ByteArray,
         statelessResetToken: ByteArray,
     ) {
-        when (
+        val recordResult =
             pathValidator.recordPeerNewConnectionId(
                 sequenceNumber = sequenceNumber,
                 retirePriorTo = retirePriorTo,
                 connectionId = connectionId,
                 statelessResetToken = statelessResetToken,
             )
-        ) {
-            PathValidator.RecordResult.Stored -> {
-                Unit
-            }
-
-            PathValidator.RecordResult.Duplicate -> {
-                Unit
-            }
-
-            PathValidator.RecordResult.AlreadyRetired -> {
+        when (recordResult) {
+            PathValidator.RecordResult.Stored,
+            PathValidator.RecordResult.Duplicate,
+            PathValidator.RecordResult.AlreadyRetired,
+            -> {
                 Unit
             }
 
@@ -1953,31 +1960,65 @@ class QuicConnection(
                 // we MAY treat this as CONNECTION_ID_LIMIT_ERROR. We
                 // only drop silently here — pinning memory is the
                 // real concern, and the cap defense already handled
-                // that.
+                // that. Skip the watermark check below; this offer
+                // wasn't accepted.
+                return
             }
 
             PathValidator.RecordResult.RetirePriorToExceedsSequence -> {
                 markClosedExternally(
                     "FRAME_ENCODING_ERROR: NEW_CONNECTION_ID retire_prior_to ($retirePriorTo) > sequence_number ($sequenceNumber)",
                 )
+                return
             }
 
             PathValidator.RecordResult.DuplicateSequenceMismatch -> {
                 markClosedExternally(
                     "PROTOCOL_VIOLATION: NEW_CONNECTION_ID seq=$sequenceNumber re-issued with different bytes",
                 )
+                return
             }
 
             PathValidator.RecordResult.InvalidCidLength -> {
                 markClosedExternally(
                     "FRAME_ENCODING_ERROR: NEW_CONNECTION_ID has invalid cid length",
                 )
+                return
             }
 
             PathValidator.RecordResult.InvalidStatelessResetToken -> {
                 markClosedExternally(
                     "FRAME_ENCODING_ERROR: NEW_CONNECTION_ID has invalid stateless reset token length",
                 )
+                return
+            }
+        }
+
+        // Bug-C fix: §5.1.2 server-forced rotation. The watermark
+        // may have advanced past our active CID as a side effect of
+        // [recordPeerNewConnectionId]. If so we MUST swap on the
+        // same path before the next outbound packet (which would
+        // otherwise stamp a now-retired CID).
+        when (val rotation = pathValidator.forceRotateToHigherSequence()) {
+            null -> {
+                Unit
+            }
+
+            // active CID is still valid; nothing to do.
+            PathValidator.ForcedRotationResult.NoSpareCid -> {
+                // Watermark forced retirement of the active CID but
+                // the pool is empty — we have nothing valid to use.
+                // RFC 9000 §5.1.2 leaves recovery to the endpoint;
+                // CONNECTION_ID_LIMIT_ERROR is the canonical close.
+                markClosedExternally(
+                    "CONNECTION_ID_LIMIT_ERROR: peer retired our active CID with no spare available",
+                )
+            }
+
+            is PathValidator.ForcedRotationResult.Rotated -> {
+                destinationConnectionId = ConnectionId(rotation.connectionId)
+                qlogObserver.onConnectionIdActivated("peer", rotation.newSequence, rotation.connectionId)
+                qlogObserver.onConnectionIdRetired("peer", rotation.retiredSequence)
             }
         }
     }
@@ -2014,14 +2055,12 @@ class QuicConnection(
                 qlogObserver.onConnectionIdActivated("peer", outcome.newSequence, outcome.connectionId)
                 qlogObserver.onConnectionIdRetired("peer", outcome.retiredSequence)
                 pathValidator.acknowledgeTerminal()
-                // Note: the writer's `destinationConnectionId` was
-                // already swapped to [outcome.connectionId] inside
+                // The writer's `destinationConnectionId` was already
+                // swapped at challenge time inside
                 // [triggerPathMigrationLocked] (abrupt-migration
-                // model — the challenge itself MUST go out on the
-                // new path per RFC 9000 §9.3). On success there's
-                // nothing more to swap; we just confirm the
-                // promotion is durable by re-stamping (idempotent).
-                destinationConnectionId = ConnectionId(outcome.connectionId)
+                // model — RFC 9000 §9.3 requires the challenge on
+                // the new path). On success there is no further
+                // mutation to make.
             }
         }
     }

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
@@ -519,11 +519,15 @@ class QuicConnection(
      */
     internal val pathValidator: PathValidator =
         PathValidator(
-            initialActiveCidSequence = 0L,
+            // Cap the unused-CID buffer at the smaller of our own
+            // [activeConnectionIdLimit] (which we advertised to the
+            // peer in transport parameters) and the validator's hard
+            // [PathValidator.DEFAULT_MAX_UNUSED_CIDS] memory cap. A
+            // peer that issues more CIDs than we said we'd accept
+            // hits the cap and excess offers are dropped.
             maxUnusedCids =
                 config.activeConnectionIdLimit
                     .coerceAtMost(PathValidator.DEFAULT_MAX_UNUSED_CIDS.toLong())
-                    .coerceAtLeast(2L)
                     .toInt(),
         )
 
@@ -2000,60 +2004,99 @@ class QuicConnection(
             }
 
             is PathValidator.ValidationOutcome.Validated -> {
-                destinationConnectionId = ConnectionId(outcome.newConnectionIdBytes)
+                // Bug-7 fix: a valid PATH_RESPONSE proves the peer
+                // can reach us on the new path. Reset the PTO
+                // backoff so the send loop returns to baseline
+                // pacing instead of carrying a stale "many PTOs
+                // expired" multiplier into healthy traffic.
+                consecutivePtoCount = 0
                 qlogObserver.onPathValidationSucceeded(outcome.newSequence)
-                qlogObserver.onConnectionIdActivated("peer", outcome.newSequence, outcome.newConnectionIdBytes)
+                qlogObserver.onConnectionIdActivated("peer", outcome.newSequence, outcome.connectionId)
+                qlogObserver.onConnectionIdRetired("peer", outcome.retiredSequence)
                 pathValidator.acknowledgeTerminal()
+                // Note: the writer's `destinationConnectionId` was
+                // already swapped to [outcome.connectionId] inside
+                // [triggerPathMigrationLocked] (abrupt-migration
+                // model — the challenge itself MUST go out on the
+                // new path per RFC 9000 §9.3). On success there's
+                // nothing more to swap; we just confirm the
+                // promotion is durable by re-stamping (idempotent).
+                destinationConnectionId = ConnectionId(outcome.connectionId)
             }
         }
     }
 
     /**
      * RFC 9000 §19.16: peer asked us to retire one of our own
-     * source CIDs. Today we only ever issue one source CID at
-     * connection start (sequence 0), so any RETIRE_CONNECTION_ID
-     * the peer sends about a sequence > 0 references a CID we
-     * never issued — RFC 9000 says this is PROTOCOL_VIOLATION.
-     * Sequence 0 retire is also a violation per §19.16: "Receipt
-     * of a RETIRE_CONNECTION_ID frame containing a sequence number
-     * greater than any previously sent to the peer MUST be
-     * treated as a connection error of type PROTOCOL_VIOLATION."
+     * source CIDs.
+     *
+     * Two cases:
+     *  - Sequence > 0: we never issued anything beyond seq 0, so
+     *    this references a CID we never advertised. PROTOCOL_VIOLATION
+     *    per §19.16.
+     *  - Sequence == 0: peer is asking us to retire the SCID we
+     *    picked at connection start. Per RFC 9000 §5.1.1 we'd be
+     *    expected to have already issued a replacement via
+     *    NEW_CONNECTION_ID and switch the peer to it. We don't
+     *    issue our own NEW_CONNECTION_ID frames today, so we have
+     *    no replacement to give the peer. Closing the connection
+     *    surfaces this as a known limitation rather than continuing
+     *    against a peer that thinks we agreed to stop using our
+     *    only CID.
      *
      * Caller must hold [streamsLock].
      */
     internal fun applyPeerRetireConnectionIdLocked(sequenceNumber: Long) {
-        // We only issue sequence 0 today; any retire request beyond
-        // that references a CID we never advertised. This is a
-        // peer-side violation per §19.16.
         if (sequenceNumber > 0L) {
             markClosedExternally(
                 "PROTOCOL_VIOLATION: RETIRE_CONNECTION_ID seq=$sequenceNumber > any we issued (0)",
             )
+            return
         }
-        // Sequence 0 retire today means "stop using your initial
-        // SCID." We don't model client-issued CID rotation, so the
-        // request is silently honored at the protocol level (we
-        // never re-use the SCID in any new long-header packet —
-        // long headers are gone after handshake completion).
+        // Sequence 0: peer wants us off our initial SCID, but we
+        // haven't issued any replacements. Close — see kdoc above.
+        markClosedExternally(
+            "INTERNAL_ERROR: peer asked to retire our initial SCID but we have no replacement to offer",
+        )
     }
 
     /**
      * Try to start client-initiated path validation + DCID rotation
      * (RFC 9000 §9). Picks the lowest-sequence unused CID from the
-     * pool, queues a fresh PATH_CHALLENGE, and records the
-     * outstanding state. Returns the result so the caller can
-     * decide whether to retry later (e.g. on the next PTO if the
-     * pool was empty when this fired).
+     * pool, queues a fresh PATH_CHALLENGE, **swaps the writer's
+     * outbound DCID to the new CID**, and records the outstanding
+     * state. Returns the result so the caller can decide whether
+     * to retry later (e.g. on the next PTO if the pool was empty
+     * when this fired).
      *
-     * Caller must hold [streamsLock].
+     * Bug-1 fix — abrupt-migration model: the writer stamps a
+     * single connection-level [destinationConnectionId] onto every
+     * outbound short-header packet. To put the PATH_CHALLENGE on
+     * the new path (RFC 9000 §9.3) we rotate the DCID immediately
+     * here, not on validation success. The trigger condition
+     * ("path probably dead — N consecutive PTOs without ACKs")
+     * makes abrupt migration appropriate; we don't gain anything
+     * by holding the old DCID alongside. If validation later fails
+     * (3 * PTO timeout), [checkPathValidationTimeoutLocked]
+     * abandons the new CID without rolling back — by then the
+     * connection is in trouble and the next PTO either picks
+     * another spare CID or the connection idles out.
+     *
+     * Caller must hold [streamsLock]. Refuses to start before
+     * handshake confirmation per RFC 9000 §9.1 (returns
+     * [PathMigrationResult.NotConnected]).
      */
     internal fun triggerPathMigrationLocked(
         nowMillis: Long,
         currentPtoMillis: Long,
     ): PathMigrationResult {
+        if (!handshakeComplete || status != Status.CONNECTED) {
+            return PathMigrationResult.NotConnected
+        }
         val result = pathValidator.tryStartValidation(nowMillis, currentPtoMillis)
         if (result == PathMigrationResult.Started) {
             val validating = pathValidator.state as PathValidationState.Validating
+            destinationConnectionId = ConnectionId(validating.newConnectionId)
             qlogObserver.onPathValidationStarted(validating.newCidSequence)
         }
         return result
@@ -2073,16 +2116,22 @@ class QuicConnection(
     /**
      * Check whether an outstanding PATH_CHALLENGE has exceeded the
      * 3 * PTO budget (RFC 9000 §8.2.4). Called from the driver's
-     * PTO timer path. Returns true when validation just timed out
-     * — caller may surface that to qlog and decide to retry with
-     * another CID, or close the connection if the budget for
-     * retries is exhausted.
+     * PTO timer path. Returns true when validation just timed out.
+     *
+     * On timeout the validator queues the failed CID's sequence
+     * number into [PathValidator.pendingRetireSequences] (Bug-2
+     * fix) so the writer's next drain emits a
+     * RETIRE_CONNECTION_ID. Without this the peer keeps the
+     * routing entry forever — we promised by sending the challenge
+     * that we might use the CID, and §5.1.2 obligates us to
+     * retire it once we abandon it.
      *
      * Caller must hold [streamsLock].
      */
     internal fun checkPathValidationTimeoutLocked(nowMillis: Long): Boolean {
         val abandoned = pathValidator.checkValidationTimeout(nowMillis) ?: return false
         qlogObserver.onPathValidationFailed(abandoned.newCidSequence)
+        qlogObserver.onConnectionIdRetired("peer", abandoned.newCidSequence)
         pathValidator.acknowledgeTerminal()
         return true
     }

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
@@ -506,6 +506,28 @@ class QuicConnection(
     internal val pendingPathChallengePayloads: ArrayDeque<ByteArray> = ArrayDeque()
 
     /**
+     * RFC 9000 §9 client-initiated path validation + DCID rotation.
+     * The pool of unused peer-issued connection IDs, the outbound
+     * `PATH_CHALLENGE` queue, the matching state machine, and the
+     * `RETIRE_CONNECTION_ID` retransmit queue all live here. The
+     * parser populates the pool from inbound `NEW_CONNECTION_ID`;
+     * the writer drains the challenge + retire queues; the driver
+     * triggers a fresh validation when consecutive PTO threshold is
+     * exceeded.
+     *
+     * Caller of any read/write must hold [streamsLock].
+     */
+    internal val pathValidator: PathValidator =
+        PathValidator(
+            initialActiveCidSequence = 0L,
+            maxUnusedCids =
+                config.activeConnectionIdLimit
+                    .coerceAtMost(PathValidator.DEFAULT_MAX_UNUSED_CIDS.toLong())
+                    .coerceAtLeast(2L)
+                    .toInt(),
+        )
+
+    /**
      * RFC 9002 RTT estimator + loss-detection algorithm. Single
      * shared instance per connection (RTT is per-path; we model a
      * single path). Per-space `largestAcked*` lives on
@@ -1882,6 +1904,190 @@ class QuicConnection(
     }
 
     /**
+     * RFC 9000 §19.15: store a peer-issued connection ID into the
+     * [pathValidator] pool, enforcing `retire_prior_to` semantics
+     * and capping pool size. On a peer protocol violation
+     * ([PathValidator.RecordResult.RetirePriorToExceedsSequence] /
+     * [PathValidator.RecordResult.RetirePriorToRegressed] /
+     * [PathValidator.RecordResult.DuplicateSequenceMismatch] /
+     * [PathValidator.RecordResult.InvalidCidLength] /
+     * [PathValidator.RecordResult.InvalidStatelessResetToken]) the
+     * connection is closed with FRAME_ENCODING_ERROR — these are
+     * MUSTs in the spec.
+     *
+     * Caller must hold [streamsLock].
+     */
+    internal fun applyPeerNewConnectionIdLocked(
+        sequenceNumber: Long,
+        retirePriorTo: Long,
+        connectionId: ByteArray,
+        statelessResetToken: ByteArray,
+    ) {
+        when (
+            pathValidator.recordPeerNewConnectionId(
+                sequenceNumber = sequenceNumber,
+                retirePriorTo = retirePriorTo,
+                connectionId = connectionId,
+                statelessResetToken = statelessResetToken,
+            )
+        ) {
+            PathValidator.RecordResult.Stored -> {
+                Unit
+            }
+
+            PathValidator.RecordResult.Duplicate -> {
+                Unit
+            }
+
+            PathValidator.RecordResult.AlreadyRetired -> {
+                Unit
+            }
+
+            PathValidator.RecordResult.PoolFull -> {
+                // Peer over-issued past its own advertised
+                // active_connection_id_limit. RFC 9000 §5.1.1 says
+                // we MAY treat this as CONNECTION_ID_LIMIT_ERROR. We
+                // only drop silently here — pinning memory is the
+                // real concern, and the cap defense already handled
+                // that.
+            }
+
+            PathValidator.RecordResult.RetirePriorToExceedsSequence -> {
+                markClosedExternally(
+                    "FRAME_ENCODING_ERROR: NEW_CONNECTION_ID retire_prior_to ($retirePriorTo) > sequence_number ($sequenceNumber)",
+                )
+            }
+
+            PathValidator.RecordResult.DuplicateSequenceMismatch -> {
+                markClosedExternally(
+                    "PROTOCOL_VIOLATION: NEW_CONNECTION_ID seq=$sequenceNumber re-issued with different bytes",
+                )
+            }
+
+            PathValidator.RecordResult.InvalidCidLength -> {
+                markClosedExternally(
+                    "FRAME_ENCODING_ERROR: NEW_CONNECTION_ID has invalid cid length",
+                )
+            }
+
+            PathValidator.RecordResult.InvalidStatelessResetToken -> {
+                markClosedExternally(
+                    "FRAME_ENCODING_ERROR: NEW_CONNECTION_ID has invalid stateless reset token length",
+                )
+            }
+        }
+    }
+
+    /**
+     * Process an inbound `PATH_RESPONSE` (RFC 9000 §19.18). If the
+     * payload matches our outstanding `PATH_CHALLENGE`, the writer
+     * gets a new `destinationConnectionId` to stamp into outbound
+     * short-headers and a `RETIRE_CONNECTION_ID` is queued for the
+     * old sequence number. Mismatches and unsolicited responses are
+     * silently dropped — RFC 9000 §8.2.2 says "an endpoint that
+     * receives a PATH_RESPONSE with a different payload than what
+     * it sent in the PATH_CHALLENGE on the path" is allowed to
+     * ignore.
+     *
+     * Caller must hold [streamsLock].
+     */
+    internal fun applyPeerPathResponseLocked(payload: ByteArray) {
+        when (val outcome = pathValidator.applyPathResponse(payload)) {
+            PathValidator.ValidationOutcome.NotValidating,
+            PathValidator.ValidationOutcome.PayloadMismatch,
+            -> {
+                Unit
+            }
+
+            is PathValidator.ValidationOutcome.Validated -> {
+                destinationConnectionId = ConnectionId(outcome.newConnectionIdBytes)
+                qlogObserver.onPathValidationSucceeded(outcome.newSequence)
+                qlogObserver.onConnectionIdActivated("peer", outcome.newSequence, outcome.newConnectionIdBytes)
+                pathValidator.acknowledgeTerminal()
+            }
+        }
+    }
+
+    /**
+     * RFC 9000 §19.16: peer asked us to retire one of our own
+     * source CIDs. Today we only ever issue one source CID at
+     * connection start (sequence 0), so any RETIRE_CONNECTION_ID
+     * the peer sends about a sequence > 0 references a CID we
+     * never issued — RFC 9000 says this is PROTOCOL_VIOLATION.
+     * Sequence 0 retire is also a violation per §19.16: "Receipt
+     * of a RETIRE_CONNECTION_ID frame containing a sequence number
+     * greater than any previously sent to the peer MUST be
+     * treated as a connection error of type PROTOCOL_VIOLATION."
+     *
+     * Caller must hold [streamsLock].
+     */
+    internal fun applyPeerRetireConnectionIdLocked(sequenceNumber: Long) {
+        // We only issue sequence 0 today; any retire request beyond
+        // that references a CID we never advertised. This is a
+        // peer-side violation per §19.16.
+        if (sequenceNumber > 0L) {
+            markClosedExternally(
+                "PROTOCOL_VIOLATION: RETIRE_CONNECTION_ID seq=$sequenceNumber > any we issued (0)",
+            )
+        }
+        // Sequence 0 retire today means "stop using your initial
+        // SCID." We don't model client-issued CID rotation, so the
+        // request is silently honored at the protocol level (we
+        // never re-use the SCID in any new long-header packet —
+        // long headers are gone after handshake completion).
+    }
+
+    /**
+     * Try to start client-initiated path validation + DCID rotation
+     * (RFC 9000 §9). Picks the lowest-sequence unused CID from the
+     * pool, queues a fresh PATH_CHALLENGE, and records the
+     * outstanding state. Returns the result so the caller can
+     * decide whether to retry later (e.g. on the next PTO if the
+     * pool was empty when this fired).
+     *
+     * Caller must hold [streamsLock].
+     */
+    internal fun triggerPathMigrationLocked(
+        nowMillis: Long,
+        currentPtoMillis: Long,
+    ): PathMigrationResult {
+        val result = pathValidator.tryStartValidation(nowMillis, currentPtoMillis)
+        if (result == PathMigrationResult.Started) {
+            val validating = pathValidator.state as PathValidationState.Validating
+            qlogObserver.onPathValidationStarted(validating.newCidSequence)
+        }
+        return result
+    }
+
+    /**
+     * Public counterpart to [triggerPathMigrationLocked] — acquires
+     * the lock internally. Suitable for application / driver code
+     * that wants to force a rotation without coupling to the
+     * locking discipline.
+     */
+    suspend fun triggerPathMigration(
+        nowMillis: Long = nowMillis(),
+        currentPtoMillis: Long = lossDetection.ptoBaseMs(peerTransportParameters?.maxAckDelay ?: 0L),
+    ): PathMigrationResult = streamsLock.withLock { triggerPathMigrationLocked(nowMillis, currentPtoMillis) }
+
+    /**
+     * Check whether an outstanding PATH_CHALLENGE has exceeded the
+     * 3 * PTO budget (RFC 9000 §8.2.4). Called from the driver's
+     * PTO timer path. Returns true when validation just timed out
+     * — caller may surface that to qlog and decide to retry with
+     * another CID, or close the connection if the budget for
+     * retries is exhausted.
+     *
+     * Caller must hold [streamsLock].
+     */
+    internal fun checkPathValidationTimeoutLocked(nowMillis: Long): Boolean {
+        val abandoned = pathValidator.checkValidationTimeout(nowMillis) ?: return false
+        qlogObserver.onPathValidationFailed(abandoned.newCidSequence)
+        pathValidator.acknowledgeTerminal()
+        return true
+    }
+
+    /**
      * Queue a PATH_RESPONSE for the given [challengeData]. Called by
      * the parser when a PATH_CHALLENGE arrives. Idempotent on
      * duplicate challenges (peer retransmit) — the writer drains
@@ -1956,12 +2162,19 @@ class QuicConnection(
                 is com.vitorpamplona.quic.connection.recovery.RecoveryToken.MaxData,
                 is com.vitorpamplona.quic.connection.recovery.RecoveryToken.MaxStreamData,
                 is com.vitorpamplona.quic.connection.recovery.RecoveryToken.NewConnectionId,
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.PathChallenge,
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.RetireConnectionId,
                 -> {
-                    // Flow-control extensions and NEW_CONNECTION_ID
-                    // have no per-buffer state to release on ACK; the
+                    // Flow-control extensions, NEW_CONNECTION_ID,
+                    // PATH_CHALLENGE, and RETIRE_CONNECTION_ID have
+                    // no per-buffer state to release on ACK; the
                     // pending* maps are populated only on loss, so an
                     // ACK for a frame that never lost is naturally
-                    // absent.
+                    // absent. PATH_CHALLENGE specifically: a peer ACK
+                    // means "we received the challenge frame" — but
+                    // that's NOT path validation success. Validation
+                    // requires the matching PATH_RESPONSE
+                    // (handled in [applyPeerPathResponseLocked]).
                 }
 
                 is com.vitorpamplona.quic.connection.recovery.RecoveryToken.ResetStream -> {
@@ -2085,6 +2298,33 @@ class QuicConnection(
 
                 is com.vitorpamplona.quic.connection.recovery.RecoveryToken.NewConnectionId -> {
                     pendingNewConnectionId[token.sequenceNumber] = token
+                }
+
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.PathChallenge -> {
+                    // RFC 9000 §8.2.1: if a PATH_CHALLENGE is lost
+                    // (carrying packet declared lost without an
+                    // ACK), the spec permits but does not require
+                    // retransmission — validation simply runs against
+                    // the 3 * PTO budget. We re-queue iff the
+                    // outstanding validation still matches this
+                    // payload (state hasn't progressed to Succeeded /
+                    // Failed / a different challenge). The writer
+                    // will pick it up on the next drain and emit a
+                    // fresh PATH_CHALLENGE with the SAME 8 bytes —
+                    // the peer must echo whichever it sees first.
+                    val s = pathValidator.state
+                    if (s is PathValidationState.Validating && s.challengeData.contentEquals(token.data)) {
+                        if (!pathValidator.pendingChallenges.any { it.contentEquals(token.data) }) {
+                            pathValidator.pendingChallenges.addLast(token.data)
+                        }
+                    }
+                }
+
+                is com.vitorpamplona.quic.connection.recovery.RecoveryToken.RetireConnectionId -> {
+                    // RFC 9000 §13.3: RETIRE_CONNECTION_ID is
+                    // reliable. Re-queue on loss — idempotent on
+                    // duplicate (queueRetireSequence dedupes).
+                    pathValidator.queueRetireSequence(token.sequenceNumber)
                 }
             }
         }

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionDriver.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionDriver.kt
@@ -362,7 +362,56 @@ internal suspend fun handlePtoFired(conn: QuicConnection) {
         conn.streamsLock.withLock {
             conn.requeueAllInflightStreamData()
             conn.requeueAllInflightCrypto(EncryptionLevel.APPLICATION)
+            // RFC 9000 §9 client-initiated path validation. After
+            // [PATH_PROBE_PTO_THRESHOLD] consecutive PTOs without
+            // any inbound ACK we suspect the path is dead (NAT
+            // rebind, route flap, dead peer). If the peer has
+            // issued spare CIDs via NEW_CONNECTION_ID, rotate to
+            // one and emit a PATH_CHALLENGE on the new DCID. The
+            // validator only triggers on the FIRST crossing of
+            // the threshold per validation cycle — the
+            // [PathValidator] internally rejects re-entry while
+            // [PathValidationState.Validating] holds.
+            //
+            // Also check the §8.2.4 budget on any in-flight
+            // validation: 3*PTO since the challenge went out
+            // without a matching response means the new path is
+            // also dead — abandon and let the next PTO try with
+            // another CID (or surface the failure to the higher
+            // layer).
+            val nowMillis =
+                kotlin.time.Clock.System
+                    .now()
+                    .toEpochMilliseconds()
+            val maxAckDelayMs =
+                if (conn.application.sendProtection != null) {
+                    conn.peerTransportParameters?.maxAckDelay ?: 0L
+                } else {
+                    0L
+                }
+            val ptoBaseMs = conn.lossDetection.ptoBaseMs(maxAckDelayMs).coerceAtLeast(1L)
+            conn.checkPathValidationTimeoutLocked(nowMillis)
+            if (conn.consecutivePtoCount >= PATH_PROBE_PTO_THRESHOLD) {
+                conn.triggerPathMigrationLocked(nowMillis = nowMillis, currentPtoMillis = ptoBaseMs)
+            }
         }
     }
     conn.consecutivePtoCount = (conn.consecutivePtoCount + 1).coerceAtMost(6)
 }
+
+/**
+ * RFC 9000 §9 / §10.1.2 — number of consecutive PTOs we tolerate on
+ * the active path before assuming it's dead and probing a new one.
+ * The QUIC RFC doesn't pin a specific value (the spec only says "an
+ * endpoint that has previously discovered a particular path
+ * works"); 2 matches Firefox neqo's `PATH_PROBE_PTO_THRESHOLD`
+ * default and Chrome's behavior. Picking 1 is too aggressive
+ * (single dropped packet trips a rotation); 4+ is too late (user
+ * notices the silence).
+ *
+ * Once the threshold is crossed, [handlePtoFired] calls into
+ * [QuicConnection.triggerPathMigrationLocked] which is itself
+ * idempotent — a second crossing while validation is already in
+ * flight is a no-op.
+ */
+internal const val PATH_PROBE_PTO_THRESHOLD: Int = 2

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionDriver.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionDriver.kt
@@ -350,6 +350,12 @@ internal suspend fun handlePtoFired(conn: QuicConnection) {
     if (conn.initial.sendProtection != null && !conn.initial.keysDiscarded) {
         conn.requeueAllInflightCrypto(EncryptionLevel.INITIAL)
     }
+    // Bug-6 fix: increment BEFORE the threshold check. With the
+    // pre-fix ordering and threshold=2, the rotation actually fired
+    // on the 3rd PTO (count went 0→1→2 before check). Now the count
+    // matches the constant's natural reading: "after 2 consecutive
+    // PTOs with no progress, trigger migration on the 2nd PTO firing."
+    conn.consecutivePtoCount = (conn.consecutivePtoCount + 1).coerceAtMost(6)
     // Once 1-RTT keys are installed, PTO must also retransmit application
     // data — STREAM bytes that were sent but never ACK'd. Without this,
     // a single corrupted/lost 1-RTT packet (especially the first one
@@ -379,16 +385,14 @@ internal suspend fun handlePtoFired(conn: QuicConnection) {
             // also dead — abandon and let the next PTO try with
             // another CID (or surface the failure to the higher
             // layer).
-            val nowMillis =
-                kotlin.time.Clock.System
-                    .now()
-                    .toEpochMilliseconds()
-            val maxAckDelayMs =
-                if (conn.application.sendProtection != null) {
-                    conn.peerTransportParameters?.maxAckDelay ?: 0L
-                } else {
-                    0L
-                }
+            //
+            // Bug-5 fix: use [conn.nowMillis] so a test-injected
+            // virtual clock takes effect. The pre-fix shape called
+            // [Clock.System.now()] directly, ignoring the
+            // connection's clock supplier and breaking timing
+            // assertions in unit tests.
+            val nowMillis = conn.nowMillis()
+            val maxAckDelayMs = conn.peerTransportParameters?.maxAckDelay ?: 0L
             val ptoBaseMs = conn.lossDetection.ptoBaseMs(maxAckDelayMs).coerceAtLeast(1L)
             conn.checkPathValidationTimeoutLocked(nowMillis)
             if (conn.consecutivePtoCount >= PATH_PROBE_PTO_THRESHOLD) {
@@ -396,7 +400,6 @@ internal suspend fun handlePtoFired(conn: QuicConnection) {
             }
         }
     }
-    conn.consecutivePtoCount = (conn.consecutivePtoCount + 1).coerceAtMost(6)
 }
 
 /**
@@ -408,6 +411,11 @@ internal suspend fun handlePtoFired(conn: QuicConnection) {
  * default and Chrome's behavior. Picking 1 is too aggressive
  * (single dropped packet trips a rotation); 4+ is too late (user
  * notices the silence).
+ *
+ * The check in [handlePtoFired] runs AFTER the consecutive-PTO
+ * counter is incremented, so the threshold value is the count of
+ * PTOs that fired without an inbound ACK arriving in between.
+ * With value 2 migration triggers on the 2nd consecutive PTO.
  *
  * Once the threshold is crossed, [handlePtoFired] calls into
  * [QuicConnection.triggerPathMigrationLocked] which is itself

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionParser.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionParser.kt
@@ -36,6 +36,7 @@ import com.vitorpamplona.quic.frame.PathChallengeFrame
 import com.vitorpamplona.quic.frame.PathResponseFrame
 import com.vitorpamplona.quic.frame.PingFrame
 import com.vitorpamplona.quic.frame.ResetStreamFrame
+import com.vitorpamplona.quic.frame.RetireConnectionIdFrame
 import com.vitorpamplona.quic.frame.StopSendingFrame
 import com.vitorpamplona.quic.frame.StreamFrame
 import com.vitorpamplona.quic.frame.decodeFrames
@@ -716,10 +717,23 @@ private fun dispatchFrames(
             }
 
             is NewConnectionIdFrame -> {
-                // RFC 9000 §13.2.1: NEW_CONNECTION_ID is ack-eliciting. We
-                // don't support migration but still need to ACK to keep
-                // peer's loss-recovery happy.
+                // RFC 9000 §13.2.1: NEW_CONNECTION_ID is ack-eliciting.
+                // §19.15 + §5.1.2: store the offered CID + stateless
+                // reset token in the [PathValidator] pool so the
+                // client-initiated migration path (RFC 9000 §9) can
+                // pick one when the active path stops receiving
+                // ACKs. Also enforces `retire_prior_to` semantics
+                // and queues RETIRE_CONNECTION_ID for any cached
+                // entry whose sequence number falls below the new
+                // watermark. Peer protocol violations close the
+                // connection upstream.
                 ackEliciting = true
+                conn.applyPeerNewConnectionIdLocked(
+                    sequenceNumber = frame.sequenceNumber,
+                    retirePriorTo = frame.retirePriorTo,
+                    connectionId = frame.connectionId,
+                    statelessResetToken = frame.statelessResetToken,
+                )
             }
 
             is PathChallengeFrame -> {
@@ -746,13 +760,26 @@ private fun dispatchFrames(
 
             is PathResponseFrame -> {
                 // RFC 9000 §13.2.1: PATH_RESPONSE is ack-eliciting.
-                // We don't yet issue PATH_CHALLENGE ourselves (that's
-                // the client-initiated migration path, out of scope
-                // for the first-pass landing here), so any PATH_RESPONSE
-                // we receive is necessarily for a challenge we never
-                // sent — drop it after marking ack-eliciting so the
-                // outbound ACK still goes out.
+                // §8.2.2: if the payload matches our outstanding
+                // PATH_CHALLENGE, validation succeeded — the writer
+                // is told to start stamping the new DCID and a
+                // RETIRE_CONNECTION_ID for the old sequence number
+                // is queued (RFC 9000 §9.5). Mismatched payloads
+                // (no outstanding challenge OR an attacker echoing
+                // random bytes) are silently ignored after the ACK.
                 ackEliciting = true
+                conn.applyPeerPathResponseLocked(frame.data)
+            }
+
+            is RetireConnectionIdFrame -> {
+                // RFC 9000 §13.2.1: RETIRE_CONNECTION_ID is
+                // ack-eliciting. §19.16: peer is asking us to
+                // retire one of OUR source CIDs. We only ever
+                // issued sequence 0 (the SCID we picked at
+                // connection start); any seq > 0 is a protocol
+                // violation per §19.16, closes the connection.
+                ackEliciting = true
+                conn.applyPeerRetireConnectionIdLocked(frame.sequenceNumber)
             }
 
             is ConnectionCloseFrame -> {

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionWriter.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionWriter.kt
@@ -91,6 +91,17 @@ fun drainOutbound(
         return datagram
     }
 
+    // Bug-A fix: drive the §8.2.4 3*PTO validation budget on every
+    // drain, not just on PTO expiration. The peer ACKs PATH_CHALLENGE
+    // (it's ack-eliciting), and ACK arrival resets consecutivePtoCount —
+    // so the PTO timer that previously hosted [checkPathValidationTimeoutLocked]
+    // can stop firing before the budget elapses, leaving validation
+    // hung indefinitely. Drain happens at least every PTO_BASE
+    // (~30-100ms) even when the application is idle, which covers the
+    // budget-elapsed condition reliably. Cheap (one type-cast +
+    // time comparison) when the validator is in [PathValidationState.Idle].
+    conn.checkPathValidationTimeoutLocked(nowMillis)
+
     // Drain destructive frame sources into local lists, ONCE.
     val initialContents = collectHandshakeLevelFrames(conn, EncryptionLevel.INITIAL, nowMillis)
     val handshakeContents = collectHandshakeLevelFrames(conn, EncryptionLevel.HANDSHAKE, nowMillis)

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionWriter.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionWriter.kt
@@ -32,9 +32,11 @@ import com.vitorpamplona.quic.frame.MaxDataFrame
 import com.vitorpamplona.quic.frame.MaxStreamDataFrame
 import com.vitorpamplona.quic.frame.MaxStreamsFrame
 import com.vitorpamplona.quic.frame.NewConnectionIdFrame
+import com.vitorpamplona.quic.frame.PathChallengeFrame
 import com.vitorpamplona.quic.frame.PathResponseFrame
 import com.vitorpamplona.quic.frame.PingFrame
 import com.vitorpamplona.quic.frame.ResetStreamFrame
+import com.vitorpamplona.quic.frame.RetireConnectionIdFrame
 import com.vitorpamplona.quic.frame.StopSendingFrame
 import com.vitorpamplona.quic.frame.StreamFrame
 import com.vitorpamplona.quic.frame.encodeFrames
@@ -960,6 +962,26 @@ private fun appendFlowControlUpdates(
     while (conn.pendingPathChallengePayloads.isNotEmpty()) {
         val data = conn.pendingPathChallengePayloads.removeFirst()
         frames += PathResponseFrame(data)
+    }
+
+    // RFC 9000 §9 client-initiated path validation. Drain any
+    // PATH_CHALLENGE the [PathValidator] has queued — including
+    // re-queued ones from the loss dispatcher. Each emission
+    // records a [RecoveryToken.PathChallenge] so loss recovery
+    // can decide to retransmit (the validator's own 3 * PTO
+    // budget is the ultimate timeout per RFC 9000 §8.2.4).
+    while (conn.pathValidator.pendingChallenges.isNotEmpty()) {
+        val payload = conn.pathValidator.pendingChallenges.removeFirst()
+        frames += PathChallengeFrame(payload)
+        tokens += RecoveryToken.PathChallenge(payload)
+    }
+
+    // RFC 9000 §19.16 RETIRE_CONNECTION_ID. Drain pending retires;
+    // the dispatcher re-queues on loss until the peer ACKs.
+    while (conn.pathValidator.pendingRetireSequences.isNotEmpty()) {
+        val seq = conn.pathValidator.pendingRetireSequences.removeFirst()
+        frames += RetireConnectionIdFrame(seq)
+        tokens += RecoveryToken.RetireConnectionId(seq)
     }
 
     // NEW_CONNECTION_ID retransmits. No application path emits these

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/recovery/RecoveryToken.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/recovery/RecoveryToken.kt
@@ -179,9 +179,44 @@ sealed class RecoveryToken {
     ) : RecoveryToken()
 
     /**
+     * `PATH_CHALLENGE` frame we emitted as part of client-initiated
+     * path validation (RFC 9000 §8.2 / §9). Carries the same 8-byte
+     * payload the writer put on the wire so the loss dispatcher can
+     * decide whether the validation attempt should be considered
+     * failed or retransmitted.
+     *
+     * RFC 9000 §13.2.1 lists PATH_CHALLENGE as ack-eliciting; §8.2.4
+     * says path validation MUST NOT exceed `3 * PTO` of waiting before
+     * the path is declared failed. The connection-side dispatcher
+     * checks the [com.vitorpamplona.quic.connection.PathValidator]
+     * state — if validation has already moved on (succeeded, failed,
+     * or abandoned), the lost token is dropped silently.
+     */
+    data class PathChallenge(
+        val data: ByteArray,
+    ) : RecoveryToken() {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is PathChallenge) return false
+            return data.contentEquals(other.data)
+        }
+
+        override fun hashCode(): Int = data.contentHashCode()
+    }
+
+    /**
+     * `RETIRE_CONNECTION_ID` frame we emitted (RFC 9000 §19.16).
+     * Reliable per §13.3 — peer must learn that we've stopped using
+     * the connection ID, otherwise it keeps the routing entry forever.
+     */
+    data class RetireConnectionId(
+        val sequenceNumber: Long,
+    ) : RecoveryToken()
+
+    /**
      * `NEW_CONNECTION_ID` frame we sent (RFC 9000 §19.15). Reliable
-     * per §13.3. Same scaffolding-only status — connection-ID
-     * rotation isn't wired today.
+     * per §13.3. Same scaffolding-only status — client-issued
+     * connection IDs aren't yet emitted by `:quic`.
      */
     data class NewConnectionId(
         val sequenceNumber: Long,

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/frame/Frame.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/frame/Frame.kt
@@ -314,6 +314,25 @@ class NewConnectionIdFrame(
 }
 
 /**
+ * RFC 9000 §19.16 — RETIRE_CONNECTION_ID frame. Tells the peer to
+ * stop using one of the connection IDs it issued. Carries the
+ * sequence number from the corresponding [NewConnectionIdFrame].
+ *
+ * The client side emits this when it rotates to a new DCID
+ * post-handshake (see RFC 9000 §9 client-initiated migration): once
+ * the new path is validated, the previously-active CID is retired
+ * so the server can free the routing entry.
+ */
+class RetireConnectionIdFrame(
+    val sequenceNumber: Long,
+) : Frame() {
+    override fun encode(out: QuicWriter) {
+        out.writeByte(FrameType.RETIRE_CONNECTION_ID.toInt())
+        out.writeVarint(sequenceNumber)
+    }
+}
+
+/**
  * RFC 9000 §19.17 — PATH_CHALLENGE frame, used for path validation
  * (§8.2). The 8-byte [data] payload is opaque random bytes the
  * sender uses to bind a PATH_RESPONSE back to a specific
@@ -489,7 +508,7 @@ fun decodeFrames(data: ByteArray): List<Frame> {
             }
 
             type == FrameType.RETIRE_CONNECTION_ID -> {
-                r.readVarint()
+                out += RetireConnectionIdFrame(r.readVarint())
             }
 
             type == FrameType.PATH_CHALLENGE -> {

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/observability/QlogObserver.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/observability/QlogObserver.kt
@@ -160,6 +160,51 @@ interface QlogObserver {
     )
 
     /**
+     * RFC 9000 §9 client-initiated path validation just sent its
+     * first `PATH_CHALLENGE` for [newCidSequence] (the sequence
+     * number of the peer-issued connection ID we'll use on the new
+     * path). qvis renders this as a path-validation milestone.
+     */
+    fun onPathValidationStarted(newCidSequence: Long) = Unit
+
+    /**
+     * The peer echoed our PATH_CHALLENGE payload — validation
+     * succeeded. The writer has now switched to the new DCID and
+     * a `RETIRE_CONNECTION_ID` for the prior sequence is queued.
+     */
+    fun onPathValidationSucceeded(newCidSequence: Long) = Unit
+
+    /**
+     * Path validation was abandoned because more than `3 * PTO`
+     * elapsed without a matching `PATH_RESPONSE` (RFC 9000
+     * §8.2.4). Caller may retry with another CID or surface the
+     * failure as a connection close.
+     */
+    fun onPathValidationFailed(newCidSequence: Long) = Unit
+
+    /**
+     * A connection ID belonging to [keyType] (`"local"` for our
+     * source CID, `"peer"` for the peer-issued destination CID)
+     * just became active — i.e. the writer / parser will start
+     * using it for outbound / inbound packets respectively.
+     */
+    fun onConnectionIdActivated(
+        keyType: String,
+        sequenceNumber: Long,
+        connectionId: ByteArray,
+    ) = Unit
+
+    /**
+     * A connection ID was retired (RFC 9000 §19.16 — either we
+     * sent RETIRE_CONNECTION_ID for a peer-issued CID, or the
+     * peer asked us to retire one of ours).
+     */
+    fun onConnectionIdRetired(
+        keyType: String,
+        sequenceNumber: Long,
+    ) = Unit
+
+    /**
      * No-op observer. Default for production callers — every method
      * is an empty body that the JIT inlines. No allocation, no I/O.
      */

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/ClientPathMigrationTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/ClientPathMigrationTest.kt
@@ -163,14 +163,24 @@ class ClientPathMigrationTest {
                 "DCID must rotate at challenge time so PATH_CHALLENGE goes out on the new path",
             )
 
-            // Step 3 — the next outbound application packet must carry a
-            // PATH_CHALLENGE stamped with the NEW DCID.
+            // Step 3 — the next outbound application packet must carry
+            // BOTH the PATH_CHALLENGE (stamped with the NEW DCID) AND
+            // a RETIRE_CONNECTION_ID for the old sequence (Bug-B fix:
+            // abrupt migration retires the prior CID at trigger time,
+            // not at response time, so the writer drains both in the
+            // same packet).
             val challengeOut = drainOutbound(client, nowMillis = 100L)
             assertTrue(challengeOut != null, "client must emit a packet carrying PATH_CHALLENGE")
             val outboundFrames = pipe.decryptClientApplicationFrames(challengeOut)
             assertTrue(outboundFrames != null, "client outbound must decrypt with server keys")
             val challenge = outboundFrames.firstOrNull { it is PathChallengeFrame } as? PathChallengeFrame
             assertTrue(challenge != null, "outbound must contain PATH_CHALLENGE — got ${outboundFrames.map { it::class.simpleName }}")
+            val retire = outboundFrames.firstOrNull { it is RetireConnectionIdFrame } as? RetireConnectionIdFrame
+            assertTrue(
+                retire != null,
+                "outbound must contain RETIRE_CONNECTION_ID for the prior CID alongside PATH_CHALLENGE — got ${outboundFrames.map { it::class.simpleName }}",
+            )
+            assertEquals(0L, retire.sequenceNumber)
 
             // Step 4 — server echoes the payload in PATH_RESPONSE.
             val response =
@@ -179,26 +189,13 @@ class ClientPathMigrationTest {
                 )!!
             feedDatagram(client, response, nowMillis = 200L)
 
-            // Step 5 — validation succeeded; DCID is still the new bytes
-            // (already rotated at step 2), the prior sequence (0) is
-            // queued for RETIRE_CONNECTION_ID, and activeCidSequence now
-            // reflects the new sequence.
+            // Step 5 — validation succeeded; state transitions to
+            // Idle (after acknowledgeTerminal), activeCidSequence is
+            // still the new sequence (already bumped at trigger),
+            // DCID still the new bytes.
             assertContentEquals(newCidBytes, client.destinationConnectionId.bytes)
             assertEquals(1L, client.pathValidator.activeCidSequence)
-            assertTrue(
-                client.pathValidator.pendingRetireSequences.contains(0L),
-                "old sequence number must be queued for retire",
-            )
-
-            // Step 6 — the next outbound packet should carry the
-            // RETIRE_CONNECTION_ID for the old sequence.
-            val retireOut = drainOutbound(client, nowMillis = 200L)
-            assertTrue(retireOut != null, "client must emit a packet after PATH_RESPONSE")
-            val frames = pipe.decryptClientApplicationFrames(retireOut)
-            assertTrue(frames != null, "outbound after rotation must decrypt")
-            val retire = frames.firstOrNull { it is RetireConnectionIdFrame } as? RetireConnectionIdFrame
-            assertTrue(retire != null, "outbound must contain RETIRE_CONNECTION_ID — got ${frames.map { it::class.simpleName }}")
-            assertEquals(0L, retire.sequenceNumber)
+            assertEquals(1L, client.pathValidator.successfulValidations)
 
             // Sanity: connection still alive after the rotation.
             assertEquals(QuicConnection.Status.CONNECTED, client.status)
@@ -243,7 +240,11 @@ class ClientPathMigrationTest {
 
             assertContentEquals(newCid, client.destinationConnectionId.bytes, "mismatched response must not undo the rotation")
             assertTrue(client.pathValidator.state is PathValidationState.Validating, "still validating")
-            assertEquals(0L, client.pathValidator.activeCidSequence, "active sequence still old until validation succeeds")
+            assertEquals(
+                1L,
+                client.pathValidator.activeCidSequence,
+                "active sequence tracks what the writer is putting on the wire — bumped at challenge time per Bug-B fix",
+            )
         }
 
     @Test
@@ -328,6 +329,59 @@ class ClientPathMigrationTest {
                 nowMillis = 200L,
             )
             assertEquals(0, client.consecutivePtoCount, "successful path validation must reset consecutivePtoCount")
+        }
+
+    @Test
+    fun newConnectionIdWithRetirePriorToPastActiveForcesRotationOnSamePath() =
+        runBlocking {
+            // Bug-C regression: RFC 9000 §5.1.2 — a peer that
+            // advances retire_prior_to past our active CID forces
+            // us to rotate on the SAME path (no PATH_CHALLENGE).
+            // Pre-fix the parser silently accepted the offer and
+            // we'd keep stamping the now-retired seq=0 on outbound
+            // packets.
+            val (client, pipe) = newConnectedClient()
+            val originalDcid = client.destinationConnectionId
+            val replacementCid = ByteArray(8) { (0xB0 or it).toByte() }
+            val token = ByteArray(16) { 0x33 }
+
+            // First offer: seq=1, no retirement. Pool fills.
+            feedDatagram(
+                client,
+                pipe.buildServerApplicationDatagram(
+                    listOf(NewConnectionIdFrame(1L, 0L, replacementCid, token)),
+                )!!,
+                nowMillis = 0L,
+            )
+            assertEquals(originalDcid, client.destinationConnectionId, "first offer doesn't force rotation")
+
+            // Second offer: seq=2 with retire_prior_to=1. Watermark
+            // advances past our active seq=0. MUST rotate on the
+            // same path to seq=1 (the lowest spare).
+            val secondToken = ByteArray(16) { 0x44 }
+            feedDatagram(
+                client,
+                pipe.buildServerApplicationDatagram(
+                    listOf(NewConnectionIdFrame(2L, 1L, ByteArray(8) { 0xCC.toByte() }, secondToken)),
+                )!!,
+                nowMillis = 0L,
+            )
+
+            assertContentEquals(
+                replacementCid,
+                client.destinationConnectionId.bytes,
+                "DCID must rotate to the lowest spare (seq=1) when watermark advances past seq=0",
+            )
+            assertEquals(1L, client.pathValidator.activeCidSequence)
+            assertTrue(
+                client.pathValidator.pendingRetireSequences.contains(0L),
+                "old active seq=0 must be queued for RETIRE_CONNECTION_ID",
+            )
+            assertEquals(
+                QuicConnection.Status.CONNECTED,
+                client.status,
+                "server-forced rotation must NOT close the connection",
+            )
         }
 
     @Test

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/ClientPathMigrationTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/ClientPathMigrationTest.kt
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quic.connection
+
+import com.vitorpamplona.quic.frame.NewConnectionIdFrame
+import com.vitorpamplona.quic.frame.PathChallengeFrame
+import com.vitorpamplona.quic.frame.PathResponseFrame
+import com.vitorpamplona.quic.frame.RetireConnectionIdFrame
+import com.vitorpamplona.quic.frame.decodeFrames
+import com.vitorpamplona.quic.frame.encodeFrames
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for client-initiated path validation + DCID
+ * rotation (RFC 9000 §9). Drives the real client through the
+ * [InMemoryQuicPipe] harness so the assertions cover the parser /
+ * writer / [PathValidator] wiring end-to-end:
+ *
+ *  1. Server sends NEW_CONNECTION_ID — pool fills.
+ *  2. Application calls [QuicConnection.triggerPathMigration].
+ *  3. Client emits PATH_CHALLENGE (drained from
+ *     [PathValidator.pendingChallenges]).
+ *  4. Server replies with PATH_RESPONSE carrying the same 8 bytes.
+ *  5. Client switches `destinationConnectionId` and queues a
+ *     RETIRE_CONNECTION_ID for the old sequence.
+ *  6. Next outbound application packet uses the NEW DCID and
+ *     contains the RETIRE_CONNECTION_ID.
+ *
+ * Out of scope here:
+ *  - PTO-driven rotation: covered by the unit-level
+ *    [PathValidatorTest.validationTimeoutAfter3PtoTransitionsToFailed]
+ *    plus the driver-level threshold constant. Driving a real PTO
+ *    through the in-memory pipe would require simulating timer
+ *    advancement, which the pipe doesn't model today.
+ */
+class ClientPathMigrationTest {
+    @Test
+    fun retireConnectionIdFrameRoundTripsThroughCodec() {
+        val encoded = encodeFrames(listOf(RetireConnectionIdFrame(sequenceNumber = 7L)))
+        val decoded = decodeFrames(encoded)
+        assertEquals(1, decoded.size)
+        val frame = decoded.first() as RetireConnectionIdFrame
+        assertEquals(7L, frame.sequenceNumber)
+    }
+
+    @Test
+    fun newConnectionIdFromServerPopulatesPathValidatorPool() =
+        runBlocking {
+            val (client, pipe) = newConnectedClient()
+            val newCid = ByteArray(8) { (0xC0 or it).toByte() }
+            val token = ByteArray(16) { 0x42 }
+            val packet =
+                pipe.buildServerApplicationDatagram(
+                    listOf(
+                        NewConnectionIdFrame(
+                            sequenceNumber = 1L,
+                            retirePriorTo = 0L,
+                            connectionId = newCid,
+                            statelessResetToken = token,
+                        ),
+                    ),
+                )!!
+            feedDatagram(client, packet, nowMillis = 0L)
+
+            assertEquals(1, client.pathValidator.unusedCount())
+            assertEquals(listOf(1L), client.pathValidator.unusedSequences())
+        }
+
+    @Test
+    fun newConnectionIdWithRetirePriorToGreaterThanSequenceClosesConnection() =
+        runBlocking {
+            val (client, pipe) = newConnectedClient()
+            val packet =
+                pipe.buildServerApplicationDatagram(
+                    listOf(
+                        NewConnectionIdFrame(
+                            sequenceNumber = 1L,
+                            retirePriorTo = 5L,
+                            connectionId = ByteArray(8) { 0x01 },
+                            statelessResetToken = ByteArray(16),
+                        ),
+                    ),
+                )!!
+            feedDatagram(client, packet, nowMillis = 0L)
+            // FRAME_ENCODING_ERROR per RFC 9000 §19.15 — closes the connection.
+            assertTrue(
+                client.status == QuicConnection.Status.CLOSING || client.status == QuicConnection.Status.CLOSED,
+                "got ${client.status}; expected CLOSING/CLOSED",
+            )
+        }
+
+    @Test
+    fun triggerPathMigrationWithoutSpareCidIsNoOp() =
+        runBlocking {
+            val (client, _) = newConnectedClient()
+            val priorDcid = client.destinationConnectionId
+            val result = client.triggerPathMigration(nowMillis = 0L, currentPtoMillis = 100L)
+            assertEquals(PathMigrationResult.NoSpareCid, result)
+            assertEquals(priorDcid, client.destinationConnectionId, "DCID must not change without a spare CID")
+            assertTrue(client.pathValidator.state is PathValidationState.Idle)
+        }
+
+    @Test
+    fun fullMigrationRoundTripSwitchesDcidAndQueuesRetire() =
+        runBlocking {
+            val (client, pipe) = newConnectedClient()
+            val originalDcid = client.destinationConnectionId
+            val newCidBytes = ByteArray(8) { (0xA0 or it).toByte() }
+            val token = ByteArray(16) { 0x77 }
+
+            // Step 1 — server offers a fresh CID via NEW_CONNECTION_ID.
+            val offer =
+                pipe.buildServerApplicationDatagram(
+                    listOf(
+                        NewConnectionIdFrame(
+                            sequenceNumber = 1L,
+                            retirePriorTo = 0L,
+                            connectionId = newCidBytes,
+                            statelessResetToken = token,
+                        ),
+                    ),
+                )!!
+            feedDatagram(client, offer, nowMillis = 0L)
+            assertEquals(1, client.pathValidator.unusedCount())
+
+            // Drain the client's ACK for that packet so subsequent assertions about
+            // outbound contents aren't polluted by leftover ACK frames.
+            drainOutbound(client, nowMillis = 0L)
+
+            // Step 2 — application triggers migration. The validator picks
+            // sequence 1 and queues a PATH_CHALLENGE.
+            val triggered = client.triggerPathMigration(nowMillis = 100L, currentPtoMillis = 1_000L)
+            assertEquals(PathMigrationResult.Started, triggered)
+            assertTrue(client.pathValidator.state is PathValidationState.Validating)
+
+            // Step 3 — the next outbound application packet must carry a
+            // PATH_CHALLENGE.
+            val challengeOut = drainOutbound(client, nowMillis = 100L)
+            assertTrue(challengeOut != null, "client must emit a packet carrying PATH_CHALLENGE")
+            val outboundFrames = pipe.decryptClientApplicationFrames(challengeOut)
+            assertTrue(outboundFrames != null, "client outbound must decrypt with server keys")
+            val challenge = outboundFrames.firstOrNull { it is PathChallengeFrame } as? PathChallengeFrame
+            assertTrue(challenge != null, "outbound must contain PATH_CHALLENGE — got ${outboundFrames.map { it::class.simpleName }}")
+
+            // Step 4 — server echoes the payload in PATH_RESPONSE.
+            val response =
+                pipe.buildServerApplicationDatagram(
+                    listOf(PathResponseFrame(challenge.data.copyOf())),
+                )!!
+            feedDatagram(client, response, nowMillis = 200L)
+
+            // Step 5 — DCID must have rotated to the new bytes; the prior
+            // sequence (0) must be queued for RETIRE_CONNECTION_ID.
+            assertContentEquals(newCidBytes, client.destinationConnectionId.bytes, "DCID must rotate to new bytes")
+            assertEquals(1L, client.pathValidator.activeCidSequence)
+            assertTrue(
+                client.pathValidator.pendingRetireSequences.contains(0L),
+                "old sequence number must be queued for retire",
+            )
+
+            // Step 6 — the next outbound packet should carry the
+            // RETIRE_CONNECTION_ID for the old sequence.
+            val retireOut = drainOutbound(client, nowMillis = 200L)
+            assertTrue(retireOut != null, "client must emit a packet after PATH_RESPONSE")
+            val frames = pipe.decryptClientApplicationFrames(retireOut)
+            assertTrue(frames != null, "outbound after rotation must decrypt")
+            val retire = frames.firstOrNull { it is RetireConnectionIdFrame } as? RetireConnectionIdFrame
+            assertTrue(retire != null, "outbound must contain RETIRE_CONNECTION_ID — got ${frames.map { it::class.simpleName }}")
+            assertEquals(0L, retire.sequenceNumber)
+
+            // Sanity: connection still alive after the rotation.
+            assertEquals(QuicConnection.Status.CONNECTED, client.status)
+            // Sanity: original DCID changed.
+            assertTrue(originalDcid != client.destinationConnectionId)
+        }
+
+    @Test
+    fun pathResponseWithMismatchingPayloadDoesNotRotateDcid() =
+        runBlocking {
+            val (client, pipe) = newConnectedClient()
+            val originalDcid = client.destinationConnectionId
+
+            // Seed a spare CID and trigger migration.
+            val offer =
+                pipe.buildServerApplicationDatagram(
+                    listOf(
+                        NewConnectionIdFrame(
+                            sequenceNumber = 1L,
+                            retirePriorTo = 0L,
+                            connectionId = ByteArray(8) { 0x01 },
+                            statelessResetToken = ByteArray(16) { 0x10 },
+                        ),
+                    ),
+                )!!
+            feedDatagram(client, offer, nowMillis = 0L)
+            client.triggerPathMigration(nowMillis = 100L, currentPtoMillis = 1_000L)
+            drainOutbound(client, nowMillis = 100L) // emit challenge, drop content
+
+            // Server replies with WRONG payload — must not rotate.
+            val bogusResponse =
+                pipe.buildServerApplicationDatagram(
+                    listOf(PathResponseFrame(ByteArray(8) { 0xFF.toByte() })),
+                )!!
+            feedDatagram(client, bogusResponse, nowMillis = 200L)
+
+            assertEquals(originalDcid, client.destinationConnectionId, "mismatched response must NOT rotate DCID")
+            assertTrue(client.pathValidator.state is PathValidationState.Validating, "still validating")
+        }
+
+    @Test
+    fun unsolicitedPathResponseIsSilentlyDropped() =
+        runBlocking {
+            // Defence-in-depth: a peer (or attacker) sending PATH_RESPONSE
+            // without a preceding PATH_CHALLENGE from us must NOT rotate the
+            // DCID, must NOT crash, and the connection must stay alive.
+            val (client, pipe) = newConnectedClient()
+            val originalDcid = client.destinationConnectionId
+            val packet = pipe.buildServerApplicationDatagram(listOf(PathResponseFrame(ByteArray(8))))!!
+            feedDatagram(client, packet, nowMillis = 0L)
+            assertEquals(originalDcid, client.destinationConnectionId)
+            assertEquals(QuicConnection.Status.CONNECTED, client.status)
+            assertTrue(client.pathValidator.state is PathValidationState.Idle)
+        }
+
+    @Test
+    fun retireConnectionIdFromServerForUnissuedSequenceIsProtocolViolation() =
+        runBlocking {
+            val (client, pipe) = newConnectedClient()
+            // We only ever issue sequence 0; any seq > 0 is a protocol
+            // violation per RFC 9000 §19.16.
+            val packet = pipe.buildServerApplicationDatagram(listOf(RetireConnectionIdFrame(sequenceNumber = 7L)))!!
+            feedDatagram(client, packet, nowMillis = 0L)
+            assertTrue(
+                client.status == QuicConnection.Status.CLOSING || client.status == QuicConnection.Status.CLOSED,
+                "got ${client.status}",
+            )
+        }
+}

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/ClientPathMigrationTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/ClientPathMigrationTest.kt
@@ -150,13 +150,21 @@ class ClientPathMigrationTest {
             drainOutbound(client, nowMillis = 0L)
 
             // Step 2 — application triggers migration. The validator picks
-            // sequence 1 and queues a PATH_CHALLENGE.
+            // sequence 1, queues a PATH_CHALLENGE, AND swaps the writer's
+            // outbound DCID immediately so the challenge goes out on the
+            // new path (Bug-1 fix — abrupt migration model per RFC 9000
+            // §9.3).
             val triggered = client.triggerPathMigration(nowMillis = 100L, currentPtoMillis = 1_000L)
             assertEquals(PathMigrationResult.Started, triggered)
             assertTrue(client.pathValidator.state is PathValidationState.Validating)
+            assertContentEquals(
+                newCidBytes,
+                client.destinationConnectionId.bytes,
+                "DCID must rotate at challenge time so PATH_CHALLENGE goes out on the new path",
+            )
 
             // Step 3 — the next outbound application packet must carry a
-            // PATH_CHALLENGE.
+            // PATH_CHALLENGE stamped with the NEW DCID.
             val challengeOut = drainOutbound(client, nowMillis = 100L)
             assertTrue(challengeOut != null, "client must emit a packet carrying PATH_CHALLENGE")
             val outboundFrames = pipe.decryptClientApplicationFrames(challengeOut)
@@ -171,9 +179,11 @@ class ClientPathMigrationTest {
                 )!!
             feedDatagram(client, response, nowMillis = 200L)
 
-            // Step 5 — DCID must have rotated to the new bytes; the prior
-            // sequence (0) must be queued for RETIRE_CONNECTION_ID.
-            assertContentEquals(newCidBytes, client.destinationConnectionId.bytes, "DCID must rotate to new bytes")
+            // Step 5 — validation succeeded; DCID is still the new bytes
+            // (already rotated at step 2), the prior sequence (0) is
+            // queued for RETIRE_CONNECTION_ID, and activeCidSequence now
+            // reflects the new sequence.
+            assertContentEquals(newCidBytes, client.destinationConnectionId.bytes)
             assertEquals(1L, client.pathValidator.activeCidSequence)
             assertTrue(
                 client.pathValidator.pendingRetireSequences.contains(0L),
@@ -197,36 +207,43 @@ class ClientPathMigrationTest {
         }
 
     @Test
-    fun pathResponseWithMismatchingPayloadDoesNotRotateDcid() =
+    fun pathResponseWithMismatchingPayloadKeepsValidatingAndDcid() =
         runBlocking {
             val (client, pipe) = newConnectedClient()
-            val originalDcid = client.destinationConnectionId
 
-            // Seed a spare CID and trigger migration.
+            // Seed a spare CID and trigger migration. Under abrupt
+            // migration the DCID rotates at trigger time, NOT at
+            // PATH_RESPONSE — so the post-trigger state is "DCID is
+            // already the new bytes; we're awaiting validation."
+            val newCid = ByteArray(8) { 0x01 }
             val offer =
                 pipe.buildServerApplicationDatagram(
                     listOf(
                         NewConnectionIdFrame(
                             sequenceNumber = 1L,
                             retirePriorTo = 0L,
-                            connectionId = ByteArray(8) { 0x01 },
+                            connectionId = newCid,
                             statelessResetToken = ByteArray(16) { 0x10 },
                         ),
                     ),
                 )!!
             feedDatagram(client, offer, nowMillis = 0L)
             client.triggerPathMigration(nowMillis = 100L, currentPtoMillis = 1_000L)
+            assertContentEquals(newCid, client.destinationConnectionId.bytes, "DCID rotates at challenge time")
             drainOutbound(client, nowMillis = 100L) // emit challenge, drop content
 
-            // Server replies with WRONG payload — must not rotate.
+            // Server replies with WRONG payload — validation must NOT
+            // succeed and the validator state must stay in Validating
+            // until the 3 * PTO timeout (or a correct response).
             val bogusResponse =
                 pipe.buildServerApplicationDatagram(
                     listOf(PathResponseFrame(ByteArray(8) { 0xFF.toByte() })),
                 )!!
             feedDatagram(client, bogusResponse, nowMillis = 200L)
 
-            assertEquals(originalDcid, client.destinationConnectionId, "mismatched response must NOT rotate DCID")
+            assertContentEquals(newCid, client.destinationConnectionId.bytes, "mismatched response must not undo the rotation")
             assertTrue(client.pathValidator.state is PathValidationState.Validating, "still validating")
+            assertEquals(0L, client.pathValidator.activeCidSequence, "active sequence still old until validation succeeds")
         }
 
     @Test
@@ -256,5 +273,81 @@ class ClientPathMigrationTest {
                 client.status == QuicConnection.Status.CLOSING || client.status == QuicConnection.Status.CLOSED,
                 "got ${client.status}",
             )
+        }
+
+    @Test
+    fun retireConnectionIdForSequenceZeroClosesConnection() =
+        runBlocking {
+            // Bug-3 regression: peer asking us to retire our initial
+            // SCID (seq 0) leaves us with no replacement to give them.
+            // We close rather than silently honoring — see
+            // [QuicConnection.applyPeerRetireConnectionIdLocked].
+            val (client, pipe) = newConnectedClient()
+            val packet = pipe.buildServerApplicationDatagram(listOf(RetireConnectionIdFrame(sequenceNumber = 0L)))!!
+            feedDatagram(client, packet, nowMillis = 0L)
+            assertTrue(
+                client.status == QuicConnection.Status.CLOSING || client.status == QuicConnection.Status.CLOSED,
+                "got ${client.status}; seq=0 retire must close because we have no replacement SCID",
+            )
+        }
+
+    @Test
+    fun pathResponseSuccessResetsConsecutivePtoCount() =
+        runBlocking {
+            // Bug-7 regression: a successful PATH_RESPONSE proves the
+            // peer can reach us on the new path. The consecutive-PTO
+            // counter must reset so the send loop's exponential
+            // backoff returns to baseline pacing instead of carrying
+            // a stale "many PTOs expired" multiplier.
+            val (client, pipe) = newConnectedClient()
+            val newCid = ByteArray(8) { 0x55 }
+            val token = ByteArray(16) { 0x66 }
+
+            feedDatagram(
+                client,
+                pipe.buildServerApplicationDatagram(
+                    listOf(NewConnectionIdFrame(1L, 0L, newCid, token)),
+                )!!,
+                nowMillis = 0L,
+            )
+            drainOutbound(client, nowMillis = 0L)
+
+            // Pretend we burned through 4 PTOs without progress.
+            client.consecutivePtoCount = 4
+            client.triggerPathMigration(nowMillis = 100L, currentPtoMillis = 1_000L)
+            val challengeOut = drainOutbound(client, nowMillis = 100L)!!
+            val challenge =
+                pipe.decryptClientApplicationFrames(challengeOut)!!.first { it is PathChallengeFrame }
+                    as PathChallengeFrame
+
+            // PATH_RESPONSE arrives with matching payload — Bug-7 fix
+            // resets the counter inside applyPeerPathResponseLocked.
+            feedDatagram(
+                client,
+                pipe.buildServerApplicationDatagram(listOf(PathResponseFrame(challenge.data.copyOf())))!!,
+                nowMillis = 200L,
+            )
+            assertEquals(0, client.consecutivePtoCount, "successful path validation must reset consecutivePtoCount")
+        }
+
+    @Test
+    fun triggerPathMigrationBeforeHandshakeReturnsNotConnected() =
+        runBlocking {
+            // Bug-4 regression: RFC 9000 §9.1 forbids initiating
+            // migration before the handshake is confirmed. The
+            // public API must refuse rather than silently misbehave.
+            val client =
+                QuicConnection(
+                    serverName = "example.test",
+                    config = QuicConnectionConfig(),
+                    tlsCertificateValidator =
+                        com.vitorpamplona.quic.tls
+                            .PermissiveCertificateValidator(),
+                )
+            // Connection is in HANDSHAKING state; no transport
+            // parameters have been parsed yet.
+            assertEquals(QuicConnection.Status.HANDSHAKING, client.status)
+            val result = client.triggerPathMigration(nowMillis = 0L, currentPtoMillis = 100L)
+            assertEquals(PathMigrationResult.NotConnected, result)
         }
 }

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/PathValidatorTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/PathValidatorTest.kt
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quic.connection
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the in-memory [PathValidator] state machine — the
+ * piece that implements RFC 9000 §5.1 + §8.2 + §9 client-initiated
+ * path validation. Driven without a real socket so the assertions
+ * are about the state-machine contract rather than the on-wire
+ * encoding (see [PathValidationTest] for the integration shape).
+ */
+class PathValidatorTest {
+    @Test
+    fun newConnectionIdStoresInPool() {
+        val v = PathValidator()
+        val cid = byteArrayOf(0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08)
+        val tok = ByteArray(16) { 0xAA.toByte() }
+        val r = v.recordPeerNewConnectionId(sequenceNumber = 1L, retirePriorTo = 0L, connectionId = cid, statelessResetToken = tok)
+        assertEquals(PathValidator.RecordResult.Stored, r)
+        assertEquals(1, v.unusedCount())
+        assertEquals(listOf(1L), v.unusedSequences())
+    }
+
+    @Test
+    fun duplicateOfferWithSameBytesIsIdempotent() {
+        val v = PathValidator()
+        val cid = ByteArray(8) { 0x42 }
+        val tok = ByteArray(16) { 0x99.toByte() }
+        v.recordPeerNewConnectionId(1L, 0L, cid, tok)
+        val r = v.recordPeerNewConnectionId(1L, 0L, cid, tok)
+        assertEquals(PathValidator.RecordResult.Duplicate, r)
+        assertEquals(1, v.unusedCount())
+    }
+
+    @Test
+    fun duplicateOfferWithDifferentBytesIsProtocolViolation() {
+        val v = PathValidator()
+        val seq = 2L
+        v.recordPeerNewConnectionId(seq, 0L, ByteArray(8) { 0x11 }, ByteArray(16) { 0x22 })
+        val r =
+            v.recordPeerNewConnectionId(
+                sequenceNumber = seq,
+                retirePriorTo = 0L,
+                connectionId = ByteArray(8) { 0x33 },
+                statelessResetToken = ByteArray(16) { 0x44 },
+            )
+        assertEquals(PathValidator.RecordResult.DuplicateSequenceMismatch, r)
+    }
+
+    @Test
+    fun retirePriorToForcesEarlierEntriesIntoRetireQueue() {
+        val v = PathValidator()
+        v.recordPeerNewConnectionId(1L, 0L, ByteArray(8) { 0x01 }, ByteArray(16) { 0x10 })
+        v.recordPeerNewConnectionId(2L, 0L, ByteArray(8) { 0x02 }, ByteArray(16) { 0x20 })
+        // New offer with retirePriorTo = 2 forces sequences 0 and 1 into retirement.
+        val r = v.recordPeerNewConnectionId(3L, retirePriorTo = 2L, ByteArray(8) { 0x03 }, ByteArray(16) { 0x30 })
+        assertEquals(PathValidator.RecordResult.Stored, r)
+        assertEquals(2L, v.retirePriorToWatermark)
+        // Sequence 1 was in the pool — retired. Sequence 0 was the active CID;
+        // PathValidator queues it implicitly via watermark advancement, but
+        // only sequences ≥ retirePriorToWatermark (i.e. ≥ 2) survive in
+        // unusedCids.
+        assertEquals(setOf(2L, 3L), v.unusedSequences().toSet())
+        assertTrue(v.pendingRetireSequences.contains(1L), "seq 1 must be queued for retire")
+    }
+
+    @Test
+    fun retirePriorToRegressionIsClampedNotRejected() {
+        // RFC 9000 §19.15: a smaller `retire_prior_to` than what we
+        // previously saw "MUST be treated as the largest one it has
+        // seen" — i.e. clamp, don't error. Reordered NEW_CONNECTION_ID
+        // arrivals are common on the wire and aren't peer protocol
+        // violations.
+        val v = PathValidator()
+        v.recordPeerNewConnectionId(1L, 1L, ByteArray(8) { 0x01 }, ByteArray(16) { 0x10 })
+        val r = v.recordPeerNewConnectionId(2L, 0L, ByteArray(8) { 0x02 }, ByteArray(16) { 0x20 })
+        assertEquals(PathValidator.RecordResult.Stored, r)
+        assertEquals(1L, v.retirePriorToWatermark, "watermark must NOT decrease on a regressed retire_prior_to")
+    }
+
+    @Test
+    fun retirePriorToGreaterThanSequenceIsRejected() {
+        val v = PathValidator()
+        val r = v.recordPeerNewConnectionId(sequenceNumber = 1L, retirePriorTo = 5L, ByteArray(8), ByteArray(16))
+        assertEquals(PathValidator.RecordResult.RetirePriorToExceedsSequence, r)
+    }
+
+    @Test
+    fun poolFillsUpAndRejectsExcess() {
+        val v = PathValidator(maxUnusedCids = 3)
+        for (i in 1..3) {
+            assertEquals(
+                PathValidator.RecordResult.Stored,
+                v.recordPeerNewConnectionId(i.toLong(), 0L, ByteArray(8) { i.toByte() }, ByteArray(16) { i.toByte() }),
+            )
+        }
+        val r = v.recordPeerNewConnectionId(4L, 0L, ByteArray(8) { 0xAA.toByte() }, ByteArray(16))
+        assertEquals(PathValidator.RecordResult.PoolFull, r)
+        assertEquals(3, v.unusedCount())
+    }
+
+    @Test
+    fun startValidationReturnsNoSpareCidWhenPoolEmpty() {
+        val v = PathValidator()
+        assertEquals(PathMigrationResult.NoSpareCid, v.tryStartValidation(nowMillis = 0L, currentPtoMillis = 100L))
+        assertTrue(v.state is PathValidationState.Idle)
+    }
+
+    @Test
+    fun startValidationPicksLowestSequenceAndQueuesChallenge() {
+        val supplied = byteArrayOf(0xDE.toByte(), 0xAD.toByte(), 0xBE.toByte(), 0xEF.toByte(), 0x12, 0x34, 0x56, 0x78)
+        val v = PathValidator(challengePayloadFactory = { supplied.copyOf() })
+        v.recordPeerNewConnectionId(1L, 0L, ByteArray(8) { 0x01 }, ByteArray(16) { 0x10 })
+        v.recordPeerNewConnectionId(2L, 0L, ByteArray(8) { 0x02 }, ByteArray(16) { 0x20 })
+        assertEquals(PathMigrationResult.Started, v.tryStartValidation(nowMillis = 0L, currentPtoMillis = 200L))
+        val state = v.state as PathValidationState.Validating
+        assertEquals(1L, state.newCidSequence, "lowest sequence number must be picked first")
+        assertContentEquals(supplied, state.challengeData)
+        assertEquals(1, v.pendingChallenges.size)
+        assertContentEquals(supplied, v.pendingChallenges.first())
+    }
+
+    @Test
+    fun startValidationDoesNothingIfAlreadyInProgress() {
+        val v = PathValidator(challengePayloadFactory = { ByteArray(8) { 0x07 } })
+        v.recordPeerNewConnectionId(1L, 0L, ByteArray(8) { 0x01 }, ByteArray(16))
+        v.recordPeerNewConnectionId(2L, 0L, ByteArray(8) { 0x02 }, ByteArray(16))
+        assertEquals(PathMigrationResult.Started, v.tryStartValidation(0L, 100L))
+        // Second trigger before resolution — must not pick a second CID.
+        assertEquals(PathMigrationResult.AlreadyInProgress, v.tryStartValidation(0L, 100L))
+        // The second CID is still in the pool; only one challenge is in flight.
+        assertEquals(1, v.pendingChallenges.size)
+    }
+
+    @Test
+    fun pathResponseWithMatchingPayloadValidatesAndQueuesRetire() {
+        val payload = ByteArray(8) { 0x55 }
+        val v = PathValidator(challengePayloadFactory = { payload.copyOf() })
+        v.recordPeerNewConnectionId(1L, 0L, ByteArray(8) { 0xAA.toByte() }, ByteArray(16) { 0xBB.toByte() })
+        v.tryStartValidation(0L, 100L)
+        val outcome = v.applyPathResponse(payload)
+        assertTrue(outcome is PathValidator.ValidationOutcome.Validated, "got $outcome")
+        assertEquals(1L, outcome.newSequence)
+        assertEquals(0L, outcome.retiredSequence)
+        assertContentEquals(ByteArray(8) { 0xAA.toByte() }, outcome.newConnectionIdBytes)
+        assertEquals(1L, v.activeCidSequence)
+        assertTrue(v.state is PathValidationState.Succeeded)
+        assertTrue(v.pendingRetireSequences.contains(0L), "old sequence must be queued for RETIRE_CONNECTION_ID")
+        assertEquals(1L, v.successfulValidations)
+    }
+
+    @Test
+    fun pathResponseWithMismatchedPayloadIsIgnored() {
+        val v = PathValidator(challengePayloadFactory = { ByteArray(8) { 0x77 } })
+        v.recordPeerNewConnectionId(1L, 0L, ByteArray(8) { 0x01 }, ByteArray(16))
+        v.tryStartValidation(0L, 100L)
+        val outcome = v.applyPathResponse(ByteArray(8) { 0x11 })
+        assertEquals(PathValidator.ValidationOutcome.PayloadMismatch, outcome)
+        assertTrue(v.state is PathValidationState.Validating, "still validating; mismatched response is dropped")
+    }
+
+    @Test
+    fun pathResponseWithoutOutstandingChallengeIsIgnored() {
+        val v = PathValidator()
+        val outcome = v.applyPathResponse(ByteArray(8))
+        assertEquals(PathValidator.ValidationOutcome.NotValidating, outcome)
+    }
+
+    @Test
+    fun validationTimeoutAfter3PtoTransitionsToFailed() {
+        val v = PathValidator(challengePayloadFactory = { ByteArray(8) { 0x44 } })
+        v.recordPeerNewConnectionId(1L, 0L, ByteArray(8) { 0x01 }, ByteArray(16))
+        val pto = 1_000L
+        v.tryStartValidation(nowMillis = 0L, currentPtoMillis = pto)
+
+        assertNull(v.checkValidationTimeout(nowMillis = pto * 2L), "still within budget")
+        val abandoned = v.checkValidationTimeout(nowMillis = pto * 4L)
+        assertTrue(abandoned != null, "validation must time out at 3*PTO")
+        assertEquals(1L, abandoned.newCidSequence)
+        assertTrue(v.state is PathValidationState.Failed)
+        assertEquals(1L, v.failedValidations)
+    }
+
+    @Test
+    fun acknowledgeTerminalReturnsToIdle() {
+        val v = PathValidator(challengePayloadFactory = { ByteArray(8) { 0x33 } })
+        v.recordPeerNewConnectionId(1L, 0L, ByteArray(8), ByteArray(16))
+        v.tryStartValidation(0L, 100L)
+        v.applyPathResponse(ByteArray(8) { 0x33 })
+        assertTrue(v.state is PathValidationState.Succeeded)
+        v.acknowledgeTerminal()
+        assertTrue(v.state is PathValidationState.Idle)
+    }
+
+    @Test
+    fun staleOfferBelowWatermarkQueuesRetireWithoutStoring() {
+        val v = PathValidator()
+        // Seed watermark to 5 via a normal offer with retirePriorTo = 5.
+        v.recordPeerNewConnectionId(5L, 5L, ByteArray(8) { 0x05 }, ByteArray(16) { 0x50 })
+        assertEquals(5L, v.retirePriorToWatermark)
+        // Now a reordered offer arrives with seq=3 and retirePriorTo=3
+        // (the value the peer sent before raising it to 5). Even
+        // though seq=3 ≥ retirePriorTo=3 (so it isn't a frame error),
+        // the watermark we already raised says seq 3 has been retired.
+        // The validator clamps retirePriorTo to the watermark and
+        // detects that seq is now below the watermark — so the entry
+        // is queued for RETIRE_CONNECTION_ID rather than stored.
+        val r = v.recordPeerNewConnectionId(3L, 3L, ByteArray(8) { 0x03 }, ByteArray(16) { 0x30 })
+        assertEquals(PathValidator.RecordResult.AlreadyRetired, r)
+        assertTrue(v.pendingRetireSequences.contains(3L), "stale offer must be retired immediately")
+        assertEquals(1, v.unusedCount(), "stale entry must not be stored in pool")
+    }
+}

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/PathValidatorTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/PathValidatorTest.kt
@@ -166,7 +166,7 @@ class PathValidatorTest {
         assertTrue(outcome is PathValidator.ValidationOutcome.Validated, "got $outcome")
         assertEquals(1L, outcome.newSequence)
         assertEquals(0L, outcome.retiredSequence)
-        assertContentEquals(ByteArray(8) { 0xAA.toByte() }, outcome.newConnectionIdBytes)
+        assertContentEquals(ByteArray(8) { 0xAA.toByte() }, outcome.connectionId)
         assertEquals(1L, v.activeCidSequence)
         assertTrue(v.state is PathValidationState.Succeeded)
         assertTrue(v.pendingRetireSequences.contains(0L), "old sequence must be queued for RETIRE_CONNECTION_ID")
@@ -191,7 +191,12 @@ class PathValidatorTest {
     }
 
     @Test
-    fun validationTimeoutAfter3PtoTransitionsToFailed() {
+    fun validationTimeoutAfter3PtoTransitionsToFailedAndRetiresFailedCid() {
+        // Bug-2 regression: on 3 * PTO timeout the failed CID's
+        // sequence MUST be queued for RETIRE_CONNECTION_ID.
+        // Without this the peer keeps the routing entry forever
+        // because we sent a packet with that DCID (the challenge)
+        // but never told them we abandoned it.
         val v = PathValidator(challengePayloadFactory = { ByteArray(8) { 0x44 } })
         v.recordPeerNewConnectionId(1L, 0L, ByteArray(8) { 0x01 }, ByteArray(16))
         val pto = 1_000L
@@ -203,6 +208,10 @@ class PathValidatorTest {
         assertEquals(1L, abandoned.newCidSequence)
         assertTrue(v.state is PathValidationState.Failed)
         assertEquals(1L, v.failedValidations)
+        assertTrue(
+            v.pendingRetireSequences.contains(1L),
+            "abandoned CID sequence must be queued for RETIRE_CONNECTION_ID — pending=${v.pendingRetireSequences}",
+        )
     }
 
     @Test

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/PathValidatorTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/PathValidatorTest.kt
@@ -174,6 +174,106 @@ class PathValidatorTest {
     }
 
     @Test
+    fun triggerRetiresPriorSequenceImmediately() {
+        // Bug-B regression: under abrupt-migration semantics the
+        // prior CID is abandoned the moment we rotate (RFC 9000
+        // §5.1.2). Queuing the retire only at PATH_RESPONSE success
+        // means a failed first attempt followed by a never-validated
+        // second attempt would leave seq=0 unretired forever.
+        val v = PathValidator(challengePayloadFactory = { ByteArray(8) { 0x11 } })
+        v.recordPeerNewConnectionId(1L, 0L, ByteArray(8) { 0x01 }, ByteArray(16) { 0x10 })
+        v.tryStartValidation(0L, 100L)
+        assertTrue(
+            v.pendingRetireSequences.contains(0L),
+            "prior sequence must be queued for retire at trigger time, not at response time",
+        )
+        assertEquals(1L, v.activeCidSequence, "activeCidSequence advances at trigger to track the on-wire DCID")
+    }
+
+    @Test
+    fun twoConsecutiveFailedValidationsRetireAllAbandonedSequences() {
+        // Bug-B regression: prior to the fix, two failed validations
+        // would leave the original seq=0 unretired (the priorSeq
+        // queue entry was scheduled inside applyPathResponse, which
+        // never runs for failed validations).
+        val v = PathValidator(challengePayloadFactory = { ByteArray(8) { 0x22 } })
+        v.recordPeerNewConnectionId(1L, 0L, ByteArray(8) { 0x01 }, ByteArray(16) { 0x10 })
+        v.recordPeerNewConnectionId(2L, 0L, ByteArray(8) { 0x02 }, ByteArray(16) { 0x20 })
+        val pto = 1_000L
+        // First attempt fails by timeout.
+        v.tryStartValidation(0L, pto)
+        v.checkValidationTimeout(nowMillis = pto * 4L)
+        v.acknowledgeTerminal()
+        // Second attempt also fails.
+        v.tryStartValidation(nowMillis = 10_000L, currentPtoMillis = pto)
+        v.checkValidationTimeout(nowMillis = 10_000L + pto * 4L)
+
+        // All three sequences abandoned along the way (the original
+        // seq=0 plus seq=1 plus seq=2) MUST be queued for retire.
+        for (seq in listOf(0L, 1L, 2L)) {
+            assertTrue(
+                v.pendingRetireSequences.contains(seq),
+                "seq=$seq abandoned but not queued for retire — pending=${v.pendingRetireSequences}",
+            )
+        }
+    }
+
+    @Test
+    fun forceRotateRunsWhenWatermarkPassesActiveCid() {
+        // Bug-C regression: RFC 9000 §5.1.2 — "If the active
+        // connection ID's sequence number is less than the Retire
+        // Prior To value, the endpoint MUST retire the active
+        // connection ID and adopt one with a higher sequence number."
+        val v = PathValidator()
+        v.recordPeerNewConnectionId(1L, 0L, ByteArray(8) { 0x01 }, ByteArray(16) { 0x10 })
+        v.recordPeerNewConnectionId(2L, 0L, ByteArray(8) { 0x02 }, ByteArray(16) { 0x20 })
+        // Now the peer advances retire_prior_to past our active CID
+        // (seq 0), forcing same-path rotation.
+        v.recordPeerNewConnectionId(3L, retirePriorTo = 1L, ByteArray(8) { 0x03 }, ByteArray(16) { 0x30 })
+
+        val rotation = v.forceRotateToHigherSequence()
+        assertTrue(rotation is PathValidator.ForcedRotationResult.Rotated, "got $rotation")
+        assertEquals(1L, rotation.newSequence, "must pick the lowest spare sequence")
+        assertEquals(0L, rotation.retiredSequence)
+        assertContentEquals(ByteArray(8) { 0x01 }, rotation.connectionId)
+        assertEquals(1L, v.activeCidSequence)
+        assertTrue(v.pendingRetireSequences.contains(0L))
+    }
+
+    @Test
+    fun forceRotateNoOpWhenWatermarkBelowActive() {
+        val v = PathValidator()
+        v.recordPeerNewConnectionId(1L, 0L, ByteArray(8) { 0x01 }, ByteArray(16) { 0x10 })
+        // Watermark is still 0; active is also 0 (initial). Nothing
+        // to rotate.
+        assertEquals(null, v.forceRotateToHigherSequence())
+        assertEquals(0L, v.activeCidSequence)
+    }
+
+    @Test
+    fun forceRotateRotatesAgainWhenNewerOfferAdvancesWatermark() {
+        // Cascading server-forced rotation: peer issues seq=1 then
+        // (later) seq=2 with retire_prior_to=2, retiring seq=1
+        // immediately after we'd just adopted it.
+        val v = PathValidator()
+        v.recordPeerNewConnectionId(1L, 0L, ByteArray(8) { 0x01 }, ByteArray(16) { 0x10 })
+        // Tester adopts seq=1 via initial-state simulation: trigger
+        // a validation just to bump activeCidSequence past 0.
+        v.tryStartValidation(0L, 100L)
+        v.applyPathResponse(ByteArray(8) { 0x00 }) // mismatched, validation stays Validating
+        v.acknowledgeTerminal() // benign no-op (state isn't terminal)
+        assertEquals(1L, v.activeCidSequence)
+
+        // Peer now advances watermark to 2 with a fresh offer.
+        v.recordPeerNewConnectionId(2L, retirePriorTo = 2L, ByteArray(8) { 0x02 }, ByteArray(16) { 0x20 })
+        val rotation = v.forceRotateToHigherSequence()
+        assertTrue(rotation is PathValidator.ForcedRotationResult.Rotated, "got $rotation")
+        assertEquals(2L, rotation.newSequence)
+        assertEquals(1L, rotation.retiredSequence)
+        assertEquals(2L, v.activeCidSequence)
+    }
+
+    @Test
     fun pathResponseWithMismatchedPayloadIsIgnored() {
         val v = PathValidator(challengePayloadFactory = { ByteArray(8) { 0x77 } })
         v.recordPeerNewConnectionId(1L, 0L, ByteArray(8) { 0x01 }, ByteArray(16))

--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/recovery/RecoveryTokenTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/connection/recovery/RecoveryTokenTest.kt
@@ -135,6 +135,8 @@ class RecoveryTokenTest {
                     is RecoveryToken.ResetStream -> "rs:${it.streamId}:${it.errorCode}:${it.finalSize}"
                     is RecoveryToken.StopSending -> "ss:${it.streamId}:${it.errorCode}"
                     is RecoveryToken.NewConnectionId -> "ncid:${it.sequenceNumber}"
+                    is RecoveryToken.PathChallenge -> "pc"
+                    is RecoveryToken.RetireConnectionId -> "rcid:${it.sequenceNumber}"
                 }
             }
         assertEquals(


### PR DESCRIPTION
## Summary

This PR implements RFC 9000 §9 client-initiated path validation and destination connection ID (DCID) rotation for the QUIC client. The implementation allows clients to proactively migrate to new paths when the current path appears degraded (detected via consecutive PTOs), and includes proper handling of peer-issued connection IDs with automatic retirement semantics.

## Key Changes

- **New `PathValidator` class** (`PathValidator.kt`): Core state machine implementing RFC 9000 §5.1, §8.2, and §9 path validation logic
  - Manages a pool of peer-issued connection IDs with sequence number tracking
  - Implements `retire_prior_to` watermark semantics for automatic CID retirement
  - Handles `PATH_CHALLENGE`/`PATH_RESPONSE` exchange with 8-byte payload validation
  - Enforces 3×PTO timeout for validation attempts per RFC 9000 §8.2.4
  - Supports both client-initiated (application-triggered) and server-forced (via `retire_prior_to`) path rotation

- **Integration with `QuicConnection`**:
  - Added `pathValidator` field to manage the CID pool and validation state
  - New `applyPeerNewConnectionIdLocked()` method to process inbound `NEW_CONNECTION_ID` frames
  - New `applyPeerPathResponseLocked()` method to process inbound `PATH_RESPONSE` frames
  - New `triggerPathMigration()` public API for application-initiated migration
  - Made `consecutivePtoCount` volatile to safely share between driver and parser threads

- **PTO-driven rotation trigger** (`QuicConnectionDriver.kt`):
  - After `PATH_PROBE_PTO_THRESHOLD` (2) consecutive PTOs without ACK progress, automatically trigger path migration
  - Increments `consecutivePtoCount` before threshold check (Bug-6 fix)
  - Resets counter on successful validation or inbound ACK

- **Frame handling** (`QuicConnectionParser.kt`, `QuicConnectionWriter.kt`):
  - Parser dispatches `NEW_CONNECTION_ID` frames to `pathValidator.recordPeerNewConnectionId()`
  - Writer drains `pendingChallenges` queue as `PATH_CHALLENGE` frames
  - Writer drains `pendingRetireSequences` queue as `RETIRE_CONNECTION_ID` frames
  - Added `RetireConnectionIdFrame` class for frame encoding/decoding

- **Recovery integration** (`RecoveryToken.kt`):
  - New `PathChallenge` recovery token type to track in-flight `PATH_CHALLENGE` frames
  - Loss dispatcher can retransmit or abandon based on validation state

- **Observability** (`QlogObserver.kt`):
  - New qlog hooks: `onPathValidationStarted()`, `onPathValidationSucceeded()`, `onPathValidationFailed()`
  - New CID lifecycle hooks: `onConnectionIdActivated()`, `onConnectionIdRetired()`

- **Comprehensive test coverage**:
  - `PathValidatorTest.kt`: Unit tests for the state machine (pool management, watermark semantics, validation flow)
  - `ClientPathMigrationTest.kt`: Integration tests driving the full client through the in-memory pipe harness

## Notable Implementation Details

- **Abrupt migration model** (Bug-1 fix): The writer's DCID is swapped immediately when `tryStartValidation()` is called, so the `PATH_CHALLENGE` itself goes out on the new path (not the old one)
- **Atomic retire** (Bug-B fix): `RETIRE_CONNECTION_ID` for the prior CID is queued at trigger time (not response time), allowing both frames to drain in the same packet
- **Server-forced rotation** (Bug-C fix): When `retire_prior_to` advances past the active CID, the connection automatically rotates to a higher-sequence CID on the same path without requiring a `PATH_CHALLENGE`
- **PTO counter fix** (Bug-6 fix): Counter is incremented before the threshold check, ensuring rotation fires on the correct PTO event

https://claude.ai/code/session_01PVVhSQXvw4K4oQ46FzpgaT