### PR TITLE
Fix desktop app ProGuard build with Compose 1.11.0

### DIFF
--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -129,6 +129,15 @@ compose.desktop {
                 rpmPackageVersion = appVersion.replace("-", "~")
             }
         }
+
+        // Compose Multiplatform 1.11.0 tightened the default ProGuard rules so
+        // unresolved references in transitive deps (Jackson kotlin-module value
+        // classes, okhttp's optional TLS adapters, JNA cleaner internals) now
+        // fail `proguardReleaseJars`. Project-level rules below add the missing
+        // `-dontwarn` directives.
+        buildTypes.release.proguard {
+            configurationFiles.from(project.file("compose-rules.pro"))
+        }
     }
 }
 

--- a/desktopApp/compose-rules.pro
+++ b/desktopApp/compose-rules.pro
@@ -1,0 +1,40 @@
+# ProGuard rules consumed by Compose Multiplatform's `proguardReleaseJars`
+# task (see `compose.desktop.application.buildTypes.release.proguard` wiring
+# in build.gradle.kts).
+#
+# Compose Multiplatform 1.11.0 ships a stricter default ruleset than 1.10.x
+# and now treats unresolved references as fatal. The warnings below come from
+# third-party libraries that have always carried optional code paths; they
+# were silently tolerated on 1.10.3 and broke desktop packaging on 1.11.0.
+
+# --- Jackson kotlin-module 2.21.x value-class converters ---------------------
+# Generated converters call `MethodHandle.invokeExact(...)` with polymorphic
+# signatures that ProGuard cannot resolve against the abstract MethodHandle
+# declaration. They are only used reflectively by Jackson when (de)serializing
+# Kotlin `value class` types — safe to suppress.
+-dontwarn com.fasterxml.jackson.module.kotlin.**
+
+# --- okhttp optional runtime platforms --------------------------------------
+# okhttp ships TLS adapters for GraalVM native-image, Conscrypt, BouncyCastle,
+# OpenJSSE, and Jetty boot. None of these are on the desktop classpath; okhttp
+# falls back to the JDK default. Suppress the warnings without keeping the
+# unused classes.
+-dontwarn okhttp3.internal.graal.**
+-dontwarn okhttp3.internal.platform.BouncyCastlePlatform
+-dontwarn okhttp3.internal.platform.BouncyCastlePlatform$*
+-dontwarn okhttp3.internal.platform.ConscryptPlatform
+-dontwarn okhttp3.internal.platform.ConscryptPlatform$*
+-dontwarn okhttp3.internal.platform.OpenJSSEPlatform
+-dontwarn okhttp3.internal.platform.OpenJSSEPlatform$*
+-dontwarn org.conscrypt.**
+-dontwarn org.bouncycastle.**
+-dontwarn org.openjsse.**
+-dontwarn org.graalvm.**
+-dontwarn com.oracle.svm.**
+
+# --- JNA internal cleaner ---------------------------------------------------
+# `com.sun.jna.internal.Cleaner$CleanerThread` references package-private
+# synthetic accessors (`access$100` …) that ProGuard's class member analysis
+# cannot follow through nested inner classes. The accessors exist at runtime.
+-dontwarn com.sun.jna.internal.Cleaner
+-dontwarn com.sun.jna.internal.Cleaner$*


### PR DESCRIPTION
## Summary

Compose Multiplatform 1.11.0 tightened ProGuard's default ruleset to treat unresolved references as fatal errors. This breaks the desktop app build due to optional code paths in transitive dependencies (Jackson kotlin-module value-class converters, okhttp's optional TLS adapters, and JNA cleaner internals). Added a `compose-rules.pro` configuration file with `-dontwarn` directives for these known-safe unresolved references, and wired it into the release ProGuard build.

## Test plan

- [ ] Ran `./gradlew desktopApp:packageReleaseDistributable` — desktop packaging succeeds without ProGuard errors

Notes: The change adds ProGuard suppression rules for third-party library code paths that are only used reflectively or have runtime fallbacks. These warnings were silently tolerated in Compose 1.10.x and are safe to suppress in 1.11.0.

## Interop suites

- [x] N/A — change is build/packaging only, does not affect wire bytes or runtime behavior

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01FasGo1p72tm6wuagBJMmKC