### PR TITLE
Add reaction voting for zapless polls

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -651,9 +651,10 @@ class Account(
     suspend fun createReactionEvent(
         note: Note,
         reaction: String,
+        allowDuplicate: Boolean = false,
     ): Pair<Event, Set<NormalizedRelayUrl>>? {
         if (!signer.isWriteable()) return null
-        if (note.hasReacted(userProfile(), reaction)) return null
+        if (!allowDuplicate && note.hasReacted(userProfile(), reaction)) return null
 
         val eventHint = note.toEventHint<Event>() ?: return null
 
@@ -664,6 +665,18 @@ class Account(
         val relays = computeRelayListToBroadcast(event)
 
         return event to relays
+    }
+
+    suspend fun reactToWithoutDuplicateCheck(
+        note: Note,
+        reaction: String,
+    ) {
+        if (!signer.isWriteable()) return
+
+        val eventHint = note.toEventHint<Event>() ?: return
+        val event = ReactionAction.reactTo(eventHint, reaction, signer)
+
+        sendAutomatic(event)
     }
 
     /**

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapPollNote.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapPollNote.kt
@@ -80,6 +80,7 @@ import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.ZapPaymentHandler
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.observeNoteReactions
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.observeNoteZaps
 import com.vitorpamplona.amethyst.ui.components.TranslatableRichTextViewer
 import com.vitorpamplona.amethyst.ui.components.toasts.StringToastMsg
@@ -272,7 +273,7 @@ fun ZapPollNote(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    WatchZapsAndUpdateTallies(baseNote, pollViewModel, accountViewModel)
+    WatchVotesAndUpdateTallies(baseNote, pollViewModel, accountViewModel)
 
     pollViewModel.tallies.forEach { option ->
         OptionNote(
@@ -288,14 +289,20 @@ fun ZapPollNote(
 }
 
 @Composable
-private fun WatchZapsAndUpdateTallies(
+private fun WatchVotesAndUpdateTallies(
     baseNote: Note,
     pollViewModel: PollNoteViewModel,
     accountViewModel: AccountViewModel,
 ) {
-    val zapsState by observeNoteZaps(baseNote, accountViewModel)
+    if (pollViewModel.isZaplessPoll()) {
+        val reactionsState by observeNoteReactions(baseNote, accountViewModel)
 
-    LaunchedEffect(key1 = zapsState) { pollViewModel.refreshTallies() }
+        LaunchedEffect(key1 = reactionsState) { pollViewModel.refreshTallies() }
+    } else {
+        val zapsState by observeNoteZaps(baseNote, accountViewModel)
+
+        LaunchedEffect(key1 = zapsState) { pollViewModel.refreshTallies() }
+    }
 }
 
 @Composable
@@ -314,7 +321,41 @@ private fun OptionNote(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier.padding(vertical = 3.dp),
     ) {
-        if (!pollViewModel.canZap.value) {
+        if (pollViewModel.isZaplessPoll()) {
+            ReactionVote(
+                baseNote,
+                poolOption,
+                pollViewModel = pollViewModel,
+                nonClickablePrepend = {
+                    if (!pollViewModel.canZap.value) {
+                        RenderOptionAfterVote(
+                            baseNote,
+                            poolOption,
+                            poolOption.consensusThreadhold.value,
+                            canPreview,
+                            tags,
+                            backgroundColor,
+                            accountViewModel,
+                            nav,
+                        )
+                    }
+                },
+                clickablePrepend = {
+                    if (pollViewModel.canZap.value) {
+                        RenderOptionBeforeVote(
+                            baseNote,
+                            poolOption.descriptor,
+                            canPreview,
+                            tags,
+                            backgroundColor,
+                            accountViewModel,
+                            nav,
+                        )
+                    }
+                },
+                accountViewModel = accountViewModel,
+            )
+        } else if (!pollViewModel.canZap.value) {
             ZapVote(
                 baseNote,
                 poolOption,
@@ -511,6 +552,84 @@ private fun RenderOptionBeforeVote(
                 nav = nav,
             )
         }
+    }
+}
+
+@Composable
+@OptIn(ExperimentalFoundationApi::class)
+fun ReactionVote(
+    baseNote: Note,
+    poolOption: PollOption,
+    modifier: Modifier = Modifier,
+    pollViewModel: PollNoteViewModel,
+    nonClickablePrepend: @Composable () -> Unit,
+    clickablePrepend: @Composable () -> Unit,
+    accountViewModel: AccountViewModel,
+) {
+    val isLoggedUser by remember { derivedStateOf { accountViewModel.isLoggedUser(baseNote.author) } }
+
+    nonClickablePrepend()
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier =
+            Modifier.combinedClickable(
+                role = Role.Button,
+                interactionSource = remember { MutableInteractionSource() },
+                indication = ripple24dp,
+                onClick = {
+                    if (!accountViewModel.isWriteable()) {
+                        accountViewModel.toastManager.toast(
+                            R.string.read_only_user,
+                            R.string.login_with_a_private_key_to_be_able_to_sign_events,
+                        )
+                    } else if (pollViewModel.isPollClosed()) {
+                        accountViewModel.toastManager.toast(
+                            R.string.poll_unable_to_vote,
+                            R.string.poll_is_closed_explainer,
+                        )
+                    } else if (isLoggedUser) {
+                        accountViewModel.toastManager.toast(
+                            R.string.poll_unable_to_vote,
+                            R.string.poll_author_no_vote,
+                        )
+                    } else if (poolOption.zappedByLoggedIn.value) {
+                        accountViewModel.toastManager.toast(
+                            R.string.poll_unable_to_vote,
+                            R.string.one_vote_per_user_on_atomic_votes,
+                        )
+                    } else {
+                        accountViewModel.reactTo(baseNote, poolOption.option.toString(), allowDuplicate = true)
+                    }
+                },
+            ),
+    ) {
+        clickablePrepend()
+
+        if (poolOption.zappedByLoggedIn.value) {
+            Icon(
+                symbol = MaterialSymbols.Check,
+                contentDescription = stringRes(R.string.kind_poll),
+                modifier = Modifier.size(20.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+        } else {
+            Icon(
+                symbol = MaterialSymbols.Poll,
+                contentDescription = stringRes(R.string.kind_poll),
+                modifier = Modifier.size(20.dp),
+                tint = MaterialTheme.colorScheme.placeholderText,
+            )
+        }
+    }
+
+    if (!pollViewModel.canZap.value) {
+        Text(
+            text = poolOption.voteCount.value.toString(),
+            fontSize = Font14SP,
+            color = MaterialTheme.colorScheme.placeholderText,
+            modifier = modifier,
+        )
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapPollNoteViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapPollNoteViewModel.kt
@@ -46,6 +46,7 @@ data class PollOption(
     var tally: MutableState<Float> = mutableFloatStateOf(0f),
     var consensusThreadhold: MutableState<Boolean> = mutableStateOf(false),
     var zappedByLoggedIn: MutableState<Boolean> = mutableStateOf(false),
+    var voteCount: MutableState<Int> = mutableStateOf(0),
 )
 
 @Stable
@@ -59,6 +60,7 @@ class PollNoteViewModel : ViewModel() {
     private var valueMinimum: Long? = null
     private var valueMaximumBD: BigDecimal? = null
     private var valueMinimumBD: BigDecimal? = null
+    private var zaplessPoll: Boolean = false
 
     private var closedAt: Long? = null
     private var consensusThreshold: BigDecimal? = null
@@ -82,6 +84,7 @@ class PollNoteViewModel : ViewModel() {
             valueMinimum = pollEvent?.minAmount()
             valueMinimumBD = valueMinimum?.let { BigDecimal(it) }
             valueMaximumBD = valueMaximum?.let { BigDecimal(it) }
+            zaplessPoll = pollEvent?.isZapless() == true
             consensusThreshold = pollEvent?.consensusThreshold()?.toBigDecimal()
             closedAt = pollEvent?.closedAt()
 
@@ -101,33 +104,75 @@ class PollNoteViewModel : ViewModel() {
 
     fun refreshTallies() {
         viewModelScope.launch(Dispatchers.IO) {
-            totalZapped = totalZapped()
-            wasZappedByLoggedInAccount = false
-            wasZappedByLoggedInAccount = account.calculateIfNoteWasZappedByAccount(pollNote, 0)
-            canZap.value = checkIfCanZap()
+            if (zaplessPoll) {
+                refreshReactionTallies()
+            } else {
+                totalZapped = totalZapped()
+                wasZappedByLoggedInAccount = false
+                wasZappedByLoggedInAccount = account.calculateIfNoteWasZappedByAccount(pollNote, 0)
+                canZap.value = checkIfCanZap()
 
-            tallies.forEach {
-                val zappedValue = zappedPollOptionAmount(it.option)
-                val tallyValue =
-                    if (totalZapped > BigDecimal.ZERO) {
-                        zappedValue.divide(totalZapped, 2, RoundingMode.HALF_UP)
-                    } else {
-                        BigDecimal.ZERO
-                    }
+                tallies.forEach {
+                    val zappedValue = zappedPollOptionAmount(it.option)
+                    val tallyValue =
+                        if (totalZapped > BigDecimal.ZERO) {
+                            zappedValue.divide(totalZapped, 2, RoundingMode.HALF_UP)
+                        } else {
+                            BigDecimal.ZERO
+                        }
 
-                it.zappedValue.value = zappedValue
-                it.tally.value = tallyValue.toFloat()
-                it.consensusThreadhold.value = consensusThreshold != null && tallyValue >= consensusThreshold!!
-                it.zappedByLoggedIn.value = account.userProfile().let { it1 -> cachedIsPollOptionZappedBy(it.option, it1) }
+                    it.zappedValue.value = zappedValue
+                    it.voteCount.value = 0
+                    it.tally.value = tallyValue.toFloat()
+                    it.consensusThreadhold.value = consensusThreshold != null && tallyValue >= consensusThreshold!!
+                    it.zappedByLoggedIn.value = account.userProfile().let { it1 -> cachedIsPollOptionZappedBy(it.option, it1) }
+                }
             }
+        }
+    }
+
+    private fun refreshReactionTallies() {
+        val note = pollNote ?: return
+        val validOptions = pollOptions?.keys?.map { it.toString() }?.toSet() ?: emptySet()
+        val latestVoteByAuthor =
+            note.reactions
+                .values
+                .flatten()
+                .filter { it.author != null && it.event?.content in validOptions }
+                .groupBy { it.author!!.pubkeyHex }
+                .mapValues { (_, reactions) -> reactions.maxByOrNull { it.createdAt() ?: 0L }!! }
+
+        val loggedInVote = latestVoteByAuthor[account.userProfile().pubkeyHex]?.event?.content
+        wasZappedByLoggedInAccount = loggedInVote != null
+        canZap.value = checkIfCanZap()
+
+        val totalVotes = latestVoteByAuthor.size
+
+        tallies.forEach {
+            val option = it.option.toString()
+            val voteCount = latestVoteByAuthor.values.count { reaction -> reaction.event?.content == option }
+            val tallyValue =
+                if (totalVotes > 0) {
+                    BigDecimal(voteCount).divide(BigDecimal(totalVotes), 2, RoundingMode.HALF_UP)
+                } else {
+                    BigDecimal.ZERO
+                }
+
+            it.zappedValue.value = BigDecimal.ZERO
+            it.voteCount.value = voteCount
+            it.tally.value = tallyValue.toFloat()
+            it.consensusThreadhold.value = consensusThreshold != null && tallyValue >= consensusThreshold!!
+            it.zappedByLoggedIn.value = loggedInVote == option
         }
     }
 
     fun checkIfCanZap(): Boolean {
         val account = account
         val note = pollNote ?: return false
-        return account.userProfile() != note.author && !wasZappedByLoggedInAccount
+        return account.userProfile() != note.author && !wasZappedByLoggedInAccount && !isPollClosed()
     }
+
+    fun isZaplessPoll() = zaplessPoll
 
     fun isVoteAmountAtomic() = valueMaximum != null && valueMinimum != null && valueMinimum == valueMaximum
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -473,6 +473,30 @@ class AccountViewModel(
         reactToOrDelete(note, reaction)
     }
 
+    fun reactTo(
+        note: Note,
+        reaction: String,
+        allowDuplicate: Boolean = false,
+    ) {
+        launchSigner {
+            if (settings.useTrackedBroadcasts() && note.event !is NIP17Group) {
+                account.createReactionEvent(note, reaction, allowDuplicate)?.let { (event, relays) ->
+                    broadcastTracker.trackBroadcast(
+                        event = event,
+                        relays = relays,
+                        client = account.client,
+                    )
+
+                    account.consumeReactionEvent(event)
+                }
+            } else if (allowDuplicate) {
+                account.reactToWithoutDuplicateCheck(note, reaction)
+            } else {
+                account.reactTo(note, reaction)
+            }
+        }
+    }
+
     @Immutable
     data class NoteComposeReportState(
         val isPostHidden: Boolean = false,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostViewModel.kt
@@ -1586,13 +1586,13 @@ open class ShortNotePostViewModel :
     // ---
 
     fun updateMinZapAmountForPoll(textMin: String) {
-        zapPollValueMinimum = textMin.toLongOrNull()?.takeIf { it > 0 }
+        zapPollValueMinimum = textMin.toLongOrNull()?.takeIf { it >= 0 }
         checkMinMax()
         draftTag.newVersion()
     }
 
     fun updateMaxZapAmountForPoll(textMax: String) {
-        zapPollValueMaximum = textMax.toLongOrNull()?.takeIf { it > 0 }
+        zapPollValueMaximum = textMax.toLongOrNull()?.takeIf { it >= 0 }
         checkMinMax()
         draftTag.newVersion()
     }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/zapPolls/ZapPollEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/zapPolls/ZapPollEvent.kt
@@ -119,6 +119,8 @@ class ZapPollEvent(
 
     fun maxAmount() = tags.firstNotNullOfOrNull(MaximumTag::parse)
 
+    fun isZapless() = minAmount() == 0L && maxAmount() == 0L
+
     fun closedAt() = tags.firstNotNullOfOrNull(ClosedAtTag::parse)
 
     fun consensusThreshold() = tags.firstNotNullOfOrNull(ConsensusThresholdTag::parse)

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/experimental/zapPolls/ZapPollEventTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/experimental/zapPolls/ZapPollEventTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.experimental.zapPolls
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ZapPollEventTest {
+    @Test
+    fun detectsZaplessPollsWithZeroValueBounds() {
+        val event =
+            zapPollEvent(
+                arrayOf("poll_option", "0", "Yes"),
+                arrayOf("poll_option", "1", "No"),
+                arrayOf("value_minimum", "0"),
+                arrayOf("value_maximum", "0"),
+            )
+
+        assertTrue(event.isZapless())
+    }
+
+    @Test
+    fun rejectsPaidZapPolls() {
+        val event =
+            zapPollEvent(
+                arrayOf("poll_option", "0", "Yes"),
+                arrayOf("value_minimum", "1"),
+                arrayOf("value_maximum", "100"),
+            )
+
+        assertFalse(event.isZapless())
+    }
+
+    @Test
+    fun rejectsPollsWithoutExplicitZeroBounds() {
+        val event =
+            zapPollEvent(
+                arrayOf("poll_option", "0", "Yes"),
+            )
+
+        assertFalse(event.isZapless())
+    }
+
+    private fun zapPollEvent(vararg tags: Array<String>) =
+        ZapPollEvent(
+            id = "6ff9bc13d27490f6e3953325260bd996901a143de89886a0608c39e7d0160a72",
+            pubKey = "f8ff11c7a7d3478355d3b4d174e5a473797a906ea4aa61aa9b6bc0652c1ea17a",
+            createdAt = 1729186078,
+            tags = arrayOf(*tags),
+            content = "Testing polls",
+            sig = "540101837a8826e2ae28401ee5f4fd8606def8501bec92a74a9e05264bb2c67558b927edf23bb085f5b5f0d91a61c65a25c37a3b92075bf10c9be03dbbe8e94e",
+        )
+}


### PR DESCRIPTION
## Summary
- detect kind 6969 polls with `value_minimum=0` and `value_maximum=0` as zapless polls
- tally zapless poll votes from kind 7 reactions, using the latest valid vote per pubkey
- publish reaction votes for zapless poll options while preserving paid zap-poll behavior
- allow the zap-poll composer to emit explicit zero min/max bounds

## Verification
- `HOME=/private/tmp/codex-home JAVA_HOME=/private/tmp/codex-jdks/temurin-21-arm64/Contents/Home GRADLE_USER_HOME=/private/tmp/codex-gradle-home ANDROID_USER_HOME=/private/tmp/codex-android-home ANDROID_HOME=/private/tmp/codex-android-sdk ./gradlew -Duser.home=/private/tmp/codex-home :quartz:jvmTest --tests com.vitorpamplona.quartz.experimental.zapPolls.ZapPollEventTest`
- `HOME=/private/tmp/codex-home JAVA_HOME=/private/tmp/codex-jdks/temurin-21-arm64/Contents/Home GRADLE_USER_HOME=/private/tmp/codex-gradle-home ANDROID_USER_HOME=/private/tmp/codex-android-home ANDROID_HOME=/private/tmp/codex-android-sdk ./gradlew -Duser.home=/private/tmp/codex-home :amethyst:compileFdroidDebugKotlin -x installGitHook`
- `git diff --check`

Bounty: closes #935
BTC payout address: 39Q34P8A7g375yqEr8buvNJkUbRgKfbKQZ