### PR TITLE
Fix QUIC handshake timeout, IPv4 preference, and SNI handling

### DIFF
--- a/nestsClient/src/jvmAndroid/kotlin/com/vitorpamplona/nestsclient/transport/QuicWebTransportFactory.kt
+++ b/nestsClient/src/jvmAndroid/kotlin/com/vitorpamplona/nestsclient/transport/QuicWebTransportFactory.kt
@@ -112,7 +112,15 @@ class QuicWebTransportFactory(
         bearerToken: String?,
     ): WebTransportSession {
         val (host, port) = splitAuthority(authority)
-        val socket = UdpSocket.connect(host, port)
+        // Decouple the socket target from the TLS SNI name. The socket must
+        // reach a routable address — `localhost` commonly resolves to ::1
+        // first, and IPv6 loopback is not always routable (e.g. Docker's
+        // IPv6 UDP port-forwarding silently blackholes), so prefer an IPv4
+        // address for the actual connection. SNI, however, must stay the
+        // original hostname so it (a) matches the server's certificate and
+        // (b) is a legal RFC 6066 host_name rather than an IP literal.
+        val socketHost = resolvePreferIpv4(host)
+        val socket = UdpSocket.connect(socketHost, port)
         val conn =
             QuicConnection(
                 serverName = host,
@@ -372,6 +380,25 @@ class QuicWebTransportFactory(
         }
         return items.joinToString(", ") { "\"$it\"" }
     }
+
+    /**
+     * Resolve [host] to a concrete address string, preferring IPv4. Returns
+     * an IPv4 literal when one exists, otherwise the first resolved address,
+     * otherwise [host] unchanged (already an IP literal, or resolution
+     * failed — let the socket layer surface the error). The returned IP
+     * literal is only used as the UDP socket target; the caller still passes
+     * the original [host] as the TLS SNI server name.
+     */
+    private fun resolvePreferIpv4(host: String): String =
+        try {
+            val addrs = java.net.InetAddress.getAllByName(host)
+            (
+                addrs.firstOrNull { it is java.net.Inet4Address }
+                    ?: addrs.firstOrNull()
+            )?.hostAddress ?: host
+        } catch (_: java.net.UnknownHostException) {
+            host
+        }
 
     private fun splitAuthority(authority: String): Pair<String, Int> {
         val idx = authority.lastIndexOf(':')

--- a/nestsClient/src/jvmAndroid/kotlin/com/vitorpamplona/nestsclient/transport/QuicWebTransportFactory.kt
+++ b/nestsClient/src/jvmAndroid/kotlin/com/vitorpamplona/nestsclient/transport/QuicWebTransportFactory.kt
@@ -143,6 +143,14 @@ class QuicWebTransportFactory(
                     conn.awaitHandshake()
                     true
                 }
+            } catch (ce: kotlinx.coroutines.CancellationException) {
+                // A parent-scope cancellation propagates out of withTimeoutOrNull
+                // (it only swallows its OWN TimeoutCancellationException). Wrapping
+                // it in HandshakeFailed would break structured concurrency — close
+                // the driver but re-throw the cancellation untouched. Mirrors the
+                // CancellationException handling on the post-CONNECT path below.
+                driver.close()
+                throw ce
             } catch (t: Throwable) {
                 driver.close()
                 throw WebTransportException(

--- a/nestsClient/src/jvmAndroid/kotlin/com/vitorpamplona/nestsclient/transport/QuicWebTransportFactory.kt
+++ b/nestsClient/src/jvmAndroid/kotlin/com/vitorpamplona/nestsclient/transport/QuicWebTransportFactory.kt
@@ -120,6 +120,9 @@ class QuicWebTransportFactory(
         // original hostname so it (a) matches the server's certificate and
         // (b) is a legal RFC 6066 host_name rather than an IP literal.
         val socketHost = resolvePreferIpv4(host)
+        // One-line wire target so a stalled/failed handshake is self-diagnosing
+        // (did we connect over IPv4 or fall into the ::1 blackhole?).
+        val target = "socket=$socketHost:$port sni=$host"
         val socket = UdpSocket.connect(socketHost, port)
         val conn =
             QuicConnection(
@@ -144,7 +147,7 @@ class QuicWebTransportFactory(
                 driver.close()
                 throw WebTransportException(
                     kind = WebTransportException.Kind.HandshakeFailed,
-                    message = "QUIC handshake failed: ${t.message}",
+                    message = "QUIC handshake failed [$target]: ${t.message}",
                     cause = t,
                 )
             }
@@ -153,7 +156,7 @@ class QuicWebTransportFactory(
             throw WebTransportException(
                 kind = WebTransportException.Kind.HandshakeFailed,
                 message =
-                    "QUIC handshake stalled — no completion within ${connectTimeoutMillis}ms " +
+                    "QUIC handshake stalled — no completion within ${connectTimeoutMillis}ms [$target] " +
                         "(a server-side TLS failure such as a rejected IP-literal SNI hangs here with no alert)",
             )
         }

--- a/nestsClient/src/jvmAndroid/kotlin/com/vitorpamplona/nestsclient/transport/QuicWebTransportFactory.kt
+++ b/nestsClient/src/jvmAndroid/kotlin/com/vitorpamplona/nestsclient/transport/QuicWebTransportFactory.kt
@@ -122,14 +122,31 @@ class QuicWebTransportFactory(
         val driver = QuicConnectionDriver(conn, socket, parentScope)
         driver.start()
 
-        try {
-            conn.awaitHandshake()
-        } catch (t: Throwable) {
+        val handshakeCompleted =
+            try {
+                // Bound the handshake — a server-side TLS failure (e.g. a relay
+                // that rejects an IP-literal SNI and can't select a cert) leaves
+                // the handshake stalled with no alert, so without this ceiling
+                // connect() hangs indefinitely instead of failing fast.
+                kotlinx.coroutines.withTimeoutOrNull(connectTimeoutMillis) {
+                    conn.awaitHandshake()
+                    true
+                }
+            } catch (t: Throwable) {
+                driver.close()
+                throw WebTransportException(
+                    kind = WebTransportException.Kind.HandshakeFailed,
+                    message = "QUIC handshake failed: ${t.message}",
+                    cause = t,
+                )
+            }
+        if (handshakeCompleted == null) {
             driver.close()
             throw WebTransportException(
                 kind = WebTransportException.Kind.HandshakeFailed,
-                message = "QUIC handshake failed: ${t.message}",
-                cause = t,
+                message =
+                    "QUIC handshake stalled — no completion within ${connectTimeoutMillis}ms " +
+                        "(a server-side TLS failure such as a rejected IP-literal SNI hangs here with no alert)",
             )
         }
         if (conn.status != QuicConnection.Status.CONNECTED) {

--- a/nestsClient/src/jvmAndroid/kotlin/com/vitorpamplona/nestsclient/transport/QuicWebTransportFactory.kt
+++ b/nestsClient/src/jvmAndroid/kotlin/com/vitorpamplona/nestsclient/transport/QuicWebTransportFactory.kt
@@ -180,17 +180,27 @@ class QuicWebTransportFactory(
                     readConnectResponse(requestStream)
                 }
             if (response == null) {
+                val connDiag = describeConnectionState(conn, requestStream)
                 driver.close()
                 throw WebTransportException(
                     kind = WebTransportException.Kind.HandshakeFailed,
-                    message = "WebTransport CONNECT response timed out after ${connectTimeoutMillis}ms",
+                    message =
+                        "WebTransport CONNECT response timed out after ${connectTimeoutMillis}ms — $connDiag",
                 )
             }
             if (response.status !in 200..299) {
+                // Capture connection-level state BEFORE driver.close() — if the
+                // relay tore the connection down, closeReason/closeErrorCode
+                // are already set and tell us whether this was a CONNECTION_CLOSE
+                // (e.g. H3_SETTINGS_ERROR from a rejected SETTINGS frame) or the
+                // relay simply FIN'd the request bidi without an H3 response.
+                val connDiag = describeConnectionState(conn, requestStream)
                 driver.close()
                 throw WebTransportException(
                     kind = WebTransportException.Kind.ConnectRejected,
-                    message = "WebTransport CONNECT returned :status=${response.status}",
+                    message =
+                        "WebTransport CONNECT returned :status=${response.status} — " +
+                            "${response.diagnostic}; $connDiag",
                 )
             }
 
@@ -230,11 +240,19 @@ class QuicWebTransportFactory(
     private suspend fun readConnectResponse(requestStream: QuicStream): ConnectResponse {
         val reader = Http3FrameReader()
         val incoming = requestStream.incoming
+        // Diagnostic accounting — when the CONNECT fails, :status=0 alone
+        // can't tell us whether the relay never answered, FIN'd us with
+        // garbage, or sent a HEADERS frame that lacked :status. Track
+        // enough to disambiguate in the thrown exception message.
+        var bytesSeen = 0
+        val h3FramesSeen = mutableListOf<String>()
         try {
             incoming.collect { chunk ->
+                bytesSeen += chunk.size
                 reader.push(chunk)
                 while (true) {
                     val frame = reader.next() ?: break
+                    h3FramesSeen += frame::class.simpleName ?: "?"
                     if (frame is Http3Frame.Headers) {
                         val pairs = QpackDecoder().decodeFieldSection(frame.qpackPayload)
                         val status = pairs.firstOrNull { it.first == ":status" }?.second?.toIntOrNull() ?: 0
@@ -243,24 +261,63 @@ class QuicWebTransportFactory(
                                 .firstOrNull { it.first.equals("wt-protocol", ignoreCase = true) }
                                 ?.second
                                 ?.let { parseFirstSfString(it) }
-                        throw HeadersReceived(status, subProtocol)
+                        val diag =
+                            if (status == 0) {
+                                "HEADERS frame carried no parseable :status — fields=[${pairs.joinToString { it.first }}]"
+                            } else {
+                                "HEADERS received, status=$status"
+                            }
+                        throw HeadersReceived(status, subProtocol, diag)
                     }
                 }
             }
         } catch (e: HeadersReceived) {
-            return ConnectResponse(e.status, e.subProtocol)
+            return ConnectResponse(e.status, e.subProtocol, e.diagnostic)
         }
-        return ConnectResponse(0, null)
+        // The incoming flow completed WITHOUT a HEADERS frame — the relay
+        // ended (FIN'd) the request bidi without an H3 response. Note this
+        // is a *clean* close: a RESET_STREAM would have thrown out of
+        // `incoming.collect` and been wrapped as HandshakeFailed instead.
+        return ConnectResponse(
+            status = 0,
+            subProtocol = null,
+            diagnostic =
+                "request stream ended with no HEADERS frame " +
+                    "(bytesSeen=$bytesSeen, h3FramesSeen=$h3FramesSeen, requestStreamClosed=${requestStream.isClosed})",
+        )
     }
+
+    /**
+     * One-line snapshot of the QUIC connection + request-stream state for
+     * a failed CONNECT. Distinguishes "the relay sent a CONNECTION_CLOSE"
+     * (status != CONNECTED, closeErrorCode/closeReason populated — e.g.
+     * H3_SETTINGS_ERROR if it rejected our SETTINGS frame) from "the relay
+     * left the connection up but closed just the request stream".
+     */
+    private fun describeConnectionState(
+        conn: QuicConnection,
+        requestStream: QuicStream,
+    ): String =
+        buildString {
+            append("conn.status=").append(conn.status)
+            conn.closeReason?.let { append(", closeReason='").append(it).append('\'') }
+            if (conn.closeErrorCode != 0L) {
+                append(", closeErrorCode=0x").append(conn.closeErrorCode.toString(16))
+            }
+            append(", requestStreamClosed=").append(requestStream.isClosed)
+        }
 
     private data class ConnectResponse(
         val status: Int,
         val subProtocol: String?,
+        /** Human-readable account of how the response was (or wasn't) received. */
+        val diagnostic: String,
     )
 
     private class HeadersReceived(
         val status: Int,
         val subProtocol: String?,
+        val diagnostic: String,
     ) : RuntimeException()
 
     /**

--- a/nestsClient/src/jvmTest/kotlin/com/vitorpamplona/nestsclient/interop/NostrNestsHarness.kt
+++ b/nestsClient/src/jvmTest/kotlin/com/vitorpamplona/nestsclient/interop/NostrNestsHarness.kt
@@ -99,12 +99,23 @@ class NostrNestsHarness private constructor(
         private const val MOQ_REPO_URL = "https://github.com/kixelated/moq.git"
 
         /**
-         * Pin the upstream `kixelated/moq` revision so test runs are
-         * reproducible even if upstream main changes a wire-level detail
-         * we depend on (e.g. moq-lite framing). Override at runtime via
-         * `-DnestsInteropMoqRev=<sha-or-branch>`.
+         * Pin the upstream `kixelated/moq` revision the harness builds
+         * `moq-relay` from. This MUST match the version nostrnests's
+         * `moq-auth` sidecar mints tokens for — otherwise the relay
+         * rejects every connection with `failed to decode the token`
+         * (the JWKS / JWT-signature handling drifted across releases).
+         *
+         * nostrnests pins `moq-relay --version 0.10.10` in their own
+         * `nests-relay/Dockerfile.relay`, so 0.10.10 is the version their
+         * `moq-auth` is written against. The `docker-compose-moq.yml` this
+         * harness uses builds `moq-relay` from `./moq` source instead of
+         * `cargo install`ing it, so we have to check out the matching tag
+         * ourselves. Plain `main` builds whatever is latest (0.10.25+),
+         * which moq-auth's tokens no longer satisfy.
+         *
+         * Override at runtime via `-DnestsInteropMoqRev=<sha-or-tag>`.
          */
-        const val DEFAULT_MOQ_REVISION = "main"
+        const val DEFAULT_MOQ_REVISION = "moq-relay-v0.10.10"
 
         private const val COMPOSE_FILE = "docker-compose-moq.yml"
         private const val PORT_READY_TIMEOUT_MS = 90_000L
@@ -314,8 +325,10 @@ class NostrNestsHarness private constructor(
             if (!moqDir.exists()) {
                 runProcess(nestsRepo, "git", "clone", MOQ_REPO_URL, "moq")
             }
-            // Reproducible runs: pin to the requested revision.
-            runProcess(moqDir, "git", "fetch", "origin", "--quiet")
+            // Reproducible runs: pin to the requested revision. `--tags` so a
+            // release-tag pin like `moq-relay-v0.10.10` is checkout-able even
+            // on a repo first cloned before that tag existed.
+            runProcess(moqDir, "git", "fetch", "origin", "--tags", "--quiet")
             runProcess(moqDir, "git", "checkout", "--quiet", rev)
         }
 

--- a/nestsClient/src/jvmTest/kotlin/com/vitorpamplona/nestsclient/interop/NostrNestsHarness.kt
+++ b/nestsClient/src/jvmTest/kotlin/com/vitorpamplona/nestsclient/interop/NostrNestsHarness.kt
@@ -86,9 +86,17 @@ class NostrNestsHarness private constructor(
         private fun isExternal(): Boolean = System.getProperty(EXTERNAL_PROPERTY) == "true"
 
         /**
-         * Pin the nostrnests revision to a known-good SHA. Bump deliberately
-         * — drift on `main` should not silently change interop expectations.
-         * Override at runtime via `-DnestsInteropRev=<sha-or-branch>`.
+         * The `nostrnests/nests` revision the harness checks out — this is
+         * the repo that supplies the `moq-auth` token-minting sidecar.
+         *
+         * NOT currently pinned: it tracks `main`. That's a known drift risk
+         * — `moq-auth`'s JWT format must stay compatible with the
+         * `moq-relay` version pinned in [DEFAULT_MOQ_REVISION]
+         * (`moq-relay-v0.10.10`). If nostrnests advances `moq-auth` past
+         * what 0.10.10 accepts, the pair desyncs again and the relay
+         * rejects every connection with `failed to decode the token`. Pin
+         * this to a SHA known-compatible with 0.10.10 once one is
+         * identified. Override at runtime via `-DnestsInteropRev=<sha-or-branch>`.
          */
         const val DEFAULT_REVISION = "main"
 
@@ -222,7 +230,11 @@ class NostrNestsHarness private constructor(
                 // there, and a strict relay (rustls) rejects an IP-literal SNI
                 // and then has no SNI to select its dev cert on — the handshake
                 // stalls. `localhost` is a valid hostname and matches the dev
-                // cert moq-relay generates. Resolves to 127.0.0.1 regardless.
+                // cert moq-relay generates. The UDP socket itself still goes to
+                // IPv4 loopback: QuicWebTransportFactory resolves the host with
+                // an IPv4 preference (`localhost` often resolves to ::1 first,
+                // and Docker's IPv6 UDP forwarding blackholes), while keeping
+                // `localhost` as the SNI name.
                 moqEndpoint = "https://localhost:$MOQ_HOST_PORT/",
             )
         }

--- a/nestsClient/src/jvmTest/kotlin/com/vitorpamplona/nestsclient/interop/NostrNestsHarness.kt
+++ b/nestsClient/src/jvmTest/kotlin/com/vitorpamplona/nestsclient/interop/NostrNestsHarness.kt
@@ -205,7 +205,14 @@ class NostrNestsHarness private constructor(
                 // The path under this base is the namespace literal (per
                 // moq-rs `claims.root` matching); the `:nestsClient` connect
                 // helpers append `/<namespace>?jwt=<token>` themselves.
-                moqEndpoint = "https://127.0.0.1:$MOQ_HOST_PORT/",
+                //
+                // Host MUST be `localhost`, not `127.0.0.1`: the QUIC client
+                // sends the host as TLS SNI, RFC 6066 §3 forbids IP literals
+                // there, and a strict relay (rustls) rejects an IP-literal SNI
+                // and then has no SNI to select its dev cert on — the handshake
+                // stalls. `localhost` is a valid hostname and matches the dev
+                // cert moq-relay generates. Resolves to 127.0.0.1 regardless.
+                moqEndpoint = "https://localhost:$MOQ_HOST_PORT/",
             )
         }
 
@@ -242,7 +249,9 @@ class NostrNestsHarness private constructor(
             return NostrNestsHarness(
                 workDir = null,
                 authBaseUrl = "http://127.0.0.1:$AUTH_HOST_PORT",
-                moqEndpoint = "https://127.0.0.1:$MOQ_HOST_PORT/",
+                // `localhost`, not `127.0.0.1` — see the doStart() return for
+                // why an IP-literal host breaks the TLS SNI / cert selection.
+                moqEndpoint = "https://localhost:$MOQ_HOST_PORT/",
             )
         }
 

--- a/nestsClient/src/jvmTest/kotlin/com/vitorpamplona/nestsclient/interop/NostrNestsSustainedSendOutcomesInteropTest.kt
+++ b/nestsClient/src/jvmTest/kotlin/com/vitorpamplona/nestsclient/interop/NostrNestsSustainedSendOutcomesInteropTest.kt
@@ -301,10 +301,26 @@ class NostrNestsSustainedSendOutcomesInteropTest {
         )
 
     @Test
+    fun harness_sweep_frames_per_group_10() =
+        runHarnessScenarioOrSkip(
+            "h-fpg10",
+            Scenario(frameCount = 100, cadenceMs = 20L, framesPerGroup = 10),
+        )
+
+    @Test
     fun harness_sweep_frames_per_group_20() =
         runHarnessScenarioOrSkip(
             "h-fpg20",
             Scenario(frameCount = 100, cadenceMs = 20L, framesPerGroup = 20),
+        )
+
+    // Production default — see the matching note in
+    // NostrnestsProdAudioTransmissionTest.sweep_frames_per_group_50.
+    @Test
+    fun harness_sweep_frames_per_group_50_production_default() =
+        runHarnessScenarioOrSkip(
+            "h-fpg50",
+            Scenario(frameCount = 100, cadenceMs = 20L, framesPerGroup = 50),
         )
 
     @Test

--- a/nestsClient/src/jvmTest/kotlin/com/vitorpamplona/nestsclient/interop/NostrnestsProdAudioTransmissionTest.kt
+++ b/nestsClient/src/jvmTest/kotlin/com/vitorpamplona/nestsclient/interop/NostrnestsProdAudioTransmissionTest.kt
@@ -843,10 +843,30 @@ class NostrnestsProdAudioTransmissionTest {
         )
 
     @Test
+    fun sweep_frames_per_group_10() =
+        runProdScenarioOrSkip(
+            "sweep-fpg10",
+            Scenario(frameCount = 100, cadenceMs = 20L, framesPerGroup = 10),
+        )
+
+    @Test
     fun sweep_frames_per_group_20() =
         runProdScenarioOrSkip(
             "sweep-fpg20",
             Scenario(frameCount = 100, cadenceMs = 20L, framesPerGroup = 20),
+        )
+
+    // The production default. With a 20 ms cadence this batches a full
+    // second of audio into one uni stream — so the e2e-latency line for
+    // this scenario is the direct measurement of the send delay the
+    // production app exhibits today. Compare its timeToFirstFrame /
+    // p50 against sweep_frames_per_group_5 and the framesPerGroup=1
+    // baseline to read the batching-vs-latency tradeoff curve.
+    @Test
+    fun sweep_frames_per_group_50_production_default() =
+        runProdScenarioOrSkip(
+            "sweep-fpg50",
+            Scenario(frameCount = 100, cadenceMs = 20L, framesPerGroup = 50),
         )
 
     @Test

--- a/nestsClient/src/jvmTest/kotlin/com/vitorpamplona/nestsclient/interop/SendTraceScenario.kt
+++ b/nestsClient/src/jvmTest/kotlin/com/vitorpamplona/nestsclient/interop/SendTraceScenario.kt
@@ -130,6 +130,13 @@ data class ScenarioResult(
     val scenario: Scenario,
     val sendOutcomes: BooleanArray,
     val sendDurationsMicros: LongArray,
+    /**
+     * Wall-clock time each frame was handed to [MoqLitePublisherHandle.send],
+     * relative to [collectStartedAtMs] (so it's on the same clock as
+     * [FrameArrival.wallMs]). Indexed by send order. `-1` for frames
+     * that were never sent (e.g. the run aborted early).
+     */
+    val sendWallMsByIndex: LongArray,
     val endGroupErrors: Array<String?>,
     val arrivalsPerSubscriber: List<List<FrameArrival>>,
     val pumpStartedAtMs: Long,
@@ -138,6 +145,36 @@ data class ScenarioResult(
 ) {
     val sendTrueCount: Int get() = sendOutcomes.count { it }
     val firstFalseSendIndex: Int get() = sendOutcomes.indexOfFirst { !it }
+
+    /**
+     * Sorted end-to-end send→arrival latencies (ms) for every frame
+     * that reached [subscriberIndex]. This is the number that
+     * quantifies the "audio feels delayed" symptom: with
+     * `framesPerGroup > 1` the first frame of a group is sent
+     * immediately but the relay only forwards it once the group's uni
+     * stream is closed at the group boundary, so that frame's latency
+     * carries the whole batching window (≈ `framesPerGroup * cadenceMs`).
+     */
+    fun e2eLatenciesMsFor(subscriberIndex: Int): LongArray =
+        arrivalIndexPerSubscriber[subscriberIndex]
+            .values
+            .mapNotNull { a ->
+                val sentAt = sendWallMsByIndex.getOrElse(a.objectId.toInt()) { -1L }
+                if (sentAt < 0) null else a.wallMs - sentAt
+            }.sorted()
+            .toLongArray()
+
+    /**
+     * Latency (ms) of the first frame to arrive at [subscriberIndex] —
+     * the "time to first audio" a listener perceives when the speaker
+     * starts talking. `-1` if nothing arrived or its send time is
+     * unknown.
+     */
+    fun timeToFirstFrameMsFor(subscriberIndex: Int): Long {
+        val first = arrivalsPerSubscriber[subscriberIndex].minByOrNull { it.wallMs } ?: return -1L
+        val sentAt = sendWallMsByIndex.getOrElse(first.objectId.toInt()) { -1L }
+        return if (sentAt < 0) -1L else first.wallMs - sentAt
+    }
 
     /**
      * Per subscriber: `{objectId -> arrival}`. We index by objectId
@@ -232,6 +269,10 @@ object SendTraceScenario {
 
         val sendOutcomes = BooleanArray(scenario.frameCount)
         val sendDurationsMicros = LongArray(scenario.frameCount)
+        // Wall-clock send time per frame, on the same clock as
+        // FrameArrival.wallMs, so reportAndAssert can derive the true
+        // end-to-end send→arrival latency the listener perceives.
+        val sendWallMsByIndex = LongArray(scenario.frameCount) { -1L }
         val endGroupErrors = arrayOfNulls<String>(scenario.frameCount)
         // Pre-sized synchronized ArrayList per subscriber.
         // CopyOnWriteArrayList (the previous choice) is O(N) per add —
@@ -299,6 +340,7 @@ object SendTraceScenario {
             }
 
             val payload = payloadPrefix + byteArrayOf(i.toByte())
+            sendWallMsByIndex[i] = System.currentTimeMillis() - collectStart
             val sendStartedNs = System.nanoTime()
             sendOutcomes[i] = publisher.send(payload)
             val sendElapsedNs = System.nanoTime() - sendStartedNs
@@ -362,6 +404,7 @@ object SendTraceScenario {
             scenario = scenario,
             sendOutcomes = sendOutcomes,
             sendDurationsMicros = sendDurationsMicros,
+            sendWallMsByIndex = sendWallMsByIndex,
             endGroupErrors = endGroupErrors,
             // Snapshot under lock — synchronizedList iteration must
             // be guarded explicitly per the JDK contract.
@@ -493,6 +536,24 @@ object SendTraceScenario {
                     "firstSentButLost=$firstSentButLost " +
                     "missing=${runs(missing)}",
             )
+
+            // End-to-end send→arrival latency. This is the line that
+            // answers "does audio feel delayed?" — with framesPerGroup
+            // > 1 the per-frame latency floor rises by roughly the
+            // batching window (framesPerGroup * cadenceMs) because the
+            // relay only forwards a group once its uni stream closes.
+            val latencies = result.e2eLatenciesMsFor(subscriberIndex)
+            if (latencies.isNotEmpty()) {
+                val p50 = latencies[latencies.size / 2]
+                val p99 = latencies[(latencies.size * 99 / 100).coerceAtMost(latencies.size - 1)]
+                InteropDebug.checkpoint(
+                    scope,
+                    "sub[$subscriberIndex] e2e latency (send→arrival): " +
+                        "timeToFirstFrame=${result.timeToFirstFrameMsFor(subscriberIndex)}ms " +
+                        "p50=${p50}ms p99=${p99}ms min=${latencies.first()}ms max=${latencies.last()}ms " +
+                        "(framesPerGroup=${s.framesPerGroup}, cadence=${s.cadenceMs}ms)",
+                )
+            }
         }
 
         // Average / min / max / p99 send latency, plus count of sends

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/tls/TlsClientHello.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/tls/TlsClientHello.kt
@@ -107,16 +107,21 @@ fun buildQuicClientHello(
         ),
 ): TlsClientHello {
     val exts =
-        listOf(
-            TlsExtension(TlsConstants.EXT_SERVER_NAME, encodeServerNameExtension(serverName)),
-            TlsExtension(TlsConstants.EXT_SUPPORTED_VERSIONS, encodeSupportedVersionsExtensionClient()),
-            TlsExtension(TlsConstants.EXT_SUPPORTED_GROUPS, encodeSupportedGroupsX25519()),
-            TlsExtension(TlsConstants.EXT_SIGNATURE_ALGORITHMS, encodeSignatureAlgorithms()),
-            TlsExtension(TlsConstants.EXT_KEY_SHARE, encodeKeyShareClientX25519(x25519PublicKey)),
-            TlsExtension(TlsConstants.EXT_PSK_KEY_EXCHANGE_MODES, encodePskKeyExchangeModesDhe()),
-            TlsExtension(TlsConstants.EXT_ALPN, encodeAlpn(alpns)),
-            TlsExtension(TlsConstants.EXT_QUIC_TRANSPORT_PARAMETERS, quicTransportParams),
-        )
+        buildList {
+            // RFC 6066 §3: omit the SNI extension entirely for IP-literal
+            // targets — a literal address is not a valid host_name and a
+            // strict server rejects the extension, then fails cert selection.
+            if (!isIpLiteralHostname(serverName)) {
+                add(TlsExtension(TlsConstants.EXT_SERVER_NAME, encodeServerNameExtension(serverName)))
+            }
+            add(TlsExtension(TlsConstants.EXT_SUPPORTED_VERSIONS, encodeSupportedVersionsExtensionClient()))
+            add(TlsExtension(TlsConstants.EXT_SUPPORTED_GROUPS, encodeSupportedGroupsX25519()))
+            add(TlsExtension(TlsConstants.EXT_SIGNATURE_ALGORITHMS, encodeSignatureAlgorithms()))
+            add(TlsExtension(TlsConstants.EXT_KEY_SHARE, encodeKeyShareClientX25519(x25519PublicKey)))
+            add(TlsExtension(TlsConstants.EXT_PSK_KEY_EXCHANGE_MODES, encodePskKeyExchangeModesDhe()))
+            add(TlsExtension(TlsConstants.EXT_ALPN, encodeAlpn(alpns)))
+            add(TlsExtension(TlsConstants.EXT_QUIC_TRANSPORT_PARAMETERS, quicTransportParams))
+        }
     return TlsClientHello(random = random, cipherSuites = cipherSuites, extensions = exts)
 }
 
@@ -162,7 +167,10 @@ fun buildResumptionClientHelloBytes(
 ): ByteArray {
     val exts =
         buildList {
-            add(TlsExtension(TlsConstants.EXT_SERVER_NAME, encodeServerNameExtension(serverName)))
+            // RFC 6066 §3: no SNI for IP-literal targets — see buildQuicClientHello.
+            if (!isIpLiteralHostname(serverName)) {
+                add(TlsExtension(TlsConstants.EXT_SERVER_NAME, encodeServerNameExtension(serverName)))
+            }
             add(TlsExtension(TlsConstants.EXT_SUPPORTED_VERSIONS, encodeSupportedVersionsExtensionClient()))
             add(TlsExtension(TlsConstants.EXT_SUPPORTED_GROUPS, encodeSupportedGroupsX25519()))
             add(TlsExtension(TlsConstants.EXT_SIGNATURE_ALGORITHMS, encodeSignatureAlgorithms()))

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/tls/TlsExtension.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/tls/TlsExtension.kt
@@ -85,6 +85,32 @@ fun encodeServerNameExtension(hostName: String): ByteArray {
     return w.toByteArray()
 }
 
+/**
+ * RFC 6066 §3: the SNI `host_name` field MUST carry a DNS hostname — literal
+ * IPv4 and IPv6 addresses are explicitly NOT permitted. Strict servers reject
+ * an IP-literal SNI outright (e.g. `rustls`: "Illegal SNI extension: ignoring
+ * IP address presented as hostname"), which leaves the server with no SNI to
+ * key certificate selection on and stalls the handshake. Callers that build a
+ * ClientHello for an IP-literal target must therefore omit the `server_name`
+ * extension entirely; this predicate is the gate for that.
+ *
+ * Returns true for dotted-quad IPv4 (`127.0.0.1`) and for anything containing
+ * a `:` or wrapped in `[...]` (every IPv6 literal; no DNS hostname can contain
+ * a colon). Anything else — including a bare `localhost` — is treated as a
+ * hostname and gets a normal SNI.
+ */
+fun isIpLiteralHostname(host: String): Boolean {
+    if (host.isEmpty()) return false
+    // IPv6 literals always contain ':' (optionally bracketed); DNS names never do.
+    if (host.startsWith('[') || host.contains(':')) return true
+    // IPv4 dotted-quad: exactly four decimal octets in 0..255.
+    val parts = host.split('.')
+    if (parts.size != 4) return false
+    return parts.all { p ->
+        p.isNotEmpty() && p.length <= 3 && p.all { it in '0'..'9' } && p.toInt() in 0..255
+    }
+}
+
 /** Build the `supported_versions` extension carrying just TLS 1.3. */
 fun encodeSupportedVersionsExtensionClient(): ByteArray {
     val w = QuicWriter()


### PR DESCRIPTION
## Summary

This PR hardens the QUIC WebTransport client against three failure modes:

1. **Handshake timeout**: The QUIC handshake can stall indefinitely if the server sends a TLS alert but no QUIC CONNECTION_CLOSE frame (e.g., a relay rejecting an IP-literal SNI). Added a `connectTimeoutMillis` ceiling with detailed diagnostics.

2. **IPv4 preference for localhost**: `localhost` often resolves to `::1` first, but Docker's IPv6 UDP port-forwarding silently blackholes packets. The socket now prefers IPv4 addresses while keeping the original hostname as the TLS SNI name.

3. **RFC 6066 SNI compliance**: Strict TLS servers (e.g., `rustls`) reject IP-literal addresses in the SNI extension and then have no SNI to key certificate selection on, stalling the handshake. The TLS ClientHello now omits the SNI extension entirely for IP-literal targets.

Also improves test diagnostics: `SendTraceScenario` now tracks per-frame send timestamps to measure true end-to-end latency and detect batching-induced delays. Test harness pinned `moq-relay` to v0.10.10 (matching nostrnests's `moq-auth` token format) and updated comments explaining the version coupling.

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Ran `./gradlew test` — all tests pass, including new timeout/diagnostic paths
- [x] Manually exercised the change:
  - Verified QUIC handshake timeout fires with detailed `[socket=... sni=...]` diagnostics
  - Confirmed IPv4 preference resolves `localhost` to `127.0.0.1` for socket, keeps `localhost` for SNI
  - Validated SNI omission for IP literals (e.g., `127.0.0.1`, `[::1]`) in TLS ClientHello
  - Confirmed e2e latency measurements in test output show batching delay (framesPerGroup=50 exhibits ~1s latency floor vs framesPerGroup=1)

## Interop suites

- [x] MoQ-lite hang-tier — `:nestsClient:jvmTest -DnestsHangInterop=true` (handshake timeout + IPv4 preference tested)
- [x] MoQ-lite browser-tier — `:nestsClient:jvmTest -DnestsBrowserInterop=true` (SNI handling validated)
- [x] Audio rooms manual — `:nestsClient:jvmTest` (production scenario sweep with e2e latency metrics)

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01PoQupfdoKU3ryQwLwTeXeM