### PR TITLE
Show on-chain Bitcoin zappers as a dedicated ₿ row in the expanded reactions gallery

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -1772,13 +1772,13 @@ object LocalCache : ILocalCache, ICacheProvider {
                 when (val result = verifier.verify(event)) {
                     is VerifiedOnchainZap.Confirmed -> {
                         repliesTo.forEach {
-                            it.addOnchainZap(result.txid, result.verifiedSats, confirmed = true)
+                            it.addOnchainZap(note, result.txid, result.verifiedSats, confirmed = true)
                         }
                     }
 
                     is VerifiedOnchainZap.Pending -> {
                         repliesTo.forEach {
-                            it.addOnchainZap(result.txid, result.verifiedSats, confirmed = false)
+                            it.addOnchainZap(note, result.txid, result.verifiedSats, confirmed = false)
                         }
                     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/Icons.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/Icons.kt
@@ -420,3 +420,23 @@ fun VerticalDotsIcon() {
         tint = MaterialTheme.colorScheme.placeholderText,
     )
 }
+
+@Composable
+fun OnchainZappedIcon(modifier: Modifier) {
+    Icon(
+        symbol = MaterialSymbols.CurrencyBitcoin,
+        contentDescription = stringRes(R.string.onchain_zap_description),
+        tint = BitcoinOrange,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun PendingClockBadge(modifier: Modifier) {
+    Icon(
+        symbol = MaterialSymbols.Schedule,
+        contentDescription = stringRes(R.string.onchain_zap_pending),
+        tint = BitcoinOrange,
+        modifier = modifier,
+    )
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/OnchainZapGallery.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/OnchainZapGallery.kt
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.note
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.vitorpamplona.amethyst.commons.model.OnchainZapEntry
+import com.vitorpamplona.amethyst.model.Note
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.observeNoteZaps
+import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.routes.routeFor
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.theme.Size25dp
+import com.vitorpamplona.amethyst.ui.theme.Size35Modifier
+import com.vitorpamplona.amethyst.ui.theme.Size35dp
+import com.vitorpamplona.amethyst.ui.theme.StdStartPadding
+import com.vitorpamplona.amethyst.ui.theme.WidthAuthorPictureModifier
+import com.vitorpamplona.amethyst.ui.theme.bitcoinColor
+import com.vitorpamplona.amethyst.ui.theme.overPictureBackground
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import java.math.BigDecimal
+
+private fun onOnchainZapEntryClick(
+    entry: OnchainZapEntry,
+    nav: INav,
+) {
+    entry.source.author?.let { nav.nav(routeFor(it)) }
+}
+
+@Composable
+internal fun WatchOnchainZapsAndRenderGallery(
+    baseNote: Note,
+    nav: INav,
+    accountViewModel: AccountViewModel,
+) {
+    // Reuse the same flow the lightning gallery subscribes to. Note.addOnchainZap
+    // invalidates flowSet.zaps, so this composable refreshes when on-chain zaps
+    // arrive or upgrade pending → confirmed.
+    val zapsState by observeNoteZaps(baseNote, accountViewModel)
+    val entries =
+        zapsState
+            ?.note
+            ?.onchainZaps
+            ?.values
+            ?.toImmutableList() ?: persistentListOf()
+
+    if (entries.isNotEmpty()) {
+        RenderOnchainZapGallery(entries, nav, accountViewModel)
+    }
+}
+
+@Composable
+private fun RenderOnchainZapGallery(
+    entries: ImmutableList<OnchainZapEntry>,
+    nav: INav,
+    accountViewModel: AccountViewModel,
+) {
+    Row(Modifier.fillMaxWidth()) {
+        Box(modifier = WidthAuthorPictureModifier) {
+            OnchainZappedIcon(
+                modifier = Modifier.size(Size25dp).align(Alignment.TopEnd),
+            )
+        }
+
+        OnchainZapAuthorGallery(entries, nav, accountViewModel)
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun OnchainZapAuthorGallery(
+    entries: ImmutableList<OnchainZapEntry>,
+    nav: INav,
+    accountViewModel: AccountViewModel,
+) {
+    Column(modifier = StdStartPadding) {
+        FlowRow {
+            entries.forEach { entry ->
+                OnchainZapEntryRow(entry, nav, accountViewModel)
+            }
+        }
+    }
+}
+
+@Composable
+private fun OnchainZapEntryRow(
+    entry: OnchainZapEntry,
+    nav: INav,
+    accountViewModel: AccountViewModel,
+) {
+    val user = entry.source.author
+    val amountText =
+        remember(entry.verifiedSats) {
+            showAmount(BigDecimal.valueOf(entry.verifiedSats))
+        }
+    val avatarAlpha = if (entry.confirmed) 1f else 0.6f
+
+    Row(
+        modifier =
+            Modifier.clickable { onOnchainZapEntryClick(entry, nav) },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Size35Modifier,
+            contentAlignment = Alignment.BottomCenter,
+        ) {
+            // Only the avatar dims for pending entries. The amount overlay and clock
+            // badge stay at full opacity so they remain readable.
+            Box(modifier = Modifier.alpha(avatarAlpha)) {
+                WatchUserMetadataAndFollowsAndRenderUserProfilePictureOrDefaultAuthor(
+                    user,
+                    accountViewModel,
+                )
+            }
+
+            // Amount overlay — same look as the lightning row's CrossfadeToDisplayAmount.
+            Box(
+                modifier =
+                    Modifier
+                        .size(Size35dp)
+                        .clip(CircleShape),
+                contentAlignment = Alignment.BottomCenter,
+            ) {
+                val overlayBg = MaterialTheme.colorScheme.overPictureBackground
+                Box(
+                    modifier = remember(overlayBg) { Modifier.width(Size35dp).background(overlayBg) },
+                    contentAlignment = Alignment.BottomCenter,
+                ) {
+                    Text(
+                        text = amountText,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.bitcoinColor,
+                        fontSize = 12.sp,
+                        modifier = bottomPadding1dp,
+                    )
+                }
+            }
+
+            if (!entry.confirmed) {
+                // TopStart so the badge doesn't collide with the FollowingIcon
+                // that WatchUserMetadataAndFollowsAndRenderUserProfilePicture
+                // paints at TopEnd for followed users.
+                Box(
+                    modifier = Modifier.align(Alignment.TopStart),
+                ) {
+                    PendingClockBadge(modifier = Modifier.size(14.dp))
+                }
+            }
+        }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/OnchainZapGallery.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/OnchainZapGallery.kt
@@ -20,7 +20,6 @@
  */
 package com.vitorpamplona.amethyst.ui.note
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -29,20 +28,13 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.vitorpamplona.amethyst.commons.model.OnchainZapEntry
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.observeNoteZaps
@@ -51,11 +43,8 @@ import com.vitorpamplona.amethyst.ui.navigation.routes.routeFor
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.theme.Size25dp
 import com.vitorpamplona.amethyst.ui.theme.Size35Modifier
-import com.vitorpamplona.amethyst.ui.theme.Size35dp
 import com.vitorpamplona.amethyst.ui.theme.StdStartPadding
 import com.vitorpamplona.amethyst.ui.theme.WidthAuthorPictureModifier
-import com.vitorpamplona.amethyst.ui.theme.bitcoinColor
-import com.vitorpamplona.amethyst.ui.theme.overPictureBackground
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -76,14 +65,17 @@ internal fun WatchOnchainZapsAndRenderGallery(
 ) {
     // Reuse the same flow the lightning gallery subscribes to. Note.addOnchainZap
     // invalidates flowSet.zaps, so this composable refreshes when on-chain zaps
-    // arrive or upgrade pending → confirmed.
+    // arrive or upgrade pending → confirmed. The flow also fires for lightning
+    // zap arrivals on the same note, so memoize the list snapshot.
     val zapsState by observeNoteZaps(baseNote, accountViewModel)
     val entries =
-        zapsState
-            ?.note
-            ?.onchainZaps
-            ?.values
-            ?.toImmutableList() ?: persistentListOf()
+        remember(zapsState) {
+            zapsState
+                ?.note
+                ?.onchainZaps
+                ?.values
+                ?.toImmutableList() ?: persistentListOf()
+        }
 
     if (entries.isNotEmpty()) {
         RenderOnchainZapGallery(entries, nav, accountViewModel)
@@ -136,56 +128,27 @@ private fun OnchainZapEntryRow(
         }
     val avatarAlpha = if (entry.confirmed) 1f else 0.6f
 
-    Row(
-        modifier =
-            Modifier.clickable { onOnchainZapEntryClick(entry, nav) },
-        verticalAlignment = Alignment.CenterVertically,
+    Box(
+        modifier = Size35Modifier.clickable { onOnchainZapEntryClick(entry, nav) },
+        contentAlignment = Alignment.BottomCenter,
     ) {
-        Box(
-            modifier = Size35Modifier,
-            contentAlignment = Alignment.BottomCenter,
-        ) {
-            // Only the avatar dims for pending entries. The amount overlay and clock
-            // badge stay at full opacity so they remain readable.
-            Box(modifier = Modifier.alpha(avatarAlpha)) {
-                WatchUserMetadataAndFollowsAndRenderUserProfilePictureOrDefaultAuthor(
-                    user,
-                    accountViewModel,
-                )
-            }
+        // Only the avatar dims for pending entries. The amount overlay and clock
+        // badge stay at full opacity so they remain readable.
+        Box(modifier = Modifier.alpha(avatarAlpha)) {
+            WatchUserMetadataAndFollowsAndRenderUserProfilePictureOrDefaultAuthor(
+                user,
+                accountViewModel,
+            )
+        }
 
-            // Amount overlay — same look as the lightning row's CrossfadeToDisplayAmount.
-            Box(
-                modifier =
-                    Modifier
-                        .size(Size35dp)
-                        .clip(CircleShape),
-                contentAlignment = Alignment.BottomCenter,
-            ) {
-                val overlayBg = MaterialTheme.colorScheme.overPictureBackground
-                Box(
-                    modifier = remember(overlayBg) { Modifier.width(Size35dp).background(overlayBg) },
-                    contentAlignment = Alignment.BottomCenter,
-                ) {
-                    Text(
-                        text = amountText,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.bitcoinColor,
-                        fontSize = 12.sp,
-                        modifier = bottomPadding1dp,
-                    )
-                }
-            }
+        CrossfadeToDisplayAmount(amountText)
 
-            if (!entry.confirmed) {
-                // TopStart so the badge doesn't collide with the FollowingIcon
-                // that WatchUserMetadataAndFollowsAndRenderUserProfilePicture
-                // paints at TopEnd for followed users.
-                Box(
-                    modifier = Modifier.align(Alignment.TopStart),
-                ) {
-                    PendingClockBadge(modifier = Modifier.size(14.dp))
-                }
+        if (!entry.confirmed) {
+            // TopStart so the badge doesn't collide with the FollowingIcon
+            // that WatchUserMetadataAndFollowsAndRenderUserProfilePicture
+            // paints at TopEnd for followed users.
+            Box(modifier = Modifier.align(Alignment.TopStart)) {
+                PendingClockBadge(modifier = Modifier.size(14.dp))
             }
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
@@ -597,6 +597,7 @@ private fun ReactionDetailGallery(
         ) {
             Column {
                 WatchZapAndRenderGallery(baseNote, backgroundColor, nav, accountViewModel)
+                WatchOnchainZapsAndRenderGallery(baseNote, nav, accountViewModel)
                 WatchBoostsAndRenderGallery(baseNote, nav, accountViewModel)
                 WatchReactionsAndRenderGallery(baseNote, nav, accountViewModel)
             }

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -1887,6 +1887,8 @@
     <string name="boost_or_quote_description">Boost Or Quote</string>
     <string name="like_description">Like</string>
     <string name="zap_description">Zap</string>
+    <string name="onchain_zap_description">On-chain Bitcoin zap</string>
+    <string name="onchain_zap_pending">Pending confirmation</string>
 
     <string name="change_reaction">Change Quick Reactions</string>
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Note.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Note.kt
@@ -158,11 +158,13 @@ open class Note(
 
     /**
      * NIP-BC verified onchain zaps targeting this note.
-     * Key: Bitcoin txid (lowercase 64-char hex). Value: verified satoshis paid to the recipient
-     * (NOT the sender-claimed amount). Confirmed and pending entries live here together;
-     * `updateZapTotal` only counts confirmed amounts.
+     * Key: Bitcoin txid (lowercase 64-char hex). Value: verified entry with the source
+     * OnchainZapEvent note (so `source.author` identifies the sender), the verified
+     * satoshis paid to the recipient (NOT the sender-claimed amount), and a confirmed
+     * flag. Confirmed and pending entries live here together; `updateZapTotal` only
+     * counts confirmed amounts.
      */
-    var onchainZaps = mapOf<String, OnchainZapAmount>()
+    var onchainZaps = mapOf<String, OnchainZapEntry>()
         private set
 
     var zapPayments = mapOf<Note, Note?>()
@@ -430,27 +432,35 @@ open class Note(
     @Synchronized
     private fun innerAddOnchainZap(
         txid: String,
-        amount: OnchainZapAmount,
+        entry: OnchainZapEntry,
     ): Boolean {
         val existing = onchainZaps[txid]
-        // Allow upgrading pending → confirmed but never reduce already-stored confirmations.
-        if (existing != null && existing.confirmed && !amount.confirmed) return false
-        if (existing == amount) return false
-        onchainZaps = onchainZaps + Pair(txid, amount)
+        if (existing == null) {
+            onchainZaps = onchainZaps + Pair(txid, entry)
+            return true
+        }
+        // Same-state duplicate: keep the first source and amount we got.
+        if (existing.confirmed == entry.confirmed) return false
+        // Downgrade confirmed → pending: never accept.
+        if (existing.confirmed && !entry.confirmed) return false
+        // Upgrade pending → confirmed: replace, so the upgrading event's source wins.
+        onchainZaps = onchainZaps + Pair(txid, entry)
         return true
     }
 
     /**
      * Register a NIP-BC verified onchain zap targeting this note. `verifiedSats` MUST come
      * from on-chain verification (sum of outputs paying the recipient's derived Taproot
-     * address), not the sender-claimed `amount` tag.
+     * address), not the sender-claimed `amount` tag. `source` is the OnchainZapEvent's own
+     * note — `source.author` is the sender shown in the reactions gallery.
      */
     fun addOnchainZap(
+        source: Note,
         txid: String,
         verifiedSats: Long,
         confirmed: Boolean,
     ) {
-        val inserted = innerAddOnchainZap(txid, OnchainZapAmount(verifiedSats, confirmed))
+        val inserted = innerAddOnchainZap(txid, OnchainZapEntry(source, verifiedSats, confirmed))
         if (inserted) {
             updateZapTotal()
             flowSet?.zaps?.invalidateData()

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Note.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Note.kt
@@ -310,7 +310,7 @@ open class Note(
     fun removeAllChildNotes(): List<Note> {
         val repliesChanged = replies.isNotEmpty()
         val reactionsChanged = reactions.isNotEmpty()
-        val zapsChanged = zaps.isNotEmpty() || zapPayments.isNotEmpty()
+        val zapsChanged = zaps.isNotEmpty() || zapPayments.isNotEmpty() || onchainZaps.isNotEmpty()
         val boostsChanged = boosts.isNotEmpty()
         val reportsChanged = reports.isNotEmpty()
 
@@ -435,15 +435,14 @@ open class Note(
         entry: OnchainZapEntry,
     ): Boolean {
         val existing = onchainZaps[txid]
-        if (existing == null) {
-            onchainZaps = onchainZaps + Pair(txid, entry)
-            return true
+        if (existing != null) {
+            // Same-state duplicate: keep the first source and amount we got.
+            if (existing.confirmed == entry.confirmed) return false
+            // Downgrade confirmed → pending: never accept. States differ here,
+            // so existing.confirmed alone is sufficient to identify the downgrade.
+            if (existing.confirmed) return false
+            // Else: existing pending + incoming confirmed — fall through to upgrade.
         }
-        // Same-state duplicate: keep the first source and amount we got.
-        if (existing.confirmed == entry.confirmed) return false
-        // Downgrade confirmed → pending: never accept.
-        if (existing.confirmed && !entry.confirmed) return false
-        // Upgrade pending → confirmed: replace, so the upgrading event's source wins.
         onchainZaps = onchainZaps + Pair(txid, entry)
         return true
     }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/OnchainZapEntry.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/OnchainZapEntry.kt
@@ -20,11 +20,14 @@
  */
 package com.vitorpamplona.amethyst.commons.model
 
-import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
 
 /**
  * Per-(note, txid) verified NIP-BC onchain zap state.
  *
+ * @property source The OnchainZapEvent note that contributed this entry. `source.author` is the
+ *                  sender shown in the reactions gallery. When pending → confirmed upgrades
+ *                  happen, the upgrading event's note replaces the existing `source`.
  * @property verifiedSats Satoshis verified to have paid the recipient's derived Taproot
  *                        address on chain. NEVER the sender-claimed `amount` tag.
  * @property confirmed True when the transaction has at least one confirmation. Unconfirmed
@@ -33,8 +36,9 @@ import androidx.compose.runtime.Immutable
  *                     SHOULD either exclude them from aggregate totals or clearly label
  *                     them as pending").
  */
-@Immutable
-data class OnchainZapAmount(
+@Stable
+data class OnchainZapEntry(
+    val source: Note,
     val verifiedSats: Long,
     val confirmed: Boolean,
 )

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/NoteOnchainZapTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/NoteOnchainZapTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model
+
+import java.math.BigDecimal
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class NoteOnchainZapTest {
+    private fun freshNote(idHex: String = "a".repeat(64)) = Note(idHex)
+
+    private fun sourceNote(idHex: String) = Note(idHex)
+
+    @Test
+    fun pendingEntryIsStoredWithSourceAndDoesNotAffectTotal() {
+        val target = freshNote()
+        val src = sourceNote("b".repeat(64))
+
+        target.addOnchainZap(source = src, txid = "tx1", verifiedSats = 1000L, confirmed = false)
+
+        val entry = target.onchainZaps["tx1"]
+        assertEquals(1, target.onchainZaps.size)
+        assertSame(src, entry?.source)
+        assertEquals(1000L, entry?.verifiedSats)
+        assertEquals(false, entry?.confirmed)
+        assertEquals(BigDecimal.ZERO, target.zapsAmount)
+    }
+
+    @Test
+    fun confirmedEntryIsStoredAndAddsToTotal() {
+        val target = freshNote()
+        val src = sourceNote("c".repeat(64))
+
+        target.addOnchainZap(source = src, txid = "tx1", verifiedSats = 5000L, confirmed = true)
+
+        assertEquals(true, target.onchainZaps["tx1"]?.confirmed)
+        assertEquals(BigDecimal.valueOf(5000L), target.zapsAmount)
+    }
+
+    @Test
+    fun pendingThenConfirmedReplacesSourceAndUpdatesTotal() {
+        val target = freshNote()
+        val firstSrc = sourceNote("d".repeat(64))
+        val secondSrc = sourceNote("e".repeat(64))
+
+        target.addOnchainZap(firstSrc, "tx1", 2500L, confirmed = false)
+        target.addOnchainZap(secondSrc, "tx1", 2500L, confirmed = true)
+
+        val entry = target.onchainZaps["tx1"]
+        assertSame(secondSrc, entry?.source)
+        assertEquals(true, entry?.confirmed)
+        assertEquals(BigDecimal.valueOf(2500L), target.zapsAmount)
+    }
+
+    @Test
+    fun confirmedThenPendingIsIgnored() {
+        val target = freshNote()
+        val firstSrc = sourceNote("f".repeat(64))
+        val secondSrc = sourceNote("0".repeat(64))
+
+        target.addOnchainZap(firstSrc, "tx1", 7500L, confirmed = true)
+        target.addOnchainZap(secondSrc, "tx1", 7500L, confirmed = false)
+
+        val entry = target.onchainZaps["tx1"]
+        assertSame(firstSrc, entry?.source)
+        assertEquals(true, entry?.confirmed)
+        assertEquals(BigDecimal.valueOf(7500L), target.zapsAmount)
+    }
+
+    @Test
+    fun sameStateDuplicateIsIgnored() {
+        val target = freshNote()
+        val firstSrc = sourceNote("1".repeat(64))
+        val secondSrc = sourceNote("2".repeat(64))
+
+        target.addOnchainZap(firstSrc, "tx1", 100L, confirmed = true)
+        target.addOnchainZap(secondSrc, "tx1", 100L, confirmed = true)
+
+        assertSame(firstSrc, target.onchainZaps["tx1"]?.source)
+        assertEquals(BigDecimal.valueOf(100L), target.zapsAmount)
+    }
+
+    @Test
+    fun updateZapTotalSumsConfirmedAcrossMultipleTxids() {
+        val target = freshNote()
+        target.addOnchainZap(sourceNote("3".repeat(64)), "tx1", 1000L, confirmed = true)
+        target.addOnchainZap(sourceNote("4".repeat(64)), "tx2", 2000L, confirmed = true)
+        target.addOnchainZap(sourceNote("5".repeat(64)), "tx3", 9999L, confirmed = false)
+
+        assertEquals(BigDecimal.valueOf(3000L), target.zapsAmount)
+        assertEquals(3, target.onchainZaps.size)
+        assertTrue(target.onchainZaps.containsKey("tx3"))
+    }
+}

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/NoteOnchainZapTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/NoteOnchainZapTest.kt
@@ -94,9 +94,13 @@ class NoteOnchainZapTest {
         val secondSrc = sourceNote("2".repeat(64))
 
         target.addOnchainZap(firstSrc, "tx1", 100L, confirmed = true)
-        target.addOnchainZap(secondSrc, "tx1", 100L, confirmed = true)
+        // Mismatched verifiedSats so we can detect a regression that silently
+        // overwrites the first entry with the second.
+        target.addOnchainZap(secondSrc, "tx1", 999L, confirmed = true)
 
-        assertSame(firstSrc, target.onchainZaps["tx1"]?.source)
+        val entry = target.onchainZaps["tx1"]
+        assertSame(firstSrc, entry?.source)
+        assertEquals(100L, entry?.verifiedSats)
         assertEquals(BigDecimal.valueOf(100L), target.zapsAmount)
     }
 


### PR DESCRIPTION

<img width="300" alt="Screenshot_20260519-124219" src="https://github.com/user-attachments/assets/df007e63-52bb-44bf-9f3d-2fa08fff5ac3" valign="top"/> <img width="300" alt="Screenshot_20260519-085235" src="https://github.com/user-attachments/assets/4791a675-38e7-4ba6-9abd-ce7c4f82dd4c" />


**Summary**
  
  - Adds a new on-chain ₿ row directly below the existing ⚡ row in the expanded reactions gallery, so NIP-BC on-chain zappers appear as avatars alongside lightning zappers.
  - Extends Note.onchainZaps map values to carry the source OnchainZapEvent note, so source.author can be rendered as the sender's avatar.
  - Pending on-chain zaps are dimmed and badged with a clock icon; confirmed zaps render at full opacity.
  - The headline ⚡ counter is unchanged — Note.zapsAmount already included confirmed on-chain.

  **Root cause**

  NIP-BC on-chain Bitcoin zaps were added in main alongside NIP-57 lightning zaps. Note.zapsAmount already summed both via updateZapTotal(), so the headline ⚡ count was correct. The expanded reactions gallery, however,
  iterates only Note.zaps (the lightning map) in WatchZapAndRenderGallery. On-chain zappers contributed to the headline but were invisible in the avatar row — a post could show ⚡ 132k at the top while the expanded gallery
  only displayed ~1k of lightning zappers.
  
  A secondary blocker was that Note.onchainZaps was Map<String, OnchainZapAmount> keyed by txid, with OnchainZapAmount(verifiedSats, confirmed) carrying no reference back to the source OnchainZapEvent. The gallery had no way
  to recover the sender's pubkey from the existing data model.

  **How the fix works**
  
  OnchainZapAmount is renamed to OnchainZapEntry and gains a source: Note field that holds the OnchainZapEvent's own note. source.author is the sender shown in the gallery. The map is still keyed by txid so a single Bitcoin
  payment maps to a single avatar regardless of how many publishers reproduce the event.

  Note.addOnchainZap gains a source: Note parameter. Dedup rules: pending → confirmed upgrades replace the entry (so the publisher who proved the payment wins); confirmed → pending writes and same-state duplicates are
  rejected. updateZapTotal() and flowSet.zaps.invalidateData() are gated on actual inserts.

  LocalCache.consume(OnchainZapEvent) passes the already-in-scope note through to addOnchainZap() at both call sites.

  A new OnchainZapGallery.kt file hosts WatchOnchainZapsAndRenderGallery plus a private per-entry row. It subscribes to the same observeNoteZaps flow the lightning gallery uses, reuses the existing CrossfadeToDisplayAmount for
   the sats overlay, and uses WatchUserMetadataAndFollowsAndRenderUserProfilePictureOrDefaultAuthor for the avatar. A one-line wire-in in ReactionsRow.ReactionDetailGallery places the new row directly below the ⚡ row.

  Pending entries dim the avatar to 60% opacity and draw a clock badge (MaterialSymbols.Schedule) at Alignment.TopStart — the opposite corner from the FollowingIcon at TopEnd, so the two badges don't collide. The amount
  overlay and clock badge stay at full opacity for legibility.

  **Performance impact**
  
  - No new relay subscriptions or filter assemblers; reuses observeNoteZaps.
  - WatchOnchainZapsAndRenderGallery memoizes the entries snapshot via remember(zapsState), so the on-chain row does not re-allocate its ImmutableList on every lightning-zap emission of the shared flow.
  - Per-entry composables take ImmutableList<OnchainZapEntry> (stable) and use remember-keyed allocations for the amount text and overlay background modifier, preserving Compose strong skipping.
  - The new tree is invoked only when the user expands the reactions panel; never runs on feed scroll.
  - ~175 lines of Kotlin added, no new dependencies, two new strings, three Material Symbols glyphs already shipping.

**Automated testing**
- [x]   NoteOnchainZapTest — pending entry stored with source, excluded from total
- [x]   NoteOnchainZapTest — confirmed entry stored, added to total
- [x]   NoteOnchainZapTest — pending → confirmed upgrade replaces both source and total
- [x]   NoteOnchainZapTest — confirmed → pending downgrade ignored (mismatched verifiedSats proves no silent overwrite)
- [x]   NoteOnchainZapTest — same-state duplicate ignored (mismatched verifiedSats proves no silent overwrite)
- [x]   NoteOnchainZapTest — updateZapTotal sums confirmed across multiple txids, excludes pending
- [x]   ./gradlew :commons:jvmTest — full commons suite green
- [x]   ./gradlew :amethyst:assemblePlayDebug — clean build
- [x]   ./gradlew spotlessApply — no formatting changes required
- [x]   Pre-commit static-analysis hook — clean

**Manual testing**
- [x] Installed :amethyst:installPlayBenchmark on a Pixel 9a (Android 16)
- [x] Opened the repro post nostr:nevent1qqsygzatk9…6h05k — headline still reads ⚡ 132k
- [x] ⚡ row in the expanded gallery still shows the two lightning zappers (10 + 1000 = 1010 sats)
- [x]  New ₿ row appears directly below the ⚡ row with the on-chain zapper accounting for the ~131k gap
- [x]  Tapping the ₿ avatar navigates to the sender's Nostr profile (same as lightning zappers)
- [x]  Verified the pending visual treatment using a temporary dev-preview that injected a synthetic pending entry sourced from Vitor's npub: clock badge at TopStart and follow dot at TopEnd rendered without overlap; the avatar dim respected the alpha boundary so the badge stayed at full opacity
- [x]  Dev-preview reverted before push; branch contains no preview/debug code

## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
