### PR TITLE
Rename lock fields to reflect their specific purposes

### DIFF
--- a/quic/src/commonTest/kotlin/com/vitorpamplona/quic/observability/QlogObserverTest.kt
+++ b/quic/src/commonTest/kotlin/com/vitorpamplona/quic/observability/QlogObserverTest.kt
@@ -53,7 +53,7 @@ class QlogObserverTest {
         runBlocking {
             val client = handshakedClient(QlogObserver.NoOp)
             // Drive a tiny operation post-handshake.
-            client.lock.withLock {
+            client.lifecycleLock.withLock {
                 // No-op — just confirm we can still take the lock.
                 assertEquals(QuicConnection.Status.CONNECTED, client.status)
             }
@@ -141,7 +141,7 @@ class QlogObserverTest {
                     0x00, // pn byte
                     0x00, // payload byte (will fail AEAD)
                 )
-            client.lock.withLock {
+            client.streamsLock.withLock {
                 feedDatagram(client, garbage, nowMillis = 1L)
             }
             val drops = recorder.events.filter { it.name == "packetDropped" }


### PR DESCRIPTION
This PR refactors lock field names in the QuicConnection class to better reflect their intended use and improve code clarity.

## Summary
Updated lock field references in QlogObserverTest to use more descriptive names that indicate the specific resources each lock protects.

## Key Changes
- Renamed `client.lock` to `client.lifecycleLock` in the post-handshake connection status test, clarifying that this lock protects the connection's lifecycle state
- Renamed `client.lock` to `client.streamsLock` in the packet drop test, indicating that this lock protects stream-related operations

## Implementation Details
These changes improve code maintainability by making the purpose of each lock explicit at the call site. The renaming suggests that QuicConnection now uses multiple specialized locks rather than a single general-purpose lock, allowing for better concurrency control over different aspects of the connection (lifecycle management vs. stream operations).

https://claude.ai/code/session_01GPRK4E96nHqGsoraJuYsKe