### PR TITLE
Stop reporting verification errors as Verified

### DIFF
--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip05DnsIdentifiers/Nip05State.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip05DnsIdentifiers/Nip05State.kt
@@ -45,7 +45,7 @@ sealed interface Nip05State {
 
         fun markAsVerifying() = verificationState.tryEmit(Nip05VerifState.Verifying(TimeUtils.fiveMinutesAhead()))
 
-        fun markAsError() = verificationState.tryEmit(Nip05VerifState.Verified(TimeUtils.fiveMinutesAhead()))
+        fun markAsError() = verificationState.tryEmit(Nip05VerifState.Error(TimeUtils.fiveMinutesAhead()))
 
         fun reset() = verificationState.tryEmit(Nip05VerifState.NotStarted)
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/Nip05Id.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/Nip05Id.kt
@@ -47,14 +47,21 @@ data class Nip05Id(
     fun toDomainUrl(): String = domainUrl(domain)
 
     companion object {
+        // NIP-05 localpart: a-z, 0-9, -, _, .
+        private val LOCAL_PART_REGEX = Regex("^[a-z0-9._-]+$")
+
+        // Hostname: dot-separated labels of [a-z0-9-], no leading/trailing hyphen,
+        // require at least one dot so single-label garbage (e.g. "s!ayer") is rejected.
+        private val DOMAIN_REGEX =
+            Regex("^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)(\\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$")
+
         fun parse(nip05address: String): Nip05Id? {
             val parts = nip05address.trim().lowercase().split("@")
-
-            return when (parts.size) {
-                2 -> Nip05Id(parts[0], parts[1])
-                1 -> Nip05Id(parts[0], "_")
-                else -> null
-            }
+            if (parts.size != 2) return null
+            val (name, domain) = parts[0] to parts[1]
+            if (!LOCAL_PART_REGEX.matches(name)) return null
+            if (!DOMAIN_REGEX.matches(domain)) return null
+            return Nip05Id(name, domain)
         }
 
         fun assemble(

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/Nip05Id.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/Nip05Id.kt
@@ -47,8 +47,9 @@ data class Nip05Id(
     fun toDomainUrl(): String = domainUrl(domain)
 
     companion object {
-        // NIP-05 localpart: a-z, 0-9, -, _, .
-        private val LOCAL_PART_REGEX = Regex("^[a-z0-9._-]+$")
+        // NIP-05 localpart: dot-separated atoms of [a-z0-9_-]. Forbids leading,
+        // trailing, and consecutive dots (NIP-05 + RFC 5321 local-part rules).
+        private val LOCAL_PART_REGEX = Regex("^[a-z0-9_-]+(\\.[a-z0-9_-]+)*$")
 
         // Hostname: dot-separated labels of [a-z0-9-], no leading/trailing hyphen,
         // require at least one dot so single-label garbage (e.g. "s!ayer") is rejected.
@@ -58,9 +59,13 @@ data class Nip05Id(
         fun parse(nip05address: String): Nip05Id? {
             val parts = nip05address.trim().lowercase().split("@")
             if (parts.size != 2) return null
-            val (name, domain) = parts[0] to parts[1]
+            val name = parts[0]
+            val domain = parts[1]
             if (!LOCAL_PART_REGEX.matches(name)) return null
             if (!DOMAIN_REGEX.matches(domain)) return null
+            // Reject IP literals — NIP-05 expects a hostname, and a digits-only
+            // TLD is the cheapest way to tell them apart from real domains.
+            if (domain.substringAfterLast('.').all { it.isDigit() }) return null
             return Nip05Id(name, domain)
         }
 

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/Nip05Test.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/Nip05Test.kt
@@ -134,6 +134,27 @@ class Nip05Test {
     }
 
     @Test
+    fun `parse rejects localpart with leading trailing or consecutive dots`() {
+        assertNull(Nip05Id.parse(".alice@example.com"))
+        assertNull(Nip05Id.parse("alice.@example.com"))
+        assertNull(Nip05Id.parse("alice..bob@example.com"))
+    }
+
+    @Test
+    fun `parse rejects IPv4 literal as domain`() {
+        assertNull(Nip05Id.parse("alice@192.168.1.1"))
+        assertNull(Nip05Id.parse("alice@8.8.8.8"))
+    }
+
+    @Test
+    fun `parse accepts wildcard underscore localpart`() {
+        val nip05 = Nip05Id.parse("_@example.com")
+        assertNotNull(nip05)
+        assertEquals("_", nip05.name)
+        assertEquals("example.com", nip05.domain)
+    }
+
+    @Test
     fun `execute assemble url with valid value returns nip05 url`() {
         // given
         val userName = "TheUser"

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/Nip05Test.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/Nip05Test.kt
@@ -95,6 +95,45 @@ class Nip05Test {
     }
 
     @Test
+    fun `parse rejects empty localpart`() {
+        assertNull(Nip05Id.parse("@example.com"))
+    }
+
+    @Test
+    fun `parse rejects empty domain`() {
+        assertNull(Nip05Id.parse("alice@"))
+    }
+
+    @Test
+    fun `parse rejects domain without a dot`() {
+        assertNull(Nip05Id.parse("alice@localhost"))
+    }
+
+    @Test
+    fun `parse rejects domain with illegal character`() {
+        assertNull(Nip05Id.parse("_@s!ayer"))
+        assertNull(Nip05Id.parse("@s!ayer"))
+    }
+
+    @Test
+    fun `parse rejects localpart with illegal character`() {
+        assertNull(Nip05Id.parse("al!ce@example.com"))
+        assertNull(Nip05Id.parse("alice space@example.com"))
+    }
+
+    @Test
+    fun `parse rejects bare string without at-sign`() {
+        assertNull(Nip05Id.parse("alice"))
+        assertNull(Nip05Id.parse("example.com"))
+    }
+
+    @Test
+    fun `parse rejects domain label with leading or trailing hyphen`() {
+        assertNull(Nip05Id.parse("alice@-example.com"))
+        assertNull(Nip05Id.parse("alice@example-.com"))
+    }
+
+    @Test
     fun `execute assemble url with valid value returns nip05 url`() {
         // given
         val userName = "TheUser"


### PR DESCRIPTION
Fixing the `markAsError` copy-paste error was the main fix. The added domain verification hardening is just a bonus that avoids network calls that would fail anyway.

Funny note: a nip05 bug fix was my first amethyst contribution 3(?) years ago 😄 

## Summary
  `Nip05State.Exists.markAsError` was emitting `Nip05VerifState.Verified` instead of `Nip05VerifState.Error`, so any thrown exception inside `Nip05Client.verify` — DNS failure, malformed URL, network error, JSON parse error —
  silently rendered the user as verified. Regression introduced 2026-02-04 in 7bc726575 ("Refactors the old NIP-05 code on Quartz"). The UI already had an `Error` branch at `NIP05VerificationDisplay.kt:496`; it just never
  received any input.

  Also tightens `Nip05Id.parse` so malformed identifiers are rejected at parse time instead of triggering a network call that throws and lands in the `markAsError` path:
  - Localpart must match `[a-z0-9_-]+(\.[a-z0-9_-]+)*` — no leading, trailing, or consecutive dots.
  - Domain must be dot-separated `[a-z0-9-]` labels with no leading/trailing hyphen and at least one dot.
  - IPv4 literals (all-digit final label) rejected — NIP-05 expects a hostname, not a network address.

  ## Repro
  Npub: `npub1ehkvx8rdjsrwnf7kkqr8gy42vcwe6vwgqdwrl4juqccp689v8wfqr3mz4s`
  This profile's `nip05` field is the literal string `@s!ayer`. On `main` it currently displays as verified; with this fix it no longer does.

  ## Test plan
  - [x] `./gradlew :quartz:jvmTest --tests Nip05Test` — all green (10 new rejection-case tests + 1 positive wildcard test added)
  - [x] `./gradlew spotlessApply` — clean
  - [x] Pre-push hook ran full test suite — passed
  - [x] Installed `:amethyst:installPlayBenchmark` on Pixel 9a; the repro profile no longer shows the verified badge

## License

- [ ] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
