### PR TITLE
feat: add audio playback support for .f4a files

### DIFF
--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
@@ -420,7 +420,7 @@ class RichTextParser {
             )
 
         val imageExt = listOf("png", "jpg", "gif", "bmp", "jpeg", "webp", "svg", "avif")
-        val videoExt = listOf("mp4", "avi", "wmv", "mpg", "amv", "webm", "mov", "mp3", "m3u8", "ogg", "wav", "flac", "aac", "opus", "m4a")
+        val videoExt = listOf("mp4", "avi", "wmv", "mpg", "amv", "webm", "mov", "mp3", "m3u8", "ogg", "wav", "flac", "aac", "opus", "m4a", "f4a")
         val pdfExt = listOf("pdf")
 
         val imageExtensions = imageExt + imageExt.map { it.uppercase() }
@@ -556,6 +556,7 @@ val mimeTypeMap: Map<String, String> =
         "wav" to "audio/wav",
         "ogg" to "audio/ogg",
         "m4a" to "audio/mp4",
+        "f4a" to "audio/mp4",
         "aac" to "audio/aac",
         "flac" to "audio/flac",
         // Documents

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/F4aAudioParserTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/F4aAudioParserTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.richtext
+
+import com.vitorpamplona.amethyst.commons.model.EmptyTagList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class F4aAudioParserTest {
+    @Test
+    fun detectsF4aByExtension() {
+        val url = "https://example.com/audio/track.f4a"
+        val state = RichTextParser().parseText(url, EmptyTagList, null)
+
+        val media = state.mediaForPager[url]
+        assertTrue(media is MediaUrlVideo, "Expected MediaUrlVideo for .f4a URL")
+
+        val segment = state.paragraphs[0].words[0]
+        assertTrue(segment is VideoSegment, "Expected VideoSegment for .f4a URL, got ${segment::class.simpleName}")
+        assertEquals(url, segment.segmentText)
+    }
+
+    @Test
+    fun isVideoUrlHelperMatchesF4aExtension() {
+        assertTrue(RichTextParser.isVideoUrl("https://example.com/track.f4a"))
+        assertTrue(RichTextParser.isVideoUrl("https://example.com/track.F4A"))
+        assertTrue(RichTextParser.isVideoUrl("https://example.com/track.f4a?sig=abc"))
+    }
+
+    @Test
+    fun f4aMapsToMp4AudioMimeType() {
+        assertEquals("audio/mp4", mimeTypeMap["f4a"])
+    }
+}


### PR DESCRIPTION
F4A is AAC audio in an MP4 container (Adobe's variant of .m4a).
Register the extension in the media URL list so it routes to the
player, and map it to audio/mp4 so ExoPlayer picks the MP4 extractor.

https://claude.ai/code/session_01EuB46tfwBxtvRNDz9Ju99J