### PR TITLE
Convert hashtag-limit message to <plurals> 

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/BlankNote.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/BlankNote.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -149,7 +150,7 @@ fun HiddenNote(
             ) {
                 if (hasExcessiveHashtags) {
                     Text(
-                        text = stringRes(R.string.post_was_hidden_due_to_too_many_hashtags, hashtagLimit),
+                        text = pluralStringResource(R.plurals.post_was_hidden_due_to_too_many_hashtags, hashtagLimit, hashtagLimit),
                         color = Color.Gray,
                         textAlign = TextAlign.Center,
                     )

--- a/amethyst/src/main/res/values-cs-rCZ/strings.xml
+++ b/amethyst/src/main/res/values-cs-rCZ/strings.xml
@@ -2624,4 +2624,28 @@
     <string name="community_rules_violation_wot_gate_failed">Nesplňuješ požadavky sítě důvěry této komunity.</string>
     <string name="community_rules_violation_stale_rules">Nejnovější dokument s pravidly komunity byl odmítnut jako zastaralý.</string>
     <!-- Nowhere links (hostednowhere.com / nowhr.xyz). The site name "Nowhere" is a proper noun, do not translate. -->
+    <string name="copied_to_clipboard">Zkopírováno do schránky</string>
+    <string name="notification_channel_status_off">Vypnuto</string>
+    <string name="notification_channel_status_on">Zapnuto</string>
+    <string name="notification_channel_status_silent">Ztlumeno</string>
+    <string name="notification_settings">Oznámení</string>
+    <string name="notification_settings_categories_explainer">Klepněte na kategorii a otevřete pro ni nastavení oznámení Androidu — zvuk, důležitost, odznaky a režim Nerušit najdete tam.</string>
+    <string name="notification_settings_section_categories">Kategorie</string>
+    <string name="notification_settings_section_delivery">Doručování</string>
+    <string name="notification_settings_section_display">Zobrazení v aplikaci</string>
+    <string name="nowhere_link_card_art">Nowhere Umění</string>
+    <string name="nowhere_link_card_drop">Nowhere Drop</string>
+    <string name="nowhere_link_card_event">Nowhere Událost</string>
+    <string name="nowhere_link_card_forum">Nowhere Fórum</string>
+    <string name="nowhere_link_card_fundraiser">Nowhere Sbírka</string>
+    <string name="nowhere_link_card_generic">Stránka Nowhere</string>
+    <string name="nowhere_link_card_message">Nowhere Zpráva</string>
+    <string name="nowhere_link_card_petition">Nowhere Petice</string>
+    <string name="nowhere_link_card_store">Nowhere Obchod</string>
+    <plurals name="post_was_hidden_due_to_too_many_hashtags">
+        <item quantity="one">Tento příspěvek má více než %1$d hashtag</item>
+        <item quantity="few">Tento příspěvek má více než %1$d hashtagy</item>
+        <item quantity="many">Tento příspěvek má více než %1$d hashtagů</item>
+        <item quantity="other">Tento příspěvek má více než %1$d hashtagů</item>
+    </plurals>
 </resources>

--- a/amethyst/src/main/res/values-de-rDE/strings.xml
+++ b/amethyst/src/main/res/values-de-rDE/strings.xml
@@ -2603,4 +2603,26 @@ anz der Bedingungen ist erforderlich</string>
     <string name="community_rules_violation_wot_gate_failed">Du erfüllst die Web-of-Trust-Anforderungen dieser Community nicht.</string>
     <string name="community_rules_violation_stale_rules">Das aktuelle Community-Regeldokument wurde als veraltet abgelehnt.</string>
     <!-- Nowhere links (hostednowhere.com / nowhr.xyz). The site name "Nowhere" is a proper noun, do not translate. -->
+    <string name="copied_to_clipboard">In die Zwischenablage kopiert</string>
+    <string name="notification_channel_status_off">Aus</string>
+    <string name="notification_channel_status_on">An</string>
+    <string name="notification_channel_status_silent">Lautlos</string>
+    <string name="notification_settings">Benachrichtigungen</string>
+    <string name="notification_settings_categories_explainer">Tippe auf eine Kategorie, um die Android-Benachrichtigungseinstellungen dafür zu öffnen — Ton, Wichtigkeit, Badges und „Nicht stören\" findest du dort.</string>
+    <string name="notification_settings_section_categories">Kategorien</string>
+    <string name="notification_settings_section_delivery">Zustellung</string>
+    <string name="notification_settings_section_display">Anzeige in der App</string>
+    <string name="nowhere_link_card_art">Nowhere Kunst</string>
+    <string name="nowhere_link_card_drop">Nowhere Drop</string>
+    <string name="nowhere_link_card_event">Nowhere Event</string>
+    <string name="nowhere_link_card_forum">Nowhere Forum</string>
+    <string name="nowhere_link_card_fundraiser">Nowhere Spendenaktion</string>
+    <string name="nowhere_link_card_generic">Nowhere-Seite</string>
+    <string name="nowhere_link_card_message">Nowhere Nachricht</string>
+    <string name="nowhere_link_card_petition">Nowhere Petition</string>
+    <string name="nowhere_link_card_store">Nowhere Shop</string>
+    <plurals name="post_was_hidden_due_to_too_many_hashtags">
+        <item quantity="one">Dieser Beitrag hat mehr als %1$d Hashtag</item>
+        <item quantity="other">Dieser Beitrag hat mehr als %1$d Hashtags</item>
+    </plurals>
 </resources>

--- a/amethyst/src/main/res/values-pt-rBR/strings.xml
+++ b/amethyst/src/main/res/values-pt-rBR/strings.xml
@@ -2598,4 +2598,26 @@
     <string name="community_rules_violation_wot_gate_failed">Você não atende aos requisitos da rede de confiança desta comunidade.</string>
     <string name="community_rules_violation_stale_rules">O documento mais recente de regras da comunidade foi rejeitado por estar desatualizado.</string>
     <!-- Nowhere links (hostednowhere.com / nowhr.xyz). The site name "Nowhere" is a proper noun, do not translate. -->
+    <string name="copied_to_clipboard">Copiado para a área de transferência</string>
+    <string name="notification_channel_status_off">Desativado</string>
+    <string name="notification_channel_status_on">Ativado</string>
+    <string name="notification_channel_status_silent">Silencioso</string>
+    <string name="notification_settings">Notificações</string>
+    <string name="notification_settings_categories_explainer">Toque em uma categoria para abrir as configurações de notificação do Android — som, importância, selos e Não Perturbe ficam lá.</string>
+    <string name="notification_settings_section_categories">Categorias</string>
+    <string name="notification_settings_section_delivery">Entrega</string>
+    <string name="notification_settings_section_display">Exibição no app</string>
+    <string name="nowhere_link_card_art">Nowhere Arte</string>
+    <string name="nowhere_link_card_drop">Nowhere Drop</string>
+    <string name="nowhere_link_card_event">Nowhere Evento</string>
+    <string name="nowhere_link_card_forum">Nowhere Fórum</string>
+    <string name="nowhere_link_card_fundraiser">Nowhere Arrecadação</string>
+    <string name="nowhere_link_card_generic">Site Nowhere</string>
+    <string name="nowhere_link_card_message">Nowhere Mensagem</string>
+    <string name="nowhere_link_card_petition">Nowhere Petição</string>
+    <string name="nowhere_link_card_store">Nowhere Loja</string>
+    <plurals name="post_was_hidden_due_to_too_many_hashtags">
+        <item quantity="one">Esta publicação tem mais de %1$d hashtag</item>
+        <item quantity="other">Esta publicação tem mais de %1$d hashtags</item>
+    </plurals>
 </resources>

--- a/amethyst/src/main/res/values-sv-rSE/strings.xml
+++ b/amethyst/src/main/res/values-sv-rSE/strings.xml
@@ -2599,4 +2599,26 @@
     <string name="community_rules_violation_wot_gate_failed">Du uppfyller inte den här gemenskapens krav på förtroendenät.</string>
     <string name="community_rules_violation_stale_rules">Det senaste dokumentet med gemenskapsregler avvisades som föråldrat.</string>
     <!-- Nowhere links (hostednowhere.com / nowhr.xyz). The site name "Nowhere" is a proper noun, do not translate. -->
+    <string name="copied_to_clipboard">Kopierat till urklipp</string>
+    <string name="notification_channel_status_off">Av</string>
+    <string name="notification_channel_status_on">På</string>
+    <string name="notification_channel_status_silent">Tyst</string>
+    <string name="notification_settings">Aviseringar</string>
+    <string name="notification_settings_categories_explainer">Tryck på en kategori för att öppna Androids aviseringsinställningar — ljud, prioritet, märken och Stör ej finns där.</string>
+    <string name="notification_settings_section_categories">Kategorier</string>
+    <string name="notification_settings_section_delivery">Leverans</string>
+    <string name="notification_settings_section_display">Visning i appen</string>
+    <string name="nowhere_link_card_art">Nowhere Konst</string>
+    <string name="nowhere_link_card_drop">Nowhere Drop</string>
+    <string name="nowhere_link_card_event">Nowhere Evenemang</string>
+    <string name="nowhere_link_card_forum">Nowhere Forum</string>
+    <string name="nowhere_link_card_fundraiser">Nowhere Insamling</string>
+    <string name="nowhere_link_card_generic">Nowhere-webbplats</string>
+    <string name="nowhere_link_card_message">Nowhere Meddelande</string>
+    <string name="nowhere_link_card_petition">Nowhere Namninsamling</string>
+    <string name="nowhere_link_card_store">Nowhere Butik</string>
+    <plurals name="post_was_hidden_due_to_too_many_hashtags">
+        <item quantity="one">Det här inlägget har fler än %1$d hashtagg</item>
+        <item quantity="other">Det här inlägget har fler än %1$d hashtaggar</item>
+    </plurals>
 </resources>

--- a/amethyst/src/main/res/values-zh-rCN/strings.xml
+++ b/amethyst/src/main/res/values-zh-rCN/strings.xml
@@ -8,7 +8,9 @@
     <string name="show_anyway">仍然显示</string>
     <string name="post_was_hidden">此帖被隐藏，因为它提到了你隐藏的用户或单词</string>
     <string name="post_was_flagged_as_inappropriate_by">帖文被标记为不当</string>
-    <string name="post_was_hidden_due_to_too_many_hashtags">此帖有超过 %1$d 个话题标签</string>
+    <plurals name="post_was_hidden_due_to_too_many_hashtags">
+        <item quantity="other">此帖有超过 %1$d 个话题标签</item>
+    </plurals>
     <string name="post_not_found">事件正在加载或无法在你的中继列表中找到</string>
     <string name="post_not_found_short">👀</string>
     <string name="channel_image">频道图片</string>

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -10,7 +10,10 @@
     <string name="show_anyway">Show Anyway</string>
     <string name="post_was_hidden">This post was hidden because it mentions your hidden users or words</string>
     <string name="post_was_flagged_as_inappropriate_by">Post was muted or reported by</string>
-    <string name="post_was_hidden_due_to_too_many_hashtags">This post has more than %1$d hashtags</string>
+    <plurals name="post_was_hidden_due_to_too_many_hashtags">
+        <item quantity="one">This post has more than %1$d hashtag</item>
+        <item quantity="other">This post has more than %1$d hashtags</item>
+    </plurals>
     <string name="post_not_found">Event is loading or can\'t be found in your relay list</string>
     <string name="post_not_found_short">👀</string>
     <string name="channel_image">Channel Image</string>


### PR DESCRIPTION
- Convert hashtag-limit message to `<plurals>` because slavic languages need it
- add cs/pt-BR/sv/de translations