### PR TITLE
Fix PrivacyOptionsScreen initialization with LaunchedEffect

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/privacy/PrivacyOptionsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/privacy/PrivacyOptionsScreen.kt
@@ -30,7 +30,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -78,11 +78,10 @@ fun PrivacyOptionsScreen(
 
     // Reset all three view models from disk-loaded state exactly once,
     // mirroring how the old screen reset only the Tor VM.
-    remember(torVm, i2pVm, pickerVm) {
+    LaunchedEffect(torVm, i2pVm, pickerVm) {
         torVm.reset(torSettingsFlow.toSettings())
         i2pVm.reset(i2pSettingsFlow.toSettings())
         pickerVm.reset(preferredTransport)
-        Unit
     }
 
     PrivacyOptionsScreenContents(


### PR DESCRIPTION
## Summary

Replace `remember` with `LaunchedEffect` in `PrivacyOptionsScreen` to properly initialize view models on composition. The `remember` block was executing synchronously during composition, but the intent is to reset view models as a side effect after the composable enters the composition tree. `LaunchedEffect` is the correct API for this use case.

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes / screenshots:

Navigate to the Privacy Options screen and verify that Tor, I2P, and transport picker settings load correctly from disk and are properly initialized.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

https://claude.ai/code/session_011tfcR8AKZYJ4WQZiLErw3R