### PR TITLE
Add profile lists tab

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/ProfileScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/ProfileScreen.kt
@@ -89,6 +89,8 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.header.ProfileHeade
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.header.ProfileTopBar
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.header.apps.UserAppRecommendationsFeedViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.header.identity.UserExternalIdentitiesViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.lists.TabProfileLists
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.lists.dal.UserProfileListsFeedViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.mutual.TabMutualConversations
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.mutual.dal.UserProfileMutualFeedViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.newthreads.TabNotesNewThreads
@@ -230,6 +232,16 @@ fun PrepareViewModels(
                 ),
         )
 
+    val listsFeedViewModel: UserProfileListsFeedViewModel =
+        viewModel(
+            key = baseUser.pubkeyHex + "UserProfileListsFeedViewModel",
+            factory =
+                UserProfileListsFeedViewModel.Factory(
+                    baseUser,
+                    accountViewModel.account,
+                ),
+        )
+
     val pinnedNotesFeedViewModel: UserProfilePinnedNotesFeedViewModel =
         viewModel(
             key = baseUser.pubkeyHex + "UserProfilePinnedNotesFeedViewModel",
@@ -261,6 +273,7 @@ fun PrepareViewModels(
         externalIdentities,
         zapFeedViewModel,
         bookmarksFeedViewModel,
+        listsFeedViewModel,
         pinnedNotesFeedViewModel,
         galleryFeedViewModel,
         reportsFeedViewModel,
@@ -281,6 +294,7 @@ fun ProfileScreen(
     externalIdentities: UserExternalIdentitiesViewModel,
     zapFeedViewModel: UserProfileZapsViewModel,
     bookmarksFeedViewModel: UserProfileBookmarksFeedViewModel,
+    listsFeedViewModel: UserProfileListsFeedViewModel,
     pinnedNotesFeedViewModel: UserProfilePinnedNotesFeedViewModel,
     galleryFeedViewModel: UserProfileGalleryFeedViewModel,
     reportsFeedViewModel: UserProfileReportFeedViewModel,
@@ -292,6 +306,7 @@ fun ProfileScreen(
     WatchLifecycleAndUpdateModel(mutualViewModel)
     WatchLifecycleAndUpdateModel(appRecommendations)
     WatchLifecycleAndUpdateModel(bookmarksFeedViewModel)
+    WatchLifecycleAndUpdateModel(listsFeedViewModel)
     WatchLifecycleAndUpdateModel(pinnedNotesFeedViewModel)
     WatchLifecycleAndUpdateModel(galleryFeedViewModel)
 
@@ -334,6 +349,7 @@ fun ProfileScreen(
                     followersFeedViewModel,
                     zapFeedViewModel,
                     bookmarksFeedViewModel,
+                    listsFeedViewModel,
                     pinnedNotesFeedViewModel,
                     galleryFeedViewModel,
                     reportsFeedViewModel,
@@ -433,13 +449,14 @@ private fun RenderScreen(
     followersFeedViewModel: UserProfileFollowersUserFeedViewModel,
     zapFeedViewModel: UserProfileZapsViewModel,
     bookmarksFeedViewModel: UserProfileBookmarksFeedViewModel,
+    listsFeedViewModel: UserProfileListsFeedViewModel,
     pinnedNotesFeedViewModel: UserProfilePinnedNotesFeedViewModel,
     galleryFeedViewModel: UserProfileGalleryFeedViewModel,
     reportsFeedViewModel: UserProfileReportFeedViewModel,
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    val pagerState = rememberPagerState { 11 }
+    val pagerState = rememberPagerState { 12 }
 
     Column {
         ProfileHeader(baseUser, appRecommendations, externalIdentities, nav, accountViewModel)
@@ -480,6 +497,7 @@ private fun RenderScreen(
                 followersFeedViewModel,
                 zapFeedViewModel,
                 bookmarksFeedViewModel,
+                listsFeedViewModel,
                 pinnedNotesFeedViewModel,
                 galleryFeedViewModel,
                 reportsFeedViewModel,
@@ -501,6 +519,7 @@ private fun CreateAndRenderPages(
     followersFeedViewModel: UserProfileFollowersUserFeedViewModel,
     zapFeedViewModel: UserProfileZapsViewModel,
     bookmarksFeedViewModel: UserProfileBookmarksFeedViewModel,
+    listsFeedViewModel: UserProfileListsFeedViewModel,
     pinnedNotesFeedViewModel: UserProfilePinnedNotesFeedViewModel,
     galleryFeedViewModel: UserProfileGalleryFeedViewModel,
     reportsFeedViewModel: UserProfileReportFeedViewModel,
@@ -523,9 +542,10 @@ private fun CreateAndRenderPages(
         5 -> TabFollowers(followersFeedViewModel, accountViewModel, nav)
         6 -> TabReceivedZaps(baseUser, zapFeedViewModel, accountViewModel, nav)
         7 -> TabBookmarks(bookmarksFeedViewModel, accountViewModel, nav)
-        8 -> TabFollowedTags(baseUser, accountViewModel, nav)
-        9 -> TabReports(baseUser, reportsFeedViewModel, accountViewModel, nav)
-        10 -> TabRelays(baseUser, accountViewModel, nav)
+        8 -> TabProfileLists(listsFeedViewModel, accountViewModel, nav)
+        9 -> TabFollowedTags(baseUser, accountViewModel, nav)
+        10 -> TabReports(baseUser, reportsFeedViewModel, accountViewModel, nav)
+        11 -> TabRelays(baseUser, accountViewModel, nav)
     }
 }
 
@@ -571,6 +591,7 @@ private fun CreateAndRenderTabs(
             { FollowersTabHeader(baseUser, followersFeedViewModel, accountViewModel) },
             { ZapTabHeader(zapFeedViewModel, accountViewModel) },
             { BookmarkTabHeader(baseUser, accountViewModel) },
+            { Text(text = stringRes(R.string.feed_group_lists)) },
             { FollowedTagsTabHeader(baseUser, accountViewModel) },
             { ReportsTabHeader(baseUser, reportsFeedViewModel, accountViewModel) },
             { RelaysTabHeader(baseUser, accountViewModel) },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/lists/TabProfileLists.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/lists/TabProfileLists.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.lists
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.screen.RefresheableFeedView
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.lists.dal.UserProfileListsFeedViewModel
+
+@Composable
+fun TabProfileLists(
+    feedViewModel: UserProfileListsFeedViewModel,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    LaunchedEffect(Unit) { feedViewModel.invalidateData() }
+
+    Column(Modifier.fillMaxHeight()) {
+        Column(
+            modifier = Modifier.padding(vertical = 0.dp),
+        ) {
+            RefresheableFeedView(
+                feedViewModel,
+                null,
+                enablePullRefresh = false,
+                accountViewModel = accountViewModel,
+                nav = nav,
+            )
+        }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/lists/dal/UserProfileListsFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/lists/dal/UserProfileListsFeedFilter.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+@file:Suppress("DEPRECATION")
+
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.lists.dal
+
+import com.vitorpamplona.amethyst.model.Account
+import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.model.Note
+import com.vitorpamplona.amethyst.model.User
+import com.vitorpamplona.amethyst.model.filter
+import com.vitorpamplona.amethyst.ui.dal.AdditiveFeedFilter
+import com.vitorpamplona.amethyst.ui.dal.DefaultFeedOrder
+import com.vitorpamplona.quartz.nip51Lists.PinListEvent
+import com.vitorpamplona.quartz.nip51Lists.bookmarkList.BookmarkListEvent
+import com.vitorpamplona.quartz.nip51Lists.bookmarkList.OldBookmarkListEvent
+import com.vitorpamplona.quartz.nip51Lists.followList.FollowListEvent
+import com.vitorpamplona.quartz.nip51Lists.hashtagList.HashtagListEvent
+import com.vitorpamplona.quartz.nip51Lists.peopleList.PeopleListEvent
+
+private val UserProfileDisplayListKinds =
+    listOf(
+        BookmarkListEvent.KIND,
+        OldBookmarkListEvent.KIND,
+        PinListEvent.KIND,
+        PeopleListEvent.KIND,
+        FollowListEvent.KIND,
+        HashtagListEvent.KIND,
+    )
+
+class UserProfileListsFeedFilter(
+    val user: User,
+    val account: Account,
+) : AdditiveFeedFilter<Note>() {
+    override fun feedKey(): String = account.userProfile().pubkeyHex + "-" + user.pubkeyHex + "-ProfileLists"
+
+    override fun feed(): List<Note> =
+        sort(
+            LocalCache.addressables.filter(UserProfileDisplayListKinds, user.pubkeyHex) { _, note ->
+                acceptableEvent(note)
+            },
+        )
+
+    override fun applyFilter(newItems: Set<Note>): Set<Note> = newItems.filterTo(HashSet()) { acceptableEvent(it) }
+
+    private fun acceptableEvent(note: Note): Boolean =
+        note.event?.pubKey == user.pubkeyHex &&
+            isDisplayListEvent(note) &&
+            account.isAcceptable(note)
+
+    private fun isDisplayListEvent(note: Note): Boolean =
+        when (note.event) {
+            is BookmarkListEvent,
+            is OldBookmarkListEvent,
+            is PinListEvent,
+            is PeopleListEvent,
+            is FollowListEvent,
+            is HashtagListEvent,
+            -> true
+
+            else -> false
+        }
+
+    override fun sort(items: Set<Note>): List<Note> = items.sortedWith(DefaultFeedOrder)
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/lists/dal/UserProfileListsFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/lists/dal/UserProfileListsFeedViewModel.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.lists.dal
+
+import androidx.compose.runtime.Stable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.vitorpamplona.amethyst.model.Account
+import com.vitorpamplona.amethyst.model.User
+import com.vitorpamplona.amethyst.ui.screen.AndroidFeedViewModel
+
+@Stable
+class UserProfileListsFeedViewModel(
+    val user: User,
+    val account: Account,
+) : AndroidFeedViewModel(UserProfileListsFeedFilter(user, account)) {
+    class Factory(
+        val user: User,
+        val account: Account,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T = UserProfileListsFeedViewModel(user, account) as T
+    }
+}


### PR DESCRIPTION
## Summary
- adds a Lists tab to user profiles
- renders list-style events authored by the profile using the existing feed/note card pipeline
- includes bookmark, pin, people, follow, and hashtag list events fetched by the profile subscription

Fixes #616

## Verification
- ./gradlew.bat --no-daemon :amethyst:compileFdroidDebugKotlin
- ./gradlew.bat --no-daemon :amethyst:compilePlayDebugKotlin