### PR TITLE
Fix Blossom bridge to only rewrite last path segment as SHA256

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/okhttp/LocalBlossomCacheRedirectInterceptor.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/okhttp/LocalBlossomCacheRedirectInterceptor.kt
@@ -72,18 +72,18 @@ class LocalBlossomCacheRedirectInterceptor(
     }
 
     private fun findSha256AndExtensionInPath(url: HttpUrl): Triple<Int, String, String>? {
-        // Walk segments right-to-left so CDNs that put a cache prefix (itself a
-        // 64-char hex segment) ahead of the blob hash — e.g.
-        // `https://share.yabu.me/<prefix>/<sha>.webp` — still resolve to the
-        // blob and leave the prefix in `xs`.
-        for (index in url.pathSegments.indices.reversed()) {
-            val segment = url.pathSegments[index]
-            val match = SHA256_SEGMENT_REGEX.find(segment) ?: continue
-            val sha = match.value.lowercase()
-            val ext = guessExtensionFrom(segment, sha) ?: "bin"
-            return Triple(index, sha, ext)
-        }
-        return null
+        // Per Blossom (BUD-01) the blob is always the last path segment. If the
+        // last segment isn't a sha256, this isn't a Blossom URL and the bridge
+        // must leave it alone — even if an earlier path segment happens to be
+        // a 64-char hex (e.g. a per-user cache prefix). The prefix segments
+        // are preserved verbatim via `buildServerBase`.
+        val lastIndex = url.pathSegments.lastIndex
+        if (lastIndex < 0) return null
+        val segment = url.pathSegments[lastIndex]
+        val match = SHA256_SEGMENT_REGEX.find(segment) ?: return null
+        val sha = match.value.lowercase()
+        val ext = guessExtensionFrom(segment, sha) ?: "bin"
+        return Triple(lastIndex, sha, ext)
     }
 
     /**

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/okhttp/LocalBlossomCacheRedirectInterceptor.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/okhttp/LocalBlossomCacheRedirectInterceptor.kt
@@ -72,8 +72,13 @@ class LocalBlossomCacheRedirectInterceptor(
     }
 
     private fun findSha256AndExtensionInPath(url: HttpUrl): Triple<Int, String, String>? {
-        url.pathSegments.forEachIndexed { index, segment ->
-            val match = SHA256_SEGMENT_REGEX.find(segment) ?: return@forEachIndexed
+        // Walk segments right-to-left so CDNs that put a cache prefix (itself a
+        // 64-char hex segment) ahead of the blob hash — e.g.
+        // `https://share.yabu.me/<prefix>/<sha>.webp` — still resolve to the
+        // blob and leave the prefix in `xs`.
+        for (index in url.pathSegments.indices.reversed()) {
+            val segment = url.pathSegments[index]
+            val match = SHA256_SEGMENT_REGEX.find(segment) ?: continue
             val sha = match.value.lowercase()
             val ext = guessExtensionFrom(segment, sha) ?: "bin"
             return Triple(index, sha, ext)

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/service/okhttp/LocalBlossomCacheRedirectInterceptorTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/service/okhttp/LocalBlossomCacheRedirectInterceptorTest.kt
@@ -132,6 +132,21 @@ class LocalBlossomCacheRedirectInterceptorTest {
         response.close()
     }
 
+    @Test
+    fun bridgeOnPicksRightmostShaWhenPathHasTwoHashes() {
+        // share.yabu.me layout: <cache-prefix-sha>/<blob-sha>.<ext>
+        val prefix = "84b0c46ab699ac35eb2ca286470b85e081db2087cdef63932236c397417782f5"
+        val blob = "28fa4d999af6ae3e4e11bfc2727130ef1b3a13cc0f981e5a93c3996cb2f524e5"
+        val interceptor = LocalBlossomCacheRedirectInterceptor { true }
+        val captured = mutableListOf<String>()
+        val response = interceptor.intercept(fakeChain("https://share.yabu.me/$prefix/$blob.webp", captured))
+        assertEquals(
+            "http://127.0.0.1:24242/$blob.webp?xs=https%3A%2F%2Fshare.yabu.me%2F$prefix",
+            captured.single(),
+        )
+        response.close()
+    }
+
     private fun fakeChain(
         url: String,
         captured: MutableList<String>,

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/service/okhttp/LocalBlossomCacheRedirectInterceptorTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/service/okhttp/LocalBlossomCacheRedirectInterceptorTest.kt
@@ -135,13 +135,17 @@ class LocalBlossomCacheRedirectInterceptorTest {
     @Test
     fun bridgeOnPicksRightmostShaWhenPathHasTwoHashes() {
         // share.yabu.me layout: <cache-prefix-sha>/<blob-sha>.<ext>
-        val prefix = "84b0c46ab699ac35eb2ca286470b85e081db2087cdef63932236c397417782f5"
-        val blob = "28fa4d999af6ae3e4e11bfc2727130ef1b3a13cc0f981e5a93c3996cb2f524e5"
         val interceptor = LocalBlossomCacheRedirectInterceptor { true }
         val captured = mutableListOf<String>()
-        val response = interceptor.intercept(fakeChain("https://share.yabu.me/$prefix/$blob.webp", captured))
+        val response =
+            interceptor.intercept(
+                fakeChain(
+                    "https://share.yabu.me/84b0c46ab699ac35eb2ca286470b85e081db2087cdef63932236c397417782f5/28fa4d999af6ae3e4e11bfc2727130ef1b3a13cc0f981e5a93c3996cb2f524e5.webp",
+                    captured,
+                ),
+            )
         assertEquals(
-            "http://127.0.0.1:24242/$blob.webp?xs=https%3A%2F%2Fshare.yabu.me%2F$prefix",
+            "http://127.0.0.1:24242/28fa4d999af6ae3e4e11bfc2727130ef1b3a13cc0f981e5a93c3996cb2f524e5.webp?xs=https%3A%2F%2Fshare.yabu.me%2F84b0c46ab699ac35eb2ca286470b85e081db2087cdef63932236c397417782f5",
             captured.single(),
         )
         response.close()

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/service/okhttp/LocalBlossomCacheRedirectInterceptorTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/service/okhttp/LocalBlossomCacheRedirectInterceptorTest.kt
@@ -133,7 +133,7 @@ class LocalBlossomCacheRedirectInterceptorTest {
     }
 
     @Test
-    fun bridgeOnPicksRightmostShaWhenPathHasTwoHashes() {
+    fun bridgeOnRewritesShaInLastPathSegmentWithHexPrefix() {
         // share.yabu.me layout: <cache-prefix-sha>/<blob-sha>.<ext>
         val interceptor = LocalBlossomCacheRedirectInterceptor { true }
         val captured = mutableListOf<String>()
@@ -148,6 +148,18 @@ class LocalBlossomCacheRedirectInterceptorTest {
             "http://127.0.0.1:24242/28fa4d999af6ae3e4e11bfc2727130ef1b3a13cc0f981e5a93c3996cb2f524e5.webp?xs=https%3A%2F%2Fshare.yabu.me%2F84b0c46ab699ac35eb2ca286470b85e081db2087cdef63932236c397417782f5",
             captured.single(),
         )
+        response.close()
+    }
+
+    @Test
+    fun bridgeOnSkipsWhenLastSegmentIsNotSha() {
+        // Per BUD-01 the last segment is the blob; if it isn't a sha256, the
+        // URL isn't a Blossom blob even if an earlier segment is hex.
+        val interceptor = LocalBlossomCacheRedirectInterceptor { true }
+        val captured = mutableListOf<String>()
+        val url = "https://example.com/$sha/avatar.jpg"
+        val response = interceptor.intercept(fakeChain(url, captured))
+        assertEquals(url, captured.single())
         response.close()
     }
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/MediaUrlContentExt.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/MediaUrlContentExt.kt
@@ -144,11 +144,13 @@ private fun percentEncode(input: String): String {
 }
 
 private fun extractSha256FromUrlPath(url: String): String? {
+    // Per Blossom (BUD-01) the blob is always the last path segment. If the
+    // last segment isn't a sha256, this isn't a Blossom URL and the bridge
+    // must leave it alone — even if an earlier path segment happens to be
+    // a 64-char hex (e.g. a per-user cache prefix).
     val pathPart = url.substringBefore('?').substringBefore('#')
-    // Prefer the rightmost 64-char hex segment so CDNs that put a cache prefix
-    // (itself a 64-char hex) ahead of the blob hash — e.g.
-    // `https://share.yabu.me/<prefix>/<sha>.webp` — still resolve to the blob.
-    val match = sha256InPathRegex.findAll(pathPart).lastOrNull() ?: return null
+    val lastSegment = pathPart.substringAfterLast('/')
+    val match = sha256InPathRegex.find(lastSegment) ?: return null
     return match.value.lowercase()
 }
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/MediaUrlContentExt.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/MediaUrlContentExt.kt
@@ -145,7 +145,10 @@ private fun percentEncode(input: String): String {
 
 private fun extractSha256FromUrlPath(url: String): String? {
     val pathPart = url.substringBefore('?').substringBefore('#')
-    val match = sha256InPathRegex.find(pathPart) ?: return null
+    // Prefer the rightmost 64-char hex segment so CDNs that put a cache prefix
+    // (itself a 64-char hex) ahead of the blob hash — e.g.
+    // `https://share.yabu.me/<prefix>/<sha>.webp` — still resolve to the blob.
+    val match = sha256InPathRegex.findAll(pathPart).lastOrNull() ?: return null
     return match.value.lowercase()
 }
 
@@ -189,7 +192,7 @@ private fun extractServerBase(
     val hostStart = schemeEnd + 3
     if (hostStart >= pathPart.length) return null
 
-    val shaIndex = pathPart.indexOf(sha, ignoreCase = true)
+    val shaIndex = pathPart.lastIndexOf(sha, ignoreCase = true)
     if (shaIndex >= 0) {
         // Anchor on the slash immediately preceding the sha so the cache
         // can append "/<sha>" verbatim per the local-blossom-cache spec.

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/MediaUrlContentExtTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/MediaUrlContentExtTest.kt
@@ -175,7 +175,7 @@ class MediaUrlContentExtTest {
     }
 
     @Test
-    fun bridgeOnPicksRightmostShaWhenPathHasTwoHashes() {
+    fun bridgeOnRewritesShaInLastPathSegmentWithHexPrefix() {
         // share.yabu.me layout: <cache-prefix-sha>/<blob-sha>.<ext>
         val image =
             MediaUrlImage(
@@ -189,7 +189,7 @@ class MediaUrlContentExtTest {
     }
 
     @Test
-    fun bridgeProfilePictureUrlPicksRightmostShaWhenPathHasTwoHashes() {
+    fun bridgeProfilePictureUrlRewritesShaInLastPathSegmentWithHexPrefix() {
         assertEquals(
             "http://127.0.0.1:24242/28fa4d999af6ae3e4e11bfc2727130ef1b3a13cc0f981e5a93c3996cb2f524e5.webp?xs=https%3A%2F%2Fshare.yabu.me%2F84b0c46ab699ac35eb2ca286470b85e081db2087cdef63932236c397417782f5",
             bridgeProfilePictureUrl(
@@ -197,5 +197,20 @@ class MediaUrlContentExtTest {
                 useBridge = true,
             ),
         )
+    }
+
+    @Test
+    fun bridgeOnSkipsWhenLastSegmentIsNotSha() {
+        // Per BUD-01 the last segment is the blob; if it isn't a sha256, the
+        // URL isn't a Blossom blob even if an earlier segment is hex.
+        val url = "https://example.com/$sha/avatar.jpg"
+        val image = MediaUrlImage(url = url, hash = null)
+        assertEquals(url, image.toCoilModel(useLocalBlossomBridge = true))
+    }
+
+    @Test
+    fun bridgeProfilePictureUrlSkipsWhenLastSegmentIsNotSha() {
+        val url = "https://example.com/$sha/avatar.jpg"
+        assertEquals(url, bridgeProfilePictureUrl(url, useBridge = true))
     }
 }

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/MediaUrlContentExtTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/MediaUrlContentExtTest.kt
@@ -177,23 +177,25 @@ class MediaUrlContentExtTest {
     @Test
     fun bridgeOnPicksRightmostShaWhenPathHasTwoHashes() {
         // share.yabu.me layout: <cache-prefix-sha>/<blob-sha>.<ext>
-        val prefix = "84b0c46ab699ac35eb2ca286470b85e081db2087cdef63932236c397417782f5"
-        val blob = "28fa4d999af6ae3e4e11bfc2727130ef1b3a13cc0f981e5a93c3996cb2f524e5"
-        val image = MediaUrlImage(url = "https://share.yabu.me/$prefix/$blob.webp", hash = null)
+        val image =
+            MediaUrlImage(
+                url = "https://share.yabu.me/84b0c46ab699ac35eb2ca286470b85e081db2087cdef63932236c397417782f5/28fa4d999af6ae3e4e11bfc2727130ef1b3a13cc0f981e5a93c3996cb2f524e5.webp",
+                hash = null,
+            )
         assertEquals(
-            "blossom:$blob.webp?xs=https://share.yabu.me/$prefix",
+            "blossom:28fa4d999af6ae3e4e11bfc2727130ef1b3a13cc0f981e5a93c3996cb2f524e5.webp?xs=https://share.yabu.me/84b0c46ab699ac35eb2ca286470b85e081db2087cdef63932236c397417782f5",
             image.toCoilModel(useLocalBlossomBridge = true),
         )
     }
 
     @Test
     fun bridgeProfilePictureUrlPicksRightmostShaWhenPathHasTwoHashes() {
-        val prefix = "84b0c46ab699ac35eb2ca286470b85e081db2087cdef63932236c397417782f5"
-        val blob = "28fa4d999af6ae3e4e11bfc2727130ef1b3a13cc0f981e5a93c3996cb2f524e5"
-        val url = "https://share.yabu.me/$prefix/$blob.webp"
         assertEquals(
-            "http://127.0.0.1:24242/$blob.webp?xs=https%3A%2F%2Fshare.yabu.me%2F$prefix",
-            bridgeProfilePictureUrl(url, useBridge = true),
+            "http://127.0.0.1:24242/28fa4d999af6ae3e4e11bfc2727130ef1b3a13cc0f981e5a93c3996cb2f524e5.webp?xs=https%3A%2F%2Fshare.yabu.me%2F84b0c46ab699ac35eb2ca286470b85e081db2087cdef63932236c397417782f5",
+            bridgeProfilePictureUrl(
+                "https://share.yabu.me/84b0c46ab699ac35eb2ca286470b85e081db2087cdef63932236c397417782f5/28fa4d999af6ae3e4e11bfc2727130ef1b3a13cc0f981e5a93c3996cb2f524e5.webp",
+                useBridge = true,
+            ),
         )
     }
 }

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/MediaUrlContentExtTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/MediaUrlContentExtTest.kt
@@ -173,4 +173,27 @@ class MediaUrlContentExtTest {
         val uri = "blossom:$sha.jpg?xs=https://nostr.build"
         assertEquals(uri, bridgeProfilePictureUrl(uri, useBridge = true))
     }
+
+    @Test
+    fun bridgeOnPicksRightmostShaWhenPathHasTwoHashes() {
+        // share.yabu.me layout: <cache-prefix-sha>/<blob-sha>.<ext>
+        val prefix = "84b0c46ab699ac35eb2ca286470b85e081db2087cdef63932236c397417782f5"
+        val blob = "28fa4d999af6ae3e4e11bfc2727130ef1b3a13cc0f981e5a93c3996cb2f524e5"
+        val image = MediaUrlImage(url = "https://share.yabu.me/$prefix/$blob.webp", hash = null)
+        assertEquals(
+            "blossom:$blob.webp?xs=https://share.yabu.me/$prefix",
+            image.toCoilModel(useLocalBlossomBridge = true),
+        )
+    }
+
+    @Test
+    fun bridgeProfilePictureUrlPicksRightmostShaWhenPathHasTwoHashes() {
+        val prefix = "84b0c46ab699ac35eb2ca286470b85e081db2087cdef63932236c397417782f5"
+        val blob = "28fa4d999af6ae3e4e11bfc2727130ef1b3a13cc0f981e5a93c3996cb2f524e5"
+        val url = "https://share.yabu.me/$prefix/$blob.webp"
+        assertEquals(
+            "http://127.0.0.1:24242/$blob.webp?xs=https%3A%2F%2Fshare.yabu.me%2F$prefix",
+            bridgeProfilePictureUrl(url, useBridge = true),
+        )
+    }
 }


### PR DESCRIPTION
## Summary

The Blossom bridge was incorrectly rewriting URLs with SHA256 hashes in any path segment, not just the final one. Per BUD-01 (Blossom spec), the blob is always the last path segment — if it isn't a SHA256, the URL isn't a Blossom blob even if an earlier segment happens to be 64-char hex (e.g., a per-user cache prefix like `share.yabu.me`'s layout).

This fix updates both the local bridge interceptor and the media URL content extension to only extract and rewrite the SHA256 from the last path segment, while preserving earlier segments verbatim as the server base.

## Changes

- **`LocalBlossomCacheRedirectInterceptor.kt`**: Changed `findSha256AndExtensionInPath()` to only check the last path segment instead of iterating through all segments
- **`MediaUrlContentExt.kt`**: Updated `extractSha256FromUrlPath()` to extract only from the last segment, and changed `extractServerBase()` to use `lastIndexOf()` instead of `indexOf()` to anchor on the correct SHA occurrence
- **Tests**: Added comprehensive test coverage for both the interceptor and media URL extension, including the `share.yabu.me` layout and validation that non-SHA256 last segments are skipped

## Test plan

- [x] Ran `./gradlew test` — all new and existing tests pass
- [x] Added 4 new unit tests covering:
  - `share.yabu.me` layout with cache-prefix SHA + blob SHA
  - Skipping URLs where the last segment is not a SHA256 (e.g., `avatar.jpg`)
  - Both the interceptor and media URL extension code paths

The new tests validate that URLs like `https://share.yabu.me/<cache-sha>/<blob-sha>.webp` are correctly rewritten to use only the blob SHA while preserving the cache prefix in the `xs` parameter.

## Interop suites

- [x] N/A — change only affects local bridge URL rewriting, not wire bytes or protocol state

https://claude.ai/code/session_01RBQJTR2njDom2Wnm6Di5WB