### PR TITLE
Fix private people lists metadata relay loading

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/account/metadata/AccountMetadataEoseManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/account/metadata/AccountMetadataEoseManager.kt
@@ -27,12 +27,19 @@ import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 import com.vitorpamplona.quartz.nip01Core.relay.client.subscriptions.Subscription
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
+
+internal fun preferredMetadataRelays(
+    homeRelays: Set<NormalizedRelayUrl>,
+    outboxRelays: Set<NormalizedRelayUrl>,
+): Set<NormalizedRelayUrl> = outboxRelays.ifEmpty { homeRelays }
 
 class AccountMetadataEoseManager(
     client: INostrClient,
@@ -40,13 +47,14 @@ class AccountMetadataEoseManager(
 ) : PerUserEoseManager<AccountQueryState>(client, allKeys) {
     override fun user(key: AccountQueryState) = key.account.userProfile()
 
-    fun relayFlow(query: AccountQueryState) = query.account.homeRelays.flow
-
     override fun updateFilter(
         key: AccountQueryState,
         since: SincePerRelayMap?,
     ): List<RelayBasedFilter> =
-        relayFlow(key).value.flatMap {
+        preferredMetadataRelays(
+            key.account.homeRelays.flow.value,
+            key.account.outboxRelays.flow.value,
+        ).flatMap {
             val since = since?.get(it)?.time
             listOf(
                 filterAccountInfoAndListsFromKey(it, user(key).pubkeyHex, since),
@@ -66,7 +74,18 @@ class AccountMetadataEoseManager(
         userJobMap[user] =
             listOf(
                 key.account.scope.launch(Dispatchers.IO) {
-                    relayFlow(key).collectLatest {
+                    combine(
+                        key.account.homeRelays.flow,
+                        key.account.outboxRelays.flow,
+                        ::preferredMetadataRelays,
+                    ).collectLatest {
+                        // External clients can publish authored replaceables to relays that
+                        // are writable for the account but are not part of the narrower home
+                        // relay view. Watching the preferred relay set keeps list-like
+                        // metadata, including private-only kind:30000 lists, discoverable.
+                        //
+                        // updateFilter decides which relays to query; this path only
+                        // invalidates when the source relay sets change.
                         invalidateFilters()
                     }
                 },

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/account/metadata/AccountMetadataEoseManagerTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/account/metadata/AccountMetadataEoseManagerTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.metadata
+
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.normalizeRelayUrl
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AccountMetadataEoseManagerTest {
+    @Test
+    fun prefersOutboxRelaysWhenTheyExist() {
+        val homeRelays =
+            setOf(
+                "wss://home.example".normalizeRelayUrl(),
+                "wss://shared.example".normalizeRelayUrl(),
+            )
+        val outboxRelays =
+            setOf(
+                "wss://shared.example".normalizeRelayUrl(),
+                "wss://broadcast.example".normalizeRelayUrl(),
+            )
+
+        assertEquals(outboxRelays, preferredMetadataRelays(homeRelays, outboxRelays))
+    }
+
+    @Test
+    fun fallsBackToHomeRelaysWhenOutboxIsEmpty() {
+        val homeRelays =
+            setOf(
+                "wss://home.example".normalizeRelayUrl(),
+                "wss://local.example".normalizeRelayUrl(),
+            )
+
+        assertEquals(homeRelays, preferredMetadataRelays(homeRelays, emptySet()))
+    }
+}


### PR DESCRIPTION
Fixes #1200

## Summary

- prefer outbox relays when polling authored account metadata/list events
- keep home relays as the fallback when the outbox set is empty
- add focused coverage for the relay-selection behavior

## Why

Private-only `kind:30000` lists can be created from external clients and published to relays that are writable for the account but are not represented in the narrower home-relay read path. When that happens, Amethyst never loads the authored list event into the account metadata cache, so the list never appears in the top dropdown.

## What Changed

- introduced `preferredMetadataRelays(homeRelays, outboxRelays)`
- switched `AccountMetadataEoseManager` to query authored metadata/list events from the preferred relay set
- invalidated the metadata subscription when either the home-relay set or the outbox-relay set changes
- added `AccountMetadataEoseManagerTest`

## Verification

```bash
./gradlew :amethyst:testPlayDebugUnitTest --tests "com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.metadata.AccountMetadataEoseManagerTest" --no-daemon
```

Passed in Docker.

```bash
./gradlew :amethyst:spotlessCheck --no-daemon
```

Passed in Docker.

AI assistance disclosure: I used Codex to help inspect the issue, prepare the patch, and verify the targeted tests; I reviewed the change and am responsible for the submitted code.
