### PR TITLE
Remember search stack across bottom tabs

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/navs/Nav.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/navs/Nav.kt
@@ -83,13 +83,14 @@ class Nav(
     override fun navBottomBar(route: Route) {
         navigationScope.launch {
             controller.navigate(route) {
-                // Clear sibling bottom-nav entries but keep Home (the start
-                // destination) below, so back-swipe from any tab returns to
-                // Home and back-swipe from Home leaves the app.
+                // Preserve the previous tab stack so returning to Home keeps
+                // the user's search/profile position instead of recreating it.
                 popUpTo(Route.Home) {
                     inclusive = false
+                    saveState = true
                 }
                 launchSingleTop = true
+                restoreState = true
             }
             // Mark this entry as a tab root: hides the back arrow in canPop
             // and skips the horizontal slide in composableFromEnd.


### PR DESCRIPTION
Fixes #426.\n\nThis updates bottom-bar navigation to save and restore the popped tab stack. With Navigation's saved state restoration enabled, leaving a search/profile flow for another bottom tab no longer recreates the Home/Search stack when the user returns.\n\nVerification:\n- ./gradlew.bat --no-daemon :amethyst:compileFdroidDebugKotlin\n- pre-commit spotless/static analysis