### PR TITLE
fix: subscribe and observe PaymentTargetsEvent for other users

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/DrawAdditionalInfo.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/DrawAdditionalInfo.kt
@@ -56,6 +56,8 @@ import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
 import com.vitorpamplona.amethyst.commons.model.nip05DnsIdentifiers.Nip05State
 import com.vitorpamplona.amethyst.commons.util.toShortDisplay
 import com.vitorpamplona.amethyst.model.User
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.EventFinderFilterAssemblerSubscription
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.observeNoteEvent
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserInfo
 import com.vitorpamplona.amethyst.ui.components.ClickableTextPrimary
 import com.vitorpamplona.amethyst.ui.components.CreateTextWithEmoji
@@ -393,12 +395,16 @@ fun DisplayPaymentTargets(
         }
 
     LoadAddressableNote(address, accountViewModel) { note ->
-        val targets =
-            remember(note) {
-                (note?.event as? PaymentTargetsEvent)?.paymentTargets() ?: emptyList()
+        if (note != null) {
+            EventFinderFilterAssemblerSubscription(note, accountViewModel)
+            val event by observeNoteEvent<PaymentTargetsEvent>(note, accountViewModel)
+            val targets =
+                remember(event) {
+                    event?.paymentTargets() ?: emptyList()
+                }
+            targets.forEach { target ->
+                PaymentTargetRow(target)
             }
-        targets.forEach { target ->
-            PaymentTargetRow(target)
         }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/PaymentButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/PaymentButton.kt
@@ -39,6 +39,8 @@ import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
 import com.vitorpamplona.amethyst.model.User
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.EventFinderFilterAssemblerSubscription
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.observeNoteEvent
 import com.vitorpamplona.amethyst.ui.components.M3ActionDialog
 import com.vitorpamplona.amethyst.ui.components.M3ActionRow
 import com.vitorpamplona.amethyst.ui.components.M3ActionSection
@@ -63,12 +65,16 @@ fun PaymentButton(
         }
 
     LoadAddressableNote(address, accountViewModel) { note ->
-        val targets =
-            remember(note) {
-                (note?.event as? PaymentTargetsEvent)?.paymentTargets() ?: emptyList()
+        if (note != null) {
+            EventFinderFilterAssemblerSubscription(note, accountViewModel)
+            val event by observeNoteEvent<PaymentTargetsEvent>(note, accountViewModel)
+            val targets =
+                remember(event) {
+                    event?.paymentTargets() ?: emptyList()
+                }
+            if (targets.isNotEmpty()) {
+                PaymentButtonWithTargets(targets)
             }
-        if (targets.isNotEmpty()) {
-            PaymentButtonWithTargets(targets)
         }
     }
 }


### PR DESCRIPTION
PaymentButton and DisplayPaymentTargets read note?.event inside a
remember(note) keyed on the AddressableNote reference, which is stable
across event arrival. They also rely solely on LoadAddressableNote's
cache lookup with no relay subscription, so when viewing a profile
outside the path that activates UserProfileMetadataFilterSubAssembler
(or before the event arrives) the UI never updates.

Match the canonical pattern from ProfileBadgesScreen: pair
LoadAddressableNote with EventFinderFilterAssemblerSubscription to
request the event from relays, and observeNoteEvent
to recompose when it arrives.