### PR TITLE
Add Favorite Feed Algorithms to bottom-bar catalogue

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/NavBarItem.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/NavBarItem.kt
@@ -62,6 +62,7 @@ enum class NavBarItem {
     PRODUCTS,
     EMOJI_SETS,
     SETTINGS,
+    FAVORITE_ALGO_FEEDS,
 }
 
 data class NavBarItemDef(
@@ -156,6 +157,13 @@ val NavBarCatalog: Map<NavBarItem, NavBarItemDef> =
                 labelRes = R.string.interest_sets_title,
                 icon = MaterialSymbols.Tag,
                 resolveRoute = { Route.InterestSets },
+            ),
+        NavBarItem.FAVORITE_ALGO_FEEDS to
+            NavBarItemDef(
+                id = NavBarItem.FAVORITE_ALGO_FEEDS,
+                labelRes = R.string.favorite_dvms_title,
+                icon = MaterialSymbols.Star,
+                resolveRoute = { Route.EditFavoriteAlgoFeeds },
             ),
         NavBarItem.EMOJI_PACKS to
             NavBarItemDef(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/BottomBarFeedPreloaders.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/BottomBarFeedPreloaders.kt
@@ -118,6 +118,7 @@ private fun PreloadFor(
         NavBarItem.INTEREST_SETS,
         NavBarItem.EMOJI_PACKS,
         NavBarItem.WALLET,
+        NavBarItem.FAVORITE_ALGO_FEEDS,
         NavBarItem.SETTINGS,
         -> Unit
     }


### PR DESCRIPTION
Adds Favorite Feed Algorithms as a pinnable entry in the bottom-bar customization screen (Settings → Bottom Navigation Bar). Reuses the existing route, screen, string, and Star icon — no new resources.

Catalog-only by design: not in the side drawer and not in the default 5-icon layout, so the change is opt-in and doesn't disturb existing users.

<img width="300" alt="Screenshot_20260509-101008" src="https://github.com/user-attachments/assets/dc23d4d2-e2ff-438b-808c-7d3d459e54f9" /> <img width="300" alt="Screenshot_20260509-100936" src="https://github.com/user-attachments/assets/f79ed1dc-24d1-4e03-b99f-661e65f785e3" /> 

                                                                                                                                                                                                                  
  ## Test plan                                                                                                                                                                                                                  
  - [x] `./gradlew :amethyst:compilePlayDebugKotlin` clean                                                                                                                                                                      
  - [x] `./gradlew :amethyst:spotlessKotlinCheck` clean   
  - [x] Manual on Pixel 9a: appears in Bottom Bar Settings with Star icon → pin/unpin → tap navigates to the right screen → restore default removes it → does NOT appear in any drawer section. 