### PR TITLE
ci: remove macos-13 x64 build legs

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -35,7 +35,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: macos-13,       arch: x64,   family: macos,          tasks: "packageReleaseDmg" }
           - { os: macos-14,       arch: arm64, family: macos,          tasks: "packageReleaseDmg" }
           - { os: windows-latest, arch: x64,   family: windows,        tasks: "packageReleaseMsi createReleaseDistributable" }
           - { os: ubuntu-latest,  arch: x64,   family: linux,          tasks: "packageReleaseDeb packageReleaseRpm" }
@@ -204,7 +203,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: macos-13,      arch: x64,   family: macos, tasks: "amyImage" }
           - { os: macos-14,      arch: arm64, family: macos, tasks: "amyImage" }
           - { os: ubuntu-latest, arch: x64,   family: linux, tasks: "amyImage jpackageDeb jpackageRpm" }
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
GitHub's macos-13 runner image is being retired. Drop the x64 macOS
legs from both the desktop and CLI release matrices; macos-14 arm64
continues to ship the macOS builds.