### PR TITLE
Fix feed sorting race condition with snapshot-based comparator

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/DefaultFeedOrder.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/dal/DefaultFeedOrder.kt
@@ -32,3 +32,12 @@ val DefaultFeedOrderEvent: Comparator<Event> =
 
 val DefaultFeedOrderCard: Comparator<Card> =
     compareByDescending<Card> { it.createdAt() }.thenBy { it.id() }
+
+// Snapshots createdAt once per note so the comparator stays consistent even if
+// another thread swaps a Note's event mid-sort (e.g. a newer AddressableEvent
+// arriving from a relay). Avoids TimSort's "Comparison method violates its
+// general contract!" IllegalArgumentException.
+fun Iterable<Note>.sortedByDefaultFeedOrder(): List<Note> =
+    map { it to (it.createdAt() ?: 0L) }
+        .sortedWith(compareByDescending<Pair<Note, Long>> { it.second }.thenBy { it.first.idHex })
+        .map { it.first }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/dal/ShortsFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/shorts/dal/ShortsFeedFilter.kt
@@ -28,8 +28,8 @@ import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.model.filterIntoSet
 import com.vitorpamplona.amethyst.ui.dal.AdditiveFeedFilter
-import com.vitorpamplona.amethyst.ui.dal.DefaultFeedOrder
 import com.vitorpamplona.amethyst.ui.dal.FilterByListParams
+import com.vitorpamplona.amethyst.ui.dal.sortedByDefaultFeedOrder
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.video.dal.SupportedContent
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.video.datasource.SUPPORTED_VIDEO_FEED_MIME_TYPES_SET
 import com.vitorpamplona.quartz.nip01Core.core.AddressableEvent
@@ -113,5 +113,5 @@ class ShortsFeedFilter(
             (params.isHiddenList || account.isAcceptable(note))
     }
 
-    override fun sort(items: Set<Note>): List<Note> = items.sortedWith(DefaultFeedOrder)
+    override fun sort(items: Set<Note>): List<Note> = items.sortedByDefaultFeedOrder()
 }


### PR DESCRIPTION
## Summary

Fixes a `TimSort` "Comparison method violates its general contract!" crash that occurs when sorting feeds while another thread updates a Note's underlying event mid-sort (e.g., a newer AddressableEvent arriving from a relay). The fix snapshots each Note's `createdAt()` timestamp once before sorting, ensuring the comparator remains consistent throughout the sort operation.

Replaces the direct use of `DefaultFeedOrder` comparator in `ShortsFeedFilter` with a new `sortedByDefaultFeedOrder()` extension function that captures timestamps upfront.

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes: This change prevents a known race condition in feed sorting. The new extension function is a drop-in replacement for the previous comparator-based approach and maintains the same sort order semantics. Existing feed tests should continue to pass.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

https://claude.ai/code/session_015byPUxkXJ1fmj2qBBVsUso