### PR TITLE
Rename onRefresh callback to avoid shadowing parameter

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/feeds/RefresheableBox.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/feeds/RefresheableBox.kt
@@ -73,7 +73,7 @@ fun RefresheableBox(
 ) {
     var isRefreshing by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
-    val onRefresh: () -> Unit = {
+    val onRefreshWrapped: () -> Unit = {
         isRefreshing = true
         scope.launch {
             onRefresh()
@@ -84,7 +84,7 @@ fun RefresheableBox(
 
     PullToRefreshBox(
         isRefreshing = isRefreshing,
-        onRefresh = onRefresh,
+        onRefresh = onRefreshWrapped,
         modifier = Modifier.fillMaxSize(),
         content = content,
     )


### PR DESCRIPTION
## Summary

Rename the local `onRefresh` variable to `onRefreshWrapped` in `RefresheableBox` to avoid shadowing the `onRefresh` function parameter. This improves code clarity by making it explicit that the wrapped callback is distinct from the original parameter.

## Test plan

- [ ] N/A — change is a local variable rename with no behavioral impact
- [ ] Ran `./gradlew spotlessApply` — repo is formatted

The change is a straightforward refactor that renames a local variable for clarity. No functional behavior changes; the wrapped callback is still passed to `PullToRefreshBox` identically.

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_015qWM31SeYDMnpYxVR8mKux