### PR TITLE
Clean up documentation and organize constant definitions

### DIFF
--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionParser.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionParser.kt
@@ -49,6 +49,9 @@ import com.vitorpamplona.quic.packet.ShortHeaderPacket
 import com.vitorpamplona.quic.stream.StreamId
 import com.vitorpamplona.quic.tls.TlsClient
 
+/** RFC 9000 §16: maximum varint value, also the per-stream offset ceiling. */
+private const val MAX_QUIC_OFFSET: Long = (1L shl 62) - 1L
+
 /**
  * Decode every QUIC packet inside a single inbound UDP datagram and dispatch
  * its frames to [conn]'s state.
@@ -67,10 +70,6 @@ import com.vitorpamplona.quic.tls.TlsClient
  * under streamsLock so frame-dispatch / stream creation / level state
  * remains a single critical section.
  */
-
-/** RFC 9000 §16: maximum varint value, also the per-stream offset ceiling. */
-private const val MAX_QUIC_OFFSET: Long = (1L shl 62) - 1L
-
 fun feedDatagram(
     conn: QuicConnection,
     datagram: ByteArray,

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/tls/TlsClient.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/tls/TlsClient.kt
@@ -668,7 +668,8 @@ interface TlsSecretsListener {
  * Self-contained state needed to resume a TLS 1.3 session via PSK on the
  * next connection. Produced by the TLS layer when a NewSessionTicket
  * arrives; consumed by a fresh [TlsClient] via its `resumption`
- * constructor argument.
+ * constructor argument. Lets the client offer RFC 8446 PSK-resumption +
+ * RFC 9001 §4.6 0-RTT on the next connection.
  *
  * Why store all this rather than just the ticket: the PSK derivation
  * binds to a specific cipher suite (32-byte hash for our SHA-256 suites)
@@ -676,10 +677,6 @@ interface TlsSecretsListener {
  * obfuscation arithmetic on the next connection needs both
  * [ticketAgeAdd] and [issuedAtMillis] to compute the obfuscated_ticket_age
  * the server expects.
- */
-/**
- * Cached state from a prior TLS handshake that lets the client offer
- * RFC 8446 PSK-resumption + RFC 9001 §4.6 0-RTT on the next connection.
  *
  * Plain `class` (not `data class`) intentionally:
  *  - The `data class`-generated `equals` / `hashCode` use reference


### PR DESCRIPTION
## Summary
This PR improves code organization and documentation clarity by relocating a constant definition and consolidating redundant documentation comments.

## Key Changes
- **Moved `MAX_QUIC_OFFSET` constant** from after the `feedDatagram` function's documentation block to immediately after the imports in `QuicConnectionParser.kt`, placing it closer to where it's logically grouped with other module-level definitions
- **Consolidated duplicate documentation** in `TlsClient.kt` by merging two separate comment blocks describing `TlsSessionResumption` into a single, more comprehensive comment that explains both the purpose and implementation details
- **Enhanced documentation** in `TlsClient.kt` to explicitly reference RFC 8446 PSK-resumption and RFC 9001 §4.6 0-RTT capabilities in the main description

## Implementation Details
- The constant relocation improves code readability by keeping module-level constants grouped together near imports rather than scattered before function definitions
- The documentation consolidation eliminates redundancy while preserving all technical details about PSK derivation, cipher suite binding, and ticket age obfuscation

https://claude.ai/code/session_019xfz4PDLqa2S92o4hBbLhD