### PR TITLE
Replace ConcurrentRequestStrategy.UNCOORDINATED with DeDupeConcurrentRequestStrategy

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/images/BlossomFetcher.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/images/BlossomFetcher.kt
@@ -27,8 +27,8 @@ import coil3.annotation.ExperimentalCoilApi
 import coil3.fetch.FetchResult
 import coil3.fetch.Fetcher
 import coil3.network.CacheStrategy
-import coil3.network.ConcurrentRequestStrategy
 import coil3.network.ConnectivityChecker
+import coil3.network.DeDupeConcurrentRequestStrategy
 import coil3.network.NetworkFetcher
 import coil3.network.okhttp.asNetworkClient
 import coil3.request.Options
@@ -74,7 +74,7 @@ class BlossomFetcher(
                     diskCache = lazy { imageLoader.diskCache },
                     cacheStrategy = lazy { CacheStrategy.DEFAULT },
                     connectivityChecker = lazy { connectivityCheckerLazy.get(options.context) },
-                    concurrentRequestStrategy = lazy { ConcurrentRequestStrategy.UNCOORDINATED },
+                    concurrentRequestStrategy = lazy { DeDupeConcurrentRequestStrategy() },
                 )
             }
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/images/ImageLoaderSetup.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/images/ImageLoaderSetup.kt
@@ -33,8 +33,8 @@ import coil3.gif.AnimatedImageDecoder
 import coil3.gif.GifDecoder
 import coil3.memory.MemoryCache
 import coil3.network.CacheStrategy
-import coil3.network.ConcurrentRequestStrategy
 import coil3.network.ConnectivityChecker
+import coil3.network.DeDupeConcurrentRequestStrategy
 import coil3.network.NetworkFetcher
 import coil3.network.okhttp.asNetworkClient
 import coil3.request.Options
@@ -149,7 +149,7 @@ class OkHttpFactory(
             diskCache = lazy { imageLoader.diskCache },
             cacheStrategy = cacheStrategyLazy,
             connectivityChecker = lazy { connectivityCheckerLazy.get(options.context) },
-            concurrentRequestStrategy = lazy { ConcurrentRequestStrategy.UNCOORDINATED },
+            concurrentRequestStrategy = lazy { DeDupeConcurrentRequestStrategy() },
         )
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/images/ProfilePictureFetcher.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/images/ProfilePictureFetcher.kt
@@ -30,8 +30,8 @@ import coil3.fetch.Fetcher
 import coil3.fetch.ImageFetchResult
 import coil3.key.Keyer
 import coil3.network.CacheStrategy
-import coil3.network.ConcurrentRequestStrategy
 import coil3.network.ConnectivityChecker
+import coil3.network.DeDupeConcurrentRequestStrategy
 import coil3.network.NetworkFetcher
 import coil3.network.okhttp.asNetworkClient
 import coil3.request.Options
@@ -113,7 +113,7 @@ class ProfilePictureFetcher(
                     diskCache = diskCacheLazy,
                     cacheStrategy = lazy { CacheStrategy.DEFAULT },
                     connectivityChecker = lazy { connectivityCheckerLazy.get(options.context) },
-                    concurrentRequestStrategy = lazy { ConcurrentRequestStrategy.UNCOORDINATED },
+                    concurrentRequestStrategy = lazy { DeDupeConcurrentRequestStrategy() },
                 )
 
             return ProfilePictureFetcher(


### PR DESCRIPTION
## Summary

Updates three image fetcher classes to use `DeDupeConcurrentRequestStrategy` instead of the deprecated `ConcurrentRequestStrategy.UNCOORDINATED` from Coil3. This change improves concurrent request handling by deduplicating identical concurrent requests, reducing unnecessary network traffic and improving performance.

## Changes

- **BlossomFetcher.kt**: Updated `NetworkFetcher` configuration to use `DeDupeConcurrentRequestStrategy()`
- **ImageLoaderSetup.kt**: Updated `OkHttpFactory`'s `NetworkFetcher` configuration to use `DeDupeConcurrentRequestStrategy()`
- **ProfilePictureFetcher.kt**: Updated `NetworkFetcher` configuration to use `DeDupeConcurrentRequestStrategy()`

All three files also updated their imports to reflect the new strategy class.

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes: This is a straightforward dependency upgrade to use the recommended Coil3 API. The change is mechanical — replacing one strategy enum value with an equivalent strategy instance. Existing image loading tests should pass without modification.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [ ] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

https://claude.ai/code/session_01BeWZGTz48kzURQLTYyN5x9