### PR TITLE
Add client-side thread mute

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
@@ -149,6 +149,7 @@ private object PrefKeys {
     const val SIGNER_PACKAGE_NAME = "signer_package_name"
     const val HAS_DONATED_IN_VERSION = "has_donated_in_version"
     const val DISMISSED_POLL_NOTE_IDS = "dismissed_poll_note_ids"
+    const val MUTED_THREAD_ROOT_IDS = "muted_thread_root_ids"
     const val VIEWED_POLL_RESULT_NOTE_IDS = "viewed_poll_result_note_ids"
     const val PENDING_ATTESTATIONS = "pending_attestations"
 
@@ -435,6 +436,7 @@ object LocalPreferences {
                     )
                     putStringSet(PrefKeys.HAS_DONATED_IN_VERSION, settings.hasDonatedInVersion.value)
                     putStringSet(PrefKeys.DISMISSED_POLL_NOTE_IDS, settings.dismissedPollNoteIds.value)
+                    putStringSet(PrefKeys.MUTED_THREAD_ROOT_IDS, settings.mutedThreadRootIds.value)
                     putString(
                         PrefKeys.VIEWED_POLL_RESULT_NOTE_IDS,
                         JsonMapper.toJson(settings.viewedPollResultNoteIds.value),
@@ -529,6 +531,7 @@ object LocalPreferences {
                     val alwaysOnNotificationService = getBoolean(PrefKeys.ALWAYS_ON_NOTIFICATION_SERVICE, false)
                     val hasDonatedInVersion = getStringSet(PrefKeys.HAS_DONATED_IN_VERSION, null) ?: setOf()
                     val dismissedPollNoteIds = getStringSet(PrefKeys.DISMISSED_POLL_NOTE_IDS, null) ?: setOf()
+                    val mutedThreadRootIds = getStringSet(PrefKeys.MUTED_THREAD_ROOT_IDS, null) ?: setOf()
                     val viewedPollResultNoteIdsStr = getString(PrefKeys.VIEWED_POLL_RESULT_NOTE_IDS, null)
                     val localRelayServers = getStringSet(PrefKeys.LOCAL_RELAY_SERVERS, null) ?: setOf()
 
@@ -676,6 +679,7 @@ object LocalPreferences {
                         lastReadPerRoute = MutableStateFlow(lastReadPerRoute.await()),
                         hasDonatedInVersion = MutableStateFlow(hasDonatedInVersion),
                         dismissedPollNoteIds = MutableStateFlow(dismissedPollNoteIds),
+                        mutedThreadRootIds = MutableStateFlow(mutedThreadRootIds),
                         viewedPollResultNoteIds = MutableStateFlow(viewedPollResultNoteIds.await()),
                         pendingAttestations = MutableStateFlow(pendingAttestations.await()),
                         backupNipA3PaymentTargets = latestPaymentTargets.await(),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -2828,6 +2828,19 @@ class Account(
         sendMyPublicAndPrivateOutbox(muteList.showWords(words))
     }
 
+    fun threadMuteRootId(note: Note): HexKey =
+        note.replyTo?.firstOrNull { it.isNewThread() }?.idHex
+            ?: note.replyTo?.firstOrNull()?.idHex
+            ?: note.idHex
+
+    fun isThreadMuted(note: Note): Boolean =
+        note.idHex in settings.mutedThreadRootIds.value ||
+            note.replyTo?.any { it.idHex in settings.mutedThreadRootIds.value } == true
+
+    fun muteThread(note: Note) = settings.muteThread(threadMuteRootId(note))
+
+    fun unmuteThread(note: Note) = settings.unmuteThread(threadMuteRootId(note))
+
     suspend fun requestDVMContentDiscovery(
         dvmPublicKey: User,
         onReady: (event: NIP90ContentDiscoveryRequestEvent, relays: Set<NormalizedRelayUrl>) -> Unit,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -203,6 +203,7 @@ class AccountSettings(
     val lastReadPerRoute: MutableStateFlow<Map<String, MutableStateFlow<Long>>> = MutableStateFlow(mapOf()),
     val hasDonatedInVersion: MutableStateFlow<Set<String>> = MutableStateFlow(setOf()),
     val dismissedPollNoteIds: MutableStateFlow<Set<String>> = MutableStateFlow(setOf()),
+    val mutedThreadRootIds: MutableStateFlow<Set<HexKey>> = MutableStateFlow(setOf()),
     val viewedPollResultNoteIds: MutableStateFlow<Map<String, Long>> = MutableStateFlow(mapOf()),
     val pendingAttestations: MutableStateFlow<Map<HexKey, String>> = MutableStateFlow(mapOf()),
     var backupNipA3PaymentTargets: PaymentTargetsEvent? = null,
@@ -971,6 +972,30 @@ class AccountSettings(
         if (!dismissedPollNoteIds.value.contains(noteId)) {
             dismissedPollNoteIds.update {
                 it + noteId
+            }
+            saveAccountSettings()
+        }
+    }
+
+    // ---
+    // muted threads
+    // ---
+
+    fun isMutedThread(threadRootId: HexKey): Boolean = mutedThreadRootIds.value.contains(threadRootId)
+
+    fun muteThread(threadRootId: HexKey) {
+        if (!mutedThreadRootIds.value.contains(threadRootId)) {
+            mutedThreadRootIds.update {
+                it + threadRootId
+            }
+            saveAccountSettings()
+        }
+    }
+
+    fun unmuteThread(threadRootId: HexKey) {
+        if (mutedThreadRootIds.value.contains(threadRootId)) {
+            mutedThreadRootIds.update {
+                it - threadRootId
             }
             saveAccountSettings()
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
@@ -204,6 +204,10 @@ class EventNotificationConsumer(
         // to repeat either check.
         if (event.pubKey == account.signer.pubKey) return
 
+        LocalCache.getNoteIfExists(event.id)?.let {
+            if (account.isThreadMuted(it)) return
+        }
+
         when (event) {
             is PrivateDmEvent -> notify(event, account)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DropDownMenu.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DropDownMenu.kt
@@ -102,6 +102,7 @@ data class DropDownParams(
     val isLoggedUser: Boolean,
     val isSensitive: Boolean,
     val showSensitiveContent: Boolean?,
+    val isThreadMuted: Boolean,
     val isEmojiPackInMyList: Boolean = false,
 )
 
@@ -124,6 +125,7 @@ fun NoteDropDownMenu(
             isLoggedUser = false,
             isSensitive = false,
             showSensitiveContent = null,
+            isThreadMuted = false,
         ),
     )
 
@@ -335,6 +337,17 @@ fun NoteDropDownMenu(
 
         // Moderation section
         M3ActionSection {
+            if (state.isThreadMuted) {
+                M3ActionRow(icon = MaterialSymbols.Forum, text = stringRes(R.string.unmute_thread)) {
+                    accountViewModel.unmuteThread(note)
+                    onDismiss()
+                }
+            } else {
+                M3ActionRow(icon = MaterialSymbols.Forum, text = stringRes(R.string.mute_thread)) {
+                    accountViewModel.muteThread(note)
+                    onDismiss()
+                }
+            }
             if (state.isLoggedUser) {
                 M3ActionRow(icon = MaterialSymbols.Delete, text = stringRes(R.string.request_deletion), isDestructive = true) {
                     accountViewModel.delete(note)
@@ -383,6 +396,7 @@ fun observeBookmarksFollowsAndAccount(
             isLoggedUser = accountViewModel.isLoggedUser(note.author),
             isSensitive = note.event?.isSensitiveOrNSFW() ?: false,
             showSensitiveContent = showSensitiveContent,
+            isThreadMuted = accountViewModel.account.isThreadMuted(note),
             isEmojiPackInMyList = isEmojiPackInMyList,
         )
     }.onStart {
@@ -395,6 +409,7 @@ fun observeBookmarksFollowsAndAccount(
                 isLoggedUser = accountViewModel.isLoggedUser(note.author),
                 isSensitive = note.event?.isSensitiveOrNSFW() ?: false,
                 showSensitiveContent = accountViewModel.showSensitiveContent().value,
+                isThreadMuted = accountViewModel.account.isThreadMuted(note),
                 isEmojiPackInMyList =
                     noteIdForEmoji?.let {
                         accountViewModel.account.emoji

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -1220,6 +1220,10 @@ class AccountViewModel(
 
     fun showWords(words: List<String>) = launchSigner { account.showWords(words) }
 
+    fun muteThread(note: Note) = account.muteThread(note)
+
+    fun unmuteThread(note: Note) = account.unmuteThread(note)
+
     fun createStatus(newStatus: String) = launchSigner { account.createStatus(newStatus) }
 
     fun updateStatus(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/display/BookmarkGroupItemOptions.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/bookmarkgroups/display/BookmarkGroupItemOptions.kt
@@ -116,6 +116,7 @@ fun BookmarkGroupItemOptionsMenu(
             isLoggedUser = false,
             isSensitive = false,
             showSensitiveContent = null,
+            isThreadMuted = false,
         ),
     )
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationScreen.kt
@@ -115,8 +115,11 @@ fun WatchAccountForNotifications(
 ) {
     val listState by
         accountViewModel.account.liveNotificationFollowLists.collectAsStateWithLifecycle()
+    val mutedThreadRootIds by
+        accountViewModel.account.settings.mutedThreadRootIds
+            .collectAsStateWithLifecycle()
 
-    LaunchedEffect(accountViewModel, listState) {
+    LaunchedEffect(accountViewModel, listState, mutedThreadRootIds) {
         notifFeedContentState.checkKeysInvalidateDataAndSendToTop()
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationFeedFilter.kt
@@ -222,6 +222,7 @@ class NotificationFeedFilter(
             (isChessEvent || filterParams.isGlobal() || notifAuthor == null || filterParams.isAuthorInFollows(notifAuthor)) &&
             noteEvent?.isTaggedUser(loggedInUserHex) ?: false &&
             (filterParams.isHiddenList || notifAuthor == null || !account.isHidden(notifAuthor)) &&
+            !account.isThreadMuted(it) &&
             (noteEvent !is PrivateDmEvent || !account.isDecryptedContentHidden(noteEvent)) &&
             tagsAnEventByUser(it, loggedInUserHex)
     }

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -1652,6 +1652,8 @@
 
     <string name="payment_required_title">Message from %1$s</string>
     <string name="thread_title">Thread</string>
+    <string name="mute_thread">Mute thread</string>
+    <string name="unmute_thread">Unmute thread</string>
     <string name="send_the_seller_a_message">Send the seller a message</string>
     <string name="hi_seller_is_this_still_available">Hi %1$s, is this still available?</string>
     <string name="hi_there_is_this_still_available">Hi there, is this still available?</string>


### PR DESCRIPTION
Fixes #161.\n\nThis adds a local per-account thread mute that does not publish to the user's Nostr mute list. Muted thread roots are stored in encrypted local preferences, exposed as a note-menu Mute thread / Unmute thread action, and applied to both the in-app notifications feed and Android notification dispatch.\n\nVerification:\n- ./gradlew.bat --no-daemon :amethyst:compileFdroidDebugKotlin\n- ./gradlew.bat --no-daemon :amethyst:compilePlayDebugKotlin\n- pre-commit spotless/static analysis