### PR TITLE
Reorder FeedGroup enum for improved UX

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/FeedFilterSpinner.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/FeedFilterSpinner.kt
@@ -336,10 +336,10 @@ private enum class FeedGroup(
     FEEDS(R.string.feed_group_feeds),
     RELAYS(R.string.feed_group_relays),
     HASHTAGS(R.string.feed_group_hashtags),
+    INTEREST_SETS(R.string.feed_group_interest_sets),
     LOCATIONS(R.string.feed_group_locations),
     COMMUNITIES(R.string.feed_group_communities),
     LISTS(R.string.feed_group_lists),
-    INTEREST_SETS(R.string.feed_group_interest_sets),
     DVMS(R.string.feed_group_dvms),
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/FeedFilterSpinner.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/FeedFilterSpinner.kt
@@ -334,13 +334,13 @@ private enum class FeedGroup(
     @param:androidx.annotation.StringRes val labelRes: Int,
 ) {
     FEEDS(R.string.feed_group_feeds),
-    HASHTAGS(R.string.feed_group_hashtags),
-    INTEREST_SETS(R.string.feed_group_interest_sets),
-    COMMUNITIES(R.string.feed_group_communities),
-    LOCATIONS(R.string.feed_group_locations),
-    LISTS(R.string.feed_group_lists),
-    DVMS(R.string.feed_group_dvms),
     RELAYS(R.string.feed_group_relays),
+    HASHTAGS(R.string.feed_group_hashtags),
+    LOCATIONS(R.string.feed_group_locations),
+    COMMUNITIES(R.string.feed_group_communities),
+    LISTS(R.string.feed_group_lists),
+    INTEREST_SETS(R.string.feed_group_interest_sets),
+    DVMS(R.string.feed_group_dvms),
 }
 
 private fun FeedDefinition.group(): FeedGroup =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/FeedFilterSpinner.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/FeedFilterSpinner.kt
@@ -338,9 +338,9 @@ private enum class FeedGroup(
     HASHTAGS(R.string.feed_group_hashtags),
     INTEREST_SETS(R.string.feed_group_interest_sets),
     LOCATIONS(R.string.feed_group_locations),
+    DVMS(R.string.feed_group_dvms),
     COMMUNITIES(R.string.feed_group_communities),
     LISTS(R.string.feed_group_lists),
-    DVMS(R.string.feed_group_dvms),
 }
 
 private fun FeedDefinition.group(): FeedGroup =


### PR DESCRIPTION
## Summary

Reordered the `FeedGroup` enum in `FeedFilterSpinner.kt` to improve the logical grouping and presentation order of feed filter categories. Moved `RELAYS` to appear immediately after `FEEDS`, and grouped `COMMUNITIES` and `LISTS` together at the end, creating a more intuitive hierarchy for users navigating feed filters.

## Test plan

- [ ] N/A — change is a UI ordering adjustment with no functional impact
- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Manually exercised the change: Opened feed filter spinner and verified the new category order displays correctly

Notes: This is a pure enum reordering with no logic changes. The string resource references remain identical; only their declaration order changes.

## Interop suites

- [ ] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [ ] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01F65cRVopEPkRMYUd5MucEq