### PR TITLE
Include thread name in crash reports

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/crashreports/ReportAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/crashreports/ReportAssembler.kt
@@ -24,7 +24,10 @@ import android.os.Build
 import com.vitorpamplona.amethyst.BuildConfig
 
 class ReportAssembler {
-    fun buildReport(e: Throwable): String =
+    fun buildReport(
+        e: Throwable,
+        threadName: String = Thread.currentThread().name,
+    ): String =
         buildString {
             append(e.javaClass.simpleName)
             append(": ")
@@ -70,9 +73,14 @@ class ReportAssembler {
             append("| User | ")
             append(Build.USER)
             appendLine(" |")
+            append("| Thread | ")
+            append(threadName)
+            appendLine(" |")
             appendLine()
 
             appendLine("```")
+            append("Thread: ")
+            appendLine(threadName)
             appendLine(e.toString())
             e.stackTrace.forEach {
                 append("    ")

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/crashreports/UnexpectedCrashSaver.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/crashreports/UnexpectedCrashSaver.kt
@@ -35,8 +35,9 @@ class UnexpectedCrashSaver(
     ) {
         if (e !is OutOfMemoryError) {
             // OOM reports are junk
+            val threadName = t.name
             scope.launch {
-                cache.writeReport(ReportAssembler().buildReport(e))
+                cache.writeReport(ReportAssembler().buildReport(e, threadName))
             }
         }
         defaultUEH!!.uncaughtException(t, e)


### PR DESCRIPTION
## Summary

Add thread name to crash reports to help diagnose which thread an exception occurred on. The thread name is captured at the time of the crash and included in both the markdown metadata table and the stack trace section of the report.

## Changes

- Modified `ReportAssembler.buildReport()` to accept an optional `threadName` parameter (defaults to current thread name)
- Added thread name to the crash report markdown table under a new "Thread" row
- Added thread name to the stack trace section for additional context
- Updated `UnexpectedCrashSaver` to capture the thread name from the `Thread` parameter and pass it to `buildReport()`

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes: This is a straightforward enhancement to crash reporting. The changes are defensive (optional parameter with sensible default) and additive (only adds information to reports). Existing crash report generation continues to work unchanged if the thread name is not provided.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

https://claude.ai/code/session_01A7Vs8Fs6qYQGYn4Ze4CLya