### PR TITLE
Thread-safe authStatus in RelayAuthenticator (#2946)

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/auth/RelayAuthenticator.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/auth/RelayAuthenticator.kt
@@ -36,6 +36,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 interface IAuthStatus {
     fun hasFinishedAuthentication(relay: NormalizedRelayUrl): Boolean
@@ -45,12 +47,36 @@ object EmptyIAuthStatus : IAuthStatus {
     override fun hasFinishedAuthentication(relay: NormalizedRelayUrl) = true
 }
 
+@OptIn(ExperimentalAtomicApi::class)
 class RelayAuthenticator(
     val client: INostrClient,
     val scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
     val signWithAllLoggedInUsers: suspend (EventTemplate<RelayAuthEvent>) -> List<RelayAuthEvent>,
 ) : IAuthStatus {
-    private val authStatus = mutableMapOf<NormalizedRelayUrl, RelayAuthStatus>()
+    // Connection callbacks fire on the per-relay OkHttp dispatcher thread, so
+    // this state is mutated concurrently — copy-on-write under AtomicReference.
+    private val authStatus: AtomicReference<Map<NormalizedRelayUrl, RelayAuthStatus>> =
+        AtomicReference(emptyMap())
+
+    private fun putAuthStatus(
+        relay: NormalizedRelayUrl,
+        status: RelayAuthStatus,
+    ) {
+        while (true) {
+            val current = authStatus.load()
+            val next = current + (relay to status)
+            if (authStatus.compareAndSet(current, next)) return
+        }
+    }
+
+    private fun removeAuthStatus(relay: NormalizedRelayUrl) {
+        while (true) {
+            val current = authStatus.load()
+            if (relay !in current) return
+            val next = current - relay
+            if (authStatus.compareAndSet(current, next)) return
+        }
+    }
 
     private val clientListener =
         object : RelayConnectionListener {
@@ -66,11 +92,11 @@ class RelayAuthenticator(
             }
 
             override fun onConnecting(relay: IRelayClient) {
-                authStatus[relay.url] = RelayAuthStatus()
+                putAuthStatus(relay.url, RelayAuthStatus())
             }
 
             override fun onDisconnected(relay: IRelayClient) {
-                authStatus.remove(relay.url)
+                removeAuthStatus(relay.url)
             }
         }
 
@@ -82,7 +108,7 @@ class RelayAuthenticator(
             val ev = RelayAuthEvent.build(relay.url, msg.challenge)
             signWithAllLoggedInUsers(ev).forEach { authEvent ->
                 // only send replies to new challenges to avoid infinite loop:
-                if (authStatus[relay.url]?.saveAuthSubmission(authEvent) == true) {
+                if (authStatus.load()[relay.url]?.saveAuthSubmission(authEvent) == true) {
                     relay.sendIfConnected(AuthCmd(authEvent))
                 }
             }
@@ -94,12 +120,12 @@ class RelayAuthenticator(
         msg: OkMessage,
     ) {
         // if this is the OK of an auth event, renew all subscriptions and resend all outgoing events.
-        if (authStatus[relay.url]?.checkAuthResults(msg.eventId, msg.success) == true) {
+        if (authStatus.load()[relay.url]?.checkAuthResults(msg.eventId, msg.success) == true) {
             client.syncFilters(relay)
         }
     }
 
-    override fun hasFinishedAuthentication(relay: NormalizedRelayUrl) = authStatus[relay]?.hasFinishedAllAuths() != false
+    override fun hasFinishedAuthentication(relay: NormalizedRelayUrl) = authStatus.load()[relay]?.hasFinishedAllAuths() != false
 
     init {
         Log.d("RelayAuthenticator", "Init, Subscribe")

--- a/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/auth/RelayAuthenticatorConcurrencyTest.kt
+++ b/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/auth/RelayAuthenticatorConcurrencyTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.relay.client.auth
+
+import com.vitorpamplona.quartz.nip01Core.relay.client.EmptyNostrClient
+import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
+import com.vitorpamplona.quartz.nip01Core.relay.client.listeners.RelayConnectionListener
+import com.vitorpamplona.quartz.nip01Core.relay.client.single.IRelayClient
+import com.vitorpamplona.quartz.nip01Core.relay.commands.toRelay.Command
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlin.test.Test
+
+/**
+ * Reproduces issue #2946 — `ClassCastException: LinkedHashMap$Entry cannot be
+ * cast to HashMap$TreeNode` thrown from
+ * `RelayAuthenticator$clientListener.onDisconnected`.
+ *
+ * OkHttp dispatches WebSocket callbacks on one thread per relay, so when many
+ * relays connect/disconnect simultaneously the listener's internal map is
+ * mutated concurrently. Once a bucket exceeds the HashMap TREEIFY_THRESHOLD (8)
+ * the concurrent treeification corrupts internal state.
+ *
+ * On the buggy code this test fails non-deterministically with a
+ * `ClassCastException` (or `ConcurrentModificationException` /
+ * `NullPointerException`). After the fix it must pass cleanly every run.
+ */
+class RelayAuthenticatorConcurrencyTest {
+    private class CapturingClient(
+        private val delegate: INostrClient = EmptyNostrClient(),
+    ) : INostrClient by delegate {
+        @Volatile var captured: RelayConnectionListener? = null
+
+        override fun addConnectionListener(listener: RelayConnectionListener) {
+            captured = listener
+        }
+    }
+
+    private class FakeRelayClient(
+        override val url: NormalizedRelayUrl,
+    ) : IRelayClient {
+        override fun connect() = Unit
+
+        override fun needsToReconnect() = false
+
+        override fun connectAndSyncFiltersIfDisconnected(ignoreRetryDelays: Boolean) = Unit
+
+        override fun isConnected() = false
+
+        override fun sendOrConnectAndSync(cmd: Command) = Unit
+
+        override fun sendIfConnected(cmd: Command) = Unit
+
+        override fun disconnect() = Unit
+    }
+
+    @Test
+    fun concurrentConnectingAndDisconnecting_doesNotCorruptInternalState() {
+        runBlocking {
+            // The race only fires while the underlying HashMap is structurally
+            // growing — rehashing and bucket treeification. Once the map reaches
+            // its steady-state size, put/remove on existing keys touch a single
+            // node and won't reproduce. So drive many short "burst" cycles, each
+            // starting from an empty map and growing it past
+            // MIN_TREEIFY_CAPACITY (64) under concurrent load.
+            repeat(50) { burst ->
+                val client = CapturingClient()
+                val authenticator =
+                    RelayAuthenticator(
+                        client = client,
+                        signWithAllLoggedInUsers = { emptyList() },
+                    )
+                val listener =
+                    client.captured
+                        ?: error("RelayAuthenticator did not register a listener")
+
+                val relays =
+                    (0 until 256).map {
+                        FakeRelayClient(NormalizedRelayUrl("wss://relay-$burst-$it.example/"))
+                    }
+
+                withContext(Dispatchers.IO) {
+                    (0 until 64)
+                        .map { workerId ->
+                            async {
+                                // Each worker walks the relay set, connecting and
+                                // disconnecting. Connects grow the map (rehash /
+                                // treeify); disconnects shrink it; concurrent reads
+                                // run alongside.
+                                relays.forEachIndexed { idx, relay ->
+                                    if ((workerId + idx) and 1 == 0) {
+                                        listener.onConnecting(relay)
+                                    } else {
+                                        listener.onDisconnected(relay)
+                                    }
+                                    authenticator.hasFinishedAuthentication(relay.url)
+                                }
+                            }
+                        }.awaitAll()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Caveat: I wasn't able to reproduce the issue on device despite heavy testing around the suspected root cause so I wasn't able to verify the fix on device. The bug is dependent on mobile hardware, relays used, the followers and on the network environment.

I was able to reproduce and fix with automated test.

TL;DR:
- 2/30 automated test runs (~6.7%) failed on buggy main, zero spurious failures. 100% success with this fix
- Per-write cost: ~1–5 µs → ~10–20 µs (150–250× slower vs the old in-place mutation).
- Per-write allocation: ~1.5 KB → ~23 KB

**We can potentially park this fix until we see more similar crash reports.**

## Summary
  
Hypothetical fix for #2946 and #2945 — `ClassCastException: LinkedHashMap$Entry cannot be cast to HashMap$TreeNode` thrown from `RelayAuthenticator$clientListener.onDisconnected` on an OkHttp dispatcher thread.

  ## Root cause

  `RelayAuthenticator.authStatus` was a plain `mutableMapOf<NormalizedRelayUrl, RelayAuthStatus>()`. Connection callbacks (`onConnecting`, `onDisconnected`, `onIncomingMessage`) are invoked once per relay socket on that
  socket's own OkHttp dispatcher thread — `BasicRelayClient.MyWebsocketListener` calls `listener.onXxx(...)` directly from its `WebSocketListener` callbacks, and `NostrClient` fans them out via a single `listeners.forEach {
  ... }` on the calling thread.
  
  With N relays you get N concurrent threads mutating the same `LinkedHashMap`. When a bucket reaches `TREEIFY_THRESHOLD = 8` and one thread runs `treeifyBin` while another inserts, internal pointers become inconsistent and a `Node` slot ends up holding a `LinkedHashMap$Entry` where a `TreeNode` is expected — the exact exception from #2946.

  ## Fix
  
  Hold the per-relay status in an `AtomicReference<Map<...>>` and mutate via copy-on-write CAS:

  ```kotlin
  private val authStatus: AtomicReference<Map<NormalizedRelayUrl, RelayAuthStatus>> =
      AtomicReference(emptyMap())

  private fun putAuthStatus(relay: NormalizedRelayUrl, status: RelayAuthStatus) {
      while (true) {
          val current = authStatus.load()
          val next = current + (relay to status)
          if (authStatus.compareAndSet(current, next)) return
      }
  }

  private fun removeAuthStatus(relay: NormalizedRelayUrl) {                                                                                                                                                
      while (true) {
          val current = authStatus.load()
          if (relay !in current) return
          val next = current - relay
          if (authStatus.compareAndSet(current, next)) return
      }
  }
  ```
  
  This matches the existing pattern used in `FilterIndex`, `LiveEventStore`, `SeedModule`, and `BanStore` — same `kotlin.concurrent.atomics.AtomicReference` + CAS loop with immutable map copies. KMP-friendly, no JVM-only
  primitives. Public API and behavior are unchanged; the four read sites now read via `authStatus.load()`.

  ## Performance impact
  
  Under the outbox model the active `authStatus` size is **not** the user's configured relay count (typically 5–20) but the union of all outbox relays of everyone they follow. For an active account this lands in the **~400 
  entry** range. The analysis below uses N=400 as the realistic working size.

  <table>
  <thead>
  <tr><th>Operation</th><th>Before (<code>LinkedHashMap</code>)</th><th>After (<code>AtomicReference&lt;Map&gt;</code> + CAS)</th><th>Delta</th></tr>
  </thead>
  <tbody>
  <tr>
  <td><strong>Read</strong> — <code>hasFinishedAuthentication</code>, <code>authenticate</code>, <code>checkAuthResults</code></td>
  <td><code>LinkedHashMap.get</code> ≈ 5–10 ns</td>
  <td>volatile <code>load()</code> + <code>LinkedHashMap.get</code> ≈ 6–12 ns</td>
  <td>+1–2 ns per read (one volatile load)</td>
  </tr>
  <tr>
  <td><strong>Write</strong> — <code>onConnecting</code>, <code>onDisconnected</code></td>
  <td>in-place <code>put</code> / <code>remove</code> ≈ 50–100 ns</td>
  <td>copy-on-write of ~400 entries + CAS ≈ 10–20 µs</td>
  <td>~150–250× slower per write</td>
  </tr>
  <tr>
  <td><strong>Per-write allocation</strong></td>
  <td>1 Entry on insert (~48 B)</td>
  <td>~400 Entry + ~4 KB backing array + 1 map header ≈ ~23 KB short-lived</td>
  <td>new eden-only GC pressure</td>
  </tr>
  <tr>
  <td><strong>Lock contention</strong></td>
  <td>none — but data race corrupts the map</td>                                                                                                                                                           
  <td>lock-free CAS, retry under contention</td>
  <td>rarely &gt; 1 attempt in practice</td>
  </tr>
  </tbody>
  </table>

  Reads dominate by orders of magnitude (called per feed assembly). Writes only fire on socket lifecycle events. Realistic workload at N=400:

  <table>
  <thead>
  <tr><th>Workload</th><th>Writes / min</th><th>Total CPU / min</th><th>Short-lived alloc</th></tr>
  </thead>
  <tbody>
  <tr><td>Steady state</td><td>~1–5</td><td>~75 µs</td><td>~115 KB/min</td></tr>
  <tr><td>Cold start (400 outbox relays connecting)</td><td>~400 in a 1–2 s burst</td><td>~6 ms once</td><td>~9 MB once</td></tr>
  <tr><td>WiFi mass-fail storm</td><td>~800 in 5 s (400 disconnect + 400 reconnect)</td><td>~12 ms total</td><td>~18 MB short-lived</td></tr>
  <tr><td>Pathological reconnect loop (30 flaky relays)</td><td>~300</td><td>~5 ms/min</td><td>~7 MB/min</td></tr>
  </tbody>
  </table>

  Even at N=400 the absolute numbers stay small — 12 ms of CPU spread across many OkHttp dispatcher threads is invisible to the UI, and 18 MB of eden-only short-lived garbage during a 5-second storm is well within what
  ART/HotSpot collect without a visible pause. The pattern is already exercised in production by `FilterIndex` (hit on every incoming relay event with comparable-sized bucket maps) without showing as a perf hotspot.

  ### Future optimization (out of scope)                                                                                                                                                                   
  
  If the working size grows substantially beyond ~400 entries, swap `Map.plus`/`Map.minus` for `kotlinx.collections.immutable.persistentHashMapOf` (already a project dependency via `commons`). `persistentHashMap.put`/`.remove` is O(log₃₂ N) ≈ 4 structural-sharing hops at N=400 — replacing the O(N) full copy with ~50× less CPU and ~100× less allocation per write while preserving the same `AtomicReference` + CAS shape. Not warranted at current scale; noted for future reference.
  
  ### Why not a JVM `ConcurrentHashMap`?

  `java.util.concurrent.ConcurrentHashMap` would be ~50 ns per put but is unavailable in `commonMain` — it would force an `expect`/`actual` split and make iOS/Linux/macOS-native targets second-class. The absolute savings don't justify the KMP split.

## Testing
  
  New stress test: `quartz/src/jvmAndroidTest/.../auth/RelayAuthenticatorConcurrencyTest.kt` — 50 bursts × 64 concurrent workers × 256 fresh relays per burst (~819 200 mutation/read operations on `Dispatchers.IO`). The "fresh
  map per burst" structure forces the underlying `HashMap` through repeated growth/treeify cycles, which is the only window in which the race can fire.

  Measured against this PR's branch and against pre-fix `main` (30 sequential runs each on the same hardware):

  <table>
  <thead>
  <tr><th>Branch</th><th>Runs</th><th>Pass</th><th>#2946 fails</th><th>Other fails</th><th>Mean test time</th></tr>
  </thead>
  <tbody>
  <tr><td><code>main</code> (buggy)</td><td>30</td><td>28</td><td>2</td><td>0</td><td>~0.2 s</td></tr>
  <tr><td>this PR</td><td>30</td><td>30</td><td>0</td><td>0</td><td>1.83 s</td></tr>
  </tbody>
  </table>

Both failures on `main` reproduced concurrent-`HashMap`-corruption signatures: one `ClassCastException: LinkedHashMap$Entry cannot be cast to HashMap$TreeNode` (bit-for-bit the #2946 stack frame, modulo R8 obfuscation) and one `NullPointerException` from a half-written entry during treeify. Reproduction rate is intermittent (~6.7 %) — typical for a JVM `treeifyBin` timing race — but every failure was the expected root-cause signature, no spurious failures. CI flake risk for this PR is essentially zero: the fix is structurally race-free (atomic snapshot + CAS over immutable maps), the test exercises no other concurrency hazard, and runtime is tight (~1.8 s ±0.15 s).

 On-device storms (Pixel 9a + Android 16, USB-adb, ~400-relay outbox account): 42 cold-start cycles of the shipped release v1.10.0 (versionCode 446, the exact build from the crash report) combined with 168 mass-WiFi-fail events and ~591 k logcat lines did not reproduce the race on this hardware — consistent with the original report (once-off, not repeatable), and consistent with what we'd expect from a JVM `treeifyBin` timing race on modern ART. Absence of repro is not absence of bug; the production trace in #2946 and the JVM-test failure rate above are the unambiguous proof.

 Sanity-check on the test runtime delta main's ~0.2 s vs the PR's ~1.83 s is the test artificially compressing ~years of production write traffic into a single run: ~819 K writes in 2 s = ~410 K writes/s sustained, vs production's ~1-2 writes/min at steady state and ~800 writes/5 s under a WiFi mass-fail storm. The 9× test-wall-time difference does not translate to a 9× production slowdown — it reflects the perf table's per-write costs scaled by an artificially extreme write rate. Production CPU/min stays in the µs–ms range (see the workload table in the Performance impact section).
  
  ## Out of scope
  
  Independent review on this branch surfaced six pre-existing concerns in `RelayAuthenticator` and sibling classes (scope cancellation in `destroy()`, `RelayAuthStatus` value mutability, missing `when`-exhaustiveness, public
  constructor `val`s, `Dispatchers.IO` default, and the same outer-map anti-pattern in `RelayActiveRequestStates` / `RelayActiveCountStates` / `CountQueryState` / `RequestSubscriptionState` / `NegSessionRegistry`). All
  pre-date this PR; none block it. Tracked for follow-up.
  
  ## Test plan
  
  - [x] `./gradlew :quartz:jvmTest` — new + existing tests pass
  - [x] `./gradlew :amethyst:compilePlayDebugKotlin` — downstream Android compiles
  - [x] `./gradlew :desktopApp:compileKotlin` — downstream Desktop compiles
  - [x] `./gradlew :quartz:spotlessApply` — formatted
  - [x] On-device install of the fixed benchmark APK survives connection storms (42 cold-starts + 168 WiFi mass-fails) on a ~400-relay outbox account without crashing
  - [x] Independent code review (no regressions found; pre-existing findings deferred)
  
## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
