### PR TITLE
Align favourites icon, add to default bar, redesign empty state

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -233,7 +233,7 @@ fun BuildNavigation(
         composable<Route.Home> { HomeScreen(accountViewModel, nav) }
         composable<Route.Message> { MessagesScreen(accountViewModel, nav) }
         composable<Route.Video> { VideoScreen(accountViewModel, nav) }
-        composable<Route.Discover> { DiscoverScreen(accountViewModel, nav) }
+        composableArgs<Route.Discover> { DiscoverScreen(it.initialTab, accountViewModel, nav) }
         composableArgs<Route.Notification> { NotificationScreen(it.scrollToEventId, accountViewModel, nav) }
         composableFromEnd<Route.Polls> { PollsScreen(accountViewModel, nav) }
         composableFromEnd<Route.Communities> { CommunitiesScreen(accountViewModel, nav) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/NavBarItem.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/NavBarItem.kt
@@ -285,8 +285,8 @@ val DefaultBottomBarItems: List<NavBarItem> =
         NavBarItem.MESSAGES,
         NavBarItem.VIDEO,
         NavBarItem.DISCOVER,
-        NavBarItem.NOTIFICATIONS,
         NavBarItem.FAVORITE_ALGO_FEEDS,
+        NavBarItem.NOTIFICATIONS,
     )
 
 // Ordered membership lists for each drawer section. The drawer renders these by looking up

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/NavBarItem.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/NavBarItem.kt
@@ -100,7 +100,7 @@ val NavBarCatalog: Map<NavBarItem, NavBarItemDef> =
                 id = NavBarItem.DISCOVER,
                 labelRes = R.string.route_discover,
                 icon = MaterialSymbols.Sensors,
-                resolveRoute = { Route.Discover },
+                resolveRoute = { Route.Discover() },
             ),
         NavBarItem.NOTIFICATIONS to
             NavBarItemDef(
@@ -162,7 +162,7 @@ val NavBarCatalog: Map<NavBarItem, NavBarItemDef> =
             NavBarItemDef(
                 id = NavBarItem.FAVORITE_ALGO_FEEDS,
                 labelRes = R.string.favorite_dvms_title,
-                icon = MaterialSymbols.Star,
+                icon = MaterialSymbols.AutoAwesome,
                 resolveRoute = { Route.EditFavoriteAlgoFeeds },
             ),
         NavBarItem.EMOJI_PACKS to
@@ -286,6 +286,7 @@ val DefaultBottomBarItems: List<NavBarItem> =
         NavBarItem.VIDEO,
         NavBarItem.DISCOVER,
         NavBarItem.NOTIFICATIONS,
+        NavBarItem.FAVORITE_ALGO_FEEDS,
     )
 
 // Ordered membership lists for each drawer section. The drawer renders these by looking up

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
@@ -37,7 +37,9 @@ sealed class Route {
 
     @Serializable object Video : Route()
 
-    @Serializable object Discover : Route()
+    @Serializable data class Discover(
+        val initialTab: DiscoverTab? = null,
+    ) : Route()
 
     @Serializable data class Notification(
         val scrollToEventId: String? = null,
@@ -529,6 +531,17 @@ fun <T : Route> getRouteWithArguments(
     } else {
         null
     }
+}
+
+@Serializable
+enum class DiscoverTab {
+    FOLLOWS,
+    READS,
+    ALGOS,
+    LIVE,
+    COMMUNITY,
+    MARKETPLACE,
+    CHATS,
 }
 
 fun isSameRoute(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/DiscoverScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/DiscoverScreen.kt
@@ -189,10 +189,7 @@ fun DiscoverScreen(
     val pagerState = rememberForeverPagerState(key = PagerStateKeys.DISCOVER_SCREEN) { feedTabs.size }
 
     LaunchedEffect(initialTab) {
-        val target = initialTab?.toTabIndex() ?: return@LaunchedEffect
-        if (target in feedTabs.indices && pagerState.currentPage != target) {
-            pagerState.scrollToPage(target)
-        }
+        initialTab?.let { pagerState.scrollToPage(it.toTabIndex()) }
     }
 
     WatchAccountForDiscoveryScreen(
@@ -538,7 +535,7 @@ private fun DiscoverFeedColumnsLoaded(
     }
 }
 
-// Tab positions match the order built in DiscoverScreen above. Update both together.
+// Exhaustive on DiscoverTab so adding a new enum value forces an update of feedTabs above.
 private fun DiscoverTab.toTabIndex(): Int =
     when (this) {
         DiscoverTab.FOLLOWS -> 0

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/DiscoverScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/DiscoverScreen.kt
@@ -72,6 +72,7 @@ import com.vitorpamplona.amethyst.ui.layouts.rememberFeedContentPadding
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.AppBottomBar
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.FabBottomBarPadded
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.routes.DiscoverTab
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.discover.datasource.DiscoveryFilterAssemblerSubscription
@@ -95,10 +96,12 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun DiscoverScreen(
+    initialTab: DiscoverTab?,
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
     DiscoverScreen(
+        initialTab = initialTab,
         discoveryFollowSetsFeedContentState = accountViewModel.feedStates.discoverFollowSets,
         discoveryReadsFeedContentState = accountViewModel.feedStates.discoverReads,
         discoveryContentNIP89FeedContentState = accountViewModel.feedStates.discoverDVMs,
@@ -114,6 +117,7 @@ fun DiscoverScreen(
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun DiscoverScreen(
+    initialTab: DiscoverTab?,
     discoveryFollowSetsFeedContentState: FeedContentState,
     discoveryReadsFeedContentState: FeedContentState,
     discoveryContentNIP89FeedContentState: FeedContentState,
@@ -184,6 +188,13 @@ fun DiscoverScreen(
 
     val pagerState = rememberForeverPagerState(key = PagerStateKeys.DISCOVER_SCREEN) { feedTabs.size }
 
+    LaunchedEffect(initialTab) {
+        val target = initialTab?.toTabIndex() ?: return@LaunchedEffect
+        if (target in feedTabs.indices && pagerState.currentPage != target) {
+            pagerState.scrollToPage(target)
+        }
+    }
+
     WatchAccountForDiscoveryScreen(
         discoveryFollowSetsFeedContentState = discoveryFollowSetsFeedContentState,
         discoveryReadsFeedContentState = discoveryReadsFeedContentState,
@@ -240,8 +251,8 @@ private fun DiscoverPages(
             }
         },
         bottomBar = {
-            AppBottomBar(Route.Discover, nav, accountViewModel) { route ->
-                if (route == Route.Discover) {
+            AppBottomBar(Route.Discover(), nav, accountViewModel) { route ->
+                if (route is Route.Discover) {
                     val currentPage = pagerState.currentPage
                     if (currentPage >= 0 && currentPage < feedTabs.size) {
                         feedTabs[currentPage].feedState.sendToTop()
@@ -526,3 +537,15 @@ private fun DiscoverFeedColumnsLoaded(
         }
     }
 }
+
+// Tab positions match the order built in DiscoverScreen above. Update both together.
+private fun DiscoverTab.toTabIndex(): Int =
+    when (this) {
+        DiscoverTab.FOLLOWS -> 0
+        DiscoverTab.READS -> 1
+        DiscoverTab.ALGOS -> 2
+        DiscoverTab.LIVE -> 3
+        DiscoverTab.COMMUNITY -> 4
+        DiscoverTab.MARKETPLACE -> 5
+        DiscoverTab.CHATS -> 6
+    }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/dvms/favorites/FavoriteAlgoFeedsListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/dvms/favorites/FavoriteAlgoFeedsListScreen.kt
@@ -31,8 +31,11 @@ import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -55,6 +58,7 @@ import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
 import com.vitorpamplona.amethyst.model.AddressableNote
 import com.vitorpamplona.amethyst.ui.components.MyAsyncImage
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.routes.DiscoverTab
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.navigation.topbars.TopBarWithBackButton
 import com.vitorpamplona.amethyst.ui.note.elements.BannerImage
@@ -118,12 +122,33 @@ private fun FavoriteAlgoFeedList(
             modifier = Modifier.fillMaxSize().padding(24.dp),
             contentAlignment = Alignment.Center,
         ) {
-            Text(
-                text = stringRes(R.string.favorite_dvms_empty),
-                textAlign = TextAlign.Center,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.grayText,
-            )
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Icon(
+                    symbol = MaterialSymbols.AutoAwesome,
+                    contentDescription = null,
+                    modifier = Modifier.size(72.dp),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+                Text(
+                    text = stringRes(R.string.favorite_dvms_empty_headline),
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text = stringRes(R.string.favorite_dvms_empty_subtitle),
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.grayText,
+                    modifier = Modifier.widthIn(max = 280.dp),
+                )
+                Button(onClick = { nav.nav(Route.Discover(initialTab = DiscoverTab.ALGOS)) }) {
+                    Text(text = stringRes(R.string.favorite_dvms_empty_cta))
+                }
+            }
         }
         return
     }

--- a/amethyst/src/main/res/values-cs-rCZ/strings.xml
+++ b/amethyst/src/main/res/values-cs-rCZ/strings.xml
@@ -1856,7 +1856,6 @@
     <string name="remove_dvm_from_favorites">Odebrat z oblíbených</string>
     <string name="favorite_dvms_title">Oblíbené algoritmy zdrojů</string>
     <string name="favorite_dvms_explainer">Algoritmy zdrojů, které zde označíte hvězdičkou, se zobrazí jako filtry na hlavním zdroji. Otevřete Objevovat pro přidání dalších.</string>
-    <string name="favorite_dvms_empty">Zatím nemáte žádné oblíbené algoritmy zdrojů. Otevřete Objevovat, klepněte na nějaký a označte ho hvězdičkou.</string>
     <string name="dvm_home_status_requesting">Žádost %1$s o zdroj…</string>
     <string name="dvm_home_status_requesting_all">Žádost oblíbených algoritmů o zdroje…</string>
     <string name="dvm_home_status_processing">Zpracování zdroje…</string>

--- a/amethyst/src/main/res/values-de-rDE/strings.xml
+++ b/amethyst/src/main/res/values-de-rDE/strings.xml
@@ -1848,7 +1848,6 @@ anz der Bedingungen ist erforderlich</string>
     <string name="remove_dvm_from_favorites">Aus Favoriten entfernen</string>
     <string name="favorite_dvms_title">Bevorzugte Feed-Algorithmen</string>
     <string name="favorite_dvms_explainer">Feed-Algorithmen, die du mit einem Stern markierst, erscheinen als Filter-Chips im Home-Feed. Öffne Entdecken, um weitere hinzuzufügen.</string>
-    <string name="favorite_dvms_empty">Noch keine bevorzugten Feed-Algorithmen. Öffne Entdecken, tippe einen an und markiere ihn mit einem Stern, um ihn hier hinzuzufügen.</string>
     <string name="dvm_home_status_requesting">Frage %1$s nach einem Feed…</string>
     <string name="dvm_home_status_requesting_all">Frage deine bevorzugten Feed-Algorithmen nach Feeds…</string>
     <string name="dvm_home_status_processing">Feed wird verarbeitet…</string>

--- a/amethyst/src/main/res/values-hi-rIN/strings.xml
+++ b/amethyst/src/main/res/values-hi-rIN/strings.xml
@@ -1890,7 +1890,6 @@
     <string name="remove_dvm_from_favorites">इष्टसूची में से हटाएँ</string>
     <string name="favorite_dvms_title">इष्ट सूचनावली कलनविधियाँ</string>
     <string name="favorite_dvms_explainer">सूचनावली कलनविधियाँ जिनहें आपने यहाँ ताराचिह्नित किए मूल सूचनावली पर छलनी खण्डों के जैसे दिखेंगे। खोज पटल खोलें अधिक जोडने के लिए।</string>
-    <string name="favorite_dvms_empty">कोई इष्ट सूचनावली कलनविधियाँ नहीं अभी तक। खोज पटल खोलें तथा एक पर दबाएँ तथा ताराचिह्नित करें यहाँ जोडने के लिए।</string>
     <string name="dvm_home_status_requesting">अनुरोध %1$s को सूचनावली के लिए…</string>
     <string name="dvm_home_status_requesting_all">आपके इष्ट सूचनावली कलनविधियों को अनुरोध किया जा रहा है सूचनावलियों के लिए…</string>
     <string name="dvm_home_status_processing">आपकी सूचनावली पर कार्य चालू…</string>

--- a/amethyst/src/main/res/values-hu-rHU/strings.xml
+++ b/amethyst/src/main/res/values-hu-rHU/strings.xml
@@ -1889,7 +1889,6 @@
     <string name="remove_dvm_from_favorites">Eltávolítás a kedvencekből</string>
     <string name="favorite_dvms_title">Kedvenc hírfolyam-algoritmusok</string>
     <string name="favorite_dvms_explainer">Az itt kedvencként megjelölt hírfolyam-algoritmusok szűrőgombként jelennek meg a főoldal hírfolyamán. Nyissa meg a felfedezés menüpontot, ha továbbiakat szeretne hozzáadni.</string>
-    <string name="favorite_dvms_empty">Még nincsenek kedvenc hírfolyam-algoritmusok. Nyissa meg a „Felfedezés” menüpontot, válasszon ki egyet, majd jelölje meg csillaggal, hogy itt megjelenjen.</string>
     <string name="dvm_home_status_requesting">%1$s lekérdezése egy hírfolyamért…</string>
     <string name="dvm_home_status_requesting_all">Hírfolyamok keresése a kedvenc hírfolyam-algoritmusok segítségével…</string>
     <string name="dvm_home_status_processing">Hírfolyam feldolgozása…</string>

--- a/amethyst/src/main/res/values-nl-rNL/strings.xml
+++ b/amethyst/src/main/res/values-nl-rNL/strings.xml
@@ -1668,7 +1668,6 @@
     <string name="remove_dvm_from_favorites">Verwijderen uit favorieten</string>
     <string name="favorite_dvms_title">Favoriete feed-algoritmes</string>
     <string name="favorite_dvms_explainer">Feed-algoritmes die je hier hebt gesterd, verschijnen als filterchips op de startfeed. Open Ontdekken om meer toe te voegen.</string>
-    <string name="favorite_dvms_empty">Nog geen favoriete feed-algoritmes. Open Ontdekken, tik op een en ster het om hier toe te voegen.</string>
     <string name="dvm_home_status_requesting">%1$s vragen voor een feed…</string>
     <string name="dvm_home_status_requesting_all">Je favoriete feed-algoritmes vragen voor feeds…</string>
     <string name="dvm_home_status_processing">Je feed verwerken…</string>

--- a/amethyst/src/main/res/values-pl-rPL/strings.xml
+++ b/amethyst/src/main/res/values-pl-rPL/strings.xml
@@ -1900,7 +1900,6 @@ Zaplanowane posty z innych kont nie zostaną opublikowane, dopóki to konto jest
     <string name="remove_dvm_from_favorites">Usuń z ulubionych</string>
     <string name="favorite_dvms_title">Algorytmy ulubionych kanałów</string>
     <string name="favorite_dvms_explainer">Algorytmy kanałów, które tutaj oznaczyłeś gwiazdką, pojawiają się jako ikony filtrów na stronie głównej. Otwórz sekcję Odkryj, aby dodać kolejne.</string>
-    <string name="favorite_dvms_empty">Brak algorytmów ulubionych kanałów. Otwórz sekcję „Odkrywaj”, wybierz jeden z nich i oznacz go gwiazdką, aby dodać go tutaj.</string>
     <string name="dvm_home_status_requesting">Poproś %1$s o wyświetlenie treści…</string>
     <string name="dvm_home_status_requesting_all">Poproś algorytmy o wyświetlenie ulubionych treści…</string>
     <string name="dvm_home_status_processing">Przetwarzanie statusu kanału…</string>

--- a/amethyst/src/main/res/values-pt-rBR/strings.xml
+++ b/amethyst/src/main/res/values-pt-rBR/strings.xml
@@ -1844,7 +1844,6 @@
     <string name="remove_dvm_from_favorites">Remover dos favoritos</string>
     <string name="favorite_dvms_title">Algoritmos de feed favoritos</string>
     <string name="favorite_dvms_explainer">Os algoritmos de feed marcados com estrela aparecem como chips de filtro no feed Início. Abra Descobrir para adicionar mais.</string>
-    <string name="favorite_dvms_empty">Ainda não há algoritmos favoritos. Abra Descobrir, toque em um e marque com estrela para adicioná-lo aqui.</string>
     <string name="dvm_home_status_requesting">Solicitando feed a %1$s…</string>
     <string name="dvm_home_status_requesting_all">Solicitando feeds aos seus algoritmos favoritos…</string>
     <string name="dvm_home_status_processing">Processando seu feed…</string>

--- a/amethyst/src/main/res/values-sl-rSI/strings.xml
+++ b/amethyst/src/main/res/values-sl-rSI/strings.xml
@@ -1804,7 +1804,6 @@ Za podpisovanje se je potrebno prijaviti s privatnim ključem</string>
     <string name="remove_dvm_from_favorites">Odstrani iz priljubljenih</string>
     <string name="favorite_dvms_title">Priljubljeni algoritmi vsebin</string>
     <string name="favorite_dvms_explainer">Algoritmi vsebin, ki jih tukaj označite z zvezdico, se bodo prikazali kot filtri na začetnem zaslonu. Za nove odprite »Odkrij«.</string>
-    <string name="favorite_dvms_empty">Še nimate priljubljenih algoritmov vsebin. Odprite »Odkrij«, izberite enega in ga označite z zvezdico, da ga dodate sem.</string>
     <string name="dvm_home_status_requesting">Poizvedba pri %1$s za vsebine…</string>
     <string name="dvm_home_status_requesting_all">Pridobivanje vsebin iz vaših najljubših algoritmov…</string>
     <string name="dvm_home_status_processing">Priprava vaših vsebin…</string>

--- a/amethyst/src/main/res/values-sv-rSE/strings.xml
+++ b/amethyst/src/main/res/values-sv-rSE/strings.xml
@@ -1843,7 +1843,6 @@
     <string name="remove_dvm_from_favorites">Ta bort från favoriter</string>
     <string name="favorite_dvms_title">Favorit-flödesalgoritmer</string>
     <string name="favorite_dvms_explainer">Flödesalgoritmer du stjärnmarkerar visas som filterchips på Hem-flödet. Öppna Upptäck för att lägga till fler.</string>
-    <string name="favorite_dvms_empty">Inga favorit-flödesalgoritmer än. Öppna Upptäck, tryck på en och stjärnmarkera för att lägga till den här.</string>
     <string name="dvm_home_status_requesting">Frågar %1$s om ett flöde…</string>
     <string name="dvm_home_status_requesting_all">Frågar dina favorit-flödesalgoritmer om flöden…</string>
     <string name="dvm_home_status_processing">Bearbetar ditt flöde…</string>

--- a/amethyst/src/main/res/values-zh-rCN/strings.xml
+++ b/amethyst/src/main/res/values-zh-rCN/strings.xml
@@ -1882,7 +1882,6 @@
     <string name="remove_dvm_from_favorites">从收藏中移除</string>
     <string name="favorite_dvms_title">收藏源算法</string>
     <string name="favorite_dvms_explainer">此处加星的订阅源算法在主页源上显示为筛选缺口。打开发现添加更多。</string>
-    <string name="favorite_dvms_empty">还没有收藏的订阅源算法。打开发现、轻触一个、加星将其添加到这里。</string>
     <string name="dvm_home_status_requesting">正请求 %1$s 获得一个源…</string>
     <string name="dvm_home_status_requesting_all">正向收藏的源算法请求订阅源…</string>
     <string name="dvm_home_status_processing">正处理你的源…</string>

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -2138,8 +2138,10 @@
     <string name="add_dvm_to_favorites">Add feed algorithm to favorites</string>
     <string name="remove_dvm_from_favorites">Remove from favorites</string>
     <string name="favorite_dvms_title">Favorite Feed Algorithms</string>
-    <string name="favorite_dvms_explainer">Feed algorithms you starred here appear as filter chips on the Home feed. Open Discover to add more.</string>
-    <string name="favorite_dvms_empty">No favorite feed algorithms yet. Open Discover, tap one, and star it to add it here.</string>
+    <string name="favorite_dvms_explainer">Feed algorithms you star appear here and as filter chips on the Home feed.</string>
+    <string name="favorite_dvms_empty_headline">Pin your favorite algorithms</string>
+    <string name="favorite_dvms_empty_subtitle">Tap the button below to browse algorithms and star the ones you want to keep here.</string>
+    <string name="favorite_dvms_empty_cta">Add some feeds</string>
     <string name="dvm_home_status_requesting">Asking %1$s for a feed…</string>
     <string name="dvm_home_status_requesting_all">Asking your favorite feed algorithms for feeds…</string>
     <string name="dvm_home_status_processing">Processing your feed…</string>


### PR DESCRIPTION
Improve content discovery especially for brand new users

1. Make favourite feeds icon default in bottom bar
2. Empty favourite feed screen has new call to action button
3. Button navigates directly to discovery of feeds
4. Back button goes back to favourite feeds screen


<img width="350" alt="Screenshot_20260510-084901" src="https://github.com/user-attachments/assets/97dda516-0983-4134-9afa-ce6708bed2d7" valign="top"/> <img width="350"  alt="Screenshot_20260510-084913" src="https://github.com/user-attachments/assets/ac947a4a-844d-458d-ae7a-57f1df51fe7a" />
 
<img width="350" alt="Screenshot_20260510-084929" src="https://github.com/user-attachments/assets/e73d5d27-a422-4bdf-a124-63951deda4e6" /> <img width="350" alt="Screenshot_20260510-084941" src="https://github.com/user-attachments/assets/051421f3-514b-44a1-92f2-9530c81a5ddd"  valign="top"/>

## Summary                              
  - Bottom-nav `FAVORITE_ALGO_FEEDS` now uses `MaterialSymbols.AutoAwesome` (multi-stars), matching the icon already used in the settings drawer and the top-bar feed-filter spinner. The previous single `Star` was the odd one out.                                                                                                                                                                                                                         
  - Adds `FAVORITE_ALGO_FEEDS` to `DefaultBottomBarItems` so new installs see the entry by default (existing users keep their persisted layout).                                                                                
  - Redesigns the empty state of the Favorite Feed Algorithms screen — was a single line of grey text telling users to open Discover, find an algo, and star it. Now shows the multi-stars icon, a "Pin your favorite algorithms" headline, and an **Add some feeds** primary button that deep-links to the Discover screen's algo tab.                                                                                                             
  - To make the deep-link actually work, `Route.Discover` becomes `data class Discover(val initialTab: DiscoverTab? = null)`. `DiscoverScreen` scrolls the pager to `initialTab` on first composition; the bottom-bar Discover tap still uses the saved `rememberForeverPagerState` position.                                                                                                                                                                
                                                                                                                                                                                                                                
  ## Test plan                                                                                                                                                                                                                  
  - [x] Fresh install: bottom bar shows the multi-stars Favourites entry by default                                                                                                                                             
  - [x] Open Favourites with no feeds → empty state renders with icon, headline, sub-line, and CTA                                                                                                                              
  - [x] Tap **Add some feeds** → lands directly on the Algos tab in Discover                                                                                                                                                    
  - [x] Star an algo, press Back → returns to Favourites with the new entry visible                                                                                                                                             
  - [x] Bottom-bar Discover tap still lands on the user's last-viewed tab (not forced to Algos)