### PR TITLE
fix: scope search to current tab kind

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/searchCommand/SearchFilterAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/searchCommand/SearchFilterAssembler.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 class SearchQueryState(
     val searchQuery: MutableStateFlow<String>,
     val account: Account,
+    val kind: Int? = null,
 ) : MutableQueryState {
     override fun flow(): Flow<String> = searchQuery
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/searchCommand/subassemblies/SearchPostWatcherSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/searchCommand/subassemblies/SearchPostWatcherSubAssembler.kt
@@ -86,11 +86,11 @@ class SearchPostWatcherSubAssembler(
 
         val searchFilters =
             key.account.searchRelayList.flow.value.flatMap {
-                searchPostsByText(mySearchString, it)
+                searchPostsByText(mySearchString, it, key.kind)
             }
 
         return directFilters + searchFilters
     }
 
-    override fun id(key: SearchQueryState) = key.searchQuery.hashCode()
+    override fun id(key: SearchQueryState) = 31 * key.searchQuery.hashCode() + (key.kind ?: -1)
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/searchCommand/subassemblies/SearchPostsByText.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/searchCommand/subassemblies/SearchPostsByText.kt
@@ -100,32 +100,47 @@ val SearchPostsByTextKinds3 =
 fun searchPostsByText(
     searchString: HexKey,
     relay: NormalizedRelayUrl,
-) = listOf(
-    RelayBasedFilter(
-        relay = relay,
-        filter =
-            Filter(
-                kinds = SearchPostsByTextKinds1,
-                search = searchString,
-                limit = 100,
-            ),
-    ),
-    RelayBasedFilter(
-        relay = relay,
-        filter =
-            Filter(
-                kinds = SearchPostsByTextKinds2,
-                search = searchString,
-                limit = 100,
-            ),
-    ),
-    RelayBasedFilter(
-        relay = relay,
-        filter =
-            Filter(
-                kinds = SearchPostsByTextKinds3,
-                search = searchString,
-                limit = 100,
-            ),
-    ),
-)
+    kind: Int? = null,
+) = if (kind != null) {
+    listOf(
+        RelayBasedFilter(
+            relay = relay,
+            filter =
+                Filter(
+                    kinds = listOf(kind),
+                    search = searchString,
+                    limit = 100,
+                ),
+        ),
+    )
+} else {
+    listOf(
+        RelayBasedFilter(
+            relay = relay,
+            filter =
+                Filter(
+                    kinds = SearchPostsByTextKinds1,
+                    search = searchString,
+                    limit = 100,
+                ),
+        ),
+        RelayBasedFilter(
+            relay = relay,
+            filter =
+                Filter(
+                    kinds = SearchPostsByTextKinds2,
+                    search = searchString,
+                    limit = 100,
+                ),
+        ),
+        RelayBasedFilter(
+            relay = relay,
+            filter =
+                Filter(
+                    kinds = SearchPostsByTextKinds3,
+                    search = searchString,
+                    limit = 100,
+                ),
+        ),
+    )
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/searchCommand/subassemblies/SearchUserWatcherSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/searchCommand/subassemblies/SearchUserWatcherSubAssembler.kt
@@ -52,6 +52,8 @@ class SearchUserWatcherSubAssembler(
         key: SearchQueryState,
         since: SincePerRelayMap?,
     ): List<RelayBasedFilter>? {
+        if (key.kind != null) return null
+
         val mySearchString = key.searchQuery.value
 
         if (mySearchString.isBlank()) return null
@@ -96,5 +98,5 @@ class SearchUserWatcherSubAssembler(
         return directFilters + searchFilters
     }
 
-    override fun id(key: SearchQueryState) = key.searchQuery.hashCode()
+    override fun id(key: SearchQueryState) = 31 * key.searchQuery.hashCode() + (key.kind ?: -1)
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -292,7 +292,7 @@ fun BuildNavigation(
         composableFromBottomArgs<Route.ManualZapSplitPayment> { PayViaIntentScreen(it.paymentId, accountViewModel, nav) }
 
         composableFromBottomArgs<Route.EditProfile> { NewUserMetadataScreen(nav, accountViewModel) }
-        composable<Route.Search> { SearchScreen(accountViewModel, nav) }
+        composableArgs<Route.Search> { SearchScreen(accountViewModel, nav, it.kind) }
 
         composableFromEnd<Route.AllSettings> { AllSettingsScreen(accountViewModel, nav) }
         composableFromEnd<Route.AccountBackup> { AccountBackupScreen(accountViewModel, nav) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
@@ -118,7 +118,9 @@ sealed class Route {
 
     @Serializable object WalletAdd : Route()
 
-    @Serializable object Search : Route()
+    @Serializable data class Search(
+        val kind: Int? = null,
+    ) : Route()
 
     @Serializable object SecurityFilters : Route()
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/UserDrawerSearchTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/UserDrawerSearchTopBar.kt
@@ -50,6 +50,7 @@ import com.vitorpamplona.amethyst.ui.theme.placeholderText
 fun UserDrawerSearchTopBar(
     accountViewModel: AccountViewModel,
     nav: INav,
+    searchRoute: Route = Route.Search(),
     content: @Composable () -> Unit,
 ) {
     ShorterTopAppBar(
@@ -75,7 +76,7 @@ fun UserDrawerSearchTopBar(
             }
         },
         actions = {
-            IconButton(onClick = { nav.nav(Route.Search) }) {
+            IconButton(onClick = { nav.nav(searchRoute) }) {
                 SearchIcon(modifier = Size22Modifier, MaterialTheme.colorScheme.placeholderText)
             }
         },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/DiscoverScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/DiscoverScreen.kt
@@ -227,7 +227,8 @@ private fun DiscoverPages(
         isInvertedLayout = false,
         topBar = {
             Column {
-                DiscoveryTopBar(accountViewModel, nav)
+                val searchKind = feedTabs.getOrNull(pagerState.currentPage)?.forceEventKind
+                DiscoveryTopBar(accountViewModel, nav, searchRoute = Route.Search(kind = searchKind))
                 SecondaryScrollableTabRow(
                     containerColor = MaterialTheme.colorScheme.background,
                     contentColor = MaterialTheme.colorScheme.onBackground,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/DiscoveryTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/DiscoveryTopBar.kt
@@ -26,6 +26,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.navigation.topbars.FeedFilterSpinner
 import com.vitorpamplona.amethyst.ui.navigation.topbars.UserDrawerSearchTopBar
 import com.vitorpamplona.amethyst.ui.screen.FeedDefinition
@@ -37,8 +38,9 @@ import com.vitorpamplona.amethyst.ui.stringRes
 fun DiscoveryTopBar(
     accountViewModel: AccountViewModel,
     nav: INav,
+    searchRoute: Route = Route.Search(),
 ) {
-    UserDrawerSearchTopBar(accountViewModel, nav) {
+    UserDrawerSearchTopBar(accountViewModel, nav, searchRoute = searchRoute) {
         val list by accountViewModel.account.settings.defaultDiscoveryFollowList
             .collectAsStateWithLifecycle()
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/followPacks/list/FollowPacksTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/followPacks/list/FollowPacksTopBar.kt
@@ -26,19 +26,21 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.navigation.topbars.FeedFilterSpinner
 import com.vitorpamplona.amethyst.ui.navigation.topbars.UserDrawerSearchTopBar
 import com.vitorpamplona.amethyst.ui.screen.FeedDefinition
 import com.vitorpamplona.amethyst.ui.screen.TopNavFilterState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.quartz.nip51Lists.followList.FollowListEvent
 
 @Composable
 fun FollowPacksTopBar(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    UserDrawerSearchTopBar(accountViewModel, nav) {
+    UserDrawerSearchTopBar(accountViewModel, nav, searchRoute = Route.Search(kind = FollowListEvent.KIND)) {
         val list by accountViewModel.account.settings.defaultFollowPacksFollowList
             .collectAsStateWithLifecycle()
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/products/ProductsTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/products/ProductsTopBar.kt
@@ -26,19 +26,21 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.navigation.topbars.FeedFilterSpinner
 import com.vitorpamplona.amethyst.ui.navigation.topbars.UserDrawerSearchTopBar
 import com.vitorpamplona.amethyst.ui.screen.FeedDefinition
 import com.vitorpamplona.amethyst.ui.screen.TopNavFilterState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.quartz.nip99Classifieds.ClassifiedsEvent
 
 @Composable
 fun ProductsTopBar(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    UserDrawerSearchTopBar(accountViewModel, nav) {
+    UserDrawerSearchTopBar(accountViewModel, nav, searchRoute = Route.Search(kind = ClassifiedsEvent.KIND)) {
         val list by accountViewModel.account.settings.defaultProductsFollowList
             .collectAsStateWithLifecycle()
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/search/SearchBarViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/search/SearchBarViewModel.kt
@@ -80,6 +80,7 @@ import kotlinx.coroutines.flow.update
 class SearchBarViewModel(
     val account: Account,
     val nip05Client: INip05Client,
+    val kind: Int? = null,
 ) : ViewModel(),
     InvalidatableContent {
     val focusRequester = FocusRequester()
@@ -88,7 +89,7 @@ class SearchBarViewModel(
     val invalidations = MutableStateFlow(0)
     val searchValueFlow = MutableStateFlow("")
 
-    val scope = MutableStateFlow(SearchScope.ALL)
+    val scope = MutableStateFlow(if (kind == null) SearchScope.ALL else SearchScope.NOTES)
     val source = MutableStateFlow(SearchSource.RELAYS)
     val followsOnly = MutableStateFlow(false)
     val sortOrder = MutableStateFlow(SearchSortOrder.EVENT_DEFAULT)
@@ -100,7 +101,7 @@ class SearchBarViewModel(
             .onEach(::updateDataSource)
             .stateIn(viewModelScope, SharingStarted.Eagerly, searchValue)
 
-    val searchDataSourceState = SearchQueryState(MutableStateFlow(searchValue), account)
+    val searchDataSourceState = SearchQueryState(MutableStateFlow(searchValue), account, kind)
 
     @Suppress("unused")
     val sourceWatcher =
@@ -226,6 +227,7 @@ class SearchBarViewModel(
                 if (only) follows.authorsPlusMe else null
             },
         ) { term, _, nip05Resolver, currentScope, follows ->
+            if (kind != null) return@combine emptyList<User>()
             if (currentScope == SearchScope.NOTES) return@combine emptyList<User>()
 
             if (nip05Resolver != null) {
@@ -254,7 +256,10 @@ class SearchBarViewModel(
         ) { term, _, currentScope, order, follows ->
             if (currentScope == SearchScope.PEOPLE) return@combine emptyList()
 
-            val raw = LocalCache.findNotesStartingWith(term, account.hiddenUsers)
+            val raw =
+                LocalCache
+                    .findNotesStartingWith(term, account.hiddenUsers)
+                    .filter { note -> kind == null || note.event?.kind == kind }
             val filtered = if (follows != null) raw.filter { it.author?.pubkeyHex in follows } else raw
 
             when (order) {
@@ -286,6 +291,7 @@ class SearchBarViewModel(
             invalidations,
             scope,
         ) { term, _, currentScope ->
+            if (kind != null) return@combine emptyList()
             if (currentScope != SearchScope.ALL) emptyList() else LocalCache.findPublicChatChannelsStartingWith(term)
         }.flowOn(Dispatchers.IO)
             .stateIn(viewModelScope, WhileSubscribed(5000), emptyList())
@@ -296,6 +302,7 @@ class SearchBarViewModel(
             invalidations,
             scope,
         ) { term, _, currentScope ->
+            if (kind != null) return@combine emptyList()
             if (currentScope != SearchScope.ALL) emptyList() else LocalCache.findEphemeralChatChannelsStartingWith(term)
         }.flowOn(Dispatchers.IO)
             .stateIn(viewModelScope, WhileSubscribed(5000), emptyList())
@@ -306,6 +313,7 @@ class SearchBarViewModel(
             invalidations,
             scope,
         ) { term, _, currentScope ->
+            if (kind != null) return@combine emptyList()
             if (currentScope != SearchScope.ALL) emptyList() else LocalCache.findLiveActivityChannelsStartingWith(term)
         }.flowOn(Dispatchers.IO)
             .stateIn(viewModelScope, WhileSubscribed(5000), emptyList())
@@ -316,6 +324,7 @@ class SearchBarViewModel(
             invalidations,
             scope,
         ) { term, _, currentScope ->
+            if (kind != null) return@combine emptyList()
             if (currentScope == SearchScope.PEOPLE) emptyList() else findHashtags(term)
         }.flowOn(Dispatchers.IO)
             .stateIn(viewModelScope, WhileSubscribed(5000), emptyList())
@@ -326,6 +335,7 @@ class SearchBarViewModel(
             invalidations,
             scope,
         ) { term, _, currentScope ->
+            if (kind != null) return@combine emptyList()
             if (currentScope != SearchScope.ALL) return@combine emptyList()
             if (term.length > 1) {
                 val isTypingRelay = term.length > 7 && (term.startsWith("wss://") || term.startsWith("ws://"))
@@ -397,8 +407,9 @@ class SearchBarViewModel(
     class Factory(
         val account: Account,
         val nip05: INip05Client,
+        val kind: Int? = null,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(modelClass: Class<T>): T = SearchBarViewModel(account, nip05) as T
+        override fun <T : ViewModel> create(modelClass: Class<T>): T = SearchBarViewModel(account, nip05, kind) as T
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/search/SearchScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/search/SearchScreen.kt
@@ -108,14 +108,16 @@ import kotlinx.coroutines.launch
 fun SearchScreen(
     accountViewModel: AccountViewModel,
     nav: INav,
+    kind: Int? = null,
 ) {
     val searchBarViewModel: SearchBarViewModel =
         viewModel(
-            key = "SearchBarViewModel",
+            key = "SearchBarViewModel-${kind ?: "all"}",
             factory =
                 SearchBarViewModel.Factory(
                     accountViewModel.account,
                     accountViewModel.nip05ClientBuilder(),
+                    kind,
                 ),
         )
 
@@ -142,7 +144,7 @@ fun SearchScreen(
             SearchBar(searchBarViewModel, accountViewModel, nav)
         },
         bottomBar = {
-            AppBottomBar(Route.Search, nav, accountViewModel) { route ->
+            AppBottomBar(Route.Search(), nav, accountViewModel) { route ->
                 nav.navBottomBar(route)
             }
         },


### PR DESCRIPTION
## Summary
- add an optional kind argument to the search route so top-bar search can inherit the current section context
- pass the current Discover tab kind, Marketplace/Product kind, and Follow Packs kind into search navigation
- constrain relay text-search filters and local note results to that kind when present
- suppress unrelated people/channel/hashtag/relay suggestions in scoped search mode

Fixes #1617

## Verification
- Checked for duplicate open PRs and claim comments before implementation; none found.
- git diff --check

## Notes
- I could not run Gradle locally because this machine has no Java Runtime installed.
- Lightning payout address: landedrube511@minibits.cash
