### PR TITLE
bugfix: break a-tag cycle in computeRelayListToBroadcast

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -965,7 +965,15 @@ class Account(
         return true
     }
 
-    fun computeRelayListToBroadcast(event: Event): Set<NormalizedRelayUrl> {
+    fun computeRelayListToBroadcast(event: Event): Set<NormalizedRelayUrl> = computeRelayListToBroadcast(event, mutableSetOf())
+
+    private fun computeRelayListToBroadcast(
+        event: Event,
+        visited: MutableSet<HexKey>,
+    ): Set<NormalizedRelayUrl> {
+        // a-tagged events can form cycles; without this the two recursive descents stack-overflow.
+        if (!visited.add(event.id)) return emptySet()
+
         if (event is GiftWrapEvent) {
             val receiver = event.recipientPubKey()
             return if (receiver != null) {
@@ -1044,7 +1052,7 @@ class Account(
                     }
 
                     linkedNote.event?.let { linkedEvent ->
-                        relayList.addAll(computeRelayListToBroadcast(linkedEvent))
+                        relayList.addAll(computeRelayListToBroadcast(linkedEvent, visited))
                     }
                 }
             }
@@ -1065,7 +1073,7 @@ class Account(
                     }
 
                     linkedNote.event?.let { linkedEvent ->
-                        relayList.addAll(computeRelayListToBroadcast(linkedEvent))
+                        relayList.addAll(computeRelayListToBroadcast(linkedEvent, visited))
                     }
                 }
             }


### PR DESCRIPTION
## Root cause

  `Account.computeRelayListToBroadcast(Event)` recursed unbounded over events linked by `a` / `e` tags. When a published event reached a cached event whose own `a` tags form a cycle — most commonly an addressable event (kind
   30023) that includes its own naddr in its `a` tags (YakiHonne-style self-mention) — the two recursive descents at the `AddressHintProvider` and `EventHintProvider` branches never terminated. Result: `StackOverflowError`
  on a `DefaultDispatcher` worker during publish, the compose screen hanging on the spinner, and the event being written to `LocalCache` but never reaching relays (because `signAndComputeBroadcast` throws *before*
  `client.publish`).

  Reproduced twice on-device (Pixel 9a, debug build), stack identical both times:

  ```
StackOverflowError
    at Account.computeRelayListToBroadcast(Account.kt:1068)  ×1000+
    at Account.computeRelayListToBroadcast(Account.kt:1098)
    at Account.signAndComputeBroadcast(Account.kt:1693)
    at ShortNotePostViewModel.sendPostSync(ShortNotePostViewModel.kt:889)
```

  ## Fix

  Standard DFS cycle-detection. Public signature unchanged — it now delegates to a private helper that threads a `MutableSet<HexKey>` of visited event ids. On entry, `visited.add(event.id)` short-circuits any second visit
  with `emptySet()`. 11-line diff in `Account.kt`, no other files touched.

  ## Failing input (real example)

  The "Cryptography, the Commons and Proof of Place" article by `nathan@btcmap.org` (kind 30023, d-tag `2uBWmmKOqd-09vQVMH8X0`) carries its own naddr as an `a` tag:

  ```json
  ["a", "30023:c4f5e7a7…:2uBWmmKOqd-09vQVMH8X0", "wss://relay.primal.net/", "mention"]
```

  Once that article is in LocalCache (e.g. after a user views or quotes it), any subsequent publish whose a tags reach this article crashes the publish coroutine — linkedNote.event is non-null and identical to its own a tag
  target, so the recursion never bottoms out.

  Manual testing

  

- [x] Pixel 9a, gesture nav, Amethyst tester account (f512…ff1f), debug client.
- [x]   Pre-fix repro: publishing a kind-1 short note whose body referenced the article above (so the mention extractor adds its a tag) crashed on a background coroutine — UI stuck on compose, event written locally but never broadcast. Confirmed by querying nos.lol, nostr.bitcoiner.social, nostr.mom: the event was not on any relay.
- [x]   Post-fix: rebuilt + reinstalled :amethyst:installPlayDebug, retried the same publish flow. Compose screen dismissed cleanly, event broadcast to all three NIP-65 outbox relays, no StackOverflowError in adb logcat -b crash.
- [x]   Verified post-fix publish externally with nak req -a f512…ff1f -k 1 --limit 5 …. Four subsequent test posts (autolink form, markdown-link form, deletions, bookmark list updates) all clean.
- [x]   Build green via ./gradlew :amethyst:compilePlayPlayDebugKotlin and pre-commit spotless.



## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
