### PR TITLE
Add AVIF to animated image handling

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/AnimatedImageSupport.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/AnimatedImageSupport.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.components
+
+import androidx.annotation.StringRes
+import com.vitorpamplona.amethyst.R
+
+fun isAnimatedImageUrl(url: String): Boolean = isGifUrl(url) || isAvifUrl(url)
+
+fun isGifUrl(url: String): Boolean = hasImageExtension(url, ".gif")
+
+fun isAvifUrl(url: String): Boolean = hasImageExtension(url, ".avif")
+
+fun isAnimatedImageMimeType(mimeType: String?): Boolean =
+    mimeType.equals("image/gif", ignoreCase = true) ||
+        mimeType.equals("image/avif", ignoreCase = true)
+
+fun isAnimatedImageFileName(fileName: String?): Boolean =
+    fileName != null && (isGifUrl(fileName) || isAvifUrl(fileName))
+
+@StringRes
+fun animatedImageLabelRes(
+    url: String?,
+    mimeType: String?,
+): Int =
+    if (mimeType.equals("image/avif", ignoreCase = true) || (url != null && isAvifUrl(url))) {
+        R.string.avif
+    } else {
+        R.string.gif
+    }
+
+private fun hasImageExtension(
+    value: String,
+    extension: String,
+): Boolean =
+    value.endsWith(extension, ignoreCase = true) ||
+        value.contains("$extension?", ignoreCase = true) ||
+        value.contains("$extension#", ignoreCase = true)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/GifVideoView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/GifVideoView.kt
@@ -48,7 +48,6 @@ import coil3.asDrawable
 import coil3.compose.AsyncImagePainter
 import coil3.compose.SubcomposeAsyncImage
 import coil3.compose.SubcomposeAsyncImageContent
-import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.MediaAspectRatioCache
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.theme.Font10SP
@@ -67,6 +66,7 @@ fun GifVideoView(
     onDialog: (() -> Unit)? = null,
     accountViewModel: AccountViewModel,
     thumbhash: String? = null,
+    mimeType: String? = null,
 ) {
     // Pure read path — DimensionTag.aspectRatio() is a one-line int division and
     // MediaAspectRatioCache.get() is a synchronized LruCache lookup. Wrapping this in
@@ -74,6 +74,7 @@ fun GifVideoView(
     // than the work it saves; that's why this stays as a plain expression.
     val ratio = dimensions?.aspectRatio() ?: MediaAspectRatioCache.get(videoUri)
     val autoPlay = accountViewModel.settings.autoPlayVideos()
+    val imageTypeLabel = stringResource(animatedImageLabelRes(videoUri, mimeType))
     val borderModifier = if (roundedCorner) MaterialTheme.colorScheme.imageModifier else Modifier
     val context = LocalContext.current
 
@@ -133,7 +134,7 @@ fun GifVideoView(
 
         if (!autoPlay) {
             Text(
-                text = stringResource(R.string.gif),
+                text = imageTypeLabel,
                 color = Color.White,
                 fontWeight = FontWeight.Bold,
                 fontSize = Font10SP,
@@ -146,6 +147,39 @@ fun GifVideoView(
                         .background(Color.Black.copy(alpha = 0.6f))
                         .padding(horizontal = 4.dp, vertical = 1.dp),
             )
+        }
+    }
+}
+
+@Composable
+fun AnimatedUrlImage(
+    imageUrl: String,
+    contentDescription: String?,
+    modifier: Modifier,
+    contentScale: ContentScale,
+    autoPlay: Boolean,
+) {
+    val context = LocalContext.current
+
+    SubcomposeAsyncImage(
+        model = imageUrl,
+        contentDescription = contentDescription,
+        modifier = modifier,
+        contentScale = contentScale,
+    ) {
+        val state by painter.state.collectAsState()
+        val successState = state as? AsyncImagePainter.State.Success
+        val drawable = successState?.result?.image?.asDrawable(context.resources)
+
+        LaunchedEffect(autoPlay, drawable) {
+            if (drawable is Animatable) {
+                if (autoPlay) drawable.start() else drawable.stop()
+            }
+        }
+
+        when (state) {
+            is AsyncImagePainter.State.Success -> SubcomposeAsyncImageContent()
+            else -> {}
         }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/MyAsyncImage.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/MyAsyncImage.kt
@@ -56,7 +56,7 @@ fun MyAsyncImage(
     onLoadingBackground: (@Composable () -> Unit)?,
     onError: (@Composable () -> Unit)?,
 ) {
-    if (isGifUrl(imageUrl)) {
+    if (isAnimatedImageUrl(imageUrl)) {
         GifVideoView(
             videoUri = imageUrl,
             contentDescription = contentDescription,
@@ -153,8 +153,3 @@ fun MyAsyncImage(
         }
     }
 }
-
-fun isGifUrl(url: String): Boolean =
-    url.endsWith(".gif", ignoreCase = true) ||
-        url.contains(".gif?", ignoreCase = true) ||
-        url.contains(".gif#", ignoreCase = true)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/RobohashAsyncImage.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/RobohashAsyncImage.kt
@@ -125,7 +125,7 @@ fun RobohashFallbackAsyncImage(
         remember(model, robot, useBridge) {
             bridgeProfilePictureUrl(model, useBridge, robot)
         }
-    if (bridgedModel != null && loadProfilePicture && isGifUrl(bridgedModel)) {
+    if (bridgedModel != null && loadProfilePicture && isAnimatedImageUrl(bridgedModel)) {
         GifProfilePicture(
             userHex = robot,
             userPicture = bridgedModel,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
@@ -167,7 +167,7 @@ fun ZoomableContentView(
                 modifier = mediaSizingModifier(ratio, contentScale),
                 backdrop = (content.thumbhash ?: content.blurhash)?.let { { BlurhashBackdrop(content.blurhash, content.description, content.thumbhash) } },
             ) {
-                if (content.isGif()) {
+                if (content.isAnimatedImage()) {
                     GifVideoView(
                         videoUri = bridgedUrl,
                         contentDescription = content.description,
@@ -178,6 +178,7 @@ fun ZoomableContentView(
                         onDialog = { dialogOpen = true },
                         accountViewModel = accountViewModel,
                         thumbhash = content.thumbhash,
+                        mimeType = content.mimeType,
                     )
                 } else {
                     TwoSecondController(content) { controllerVisible ->
@@ -233,7 +234,7 @@ fun ZoomableContentView(
         }
 
         is MediaLocalImage -> {
-            if (content.isGif()) {
+            if (content.isAnimatedImage()) {
                 content.localFile?.let {
                     GifVideoView(
                         videoUri = it.toUri().toString(),
@@ -245,6 +246,7 @@ fun ZoomableContentView(
                         onDialog = { dialogOpen = true },
                         accountViewModel = accountViewModel,
                         thumbhash = content.thumbhash,
+                        mimeType = content.mimeType,
                     )
                 }
             } else {
@@ -695,11 +697,11 @@ fun ShowHash(content: MediaUrlContent) {
     verifiedHash?.let { HashVerificationSymbol(it) }
 }
 
-fun BaseMediaContent.isGif(): Boolean =
+fun BaseMediaContent.isAnimatedImage(): Boolean =
     if (this is MediaUrlContent) {
-        mimeType == "image/gif" || url.endsWith(".gif", ignoreCase = true) || url.contains(".gif?", ignoreCase = true) || url.contains(".gif#", ignoreCase = true)
+        isAnimatedImageMimeType(mimeType) || isAnimatedImageUrl(url)
     } else if (this is MediaPreloadedContent) {
-        mimeType == "image/gif" || localFile?.name?.endsWith(".gif", ignoreCase = true) == true
+        isAnimatedImageMimeType(mimeType) || isAnimatedImageFileName(localFile?.name)
     } else {
         false
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/emojiSuggestions/ShowEmojiSuggestionList.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/emojiSuggestions/ShowEmojiSuggestionList.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -43,6 +44,8 @@ import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
 import com.vitorpamplona.amethyst.commons.model.nip30CustomEmojis.EmojiPackState
+import com.vitorpamplona.amethyst.ui.components.AnimatedUrlImage
+import com.vitorpamplona.amethyst.ui.components.isAnimatedImageUrl
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.DividerThickness
 import com.vitorpamplona.amethyst.ui.theme.Size10dp
@@ -74,11 +77,21 @@ fun ShowEmojiSuggestionList(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = spacedBy(Size10dp),
                 ) {
-                    AsyncImage(
-                        it.link,
-                        contentDescription = it.code,
-                        modifier = Size40Modifier,
-                    )
+                    if (isAnimatedImageUrl(it.link)) {
+                        AnimatedUrlImage(
+                            imageUrl = it.link,
+                            contentDescription = it.code,
+                            modifier = Size40Modifier,
+                            contentScale = ContentScale.Fit,
+                            autoPlay = true,
+                        )
+                    } else {
+                        AsyncImage(
+                            it.link,
+                            contentDescription = it.code,
+                            modifier = Size40Modifier,
+                        )
+                    }
                     Text(it.code, fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f))
                     IconButton(
                         modifier = Size40Modifier,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Emoji.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Emoji.kt
@@ -51,7 +51,9 @@ import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.observeNoteAndMap
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.observeNoteEvent
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
+import com.vitorpamplona.amethyst.ui.components.AnimatedUrlImage
 import com.vitorpamplona.amethyst.ui.components.ShowMoreButton
+import com.vitorpamplona.amethyst.ui.components.isAnimatedImageUrl
 import com.vitorpamplona.amethyst.ui.note.LoadAddressableNote
 import com.vitorpamplona.amethyst.ui.note.elements.AddButton
 import com.vitorpamplona.amethyst.ui.note.elements.RemoveButton
@@ -137,22 +139,22 @@ fun RenderEmojiPack(
         ) {
             emojisToShow.forEach { emoji ->
                 if (onClick != null) {
-                    AsyncImage(
-                        model = emoji.url,
-                        contentDescription = emoji.code,
+                    EmojiImage(
+                        emoji = emoji,
                         modifier = Size35Modifier.clickable { onClick(emoji) },
                         contentScale = ContentScale.Crop,
+                        accountViewModel = accountViewModel,
                     )
                 } else {
                     Box(
                         modifier = Size35Modifier,
                         contentAlignment = Alignment.Center,
                     ) {
-                        AsyncImage(
-                            model = emoji.url,
-                            contentDescription = emoji.code,
+                        EmojiImage(
+                            emoji = emoji,
                             modifier = Size35Modifier,
                             contentScale = ContentScale.Crop,
+                            accountViewModel = accountViewModel,
                         )
                     }
                 }
@@ -172,6 +174,31 @@ fun RenderEmojiPack(
                 ShowMoreButton { expanded = !expanded }
             }
         }
+    }
+}
+
+@Composable
+private fun EmojiImage(
+    emoji: EmojiUrlTag,
+    modifier: Modifier,
+    contentScale: ContentScale,
+    accountViewModel: AccountViewModel,
+) {
+    if (isAnimatedImageUrl(emoji.url)) {
+        AnimatedUrlImage(
+            imageUrl = emoji.url,
+            contentDescription = emoji.code,
+            modifier = modifier,
+            contentScale = contentScale,
+            autoPlay = accountViewModel.settings.autoPlayVideos(),
+        )
+    } else {
+        AsyncImage(
+            model = emoji.url,
+            contentDescription = emoji.code,
+            modifier = modifier,
+            contentScale = contentScale,
+        )
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/emojipacks/common/EmojiPackCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/emojipacks/common/EmojiPackCard.kt
@@ -47,6 +47,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.ui.components.AnimatedUrlImage
+import com.vitorpamplona.amethyst.ui.components.isAnimatedImageUrl
 import com.vitorpamplona.amethyst.ui.stringRes
 
 private const val PREVIEW_SLOTS = 6
@@ -149,12 +151,22 @@ private fun EmojiPreviewGrid(urls: List<String>) {
 @Composable
 private fun EmojiPreviewSlot(url: String?) {
     if (url != null) {
-        AsyncImage(
-            model = url,
-            contentDescription = null,
-            modifier = Modifier.size(ThumbSize),
-            contentScale = ContentScale.Fit,
-        )
+        if (isAnimatedImageUrl(url)) {
+            AnimatedUrlImage(
+                imageUrl = url,
+                contentDescription = null,
+                modifier = Modifier.size(ThumbSize),
+                contentScale = ContentScale.Fit,
+                autoPlay = true,
+            )
+        } else {
+            AsyncImage(
+                model = url,
+                contentDescription = null,
+                modifier = Modifier.size(ThumbSize),
+                contentScale = ContentScale.Fit,
+            )
+        }
     } else {
         Box(
             modifier =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/emojipacks/display/EmojiPackScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/emojipacks/display/EmojiPackScreen.kt
@@ -60,9 +60,11 @@ import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
 import com.vitorpamplona.amethyst.model.nip30CustomEmojis.OwnedEmojiPack
+import com.vitorpamplona.amethyst.ui.components.AnimatedUrlImage
 import com.vitorpamplona.amethyst.ui.components.M3ActionDialog
 import com.vitorpamplona.amethyst.ui.components.M3ActionRow
 import com.vitorpamplona.amethyst.ui.components.M3ActionSection
+import com.vitorpamplona.amethyst.ui.components.isAnimatedImageUrl
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.FabBottomBarPadded
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.ShorterTopAppBar
@@ -169,6 +171,7 @@ private fun EmojiPackScreenView(
                 }
                 EmojiGrid(
                     pack = currentPack,
+                    accountViewModel = accountViewModel,
                     onLongPress = { emoji, isPrivate -> pendingDelete = EmojiDeleteTarget(emoji, isPrivate) },
                 )
             }
@@ -222,6 +225,7 @@ private data class EmojiDeleteTarget(
 @Composable
 private fun EmojiGrid(
     pack: OwnedEmojiPack,
+    accountViewModel: AccountViewModel,
     onLongPress: (EmojiUrlTag, Boolean) -> Unit,
 ) {
     val allEmojis =
@@ -241,6 +245,7 @@ private fun EmojiGrid(
             EmojiCell(
                 emoji = emoji,
                 isPrivate = isPrivate,
+                accountViewModel = accountViewModel,
                 onLongClick = { onLongPress(emoji, isPrivate) },
             )
         }
@@ -252,6 +257,7 @@ private fun EmojiGrid(
 private fun EmojiCell(
     emoji: EmojiUrlTag,
     isPrivate: Boolean,
+    accountViewModel: AccountViewModel,
     onLongClick: () -> Unit,
 ) {
     val privateLabel = stringRes(R.string.emoji_private_badge)
@@ -264,12 +270,23 @@ private fun EmojiCell(
                 ),
         contentAlignment = Alignment.Center,
     ) {
-        AsyncImage(
-            model = emoji.url,
-            contentDescription = if (isPrivate) "${emoji.code} ($privateLabel)" else emoji.code,
-            modifier = Size35Modifier,
-            contentScale = ContentScale.Fit,
-        )
+        val contentDescription = if (isPrivate) "${emoji.code} ($privateLabel)" else emoji.code
+        if (isAnimatedImageUrl(emoji.url)) {
+            AnimatedUrlImage(
+                imageUrl = emoji.url,
+                contentDescription = contentDescription,
+                modifier = Size35Modifier,
+                contentScale = ContentScale.Fit,
+                autoPlay = accountViewModel.settings.autoPlayVideos(),
+            )
+        } else {
+            AsyncImage(
+                model = emoji.url,
+                contentDescription = contentDescription,
+                modifier = Size35Modifier,
+                contentScale = ContentScale.Fit,
+            )
+        }
         if (isPrivate) {
             Box(
                 modifier =

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -2804,6 +2804,7 @@
     <string name="emoji_public_explainer">Public emojis are visible to everyone and appear in your reaction menu and \":\" autocomplete picker when this pack is in your emoji list.</string>
     <string name="emoji_private_explainer">Private emojis are stored encrypted on relays and visible only to you. They appear in your reaction menu and \":\" autocomplete just like public ones.</string>
     <string name="gif">Gif</string>
+    <string name="avif" translatable="false">AVIF</string>
     <!-- NIP-9A community rules composer-side validation. -->
     <string name="community_rules_violation_icon">Community rule violation</string>
     <string name="community_rules_violation_author_denied">You are on this community\'s deny-list. Posts will not be accepted.</string>

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/components/AnimatedImageSupportTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/components/AnimatedImageSupportTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.components
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AnimatedImageSupportTest {
+    @Test
+    fun avifUrlsAreAnimatedImages() {
+        assertTrue(isAnimatedImageUrl("https://cdn.example.com/emoji.avif"))
+        assertTrue(isAnimatedImageUrl("https://cdn.example.com/emoji.AVIF?name=pack.avif"))
+        assertTrue(isAnimatedImageUrl("blossom:abcd.avif?xs=https://cdn.example.com"))
+    }
+
+    @Test
+    fun gifUrlsStillAreAnimatedImages() {
+        assertTrue(isAnimatedImageUrl("https://cdn.example.com/emoji.gif"))
+        assertTrue(isAnimatedImageUrl("https://cdn.example.com/emoji.GIF#preview"))
+    }
+
+    @Test
+    fun staticImageUrlsAreNotAnimatedImages() {
+        assertFalse(isAnimatedImageUrl("https://cdn.example.com/emoji.png"))
+        assertFalse(isAnimatedImageUrl("https://cdn.example.com/emoji.webp"))
+    }
+
+    @Test
+    fun animatedImageMimeTypesIncludeAvifAndGif() {
+        assertTrue(isAnimatedImageMimeType("image/avif"))
+        assertTrue(isAnimatedImageMimeType("IMAGE/GIF"))
+        assertFalse(isAnimatedImageMimeType("image/png"))
+        assertFalse(isAnimatedImageMimeType(null))
+    }
+}


### PR DESCRIPTION
Fixes #837.

## Summary
- Treat `.avif` / `image/avif` as animated image content alongside GIF.
- Route AVIF media, profile pictures, emoji packs, emoji suggestions, and emoji pack previews through the existing animated drawable start/stop path.
- Add an AVIF paused-state label and coverage for animated image URL/MIME detection.

## Verification
- `git diff --check`
- Could not run Gradle tests locally because this environment has no Java runtime installed (`./gradlew --version` fails before Gradle starts).

Bounty payment address if accepted: BTC `39Q34P8A7g375yqEr8buvNJkUbRgKfbKQZ`