### PR TITLE
Add F-Droid LibreTranslate support

### DIFF
--- a/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/service/lang/LanguageTranslatorService.kt
+++ b/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/service/lang/LanguageTranslatorService.kt
@@ -51,24 +51,31 @@ object LanguageTranslatorService {
         dontTranslateFrom: Set<String>,
         translateTo: String,
         serverUrl: String,
+        apiKey: String,
     ): ResultOrError? {
         if (serverUrl.isBlank() || !TranslationDictionary.isWorthTranslating(text)) return null
 
         val url = normalizedTranslateUrl(serverUrl) ?: return null
         val dict = TranslationDictionary.build(text)
         val encoded = TranslationDictionary.encode(text, dict)
+        val normalizedApiKey = apiKey.trim()
 
         return withContext(Dispatchers.IO) {
+            val payload =
+                mutableMapOf(
+                    "q" to encoded,
+                    "source" to "auto",
+                    "target" to translateTo,
+                )
+
+            if (normalizedApiKey.isNotBlank()) {
+                payload["api_key"] = normalizedApiKey
+            }
+
             val requestBody =
                 json
-                    .writeValueAsString(
-                        mapOf(
-                            "q" to encoded,
-                            "source" to "auto",
-                            "target" to translateTo,
-                            "format" to "text",
-                        ),
-                    ).toRequestBody(jsonMediaType)
+                    .writeValueAsString(payload)
+                    .toRequestBody(jsonMediaType)
 
             val request =
                 Request

--- a/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/service/lang/LanguageTranslatorService.kt
+++ b/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/service/lang/LanguageTranslatorService.kt
@@ -20,6 +20,94 @@
  */
 package com.vitorpamplona.amethyst.service.lang
 
+import androidx.compose.runtime.Immutable
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.vitorpamplona.amethyst.Amethyst
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.coroutines.executeAsync
+
+@Immutable
+data class ResultOrError(
+    val result: String?,
+    val sourceLang: String?,
+    val targetLang: String?,
+)
+
 object LanguageTranslatorService {
-    fun clear() {}
+    private val json = jacksonObjectMapper()
+    private val jsonMediaType = "application/json; charset=utf-8".toMediaType()
+
+    fun clear() {
+        TranslationsCache.clear()
+    }
+
+    suspend fun autoTranslate(
+        text: String,
+        dontTranslateFrom: Set<String>,
+        translateTo: String,
+        serverUrl: String,
+    ): ResultOrError? {
+        if (serverUrl.isBlank() || !TranslationDictionary.isWorthTranslating(text)) return null
+
+        val url = normalizedTranslateUrl(serverUrl) ?: return null
+        val dict = TranslationDictionary.build(text)
+        val encoded = TranslationDictionary.encode(text, dict)
+
+        return withContext(Dispatchers.IO) {
+            val requestBody =
+                json
+                    .writeValueAsString(
+                        mapOf(
+                            "q" to encoded,
+                            "source" to "auto",
+                            "target" to translateTo,
+                            "format" to "text",
+                        ),
+                    ).toRequestBody(jsonMediaType)
+
+            val request =
+                Request
+                    .Builder()
+                    .url(url)
+                    .post(requestBody)
+                    .build()
+
+            val client = Amethyst.instance.roleBasedHttpClientBuilder.okHttpClientForNip05(url)
+
+            client.newCall(request).executeAsync().use { response ->
+                if (!response.isSuccessful) {
+                    throw IllegalArgumentException("LibreTranslate returned HTTP ${response.code}")
+                }
+
+                val body = response.body.string()
+                val tree = json.readTree(body)
+                val translated = TranslationDictionary.decode(tree["translatedText"]?.asText(), dict)
+                val source = tree["detectedLanguage"]?.get("language")?.asText()
+
+                if (translated.isNullOrBlank()) return@use null
+                if (source == null || source == "und") return@use null
+                if (source.equals(translateTo, ignoreCase = true)) return@use null
+                if (source in dontTranslateFrom) return@use null
+
+                ResultOrError(translated, source, translateTo)
+            }
+        }
+    }
+
+    private fun normalizedTranslateUrl(serverUrl: String): String? {
+        val root = serverUrl.trim().trimEnd('/')
+        if (root.isBlank()) return null
+        val baseUrl = root.toHttpUrlOrNull() ?: return null
+        if (baseUrl.encodedPath.trimEnd('/').endsWith("/translate")) return baseUrl.toString()
+        return baseUrl
+            .newBuilder()
+            .addPathSegment("translate")
+            .build()
+            .toString()
+    }
 }

--- a/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/service/lang/TranslationDictionary.kt
+++ b/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/service/lang/TranslationDictionary.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.lang
+
+import com.vitorpamplona.quartz.utils.urldetector.detection.UrlDetector
+import java.util.regex.Pattern
+
+internal object TranslationDictionary {
+    const val PLACEHOLDER_BASE: Int = 0xE000
+    const val PLACEHOLDER_LIMIT: Int = 0xF8FF - PLACEHOLDER_BASE
+
+    private const val MIN_TRANSLATABLE_LENGTH = 4
+
+    val lnRegex: Pattern = Pattern.compile("\\blnbc[a-z0-9]+\\b", Pattern.CASE_INSENSITIVE)
+    val tagRegex: Pattern =
+        Pattern.compile(
+            "(nostr:)?@?(nsec1|npub1|nevent1|naddr1|note1|nprofile1|nrelay1)([qpzry9x8gf2tvdw0s3jn54khce6mua7l]+)",
+            Pattern.CASE_INSENSITIVE,
+        )
+    val nip08RefRegex: Pattern = Pattern.compile("#\\[\\d+]")
+
+    fun isWorthTranslating(text: String): Boolean {
+        if (text.length < MIN_TRANSLATABLE_LENGTH) return false
+        for (cp in text.codePoints()) {
+            if (Character.isLetter(cp)) return true
+        }
+        return false
+    }
+
+    fun build(text: String): Map<String, String> {
+        val dict = LinkedHashMap<String, String>()
+        var counter = 0
+
+        fun addUnique(value: String) {
+            if (value.isEmpty()) return
+            if (counter > PLACEHOLDER_LIMIT) return
+            if (dict.containsValue(value)) return
+            dict[placeholder(counter++)] = value
+        }
+
+        lnRegex.forEachMatch(text, ::addUnique)
+        tagRegex.forEachMatch(text, ::addUnique)
+        nip08RefRegex.forEachMatch(text, ::addUnique)
+
+        for (url in UrlDetector(text).detect()) {
+            val original = url.originalUrl
+            if (original.contains('，') || original.contains('。')) continue
+            addUnique(original)
+        }
+
+        return dict
+    }
+
+    private inline fun Pattern.forEachMatch(
+        text: String,
+        block: (String) -> Unit,
+    ) {
+        val matcher = matcher(text)
+        while (matcher.find()) block(matcher.group())
+    }
+
+    fun encode(
+        text: String,
+        dict: Map<String, String>,
+    ): String {
+        if (dict.isEmpty()) return text
+        var newText = text
+        for ((token, original) in dict.entries.sortedByDescending { it.value.length }) {
+            newText = newText.replace(original, token, ignoreCase = false)
+        }
+        return newText
+    }
+
+    fun decode(
+        text: String?,
+        dict: Map<String, String>,
+    ): String? {
+        if (text == null || dict.isEmpty()) return text
+        var newText: String = text
+        for ((token, original) in dict) {
+            newText = newText.replace(token, original, ignoreCase = false)
+        }
+        return newText
+    }
+
+    fun placeholder(index: Int): String {
+        require(index in 0..PLACEHOLDER_LIMIT) { "placeholder index $index out of range" }
+        return String(Character.toChars(PLACEHOLDER_BASE + index))
+    }
+}

--- a/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/service/lang/TranslationsCache.kt
+++ b/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/service/lang/TranslationsCache.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.lang
+
+import android.util.LruCache
+import com.vitorpamplona.amethyst.ui.components.TranslationConfig
+
+object TranslationsCache {
+    private const val MAX_ENTRIES = 500
+
+    private data class Key(
+        val content: String,
+        val translateTo: String,
+        val dontTranslateFrom: Set<String>,
+        val serverUrl: String,
+    )
+
+    private val cache = LruCache<Key, TranslationConfig>(MAX_ENTRIES)
+
+    fun get(
+        content: String,
+        translateTo: String,
+        dontTranslateFrom: Set<String>,
+        serverUrl: String,
+    ): TranslationConfig? = cache.get(Key(content, translateTo, dontTranslateFrom, serverUrl))
+
+    fun set(
+        content: String,
+        translateTo: String,
+        dontTranslateFrom: Set<String>,
+        serverUrl: String,
+        config: TranslationConfig,
+    ) {
+        cache.put(Key(content, translateTo, dontTranslateFrom, serverUrl), config)
+    }
+
+    fun clear() {
+        cache.evictAll()
+    }
+}

--- a/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/service/lang/TranslationsCache.kt
+++ b/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/service/lang/TranslationsCache.kt
@@ -31,6 +31,7 @@ object TranslationsCache {
         val translateTo: String,
         val dontTranslateFrom: Set<String>,
         val serverUrl: String,
+        val apiKeyFingerprint: Int,
     )
 
     private val cache = LruCache<Key, TranslationConfig>(MAX_ENTRIES)
@@ -40,16 +41,18 @@ object TranslationsCache {
         translateTo: String,
         dontTranslateFrom: Set<String>,
         serverUrl: String,
-    ): TranslationConfig? = cache.get(Key(content, translateTo, dontTranslateFrom, serverUrl))
+        apiKey: String,
+    ): TranslationConfig? = cache.get(Key(content, translateTo, dontTranslateFrom, serverUrl, apiKey.trim().hashCode()))
 
     fun set(
         content: String,
         translateTo: String,
         dontTranslateFrom: Set<String>,
         serverUrl: String,
+        apiKey: String,
         config: TranslationConfig,
     ) {
-        cache.put(Key(content, translateTo, dontTranslateFrom, serverUrl), config)
+        cache.put(Key(content, translateTo, dontTranslateFrom, serverUrl, apiKey.trim().hashCode()), config)
     }
 
     fun clear() {

--- a/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/ui/components/TranslatableRichTextViewer.kt
+++ b/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/ui/components/TranslatableRichTextViewer.kt
@@ -20,16 +20,25 @@
  */
 package com.vitorpamplona.amethyst.ui.components
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.commons.model.ImmutableListOfLists
+import com.vitorpamplona.amethyst.service.lang.LanguageTranslatorService
+import com.vitorpamplona.amethyst.service.lang.ResultOrError
+import com.vitorpamplona.amethyst.service.lang.TranslationsCache
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.theme.MaxWidthPaddingTop5dp
+import kotlinx.coroutines.CancellationException
 
 @Composable
 fun TranslatableRichTextViewer(
@@ -44,19 +53,27 @@ fun TranslatableRichTextViewer(
     authorPubKey: String? = null,
     accountViewModel: AccountViewModel,
     nav: INav,
-) = ExpandableRichTextViewer(
-    content,
-    canPreview,
-    quotesLeft,
-    modifier,
-    tags,
-    backgroundColor,
-    id,
-    callbackUri,
-    authorPubKey,
-    accountViewModel,
-    nav,
-)
+) {
+    TranslatableRichTextViewer(
+        content = content,
+        id = id,
+        accountViewModel = accountViewModel,
+    ) {
+        ExpandableRichTextViewer(
+            it,
+            canPreview,
+            quotesLeft,
+            modifier,
+            tags,
+            backgroundColor,
+            id,
+            callbackUri,
+            authorPubKey,
+            accountViewModel,
+            nav,
+        )
+    }
+}
 
 @Composable
 fun TranslatableRichTextViewer(
@@ -65,4 +82,101 @@ fun TranslatableRichTextViewer(
     translationMessageModifier: Modifier = MaxWidthPaddingTop5dp,
     accountViewModel: AccountViewModel,
     displayText: @Composable (String) -> Unit,
-) = displayText(content)
+) {
+    val languages = accountViewModel.account.settings.syncedSettings.languages
+    val translateTo by languages.translateTo.collectAsStateWithLifecycle()
+    val dontTranslateFrom by languages.dontTranslateFrom.collectAsStateWithLifecycle()
+    val languagePreferences by languages.languagePreferences.collectAsStateWithLifecycle()
+    val serverUrl by languages.translationServiceUrl.collectAsStateWithLifecycle()
+
+    val translatedTextState =
+        remember(id, content, translateTo, dontTranslateFrom, serverUrl) {
+            mutableStateOf(
+                TranslationsCache.get(content, translateTo, dontTranslateFrom, serverUrl)
+                    ?: TranslationConfig(content, null, null),
+            )
+        }
+
+    LaunchedEffect(content, translateTo, dontTranslateFrom, serverUrl) {
+        try {
+            translatedTextState.value = translateAndCache(content, translateTo, dontTranslateFrom, serverUrl)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+        }
+    }
+
+    RenderTextWithTranslateOptions(
+        translatedTextState = translatedTextState.value,
+        content = content,
+        languagePreferences = languagePreferences,
+        translationMessageModifier = translationMessageModifier,
+        accountViewModel = accountViewModel,
+        displayText = displayText,
+    )
+}
+
+@Composable
+private fun RenderTextWithTranslateOptions(
+    translatedTextState: TranslationConfig,
+    content: String,
+    languagePreferences: Map<String, String>,
+    translationMessageModifier: Modifier = MaxWidthPaddingTop5dp,
+    accountViewModel: AccountViewModel,
+    displayText: @Composable (String) -> Unit,
+) {
+    val source = translatedTextState.sourceLang
+    val target = translatedTextState.targetLang
+    val translationOccurred = source != null && target != null && source != target
+
+    val storedPreference = if (translationOccurred) languagePreferences["$source,$target"] else null
+    var showOriginal by
+        remember(translatedTextState, storedPreference) {
+            mutableStateOf(storedPreference == source)
+        }
+
+    val toBeViewed = if (showOriginal || !translationOccurred) content else translatedTextState.result
+
+    Column {
+        displayText(toBeViewed)
+
+        if (translationOccurred) {
+            TranslationStatusBar(
+                source = source,
+                target = target,
+                modifier = translationMessageModifier,
+                accountViewModel = accountViewModel,
+            ) { showOriginal = it }
+        }
+    }
+}
+
+private suspend fun translateAndCache(
+    content: String,
+    translateTo: String,
+    dontTranslateFrom: Set<String>,
+    serverUrl: String,
+): TranslationConfig {
+    TranslationsCache.get(content, translateTo, dontTranslateFrom, serverUrl)?.let { return it }
+
+    val noOp = TranslationConfig(content, null, null)
+    val raw =
+        LanguageTranslatorService.autoTranslate(
+            text = content,
+            dontTranslateFrom = dontTranslateFrom,
+            translateTo = translateTo,
+            serverUrl = serverUrl,
+        ) ?: return noOp.also { TranslationsCache.set(content, translateTo, dontTranslateFrom, serverUrl, it) }
+
+    val config = raw.toTranslationConfig(content) ?: noOp
+    TranslationsCache.set(content, translateTo, dontTranslateFrom, serverUrl, config)
+    return config
+}
+
+private fun ResultOrError.toTranslationConfig(content: String): TranslationConfig? {
+    val translated = result ?: return null
+    val source = sourceLang ?: return null
+    val target = targetLang ?: return null
+    if (source == target || translated == content) return null
+    return TranslationConfig(translated, source, target)
+}

--- a/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/ui/components/TranslatableRichTextViewer.kt
+++ b/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/ui/components/TranslatableRichTextViewer.kt
@@ -88,18 +88,20 @@ fun TranslatableRichTextViewer(
     val dontTranslateFrom by languages.dontTranslateFrom.collectAsStateWithLifecycle()
     val languagePreferences by languages.languagePreferences.collectAsStateWithLifecycle()
     val serverUrl by languages.translationServiceUrl.collectAsStateWithLifecycle()
+    val apiKey by accountViewModel.account.settings.translationServiceApiKey
+        .collectAsStateWithLifecycle()
 
     val translatedTextState =
-        remember(id, content, translateTo, dontTranslateFrom, serverUrl) {
+        remember(id, content, translateTo, dontTranslateFrom, serverUrl, apiKey) {
             mutableStateOf(
-                TranslationsCache.get(content, translateTo, dontTranslateFrom, serverUrl)
+                TranslationsCache.get(content, translateTo, dontTranslateFrom, serverUrl, apiKey)
                     ?: TranslationConfig(content, null, null),
             )
         }
 
-    LaunchedEffect(content, translateTo, dontTranslateFrom, serverUrl) {
+    LaunchedEffect(content, translateTo, dontTranslateFrom, serverUrl, apiKey) {
         try {
-            translatedTextState.value = translateAndCache(content, translateTo, dontTranslateFrom, serverUrl)
+            translatedTextState.value = translateAndCache(content, translateTo, dontTranslateFrom, serverUrl, apiKey)
         } catch (e: CancellationException) {
             throw e
         } catch (_: Exception) {
@@ -156,8 +158,9 @@ private suspend fun translateAndCache(
     translateTo: String,
     dontTranslateFrom: Set<String>,
     serverUrl: String,
+    apiKey: String,
 ): TranslationConfig {
-    TranslationsCache.get(content, translateTo, dontTranslateFrom, serverUrl)?.let { return it }
+    TranslationsCache.get(content, translateTo, dontTranslateFrom, serverUrl, apiKey)?.let { return it }
 
     val noOp = TranslationConfig(content, null, null)
     val raw =
@@ -166,10 +169,11 @@ private suspend fun translateAndCache(
             dontTranslateFrom = dontTranslateFrom,
             translateTo = translateTo,
             serverUrl = serverUrl,
-        ) ?: return noOp.also { TranslationsCache.set(content, translateTo, dontTranslateFrom, serverUrl, it) }
+            apiKey = apiKey,
+        ) ?: return noOp.also { TranslationsCache.set(content, translateTo, dontTranslateFrom, serverUrl, apiKey, it) }
 
     val config = raw.toTranslationConfig(content) ?: noOp
-    TranslationsCache.set(content, translateTo, dontTranslateFrom, serverUrl, config)
+    TranslationsCache.set(content, translateTo, dontTranslateFrom, serverUrl, apiKey, config)
     return config
 }
 

--- a/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/ui/components/TranslationStatusBar.kt
+++ b/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/ui/components/TranslationStatusBar.kt
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.components
+
+import android.content.res.Resources
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.core.os.ConfigurationCompat
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
+import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.amethyst.ui.theme.DividerThickness
+import com.vitorpamplona.amethyst.ui.theme.Font14SP
+import com.vitorpamplona.amethyst.ui.theme.MaxWidthPaddingTop5dp
+import com.vitorpamplona.amethyst.ui.theme.lessImportantLink
+import java.util.Locale
+
+@Composable
+internal fun TranslationStatusBar(
+    source: String,
+    target: String,
+    modifier: Modifier = MaxWidthPaddingTop5dp,
+    accountViewModel: AccountViewModel,
+    onShowOriginalChange: (Boolean) -> Unit,
+) {
+    var dropdownExpanded by remember { mutableStateOf(false) }
+
+    val sourceDisplay = remember(source) { Locale.forLanguageTag(source).displayName }
+    val targetDisplay = remember(target) { Locale.forLanguageTag(target).displayName }
+
+    Row(modifier = modifier) {
+        TranslationStatusText(
+            sourceDisplay = sourceDisplay,
+            targetDisplay = targetDisplay,
+            onAutoLabelClick = { dropdownExpanded = !dropdownExpanded },
+            onSourceLabelClick = { onShowOriginalChange(true) },
+            onTargetLabelClick = { onShowOriginalChange(false) },
+        )
+
+        if (dropdownExpanded) {
+            LangSettingsDropdown(
+                source = source,
+                target = target,
+                sourceDisplay = sourceDisplay,
+                targetDisplay = targetDisplay,
+                accountViewModel = accountViewModel,
+                onDismiss = { dropdownExpanded = false },
+            )
+        }
+    }
+}
+
+@Composable
+private fun TranslationStatusText(
+    sourceDisplay: String,
+    targetDisplay: String,
+    onAutoLabelClick: () -> Unit,
+    onSourceLabelClick: () -> Unit,
+    onTargetLabelClick: () -> Unit,
+) {
+    val textColor = MaterialTheme.colorScheme.lessImportantLink
+    val autoLabel = stringRes(R.string.translations_auto)
+    val translatedFromLabel = stringRes(R.string.translations_translated_from)
+    val toLabel = stringRes(R.string.translations_to)
+
+    Text(
+        text =
+            buildAnnotatedString {
+                appendLink(autoLabel, textColor, onAutoLabelClick)
+                append(" $translatedFromLabel ")
+                appendLink(sourceDisplay, textColor, onSourceLabelClick)
+                append(" $toLabel ")
+                appendLink(targetDisplay, textColor, onTargetLabelClick)
+            },
+        style =
+            LocalTextStyle.current.copy(
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.32f),
+                fontSize = Font14SP,
+            ),
+        overflow = TextOverflow.Visible,
+        maxLines = 3,
+    )
+}
+
+@Composable
+private fun LangSettingsDropdown(
+    source: String,
+    target: String,
+    sourceDisplay: String,
+    targetDisplay: String,
+    accountViewModel: AccountViewModel,
+    onDismiss: () -> Unit,
+) {
+    val deviceLocales = rememberDeviceLocales()
+    val settings = accountViewModel.account.settings
+    val preferenceForPair = settings.preferenceBetween(source, target)
+
+    DropdownMenu(expanded = true, onDismissRequest = onDismiss) {
+        LangMenuItem(
+            checked = source in accountViewModel.dontTranslateFrom(),
+            label = stringRes(R.string.translations_never_translate_from_lang, sourceDisplay),
+            onClick = {
+                accountViewModel.toggleDontTranslateFrom(source)
+                onDismiss()
+            },
+        )
+        HorizontalDivider(thickness = DividerThickness)
+        LangMenuItem(
+            checked = preferenceForPair == source,
+            label = stringRes(R.string.translations_show_in_lang_first, sourceDisplay),
+            onClick = {
+                accountViewModel.prefer(source, target, source)
+                onDismiss()
+            },
+        )
+        LangMenuItem(
+            checked = preferenceForPair == target,
+            label = stringRes(R.string.translations_show_in_lang_first, targetDisplay),
+            onClick = {
+                accountViewModel.prefer(source, target, target)
+                onDismiss()
+            },
+        )
+        HorizontalDivider(thickness = DividerThickness)
+        for (lang in deviceLocales) {
+            LangMenuItem(
+                checked = settings.translateToContains(lang.language),
+                label = stringRes(R.string.translations_always_translate_to_lang, lang.displayName),
+                onClick = {
+                    onDismiss()
+                    accountViewModel.updateTranslateTo(lang.language)
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun rememberDeviceLocales(): List<Locale> =
+    remember {
+        val list = ConfigurationCompat.getLocales(Resources.getSystem().configuration)
+        (0 until list.size()).mapNotNull { list.get(it) }
+    }
+
+@Composable
+private fun LangMenuItem(
+    checked: Boolean,
+    label: String,
+    onClick: () -> Unit,
+) {
+    DropdownMenuItem(
+        text = { CheckmarkRow(checked, label) },
+        onClick = onClick,
+    )
+}
+
+@Composable
+private fun CheckmarkRow(
+    checked: Boolean,
+    label: String,
+) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        if (checked) {
+            Icon(
+                symbol = MaterialSymbols.Check,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+            )
+        } else {
+            Spacer(modifier = Modifier.size(24.dp))
+        }
+        Spacer(modifier = Modifier.size(10.dp))
+        Text(label)
+    }
+}

--- a/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/TranslationServiceUrlSetting.kt
+++ b/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/TranslationServiceUrlSetting.kt
@@ -21,9 +21,14 @@
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -33,6 +38,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -53,6 +60,8 @@ fun TranslationServiceUrlSetting(accountViewModel: AccountViewModel) {
 
     Column(modifier = Modifier.fillMaxWidth()) {
         HorizontalDivider(thickness = DividerThickness)
+        TranslationPrivacyWarning()
+        Spacer(modifier = Modifier.height(12.dp))
         SettingsRow(
             name = R.string.translation_service_url,
             description = R.string.translation_service_url_description,
@@ -69,6 +78,34 @@ fun TranslationServiceUrlSetting(accountViewModel: AccountViewModel) {
                     Text(stringRes(R.string.save))
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun TranslationPrivacyWarning() {
+    Surface(
+        color = MaterialTheme.colorScheme.errorContainer,
+        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        shape = MaterialTheme.shapes.small,
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(top = 12.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+        ) {
+            Text(
+                text = stringRes(R.string.translation_service_privacy_warning_title),
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stringRes(R.string.translation_service_privacy_warning_description),
+                style = MaterialTheme.typography.bodySmall,
+            )
         }
     }
 }

--- a/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/TranslationServiceUrlSetting.kt
+++ b/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/TranslationServiceUrlSetting.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.amethyst.ui.theme.DividerThickness
+
+@Composable
+fun TranslationServiceUrlSetting(accountViewModel: AccountViewModel) {
+    val savedUrl by accountViewModel.account.settings.syncedSettings.languages.translationServiceUrl
+        .collectAsStateWithLifecycle()
+    var text by remember { mutableStateOf(savedUrl) }
+
+    LaunchedEffect(savedUrl) {
+        if (savedUrl != text) {
+            text = savedUrl
+        }
+    }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        HorizontalDivider(thickness = DividerThickness)
+        SettingsRow(
+            name = R.string.translation_service_url,
+            description = R.string.translation_service_url_description,
+        ) {
+            OutlinedTextField(
+                value = text,
+                onValueChange = { text = it },
+                singleLine = true,
+                placeholder = { Text("https://translate.nostr.wine") },
+                modifier = Modifier.fillMaxWidth(),
+            )
+            if (text.trim().trimEnd('/') != savedUrl) {
+                TextButton(onClick = { accountViewModel.updateTranslationServiceUrl(text) }) {
+                    Text(stringRes(R.string.save))
+                }
+            }
+        }
+    }
+}

--- a/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/TranslationServiceUrlSetting.kt
+++ b/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/TranslationServiceUrlSetting.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -39,6 +40,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
@@ -50,11 +53,20 @@ import com.vitorpamplona.amethyst.ui.theme.DividerThickness
 fun TranslationServiceUrlSetting(accountViewModel: AccountViewModel) {
     val savedUrl by accountViewModel.account.settings.syncedSettings.languages.translationServiceUrl
         .collectAsStateWithLifecycle()
+    val savedApiKey by accountViewModel.account.settings.translationServiceApiKey
+        .collectAsStateWithLifecycle()
     var text by remember { mutableStateOf(savedUrl) }
+    var apiKeyText by remember { mutableStateOf(savedApiKey) }
 
     LaunchedEffect(savedUrl) {
         if (savedUrl != text) {
             text = savedUrl
+        }
+    }
+
+    LaunchedEffect(savedApiKey) {
+        if (savedApiKey != apiKeyText) {
+            apiKeyText = savedApiKey
         }
     }
 
@@ -75,6 +87,25 @@ fun TranslationServiceUrlSetting(accountViewModel: AccountViewModel) {
             )
             if (text.trim().trimEnd('/') != savedUrl) {
                 TextButton(onClick = { accountViewModel.updateTranslationServiceUrl(text) }) {
+                    Text(stringRes(R.string.save))
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+        SettingsRow(
+            name = R.string.translation_service_api_key,
+            description = R.string.translation_service_api_key_description,
+        ) {
+            OutlinedTextField(
+                value = apiKeyText,
+                onValueChange = { apiKeyText = it },
+                singleLine = true,
+                visualTransformation = PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                modifier = Modifier.fillMaxWidth(),
+            )
+            if (apiKeyText.trim() != savedApiKey) {
+                TextButton(onClick = { accountViewModel.updateTranslationServiceApiKey(apiKeyText) }) {
                     Text(stringRes(R.string.save))
                 }
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
@@ -151,6 +151,7 @@ private object PrefKeys {
     const val DISMISSED_POLL_NOTE_IDS = "dismissed_poll_note_ids"
     const val VIEWED_POLL_RESULT_NOTE_IDS = "viewed_poll_result_note_ids"
     const val PENDING_ATTESTATIONS = "pending_attestations"
+    const val TRANSLATION_SERVICE_API_KEY = "translationServiceApiKey"
 
     const val ALL_ACCOUNT_INFO = "all_saved_accounts_info"
     const val SHARED_SETTINGS = "shared_settings"
@@ -444,6 +445,12 @@ object LocalPreferences {
                         PrefKeys.PENDING_ATTESTATIONS,
                         JsonMapper.toJson(settings.pendingAttestations.value),
                     )
+
+                    if (settings.translationServiceApiKey.value.isNotBlank()) {
+                        putString(PrefKeys.TRANSLATION_SERVICE_API_KEY, settings.translationServiceApiKey.value)
+                    } else {
+                        remove(PrefKeys.TRANSLATION_SERVICE_API_KEY)
+                    }
                 }
             }
         }
@@ -540,6 +547,7 @@ object LocalPreferences {
                     val defaultFileServerStr = getString(PrefKeys.DEFAULT_FILE_SERVER, null)
 
                     val pendingAttestationsStr = getString(PrefKeys.PENDING_ATTESTATIONS, null)
+                    val translationServiceApiKey = getString(PrefKeys.TRANSLATION_SERVICE_API_KEY, "") ?: ""
                     val latestUserMetadataStr = getString(PrefKeys.LATEST_USER_METADATA, null)
                     val latestContactListStr = getString(PrefKeys.LATEST_CONTACT_LIST, null)
                     val latestDmRelayListStr = getString(PrefKeys.LATEST_DM_RELAY_LIST, null)
@@ -678,6 +686,7 @@ object LocalPreferences {
                         dismissedPollNoteIds = MutableStateFlow(dismissedPollNoteIds),
                         viewedPollResultNoteIds = MutableStateFlow(viewedPollResultNoteIds.await()),
                         pendingAttestations = MutableStateFlow(pendingAttestations.await()),
+                        translationServiceApiKey = MutableStateFlow(translationServiceApiKey),
                         backupNipA3PaymentTargets = latestPaymentTargets.await(),
                         callsEnabled = MutableStateFlow(callsEnabled),
                     )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -620,6 +620,12 @@ class Account(
         }
     }
 
+    suspend fun updateTranslationServiceUrl(url: String) {
+        if (settings.updateTranslationServiceUrl(url)) {
+            sendNewAppSpecificData()
+        }
+    }
+
     suspend fun prefer(
         source: String,
         target: String,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -626,6 +626,10 @@ class Account(
         }
     }
 
+    fun updateTranslationServiceApiKey(apiKey: String) {
+        settings.updateTranslationServiceApiKey(apiKey)
+    }
+
     suspend fun prefer(
         source: String,
         target: String,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -205,6 +205,7 @@ class AccountSettings(
     val dismissedPollNoteIds: MutableStateFlow<Set<String>> = MutableStateFlow(setOf()),
     val viewedPollResultNoteIds: MutableStateFlow<Map<String, Long>> = MutableStateFlow(mapOf()),
     val pendingAttestations: MutableStateFlow<Map<HexKey, String>> = MutableStateFlow(mapOf()),
+    val translationServiceApiKey: MutableStateFlow<String> = MutableStateFlow(""),
     var backupNipA3PaymentTargets: PaymentTargetsEvent? = null,
     var callTurnServers: List<CallTurnServer> = emptyList(),
     var callVideoResolution: CallVideoResolution = CallVideoResolution.HD_720,
@@ -663,6 +664,16 @@ class AccountSettings(
 
     fun updateTranslationServiceUrl(url: String): Boolean {
         if (syncedSettings.languages.updateTranslationServiceUrl(url)) {
+            saveAccountSettings()
+            return true
+        }
+        return false
+    }
+
+    fun updateTranslationServiceApiKey(apiKey: String): Boolean {
+        val normalized = apiKey.trim()
+        if (translationServiceApiKey.value != normalized) {
+            translationServiceApiKey.tryEmit(normalized)
             saveAccountSettings()
             return true
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -661,6 +661,14 @@ class AccountSettings(
         return false
     }
 
+    fun updateTranslationServiceUrl(url: String): Boolean {
+        if (syncedSettings.languages.updateTranslationServiceUrl(url)) {
+            saveAccountSettings()
+            return true
+        }
+        return false
+    }
+
     fun prefer(
         source: String,
         target: String,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettings.kt
@@ -47,6 +47,7 @@ class AccountSyncedSettings(
             MutableStateFlow(internalSettings.languages.dontTranslateFrom),
             MutableStateFlow(internalSettings.languages.languagePreferences),
             MutableStateFlow(internalSettings.languages.translateTo),
+            MutableStateFlow(internalSettings.languages.translationServiceUrl),
         )
     val security =
         AccountSecurityPreferences(
@@ -75,6 +76,7 @@ class AccountSyncedSettings(
                     languages.dontTranslateFrom.value,
                     languages.languagePreferences.value,
                     languages.translateTo.value,
+                    languages.translationServiceUrl.value,
                 ),
             security =
                 AccountSecurityPreferencesInternal(
@@ -118,6 +120,10 @@ class AccountSyncedSettings(
 
         if (languages.translateTo.value != syncedSettingsInternal.languages.translateTo) {
             languages.translateTo.value = syncedSettingsInternal.languages.translateTo
+        }
+
+        if (languages.translationServiceUrl.value != syncedSettingsInternal.languages.translationServiceUrl) {
+            languages.translationServiceUrl.value = syncedSettingsInternal.languages.translationServiceUrl
         }
 
         if (security.showSensitiveContent.value != syncedSettingsInternal.security.showSensitiveContent) {
@@ -175,6 +181,7 @@ class AccountLanguagePreferences(
     var dontTranslateFrom: MutableStateFlow<Set<String>>,
     var languagePreferences: MutableStateFlow<Map<String, String>>,
     var translateTo: MutableStateFlow<String>,
+    var translationServiceUrl: MutableStateFlow<String>,
 ) {
     // ---
     // language services
@@ -202,6 +209,15 @@ class AccountLanguagePreferences(
     fun updateTranslateTo(languageCode: String): Boolean {
         if (translateTo.value != languageCode) {
             translateTo.tryEmit(languageCode)
+            return true
+        }
+        return false
+    }
+
+    fun updateTranslationServiceUrl(url: String): Boolean {
+        val normalized = url.trim().trimEnd('/')
+        if (translationServiceUrl.value != normalized) {
+            translationServiceUrl.tryEmit(normalized)
             return true
         }
         return false

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettingsInternal.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettingsInternal.kt
@@ -138,6 +138,7 @@ class AccountLanguagePreferencesInternal(
     var dontTranslateFrom: Set<String> = getLanguagesSpokenByUser(),
     var languagePreferences: Map<String, String> = mapOf(),
     var translateTo: String = Locale.getDefault().language,
+    var translationServiceUrl: String = "",
 )
 
 @Serializable

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -1137,6 +1137,8 @@ class AccountViewModel(
 
     fun translationServiceUrl() = account.settings.syncedSettings.languages.translationServiceUrl.value
 
+    fun translationServiceApiKey() = account.settings.translationServiceApiKey.value
+
     fun defaultZapType() = account.settings.syncedSettings.zaps.defaultZapType.value
 
     fun showSensitiveContent(): MutableStateFlow<Boolean?> = account.settings.syncedSettings.security.showSensitiveContent
@@ -1205,6 +1207,8 @@ class AccountViewModel(
     fun updateTranslateTo(languageCode: String) = launchSigner { account.updateTranslateTo(languageCode) }
 
     fun updateTranslationServiceUrl(url: String) = launchSigner { account.updateTranslationServiceUrl(url) }
+
+    fun updateTranslationServiceApiKey(apiKey: String) = launchSigner { account.updateTranslationServiceApiKey(apiKey) }
 
     fun prefer(
         source: String,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -1135,6 +1135,8 @@ class AccountViewModel(
 
     fun translateTo() = account.settings.syncedSettings.languages.translateTo.value
 
+    fun translationServiceUrl() = account.settings.syncedSettings.languages.translationServiceUrl.value
+
     fun defaultZapType() = account.settings.syncedSettings.zaps.defaultZapType.value
 
     fun showSensitiveContent(): MutableStateFlow<Boolean?> = account.settings.syncedSettings.security.showSensitiveContent
@@ -1201,6 +1203,8 @@ class AccountViewModel(
     fun removeDontTranslateFrom(languageCode: String) = launchSigner { account.removeDontTranslateFrom(languageCode) }
 
     fun updateTranslateTo(languageCode: String) = launchSigner { account.updateTranslateTo(languageCode) }
+
+    fun updateTranslationServiceUrl(url: String) = launchSigner { account.updateTranslationServiceUrl(url) }
 
     fun prefer(
         source: String,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/UserSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/UserSettingsScreen.kt
@@ -106,6 +106,7 @@ fun UserSettingsScreen(
                 verticalArrangement = SpacedBy10dp,
             ) {
                 TranslateToSetting(accountViewModel)
+                TranslationServiceUrlSetting(accountViewModel)
                 HorizontalDivider(thickness = DividerThickness)
                 DontTranslateFromSetting(accountViewModel)
                 HorizontalDivider(thickness = DividerThickness)

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -2183,6 +2183,8 @@
     <string name="dont_translate_from_description">Languages shown here will not be translated. Select a language to remove it and have it translated again.</string>
     <string name="translate_to">Translate To</string>
     <string name="translate_to_description">Choose the language to translate content into.</string>
+    <string name="translation_service_url">Translation Server</string>
+    <string name="translation_service_url_description">Optional LibreTranslate-compatible server for F-Droid translations. Leave empty to keep external translation disabled.</string>
     <string name="language_preferences">Language Display Preferences</string>
     <string name="language_preferences_description">For each translated language pair, choose which language to show first.</string>
     <string name="language_preference_pair">%1$s → %2$s</string>

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -2185,6 +2185,8 @@
     <string name="translate_to_description">Choose the language to translate content into.</string>
     <string name="translation_service_url">Translation Server</string>
     <string name="translation_service_url_description">Optional LibreTranslate-compatible server for F-Droid translations. Leave empty to keep external translation disabled.</string>
+    <string name="translation_service_privacy_warning_title">Privacy warning</string>
+    <string name="translation_service_privacy_warning_description">Any content you translate with this server is sent in plaintext to that server, including private DMs and encrypted payloads after Amethyst decrypts them. Whoever controls the server can read everything sent for translation, including passwords, private photos, and other private information.</string>
     <string name="language_preferences">Language Display Preferences</string>
     <string name="language_preferences_description">For each translated language pair, choose which language to show first.</string>
     <string name="language_preference_pair">%1$s → %2$s</string>

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -2185,6 +2185,8 @@
     <string name="translate_to_description">Choose the language to translate content into.</string>
     <string name="translation_service_url">Translation Server</string>
     <string name="translation_service_url_description">Optional LibreTranslate-compatible server for F-Droid translations. Leave empty to keep external translation disabled.</string>
+    <string name="translation_service_api_key">Translation Server API Key</string>
+    <string name="translation_service_api_key_description">Optional API key for LibreTranslate-compatible servers that require one. This key is stored locally in encrypted account preferences and is not synced.</string>
     <string name="translation_service_privacy_warning_title">Privacy warning</string>
     <string name="translation_service_privacy_warning_description">Any content you translate with this server is sent in plaintext to that server, including private DMs and encrypted payloads after Amethyst decrypts them. Whoever controls the server can read everything sent for translation, including passwords, private photos, and other private information.</string>
     <string name="language_preferences">Language Display Preferences</string>

--- a/amethyst/src/play/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/TranslationServiceUrlSetting.kt
+++ b/amethyst/src/play/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/TranslationServiceUrlSetting.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings
+
+import androidx.compose.runtime.Composable
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+
+@Composable
+fun TranslationServiceUrlSetting(accountViewModel: AccountViewModel) = Unit


### PR DESCRIPTION
## Summary
- Adds opt-in F-Droid translation through a LibreTranslate-compatible server URL in language settings.
- Reuses the translated/original display controls for F-Droid translations.
- Preserves URLs, Nostr references, and Lightning invoices during translation, with cache keys scoped by server URL.
- Keeps the Play flavor on the existing ML Kit path; the new server setting is a no-op in Play builds.

## Verification
- `git diff --check`
- `JAVA_HOME=/opt/homebrew/Cellar/openjdk/25.0.2/libexec/openjdk.jdk/Contents/Home GRADLE_USER_HOME=/private/tmp/codex-gradle-home ANDROID_USER_HOME=/private/tmp/codex-android-home ANDROID_HOME=/private/tmp/codex-android-sdk ./gradlew :amethyst:compileFdroidDebugKotlin :amethyst:compilePlayDebugKotlin -x installGitHook`

Addresses #61
Fixes #548

BTC payout address, if this qualifies for the bounty: `39Q34P8A7g375yqEr8buvNJkUbRgKfbKQZ`