### PR TITLE
Simplify Nip11Retriever by removing nested withContext

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip11RelayInfo/Nip11Retriever.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip11RelayInfo/Nip11Retriever.kt
@@ -45,7 +45,7 @@ class Nip11Retriever(
         relay: NormalizedRelayUrl,
         onInfo: (Nip11RelayInformation) -> Unit,
         onError: (NormalizedRelayUrl, ErrorCode, String?) -> Unit,
-    ) {
+    ) = withContext(Dispatchers.IO) {
         val url = relay.toHttp()
         try {
             val request: Request =
@@ -58,27 +58,25 @@ class Nip11Retriever(
             val client = okHttpClient(relay)
 
             client.newCall(request).executeAsync().use { response ->
-                withContext(Dispatchers.IO) {
-                    val body = response.body.string()
-                    try {
-                        if (response.isSuccessful) {
-                            if (body.startsWith("{")) {
-                                onInfo(Nip11RelayInformation.fromJson(body))
-                            } else {
-                                onError(relay, ErrorCode.FAIL_TO_PARSE_RESULT, body)
-                            }
+                val body = response.body.string()
+                try {
+                    if (response.isSuccessful) {
+                        if (body.startsWith("{")) {
+                            onInfo(Nip11RelayInformation.fromJson(body))
                         } else {
-                            onError(relay, ErrorCode.FAIL_WITH_HTTP_STATUS, response.code.toString())
+                            onError(relay, ErrorCode.FAIL_TO_PARSE_RESULT, body)
                         }
-                    } catch (e: Exception) {
-                        if (e is CancellationException) throw e
-                        Log.e(
-                            "RelayInfoFail",
-                            "Resulting Message from Relay ${relay.url} in not parseable: $body",
-                            e,
-                        )
-                        onError(relay, ErrorCode.FAIL_TO_PARSE_RESULT, e.message)
+                    } else {
+                        onError(relay, ErrorCode.FAIL_WITH_HTTP_STATUS, response.code.toString())
                     }
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    Log.e(
+                        "RelayInfoFail",
+                        "Resulting Message from Relay ${relay.url} in not parseable: $body",
+                        e,
+                    )
+                    onError(relay, ErrorCode.FAIL_TO_PARSE_RESULT, e.message)
                 }
             }
         } catch (e: Exception) {


### PR DESCRIPTION
## Summary

Refactored `Nip11Retriever.retrieveRelayInfo()` to move the `withContext(Dispatchers.IO)` call from the function body to the function signature, eliminating one level of nesting. This simplifies the code structure without changing behavior — the entire function body now executes on the IO dispatcher.

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes: This is a structural refactor with no behavioral changes. The function still executes on `Dispatchers.IO` and handles all error cases identically. Existing relay info retrieval tests (if any) will validate the change.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

https://claude.ai/code/session_01PiyfX4hUkuskqK4qgBWmpp