### PR TITLE
Add GIF keyboard uploads to chat composers

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupChatView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/marmotGroup/MarmotGroupChatView.kt
@@ -67,6 +67,7 @@ import com.vitorpamplona.amethyst.ui.theme.EditFieldTrailingIconModifier
 import com.vitorpamplona.amethyst.ui.theme.placeholderText
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
@@ -164,6 +165,9 @@ fun MarmotGroupMessageComposer(
     Column(modifier = EditFieldModifier) {
         ThinPaddingTextField(
             state = messageState,
+            onContentReceived = { uri, mimeType ->
+                uploadState.load(persistentListOf(SelectedMedia(uri, mimeType)))
+            },
             modifier = Modifier.fillMaxWidth(),
             shape = EditFieldBorder,
             placeholder = {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/PrivateMessageEditFieldRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/PrivateMessageEditFieldRow.kt
@@ -57,6 +57,7 @@ import com.vitorpamplona.amethyst.ui.actions.MentionPreservingInputTransformatio
 import com.vitorpamplona.amethyst.ui.actions.StrippingFailureDialog
 import com.vitorpamplona.amethyst.ui.actions.UrlUserTagOutputTransformation
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromGallery
+import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.components.ThinPaddingTextField
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -204,6 +205,9 @@ fun EditField(
     ThinPaddingTextField(
         state = channelScreenModel.message,
         onTextChanged = { channelScreenModel.onMessageChanged() },
+        onContentReceived = { uri, mimeType ->
+            channelScreenModel.pickedMedia(persistentListOf(SelectedMedia(uri, mimeType)))
+        },
         inputTransformation = MentionPreservingInputTransformation,
         keyboardOptions = PostKeyboard,
         shape = EditFieldBorder,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/send/EditFieldRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/send/EditFieldRow.kt
@@ -41,6 +41,7 @@ import com.vitorpamplona.amethyst.ui.actions.MentionPreservingInputTransformatio
 import com.vitorpamplona.amethyst.ui.actions.StrippingFailureDialog
 import com.vitorpamplona.amethyst.ui.actions.UrlUserTagOutputTransformation
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromGallery
+import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.components.ThinPaddingTextField
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.creators.emojiSuggestions.ShowEmojiSuggestionList
@@ -54,6 +55,7 @@ import com.vitorpamplona.amethyst.ui.theme.EditFieldModifier
 import com.vitorpamplona.amethyst.ui.theme.EditFieldTrailingIconModifier
 import com.vitorpamplona.amethyst.ui.theme.SuggestionListDefaultHeightChat
 import com.vitorpamplona.amethyst.ui.theme.placeholderText
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.FlowPreview
 
 @OptIn(FlowPreview::class)
@@ -117,6 +119,9 @@ fun EditFieldRow(
         ThinPaddingTextField(
             state = channelScreenModel.message,
             onTextChanged = { channelScreenModel.onMessageChanged() },
+            onContentReceived = { uri, mimeType ->
+                channelScreenModel.pickedMedia(persistentListOf(SelectedMedia(uri, mimeType)))
+            },
             inputTransformation = MentionPreservingInputTransformation,
             keyboardOptions =
                 KeyboardOptions.Default.copy(


### PR DESCRIPTION
Fixes #138.

This wires the existing `ThinPaddingTextField` receive-content support into the remaining chat composers so GIF/image content committed from the keyboard enters the same upload flow as the gallery picker.

Changes:
- private DM composer passes received keyboard images/GIFs to `ChatNewMessageViewModel.pickedMedia`
- public channel composer passes received keyboard images/GIFs to `ChannelNewMessageViewModel.pickedMedia`
- Marmot group composer passes received keyboard images/GIFs to `ChatFileUploadState.load`

Verification:
- `./gradlew spotlessKotlinCheck` passes
- `./gradlew :amethyst:compilePlayDebugKotlin` could not run locally because no Android SDK is configured (`ANDROID_HOME`/`local.properties` missing)

Bounty payout BTC address: `bc1qyz0k64a7glr2y7sk846cvwu0gkm79477hqtkcm`