### PR TITLE
Sonar cleanup — mechanical refactors only

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -2859,14 +2859,11 @@ class Account(
         if (event == null) return null
 
         return if (isWriteable()) {
-            if (event is PrivateDmEvent) {
-                privateDMDecryptionCache.cachedDM(event)
-            } else if (event is LnZapRequestEvent && event.isPrivateZap()) {
-                privateZapsDecryptionCache.cachedPrivateZap(event)?.content
-            } else if (event is DraftWrapEvent) {
-                draftsDecryptionCache.preCachedDraft(event)?.content
-            } else {
-                event.content
+            when {
+                event is PrivateDmEvent -> privateDMDecryptionCache.cachedDM(event)
+                event is LnZapRequestEvent && event.isPrivateZap() -> privateZapsDecryptionCache.cachedPrivateZap(event)?.content
+                event is DraftWrapEvent -> draftsDecryptionCache.preCachedDraft(event)?.content
+                else -> event.content
             }
         } else {
             event.content
@@ -2875,22 +2872,30 @@ class Account(
 
     suspend fun decryptContent(note: Note): String? {
         val event = note.event
-        return if (event is PrivateDmEvent && isWriteable()) {
-            privateDMDecryptionCache.decryptDM(event)
-        } else if (event is LnZapRequestEvent && isWriteable()) {
-            if (event.isPrivateZap()) {
-                if (isWriteable()) {
-                    privateZapsDecryptionCache.decryptPrivateZap(event)?.content
-                } else {
-                    null
-                }
-            } else {
-                event.content
+        return when {
+            event is PrivateDmEvent && isWriteable() -> {
+                privateDMDecryptionCache.decryptDM(event)
             }
-        } else if (event is DraftWrapEvent && isWriteable()) {
-            draftsDecryptionCache.cachedDraft(event)?.content
-        } else {
-            event?.content
+
+            event is LnZapRequestEvent && isWriteable() -> {
+                if (event.isPrivateZap()) {
+                    if (isWriteable()) {
+                        privateZapsDecryptionCache.decryptPrivateZap(event)?.content
+                    } else {
+                        null
+                    }
+                } else {
+                    event.content
+                }
+            }
+
+            event is DraftWrapEvent && isWriteable() -> {
+                draftsDecryptionCache.cachedDraft(event)?.content
+            }
+
+            else -> {
+                event?.content
+            }
         }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -943,16 +943,16 @@ class Account(
         }
         if (event is GiftWrapEvent) {
             val receiver = event.recipientPubKey()
-            if (receiver != null) {
+            return if (receiver != null) {
                 val relayList =
                     cache
                         .getOrCreateUser(receiver)
                         .dmInboxRelayList()
                         ?.relays()
                         ?.ifEmpty { null }
-                return relayList?.toSet() ?: computeRelayListForLinkedUser(receiver)
+                relayList?.toSet() ?: computeRelayListForLinkedUser(receiver)
             } else {
-                return emptySet()
+                emptySet()
             }
         }
         if (event is WrappedEvent) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -3277,10 +3277,12 @@ class Account(
         scope.launch {
             cache.antiSpam.flowSpam.collect {
                 it.cache.spamMessages.snapshot().values.forEach { spammer ->
-                    if (!hiddenUsers.isHidden(spammer.pubkeyHex) && spammer.shouldHide()) {
-                        if (spammer.pubkeyHex != userProfile().pubkeyHex && spammer.pubkeyHex !in followingKeySet()) {
-                            hiddenUsers.hideUser(spammer.pubkeyHex)
-                        }
+                    if (!hiddenUsers.isHidden(spammer.pubkeyHex) &&
+                        spammer.shouldHide() &&
+                        spammer.pubkeyHex != userProfile().pubkeyHex &&
+                        spammer.pubkeyHex !in followingKeySet()
+                    ) {
+                        hiddenUsers.hideUser(spammer.pubkeyHex)
                     }
                 }
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AntiSpamFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AntiSpamFilter.kt
@@ -143,7 +143,7 @@ class AntiSpamFilter {
     ): Spammer {
         val spammer = spamMessages.get(hashCode)
 
-        if (spammer == null) {
+        return if (spammer == null) {
             val newSpammer =
                 if (event is AddressableEvent) {
                     Spammer(
@@ -159,14 +159,14 @@ class AntiSpamFilter {
                     )
                 }
             spamMessages.put(hashCode, newSpammer)
-            return newSpammer
+            newSpammer
         } else {
             if (event is AddressableEvent) {
                 spammer.duplicatedEventAddresses += event.address()
             } else {
                 spammer.duplicatedEventIds += event.id
             }
-            return spammer
+            spammer
         }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -671,7 +671,7 @@ object LocalCache : ILocalCache, ICacheProvider {
             return false
         }
 
-        if (wasVerified || justVerify(event)) {
+        return if (wasVerified || justVerify(event)) {
             val replyTo = computeReplyTo(event)
 
             note.loadEvent(event, author, replyTo)
@@ -681,9 +681,9 @@ object LocalCache : ILocalCache, ICacheProvider {
 
             refreshNewNoteObservers(note)
 
-            return true
+            true
         } else {
-            return false
+            false
         }
     }
 
@@ -1118,7 +1118,7 @@ object LocalCache : ILocalCache, ICacheProvider {
         // Already processed this event.
         if (replaceableNote.event?.id == event.id) return isVerified
 
-        if (event.createdAt > (replaceableNote.createdAt() ?: 0L) && (isVerified || justVerify(event))) {
+        return if (event.createdAt > (replaceableNote.createdAt() ?: 0L) && (isVerified || justVerify(event))) {
             // clear index from previous tags
             replaceableNote.replyTo?.forEach {
                 it.removeNote(replaceableNote)
@@ -1128,9 +1128,9 @@ object LocalCache : ILocalCache, ICacheProvider {
 
             refreshNewNoteObservers(replaceableNote)
 
-            return true
+            true
         } else {
-            return false
+            false
         }
     }
 
@@ -1150,7 +1150,7 @@ object LocalCache : ILocalCache, ICacheProvider {
         // Already processed this event.
         if (note.event != null) return false
 
-        if (wasVerified || justVerify(event)) {
+        return if (wasVerified || justVerify(event)) {
             note.loadEvent(event, author, emptyList())
 
             if (deletionIndex.add(event, wasVerified)) {
@@ -1205,9 +1205,9 @@ object LocalCache : ILocalCache, ICacheProvider {
 
             refreshNewNoteObservers(note)
 
-            return true
+            true
         } else {
-            return false
+            false
         }
     }
 
@@ -2061,10 +2061,10 @@ object LocalCache : ILocalCache, ICacheProvider {
             }
 
             if (note.event?.isContentEncoded() == false) {
-                if (!note.isHiddenFor(hiddenUsers.flow.value)) {
-                    return@filter note.event?.content?.contains(text, true) ?: false
+                return@filter if (!note.isHiddenFor(hiddenUsers.flow.value)) {
+                    note.event?.content?.contains(text, true) ?: false
                 } else {
-                    return@filter false
+                    false
                 }
             }
 
@@ -2082,10 +2082,10 @@ object LocalCache : ILocalCache, ICacheProvider {
                 }
 
                 if (addressable.event?.isContentEncoded() == false) {
-                    if (!addressable.isHiddenFor(hiddenUsers.flow.value)) {
-                        return@filter addressable.event?.content?.contains(text, true) ?: false
+                    return@filter if (!addressable.isHiddenFor(hiddenUsers.flow.value)) {
+                        addressable.event?.content?.contains(text, true) ?: false
                     } else {
-                        return@filter false
+                        false
                     }
                 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -807,16 +807,14 @@ object LocalCache : ILocalCache, ICacheProvider {
             return false
         }
 
-        if (isVerified || justVerify(event)) {
-            if (event.createdAt > (note.createdAt() ?: 0L)) {
-                val replyTo = computeReplyTo(event)
+        if ((isVerified || justVerify(event)) && event.createdAt > (note.createdAt() ?: 0L)) {
+            val replyTo = computeReplyTo(event)
 
-                note.loadEvent(event, author, replyTo)
+            note.loadEvent(event, author, replyTo)
 
-                refreshNewNoteObservers(note)
+            refreshNewNoteObservers(note)
 
-                return true
-            }
+            return true
         }
 
         return false
@@ -852,16 +850,14 @@ object LocalCache : ILocalCache, ICacheProvider {
             return false
         }
 
-        if (isVerified || justVerify(event)) {
-            if (event.createdAt > (note.createdAt() ?: 0L)) {
-                val replyTo = computeReplyTo(event)
+        if ((isVerified || justVerify(event)) && event.createdAt > (note.createdAt() ?: 0L)) {
+            val replyTo = computeReplyTo(event)
 
-                note.loadEvent(event, author, replyTo)
+            note.loadEvent(event, author, replyTo)
 
-                refreshNewNoteObservers(note)
+            refreshNewNoteObservers(note)
 
-                return true
-            }
+            return true
         }
 
         return false
@@ -1197,10 +1193,12 @@ object LocalCache : ILocalCache, ICacheProvider {
 
                 notes.forEach { _, note ->
                     val noteEvent = note.event
-                    if (noteEvent is AddressableEvent && noteEvent.addressTag() in addressSet) {
-                        if (noteEvent.pubKey == event.pubKey && noteEvent.createdAt <= event.createdAt) {
-                            deleteNote(note)
-                        }
+                    if (noteEvent is AddressableEvent &&
+                        noteEvent.addressTag() in addressSet &&
+                        noteEvent.pubKey == event.pubKey &&
+                        noteEvent.createdAt <= event.createdAt
+                    ) {
+                        deleteNote(note)
                     }
                 }
             }
@@ -1466,10 +1464,8 @@ object LocalCache : ILocalCache, ICacheProvider {
             return false // older data, does nothing
         }
 
-        if (oldChannel.creator == null || oldChannel.creator == author) {
-            if (isVerified || justVerify(event)) {
-                oldChannel.updateChannelInfo(author, event, note)
-            }
+        if ((oldChannel.creator == null || oldChannel.creator == author) && (isVerified || justVerify(event))) {
+            oldChannel.updateChannelInfo(author, event, note)
         }
 
         return isVerified

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip30CustomEmojis/OwnedEmojiPacksState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip30CustomEmojis/OwnedEmojiPacksState.kt
@@ -200,9 +200,7 @@ class OwnedEmojiPacksState(
         isPrivate: Boolean,
         account: Account,
     ) {
-        if (!EmojiUrlTag.isValidShortcode(emojiTag.code)) {
-            throw IllegalArgumentException("Invalid emoji shortcode: ${emojiTag.code}")
-        }
+        require(EmojiUrlTag.isValidShortcode(emojiTag.code)) { "Invalid emoji shortcode: ${emojiTag.code}" }
 
         val packEvent = getOwnedEmojiPackEvent(dTag) ?: return
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/ZapPaymentHandler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/ZapPaymentHandler.kt
@@ -88,48 +88,56 @@ class ZapPaymentHandler(
         val zapSplitSetup = noteEvent?.zapSplitSetup()
 
         val unverifiedZapsToSend =
-            if (!zapSplitSetup.isNullOrEmpty()) {
-                zapSplitSetup.map { setup ->
-                    when (setup) {
-                        is ZapSplitSetupLnAddress -> {
-                            UnverifiedZapSplitSetup(
-                                lnAddress = setup.lnAddress,
-                                weight = setup.weight,
-                            )
-                        }
+            when {
+                !zapSplitSetup.isNullOrEmpty() -> {
+                    zapSplitSetup.map { setup ->
+                        when (setup) {
+                            is ZapSplitSetupLnAddress -> {
+                                UnverifiedZapSplitSetup(
+                                    lnAddress = setup.lnAddress,
+                                    weight = setup.weight,
+                                )
+                            }
 
-                        is ZapSplitSetup -> {
-                            val user = LocalCache.checkGetOrCreateUser(setup.pubKeyHex)
-                            UnverifiedZapSplitSetup(
-                                lnAddress = user?.lnAddress(),
-                                weight = setup.weight,
-                                relay = setup.relay,
-                                user = user,
-                            )
+                            is ZapSplitSetup -> {
+                                val user = LocalCache.checkGetOrCreateUser(setup.pubKeyHex)
+                                UnverifiedZapSplitSetup(
+                                    lnAddress = user?.lnAddress(),
+                                    weight = setup.weight,
+                                    relay = setup.relay,
+                                    user = user,
+                                )
+                            }
                         }
                     }
                 }
-            } else if (noteEvent is LiveActivitiesEvent && noteEvent.hasHost()) {
-                noteEvent.hosts().map {
-                    val user = LocalCache.checkGetOrCreateUser(it.pubKey)
-                    val lnAddress = user?.lnAddress()
-                    UnverifiedZapSplitSetup(lnAddress, relay = it.relayHint, user = user)
+
+                noteEvent is LiveActivitiesEvent && noteEvent.hasHost() -> {
+                    noteEvent.hosts().map {
+                        val user = LocalCache.checkGetOrCreateUser(it.pubKey)
+                        val lnAddress = user?.lnAddress()
+                        UnverifiedZapSplitSetup(lnAddress, relay = it.relayHint, user = user)
+                    }
                 }
-            } else if (noteEvent is AppDefinitionEvent) {
-                val appLud16 = noteEvent.appMetaData()?.lnAddress()
-                if (appLud16 != null) {
-                    listOf(UnverifiedZapSplitSetup(appLud16))
-                } else {
-                    val lud16 =
-                        note.author?.lnAddress()
-                    listOf(UnverifiedZapSplitSetup(lud16))
+
+                noteEvent is AppDefinitionEvent -> {
+                    val appLud16 = noteEvent.appMetaData()?.lnAddress()
+                    if (appLud16 != null) {
+                        listOf(UnverifiedZapSplitSetup(appLud16))
+                    } else {
+                        val lud16 =
+                            note.author?.lnAddress()
+                        listOf(UnverifiedZapSplitSetup(lud16))
+                    }
                 }
-            } else {
-                listOf(
-                    UnverifiedZapSplitSetup(
-                        note.author?.lnAddress(),
-                    ),
-                )
+
+                else -> {
+                    listOf(
+                        UnverifiedZapSplitSetup(
+                            note.author?.lnAddress(),
+                        ),
+                    )
+                }
             }
 
         if (showErrorIfNoLnAddress) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/lnurl/LightningAddressResolver.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/lnurl/LightningAddressResolver.kt
@@ -171,10 +171,12 @@ class LightningAddressResolver {
                 val messageNode = tree.get("message")
                 val statusNode = tree.get("status")
 
-                if (tree.get("error") != null && tree.get("error").isBoolean && messageNode != null) {
-                    if (errorNode.asBoolean()) {
-                        return messageNode.asText()
-                    }
+                if (tree.get("error") != null &&
+                    tree.get("error").isBoolean &&
+                    messageNode != null &&
+                    errorNode.asBoolean()
+                ) {
+                    return messageNode.asText()
                 }
 
                 val status = statusNode?.asText()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/service/PlaybackService.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/service/PlaybackService.kt
@@ -96,7 +96,7 @@ class PlaybackService : MediaSessionService() {
 
     @OptIn(UnstableApi::class)
     fun lazyPool(proxyPort: Int): MediaSessionPool {
-        if (proxyPort <= 0) {
+        return if (proxyPort <= 0) {
             // no proxy
             poolNoProxy?.let { return it }
 
@@ -105,7 +105,7 @@ class PlaybackService : MediaSessionService() {
             val blossomServerResolver = Amethyst.instance.blossomResolver
 
             // creates new
-            return newPool(videoCache, okHttpClient, blossomServerResolver)
+            newPool(videoCache, okHttpClient, blossomServerResolver)
                 .also {
                     poolNoProxy = it
                     // Kick off the player pool warmup as soon as we know this pool is being used.
@@ -124,7 +124,7 @@ class PlaybackService : MediaSessionService() {
             val videoCache = Amethyst.instance.videoCache
             val blossomServerResolver = Amethyst.instance.blossomResolver
 
-            return newPool(videoCache, okHttpClient, blossomServerResolver)
+            newPool(videoCache, okHttpClient, blossomServerResolver)
                 .also {
                     poolWithProxy = it
                     it.exoPlayerPool.create(applicationContext)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/previews/UrlPreview.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/previews/UrlPreview.kt
@@ -63,18 +63,28 @@ class UrlPreview {
                         val mimeType =
                             response.headers["Content-Type"]?.toMediaType()
                                 ?: throw IllegalArgumentException("Website returned unknown mimetype: ${response.headers["Content-Type"]}")
-                        if (mimeType.type == "text" && mimeType.subtype == "html") {
-                            val metaTags = HtmlParser().parseHtml(response.body.source(), mimeType.charset())
-                            val data = OpenGraphParser().extractUrlInfo(metaTags)
-                            UrlInfoItem(url, data.title, data.description, data.image, mimeType.toString())
-                        } else if (mimeType.type == "image") {
-                            UrlInfoItem(url, image = url, mimeType = mimeType.toString())
-                        } else if (mimeType.type == "video") {
-                            UrlInfoItem(url, image = url, mimeType = mimeType.toString())
-                        } else if (mimeType.type == "application" && mimeType.subtype == "pdf") {
-                            UrlInfoItem(url, image = url, mimeType = mimeType.toString())
-                        } else {
-                            throw IllegalArgumentException("Website returned unknown encoding for previews: $mimeType")
+                        when {
+                            mimeType.type == "text" && mimeType.subtype == "html" -> {
+                                val metaTags = HtmlParser().parseHtml(response.body.source(), mimeType.charset())
+                                val data = OpenGraphParser().extractUrlInfo(metaTags)
+                                UrlInfoItem(url, data.title, data.description, data.image, mimeType.toString())
+                            }
+
+                            mimeType.type == "image" -> {
+                                UrlInfoItem(url, image = url, mimeType = mimeType.toString())
+                            }
+
+                            mimeType.type == "video" -> {
+                                UrlInfoItem(url, image = url, mimeType = mimeType.toString())
+                            }
+
+                            mimeType.type == "application" && mimeType.subtype == "pdf" -> {
+                                UrlInfoItem(url, image = url, mimeType = mimeType.toString())
+                            }
+
+                            else -> {
+                                throw IllegalArgumentException("Website returned unknown encoding for previews: $mimeType")
+                            }
                         }
                     } else {
                         throw IllegalArgumentException("Website returned: " + response.code)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/RelayProxyClientConnector.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/RelayProxyClientConnector.kt
@@ -70,31 +70,39 @@ class RelayProxyClientConnector(
             RelayServiceInfra(torSettings, torConnection, clearConnection, connectivity, torStatus)
         }.debounce(100)
             .onEach {
-                if (it.connectivity is ConnectivityStatus.StartingService) {
-                    // ignore
-                } else if (it.connectivity is ConnectivityStatus.Off) {
-                    Log.d("ManageRelayServices") { "Connectivity Off: Pausing Relay Services ${it.connectivity}" }
-                    if (client.isActive()) {
-                        client.disconnect()
-                    }
-                    if (it.torStatus is TorServiceStatus.Active) {
-                        Log.d("ManageRelayServices", "Connectivity off, Tor idle")
-                    }
-                } else if (it.connectivity is ConnectivityStatus.Active && !client.isActive()) {
-                    Log.d("ManageRelayServices", "Connectivity On: Resuming Relay Services")
-
-                    if (it.torStatus is TorServiceStatus.Active) {
-                        Log.d("ManageRelayServices", "Connectivity resumed, Tor active")
+                when {
+                    it.connectivity is ConnectivityStatus.StartingService -> {
+                        // ignore
                     }
 
-                    // only calls this if the client is not active. Otherwise goes to the else below
-                    client.connect()
-                } else {
-                    Log.d("ManageRelayServices", "Relay Services have changed, reconnecting relays that need to")
-                    client.reconnect(
-                        onlyIfChanged = true,
-                        ignoreRetryDelays = true,
-                    )
+                    it.connectivity is ConnectivityStatus.Off -> {
+                        Log.d("ManageRelayServices") { "Connectivity Off: Pausing Relay Services ${it.connectivity}" }
+                        if (client.isActive()) {
+                            client.disconnect()
+                        }
+                        if (it.torStatus is TorServiceStatus.Active) {
+                            Log.d("ManageRelayServices", "Connectivity off, Tor idle")
+                        }
+                    }
+
+                    it.connectivity is ConnectivityStatus.Active && !client.isActive() -> {
+                        Log.d("ManageRelayServices", "Connectivity On: Resuming Relay Services")
+
+                        if (it.torStatus is TorServiceStatus.Active) {
+                            Log.d("ManageRelayServices", "Connectivity resumed, Tor active")
+                        }
+
+                        // only calls this if the client is not active. Otherwise goes to the else below
+                        client.connect()
+                    }
+
+                    else -> {
+                        Log.d("ManageRelayServices", "Relay Services have changed, reconnecting relays that need to")
+                        client.reconnect(
+                            onlyIfChanged = true,
+                            ignoreRetryDelays = true,
+                        )
+                    }
                 }
             }.onStart {
                 Log.d("ManageRelayServices", "Resuming Relay Services")

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/eoseManagers/SingleSubNoEoseCacheEoseManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/eoseManagers/SingleSubNoEoseCacheEoseManager.kt
@@ -57,10 +57,8 @@ abstract class SingleSubNoEoseCacheEoseManager<T>(
                     relay: NormalizedRelayUrl,
                     forFilters: List<Filter>?,
                 ) {
-                    if (isLive) {
-                        if (invalidateAfterEose) {
-                            invalidateFilters()
-                        }
+                    if (isLive && invalidateAfterEose) {
+                        invalidateFilters()
                     }
                 }
             },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/MediaMetadataRetrieverExt.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/MediaMetadataRetrieverExt.kt
@@ -29,10 +29,8 @@ import com.vitorpamplona.quartz.nip94FileMetadata.tags.DimensionTag
 
 fun MediaMetadataRetriever.getThumbnail(): Bitmap? {
     val raw: ByteArray? = embeddedPicture
-    if (raw != null) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            return ImageDecoder.decodeBitmap(ImageDecoder.createSource(raw))
-        }
+    if (raw != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        return ImageDecoder.decodeBitmap(ImageDecoder.createSource(raw))
     }
 
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/UploadOrchestrator.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/UploadOrchestrator.kt
@@ -320,9 +320,7 @@ class UploadOrchestrator {
                 MetadataStripper.strip(compressed.uri, effectiveMimeType, context.applicationContext)
             }
 
-        if (!strippingResult.stripped) {
-            if (!onStrippingFailed()) return null
-        }
+        if (!strippingResult.stripped && !onStrippingFailed()) return null
 
         return strippingResult.uri
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/blossom/bud10/BlossomServerResolver.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/blossom/bud10/BlossomServerResolver.kt
@@ -136,14 +136,11 @@ class BlossomServerResolver(
         url: String,
         mimeType: String?,
     ): OkHttpClient =
-        if (mimeType == null) {
-            httpClientBuilder.okHttpClientForPreview(url)
-        } else if (mimeType.startsWith("audio/") || mimeType.startsWith("video/")) {
-            httpClientBuilder.okHttpClientForVideo(url)
-        } else if (mimeType.startsWith("image/")) {
-            httpClientBuilder.okHttpClientForImage(url)
-        } else {
-            httpClientBuilder.okHttpClientForPreview(url)
+        when {
+            mimeType == null -> httpClientBuilder.okHttpClientForPreview(url)
+            mimeType.startsWith("audio/") || mimeType.startsWith("video/") -> httpClientBuilder.okHttpClientForVideo(url)
+            mimeType.startsWith("image/") -> httpClientBuilder.okHttpClientForImage(url)
+            else -> httpClientBuilder.okHttpClientForPreview(url)
         }
 
     fun canResolve(scheme: String) = scheme == SCHEME

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/blossom/bud10/ServerHeadCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/blossom/bud10/ServerHeadCache.kt
@@ -64,13 +64,13 @@ class ServerHeadCache {
                 val contentLength = response.header("Content-Length")?.toLongOrNull()
                 val mimeType = response.header("Content-Type")?.toMediaType()?.toString()
 
-                if (contentLength != null && mimeType != null) {
+                return if (contentLength != null && mimeType != null) {
                     val result = HasFile.TypeAndSize(mimeType, contentLength)
                     cache.put(url, result)
-                    return result
+                    result
                 } else {
                     cache.put(url, HasFile.NoFile)
-                    return HasFile.NoFile
+                    HasFile.NoFile
                 }
             }
         } catch (e: Exception) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/CrossfadeIfEnabled.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/CrossfadeIfEnabled.kt
@@ -83,13 +83,11 @@ fun <T> Transition<T>.MyCrossfade(
 ) {
     val currentlyVisible = remember { mutableStateListOf<T>().apply { add(currentState) } }
     val contentMap = remember { mutableScatterMapOf<T, @Composable () -> Unit>() }
-    if (currentState == targetState) {
-        // If not animating, just display the current state
-        if (currentlyVisible.size != 1 || currentlyVisible[0] != targetState) {
-            // Remove all the intermediate items from the list once the animation is finished.
-            currentlyVisible.removeAll { it != targetState }
-            contentMap.clear()
-        }
+    // If not animating, just display the current state
+    if (currentState == targetState && (currentlyVisible.size != 1 || currentlyVisible[0] != targetState)) {
+        // Remove all the intermediate items from the list once the animation is finished.
+        currentlyVisible.removeAll { it != targetState }
+        contentMap.clear()
     }
 
     if (targetState !in contentMap) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/EditPostView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/EditPostView.kt
@@ -212,32 +212,38 @@ fun EditPostView(
                                 if (myUrlPreview != null) {
                                     Row(modifier = Modifier.padding(vertical = Size5dp, horizontal = Size10dp)) {
                                         if (RichTextParser.isValidURL(myUrlPreview)) {
-                                            if (RichTextParser.isImageUrl(myUrlPreview)) {
-                                                AsyncImage(
-                                                    model = myUrlPreview,
-                                                    contentDescription = myUrlPreview,
-                                                    contentScale = ContentScale.FillWidth,
-                                                    modifier =
-                                                        Modifier
-                                                            .padding(top = 4.dp)
-                                                            .fillMaxWidth()
-                                                            .clip(shape = QuoteBorder)
-                                                            .border(
-                                                                1.dp,
-                                                                MaterialTheme.colorScheme.subtleBorder,
-                                                                QuoteBorder,
-                                                            ),
-                                                )
-                                            } else if (RichTextParser.isVideoUrl(myUrlPreview)) {
-                                                VideoView(
-                                                    myUrlPreview,
-                                                    mimeType = null,
-                                                    roundedCorner = true,
-                                                    contentScale = ContentScale.FillWidth,
-                                                    accountViewModel = accountViewModel,
-                                                )
-                                            } else {
-                                                LoadUrlPreview(myUrlPreview, myUrlPreview, null, accountViewModel)
+                                            when {
+                                                RichTextParser.isImageUrl(myUrlPreview) -> {
+                                                    AsyncImage(
+                                                        model = myUrlPreview,
+                                                        contentDescription = myUrlPreview,
+                                                        contentScale = ContentScale.FillWidth,
+                                                        modifier =
+                                                            Modifier
+                                                                .padding(top = 4.dp)
+                                                                .fillMaxWidth()
+                                                                .clip(shape = QuoteBorder)
+                                                                .border(
+                                                                    1.dp,
+                                                                    MaterialTheme.colorScheme.subtleBorder,
+                                                                    QuoteBorder,
+                                                                ),
+                                                    )
+                                                }
+
+                                                RichTextParser.isVideoUrl(myUrlPreview) -> {
+                                                    VideoView(
+                                                        myUrlPreview,
+                                                        mimeType = null,
+                                                        roundedCorner = true,
+                                                        contentScale = ContentScale.FillWidth,
+                                                        accountViewModel = accountViewModel,
+                                                    )
+                                                }
+
+                                                else -> {
+                                                    LoadUrlPreview(myUrlPreview, myUrlPreview, null, accountViewModel)
+                                                }
                                             }
                                         } else if (RichTextParser.startsWithNIP19Scheme(myUrlPreview)) {
                                             val bgColor = MaterialTheme.colorScheme.background

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewMessageTagger.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/NewMessageTagger.kt
@@ -188,55 +188,67 @@ class NewMessageTagger(
         key = key.removePrefix("@")
 
         try {
-            if (key.startsWith("nsec1", true)) {
-                if (key.length < 63) {
-                    return null
+            when {
+                key.startsWith("nsec1", true) -> {
+                    if (key.length < 63) {
+                        return null
+                    }
+
+                    val keyB32 = key.substring(0, 63)
+                    val restOfWord = key.substring(63)
+                    // Converts to npub
+                    val pubkey =
+                        Nip19Parser.uriToRoute(Nip01Crypto.pubKeyCreate(keyB32.bechToBytes()).toNpub()) ?: return null
+
+                    return DirtyKeyInfo(pubkey, restOfWord.ifEmpty { null })
                 }
 
-                val keyB32 = key.substring(0, 63)
-                val restOfWord = key.substring(63)
-                // Converts to npub
-                val pubkey =
-                    Nip19Parser.uriToRoute(Nip01Crypto.pubKeyCreate(keyB32.bechToBytes()).toNpub()) ?: return null
+                key.startsWith("npub1", true) -> {
+                    if (key.length < 63) {
+                        return null
+                    }
 
-                return DirtyKeyInfo(pubkey, restOfWord.ifEmpty { null })
-            } else if (key.startsWith("npub1", true)) {
-                if (key.length < 63) {
-                    return null
+                    val keyB32 = key.substring(0, 63)
+                    val restOfWord = key.substring(63)
+
+                    val pubkey = Nip19Parser.uriToRoute(keyB32) ?: return null
+
+                    return DirtyKeyInfo(pubkey, restOfWord.ifEmpty { null })
                 }
 
-                val keyB32 = key.substring(0, 63)
-                val restOfWord = key.substring(63)
+                key.startsWith("note1", true) -> {
+                    if (key.length < 63) {
+                        return null
+                    }
 
-                val pubkey = Nip19Parser.uriToRoute(keyB32) ?: return null
+                    val keyB32 = key.substring(0, 63)
+                    val restOfWord = key.substring(63)
 
-                return DirtyKeyInfo(pubkey, restOfWord.ifEmpty { null })
-            } else if (key.startsWith("note1", true)) {
-                if (key.length < 63) {
-                    return null
+                    val noteId = Nip19Parser.uriToRoute(keyB32) ?: return null
+
+                    return DirtyKeyInfo(noteId, restOfWord.ifEmpty { null })
                 }
 
-                val keyB32 = key.substring(0, 63)
-                val restOfWord = key.substring(63)
+                key.startsWith("nprofile", true) -> {
+                    val pubkeyRelay = Nip19Parser.uriToRoute(key) ?: return null
 
-                val noteId = Nip19Parser.uriToRoute(keyB32) ?: return null
+                    return DirtyKeyInfo(pubkeyRelay, pubkeyRelay.additionalChars)
+                }
 
-                return DirtyKeyInfo(noteId, restOfWord.ifEmpty { null })
-            } else if (key.startsWith("nprofile", true)) {
-                val pubkeyRelay = Nip19Parser.uriToRoute(key) ?: return null
+                key.startsWith("nevent1", true) -> {
+                    val noteRelayId = Nip19Parser.uriToRoute(key) ?: return null
 
-                return DirtyKeyInfo(pubkeyRelay, pubkeyRelay.additionalChars)
-            } else if (key.startsWith("nevent1", true)) {
-                val noteRelayId = Nip19Parser.uriToRoute(key) ?: return null
+                    return DirtyKeyInfo(noteRelayId, noteRelayId.additionalChars)
+                }
 
-                return DirtyKeyInfo(noteRelayId, noteRelayId.additionalChars)
-            } else if (key.startsWith("naddr1", true)) {
-                val address = Nip19Parser.uriToRoute(key) ?: return null
+                key.startsWith("naddr1", true) -> {
+                    val address = Nip19Parser.uriToRoute(key) ?: return null
 
-                return DirtyKeyInfo(
-                    address,
-                    address.additionalChars,
-                ) // no way to know when they address ends and dirt begins
+                    return DirtyKeyInfo(
+                        address,
+                        address.additionalChars,
+                    ) // no way to know when they address ends and dirt begins
+                }
             }
         } catch (e: Exception) {
             if (e is CancellationException) throw e

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/uploads/ShowImageUploadItem.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/uploads/ShowImageUploadItem.kt
@@ -113,51 +113,69 @@ fun ShowImageGallery(
     media: SelectedMedia,
     accountViewModel: AccountViewModel,
 ) {
-    if (media.isImage() == true) {
-        AsyncImage(
-            model = media.uri.toString(),
-            contentDescription = media.uri.toString(),
-            contentScale = ContentScale.Crop,
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .windowInsetsPadding(WindowInsets(0.dp, 0.dp, 0.dp, 0.dp)),
-        )
-    } else if (media.isAudio() == true) {
-        FilePreviewPlaceholder(
-            icon = MaterialSymbols.AudioFile,
-            label = media.mimeType ?: "audio/*",
-        )
-    } else if (media.isDocument()) {
-        FilePreviewPlaceholder(
-            icon = MaterialSymbols.PictureAsPdf,
-            label = media.mimeType ?: "application/pdf",
-        )
-    } else if (media.isVideo() == true && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-        var bitmap by remember { mutableStateOf<Bitmap?>(null) }
-        val context = LocalContext.current
+    when {
+        media.isImage() == true -> {
+            AsyncImage(
+                model = media.uri.toString(),
+                contentDescription = media.uri.toString(),
+                contentScale = ContentScale.Crop,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .windowInsetsPadding(WindowInsets(0.dp, 0.dp, 0.dp, 0.dp)),
+            )
+        }
 
-        LaunchedEffect(key1 = media) {
-            launch(Dispatchers.IO) {
-                try {
-                    bitmap = createVideoThumb(context, media.uri)
-                } catch (e: Exception) {
-                    if (e is CancellationException) throw e
-                    Log.w("NewPostView", "Couldn't create thumbnail, but the video can be uploaded", e)
+        media.isAudio() == true -> {
+            FilePreviewPlaceholder(
+                icon = MaterialSymbols.AudioFile,
+                label = media.mimeType ?: "audio/*",
+            )
+        }
+
+        media.isDocument() -> {
+            FilePreviewPlaceholder(
+                icon = MaterialSymbols.PictureAsPdf,
+                label = media.mimeType ?: "application/pdf",
+            )
+        }
+
+        media.isVideo() == true && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> {
+            var bitmap by remember { mutableStateOf<Bitmap?>(null) }
+            val context = LocalContext.current
+
+            LaunchedEffect(key1 = media) {
+                launch(Dispatchers.IO) {
+                    try {
+                        bitmap = createVideoThumb(context, media.uri)
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
+                        Log.w("NewPostView", "Couldn't create thumbnail, but the video can be uploaded", e)
+                    }
                 }
+            }
+
+            if (bitmap != null) {
+                bitmap?.let {
+                    Image(
+                        bitmap = it.asImageBitmap(),
+                        contentDescription = "some useful description",
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            } else {
+                VideoView(
+                    videoUri = media.uri.toString(),
+                    mimeType = media.mimeType,
+                    roundedCorner = false,
+                    contentScale = ContentScale.Crop,
+                    accountViewModel = accountViewModel,
+                )
             }
         }
 
-        if (bitmap != null) {
-            bitmap?.let {
-                Image(
-                    bitmap = it.asImageBitmap(),
-                    contentDescription = "some useful description",
-                    contentScale = ContentScale.Crop,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
-        } else {
+        else -> {
             VideoView(
                 videoUri = media.uri.toString(),
                 mimeType = media.mimeType,
@@ -166,14 +184,6 @@ fun ShowImageGallery(
                 accountViewModel = accountViewModel,
             )
         }
-    } else {
-        VideoView(
-            videoUri = media.uri.toString(),
-            mimeType = media.mimeType,
-            roundedCorner = false,
-            contentScale = ContentScale.Crop,
-            accountViewModel = accountViewModel,
-        )
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/LoadUrlPreview.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/LoadUrlPreview.kt
@@ -95,34 +95,42 @@ fun RenderLoaded(
     callbackUri: String? = null,
     accountViewModel: AccountViewModel,
 ) {
-    if (state.previewInfo.mimeType.startsWith("image")) {
-        Box(modifier = HalfVertPadding) {
-            ZoomableContentView(
-                content = MediaUrlImage(url, uri = callbackUri),
-                roundedCorner = true,
-                contentScale = ContentScale.FillWidth,
-                accountViewModel = accountViewModel,
-            )
+    when {
+        state.previewInfo.mimeType.startsWith("image") -> {
+            Box(modifier = HalfVertPadding) {
+                ZoomableContentView(
+                    content = MediaUrlImage(url, uri = callbackUri),
+                    roundedCorner = true,
+                    contentScale = ContentScale.FillWidth,
+                    accountViewModel = accountViewModel,
+                )
+            }
         }
-    } else if (state.previewInfo.mimeType.startsWith("video")) {
-        Box(modifier = HalfVertPadding) {
-            ZoomableContentView(
-                content = MediaUrlVideo(url, uri = callbackUri),
-                roundedCorner = true,
-                contentScale = ContentScale.FillWidth,
-                accountViewModel = accountViewModel,
-            )
+
+        state.previewInfo.mimeType.startsWith("video") -> {
+            Box(modifier = HalfVertPadding) {
+                ZoomableContentView(
+                    content = MediaUrlVideo(url, uri = callbackUri),
+                    roundedCorner = true,
+                    contentScale = ContentScale.FillWidth,
+                    accountViewModel = accountViewModel,
+                )
+            }
         }
-    } else if (state.previewInfo.mimeType.startsWith("application/pdf")) {
-        Box(modifier = HalfVertPadding) {
-            ZoomableContentView(
-                content = MediaUrlPdf(url, uri = callbackUri, mimeType = state.previewInfo.mimeType),
-                roundedCorner = true,
-                contentScale = ContentScale.FillWidth,
-                accountViewModel = accountViewModel,
-            )
+
+        state.previewInfo.mimeType.startsWith("application/pdf") -> {
+            Box(modifier = HalfVertPadding) {
+                ZoomableContentView(
+                    content = MediaUrlPdf(url, uri = callbackUri, mimeType = state.previewInfo.mimeType),
+                    roundedCorner = true,
+                    contentScale = ContentScale.FillWidth,
+                    accountViewModel = accountViewModel,
+                )
+            }
         }
-    } else {
-        UrlPreviewCard(url, state.previewInfo)
+
+        else -> {
+            UrlPreviewCard(url, state.previewInfo)
+        }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ReusableZapButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ReusableZapButton.kt
@@ -293,40 +293,48 @@ private fun handleZapClick(
 
     val choices = zapAmountChoices ?: accountViewModel.zapAmountChoices()
 
-    if (choices.isEmpty()) {
-        accountViewModel.toastManager.toast(
-            stringRes(context, R.string.error_dialog_zap_error),
-            stringRes(context, R.string.no_zap_amount_setup_long_press_to_change),
-        )
-    } else if (!accountViewModel.isWriteable()) {
-        accountViewModel.toastManager.toast(
-            stringRes(context, R.string.error_dialog_zap_error),
-            stringRes(context, R.string.login_with_a_private_key_to_be_able_to_send_zaps),
-        )
-    } else if (choices.size == 1) {
-        val amount = choices.first()
-
-        if (amount > 1100 || zapAmountChoices != null) {
-            onZapStarts()
-            accountViewModel.zap(
-                baseNote,
-                amount * 1000,
-                null,
-                "",
-                context,
-                showErrorIfNoLnAddress = false,
-                onError = onError,
-                onProgress = { onZappingProgress(it) },
-                onPayViaIntent = onPayViaIntent,
+    when {
+        choices.isEmpty() -> {
+            accountViewModel.toastManager.toast(
+                stringRes(context, R.string.error_dialog_zap_error),
+                stringRes(context, R.string.no_zap_amount_setup_long_press_to_change),
             )
-        } else {
-            onMultipleChoices(listOf(1000L, 5_000L, 10_000L))
         }
-    } else {
-        if (choices.any { it > 1100 } || zapAmountChoices != null) {
-            onMultipleChoices(choices)
-        } else {
-            onMultipleChoices(listOf(1000L, 5_000L, 10_000L))
+
+        !accountViewModel.isWriteable() -> {
+            accountViewModel.toastManager.toast(
+                stringRes(context, R.string.error_dialog_zap_error),
+                stringRes(context, R.string.login_with_a_private_key_to_be_able_to_send_zaps),
+            )
+        }
+
+        choices.size == 1 -> {
+            val amount = choices.first()
+
+            if (amount > 1100 || zapAmountChoices != null) {
+                onZapStarts()
+                accountViewModel.zap(
+                    baseNote,
+                    amount * 1000,
+                    null,
+                    "",
+                    context,
+                    showErrorIfNoLnAddress = false,
+                    onError = onError,
+                    onProgress = { onZappingProgress(it) },
+                    onPayViaIntent = onPayViaIntent,
+                )
+            } else {
+                onMultipleChoices(listOf(1000L, 5_000L, 10_000L))
+            }
+        }
+
+        else -> {
+            if (choices.any { it > 1100 } || zapAmountChoices != null) {
+                onMultipleChoices(choices)
+            } else {
+                onMultipleChoices(listOf(1000L, 5_000L, 10_000L))
+            }
         }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/WindowUtils.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/WindowUtils.kt
@@ -52,7 +52,7 @@ tailrec fun Context.getActivity(): ComponentActivity =
     when (this) {
         is ComponentActivity -> this
         is ContextWrapper -> baseContext.getActivity()
-        else -> throw IllegalStateException("Requires a ComponentActivity to run")
+        else -> error("Requires a ComponentActivity to run")
     }
 
 fun Context.getActivityOrNull(): ComponentActivity? =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/DisappearingScaffold.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/DisappearingScaffold.kt
@@ -245,10 +245,10 @@ private fun ResetBarsOnResume(state: DisappearingBarState) {
     DisposableEffect(lifecycleOwner, state) {
         val observer =
             LifecycleEventObserver { _, event ->
-                if (event == Lifecycle.Event.ON_RESUME) {
-                    if (state.topHeightOffset != 0f || state.bottomHeightOffset != 0f) {
-                        scope.launch { state.resetToVisible() }
-                    }
+                if (event == Lifecycle.Event.ON_RESUME &&
+                    (state.topHeightOffset != 0f || state.bottomHeightOffset != 0f)
+                ) {
+                    scope.launch { state.resetToVisible() }
                 }
             }
         lifecycleOwner.lifecycle.addObserver(observer)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/BlockReportChecker.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/BlockReportChecker.kt
@@ -67,25 +67,31 @@ fun WatchBlockAndReport(
             mutableStateOf(false)
         }
 
-    if (showAnyway.value) {
-        normalNote(true)
-    } else if (!isHidden.isPostHidden) {
-        if (isHidden.isAcceptable) {
-            normalNote(isHidden.canPreview)
-        } else {
-            HiddenNote(
-                isHidden.relevantReports,
-                isHidden.isHiddenAuthor,
-                accountViewModel,
-                modifier,
-                nav,
-                onClick = { showAnyway.value = true },
-            )
+    when {
+        showAnyway.value -> {
+            normalNote(true)
         }
-    } else if (showHiddenWarning) {
-        // if it is a quoted or boosted note, how the hidden warning.
-        HiddenNoteByMe {
-            showAnyway.value = true
+
+        !isHidden.isPostHidden -> {
+            if (isHidden.isAcceptable) {
+                normalNote(isHidden.canPreview)
+            } else {
+                HiddenNote(
+                    isHidden.relevantReports,
+                    isHidden.isHiddenAuthor,
+                    accountViewModel,
+                    modifier,
+                    nav,
+                    onClick = { showAnyway.value = true },
+                )
+            }
+        }
+
+        showHiddenWarning -> {
+            // if it is a quoted or boosted note, how the hidden warning.
+            HiddenNoteByMe {
+                showAnyway.value = true
+            }
         }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NIP05VerificationDisplay.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NIP05VerificationDisplay.kt
@@ -293,78 +293,86 @@ fun DisplayStatusInner(
         )
     }
 
-    if (url != null) {
-        val uri = LocalUriHandler.current
-        Spacer(modifier = StdHorzSpacer)
-        IconButton(
-            modifier = Size15Modifier,
-            onClick = { runCatching { uri.openUri(url.trim()) } },
-        ) {
-            Icon(
-                symbol = MaterialSymbols.AutoMirrored.OpenInNew,
-                null,
+    when {
+        url != null -> {
+            val uri = LocalUriHandler.current
+            Spacer(modifier = StdHorzSpacer)
+            IconButton(
                 modifier = Size15Modifier,
-                tint = MaterialTheme.colorScheme.lessImportantLink,
-            )
-        }
-    } else if (nostrATag != null) {
-        LoadAddressableNote(nostrATag, accountViewModel) { note ->
-            if (note != null) {
-                Spacer(modifier = StdHorzSpacer)
-                IconButton(
+                onClick = { runCatching { uri.openUri(url.trim()) } },
+            ) {
+                Icon(
+                    symbol = MaterialSymbols.AutoMirrored.OpenInNew,
+                    null,
                     modifier = Size15Modifier,
-                    onClick = {
-                        routeFor(
-                            note,
-                            accountViewModel.account,
-                        )?.let { nav.nav(it) }
-                    },
-                ) {
-                    Icon(
-                        symbol = MaterialSymbols.AutoMirrored.OpenInNew,
-                        null,
+                    tint = MaterialTheme.colorScheme.lessImportantLink,
+                )
+            }
+        }
+
+        nostrATag != null -> {
+            LoadAddressableNote(nostrATag, accountViewModel) { note ->
+                if (note != null) {
+                    Spacer(modifier = StdHorzSpacer)
+                    IconButton(
                         modifier = Size15Modifier,
-                        tint = MaterialTheme.colorScheme.lessImportantLink,
-                    )
+                        onClick = {
+                            routeFor(
+                                note,
+                                accountViewModel.account,
+                            )?.let { nav.nav(it) }
+                        },
+                    ) {
+                        Icon(
+                            symbol = MaterialSymbols.AutoMirrored.OpenInNew,
+                            null,
+                            modifier = Size15Modifier,
+                            tint = MaterialTheme.colorScheme.lessImportantLink,
+                        )
+                    }
                 }
             }
         }
-    } else if (nostrETag != null) {
-        LoadNote(baseNoteHex = nostrETag.eventId, accountViewModel) {
-            if (it != null) {
-                Spacer(modifier = StdHorzSpacer)
-                IconButton(
-                    modifier = Size15Modifier,
-                    onClick = {
-                        routeFor(
-                            it,
-                            accountViewModel.account,
-                        )?.let { nav.nav(it) }
-                    },
-                ) {
-                    Icon(
-                        symbol = MaterialSymbols.AutoMirrored.OpenInNew,
-                        null,
+
+        nostrETag != null -> {
+            LoadNote(baseNoteHex = nostrETag.eventId, accountViewModel) {
+                if (it != null) {
+                    Spacer(modifier = StdHorzSpacer)
+                    IconButton(
                         modifier = Size15Modifier,
-                        tint = MaterialTheme.colorScheme.lessImportantLink,
-                    )
+                        onClick = {
+                            routeFor(
+                                it,
+                                accountViewModel.account,
+                            )?.let { nav.nav(it) }
+                        },
+                    ) {
+                        Icon(
+                            symbol = MaterialSymbols.AutoMirrored.OpenInNew,
+                            null,
+                            modifier = Size15Modifier,
+                            tint = MaterialTheme.colorScheme.lessImportantLink,
+                        )
+                    }
                 }
             }
         }
-    } else if (nostrPTag != null) {
-        LoadUser(baseUserHex = nostrPTag, accountViewModel) { user ->
-            if (user != null) {
-                Spacer(modifier = StdHorzSpacer)
-                IconButton(
-                    modifier = Size15Modifier,
-                    onClick = { nav.nav(routeForUser(nostrPTag)) },
-                ) {
-                    Icon(
-                        symbol = MaterialSymbols.AutoMirrored.OpenInNew,
-                        null,
+
+        nostrPTag != null -> {
+            LoadUser(baseUserHex = nostrPTag, accountViewModel) { user ->
+                if (user != null) {
+                    Spacer(modifier = StdHorzSpacer)
+                    IconButton(
                         modifier = Size15Modifier,
-                        tint = MaterialTheme.colorScheme.lessImportantLink,
-                    )
+                        onClick = { nav.nav(routeForUser(nostrPTag)) },
+                    ) {
+                        Icon(
+                            symbol = MaterialSymbols.AutoMirrored.OpenInNew,
+                            null,
+                            modifier = Size15Modifier,
+                            tint = MaterialTheme.colorScheme.lessImportantLink,
+                        )
+                    }
                 }
             }
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteQuickActionMenu.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteQuickActionMenu.kt
@@ -116,14 +116,11 @@ val graspLink = { graspNumber: String ->
 
 val externalLinkForNote = { note: Note ->
     if (note is AddressableNote) {
-        if (note.event?.bountyBaseReward() != null) {
-            "https://nostrbounties.com/b/${note.toNAddr()}"
-        } else if (note.event is PeopleListEvent) {
-            "https://listr.lol/a/${note.toNAddr()}"
-        } else if (note.event is FollowListEvent) {
-            "https://following.space/d/${note.address.dTag}?p=${note.address.pubKeyHex}"
-        } else {
-            njumpLink(note.toNAddr())
+        when {
+            note.event?.bountyBaseReward() != null -> "https://nostrbounties.com/b/${note.toNAddr()}"
+            note.event is PeopleListEvent -> "https://listr.lol/a/${note.toNAddr()}"
+            note.event is FollowListEvent -> "https://following.space/d/${note.address.dTag}?p=${note.address.pubKeyHex}"
+            else -> njumpLink(note.toNAddr())
         }
     } else {
         njumpLink(note.toNEvent())

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
@@ -1146,20 +1146,28 @@ private fun likeClick(
     }
 
     val choices = accountViewModel.reactionChoices()
-    if (choices.isEmpty()) {
-        accountViewModel.toastManager.toast(
-            R.string.no_reactions_setup,
-            R.string.no_reaction_type_setup_long_press_to_change,
-        )
-    } else if (!accountViewModel.isWriteable()) {
-        accountViewModel.toastManager.toast(
-            R.string.read_only_user,
-            R.string.login_with_a_private_key_to_like_posts,
-        )
-    } else if (choices.size == 1) {
-        onWantsToSignReaction()
-    } else if (choices.size > 1) {
-        onMultipleChoices()
+    when {
+        choices.isEmpty() -> {
+            accountViewModel.toastManager.toast(
+                R.string.no_reactions_setup,
+                R.string.no_reaction_type_setup_long_press_to_change,
+            )
+        }
+
+        !accountViewModel.isWriteable() -> {
+            accountViewModel.toastManager.toast(
+                R.string.read_only_user,
+                R.string.login_with_a_private_key_to_like_posts,
+            )
+        }
+
+        choices.size == 1 -> {
+            onWantsToSignReaction()
+        }
+
+        choices.size > 1 -> {
+            onMultipleChoices()
+        }
     }
 }
 
@@ -1369,27 +1377,35 @@ fun zapClick(
 
     val choices = accountViewModel.zapAmountChoices()
 
-    if (choices.isEmpty()) {
-        onCustomAmount()
-    } else if (!accountViewModel.isWriteable()) {
-        accountViewModel.toastManager.toast(
-            R.string.error_dialog_zap_error,
-            R.string.login_with_a_private_key_to_be_able_to_send_zaps,
-        )
-    } else if (choices.size == 1) {
-        onZapStarts()
-        accountViewModel.zap(
-            baseNote,
-            choices.first() * 1000,
-            null,
-            "",
-            context,
-            onError = onError,
-            onProgress = { onZappingProgress(it) },
-            onPayViaIntent = onPayViaIntent,
-        )
-    } else if (choices.size > 1) {
-        onMultipleChoices()
+    when {
+        choices.isEmpty() -> {
+            onCustomAmount()
+        }
+
+        !accountViewModel.isWriteable() -> {
+            accountViewModel.toastManager.toast(
+                R.string.error_dialog_zap_error,
+                R.string.login_with_a_private_key_to_be_able_to_send_zaps,
+            )
+        }
+
+        choices.size == 1 -> {
+            onZapStarts()
+            accountViewModel.zap(
+                baseNote,
+                choices.first() * 1000,
+                null,
+                "",
+                context,
+                onError = onError,
+                onProgress = { onZappingProgress(it) },
+                onPayViaIntent = onPayViaIntent,
+            )
+        }
+
+        choices.size > 1 -> {
+            onMultipleChoices()
+        }
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReplyInformation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReplyInformation.kt
@@ -86,30 +86,28 @@ fun ReplyInformationChannel(
     onUserTagClick: (User) -> Unit,
 ) {
     FlowRow {
-        if (!mentions.isNullOrEmpty()) {
-            if (!replyTo.isNullOrEmpty()) {
-                Text(
-                    stringRes(id = R.string.replying_to),
-                    fontSize = 13.sp,
-                    color = MaterialTheme.colorScheme.placeholderText,
-                )
+        if (!mentions.isNullOrEmpty() && !replyTo.isNullOrEmpty()) {
+            Text(
+                stringRes(id = R.string.replying_to),
+                fontSize = 13.sp,
+                color = MaterialTheme.colorScheme.placeholderText,
+            )
 
-                mentions.forEachIndexed { idx, user ->
-                    ReplyInfoMention(user, prefix, accountViewModel, onUserTagClick)
+            mentions.forEachIndexed { idx, user ->
+                ReplyInfoMention(user, prefix, accountViewModel, onUserTagClick)
 
-                    if (idx < mentions.size - 2) {
-                        Text(
-                            ", ",
-                            fontSize = 13.sp,
-                            color = MaterialTheme.colorScheme.placeholderText,
-                        )
-                    } else if (idx < mentions.size - 1) {
-                        Text(
-                            " ${stringRes(id = R.string.and)} ",
-                            fontSize = 13.sp,
-                            color = MaterialTheme.colorScheme.placeholderText,
-                        )
-                    }
+                if (idx < mentions.size - 2) {
+                    Text(
+                        ", ",
+                        fontSize = 13.sp,
+                        color = MaterialTheme.colorScheme.placeholderText,
+                    )
+                } else if (idx < mentions.size - 1) {
+                    Text(
+                        " ${stringRes(id = R.string.and)} ",
+                        fontSize = 13.sp,
+                        color = MaterialTheme.colorScheme.placeholderText,
+                    )
                 }
             }
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/TimeAgoFormatter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/TimeAgoFormatter.kt
@@ -56,34 +56,45 @@ fun timeAgo(
 
     val timeDifference = TimeUtils.now() - time
 
-    return if (timeDifference > TimeUtils.ONE_YEAR) {
-        // Dec 12, 2022
+    return when {
+        timeDifference > TimeUtils.ONE_YEAR -> {
+            // Dec 12, 2022
 
-        if (locale != Locale.getDefault()) {
-            locale = Locale.getDefault()
-            yearFormatter = SimpleDateFormat(YEAR_DATE_FORMAT, locale)
-            monthFormatter = SimpleDateFormat(MONTH_DATE_FORMAT, locale)
+            if (locale != Locale.getDefault()) {
+                locale = Locale.getDefault()
+                yearFormatter = SimpleDateFormat(YEAR_DATE_FORMAT, locale)
+                monthFormatter = SimpleDateFormat(MONTH_DATE_FORMAT, locale)
+            }
+
+            prefix + yearFormatter.format(time * 1000)
         }
 
-        prefix + yearFormatter.format(time * 1000)
-    } else if (timeDifference > TimeUtils.ONE_MONTH) {
-        // Dec 12
-        if (locale != Locale.getDefault()) {
-            locale = Locale.getDefault()
-            yearFormatter = SimpleDateFormat(YEAR_DATE_FORMAT, locale)
-            monthFormatter = SimpleDateFormat(MONTH_DATE_FORMAT, locale)
+        timeDifference > TimeUtils.ONE_MONTH -> {
+            // Dec 12
+            if (locale != Locale.getDefault()) {
+                locale = Locale.getDefault()
+                yearFormatter = SimpleDateFormat(YEAR_DATE_FORMAT, locale)
+                monthFormatter = SimpleDateFormat(MONTH_DATE_FORMAT, locale)
+            }
+
+            prefix + monthFormatter.format(time * 1000)
         }
 
-        prefix + monthFormatter.format(time * 1000)
-    } else if (timeDifference > TimeUtils.ONE_DAY) {
-        // 2 days
-        prefix + (timeDifference / TimeUtils.ONE_DAY).toString() + stringRes(context, days)
-    } else if (timeDifference > TimeUtils.ONE_HOUR) {
-        prefix + (timeDifference / TimeUtils.ONE_HOUR).toString() + stringRes(context, hours)
-    } else if (timeDifference > TimeUtils.ONE_MINUTE) {
-        prefix + (timeDifference / TimeUtils.ONE_MINUTE).toString() + stringRes(context, minutes)
-    } else {
-        prefix + stringRes(context, seconds)
+        timeDifference > TimeUtils.ONE_DAY -> {
+            prefix + (timeDifference / TimeUtils.ONE_DAY).toString() + stringRes(context, days)
+        }
+
+        timeDifference > TimeUtils.ONE_HOUR -> {
+            prefix + (timeDifference / TimeUtils.ONE_HOUR).toString() + stringRes(context, hours)
+        }
+
+        timeDifference > TimeUtils.ONE_MINUTE -> {
+            prefix + (timeDifference / TimeUtils.ONE_MINUTE).toString() + stringRes(context, minutes)
+        }
+
+        else -> {
+            prefix + stringRes(context, seconds)
+        }
     }
 }
 
@@ -96,34 +107,45 @@ fun timeAgoNoDot(
 
     val timeDifference = TimeUtils.now() - time
 
-    return if (timeDifference > TimeUtils.ONE_YEAR) {
-        // Dec 12, 2022
+    return when {
+        timeDifference > TimeUtils.ONE_YEAR -> {
+            // Dec 12, 2022
 
-        if (locale != Locale.getDefault()) {
-            locale = Locale.getDefault()
-            yearFormatter = SimpleDateFormat(YEAR_DATE_FORMAT, locale)
-            monthFormatter = SimpleDateFormat(MONTH_DATE_FORMAT, locale)
+            if (locale != Locale.getDefault()) {
+                locale = Locale.getDefault()
+                yearFormatter = SimpleDateFormat(YEAR_DATE_FORMAT, locale)
+                monthFormatter = SimpleDateFormat(MONTH_DATE_FORMAT, locale)
+            }
+
+            yearFormatter.format(time * 1000)
         }
 
-        yearFormatter.format(time * 1000)
-    } else if (timeDifference > TimeUtils.ONE_MONTH) {
-        // Dec 12
-        if (locale != Locale.getDefault()) {
-            locale = Locale.getDefault()
-            yearFormatter = SimpleDateFormat(YEAR_DATE_FORMAT, locale)
-            monthFormatter = SimpleDateFormat(MONTH_DATE_FORMAT, locale)
+        timeDifference > TimeUtils.ONE_MONTH -> {
+            // Dec 12
+            if (locale != Locale.getDefault()) {
+                locale = Locale.getDefault()
+                yearFormatter = SimpleDateFormat(YEAR_DATE_FORMAT, locale)
+                monthFormatter = SimpleDateFormat(MONTH_DATE_FORMAT, locale)
+            }
+
+            monthFormatter.format(time * 1000)
         }
 
-        monthFormatter.format(time * 1000)
-    } else if (timeDifference > TimeUtils.ONE_DAY) {
-        // 2 days
-        (timeDifference / TimeUtils.ONE_DAY).toString() + stringRes(context, R.string.d)
-    } else if (timeDifference > TimeUtils.ONE_HOUR) {
-        (timeDifference / TimeUtils.ONE_HOUR).toString() + stringRes(context, R.string.h)
-    } else if (timeDifference > TimeUtils.ONE_MINUTE) {
-        (timeDifference / TimeUtils.ONE_MINUTE).toString() + stringRes(context, R.string.m)
-    } else {
-        stringRes(context, R.string.now)
+        timeDifference > TimeUtils.ONE_DAY -> {
+            (timeDifference / TimeUtils.ONE_DAY).toString() + stringRes(context, R.string.d)
+        }
+
+        timeDifference > TimeUtils.ONE_HOUR -> {
+            (timeDifference / TimeUtils.ONE_HOUR).toString() + stringRes(context, R.string.h)
+        }
+
+        timeDifference > TimeUtils.ONE_MINUTE -> {
+            (timeDifference / TimeUtils.ONE_MINUTE).toString() + stringRes(context, R.string.m)
+        }
+
+        else -> {
+            stringRes(context, R.string.now)
+        }
     }
 }
 
@@ -136,34 +158,45 @@ fun timeAgoNoDotNoDay(
 
     val timeDifference = TimeUtils.now() - time
 
-    return if (timeDifference > TimeUtils.ONE_YEAR) {
-        // Dec 12, 2022
+    return when {
+        timeDifference > TimeUtils.ONE_YEAR -> {
+            // Dec 12, 2022
 
-        if (locale != Locale.getDefault()) {
-            locale = Locale.getDefault()
-            yearNoDayFormatter = SimpleDateFormat(YEAR_NO_DAY_DATE_FORMAT, locale)
-            monthNoDayFormatter = SimpleDateFormat(MONTH_NO_DAY_DATE_FORMAT, locale)
+            if (locale != Locale.getDefault()) {
+                locale = Locale.getDefault()
+                yearNoDayFormatter = SimpleDateFormat(YEAR_NO_DAY_DATE_FORMAT, locale)
+                monthNoDayFormatter = SimpleDateFormat(MONTH_NO_DAY_DATE_FORMAT, locale)
+            }
+
+            yearNoDayFormatter.format(time * 1000)
         }
 
-        yearNoDayFormatter.format(time * 1000)
-    } else if (timeDifference > TimeUtils.ONE_MONTH) {
-        // Dec 12
-        if (locale != Locale.getDefault()) {
-            locale = Locale.getDefault()
-            yearNoDayFormatter = SimpleDateFormat(YEAR_NO_DAY_DATE_FORMAT, locale)
-            monthNoDayFormatter = SimpleDateFormat(MONTH_NO_DAY_DATE_FORMAT, locale)
+        timeDifference > TimeUtils.ONE_MONTH -> {
+            // Dec 12
+            if (locale != Locale.getDefault()) {
+                locale = Locale.getDefault()
+                yearNoDayFormatter = SimpleDateFormat(YEAR_NO_DAY_DATE_FORMAT, locale)
+                monthNoDayFormatter = SimpleDateFormat(MONTH_NO_DAY_DATE_FORMAT, locale)
+            }
+
+            monthNoDayFormatter.format(time * 1000)
         }
 
-        monthNoDayFormatter.format(time * 1000)
-    } else if (timeDifference > TimeUtils.ONE_DAY) {
-        // 2 days
-        (timeDifference / TimeUtils.ONE_DAY).toString() + stringRes(context, R.string.d)
-    } else if (timeDifference > TimeUtils.ONE_HOUR) {
-        (timeDifference / TimeUtils.ONE_HOUR).toString() + stringRes(context, R.string.h)
-    } else if (timeDifference > TimeUtils.ONE_MINUTE) {
-        (timeDifference / TimeUtils.ONE_MINUTE).toString() + stringRes(context, R.string.m)
-    } else {
-        stringRes(context, R.string.now)
+        timeDifference > TimeUtils.ONE_DAY -> {
+            (timeDifference / TimeUtils.ONE_DAY).toString() + stringRes(context, R.string.d)
+        }
+
+        timeDifference > TimeUtils.ONE_HOUR -> {
+            (timeDifference / TimeUtils.ONE_HOUR).toString() + stringRes(context, R.string.h)
+        }
+
+        timeDifference > TimeUtils.ONE_MINUTE -> {
+            (timeDifference / TimeUtils.ONE_MINUTE).toString() + stringRes(context, R.string.m)
+        }
+
+        else -> {
+            stringRes(context, R.string.now)
+        }
     }
 }
 
@@ -176,34 +209,45 @@ fun timeAheadNoDot(
 
     val timeDifference = time - TimeUtils.now()
 
-    return if (timeDifference > TimeUtils.ONE_YEAR) {
-        // Dec 12, 2022
+    return when {
+        timeDifference > TimeUtils.ONE_YEAR -> {
+            // Dec 12, 2022
 
-        if (locale != Locale.getDefault()) {
-            locale = Locale.getDefault()
-            yearFormatter = SimpleDateFormat(YEAR_DATE_FORMAT, locale)
-            monthFormatter = SimpleDateFormat(MONTH_DATE_FORMAT, locale)
+            if (locale != Locale.getDefault()) {
+                locale = Locale.getDefault()
+                yearFormatter = SimpleDateFormat(YEAR_DATE_FORMAT, locale)
+                monthFormatter = SimpleDateFormat(MONTH_DATE_FORMAT, locale)
+            }
+
+            yearFormatter.format(time * 1000)
         }
 
-        yearFormatter.format(time * 1000)
-    } else if (timeDifference > TimeUtils.ONE_MONTH) {
-        // Dec 12
-        if (locale != Locale.getDefault()) {
-            locale = Locale.getDefault()
-            yearFormatter = SimpleDateFormat(YEAR_DATE_FORMAT, locale)
-            monthFormatter = SimpleDateFormat(MONTH_DATE_FORMAT, locale)
+        timeDifference > TimeUtils.ONE_MONTH -> {
+            // Dec 12
+            if (locale != Locale.getDefault()) {
+                locale = Locale.getDefault()
+                yearFormatter = SimpleDateFormat(YEAR_DATE_FORMAT, locale)
+                monthFormatter = SimpleDateFormat(MONTH_DATE_FORMAT, locale)
+            }
+
+            monthFormatter.format(time * 1000)
         }
 
-        monthFormatter.format(time * 1000)
-    } else if (timeDifference > TimeUtils.ONE_DAY) {
-        // 2 days
-        round(timeDifference / TimeUtils.ONE_DAY.toFloat()).toInt().toString() + stringRes(context, R.string.d)
-    } else if (timeDifference > TimeUtils.ONE_HOUR) {
-        round(timeDifference / TimeUtils.ONE_HOUR.toFloat()).toInt().toString() + stringRes(context, R.string.h)
-    } else if (timeDifference > TimeUtils.ONE_MINUTE) {
-        round(timeDifference / TimeUtils.ONE_MINUTE.toFloat()).toInt().toString() + stringRes(context, R.string.m)
-    } else {
-        stringRes(context, R.string.now)
+        timeDifference > TimeUtils.ONE_DAY -> {
+            round(timeDifference / TimeUtils.ONE_DAY.toFloat()).toInt().toString() + stringRes(context, R.string.d)
+        }
+
+        timeDifference > TimeUtils.ONE_HOUR -> {
+            round(timeDifference / TimeUtils.ONE_HOUR.toFloat()).toInt().toString() + stringRes(context, R.string.h)
+        }
+
+        timeDifference > TimeUtils.ONE_MINUTE -> {
+            round(timeDifference / TimeUtils.ONE_MINUTE.toFloat()).toInt().toString() + stringRes(context, R.string.m)
+        }
+
+        else -> {
+            stringRes(context, R.string.now)
+        }
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapPollNote.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapPollNote.kt
@@ -547,59 +547,69 @@ fun ZapVote(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = ripple24dp,
                 onClick = {
-                    if (!accountViewModel.isWriteable()) {
-                        accountViewModel.toastManager.toast(
-                            R.string.read_only_user,
-                            R.string.login_with_a_private_key_to_be_able_to_send_zaps,
-                        )
-                    } else if (pollViewModel.isPollClosed()) {
-                        accountViewModel.toastManager.toast(
-                            R.string.poll_unable_to_vote,
-                            R.string.poll_is_closed_explainer,
-                        )
-                    } else if (isLoggedUser) {
-                        accountViewModel.toastManager.toast(
-                            R.string.poll_unable_to_vote,
-                            R.string.poll_author_no_vote,
-                        )
-                    } else if (pollViewModel.isVoteAmountAtomic() && poolOption.zappedByLoggedIn.value) {
-                        // only allow one vote per option when min==max, i.e. atomic vote amount specified
-                        accountViewModel.toastManager.toast(
-                            R.string.poll_unable_to_vote,
-                            R.string.one_vote_per_user_on_atomic_votes,
-                        )
-                        return@combinedClickable
-                    } else if (
+                    when {
+                        !accountViewModel.isWriteable() -> {
+                            accountViewModel.toastManager.toast(
+                                R.string.read_only_user,
+                                R.string.login_with_a_private_key_to_be_able_to_send_zaps,
+                            )
+                        }
+
+                        pollViewModel.isPollClosed() -> {
+                            accountViewModel.toastManager.toast(
+                                R.string.poll_unable_to_vote,
+                                R.string.poll_is_closed_explainer,
+                            )
+                        }
+
+                        isLoggedUser -> {
+                            accountViewModel.toastManager.toast(
+                                R.string.poll_unable_to_vote,
+                                R.string.poll_author_no_vote,
+                            )
+                        }
+
+                        pollViewModel.isVoteAmountAtomic() && poolOption.zappedByLoggedIn.value -> {
+                            // only allow one vote per option when min==max, i.e. atomic vote amount specified
+                            accountViewModel.toastManager.toast(
+                                R.string.poll_unable_to_vote,
+                                R.string.one_vote_per_user_on_atomic_votes,
+                            )
+                            return@combinedClickable
+                        }
+
                         accountViewModel.zapAmountChoices().size == 1 &&
-                        pollViewModel.isValidInputVoteAmount(accountViewModel.zapAmountChoices().first())
-                    ) {
-                        accountViewModel.zap(
-                            baseNote,
-                            accountViewModel.zapAmountChoices().first() * 1000,
-                            poolOption.option,
-                            "",
-                            context,
-                            onError = { title, message, user ->
-                                zappingProgress = 0f
-                                showErrorMessageDialog = StringToastMsg(title, message)
-                            },
-                            onProgress = { scope.launch(Dispatchers.Main) { zappingProgress = it } },
-                            onPayViaIntent = {
-                                if (it.size == 1) {
-                                    val payable = it.first()
-                                    payViaIntent(payable.invoice, context, { }) { error ->
-                                        zappingProgress = 0f
-                                        showErrorMessageDialog = StringToastMsg(stringRes(context, R.string.error_dialog_zap_error), error)
+                            pollViewModel.isValidInputVoteAmount(accountViewModel.zapAmountChoices().first()) -> {
+                            accountViewModel.zap(
+                                baseNote,
+                                accountViewModel.zapAmountChoices().first() * 1000,
+                                poolOption.option,
+                                "",
+                                context,
+                                onError = { title, message, user ->
+                                    zappingProgress = 0f
+                                    showErrorMessageDialog = StringToastMsg(title, message)
+                                },
+                                onProgress = { scope.launch(Dispatchers.Main) { zappingProgress = it } },
+                                onPayViaIntent = {
+                                    if (it.size == 1) {
+                                        val payable = it.first()
+                                        payViaIntent(payable.invoice, context, { }) { error ->
+                                            zappingProgress = 0f
+                                            showErrorMessageDialog = StringToastMsg(stringRes(context, R.string.error_dialog_zap_error), error)
+                                        }
+                                    } else {
+                                        val uid = Uuid.random().toString()
+                                        accountViewModel.tempManualPaymentCache.put(uid, it)
+                                        nav.nav(Route.ManualZapSplitPayment(uid))
                                     }
-                                } else {
-                                    val uid = Uuid.random().toString()
-                                    accountViewModel.tempManualPaymentCache.put(uid, it)
-                                    nav.nav(Route.ManualZapSplitPayment(uid))
-                                }
-                            },
-                        )
-                    } else {
-                        wantsToZap = true
+                                },
+                            )
+                        }
+
+                        else -> {
+                            wantsToZap = true
+                        }
                     }
                 },
             ),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapPollNoteViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ZapPollNoteViewModel.kt
@@ -138,14 +138,11 @@ class PollNoteViewModel : ViewModel() {
         } == true
 
     fun voteAmountPlaceHolderText(sats: String): String =
-        if (valueMinimum == null && valueMaximum == null) {
-            sats
-        } else if (valueMinimum == null) {
-            "1—$valueMaximum $sats"
-        } else if (valueMaximum == null) {
-            ">$valueMinimum $sats"
-        } else {
-            "$valueMinimum—$valueMaximum $sats"
+        when {
+            valueMinimum == null && valueMaximum == null -> sats
+            valueMinimum == null -> "1—$valueMaximum $sats"
+            valueMaximum == null -> ">$valueMinimum $sats"
+            else -> "$valueMinimum—$valueMaximum $sats"
         }
 
     fun inputVoteAmountLong(textAmount: String) =
@@ -160,46 +157,66 @@ class PollNoteViewModel : ViewModel() {
         }
 
     fun isValidInputVoteAmount(amount: BigDecimal?): Boolean {
-        if (amount == null) {
-            return false
-        } else if (valueMinimum == null && valueMaximum == null) {
-            if (amount > BigDecimal.ZERO) {
-                return true
+        when {
+            amount == null -> {
+                return false
             }
-        } else if (valueMinimum == null) {
-            if (amount > BigDecimal.ZERO && amount <= valueMaximumBD!!) {
-                return true
+
+            valueMinimum == null && valueMaximum == null -> {
+                if (amount > BigDecimal.ZERO) {
+                    return true
+                }
             }
-        } else if (valueMaximum == null) {
-            if (amount >= valueMinimumBD!!) {
-                return true
+
+            valueMinimum == null -> {
+                if (amount > BigDecimal.ZERO && amount <= valueMaximumBD!!) {
+                    return true
+                }
             }
-        } else {
-            if ((valueMinimumBD!! <= amount) && (amount <= valueMaximumBD!!)) {
-                return true
+
+            valueMaximum == null -> {
+                if (amount >= valueMinimumBD!!) {
+                    return true
+                }
+            }
+
+            else -> {
+                if ((valueMinimumBD!! <= amount) && (amount <= valueMaximumBD!!)) {
+                    return true
+                }
             }
         }
         return false
     }
 
     fun isValidInputVoteAmount(amount: Long?): Boolean {
-        if (amount == null) {
-            return false
-        } else if (valueMinimum == null && valueMaximum == null) {
-            if (amount > 0) {
-                return true
+        when {
+            amount == null -> {
+                return false
             }
-        } else if (valueMinimum == null) {
-            if (amount > 0 && amount <= valueMaximum!!) {
-                return true
+
+            valueMinimum == null && valueMaximum == null -> {
+                if (amount > 0) {
+                    return true
+                }
             }
-        } else if (valueMaximum == null) {
-            if (amount >= valueMinimum!!) {
-                return true
+
+            valueMinimum == null -> {
+                if (amount > 0 && amount <= valueMaximum!!) {
+                    return true
+                }
             }
-        } else {
-            if ((valueMinimum!! <= amount) && (amount <= valueMaximum!!)) {
-                return true
+
+            valueMaximum == null -> {
+                if (amount >= valueMinimum!!) {
+                    return true
+                }
+            }
+
+            else -> {
+                if ((valueMinimum!! <= amount) && (amount <= valueMaximum!!)) {
+                    return true
+                }
             }
         }
         return false

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/previews/PreviewUrl.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/previews/PreviewUrl.kt
@@ -60,40 +60,52 @@ fun PreviewUrl(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    if (RichTextParser.isValidURL(myUrlPreview)) {
-        if (RichTextParser.isImageUrl(myUrlPreview)) {
-            AsyncImage(
-                model = myUrlPreview,
-                contentDescription = myUrlPreview,
-                contentScale = ContentScale.FillHeight,
-                modifier = Modifier.fillMaxHeight().aspectRatio(1f),
-            )
-        } else if (RichTextParser.isVideoUrl(myUrlPreview)) {
-            VideoView(
-                myUrlPreview,
-                mimeType = null,
-                roundedCorner = false,
-                gallery = false,
-                contentScale = ContentScale.FillHeight,
-                accountViewModel = accountViewModel,
-            )
-        } else {
-            MyLoadUrlPreviewDirect(myUrlPreview, myUrlPreview, accountViewModel)
-        }
-    } else if (RichTextParser.startsWithNIP19Scheme(myUrlPreview)) {
-        val bgColor = MaterialTheme.colorScheme.background
-        val backgroundColor = remember { mutableStateOf(bgColor) }
+    when {
+        RichTextParser.isValidURL(myUrlPreview) -> {
+            when {
+                RichTextParser.isImageUrl(myUrlPreview) -> {
+                    AsyncImage(
+                        model = myUrlPreview,
+                        contentDescription = myUrlPreview,
+                        contentScale = ContentScale.FillHeight,
+                        modifier = Modifier.fillMaxHeight().aspectRatio(1f),
+                    )
+                }
 
-        BechLinkPreview(
-            word = myUrlPreview,
-            canPreview = true,
-            quotesLeft = 1,
-            backgroundColor = backgroundColor,
-            accountViewModel = accountViewModel,
-            nav = nav,
-        )
-    } else if (RichTextParser.isUrlWithoutScheme(myUrlPreview)) {
-        MyLoadUrlPreviewDirect("https://$myUrlPreview", myUrlPreview, accountViewModel)
+                RichTextParser.isVideoUrl(myUrlPreview) -> {
+                    VideoView(
+                        myUrlPreview,
+                        mimeType = null,
+                        roundedCorner = false,
+                        gallery = false,
+                        contentScale = ContentScale.FillHeight,
+                        accountViewModel = accountViewModel,
+                    )
+                }
+
+                else -> {
+                    MyLoadUrlPreviewDirect(myUrlPreview, myUrlPreview, accountViewModel)
+                }
+            }
+        }
+
+        RichTextParser.startsWithNIP19Scheme(myUrlPreview) -> {
+            val bgColor = MaterialTheme.colorScheme.background
+            val backgroundColor = remember { mutableStateOf(bgColor) }
+
+            BechLinkPreview(
+                word = myUrlPreview,
+                canPreview = true,
+                quotesLeft = 1,
+                backgroundColor = backgroundColor,
+                accountViewModel = accountViewModel,
+                nav = nav,
+            )
+        }
+
+        RichTextParser.isUrlWithoutScheme(myUrlPreview) -> {
+            MyLoadUrlPreviewDirect("https://$myUrlPreview", myUrlPreview, accountViewModel)
+        }
     }
 }
 
@@ -104,24 +116,30 @@ fun PreviewUrlFillWidth(
     nav: INav,
 ) {
     if (RichTextParser.isValidURL(myUrlPreview)) {
-        if (RichTextParser.isImageUrl(myUrlPreview)) {
-            AsyncImage(
-                model = myUrlPreview,
-                contentDescription = myUrlPreview,
-                contentScale = ContentScale.FillWidth,
-                modifier = Modifier.fillMaxHeight().aspectRatio(1f),
-            )
-        } else if (RichTextParser.isVideoUrl(myUrlPreview)) {
-            VideoView(
-                myUrlPreview,
-                mimeType = null,
-                roundedCorner = false,
-                gallery = false,
-                contentScale = ContentScale.FillWidth,
-                accountViewModel = accountViewModel,
-            )
-        } else {
-            MyLoadUrlPreviewDirectFillWidth(myUrlPreview, myUrlPreview, accountViewModel)
+        when {
+            RichTextParser.isImageUrl(myUrlPreview) -> {
+                AsyncImage(
+                    model = myUrlPreview,
+                    contentDescription = myUrlPreview,
+                    contentScale = ContentScale.FillWidth,
+                    modifier = Modifier.fillMaxHeight().aspectRatio(1f),
+                )
+            }
+
+            RichTextParser.isVideoUrl(myUrlPreview) -> {
+                VideoView(
+                    myUrlPreview,
+                    mimeType = null,
+                    roundedCorner = false,
+                    gallery = false,
+                    contentScale = ContentScale.FillWidth,
+                    accountViewModel = accountViewModel,
+                )
+            }
+
+            else -> {
+                MyLoadUrlPreviewDirectFillWidth(myUrlPreview, myUrlPreview, accountViewModel)
+            }
         }
     } else if (RichTextParser.startsWithNIP19Scheme(myUrlPreview)) {
         val bgColor = MaterialTheme.colorScheme.background

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/userSuggestions/UserSuggestionState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/userSuggestions/UserSuggestionState.kt
@@ -92,50 +92,58 @@ class UserSuggestionState(
                         } else {
                             null
                         }
-                    if (nip05 != null) {
-                        runCatching {
-                            nip05Client.get(nip05)?.let { info ->
-                                val user = account.cache.checkGetOrCreateUser(info.pubkey)
-                                if (user != null) {
-                                    info.relays.forEach {
-                                        it.normalizeRelayUrlOrNull()?.let { relay ->
-                                            account.cache.relayHints.addKey(user.pubkey(), relay)
+                    when {
+                        nip05 != null -> {
+                            runCatching {
+                                nip05Client.get(nip05)?.let { info ->
+                                    val user = account.cache.checkGetOrCreateUser(info.pubkey)
+                                    if (user != null) {
+                                        info.relays.forEach {
+                                            it.normalizeRelayUrlOrNull()?.let { relay ->
+                                                account.cache.relayHints.addKey(user.pubkey(), relay)
+                                            }
+                                        }
+                                    }
+                                    user
+                                }
+                            }.getOrNull()
+                        }
+
+                        prefix.startsWithAny(userUriPrefixes) -> {
+                            runCatching {
+                                Nip19Parser.uriToRoute(prefix)?.entity?.let { parsed ->
+                                    when (parsed) {
+                                        is NSec -> {
+                                            account.cache.getOrCreateUser(parsed.toPubKey().toHexKey())
+                                        }
+
+                                        is NPub -> {
+                                            account.cache.getOrCreateUser(parsed.hex)
+                                        }
+
+                                        is NProfile -> {
+                                            val user = account.cache.getOrCreateUser(parsed.hex)
+                                            parsed.relay.forEach { relay ->
+                                                account.cache.relayHints.addKey(user.pubkey(), relay)
+                                            }
+                                            user
+                                        }
+
+                                        else -> {
+                                            null
                                         }
                                     }
                                 }
-                                user
-                            }
-                        }.getOrNull()
-                    } else if (prefix.startsWithAny(userUriPrefixes)) {
-                        runCatching {
-                            Nip19Parser.uriToRoute(prefix)?.entity?.let { parsed ->
-                                when (parsed) {
-                                    is NSec -> {
-                                        account.cache.getOrCreateUser(parsed.toPubKey().toHexKey())
-                                    }
+                            }.getOrNull()
+                        }
 
-                                    is NPub -> {
-                                        account.cache.getOrCreateUser(parsed.hex)
-                                    }
+                        prefix.length == 64 && Hex.isHex64(prefix) -> {
+                            account.cache.getOrCreateUser(prefix)
+                        }
 
-                                    is NProfile -> {
-                                        val user = account.cache.getOrCreateUser(parsed.hex)
-                                        parsed.relay.forEach { relay ->
-                                            account.cache.relayHints.addKey(user.pubkey(), relay)
-                                        }
-                                        user
-                                    }
-
-                                    else -> {
-                                        null
-                                    }
-                                }
-                            }
-                        }.getOrNull()
-                    } else if (prefix.length == 64 && Hex.isHex64(prefix)) {
-                        account.cache.getOrCreateUser(prefix)
-                    } else {
-                        null
+                        else -> {
+                            null
+                        }
                     }
                 } else {
                     null

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Attestation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Attestation.kt
@@ -331,60 +331,66 @@ fun RenderAttestationRequest(
     }
 
     if (quotesLeft > 0) {
-        if (aboutAddress != null) {
-            LoadAddressableNote(aboutAddress, accountViewModel) {
-                if (it != null) {
-                    Spacer(modifier = DoubleVertSpacer)
-                    Text(
-                        text = stringRes(R.string.attestation_requests_attestation_to),
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    NoteCompose(
-                        baseNote = it,
-                        modifier = MaterialTheme.colorScheme.replyModifier,
-                        isQuotedNote = true,
-                        unPackReply = ReplyRenderType.NONE,
-                        makeItShort = true,
-                        quotesLeft = quotesLeft - 1,
-                        parentBackgroundColor = backgroundColor,
-                        accountViewModel = accountViewModel,
-                        nav = nav,
-                    )
+        when {
+            aboutAddress != null -> {
+                LoadAddressableNote(aboutAddress, accountViewModel) {
+                    if (it != null) {
+                        Spacer(modifier = DoubleVertSpacer)
+                        Text(
+                            text = stringRes(R.string.attestation_requests_attestation_to),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        NoteCompose(
+                            baseNote = it,
+                            modifier = MaterialTheme.colorScheme.replyModifier,
+                            isQuotedNote = true,
+                            unPackReply = ReplyRenderType.NONE,
+                            makeItShort = true,
+                            quotesLeft = quotesLeft - 1,
+                            parentBackgroundColor = backgroundColor,
+                            accountViewModel = accountViewModel,
+                            nav = nav,
+                        )
+                    }
                 }
             }
-        } else if (aboutEvent != null) {
-            LoadNote(aboutEvent, accountViewModel) {
-                if (it != null) {
-                    Spacer(modifier = DoubleVertSpacer)
-                    Text(
-                        text = stringRes(R.string.attestation_requests_attestation_to),
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    NoteCompose(
-                        baseNote = it,
-                        modifier = MaterialTheme.colorScheme.replyModifier,
-                        isQuotedNote = true,
-                        unPackReply = ReplyRenderType.NONE,
-                        makeItShort = true,
-                        quotesLeft = quotesLeft - 1,
-                        parentBackgroundColor = backgroundColor,
-                        accountViewModel = accountViewModel,
-                        nav = nav,
-                    )
+
+            aboutEvent != null -> {
+                LoadNote(aboutEvent, accountViewModel) {
+                    if (it != null) {
+                        Spacer(modifier = DoubleVertSpacer)
+                        Text(
+                            text = stringRes(R.string.attestation_requests_attestation_to),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        NoteCompose(
+                            baseNote = it,
+                            modifier = MaterialTheme.colorScheme.replyModifier,
+                            isQuotedNote = true,
+                            unPackReply = ReplyRenderType.NONE,
+                            makeItShort = true,
+                            quotesLeft = quotesLeft - 1,
+                            parentBackgroundColor = backgroundColor,
+                            accountViewModel = accountViewModel,
+                            nav = nav,
+                        )
+                    }
                 }
             }
-        } else if (aboutPubkey != null) {
-            LoadUser(aboutPubkey, accountViewModel) {
-                if (it != null) {
-                    Spacer(modifier = DoubleVertSpacer)
-                    Text(
-                        text = stringRes(R.string.attestation_requests_attestation_to),
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    UserCompose(it, accountViewModel = accountViewModel, nav = nav)
+
+            aboutPubkey != null -> {
+                LoadUser(aboutPubkey, accountViewModel) {
+                    if (it != null) {
+                        Spacer(modifier = DoubleVertSpacer)
+                        Text(
+                            text = stringRes(R.string.attestation_requests_attestation_to),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        UserCompose(it, accountViewModel = accountViewModel, nav = nav)
+                    }
                 }
             }
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Highlight.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Highlight.kt
@@ -278,21 +278,29 @@ private fun DisplayQuoteAuthor(
         }
     }
 
-    if (addressable != null) {
-        addressable?.let {
-            DisplayEntryForNote(it, userBase, accountViewModel, nav)
+    when {
+        addressable != null -> {
+            addressable?.let {
+                DisplayEntryForNote(it, userBase, accountViewModel, nav)
+            }
         }
-    } else if (version != null) {
-        version?.let {
-            DisplayEntryForNote(it, userBase, accountViewModel, nav)
-        }
-    } else if (baseUrl != null) {
-        val url = "$baseUrl${if (baseUrl.contains("#")) "&" else "#"}:~:text=${Uri.encode(highlightQuote)}"
 
-        DisplayEntryForAUrl(url, userBase, accountViewModel, nav)
-    } else if (userBase != null) {
-        userBase?.let {
-            DisplayEntryForUser(it, accountViewModel, nav)
+        version != null -> {
+            version?.let {
+                DisplayEntryForNote(it, userBase, accountViewModel, nav)
+            }
+        }
+
+        baseUrl != null -> {
+            val url = "$baseUrl${if (baseUrl.contains("#")) "&" else "#"}:~:text=${Uri.encode(highlightQuote)}"
+
+            DisplayEntryForAUrl(url, userBase, accountViewModel, nav)
+        }
+
+        userBase != null -> {
+            userBase?.let {
+                DisplayEntryForUser(it, accountViewModel, nav)
+            }
         }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/MedicalData.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/MedicalData.kt
@@ -233,14 +233,11 @@ fun RenderEyeGlassesPrescription(
         val isContacts = contactsRightEye != null || contactsLeftEye != null
 
         Text(
-            if (isGlasses && isContacts) {
-                "Vision Prescription"
-            } else if (isGlasses) {
-                "Glasses Prescription"
-            } else if (isContacts) {
-                "Contact Lenses Prescription"
-            } else {
-                "Empty Prescription"
+            when {
+                isGlasses && isContacts -> "Vision Prescription"
+                isGlasses -> "Glasses Prescription"
+                isContacts -> "Contact Lenses Prescription"
+                else -> "Empty Prescription"
             },
             modifier = Modifier.padding(4.dp).fillMaxWidth(),
             textAlign = TextAlign.Center,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/AccountSessionManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/AccountSessionManager.kt
@@ -134,35 +134,45 @@ class AccountSessionManager(
         }
 
         val accountSettings =
-            if (loginWithExternalSigner) {
-                AccountSettings(
-                    keyPair = KeyPair(pubKey = pubKeyParsed),
-                    transientAccount = transientAccount,
-                    externalSignerPackageName = packageName.ifBlank { "com.greenart7c3.nostrsigner" },
-                )
-            } else if (key.startsWith("nsec")) {
-                val privHex =
-                    decodePrivateKeyAsHexOrNull(key)
-                        ?: throw Exception("Invalid nsec key")
-                AccountSettings(
-                    keyPair = KeyPair(privKey = privHex.hexToByteArray()),
-                    transientAccount = transientAccount,
-                )
-            } else if (key.contains(" ") && Nip06().isValidMnemonic(key)) {
-                AccountSettings(
-                    keyPair = KeyPair(privKey = Nip06().privateKeyFromMnemonic(key)),
-                    transientAccount = transientAccount,
-                )
-            } else if (pubKeyParsed != null) {
-                AccountSettings(
-                    keyPair = KeyPair(pubKey = pubKeyParsed),
-                    transientAccount = transientAccount,
-                )
-            } else {
-                AccountSettings(
-                    keyPair = KeyPair(Hex.decode(key)),
-                    transientAccount = transientAccount,
-                )
+            when {
+                loginWithExternalSigner -> {
+                    AccountSettings(
+                        keyPair = KeyPair(pubKey = pubKeyParsed),
+                        transientAccount = transientAccount,
+                        externalSignerPackageName = packageName.ifBlank { "com.greenart7c3.nostrsigner" },
+                    )
+                }
+
+                key.startsWith("nsec") -> {
+                    val privHex =
+                        decodePrivateKeyAsHexOrNull(key)
+                            ?: throw Exception("Invalid nsec key")
+                    AccountSettings(
+                        keyPair = KeyPair(privKey = privHex.hexToByteArray()),
+                        transientAccount = transientAccount,
+                    )
+                }
+
+                key.contains(" ") && Nip06().isValidMnemonic(key) -> {
+                    AccountSettings(
+                        keyPair = KeyPair(privKey = Nip06().privateKeyFromMnemonic(key)),
+                        transientAccount = transientAccount,
+                    )
+                }
+
+                pubKeyParsed != null -> {
+                    AccountSettings(
+                        keyPair = KeyPair(pubKey = pubKeyParsed),
+                        transientAccount = transientAccount,
+                    )
+                }
+
+                else -> {
+                    AccountSettings(
+                        keyPair = KeyPair(Hex.decode(key)),
+                        transientAccount = transientAccount,
+                    )
+                }
             }
 
         localPreferences.setDefaultAccount(accountSettings)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -1404,16 +1404,22 @@ class AccountViewModel(
         viewModelScope.launch(Dispatchers.IO) {
             for (note in notes) {
                 val noteEvent = note.event
-                if (noteEvent is IsInPublicChatChannel) {
-                    account.markAsRead("Channel/${noteEvent.channelId()}", noteEvent.createdAt)
-                } else if (noteEvent is ChatroomKeyable) {
-                    account.markAsRead("Room/${noteEvent.chatroomKey(account.signer.pubKey).hashCode()}", noteEvent.createdAt)
-                } else if (noteEvent is DraftWrapEvent) {
-                    val innerEvent = account.draftsDecryptionCache.preCachedDraft(noteEvent)
-                    if (innerEvent is IsInPublicChatChannel) {
-                        account.markAsRead("Channel/${innerEvent.channelId()}", noteEvent.createdAt)
-                    } else if (innerEvent is ChatroomKeyable) {
-                        account.markAsRead("Room/${innerEvent.chatroomKey(account.signer.pubKey).hashCode()}", noteEvent.createdAt)
+                when {
+                    noteEvent is IsInPublicChatChannel -> {
+                        account.markAsRead("Channel/${noteEvent.channelId()}", noteEvent.createdAt)
+                    }
+
+                    noteEvent is ChatroomKeyable -> {
+                        account.markAsRead("Room/${noteEvent.chatroomKey(account.signer.pubKey).hashCode()}", noteEvent.createdAt)
+                    }
+
+                    noteEvent is DraftWrapEvent -> {
+                        val innerEvent = account.draftsDecryptionCache.preCachedDraft(noteEvent)
+                        if (innerEvent is IsInPublicChatChannel) {
+                            account.markAsRead("Channel/${innerEvent.channelId()}", noteEvent.createdAt)
+                        } else if (innerEvent is ChatroomKeyable) {
+                            account.markAsRead("Room/${innerEvent.chatroomKey(account.signer.pubKey).hashCode()}", noteEvent.createdAt)
+                        }
                     }
                 }
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/feed/ChatMessageCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/feed/ChatMessageCompose.kt
@@ -172,15 +172,17 @@ fun NormalChatNote(
         remember(note) {
             derivedStateOf {
                 val noteEvent = note.event
-                if (accountViewModel.isLoggedUser(note.author)) {
-                    false // never shows the user's pictures
-                } else if (noteEvent is PrivateDmEvent) {
-                    false // one-on-one, never shows it.
-                } else if (noteEvent is ChatroomKeyable) {
+                when {
+                    accountViewModel.isLoggedUser(note.author) -> false
+
+                    // never shows the user's pictures
+                    noteEvent is PrivateDmEvent -> false
+
+                    // one-on-one, never shows it.
                     // only shows in a group chat.
-                    noteEvent.chatroomKey(accountViewModel.userProfile().pubkeyHex).users.size > 1
-                } else {
-                    true
+                    noteEvent is ChatroomKeyable -> noteEvent.chatroomKey(accountViewModel.userProfile().pubkeyHex).users.size > 1
+
+                    else -> true
                 }
             }
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/feed/layouts/ChatBubbleLayout.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/feed/layouts/ChatBubbleLayout.kt
@@ -145,10 +145,8 @@ fun ChatBubbleLayout(
             remember {
                 Modifier.combinedClickable(
                     onClick = {
-                        if (!onClick()) {
-                            if (!isComplete) {
-                                showDetails.value = !showDetails.value
-                            }
+                        if (!onClick() && !isComplete) {
+                            showDetails.value = !showDetails.value
                         }
                     },
                     onLongClick = { popupExpanded.value = true },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/ChatNewMessageViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/ChatNewMessageViewModel.kt
@@ -735,17 +735,25 @@ class ChatNewMessageViewModel :
 
     fun autocompleteWithUser(item: User) {
         userSuggestions?.let { userSuggestions ->
-            if (userSuggestionsMainMessage == UserSuggestionAnchor.MAIN_MESSAGE) {
-                val lastWord = message.currentWord()
-                userSuggestions.replaceCurrentWord(message, lastWord, item)
-                urlPreviews.update(message.text.toString())
-            } else if (userSuggestionsMainMessage == UserSuggestionAnchor.FORWARD_ZAPS) {
-                forwardZapTo.value.addItem(item)
-                forwardZapToEditting.value = TextFieldValue("")
-            } else if (userSuggestionsMainMessage == UserSuggestionAnchor.TO_USERS) {
-                val lastWord = toUsers.currentWord()
-                userSuggestions.replaceCurrentWord(toUsers, lastWord, item)
-                updateRoomFromUsersInput()
+            when (userSuggestionsMainMessage) {
+                UserSuggestionAnchor.MAIN_MESSAGE -> {
+                    val lastWord = message.currentWord()
+                    userSuggestions.replaceCurrentWord(message, lastWord, item)
+                    urlPreviews.update(message.text.toString())
+                }
+
+                UserSuggestionAnchor.FORWARD_ZAPS -> {
+                    forwardZapTo.value.addItem(item)
+                    forwardZapToEditting.value = TextFieldValue("")
+                }
+
+                UserSuggestionAnchor.TO_USERS -> {
+                    val lastWord = toUsers.currentWord()
+                    userSuggestions.replaceCurrentWord(toUsers, lastWord, item)
+                    updateRoomFromUsersInput()
+                }
+
+                else -> {}
             }
 
             userSuggestionsMainMessage = null

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/send/ChannelNewMessageViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/send/ChannelNewMessageViewModel.kt
@@ -415,112 +415,120 @@ open class ChannelNewMessageViewModel :
         val contentWarningReason = if (wantsToMarkAsSensitive) contentWarningDescription else null
         val localExpirationDate = if (wantsExpirationDate) expirationDate else null
 
-        return if (channel is PublicChatChannel) {
-            val replyingToEvent = replyTo.value?.toEventHint<ChannelMessageEvent>()
-            val channelEvent = channel.event
+        return when {
+            channel is PublicChatChannel -> {
+                val replyingToEvent = replyTo.value?.toEventHint<ChannelMessageEvent>()
+                val channelEvent = channel.event
 
-            if (replyingToEvent != null) {
-                ChannelMessageEvent.reply(tagger.message, replyingToEvent) {
-                    notify(replyingToEvent.toPTag())
+                if (replyingToEvent != null) {
+                    ChannelMessageEvent.reply(tagger.message, replyingToEvent) {
+                        notify(replyingToEvent.toPTag())
 
-                    hashtags(findHashtags(tagger.message))
-                    references(findURLs(tagger.message))
-                    quotes(findNostrUris(tagger.message))
-                    contentWarningReason?.let { contentWarning(it) }
-                    localExpirationDate?.let { expiration(it) }
+                        hashtags(findHashtags(tagger.message))
+                        references(findURLs(tagger.message))
+                        quotes(findNostrUris(tagger.message))
+                        contentWarningReason?.let { contentWarning(it) }
+                        localExpirationDate?.let { expiration(it) }
 
-                    geoHash?.let { geohash(it) }
+                        geoHash?.let { geohash(it) }
 
-                    emojis(emojis)
-                    imetas(usedAttachments)
+                        emojis(emojis)
+                        imetas(usedAttachments)
+                    }
+                } else if (channelEvent != null) {
+                    val hint = EventHintBundle(channelEvent, channelRelays.firstOrNull())
+                    ChannelMessageEvent.message(tagger.message, hint) {
+                        hashtags(findHashtags(tagger.message))
+                        references(findURLs(tagger.message))
+                        quotes(findNostrUris(tagger.message))
+                        contentWarningReason?.let { contentWarning(it) }
+                        localExpirationDate?.let { expiration(it) }
+
+                        geoHash?.let { geohash(it) }
+
+                        emojis(emojis)
+                        imetas(usedAttachments)
+                    }
+                } else {
+                    ChannelMessageEvent.message(tagger.message, ETag(channel.idHex, channelRelays.firstOrNull())) {
+                        hashtags(findHashtags(tagger.message))
+                        references(findURLs(tagger.message))
+                        quotes(findNostrUris(tagger.message))
+                        contentWarningReason?.let { contentWarning(it) }
+                        localExpirationDate?.let { expiration(it) }
+
+                        geoHash?.let { geohash(it) }
+
+                        emojis(emojis)
+                        imetas(usedAttachments)
+                    }
                 }
-            } else if (channelEvent != null) {
-                val hint = EventHintBundle(channelEvent, channelRelays.firstOrNull())
-                ChannelMessageEvent.message(tagger.message, hint) {
-                    hashtags(findHashtags(tagger.message))
-                    references(findURLs(tagger.message))
-                    quotes(findNostrUris(tagger.message))
-                    contentWarningReason?.let { contentWarning(it) }
-                    localExpirationDate?.let { expiration(it) }
+            }
 
-                    geoHash?.let { geohash(it) }
+            channel is LiveActivitiesChannel -> {
+                val replyingToEvent = replyTo.value?.toEventHint<LiveActivitiesChatMessageEvent>()
+                val activity = channel.info
 
-                    emojis(emojis)
-                    imetas(usedAttachments)
+                if (replyingToEvent != null) {
+                    LiveActivitiesChatMessageEvent.reply(tagger.message, replyingToEvent) {
+                        notify(replyingToEvent.toPTag())
+
+                        hashtags(findHashtags(tagger.message))
+                        references(findURLs(tagger.message))
+                        quotes(findNostrUris(tagger.message))
+                        contentWarningReason?.let { contentWarning(it) }
+                        localExpirationDate?.let { expiration(it) }
+
+                        emojis(emojis)
+                        imetas(usedAttachments)
+                    }
+                } else if (activity != null) {
+                    val hint = EventHintBundle(activity, channelRelays.firstOrNull())
+
+                    LiveActivitiesChatMessageEvent.message(tagger.message, hint) {
+                        hashtags(findHashtags(tagger.message))
+                        references(findURLs(tagger.message))
+                        quotes(findNostrUris(tagger.message))
+                        contentWarningReason?.let { contentWarning(it) }
+                        localExpirationDate?.let { expiration(it) }
+
+                        emojis(emojis)
+                        imetas(usedAttachments)
+                    }
+                } else {
+                    LiveActivitiesChatMessageEvent.message(tagger.message, channel.toATag()) {
+                        hashtags(findHashtags(tagger.message))
+                        references(findURLs(tagger.message))
+                        quotes(findNostrUris(tagger.message))
+                        contentWarningReason?.let { contentWarning(it) }
+                        localExpirationDate?.let { expiration(it) }
+
+                        emojis(emojis)
+                        imetas(usedAttachments)
+                    }
                 }
-            } else {
-                ChannelMessageEvent.message(tagger.message, ETag(channel.idHex, channelRelays.firstOrNull())) {
+            }
+
+            channel is EphemeralChatChannel -> {
+                EphemeralChatEvent.build(
+                    tagger.message,
+                    channel.roomId.relayUrl,
+                    channel.roomId.id,
+                ) {
                     hashtags(findHashtags(tagger.message))
                     references(findURLs(tagger.message))
                     quotes(findNostrUris(tagger.message))
                     contentWarningReason?.let { contentWarning(it) }
                     localExpirationDate?.let { expiration(it) }
-
-                    geoHash?.let { geohash(it) }
 
                     emojis(emojis)
                     imetas(usedAttachments)
                 }
             }
-        } else if (channel is LiveActivitiesChannel) {
-            val replyingToEvent = replyTo.value?.toEventHint<LiveActivitiesChatMessageEvent>()
-            val activity = channel.info
 
-            if (replyingToEvent != null) {
-                LiveActivitiesChatMessageEvent.reply(tagger.message, replyingToEvent) {
-                    notify(replyingToEvent.toPTag())
-
-                    hashtags(findHashtags(tagger.message))
-                    references(findURLs(tagger.message))
-                    quotes(findNostrUris(tagger.message))
-                    contentWarningReason?.let { contentWarning(it) }
-                    localExpirationDate?.let { expiration(it) }
-
-                    emojis(emojis)
-                    imetas(usedAttachments)
-                }
-            } else if (activity != null) {
-                val hint = EventHintBundle(activity, channelRelays.firstOrNull())
-
-                LiveActivitiesChatMessageEvent.message(tagger.message, hint) {
-                    hashtags(findHashtags(tagger.message))
-                    references(findURLs(tagger.message))
-                    quotes(findNostrUris(tagger.message))
-                    contentWarningReason?.let { contentWarning(it) }
-                    localExpirationDate?.let { expiration(it) }
-
-                    emojis(emojis)
-                    imetas(usedAttachments)
-                }
-            } else {
-                LiveActivitiesChatMessageEvent.message(tagger.message, channel.toATag()) {
-                    hashtags(findHashtags(tagger.message))
-                    references(findURLs(tagger.message))
-                    quotes(findNostrUris(tagger.message))
-                    contentWarningReason?.let { contentWarning(it) }
-                    localExpirationDate?.let { expiration(it) }
-
-                    emojis(emojis)
-                    imetas(usedAttachments)
-                }
+            else -> {
+                null
             }
-        } else if (channel is EphemeralChatChannel) {
-            EphemeralChatEvent.build(
-                tagger.message,
-                channel.roomId.relayUrl,
-                channel.roomId.id,
-            ) {
-                hashtags(findHashtags(tagger.message))
-                references(findURLs(tagger.message))
-                quotes(findNostrUris(tagger.message))
-                contentWarningReason?.let { contentWarning(it) }
-                localExpirationDate?.let { expiration(it) }
-
-                emojis(emojis)
-                imetas(usedAttachments)
-            }
-        } else {
-            null
         }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/dal/ChatroomListKnownFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/dal/ChatroomListKnownFeedFilter.kt
@@ -184,16 +184,14 @@ class ChatroomListKnownFeedFilter(
         newItems
             .forEach { newNote ->
                 val channelId = (newNote.event as? ChannelMessageEvent)?.channelId()
-                if (channelId != null) {
-                    if (channelId in followingChannels && account.isAcceptable(newNote)) {
-                        val lastNote = newRelevantPublicMessages.get(channelId)
-                        if (lastNote != null) {
-                            if ((newNote.createdAt() ?: 0L) > (lastNote.createdAt() ?: 0L)) {
-                                newRelevantPublicMessages.put(channelId, newNote)
-                            }
-                        } else {
+                if (channelId != null && channelId in followingChannels && account.isAcceptable(newNote)) {
+                    val lastNote = newRelevantPublicMessages.get(channelId)
+                    if (lastNote != null) {
+                        if ((newNote.createdAt() ?: 0L) > (lastNote.createdAt() ?: 0L)) {
                             newRelevantPublicMessages.put(channelId, newNote)
                         }
+                    } else {
+                        newRelevantPublicMessages.put(channelId, newNote)
                     }
                 }
             }
@@ -239,23 +237,21 @@ class ChatroomListKnownFeedFilter(
                 val roomKey = (newNote.event as? ChatroomKeyable)?.chatroomKey(me.pubkeyHex)
                 if (roomKey != null) {
                     val room = account.chatroomList.rooms.get(roomKey)
-                    if (room != null) {
-                        if (
-                            (
-                                newNote.author?.pubkeyHex == me.pubkeyHex ||
-                                    room.senderIntersects(followingKeySet) ||
-                                    account.chatroomList.hasSentMessagesTo(roomKey)
-                            ) &&
-                            !account.isAllHidden(roomKey.users)
-                        ) {
-                            val lastNote = newRelevantPrivateMessages.get(roomKey)
-                            if (lastNote != null) {
-                                if ((newNote.createdAt() ?: 0L) > (lastNote.createdAt() ?: 0L)) {
-                                    newRelevantPrivateMessages.put(roomKey, newNote)
-                                }
-                            } else {
+                    if (room != null &&
+                        (
+                            newNote.author?.pubkeyHex == me.pubkeyHex ||
+                                room.senderIntersects(followingKeySet) ||
+                                account.chatroomList.hasSentMessagesTo(roomKey)
+                        ) &&
+                        !account.isAllHidden(roomKey.users)
+                    ) {
+                        val lastNote = newRelevantPrivateMessages.get(roomKey)
+                        if (lastNote != null) {
+                            if ((newNote.createdAt() ?: 0L) > (lastNote.createdAt() ?: 0L)) {
                                 newRelevantPrivateMessages.put(roomKey, newNote)
                             }
+                        } else {
+                            newRelevantPrivateMessages.put(roomKey, newNote)
                         }
                     }
                 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip90DVMs/DVMCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip90DVMs/DVMCard.kt
@@ -140,18 +140,26 @@ fun RenderContentDVMThumb(
             card.amount?.let {
                 var color = Color.DarkGray
                 var amount = it
-                if (card.amount == "free" || card.amount == "0") {
-                    color = MaterialTheme.colorScheme.secondary
-                    amount = "Free"
-                } else if (card.amount == "flexible") {
-                    color = MaterialTheme.colorScheme.primaryContainer
-                    amount = "Flexible"
-                } else if (card.amount == "") {
-                    color = MaterialTheme.colorScheme.grayText
-                    amount = "Unknown"
-                } else {
-                    color = MaterialTheme.colorScheme.primary
-                    amount = card.amount + " Sats"
+                when {
+                    card.amount == "free" || card.amount == "0" -> {
+                        color = MaterialTheme.colorScheme.secondary
+                        amount = "Free"
+                    }
+
+                    card.amount == "flexible" -> {
+                        color = MaterialTheme.colorScheme.primaryContainer
+                        amount = "Flexible"
+                    }
+
+                    card.amount == "" -> {
+                        color = MaterialTheme.colorScheme.grayText
+                        amount = "Unknown"
+                    }
+
+                    else -> {
+                        color = MaterialTheme.colorScheme.primary
+                        amount = card.amount + " Sats"
+                    }
                 }
                 Text(
                     textAlign = TextAlign.End,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/dal/HomeLiveFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/dal/HomeLiveFilter.kt
@@ -287,10 +287,8 @@ class HomeLiveFilter(
 
         channel.notes.forEach { _, value ->
             val author = value.author
-            if (author != null) {
-                if (followingSet == null || author.pubkeyHex in followingSet) {
-                    count++
-                }
+            if (author != null && (followingSet == null || author.pubkeyHex in followingSet)) {
+                count++
             }
         }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationSummaryState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationSummaryState.kt
@@ -117,21 +117,22 @@ class NotificationSummaryState(
                         zaps[netDate] = (zaps[netDate] ?: BigDecimal.ZERO) + (noteEvent.amount ?: BigDecimal.ZERO)
                         takenIntoAccount.add(noteEvent.id)
                     }
-                } else if (noteEvent is BaseThreadedEvent) {
-                    if (noteEvent.isTaggedUser(currentUser) && noteEvent.pubKey != currentUser) {
-                        val isCitation =
-                            noteEvent.findCitations().any {
-                                LocalCache.getNoteIfExists(it)?.author?.pubkeyHex == currentUser
-                            }
-
-                        val netDate = formatDate(noteEvent.createdAt)
-                        if (isCitation) {
-                            boosts[netDate] = (boosts[netDate] ?: 0) + 1
-                        } else {
-                            replies[netDate] = (replies[netDate] ?: 0) + 1
+                } else if (noteEvent is BaseThreadedEvent &&
+                    noteEvent.isTaggedUser(currentUser) &&
+                    noteEvent.pubKey != currentUser
+                ) {
+                    val isCitation =
+                        noteEvent.findCitations().any {
+                            LocalCache.getNoteIfExists(it)?.author?.pubkeyHex == currentUser
                         }
-                        takenIntoAccount.add(noteEvent.id)
+
+                    val netDate = formatDate(noteEvent.createdAt)
+                    if (isCitation) {
+                        boosts[netDate] = (boosts[netDate] ?: 0) + 1
+                    } else {
+                        replies[netDate] = (replies[netDate] ?: 0) + 1
                     }
+                    takenIntoAccount.add(noteEvent.id)
                 }
             }
         }
@@ -183,22 +184,23 @@ class NotificationSummaryState(
                             takenIntoAccount.add(noteEvent.id)
                             hasNewElements = true
                         }
-                    } else if (noteEvent is BaseThreadedEvent) {
-                        if (noteEvent.isTaggedUser(currentUser) && noteEvent.pubKey != currentUser) {
-                            val isCitation =
-                                noteEvent.findCitations().any {
-                                    LocalCache.getNoteIfExists(it)?.author?.pubkeyHex == currentUser
-                                }
-
-                            val netDate = formatDate(noteEvent.createdAt)
-                            if (isCitation) {
-                                boosts[netDate] = (boosts[netDate] ?: 0) + 1
-                            } else {
-                                replies[netDate] = (replies[netDate] ?: 0) + 1
+                    } else if (noteEvent is BaseThreadedEvent &&
+                        noteEvent.isTaggedUser(currentUser) &&
+                        noteEvent.pubKey != currentUser
+                    ) {
+                        val isCitation =
+                            noteEvent.findCitations().any {
+                                LocalCache.getNoteIfExists(it)?.author?.pubkeyHex == currentUser
                             }
-                            takenIntoAccount.add(noteEvent.id)
-                            hasNewElements = true
+
+                        val netDate = formatDate(noteEvent.createdAt)
+                        if (isCitation) {
+                            boosts[netDate] = (boosts[netDate] ?: 0) + 1
+                        } else {
+                            replies[netDate] = (replies[netDate] ?: 0) + 1
                         }
+                        takenIntoAccount.add(noteEvent.id)
+                        hasNewElements = true
                     }
                 }
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationSummaryState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationSummaryState.kt
@@ -98,41 +98,48 @@ class NotificationSummaryState(
         LocalCache.notes.forEach { _, it ->
             val noteEvent = it.event
             if (noteEvent != null && !takenIntoAccount.contains(noteEvent.id)) {
-                if (noteEvent is ReactionEvent) {
-                    if (noteEvent.isTaggedUser(currentUser) && noteEvent.pubKey != currentUser) {
-                        val netDate = formatDate(noteEvent.createdAt)
-                        reactions[netDate] = (reactions[netDate] ?: 0) + 1
-                        takenIntoAccount.add(noteEvent.id)
-                    }
-                } else if (noteEvent is RepostEvent || noteEvent is GenericRepostEvent) {
-                    if (noteEvent.isTaggedUser(currentUser) && noteEvent.pubKey != currentUser) {
-                        val netDate = formatDate(noteEvent.createdAt)
-                        boosts[netDate] = (boosts[netDate] ?: 0) + 1
-                        takenIntoAccount.add(noteEvent.id)
-                    }
-                } else if (noteEvent is LnZapEvent) {
-                    // the user might be sending his own receipts noteEvent.pubKey != currentUser
-                    if (noteEvent.isTaggedUser(currentUser)) {
-                        val netDate = formatDate(noteEvent.createdAt)
-                        zaps[netDate] = (zaps[netDate] ?: BigDecimal.ZERO) + (noteEvent.amount ?: BigDecimal.ZERO)
-                        takenIntoAccount.add(noteEvent.id)
-                    }
-                } else if (noteEvent is BaseThreadedEvent &&
-                    noteEvent.isTaggedUser(currentUser) &&
-                    noteEvent.pubKey != currentUser
-                ) {
-                    val isCitation =
-                        noteEvent.findCitations().any {
-                            LocalCache.getNoteIfExists(it)?.author?.pubkeyHex == currentUser
+                when {
+                    noteEvent is ReactionEvent -> {
+                        if (noteEvent.isTaggedUser(currentUser) && noteEvent.pubKey != currentUser) {
+                            val netDate = formatDate(noteEvent.createdAt)
+                            reactions[netDate] = (reactions[netDate] ?: 0) + 1
+                            takenIntoAccount.add(noteEvent.id)
                         }
-
-                    val netDate = formatDate(noteEvent.createdAt)
-                    if (isCitation) {
-                        boosts[netDate] = (boosts[netDate] ?: 0) + 1
-                    } else {
-                        replies[netDate] = (replies[netDate] ?: 0) + 1
                     }
-                    takenIntoAccount.add(noteEvent.id)
+
+                    noteEvent is RepostEvent || noteEvent is GenericRepostEvent -> {
+                        if (noteEvent.isTaggedUser(currentUser) && noteEvent.pubKey != currentUser) {
+                            val netDate = formatDate(noteEvent.createdAt)
+                            boosts[netDate] = (boosts[netDate] ?: 0) + 1
+                            takenIntoAccount.add(noteEvent.id)
+                        }
+                    }
+
+                    noteEvent is LnZapEvent -> {
+                        // the user might be sending his own receipts noteEvent.pubKey != currentUser
+                        if (noteEvent.isTaggedUser(currentUser)) {
+                            val netDate = formatDate(noteEvent.createdAt)
+                            zaps[netDate] = (zaps[netDate] ?: BigDecimal.ZERO) + (noteEvent.amount ?: BigDecimal.ZERO)
+                            takenIntoAccount.add(noteEvent.id)
+                        }
+                    }
+
+                    noteEvent is BaseThreadedEvent &&
+                        noteEvent.isTaggedUser(currentUser) &&
+                        noteEvent.pubKey != currentUser -> {
+                        val isCitation =
+                            noteEvent.findCitations().any {
+                                LocalCache.getNoteIfExists(it)?.author?.pubkeyHex == currentUser
+                            }
+
+                        val netDate = formatDate(noteEvent.createdAt)
+                        if (isCitation) {
+                            boosts[netDate] = (boosts[netDate] ?: 0) + 1
+                        } else {
+                            replies[netDate] = (replies[netDate] ?: 0) + 1
+                        }
+                        takenIntoAccount.add(noteEvent.id)
+                    }
                 }
             }
         }
@@ -162,45 +169,52 @@ class NotificationSummaryState(
             newNotes.forEach {
                 val noteEvent = it.event
                 if (noteEvent != null && !takenIntoAccount.contains(noteEvent.id)) {
-                    if (noteEvent is ReactionEvent) {
-                        if (noteEvent.isTaggedUser(currentUser) && noteEvent.pubKey != currentUser) {
-                            val netDate = formatDate(noteEvent.createdAt)
-                            reactions[netDate] = (reactions[netDate] ?: 0) + 1
-                            takenIntoAccount.add(noteEvent.id)
-                            hasNewElements = true
-                        }
-                    } else if (noteEvent is RepostEvent || noteEvent is GenericRepostEvent) {
-                        if (noteEvent.isTaggedUser(currentUser) && noteEvent.pubKey != currentUser) {
-                            val netDate = formatDate(noteEvent.createdAt)
-                            boosts[netDate] = (boosts[netDate] ?: 0) + 1
-                            takenIntoAccount.add(noteEvent.id)
-                            hasNewElements = true
-                        }
-                    } else if (noteEvent is LnZapEvent) {
-                        if (noteEvent.isTaggedUser(currentUser)) {
-                            //  && noteEvent.pubKey != currentUser User might be sending his own receipts
-                            val netDate = formatDate(noteEvent.createdAt)
-                            zaps[netDate] = (zaps[netDate] ?: BigDecimal.ZERO) + (noteEvent.amount ?: BigDecimal.ZERO)
-                            takenIntoAccount.add(noteEvent.id)
-                            hasNewElements = true
-                        }
-                    } else if (noteEvent is BaseThreadedEvent &&
-                        noteEvent.isTaggedUser(currentUser) &&
-                        noteEvent.pubKey != currentUser
-                    ) {
-                        val isCitation =
-                            noteEvent.findCitations().any {
-                                LocalCache.getNoteIfExists(it)?.author?.pubkeyHex == currentUser
+                    when {
+                        noteEvent is ReactionEvent -> {
+                            if (noteEvent.isTaggedUser(currentUser) && noteEvent.pubKey != currentUser) {
+                                val netDate = formatDate(noteEvent.createdAt)
+                                reactions[netDate] = (reactions[netDate] ?: 0) + 1
+                                takenIntoAccount.add(noteEvent.id)
+                                hasNewElements = true
                             }
-
-                        val netDate = formatDate(noteEvent.createdAt)
-                        if (isCitation) {
-                            boosts[netDate] = (boosts[netDate] ?: 0) + 1
-                        } else {
-                            replies[netDate] = (replies[netDate] ?: 0) + 1
                         }
-                        takenIntoAccount.add(noteEvent.id)
-                        hasNewElements = true
+
+                        noteEvent is RepostEvent || noteEvent is GenericRepostEvent -> {
+                            if (noteEvent.isTaggedUser(currentUser) && noteEvent.pubKey != currentUser) {
+                                val netDate = formatDate(noteEvent.createdAt)
+                                boosts[netDate] = (boosts[netDate] ?: 0) + 1
+                                takenIntoAccount.add(noteEvent.id)
+                                hasNewElements = true
+                            }
+                        }
+
+                        noteEvent is LnZapEvent -> {
+                            if (noteEvent.isTaggedUser(currentUser)) {
+                                //  && noteEvent.pubKey != currentUser User might be sending his own receipts
+                                val netDate = formatDate(noteEvent.createdAt)
+                                zaps[netDate] = (zaps[netDate] ?: BigDecimal.ZERO) + (noteEvent.amount ?: BigDecimal.ZERO)
+                                takenIntoAccount.add(noteEvent.id)
+                                hasNewElements = true
+                            }
+                        }
+
+                        noteEvent is BaseThreadedEvent &&
+                            noteEvent.isTaggedUser(currentUser) &&
+                            noteEvent.pubKey != currentUser -> {
+                            val isCitation =
+                                noteEvent.findCitations().any {
+                                    LocalCache.getNoteIfExists(it)?.author?.pubkeyHex == currentUser
+                                }
+
+                            val netDate = formatDate(noteEvent.createdAt)
+                            if (isCitation) {
+                                boosts[netDate] = (boosts[netDate] ?: 0) + 1
+                            } else {
+                                replies[netDate] = (replies[netDate] ?: 0) + 1
+                            }
+                            takenIntoAccount.add(noteEvent.id)
+                            hasNewElements = true
+                        }
                     }
                 }
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/publicMessages/NewPublicMessageViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/publicMessages/NewPublicMessageViewModel.kt
@@ -598,16 +598,24 @@ class NewPublicMessageViewModel :
 
     fun autocompleteWithUser(item: User) {
         userSuggestions?.let { userSuggestions ->
-            if (userSuggestionsMainMessage == UserSuggestionAnchor.MAIN_MESSAGE) {
-                val lastWord = message.currentWord()
-                userSuggestions.replaceCurrentWord(message, lastWord, item)
-                urlPreviews.update(message.text.toString())
-            } else if (userSuggestionsMainMessage == UserSuggestionAnchor.FORWARD_ZAPS) {
-                forwardZapTo.value.addItem(item)
-                forwardZapToEditting.value = TextFieldValue("")
-            } else if (userSuggestionsMainMessage == UserSuggestionAnchor.TO_USERS) {
-                val lastWord = toUsers.currentWord()
-                userSuggestions.replaceCurrentWord(toUsers, lastWord, item)
+            when (userSuggestionsMainMessage) {
+                UserSuggestionAnchor.MAIN_MESSAGE -> {
+                    val lastWord = message.currentWord()
+                    userSuggestions.replaceCurrentWord(message, lastWord, item)
+                    urlPreviews.update(message.text.toString())
+                }
+
+                UserSuggestionAnchor.FORWARD_ZAPS -> {
+                    forwardZapTo.value.addItem(item)
+                    forwardZapToEditting.value = TextFieldValue("")
+                }
+
+                UserSuggestionAnchor.TO_USERS -> {
+                    val lastWord = toUsers.currentWord()
+                    userSuggestions.replaceCurrentWord(toUsers, lastWord, item)
+                }
+
+                else -> {}
             }
 
             userSuggestionsMainMessage = null

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/gallery/GalleryThumb.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/gallery/GalleryThumb.kt
@@ -79,100 +79,110 @@ fun GalleryThumbnail(
     val noteEvent = noteState.note.event ?: return
 
     val content =
-        if (noteEvent is ProfileGalleryEntryEvent) {
-            noteEvent.urls().map { url ->
-                if (isVideoUrl(url)) {
-                    MediaUrlVideo(
-                        url = url,
-                        description = noteEvent.content,
-                        hash = null,
-                        blurhash = noteEvent.blurhash(),
-                        dim = noteEvent.dimensions(),
-                        uri = null,
-                        mimeType = noteEvent.mimeType(),
-                        thumbhash = noteEvent.thumbhash(),
-                        artworkUri = noteEvent.image()?.imageUrl ?: noteEvent.thumb()?.imageUrl,
-                    )
-                } else {
+        when {
+            noteEvent is ProfileGalleryEntryEvent -> {
+                noteEvent.urls().map { url ->
+                    if (isVideoUrl(url)) {
+                        MediaUrlVideo(
+                            url = url,
+                            description = noteEvent.content,
+                            hash = null,
+                            blurhash = noteEvent.blurhash(),
+                            dim = noteEvent.dimensions(),
+                            uri = null,
+                            mimeType = noteEvent.mimeType(),
+                            thumbhash = noteEvent.thumbhash(),
+                            artworkUri = noteEvent.image()?.imageUrl ?: noteEvent.thumb()?.imageUrl,
+                        )
+                    } else {
+                        MediaUrlImage(
+                            url = url,
+                            description = noteEvent.content,
+                            // We don't want to show the hash banner here
+                            hash = null,
+                            blurhash = noteEvent.blurhash(),
+                            dim = noteEvent.dimensions(),
+                            uri = null,
+                            mimeType = noteEvent.mimeType(),
+                            thumbhash = noteEvent.thumbhash(),
+                        )
+                    }
+                }
+            }
+
+            noteEvent is PictureEvent -> {
+                noteEvent.imetaTags().map { imeta ->
                     MediaUrlImage(
-                        url = url,
+                        url = imeta.url,
                         description = noteEvent.content,
                         // We don't want to show the hash banner here
                         hash = null,
-                        blurhash = noteEvent.blurhash(),
-                        dim = noteEvent.dimensions(),
+                        blurhash = imeta.blurhash,
+                        dim = imeta.dimension,
                         uri = null,
-                        mimeType = noteEvent.mimeType(),
-                        thumbhash = noteEvent.thumbhash(),
+                        mimeType = imeta.mimeType,
+                        thumbhash = imeta.thumbhash,
                     )
                 }
             }
-        } else if (noteEvent is PictureEvent) {
-            noteEvent.imetaTags().map { imeta ->
-                MediaUrlImage(
-                    url = imeta.url,
-                    description = noteEvent.content,
-                    // We don't want to show the hash banner here
-                    hash = null,
-                    blurhash = imeta.blurhash,
-                    dim = imeta.dimension,
-                    uri = null,
-                    mimeType = imeta.mimeType,
-                    thumbhash = imeta.thumbhash,
-                )
-            }
-        } else if (noteEvent is VideoEvent) {
-            // An HLS publish writes one imeta per rendition (master + each variant) on the same
-            // NIP-71 event. Rendering them all expands a single video into a sub-grid of black
-            // tiles inside one gallery card — the .m3u8 playlist is a text manifest Coil can't
-            // decode. Collapse to a single tile when every imeta is an HLS playlist; prefer an
-            // imeta that carries a poster image, breaking ties by smallest dimensions so we
-            // pick the lowest-resolution variant. Non-HLS multi-imeta videos keep the existing
-            // per-imeta layout.
-            val imetas = noteEvent.imetaTags()
-            val isAllHls = imetas.isNotEmpty() && imetas.all { isHlsMimeType(it.mimeType) }
-            val toRender =
-                if (isAllHls) {
-                    val withPoster = imetas.filter { it.image.isNotEmpty() }
-                    val pick =
-                        withPoster.ifEmpty { imetas }.minBy {
-                            it.dimension?.let { d -> d.width * d.height } ?: Int.MAX_VALUE
-                        }
-                    listOf(pick)
-                } else {
-                    imetas
-                }
-            toRender.map { imeta ->
-                MediaUrlVideo(
-                    url = imeta.url,
-                    description = noteEvent.content,
-                    // We don't want to show the hash banner here
-                    hash = null,
-                    blurhash = imeta.blurhash,
-                    dim = imeta.dimension,
-                    uri = null,
-                    mimeType = imeta.mimeType,
-                    thumbhash = imeta.thumbhash,
-                    artworkUri = imeta.image.firstOrNull(),
-                )
-            }
-        } else if (noteEvent is LiveActivitiesClipEvent) {
-            noteEvent.videoUrl()?.let { url ->
-                listOf(
+
+            noteEvent is VideoEvent -> {
+                // An HLS publish writes one imeta per rendition (master + each variant) on the same
+                // NIP-71 event. Rendering them all expands a single video into a sub-grid of black
+                // tiles inside one gallery card — the .m3u8 playlist is a text manifest Coil can't
+                // decode. Collapse to a single tile when every imeta is an HLS playlist; prefer an
+                // imeta that carries a poster image, breaking ties by smallest dimensions so we
+                // pick the lowest-resolution variant. Non-HLS multi-imeta videos keep the existing
+                // per-imeta layout.
+                val imetas = noteEvent.imetaTags()
+                val isAllHls = imetas.isNotEmpty() && imetas.all { isHlsMimeType(it.mimeType) }
+                val toRender =
+                    if (isAllHls) {
+                        val withPoster = imetas.filter { it.image.isNotEmpty() }
+                        val pick =
+                            withPoster.ifEmpty { imetas }.minBy {
+                                it.dimension?.let { d -> d.width * d.height } ?: Int.MAX_VALUE
+                            }
+                        listOf(pick)
+                    } else {
+                        imetas
+                    }
+                toRender.map { imeta ->
                     MediaUrlVideo(
-                        url = url,
-                        description = noteEvent.title() ?: noteEvent.content,
+                        url = imeta.url,
+                        description = noteEvent.content,
+                        // We don't want to show the hash banner here
                         hash = null,
-                        blurhash = null,
-                        dim = null,
+                        blurhash = imeta.blurhash,
+                        dim = imeta.dimension,
                         uri = null,
-                        mimeType = null,
-                        thumbhash = null,
-                    ),
-                )
-            } ?: emptyList()
-        } else {
-            emptyList()
+                        mimeType = imeta.mimeType,
+                        thumbhash = imeta.thumbhash,
+                        artworkUri = imeta.image.firstOrNull(),
+                    )
+                }
+            }
+
+            noteEvent is LiveActivitiesClipEvent -> {
+                noteEvent.videoUrl()?.let { url ->
+                    listOf(
+                        MediaUrlVideo(
+                            url = url,
+                            description = noteEvent.title() ?: noteEvent.content,
+                            hash = null,
+                            blurhash = null,
+                            dim = null,
+                            uri = null,
+                            mimeType = null,
+                            thumbhash = null,
+                        ),
+                    )
+                } ?: emptyList()
+            }
+
+            else -> {
+                emptyList()
+            }
         }
 
     InnerRenderGalleryThumb(content, baseNote, accountViewModel)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/gallery/QuickActionGallery.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/gallery/QuickActionGallery.kt
@@ -40,14 +40,12 @@ fun QuickActionGallery(
 
     content { popupExpanded.value = true }
 
-    if (popupExpanded.value) {
-        if (baseNote.author == accountViewModel.account.userProfile()) {
-            DeleteFromGalleryDialog(
-                note = baseNote,
-                onDismiss = { popupExpanded.value = false },
-                accountViewModel = accountViewModel,
-            )
-        }
+    if (popupExpanded.value && baseNote.author == accountViewModel.account.userProfile()) {
+        DeleteFromGalleryDialog(
+            note = baseNote,
+            onDismiss = { popupExpanded.value = false },
+            accountViewModel = accountViewModel,
+        )
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/apps/UserProfileAppRecommendationsFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/apps/UserProfileAppRecommendationsFeedFilter.kt
@@ -48,10 +48,8 @@ class UserProfileAppRecommendationsFeedFilter(
 
     fun filterMap(it: Note): List<Note>? {
         val noteEvent = it.event
-        if (noteEvent is AppRecommendationEvent) {
-            if (noteEvent.pubKey == user.pubkeyHex) {
-                return noteEvent.recommendations().map { LocalCache.getOrCreateAddressableNote(it.address) }
-            }
+        if (noteEvent is AppRecommendationEvent && noteEvent.pubKey == user.pubkeyHex) {
+            return noteEvent.recommendations().map { LocalCache.getOrCreateAddressableNote(it.address) }
         }
 
         return null

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/search/SearchBarViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/search/SearchBarViewModel.kt
@@ -125,50 +125,58 @@ class SearchBarViewModel(
                     } else {
                         null
                     }
-                if (nip05 != null) {
-                    runCatching {
-                        nip05Client.get(nip05)?.let { info ->
-                            val user = account.cache.checkGetOrCreateUser(info.pubkey)
-                            if (user != null) {
-                                info.relays.forEach {
-                                    it.normalizeRelayUrlOrNull()?.let { relay ->
-                                        account.cache.relayHints.addKey(user.pubkey(), relay)
+                when {
+                    nip05 != null -> {
+                        runCatching {
+                            nip05Client.get(nip05)?.let { info ->
+                                val user = account.cache.checkGetOrCreateUser(info.pubkey)
+                                if (user != null) {
+                                    info.relays.forEach {
+                                        it.normalizeRelayUrlOrNull()?.let { relay ->
+                                            account.cache.relayHints.addKey(user.pubkey(), relay)
+                                        }
+                                    }
+                                }
+                                user
+                            }
+                        }.getOrNull()
+                    }
+
+                    term.startsWithAny(userUriPrefixes) -> {
+                        runCatching {
+                            Nip19Parser.uriToRoute(term)?.entity?.let { parsed ->
+                                when (parsed) {
+                                    is NSec -> {
+                                        account.cache.getOrCreateUser(parsed.toPubKey().toHexKey())
+                                    }
+
+                                    is NPub -> {
+                                        account.cache.getOrCreateUser(parsed.hex)
+                                    }
+
+                                    is NProfile -> {
+                                        val user = account.cache.getOrCreateUser(parsed.hex)
+                                        parsed.relay.forEach { relay ->
+                                            account.cache.relayHints.addKey(user.pubkey(), relay)
+                                        }
+                                        user
+                                    }
+
+                                    else -> {
+                                        null
                                     }
                                 }
                             }
-                            user
-                        }
-                    }.getOrNull()
-                } else if (term.startsWithAny(userUriPrefixes)) {
-                    runCatching {
-                        Nip19Parser.uriToRoute(term)?.entity?.let { parsed ->
-                            when (parsed) {
-                                is NSec -> {
-                                    account.cache.getOrCreateUser(parsed.toPubKey().toHexKey())
-                                }
+                        }.getOrNull()
+                    }
 
-                                is NPub -> {
-                                    account.cache.getOrCreateUser(parsed.hex)
-                                }
+                    term.length == 64 && Hex.isHex64(term) -> {
+                        account.cache.getOrCreateUser(term)
+                    }
 
-                                is NProfile -> {
-                                    val user = account.cache.getOrCreateUser(parsed.hex)
-                                    parsed.relay.forEach { relay ->
-                                        account.cache.relayHints.addKey(user.pubkey(), relay)
-                                    }
-                                    user
-                                }
-
-                                else -> {
-                                    null
-                                }
-                            }
-                        }
-                    }.getOrNull()
-                } else if (term.length == 64 && Hex.isHex64(term)) {
-                    account.cache.getOrCreateUser(term)
-                } else {
-                    null
+                    else -> {
+                        null
+                    }
                 }
             }.flowOn(Dispatchers.IO)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AppSettingsScreen.kt
@@ -151,10 +151,8 @@ fun Context.getLocaleListFromXml(): LocaleListCompat {
     try {
         val xpp: XmlPullParser = resources.getXml(R.xml.locales_config)
         while (xpp.eventType != XmlPullParser.END_DOCUMENT) {
-            if (xpp.eventType == XmlPullParser.START_TAG) {
-                if (xpp.name == "locale") {
-                    tagsList.add(xpp.getAttributeValue(0))
-                }
+            if (xpp.eventType == XmlPullParser.START_TAG && xpp.name == "locale") {
+                tagsList.add(xpp.getAttributeValue(0))
             }
             xpp.next()
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/VideoScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/video/VideoScreen.kt
@@ -168,34 +168,40 @@ fun VideoFeedLoaded(
             key = { _, item -> item.idHex },
             contentType = { _, item -> item.event?.kind ?: -1 },
         ) { _, item ->
-            if (item.event is PictureEvent) {
-                PictureCardCompose(
-                    baseNote = item,
-                    accountViewModel = accountViewModel,
-                    nav = nav,
-                )
+            when {
+                item.event is PictureEvent -> {
+                    PictureCardCompose(
+                        baseNote = item,
+                        accountViewModel = accountViewModel,
+                        nav = nav,
+                    )
 
-                HorizontalDivider(
-                    thickness = DividerThickness,
-                )
+                    HorizontalDivider(
+                        thickness = DividerThickness,
+                    )
 
-                Spacer(modifier = Modifier.height(8.dp))
-            } else if (item.event is VideoEvent) {
-                VideoCardCompose(item, accountViewModel, nav)
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
 
-                HorizontalDivider(
-                    thickness = DividerThickness,
-                )
+                item.event is VideoEvent -> {
+                    VideoCardCompose(item, accountViewModel, nav)
 
-                Spacer(modifier = Modifier.height(8.dp))
-            } else if (item.event is FileHeaderEvent) {
-                FileHeaderCardCompose(item, accountViewModel, nav)
+                    HorizontalDivider(
+                        thickness = DividerThickness,
+                    )
 
-                HorizontalDivider(
-                    thickness = DividerThickness,
-                )
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
 
-                Spacer(modifier = Modifier.height(8.dp))
+                item.event is FileHeaderEvent -> {
+                    FileHeaderCardCompose(item, accountViewModel, nav)
+
+                    HorizontalDivider(
+                        thickness = DividerThickness,
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
             }
         }
     }

--- a/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/secrets/PassphraseProvider.kt
+++ b/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/secrets/PassphraseProvider.kt
@@ -42,7 +42,7 @@ class PassphraseProvider(
     ): String {
         fileFlag?.let { path ->
             val text = File(path).readText().trimEnd('\n', '\r')
-            if (text.isEmpty()) throw IllegalArgumentException("--passphrase-file $path is empty")
+            require(text.isNotEmpty()) { "--passphrase-file $path is empty" }
             return text
         }
         System.getenv(envName)?.takeIf { it.isNotEmpty() }?.let { return it }
@@ -52,10 +52,10 @@ class PassphraseProvider(
                     "No TTY and no passphrase source: set $envName or pass --passphrase-file PATH.",
                 )
         val first = console.readPassword("$prompt: ").concatToString()
-        if (first.isEmpty()) throw IllegalArgumentException("empty passphrase")
+        require(first.isNotEmpty()) { "empty passphrase" }
         if (confirm) {
             val second = console.readPassword("Confirm passphrase: ").concatToString()
-            if (first != second) throw IllegalArgumentException("passphrases do not match")
+            require(first == second) { "passphrases do not match" }
         }
         return first
     }

--- a/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/secrets/SecretStore.kt
+++ b/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/secrets/SecretStore.kt
@@ -91,7 +91,7 @@ class SecretStore internal constructor(
                 when (secret.backend) {
                     MacosKeychainBackend.BACKEND_ID -> MacosKeychainBackend
                     SecretServiceBackend.BACKEND_ID -> SecretServiceBackend
-                    else -> throw IllegalStateException("unknown keychain backend: ${secret.backend}")
+                    else -> error("unknown keychain backend: ${secret.backend}")
                 }
             }
 


### PR DESCRIPTION
Four behaviour-preserving Sonar fixes, one commit per rule:

  - **Merge nested `if`** (22 sites, 16 files) — `if (A) { if (B) {…} }` → `if (A && B) {…}`
  - **Hoist `return` before `if`** (9 sites, 5 files) — `if (X) { return A } else { return B }` → `return if (X) A else B`
  - **Replace `if/throw` with `require`/`error`** (6 sites, 4 files) — exception types preserved
  - **Merge chained `if/else if` → `when`** (~44 sites, 33 files)

  Skipped: empty-block warnings (intentional no-op overrides), useless-null-check warnings (risky against Java platform types), and the 70-branch event-type chain in `ThreadFeedView.kt:594` (mechanically convertible but the
  diff would be unreviewable).

  ## Test plan
  - [x] `./gradlew spotlessCheck`
  - [x] `./gradlew :amethyst:compileFdroidDebugKotlin :cli:compileKotlin`
  - [x] Pre-commit + pre-push hooks pass on all 4 commits