### PR TITLE
Add preferences for home feed tab visibility

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/preferences/UISharedPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/preferences/UISharedPreferences.kt
@@ -108,6 +108,9 @@ class UiSharedPreferences(
         val UI_PROPOSE_AI_IMPROVEMENTS = stringPreferencesKey("ui.propose_ai_improvements")
         val UI_USE_TRACKED_BROADCASTS = stringPreferencesKey("ui.use_tracked_broadcasts")
         val UI_BOTTOM_BAR_ITEMS = stringPreferencesKey("ui.bottom_bar_items")
+        val UI_SHOW_HOME_NEW_THREADS_TAB = booleanPreferencesKey("ui.show_home_new_threads_tab")
+        val UI_SHOW_HOME_CONVERSATIONS_TAB = booleanPreferencesKey("ui.show_home_conversations_tab")
+        val UI_SHOW_HOME_EVERYTHING_TAB = booleanPreferencesKey("ui.show_home_everything_tab")
 
         suspend fun uiPreferences(context: Context): UiSettings? =
             try {
@@ -134,6 +137,9 @@ class UiSharedPreferences(
                         preferences[UI_USE_TRACKED_BROADCASTS]?.let { BooleanType.valueOf(it) }
                             ?: if (featureSet == FeatureSetType.COMPLETE) BooleanType.ALWAYS else BooleanType.NEVER,
                     bottomBarItems = preferences[UI_BOTTOM_BAR_ITEMS]?.let { decodeBottomBarItems(it) } ?: DefaultBottomBarItems,
+                    showHomeNewThreadsTab = preferences[UI_SHOW_HOME_NEW_THREADS_TAB] ?: true,
+                    showHomeConversationsTab = preferences[UI_SHOW_HOME_CONVERSATIONS_TAB] ?: true,
+                    showHomeEverythingTab = preferences[UI_SHOW_HOME_EVERYTHING_TAB] ?: false,
                 )
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
@@ -173,6 +179,9 @@ class UiSharedPreferences(
                     preferences[UI_PROPOSE_AI_IMPROVEMENTS] = sharedSettings.automaticallyProposeAiImprovements.name
                     preferences[UI_USE_TRACKED_BROADCASTS] = sharedSettings.useTrackedBroadcasts.name
                     preferences[UI_BOTTOM_BAR_ITEMS] = sharedSettings.bottomBarItems.joinToString(",") { it.name }
+                    preferences[UI_SHOW_HOME_NEW_THREADS_TAB] = sharedSettings.showHomeNewThreadsTab
+                    preferences[UI_SHOW_HOME_CONVERSATIONS_TAB] = sharedSettings.showHomeConversationsTab
+                    preferences[UI_SHOW_HOME_EVERYTHING_TAB] = sharedSettings.showHomeEverythingTab
                 }
             } catch (e: Exception) {
                 if (e is CancellationException) throw e


### PR DESCRIPTION
## Summary
Added three new UI preferences to control the visibility of home feed tabs: New Threads, Conversations, and Everything.

## Key Changes
- Added three new boolean preference keys:
  - `UI_SHOW_HOME_NEW_THREADS_TAB` (defaults to true)
  - `UI_SHOW_HOME_CONVERSATIONS_TAB` (defaults to true)
  - `UI_SHOW_HOME_EVERYTHING_TAB` (defaults to false)

- Updated the `uiPreferences()` function to read these preferences from DataStore and map them to the `UiSettings` model with appropriate default values

- Updated the preference persistence logic to save these boolean values back to DataStore when settings are updated

## Implementation Details
The new preferences follow the existing pattern in the codebase:
- Boolean preferences are defined using `booleanPreferencesKey()`
- Default values are applied during deserialization (New Threads and Conversations enabled by default, Everything disabled)
- Values are persisted directly as booleans (unlike some other settings that use enum names)

https://claude.ai/code/session_01UiGqRs3q3F5WcVzmt7E3Tw