### PR TITLE
fix(gallery): forward imeta hashes through gallery

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/VideoView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/VideoView.kt
@@ -70,6 +70,7 @@ fun VideoView(
     alwaysShowVideo: Boolean = false,
     thumbhash: String? = null,
     isLiveStream: Boolean = false,
+    hash: String? = null,
 ) {
     val borderModifier =
         if (roundedCorner) {
@@ -80,7 +81,7 @@ fun VideoView(
             Modifier
         }
 
-    VideoView(videoUri, mimeType, title, thumb, borderModifier, contentScale, waveform, artworkUri, authorName, dimensions, blurhash, nostrUriCallback, onDialog, alwaysShowVideo, accountViewModel = accountViewModel, thumbhash = thumbhash, isLiveStream = isLiveStream)
+    VideoView(videoUri, mimeType, title, thumb, borderModifier, contentScale, waveform, artworkUri, authorName, dimensions, blurhash, nostrUriCallback, onDialog, alwaysShowVideo, accountViewModel = accountViewModel, thumbhash = thumbhash, isLiveStream = isLiveStream, hash = hash)
 }
 
 @Composable
@@ -103,6 +104,7 @@ fun VideoView(
     isLiveStream: Boolean = false,
     accountViewModel: AccountViewModel,
     thumbhash: String? = null,
+    hash: String? = null,
 ) {
     val initialAutoStart = if (alwaysShowVideo) true else accountViewModel.settings.startVideoPlayback()
     // Reset the manual-show toggle when the video URI changes so a recycled feed slot
@@ -160,6 +162,10 @@ fun VideoView(
                     isLiveStream = isLiveStream,
                     onZoom = onDialog,
                     hasBlurhash = false,
+                    blurhash = blurhash,
+                    dim = dimensions,
+                    hash = hash,
+                    thumbhash = thumbhash,
                     accountViewModel = accountViewModel,
                     showControls = showControls,
                 )
@@ -207,6 +213,10 @@ fun VideoView(
                     isLiveStream = isLiveStream,
                     onZoom = onDialog,
                     hasBlurhash = true,
+                    blurhash = blurhash,
+                    dim = dimensions,
+                    hash = hash,
+                    thumbhash = thumbhash,
                     accountViewModel = accountViewModel,
                     showControls = showControls,
                 )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/VideoViewInner.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/VideoViewInner.kt
@@ -31,6 +31,7 @@ import com.vitorpamplona.amethyst.service.playback.composable.controls.VideoQual
 import com.vitorpamplona.amethyst.service.playback.composable.mainVideo.VideoPlayerActiveMutex
 import com.vitorpamplona.amethyst.service.playback.composable.mediaitem.GetMediaItem
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.quartz.nip94FileMetadata.tags.DimensionTag
 
 val DEFAULT_MUTED_SETTING = mutableStateOf(true)
 
@@ -54,6 +55,10 @@ fun VideoViewInner(
     onZoom: (() -> Unit)? = null,
     hasBlurhash: Boolean = false,
     isFullscreen: Boolean = false,
+    blurhash: String? = null,
+    dim: DimensionTag? = null,
+    hash: String? = null,
+    thumbhash: String? = null,
     accountViewModel: AccountViewModel,
 ) {
     // keeps a copy of the value to avoid recompositions here when the DEFAULT value changes
@@ -76,6 +81,10 @@ fun VideoViewInner(
         keepPlaying = true,
         waveformData = waveform,
         isLiveStream = isLiveStream,
+        blurhash = blurhash,
+        dim = dim,
+        hash = hash,
+        thumbhash = thumbhash,
     ) { mediaItem ->
         GetVideoController(
             mediaItem = mediaItem,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/controls/RenderTopButtons.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/controls/RenderTopButtons.kt
@@ -303,9 +303,9 @@ fun RenderTopButtons(
                 popupExpanded = shareDialogVisible,
                 videoUri = mediaData.videoUri,
                 postNostrUri = mediaData.callbackUri,
-                blurhash = null,
-                dim = null,
-                hash = null,
+                blurhash = mediaData.blurhash,
+                dim = mediaData.dim,
+                hash = mediaData.hash,
                 mimeType = mediaData.mimeType,
                 onDismiss = { shareDialogVisible.value = false },
                 content =
@@ -316,6 +316,10 @@ fun RenderTopButtons(
                         authorName = mediaData.authorName,
                         description = mediaData.title,
                         uri = mediaData.callbackUri,
+                        blurhash = mediaData.blurhash,
+                        dim = mediaData.dim,
+                        hash = mediaData.hash,
+                        thumbhash = mediaData.thumbhash,
                     ),
                 accountViewModel = accountViewModel,
             )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/mediaitem/GetMediaItem.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/mediaitem/GetMediaItem.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import com.vitorpamplona.amethyst.commons.compose.produceCachedState
 import com.vitorpamplona.amethyst.service.playback.composable.WaveformData
+import com.vitorpamplona.quartz.nip94FileMetadata.tags.DimensionTag
 
 val mediaItemCache = MediaItemCache()
 
@@ -41,6 +42,10 @@ fun GetMediaItem(
     keepPlaying: Boolean = false,
     waveformData: WaveformData? = null,
     isLiveStream: Boolean = false,
+    blurhash: String? = null,
+    dim: DimensionTag? = null,
+    hash: String? = null,
+    thumbhash: String? = null,
     inner: @Composable (LoadedMediaItem) -> Unit,
 ) {
     val data =
@@ -57,6 +62,10 @@ fun GetMediaItem(
                 keepPlaying = keepPlaying,
                 waveformData = waveformData,
                 isLiveStream = isLiveStream,
+                blurhash = blurhash,
+                dim = dim,
+                hash = hash,
+                thumbhash = thumbhash,
             )
         }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/mediaitem/MediaItemData.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/mediaitem/MediaItemData.kt
@@ -23,6 +23,7 @@ package com.vitorpamplona.amethyst.service.playback.composable.mediaitem
 import androidx.compose.runtime.Immutable
 import androidx.media3.common.MediaItem
 import com.vitorpamplona.amethyst.service.playback.composable.WaveformData
+import com.vitorpamplona.quartz.nip94FileMetadata.tags.DimensionTag
 
 @Immutable
 data class MediaItemData(
@@ -40,6 +41,13 @@ data class MediaItemData(
     // (e.g. multi-rendition NIP-71 videos) must leave this false so that
     // ExoPlayer's SimpleCache can cache their immutable segments.
     val isLiveStream: Boolean = false,
+    // Source-imeta visual fields — carried through so the player's "Add to Gallery" /
+    // "Share" actions can publish a richer ProfileGalleryEntryEvent. Optional; null when
+    // the surface that constructed this MediaItemData didn't have them.
+    val blurhash: String? = null,
+    val dim: DimensionTag? = null,
+    val hash: String? = null,
+    val thumbhash: String? = null,
 )
 
 @Immutable

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/PreviewMetadataCalculator.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/PreviewMetadataCalculator.kt
@@ -48,6 +48,8 @@ data class PreviewHashes(
 }
 
 object PreviewMetadataCalculator {
+    private const val LOG_TAG = "PreviewMetadataCalc"
+
     private fun isImage(mimeType: String?) = mimeType?.startsWith("image/", ignoreCase = true) == true
 
     private fun isVideo(mimeType: String?) = mimeType?.startsWith("video/", ignoreCase = true) == true
@@ -117,7 +119,7 @@ object PreviewMetadataCalculator {
                 }
             }
         } catch (e: Exception) {
-            Log.w("PreviewMetadataCalc", "Failed to compute metadata from uri", e)
+            Log.w(LOG_TAG, "Failed to compute metadata from uri", e)
             null
         }
     }
@@ -133,8 +135,14 @@ object PreviewMetadataCalculator {
     private fun processBitmap(bitmap: Bitmap?): PreviewHashes =
         if (bitmap != null) {
             try {
-                val blurhash = runCatching { BlurhashWrapper(bitmap.toBlurhash()) }.getOrNull()
-                val thumbhash = runCatching { ThumbhashWrapper(bitmap.toThumbhash()) }.getOrNull()
+                val blurhash =
+                    runCatching { BlurhashWrapper(bitmap.toBlurhash()) }
+                        .onFailure { Log.w(LOG_TAG, "blurhash generation failed", it) }
+                        .getOrNull()
+                val thumbhash =
+                    runCatching { ThumbhashWrapper(bitmap.toThumbhash()) }
+                        .onFailure { Log.w(LOG_TAG, "thumbhash generation failed", it) }
+                        .getOrNull()
                 PreviewHashes(
                     blurhash = blurhash,
                     thumbhash = thumbhash,
@@ -153,6 +161,9 @@ object PreviewMetadataCalculator {
     ): PreviewHashes {
         val dim = retriever.prepareDimFromVideo() ?: dimPrecomputed
         val thumb = retriever.getThumbnail()
+        if (thumb == null) {
+            Log.w(LOG_TAG) { "video frame extraction returned null; no blurhash/thumbhash will be generated" }
+        }
         val hashes = processBitmap(thumb)
         val finalDim = if (dim?.hasSize() == true) dim else hashes.dim
         return hashes.copy(dim = finalDim)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
@@ -226,6 +226,7 @@ fun ZoomableContentView(
                         accountViewModel = accountViewModel,
                         thumbhash = content.thumbhash,
                         isLiveStream = content.isLiveStream,
+                        hash = content.hash,
                     )
                 }
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
@@ -961,7 +961,10 @@ fun ShareMediaAction(
                                     // still — the .m3u8 URL itself is a text manifest. Only
                                     // MediaUrlVideo carries an artworkUri.
                                     val posterUrl = (content as? MediaUrlVideo)?.artworkUri
-                                    accountViewModel.addMediaToGallery(n19.hex, videoUri, n19.relay.getOrNull(0), blurhash, dim, hash, mimeType, image = posterUrl)
+                                    val thumbhashFromContent =
+                                        (content as? MediaUrlVideo)?.thumbhash
+                                            ?: (content as? MediaUrlImage)?.thumbhash
+                                    accountViewModel.addMediaToGallery(n19.hex, videoUri, n19.relay.getOrNull(0), blurhash, dim, hash, mimeType, thumbhash = thumbhashFromContent, image = posterUrl)
                                     accountViewModel.toastManager.toast(R.string.media_added, R.string.media_added_to_profile_gallery)
                                 }
                             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -896,8 +896,9 @@ class AccountViewModel(
         dim: DimensionTag?,
         hash: String?,
         mimeType: String?,
+        thumbhash: String? = null,
         image: String? = null,
-    ) = launchSigner { account.addToGallery(hex, url, relay, blurhash, dim, hash, mimeType, image = image) }
+    ) = launchSigner { account.addToGallery(hex, url, relay, blurhash, dim, hash, mimeType, thumbhash = thumbhash, image = image) }
 
     fun removeFromMediaGallery(note: Note) = launchSigner { account.removeFromGallery(note) }
 


### PR DESCRIPTION
Adding thumbhash support to HLS videos in Gallery via multiple PRs. 

## Summary                                                                                                                                                                                                                  
                                                                                                                                                                                                                                
Two related plumbing fixes so the published `ProfileGalleryEntryEvent` (kind 1163) carries the source's imeta visual fields (`thumbhash`, `image` / poster, `blurhash`, `dim`, `x`/hash) — instead of dropping them and leaving gallery cards to render placeholders or decode video frames on the fly. Plus a small observability fix in `PreviewMetadataCalculator` so silent hash-generation failures surface in logcat.
                                                                                                                                                                                                                                
  ## Why                                                                                                                                                                                                                      
                                          
Two paths feed the gallery and both lost imeta data before this branch:                                                                                                                                                       
                                          
1. **In-feed Add to Gallery** (long-press on an image/video tile → "Add Media to Gallery") went through `AccountViewModel.addMediaToGallery`, which silently dropped the source's `thumbhash` (it didn't take a `thumbhash`   
  parameter, even though `Account.addToGallery` already did). Source images with `thumbhash` in their imeta lost it on the way to gallery.                                                                                    
                                                                                                                                                                                                                                
2. **In-player Add to Gallery** (long-press while a video is playing → share dialog → Add Media to Gallery) went through `RenderTopButtons.kt:302`'s `ShareMediaAction` call, which hard-coded `blurhash = null, dim = null,  
  hash = null` and built an inline `MediaUrlVideo(...)` that omitted those four fields. Source videos with rich imeta lost everything except `mimeType`.
                                                                                                                                                                                                                                
End-to-end verified before vs. after on a real gallery entry: gallery cards now show the instant low-res preview from `thumbhash` (or the `image` poster for videos) immediately on cold load instead of waiting for the full 
  file to download or for `MediaMetadataRetriever` to extract a frame from the cached video.
                                                                                                                                                                                                                                
## Change                                                                                                                                                                                                                   
                                               
  **`AccountViewModel.addMediaToGallery`** — added optional `thumbhash: String? = null` parameter mirroring the existing `image` parameter, forwarded to `Account.addToGallery`.                                                
                                               
  **`ZoomableContentView.kt:214`** (in-feed Add-to-Gallery action) — pulls `thumbhash` from `MediaUrlVideo` / `MediaUrlImage` (both inherit it from `BaseMediaContent`) and passes it through.                                  
                                                                                                                                                                                                                              
  **Player chain — threading `blurhash`, `dim`, `hash`, `thumbhash` from imeta down to the share dialog:**                                                                                                                      
  - `MediaItemData` (player data class) gains four optional fields, all `null`-defaulted.                                                                                                                                     
  - `GetMediaItem`, `VideoViewInner`, `VideoView` (both overloads) gain matching pass-through params, all defaulted so existing callers compile unchanged.                                                                      
  - `RenderTopButtons.kt:302` replaces the four `null` placeholders with `mediaData.*` and populates the inline `MediaUrlVideo(...)` with the same fields.                                                                      
  - Only one feed surface (`ZoomableContentView.kt:214`) was updated to pass `hash = content.hash` since the others (`LiveActivity`, `AudioTrack`, `RenderChatClip`) don't have `imeta.hash` cleanly in scope; they continue    
  passing `null` (no regression).                                                                                                                                                                                               
                                                                                                                                                                                                                                
  **`PreviewMetadataCalculator`** (observability) — replaces silent `runCatching{}.getOrNull()` with `runCatching{}.onFailure { Log.w(LOG_TAG, "...", it) }.getOrNull()` for both `blurhash` and `thumbhash` generation in      
  `processBitmap`, plus a warning when `MediaMetadataRetriever.getThumbnail()` returns null in `processRetriever`. Also extracts a `private const val LOG_TAG` to deduplicate the four occurrences of the same string. Pure   
  observability — no behaviour change on the success path.                                                                                                                                                                      
                                                                                                                                                                                                                              
  ## Out of scope (deliberately)          
                                               
  - Publish-side imeta enrichment for HLS uploads (NIP-71 kind-34235/34236 imetas don't carry `blurhash`/`thumbhash` because `HlsVideoEventBuilder` was authored before thumbhash existed in the codebase). Tracked separately  
  as a follow-up.                              
  - The `HLS publish's sibling kind:1` short note carrying no `imeta` at all. Tracked separately.                                                                                                                               
  - `MediaItemData` already has `aspectRatio` alongside `dim` (pre-existing duplication); not touched here.                                                                                                                     
  - `VideoView`'s 19-parameter signature (was 18 before this branch); refactor into a value class would touch ~17 unrelated call sites.                                                                                         
                                                                                                                                                                                                                                
  ## Test plan                                                                                                                                                                                                                  
                                                                                                                                                                                                                                
  - [x] `./gradlew :amethyst:compilePlayDebugKotlin` clean                                                                                                                                                                      
  - [x] `./gradlew :amethyst:spotlessKotlinCheck` clean
  - [x] Manual end-to-end on Pixel 9a debug build:                                                                                                                                                                              
    - Image with `thumbhash` in source imeta → Add to Gallery → `nak req -k 1163 -a <hex> --limit 1` → confirmed published event carries `thumbhash` tag with same value.                                                       
    - Video MP4 with `blurhash` + `dim` + `x` in source imeta → in-player Add to Gallery → `nak req -k 1163 -a <hex> --limit 1` → confirmed published event now carries all four (vs. `m`-only before this branch).             
  Cross-checked against the same source pre-branch which produced a metadata-poor entry.                                                                                                                                        
    - HLS m3u8 video → confirmed gallery entry stays minimal (no thumbhash to forward — source kind:1 has no imeta; `HlsVideoEventBuilder` doesn't yet emit thumbhash). No regression; the gap is publish-side, tracked         
  separately.                                                                                                                                                                                                                   
    - No spurious `thumbhash` / `blurhash` tags emitted when source has none (null-safe `?.let { ... }` paths in `Account.addToGallery`).                                                                                     
    - No crash on null `thumbhash` / `dim` / `hash` content fields.   