### PR TITLE
feat(notifications): include onchain zaps in summary stats

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationSummaryState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationSummaryState.kt
@@ -40,6 +40,7 @@ import com.vitorpamplona.quartz.nip18Reposts.GenericRepostEvent
 import com.vitorpamplona.quartz.nip18Reposts.RepostEvent
 import com.vitorpamplona.quartz.nip25Reactions.ReactionEvent
 import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
+import com.vitorpamplona.quartz.nipBCOnchainZaps.zap.OnchainZapEvent
 import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -124,6 +125,17 @@ class NotificationSummaryState(
                         }
                     }
 
+                    noteEvent is OnchainZapEvent -> {
+                        if (noteEvent.isTaggedUser(currentUser)) {
+                            val amount = noteEvent.claimedAmountInSats()
+                            if (amount != null) {
+                                val netDate = formatDate(noteEvent.createdAt)
+                                zaps[netDate] = (zaps[netDate] ?: BigDecimal.ZERO) + BigDecimal.valueOf(amount)
+                                takenIntoAccount.add(noteEvent.id)
+                            }
+                        }
+                    }
+
                     noteEvent is BaseThreadedEvent &&
                         noteEvent.isTaggedUser(currentUser) &&
                         noteEvent.pubKey != currentUser -> {
@@ -195,6 +207,18 @@ class NotificationSummaryState(
                                 zaps[netDate] = (zaps[netDate] ?: BigDecimal.ZERO) + (noteEvent.amount ?: BigDecimal.ZERO)
                                 takenIntoAccount.add(noteEvent.id)
                                 hasNewElements = true
+                            }
+                        }
+
+                        noteEvent is OnchainZapEvent -> {
+                            if (noteEvent.isTaggedUser(currentUser)) {
+                                val amount = noteEvent.claimedAmountInSats()
+                                if (amount != null) {
+                                    val netDate = formatDate(noteEvent.createdAt)
+                                    zaps[netDate] = (zaps[netDate] ?: BigDecimal.ZERO) + BigDecimal.valueOf(amount)
+                                    takenIntoAccount.add(noteEvent.id)
+                                    hasNewElements = true
+                                }
                             }
                         }
 


### PR DESCRIPTION
Add OnchainZapEvent handling to NotificationSummaryState so NIP-BC
onchain zaps targeting the current user contribute their claimed sats
to the daily zap total and chart alongside LnZapEvent receipts.