### PR TITLE
Show descriptions in lightning invoice previews

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/lnurl/CachedLnInvoice.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/lnurl/CachedLnInvoice.kt
@@ -30,6 +30,7 @@ import java.text.NumberFormat
 data class InvoiceAmount(
     val invoice: String,
     val amount: String?,
+    val description: String?,
 )
 
 object CachedLnInvoiceParser {
@@ -48,8 +49,16 @@ object CachedLnInvoiceParser {
                     e.printStackTrace()
                     null
                 }
+            val myInvoiceDescription =
+                try {
+                    LnInvoiceUtil.getDescription(myInvoice)
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    e.printStackTrace()
+                    null
+                }
 
-            val lnInvoice = InvoiceAmount(myInvoice, myInvoiceAmount)
+            val lnInvoice = InvoiceAmount(myInvoice, myInvoiceAmount, myInvoiceDescription)
 
             lnInvoicesCache.put(lnbcWord, lnInvoice)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/invoice/InvoicePreview.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/invoice/InvoicePreview.kt
@@ -89,7 +89,7 @@ fun MayBeInvoicePreview(
     LoadValueFromInvoice(lnbcWord = lnbcWord) { invoiceAmount ->
         CrossfadeIfEnabled(targetState = invoiceAmount, label = "MayBeInvoicePreview", accountViewModel = accountViewModel) {
             if (it != null) {
-                InvoicePreview(it.invoice, it.amount)
+                InvoicePreview(it.invoice, it.amount, it.description)
             } else {
                 Text(
                     text = lnbcWord,
@@ -104,6 +104,7 @@ fun MayBeInvoicePreview(
 fun InvoicePreview(
     lnInvoice: String,
     amount: String?,
+    description: String?,
 ) {
     val context = LocalContext.current
 
@@ -154,6 +155,18 @@ fun InvoicePreview(
             }
 
             HorizontalDivider(thickness = DividerThickness)
+
+            description?.let {
+                Text(
+                    text = it,
+                    fontSize = 16.sp,
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(top = 10.dp),
+                    style = LocalTextStyle.current.copy(textDirection = TextDirection.Content),
+                )
+            }
 
             amount?.let {
                 Text(

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/lightning/LnInvoiceUtil.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/lightning/LnInvoiceUtil.kt
@@ -27,6 +27,11 @@ object LnInvoiceUtil {
     private val invoicePattern =
         Regex("lnbc((\\d+)([munp])?)?1[^1\\s]+", RegexOption.IGNORE_CASE)
 
+    private const val TIMESTAMP_WORD_LENGTH = 7
+    private const val TAG_HEADER_WORD_LENGTH = 3
+    private const val SIGNATURE_WORD_LENGTH = 104
+    private const val DESCRIPTION_TAG = 13
+
     /** The Bech32 character set for encoding. */
     private const val CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
 
@@ -210,6 +215,11 @@ object LnInvoiceUtil {
     ) : Exception(message)
 
     fun decodeUnlimitedLength(invoice: String): Boolean {
+        decodeDataPart(invoice)
+        return true
+    }
+
+    private fun decodeDataPart(invoice: String): ByteArray {
         var lower = false
         var upper = false
         for (i in 0 until invoice.length) {
@@ -240,7 +250,7 @@ object LnInvoiceUtil {
         }
         val hrp = invoice.substring(0, pos).lowercase()
         if (!verifyChecksum(hrp, values)) throw AddressFormatException("Invalid Checksum")
-        return true
+        return values.copyOfRange(0, values.size - 6)
     }
 
     /**
@@ -282,6 +292,57 @@ object LnInvoiceUtil {
     val OnePico = BigDecimal("0.000000000001")
 
     fun getAmountInSats(invoice: String): BigDecimal = getAmount(invoice).multiply(OneHundredK)
+
+    fun getDescription(invoice: String): String? {
+        val data =
+            try {
+                decodeDataPart(invoice)
+            } catch (e: AddressFormatException) {
+                throw IllegalArgumentException("Cannot decode invoice: $invoice", e)
+            }
+
+        var index = TIMESTAMP_WORD_LENGTH
+        val taggedFieldsEnd = data.size - SIGNATURE_WORD_LENGTH
+        while (index + TAG_HEADER_WORD_LENGTH <= taggedFieldsEnd) {
+            val tag = data[index].toInt() and 31
+            val dataLength = ((data[index + 1].toInt() and 31) shl 5) + (data[index + 2].toInt() and 31)
+            index += TAG_HEADER_WORD_LENGTH
+
+            if (index + dataLength > taggedFieldsEnd) return null
+
+            if (tag == DESCRIPTION_TAG) {
+                return fiveBitWordsToBytes(data, index, dataLength)
+                    .decodeToString()
+                    .ifBlank { null }
+            }
+
+            index += dataLength
+        }
+
+        return null
+    }
+
+    private fun fiveBitWordsToBytes(
+        input: ByteArray,
+        offset: Int,
+        length: Int,
+    ): ByteArray {
+        var buffer = 0L
+        val output = ArrayList<Byte>(length)
+        var count = 0
+        for (i in offset until offset + length) {
+            val b = input[i]
+            buffer = (buffer shl 5) or (b.toLong() and 31)
+            count += 5
+            while (count >= 8) {
+                output.add(((buffer shr (count - 8)) and 0xff).toByte())
+                count -= 8
+            }
+        }
+        require(count <= 4) { "Zero-padding of more than 4 bits" }
+        require((buffer and ((1L shl count) - 1L)) == 0L) { "Non-zero padding in 8-to-5 conversion" }
+        return output.toByteArray()
+    }
 
     private fun multiplier(multiplier: String): BigDecimal =
         when (multiplier.lowercase()) {

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/lightning/LnInvoiceUtilTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/lightning/LnInvoiceUtilTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.lightning
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LnInvoiceUtilTest {
+    @Test
+    fun extractsBolt11DescriptionTag() {
+        val invoice =
+            "lnbc10n1qqqqqqqdq5gdhkven9v5sxyetpdees" +
+                "qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq0xs788"
+
+        assertEquals("Coffee beans", LnInvoiceUtil.getDescription(invoice))
+    }
+}


### PR DESCRIPTION
Fixes #289

## Summary

- parse the BOLT11 `d` description tag from lightning invoices
- carry the parsed description through the cached invoice preview model
- render the description in the Lightning Invoice preview card above the amount
- add focused Quartz coverage for description extraction

## Why

The invoice preview only displayed the amount in sats. BOLT11 invoices can include a human-readable description in the `d` tagged field, so the preview can show that text without changing the payment flow.

## Verification

```bash
./gradlew :quartz:jvmTest --tests com.vitorpamplona.quartz.lightning.LnInvoiceUtilTest --no-daemon
```

Result: `BUILD SUCCESSFUL`

```bash
./gradlew :amethyst:compilePlayDebugKotlin :quartz:spotlessCheck :amethyst:spotlessCheck --no-daemon
```

Result: `BUILD SUCCESSFUL`

Manual device/emulator UI testing was not run in this environment.

AI assistance disclosure: I used Codex to help inspect the issue, prepare the patch, and verify the Docker test/build steps; I reviewed the change and am responsible for the submitted code.
