### PR TITLE
Resolve quoted notes via author's NIP-65 outbox

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -2597,7 +2597,11 @@ object LocalCache : ILocalCache, ICacheProvider {
                 nip19.relay.forEach { relayHint ->
                     relayHints.addEvent(nip19.hex, relayHint)
                 }
-                getOrCreateNote(nip19.hex)
+                val note = getOrCreateNote(nip19.hex)
+                val authorHex = nip19.author
+                if (note.author == null && authorHex != null) {
+                    note.author = checkGetOrCreateUser(authorHex)
+                }
             }
 
             is NEmbed -> {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -2598,9 +2598,8 @@ object LocalCache : ILocalCache, ICacheProvider {
                     relayHints.addEvent(nip19.hex, relayHint)
                 }
                 val note = getOrCreateNote(nip19.hex)
-                val authorHex = nip19.author
-                if (note.author == null && authorHex != null) {
-                    note.author = checkGetOrCreateUser(authorHex)
+                if (note.author == null) {
+                    nip19.author?.let { note.author = checkGetOrCreateUser(it) }
                 }
             }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/loaders/FilterMissingEvents.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/loaders/FilterMissingEvents.kt
@@ -34,6 +34,8 @@ fun potentialRelaysToFindEvent(note: Note): Set<NormalizedRelayUrl> {
 
     set.addAll(LocalCache.relayHints.hintsForEvent(note.idHex))
 
+    note.author?.outboxRelays()?.let { set.addAll(it) }
+
     LocalCache.getAnyChannel(note)?.relays()?.let { set.addAll(it) }
 
     note.replyTo?.forEach { parentNote ->

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/RichTextViewer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/RichTextViewer.kt
@@ -97,6 +97,7 @@ import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.model.checkForHashtagWithIcon
 import com.vitorpamplona.amethyst.service.CachedRichTextParser
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinderFilterAssemblerSubscription
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserInfo
 import com.vitorpamplona.amethyst.service.uploads.blossom.bud10.openBlossomUriAsIntent
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
@@ -660,6 +661,11 @@ fun BechLink(
     val loadedLink by produceCachedState(cache = accountViewModel.bechLinkCache, key = word)
 
     val baseNote = loadedLink?.baseNote
+
+    // Preload the placeholder's author NIP-65 outbox so a missing quoted event can be fetched from there.
+    baseNote?.author?.let { author ->
+        UserFinderFilterAssemblerSubscription(author, accountViewModel)
+    }
 
     if (canPreview && quotesLeft > 0 && baseNote != null) {
         Row {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -2091,6 +2091,7 @@ class AccountViewModel(
                         }
 
                         is NEvent -> {
+                            LocalCache.consume(parsed)
                             LocalCache.checkGetOrCreateNote(parsed.hex)?.let { note ->
                                 returningNote = note
                             }


### PR DESCRIPTION
## Problem
  A `nostr:nevent...` quoted inside a note can fail to render when the q-tag's relay hint goes stale, even though the author's NIP-65 outbox relays still carry the event.

  ## Repro
  Open this note in Amethyst on `main` — the quoted image post never loads:

  `nostr:nevent1qqsxk4kd6atdjzx0ndpqjsjsfv7ak6s0esjm7sahjkflz5xhal0ptwgpr9mhxue69uhhyetvv9ujuum0weexwm3wvdhju7np9upzpn0vcvwxm9qxaxnadvqxwsf25esan5cusq6u8lt9cp3sr5w2cwujqvzqqqqqqy9z2kku`

  (outer note id `6b56cdd756d908cf9b420942504b3ddb6a0fcc25bf43b79593f150d7efde15b9`; quotes `bbbc2c63…` by Claire `b59e00f7…` — hinted relay `wss://nostr.mom` no longer carries the event, but `wss://nostr.bitcoiner.social`
  (one of her NIP-65 write relays) does.)

  ## Root cause — four small gaps                                                                                                                                                                          
  1. `LocalCache.consume(NEvent)` discarded the bech32-embedded author hint, leaving the placeholder `Note.author` null.
  2. `AccountViewModel.CachedLoadedBechLink` only called `checkGetOrCreateNote(hex)` by hex, so the author wiring above never ran during inline preview.
  3. `RichTextViewer.BechLink` didn't observe the placeholder's author, so `UserOutboxFinder` never fetched the author's kind 10002.
  4. `FilterMissingEvents.potentialRelaysToFindEvent` only consulted the outboxes of replies/reactions, not of the unresolved note's own author — so even with NIP-65 loaded the outbox was never queried.

  ## Fix
  +13 / −1 across 4 files; each change targets one gap above.

  ## Test plan
  - [x] Open the repro note above; quoted image card should load.
  - [ ] Open quoted notes that already resolve on `main` (relay hint still serves the event) — regression: still resolve on the hinted relay, no extra latency.

## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
