### PR TITLE
Favourite feeds: clearer empty state + pinned "Add more…" CTA

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/dvms/favorites/FavoriteAlgoFeedsListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/dvms/favorites/FavoriteAlgoFeedsListScreen.kt
@@ -46,11 +46,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.BottomStart
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.text.buildAnnotatedString
@@ -81,6 +83,8 @@ import com.vitorpamplona.amethyst.ui.theme.SimpleImage35Modifier
 import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
 import com.vitorpamplona.amethyst.ui.theme.grayText
 import kotlinx.coroutines.launch
+
+private const val STAR_INLINE_ID = "star"
 
 @Composable
 fun FavoriteAlgoFeedsListScreen(
@@ -130,10 +134,47 @@ fun FavoriteAlgoFeedsListScreen(
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.grayText,
                 )
+                FavoriteAlgoFeedsEmptyState(nav)
+            } else {
+                FavoriteAlgoFeedList(favorites, listState, accountViewModel, nav)
             }
-
-            FavoriteAlgoFeedList(favorites, listState, accountViewModel, nav)
         }
+    }
+}
+
+@Composable
+private fun FavoriteAlgoFeedsEmptyState(nav: INav) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(horizontal = 24.dp, vertical = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Spacer(modifier = Modifier.weight(1f))
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Icon(
+                symbol = MaterialSymbols.AutoAwesome,
+                contentDescription = null,
+                modifier = Modifier.size(72.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Text(
+                text = stringRes(R.string.favorite_dvms_empty_headline),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            FavoriteAlgoFeedsEmptySteps(
+                ctaLabel = stringRes(R.string.favorite_dvms_empty_cta),
+                modifier = Modifier.widthIn(max = 320.dp),
+            )
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        BrowseAlgosButton(
+            label = stringRes(R.string.favorite_dvms_empty_cta),
+            nav = nav,
+        )
     }
 }
 
@@ -144,41 +185,6 @@ private fun ColumnScope.FavoriteAlgoFeedList(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    if (favorites.isEmpty()) {
-        Column(
-            modifier = Modifier.fillMaxSize().padding(horizontal = 24.dp, vertical = 32.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Spacer(modifier = Modifier.weight(1f))
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-            ) {
-                Icon(
-                    symbol = MaterialSymbols.AutoAwesome,
-                    contentDescription = null,
-                    modifier = Modifier.size(72.dp),
-                    tint = MaterialTheme.colorScheme.primary,
-                )
-                Text(
-                    text = stringRes(R.string.favorite_dvms_empty_headline),
-                    textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                )
-                FavoriteAlgoFeedsEmptySteps(
-                    ctaLabel = stringRes(R.string.favorite_dvms_empty_cta),
-                    modifier = Modifier.widthIn(max = 320.dp),
-                )
-            }
-            Spacer(modifier = Modifier.weight(1f))
-            Button(onClick = { nav.nav(Route.Discover(initialTab = DiscoverTab.ALGOS)) }) {
-                Text(text = stringRes(R.string.favorite_dvms_empty_cta))
-            }
-        }
-        return
-    }
-
     LazyColumn(
         modifier = Modifier.weight(1f),
         state = listState,
@@ -197,13 +203,24 @@ private fun ColumnScope.FavoriteAlgoFeedList(
             )
         }
     }
-    Box(
-        modifier = Modifier.fillMaxWidth().padding(vertical = 32.dp),
-        contentAlignment = Alignment.Center,
+    BrowseAlgosButton(
+        label = stringRes(R.string.favorite_dvms_add_more),
+        nav = nav,
+        modifier = Modifier.align(Alignment.CenterHorizontally).padding(vertical = 32.dp),
+    )
+}
+
+@Composable
+private fun BrowseAlgosButton(
+    label: String,
+    nav: INav,
+    modifier: Modifier = Modifier,
+) {
+    Button(
+        onClick = { nav.nav(Route.Discover(initialTab = DiscoverTab.ALGOS)) },
+        modifier = modifier,
     ) {
-        Button(onClick = { nav.nav(Route.Discover(initialTab = DiscoverTab.ALGOS)) }) {
-            Text(text = stringRes(R.string.favorite_dvms_add_more))
-        }
+        Text(text = label)
     }
 }
 
@@ -290,34 +307,38 @@ private fun FavoriteAlgoFeedsEmptySteps(
     ctaLabel: String,
     modifier: Modifier = Modifier,
 ) {
-    val starInlineId = "star"
     val step2Template = stringRes(R.string.favorite_dvms_empty_step2)
-    val step2Parts = step2Template.split("%1\$s", limit = 2)
+    val primaryColor = MaterialTheme.colorScheme.primary
 
     val step2Text =
-        buildAnnotatedString {
-            append(step2Parts.first())
-            appendInlineContent(starInlineId, "[star]")
-            if (step2Parts.size > 1) append(step2Parts[1])
+        remember(step2Template) {
+            val parts = step2Template.split("%1\$s", limit = 2)
+            buildAnnotatedString {
+                append(parts.first())
+                appendInlineContent(STAR_INLINE_ID, "star")
+                if (parts.size > 1) append(parts[1])
+            }
         }
 
     val starInlineContent =
-        mapOf(
-            starInlineId to
-                InlineTextContent(
-                    Placeholder(
-                        width = 18.sp,
-                        height = 18.sp,
-                        placeholderVerticalAlign = PlaceholderVerticalAlign.Center,
-                    ),
-                ) {
-                    Icon(
-                        symbol = MaterialSymbols.StarBorder,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary,
-                    )
-                },
-        )
+        remember(primaryColor) {
+            mapOf(
+                STAR_INLINE_ID to
+                    InlineTextContent(
+                        Placeholder(
+                            width = 18.sp,
+                            height = 18.sp,
+                            placeholderVerticalAlign = PlaceholderVerticalAlign.Center,
+                        ),
+                    ) {
+                        Icon(
+                            symbol = MaterialSymbols.StarBorder,
+                            contentDescription = null,
+                            tint = primaryColor,
+                        )
+                    },
+            )
+        }
 
     Column(
         modifier = modifier,
@@ -346,7 +367,10 @@ private fun NumberedStep(
     number: String,
     content: @Composable () -> Unit,
 ) {
-    Row(verticalAlignment = Alignment.Top) {
+    Row(
+        modifier = Modifier.semantics(mergeDescendants = true) {},
+        verticalAlignment = Alignment.Top,
+    ) {
         Text(
             text = number,
             style = MaterialTheme.typography.bodyMedium,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/dvms/favorites/FavoriteAlgoFeedsListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/dvms/favorites/FavoriteAlgoFeedsListScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.consumeWindowInsets
@@ -37,6 +38,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.material3.Button
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -48,10 +51,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.BottomStart
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.Placeholder
+import androidx.compose.ui.text.PlaceholderVerticalAlign
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
@@ -82,6 +89,8 @@ fun FavoriteAlgoFeedsListScreen(
 ) {
     val listState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
+    val favorites by accountViewModel.account.favoriteAlgoFeedsList.flowNotes
+        .collectAsStateWithLifecycle()
 
     DisappearingScaffold(
         isInvertedLayout = false,
@@ -113,33 +122,34 @@ fun FavoriteAlgoFeedsListScreen(
                         bottom = padding.calculateBottomPadding(),
                     ).consumeWindowInsets(padding),
         ) {
-            Text(
-                text = stringRes(R.string.favorite_dvms_explainer),
-                textAlign = TextAlign.Center,
-                modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.grayText,
-            )
+            if (favorites.isEmpty()) {
+                Text(
+                    text = stringRes(R.string.favorite_dvms_explainer),
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth().padding(top = 24.dp, bottom = 12.dp),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.grayText,
+                )
+            }
 
-            FavoriteAlgoFeedList(listState, accountViewModel, nav)
+            FavoriteAlgoFeedList(favorites, listState, accountViewModel, nav)
         }
     }
 }
 
 @Composable
-private fun FavoriteAlgoFeedList(
+private fun ColumnScope.FavoriteAlgoFeedList(
+    favorites: List<AddressableNote>,
     listState: LazyListState,
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    val favorites by accountViewModel.account.favoriteAlgoFeedsList.flowNotes
-        .collectAsStateWithLifecycle()
-
     if (favorites.isEmpty()) {
-        Box(
-            modifier = Modifier.fillMaxSize().padding(24.dp),
-            contentAlignment = Alignment.Center,
+        Column(
+            modifier = Modifier.fillMaxSize().padding(horizontal = 24.dp, vertical = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            Spacer(modifier = Modifier.weight(1f))
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(16.dp),
@@ -156,22 +166,21 @@ private fun FavoriteAlgoFeedList(
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.SemiBold,
                 )
-                Text(
-                    text = stringRes(R.string.favorite_dvms_empty_subtitle),
-                    textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.grayText,
-                    modifier = Modifier.widthIn(max = 280.dp),
+                FavoriteAlgoFeedsEmptySteps(
+                    ctaLabel = stringRes(R.string.favorite_dvms_empty_cta),
+                    modifier = Modifier.widthIn(max = 320.dp),
                 )
-                Button(onClick = { nav.nav(Route.Discover(initialTab = DiscoverTab.ALGOS)) }) {
-                    Text(text = stringRes(R.string.favorite_dvms_empty_cta))
-                }
+            }
+            Spacer(modifier = Modifier.weight(1f))
+            Button(onClick = { nav.nav(Route.Discover(initialTab = DiscoverTab.ALGOS)) }) {
+                Text(text = stringRes(R.string.favorite_dvms_empty_cta))
             }
         }
         return
     }
 
     LazyColumn(
+        modifier = Modifier.weight(1f),
         state = listState,
         verticalArrangement = Arrangement.spacedBy(4.dp),
         contentPadding = FeedPadding,
@@ -186,6 +195,14 @@ private fun FavoriteAlgoFeedList(
                 onOpen = { nav.nav(Route.ContentDiscovery(feedNote.idHex)) },
                 onRemove = { accountViewModel.unfollowFavoriteAlgoFeed(feedNote.address) },
             )
+        }
+    }
+    Box(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 32.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Button(onClick = { nav.nav(Route.Discover(initialTab = DiscoverTab.ALGOS)) }) {
+            Text(text = stringRes(R.string.favorite_dvms_add_more))
         }
     }
 }
@@ -265,5 +282,77 @@ private fun FavoriteAlgoFeedRow(
                 contentDescription = stringRes(R.string.remove_dvm_from_favorites),
             )
         }
+    }
+}
+
+@Composable
+private fun FavoriteAlgoFeedsEmptySteps(
+    ctaLabel: String,
+    modifier: Modifier = Modifier,
+) {
+    val starInlineId = "star"
+    val step2Template = stringRes(R.string.favorite_dvms_empty_step2)
+    val step2Parts = step2Template.split("%1\$s", limit = 2)
+
+    val step2Text =
+        buildAnnotatedString {
+            append(step2Parts.first())
+            appendInlineContent(starInlineId, "[star]")
+            if (step2Parts.size > 1) append(step2Parts[1])
+        }
+
+    val starInlineContent =
+        mapOf(
+            starInlineId to
+                InlineTextContent(
+                    Placeholder(
+                        width = 18.sp,
+                        height = 18.sp,
+                        placeholderVerticalAlign = PlaceholderVerticalAlign.Center,
+                    ),
+                ) {
+                    Icon(
+                        symbol = MaterialSymbols.StarBorder,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                },
+        )
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        NumberedStep(number = "1.") {
+            Text(
+                text = stringRes(R.string.favorite_dvms_empty_step1, ctaLabel),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.grayText,
+            )
+        }
+        NumberedStep(number = "2.") {
+            Text(
+                text = step2Text,
+                inlineContent = starInlineContent,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.grayText,
+            )
+        }
+    }
+}
+
+@Composable
+private fun NumberedStep(
+    number: String,
+    content: @Composable () -> Unit,
+) {
+    Row(verticalAlignment = Alignment.Top) {
+        Text(
+            text = number,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(end = 8.dp),
+        )
+        content()
     }
 }

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -2181,7 +2181,10 @@
     <string name="favorite_dvms_explainer">Feed algorithms you star appear here and as filter chips on the Home feed.</string>
     <string name="favorite_dvms_empty_headline">Pin your favorite algorithms</string>
     <string name="favorite_dvms_empty_subtitle">Tap the button below to browse algorithms and star the ones you want to keep here.</string>
+    <string name="favorite_dvms_empty_step1">Tap \"%1$s\" below to browse algorithms.</string>
+    <string name="favorite_dvms_empty_step2">Tap the %1$s next to a feed to keep it here.</string>
     <string name="favorite_dvms_empty_cta">Add some feeds</string>
+    <string name="favorite_dvms_add_more">Add more…</string>
     <string name="dvm_home_status_requesting">Asking %1$s for a feed…</string>
     <string name="dvm_home_status_requesting_all">Asking your favorite feed algorithms for feeds…</string>
     <string name="dvm_home_status_processing">Processing your feed…</string>

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -2180,8 +2180,8 @@
     <string name="favorite_dvms_title">Favorite Feed Algorithms</string>
     <string name="favorite_dvms_explainer">Feed algorithms you star appear here and as filter chips on the Home feed.</string>
     <string name="favorite_dvms_empty_headline">Pin your favorite algorithms</string>
-    <string name="favorite_dvms_empty_subtitle">Tap the button below to browse algorithms and star the ones you want to keep here.</string>
     <string name="favorite_dvms_empty_step1">Tap \"%1$s\" below to browse algorithms.</string>
+    <!-- %1$s is replaced at runtime by an inline star icon, not text. Keep the placeholder. -->
     <string name="favorite_dvms_empty_step2">Tap the %1$s next to a feed to keep it here.</string>
     <string name="favorite_dvms_empty_cta">Add some feeds</string>
     <string name="favorite_dvms_add_more">Add more…</string>


### PR DESCRIPTION
<img  height="500" alt="Screenshot_20260514-221857" src="https://github.com/user-attachments/assets/db5d15d7-3cae-42bb-83d4-6c2cc15f9d5f" /> <img  height="500" alt="Screenshot_20260514-221945" src="https://github.com/user-attachments/assets/95b3e157-2dd9-47cb-9b62-afd91b8f5c1a" />



## Summary
  
  Two UX improvements to the **Favourite Feed Algorithms** screen:
  
  - **Empty state**: hide the top explainer when the user already has favourites; when empty, replace the prose subtitle with a two-step instruction that renders the actual outlined-star icon inline ("Tap the ⭐ next to a
  feed…") so new users know what to look for on the Discover page. Layout uses weighted spacers so the icon/headline/steps group centres vertically and the CTA pins to the bottom — mirroring the populated layout.
  - **Populated state**: add an "Add more…" `Button` pinned to the bottom of the screen (same visual location as the e

  ## Test plan

  - [x] Empty state: open Favourite Feeds while signed in to a fresh account (no algo feeds starred). Confirm the top explainer shows, the icon + headline + numbered steps sit vertically centred, the inline ⭐ renders next
  to "Tap the", and the "Add some feeds" button sits near the bottom.
  - [x] Tap CTA → lands on Discover › ALGOS tab.
  - [x] Populated state: star one algo from Discover, return to Favourite Feeds. The top explainer is hidden, the list renders, and "Add more…" sits at the bottom (not inside the scrolling list).
  - [ ] Long list: scroll to bottom — "Add more…" stays pinned, not at the end of the LazyColumn.
  - [ ] TalkBack: each numbered step is announced as one utterance ("Tap Add some feeds below to browse algorithms" / "Tap the star next to a feed to keep it here") with no "[bracket] star [bracket]" noise.
  - [ ] Translation: verify in at least one non-English locale that `%1$s` survives and the icon still appears mid-sentence.

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
