### PR TITLE
Fix ChatroomListKnownFeedFilter to use flowSet instead of flow

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/dal/ChatroomListKnownFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/dal/ChatroomListKnownFeedFilter.kt
@@ -30,8 +30,6 @@ import com.vitorpamplona.quartz.experimental.ephemChat.chat.EphemeralChatEvent
 import com.vitorpamplona.quartz.experimental.ephemChat.chat.RoomId
 import com.vitorpamplona.quartz.nip17Dm.base.ChatroomKey
 import com.vitorpamplona.quartz.nip17Dm.base.ChatroomKeyable
-import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelCreateEvent
-import com.vitorpamplona.quartz.nip28PublicChat.base.IsInPublicChatChannel
 import com.vitorpamplona.quartz.nip28PublicChat.message.ChannelMessageEvent
 
 class ChatroomListKnownFeedFilter(
@@ -113,7 +111,7 @@ class ChatroomListKnownFeedFilter(
         newRelevantPublicMessages.forEach { newNotePair ->
             var hasUpdated = false
             oldList.forEach { oldNote ->
-                val channelId = publicChannelIdOf(oldNote)
+                val channelId = (oldNote.event as? ChannelMessageEvent)?.channelId()
                 if (newNotePair.key == channelId) {
                     hasUpdated = true
                     if ((newNotePair.value.createdAt() ?: 0L) > (oldNote.createdAt() ?: 0L)) {
@@ -262,16 +260,4 @@ class ChatroomListKnownFeedFilter(
     }
 
     override fun sort(items: Set<Note>): List<Note> = items.sortedWith(DefaultFeedOrder)
-
-    // The chat list keys public-channel rows by channel id, so the existing row
-    // for a channel may be backed by a ChannelCreateEvent or ChannelMetadataEvent
-    // (when no message has arrived yet) — not only a ChannelMessageEvent. Matching
-    // only ChannelMessageEvent here would leave the old row in place and append the
-    // new one, producing a duplicate LazyColumn key.
-    private fun publicChannelIdOf(note: Note): String? =
-        when (val event = note.event) {
-            is IsInPublicChatChannel -> event.channelId()
-            is ChannelCreateEvent -> event.id
-            else -> null
-        }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/dal/ChatroomListKnownFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/dal/ChatroomListKnownFeedFilter.kt
@@ -55,10 +55,10 @@ class ChatroomListKnownFeedFilter(
 
         val publicChannels =
             account
-                .publicChatList.flow.value
-                .mapNotNull { it ->
+                .publicChatList.flowSet.value
+                .mapNotNull { channelId ->
                     LocalCache
-                        .getOrCreatePublicChatChannel(it.eventId)
+                        .getOrCreatePublicChatChannel(channelId)
                         .notes
                         .filter { _, it -> account.isAcceptable(it) && it.event != null }
                         .sortedWith(DefaultFeedOrder)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/dal/ChatroomListKnownFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/dal/ChatroomListKnownFeedFilter.kt
@@ -30,6 +30,8 @@ import com.vitorpamplona.quartz.experimental.ephemChat.chat.EphemeralChatEvent
 import com.vitorpamplona.quartz.experimental.ephemChat.chat.RoomId
 import com.vitorpamplona.quartz.nip17Dm.base.ChatroomKey
 import com.vitorpamplona.quartz.nip17Dm.base.ChatroomKeyable
+import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelCreateEvent
+import com.vitorpamplona.quartz.nip28PublicChat.base.IsInPublicChatChannel
 import com.vitorpamplona.quartz.nip28PublicChat.message.ChannelMessageEvent
 
 class ChatroomListKnownFeedFilter(
@@ -111,7 +113,7 @@ class ChatroomListKnownFeedFilter(
         newRelevantPublicMessages.forEach { newNotePair ->
             var hasUpdated = false
             oldList.forEach { oldNote ->
-                val channelId = (oldNote.event as? ChannelMessageEvent)?.channelId()
+                val channelId = publicChannelIdOf(oldNote)
                 if (newNotePair.key == channelId) {
                     hasUpdated = true
                     if ((newNotePair.value.createdAt() ?: 0L) > (oldNote.createdAt() ?: 0L)) {
@@ -260,4 +262,16 @@ class ChatroomListKnownFeedFilter(
     }
 
     override fun sort(items: Set<Note>): List<Note> = items.sortedWith(DefaultFeedOrder)
+
+    // The chat list keys public-channel rows by channel id, so the existing row
+    // for a channel may be backed by a ChannelCreateEvent or ChannelMetadataEvent
+    // (when no message has arrived yet) — not only a ChannelMessageEvent. Matching
+    // only ChannelMessageEvent here would leave the old row in place and append the
+    // new one, producing a duplicate LazyColumn key.
+    private fun publicChannelIdOf(note: Note): String? =
+        when (val event = note.event) {
+            is IsInPublicChatChannel -> event.channelId()
+            is ChannelCreateEvent -> event.id
+            else -> null
+        }
 }


### PR DESCRIPTION
## Summary

Fixed `ChatroomListKnownFeedFilter` to use `publicChatList.flowSet` instead of the incorrect `publicChatList.flow` property. Also improved variable naming in the `mapNotNull` lambda from `it` to `channelId` for clarity, and updated the corresponding `getOrCreatePublicChatChannel` call to use the renamed parameter.

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes / screenshots:

This is a straightforward property accessor fix with improved naming. The change corrects the data source used for public chat channels in the known feed filter. Existing tests should cover this code path.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [ ] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.

https://claude.ai/code/session_01RNG9MqZ2yLS44MiLDnqHp4