### PR TITLE
Fix public chat deduplication by channel ID extraction

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/dal/ChatroomListKnownFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/dal/ChatroomListKnownFeedFilter.kt
@@ -30,6 +30,8 @@ import com.vitorpamplona.quartz.experimental.ephemChat.chat.EphemeralChatEvent
 import com.vitorpamplona.quartz.experimental.ephemChat.chat.RoomId
 import com.vitorpamplona.quartz.nip17Dm.base.ChatroomKey
 import com.vitorpamplona.quartz.nip17Dm.base.ChatroomKeyable
+import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelCreateEvent
+import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelMetadataEvent
 import com.vitorpamplona.quartz.nip28PublicChat.message.ChannelMessageEvent
 
 class ChatroomListKnownFeedFilter(
@@ -111,7 +113,7 @@ class ChatroomListKnownFeedFilter(
         newRelevantPublicMessages.forEach { newNotePair ->
             var hasUpdated = false
             oldList.forEach { oldNote ->
-                val channelId = (oldNote.event as? ChannelMessageEvent)?.channelId()
+                val channelId = publicChannelIdOf(oldNote)
                 if (newNotePair.key == channelId) {
                     hasUpdated = true
                     if ((newNotePair.value.createdAt() ?: 0L) > (oldNote.createdAt() ?: 0L)) {
@@ -260,4 +262,18 @@ class ChatroomListKnownFeedFilter(
     }
 
     override fun sort(items: Set<Note>): List<Note> = items.sortedWith(DefaultFeedOrder)
+
+    // Maps a note that represents a public chat row to its channel id. The
+    // representative note for a channel may be the channel's create event
+    // (id == channelId), a metadata update, or a message — match all three so
+    // an arriving ChannelMessageEvent replaces an existing placeholder
+    // metadata/create note for the same channel instead of duplicating it
+    // (which would yield the same LazyColumn key twice).
+    private fun publicChannelIdOf(note: Note): String? =
+        when (val event = note.event) {
+            is ChannelMessageEvent -> event.channelId()
+            is ChannelMetadataEvent -> event.channelId()
+            is ChannelCreateEvent -> event.id
+            else -> null
+        }
 }


### PR DESCRIPTION
## Summary

Refactor channel ID extraction in `ChatroomListKnownFeedFilter` to handle multiple event types that can represent a public chat row. Previously, only `ChannelMessageEvent` was checked; now `ChannelMetadataEvent` and `ChannelCreateEvent` are also supported. This prevents duplicate LazyColumn entries when a `ChannelMessageEvent` arrives for a channel that was previously represented by a metadata or create event.

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes / screenshots:

The change is a straightforward refactor extracting channel ID logic into a helper function that handles three event types. Existing tests should cover the deduplication behavior; no new test scenarios are required.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

https://claude.ai/code/session_017oZCGi4a2wbuKGmTXcDFXW