### PR TITLE
fix: redact secrets and sensitive payloads from debug logs (Quartz/Amethyst)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
@@ -696,7 +696,7 @@ object LocalPreferences {
             JsonMapper.fromJson<TopFilter>(value)
         } catch (e: Throwable) {
             if (e is CancellationException) throw e
-            Log.w("LocalPreferences", "Error Decoding TopFilter from Preferences with value $value", e)
+            Log.w("LocalPreferences", "Error Decoding TopFilter from Preferences", e)
             default
         }
     }
@@ -754,7 +754,7 @@ object LocalPreferences {
             }
         } catch (e: Throwable) {
             if (e is CancellationException) throw e
-            Log.w("LocalPreferences", "Error Decoding ${T::class.java} from Preferences with value $value", e)
+            Log.w("LocalPreferences", "Error Decoding ${T::class.simpleName} from Preferences", e)
             null
         }
     }
@@ -767,7 +767,7 @@ object LocalPreferences {
             Event.fromJson(value) as T?
         } catch (e: Throwable) {
             if (e is CancellationException) throw e
-            Log.w("LocalPreferences", "Error Decoding ${T::class.java} from Preferences with value $value", e)
+            Log.w("LocalPreferences", "Error Decoding ${T::class.simpleName} from Preferences", e)
             null
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip78AppSpecific/AppSpecificState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip78AppSpecific/AppSpecificState.kt
@@ -75,7 +75,7 @@ class AppSpecificState(
                         settings.syncedSettings.updateFrom(syncedSettings)
                     } catch (e: Throwable) {
                         if (e is CancellationException) throw e
-                        Log.w("LocalPreferences", "Error Decoding latestAppSpecificData from Preferences with value", e)
+                        Log.w("LocalPreferences", "Error Decoding latestAppSpecificData from Preferences", e)
                     }
                 }
             }
@@ -92,7 +92,7 @@ class AppSpecificState(
                                 settings.updateAppSpecificData(it, syncedSettings)
                             } catch (e: Throwable) {
                                 if (e is CancellationException) throw e
-                                Log.w("LocalPreferences", "Error Decoding latestAppSpecificData from Preferences with value $decrypted", e)
+                                Log.w("LocalPreferences", "Error Decoding latestAppSpecificData from Preferences", e)
                             }
                         }
                     } catch (e: Throwable) {

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/crypto/EventExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/crypto/EventExt.kt
@@ -39,7 +39,7 @@ fun Event.verifySignature(): Boolean {
 /** Checks if the ID is correct and then if the pubKey's secret key signed the event. */
 fun Event.checkSignature() {
     if (!verifyId()) {
-        throw Exception("ID mismatch: our ID is ${generateId()} for event ${toJson()}")
+        throw Exception("ID mismatch: our ID is ${generateId()} for event id=$id, pubKey=$pubKey, kind=$kind, createdAt=$createdAt")
     }
     if (!verifySignature()) {
         throw Exception("Bad signature!")
@@ -50,6 +50,6 @@ fun Event.verify(): Boolean =
     try {
         verifyId() && verifySignature()
     } catch (e: Exception) {
-        Log.w("Event", "Event $id does not have a valid signature: ${toJson()}", e)
+        Log.w("Event", "Event $id does not have a valid signature (pubKey=$pubKey, kind=$kind, createdAt=$createdAt)", e)
         false
     }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/crypto/KeyPair.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/crypto/KeyPair.kt
@@ -53,5 +53,5 @@ class KeyPair(
         }
     }
 
-    override fun toString(): String = "KeyPair(privateKey=${privKey?.toHexKey()}, publicKey=${pubKey.toHexKey()}"
+    override fun toString(): String = "KeyPair(publicKey=${pubKey.toHexKey()}, privateKey=<redacted>)"
 }


### PR DESCRIPTION
Summary                                                      
                                                                                                                                                                                                                                
  - Drop full event JSON from signature-verify failure logs in Quartz; redact private key in KeyPair.toString.                                                                                                                  
  - Stop logging decrypted NIP-78 app-specific body on sync parse failure.
  - Stop logging raw preference values on LocalPreferences parse failure.   