### PR TITLE
Add excessive hashtag detection to hidden note UI

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -3067,8 +3067,10 @@ class Account(
 
     fun isKnown(user: HexKey): Boolean = user in allFollows.flow.value.authors
 
-    private fun hasExcessiveHashtags(note: Note): Boolean {
-        val limit = settings.syncedSettings.security.maxHashtagLimit.value
+    fun maxHashtagLimit(): Int = settings.syncedSettings.security.maxHashtagLimit.value
+
+    fun hasExcessiveHashtags(note: Note): Boolean {
+        val limit = maxHashtagLimit()
         return limit > 0 && note.event?.hasMoreHashtagsThan(limit) == true
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/BlankNote.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/BlankNote.kt
@@ -107,6 +107,23 @@ fun HiddenNotePreview() {
     )
 }
 
+@Composable
+@Preview
+fun HiddenNoteExcessiveHashtagsPreview() {
+    ThemeComparisonColumn(
+        toPreview = {
+            HiddenNote(
+                reports = persistentSetOf(),
+                isHiddenAuthor = false,
+                hasExcessiveHashtags = true,
+                hashtagLimit = 8,
+                accountViewModel = mockAccountViewModel(),
+                nav = EmptyNav(),
+            ) {}
+        },
+    )
+}
+
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun HiddenNote(
@@ -115,8 +132,11 @@ fun HiddenNote(
     accountViewModel: AccountViewModel,
     modifier: Modifier = Modifier,
     nav: INav,
+    hasExcessiveHashtags: Boolean = false,
+    hashtagLimit: Int = 0,
     onClick: () -> Unit,
 ) {
+    val hasReporters = isHiddenAuthor || reports.isNotEmpty()
     Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
         Row(
             modifier = Modifier.padding(horizontal = 20.dp),
@@ -127,26 +147,42 @@ fun HiddenNote(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier.padding(30.dp),
             ) {
-                Text(
-                    text = stringRes(R.string.post_was_flagged_as_inappropriate_by),
-                    color = Color.Gray,
-                )
-                FlowRow(modifier = Modifier.padding(top = 10.dp)) {
-                    if (isHiddenAuthor) {
-                        UserPicture(
-                            user = accountViewModel.userProfile(),
-                            size = Size35dp,
-                            nav = nav,
-                            accountViewModel = accountViewModel,
-                        )
-                    }
-                    reports.forEach {
-                        NoteAuthorPicture(
-                            baseNote = it,
-                            size = Size35dp,
-                            accountViewModel = accountViewModel,
-                            nav = nav,
-                        )
+                if (hasExcessiveHashtags) {
+                    Text(
+                        text = stringRes(R.string.post_was_hidden_due_to_too_many_hashtags, hashtagLimit),
+                        color = Color.Gray,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+
+                if (hasReporters || !hasExcessiveHashtags) {
+                    Text(
+                        text = stringRes(R.string.post_was_flagged_as_inappropriate_by),
+                        color = Color.Gray,
+                        modifier =
+                            if (hasExcessiveHashtags) {
+                                Modifier.padding(top = 10.dp)
+                            } else {
+                                Modifier
+                            },
+                    )
+                    FlowRow(modifier = Modifier.padding(top = 10.dp)) {
+                        if (isHiddenAuthor) {
+                            UserPicture(
+                                user = accountViewModel.userProfile(),
+                                size = Size35dp,
+                                nav = nav,
+                                accountViewModel = accountViewModel,
+                            )
+                        }
+                        reports.forEach {
+                            NoteAuthorPicture(
+                                baseNote = it,
+                                size = Size35dp,
+                                accountViewModel = accountViewModel,
+                                nav = nav,
+                            )
+                        }
                     }
                 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/BlockReportChecker.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/BlockReportChecker.kt
@@ -77,11 +77,13 @@ fun WatchBlockAndReport(
                 normalNote(isHidden.canPreview)
             } else {
                 HiddenNote(
-                    isHidden.relevantReports,
-                    isHidden.isHiddenAuthor,
-                    accountViewModel,
-                    modifier,
-                    nav,
+                    reports = isHidden.relevantReports,
+                    isHiddenAuthor = isHidden.isHiddenAuthor,
+                    hasExcessiveHashtags = isHidden.hasExcessiveHashtags,
+                    hashtagLimit = isHidden.hashtagLimit,
+                    accountViewModel = accountViewModel,
+                    modifier = modifier,
+                    nav = nav,
                     onClick = { showAnyway.value = true },
                 )
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -514,6 +514,8 @@ class AccountViewModel(
         val canPreview: Boolean = true,
         val isHiddenAuthor: Boolean = false,
         val relevantReports: ImmutableSet<Note> = persistentSetOf(),
+        val hasExcessiveHashtags: Boolean = false,
+        val hashtagLimit: Int = 0,
     )
 
     fun isNoteAcceptable(
@@ -546,12 +548,16 @@ class AccountViewModel(
                 // No need to process reports if nothing is wrong
                 NoteComposeReportState(isPostHidden, isAcceptable = true, canPreview = true, isHiddenAuthor = false)
             } else {
+                val hashtagLimit = account.maxHashtagLimit()
+                val hasExcessiveHashtags = account.hasExcessiveHashtags(note)
                 NoteComposeReportState(
-                    isPostHidden,
-                    newIsAcceptable,
-                    newCanPreview,
-                    false,
-                    account.getRelevantReports(note).toImmutableSet(),
+                    isPostHidden = isPostHidden,
+                    isAcceptable = newIsAcceptable,
+                    canPreview = newCanPreview,
+                    isHiddenAuthor = false,
+                    relevantReports = account.getRelevantReports(note).toImmutableSet(),
+                    hasExcessiveHashtags = hasExcessiveHashtags,
+                    hashtagLimit = hashtagLimit,
                 )
             }
         }

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="show_anyway">Show Anyway</string>
     <string name="post_was_hidden">This post was hidden because it mentions your hidden users or words</string>
     <string name="post_was_flagged_as_inappropriate_by">Post was muted or reported by</string>
+    <string name="post_was_hidden_due_to_too_many_hashtags">This post has more than %1$d hashtags</string>
     <string name="post_not_found">Event is loading or can\'t be found in your relay list</string>
     <string name="post_not_found_short">👀</string>
     <string name="channel_image">Channel Image</string>


### PR DESCRIPTION
## Summary

Add support for displaying a dedicated message when posts are hidden due to exceeding the hashtag limit, separate from the existing report/mute flagging UI. This includes:

- New `hasExcessiveHashtags` and `hashtagLimit` parameters to `HiddenNote` composable
- Updated `NoteComposeReportState` to track hashtag violations
- Refactored `Account.hasExcessiveHashtags()` to public and extracted `maxHashtagLimit()` helper
- New string resource for the excessive hashtag message
- Preview composable demonstrating the new UI state

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes / screenshots:

Verified the new `HiddenNoteExcessiveHashtagsPreview()` composable renders correctly with the excessive hashtags message. The UI now displays "This post has more than X hashtags" when `hasExcessiveHashtags=true`, and falls back to the existing report/mute UI when `hasExcessiveHashtags=false` or when there are actual reporters.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

https://claude.ai/code/session_016kYvi84fwqQa4UPcnPa36B