### PR TITLE
Preserve AVIF uploads through compression and metadata stripping

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/MediaCompressor.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/MediaCompressor.kt
@@ -41,6 +41,20 @@ class MediaCompressorResult(
 )
 
 class MediaCompressor {
+    private fun isAvif(
+        contentType: String?,
+        uri: Uri,
+    ): Boolean {
+        val mimeIsAvif =
+            contentType?.startsWith("image/", ignoreCase = true) == true &&
+                contentType.contains("avif", ignoreCase = true)
+        if (mimeIsAvif) return true
+
+        val uriPath = uri.path ?: return false
+        return uriPath.endsWith(".avif", ignoreCase = true) ||
+            uriPath.endsWith(".avif-sequence", ignoreCase = true)
+    }
+
     // ALL ERRORS ARE IGNORED. The original file is returned.
     suspend fun compress(
         uri: Uri,
@@ -77,9 +91,16 @@ class MediaCompressor {
             }
 
             contentType?.startsWith("image", ignoreCase = true) == true &&
-                !contentType.contains("gif") &&
-                !contentType.contains("svg") -> {
+                !contentType.contains("gif", ignoreCase = true) &&
+                !contentType.contains("svg", ignoreCase = true) &&
+                !isAvif(contentType, uri) -> {
                 compressImage(uri, contentType, applicationContext, mediaQuality)
+            }
+
+            isAvif(contentType, uri) -> {
+                // AVIF upload should preserve original bytes and mime type to avoid JPEG
+                // re-encoding and quality loss.
+                MediaCompressorResult(uri, contentType, null)
             }
 
             else -> {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/MetadataStripper.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/MetadataStripper.kt
@@ -42,6 +42,20 @@ data class StrippingResult(
 object MetadataStripper {
     private const val DEFAULT_REMUX_BUFFER_SIZE = 8 * 1024 * 1024
 
+    private fun isAvif(
+        mimeType: String?,
+        uri: Uri,
+    ): Boolean {
+        val mimeIsAvif =
+            mimeType?.startsWith("image/", ignoreCase = true) == true &&
+                mimeType.contains("avif", ignoreCase = true)
+        if (mimeIsAvif) return true
+
+        val uriPath = uri.path ?: return false
+        return uriPath.endsWith(".avif", ignoreCase = true) ||
+            uriPath.endsWith(".avif-sequence", ignoreCase = true)
+    }
+
     private val SENSITIVE_EXIF_TAGS =
         arrayOf(
             ExifInterface.TAG_GPS_LATITUDE,
@@ -398,6 +412,9 @@ object MetadataStripper {
         context: Context,
     ): StrippingResult =
         when {
+            // ExifInterface does not support AVIF metadata rewriting reliably, so keep the
+            // original media and mark this as handled to avoid blocking uploads.
+            isAvif(mimeType, uri) -> StrippingResult(uri, true)
             mimeType?.startsWith("image/", ignoreCase = true) == true -> stripImageMetadata(uri, context)
             mimeType?.startsWith("video/", ignoreCase = true) == true -> stripVideoMetadata(uri, context)
             mimeType?.equals("audio/mpeg", ignoreCase = true) == true -> stripMp3Metadata(uri, context)

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/service/uploads/MetadataStripperTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/service/uploads/MetadataStripperTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.uploads
+
+import android.content.Context
+import android.net.Uri
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MetadataStripperTest {
+    @Test
+    fun `AVIF media should skip metadata stripper`() {
+        val uri = mockk<Uri>()
+        val context = mockk<Context>()
+
+        val result = MetadataStripper.strip(uri, "image/avif", context)
+
+        assertEquals(uri, result.uri)
+        assertTrue(result.stripped)
+    }
+
+    @Test
+    fun `AVIF extension should skip metadata stripper when mime type is generic image`() {
+        val uri = mockk<Uri>()
+        val context = mockk<Context>()
+
+        every { uri.path } returns "/tmp/sample.avif"
+
+        val result = MetadataStripper.strip(uri, "image/*", context)
+
+        assertEquals(uri, result.uri)
+        assertTrue(result.stripped)
+    }
+}

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/components/MediaCompressorTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/components/MediaCompressorTest.kt
@@ -154,6 +154,88 @@ class MediaCompressorTest {
         }
 
     @Test
+    fun `AVIF media should skip image compressor`() =
+        runTest {
+            // setup
+            val mediaQuality = CompressorQuality.MEDIUM
+            val uri = mockk<Uri>()
+            val contentType = "image/avif"
+
+            mockkObject(MediaCompressorFileUtils)
+            every { MediaCompressorFileUtils.from(any(), any()) } returns File("test")
+            coEvery { Compressor.compress(any(), any(), any(), any()) } returns File("test")
+
+            // execute
+            val result =
+                MediaCompressor().compress(
+                    uri,
+                    contentType,
+                    applicationContext = mockk<Context>(relaxed = true),
+                    mediaQuality = mediaQuality,
+                )
+
+            // verify
+            coVerify(exactly = 0) { Compressor.compress(any(), any(), any(), any()) }
+            assertEquals(uri, result.uri)
+            assertEquals(contentType, result.contentType)
+            assertEquals(null, result.size)
+        }
+
+    @Test
+    fun `AVIF sequence media should skip image compressor`() =
+        runTest {
+            // setup
+            val mediaQuality = CompressorQuality.HIGH
+            val uri = mockk<Uri>()
+            val contentType = "image/avif-sequence"
+
+            mockkObject(MediaCompressorFileUtils)
+            every { MediaCompressorFileUtils.from(any(), any()) } returns File("test")
+            coEvery { Compressor.compress(any(), any(), any(), any()) } returns File("test")
+
+            val result =
+                MediaCompressor().compress(
+                    uri,
+                    contentType,
+                    applicationContext = mockk<Context>(relaxed = true),
+                    mediaQuality = mediaQuality,
+                )
+
+            coVerify(exactly = 0) { Compressor.compress(any(), any(), any(), any()) }
+            assertEquals(uri, result.uri)
+            assertEquals(contentType, result.contentType)
+            assertEquals(null, result.size)
+        }
+
+    @Test
+    fun `Avif extension without mime should skip image compressor`() =
+        runTest {
+            // setup
+            val mediaQuality = CompressorQuality.MEDIUM
+            val uri = mockk<Uri>()
+            val contentType = "image"
+
+            every { uri.path } returns "/tmp/sample.avif"
+
+            mockkObject(MediaCompressorFileUtils)
+            every { MediaCompressorFileUtils.from(any(), any()) } returns File("test")
+            coEvery { Compressor.compress(any(), any(), any(), any()) } returns File("test")
+
+            val result =
+                MediaCompressor().compress(
+                    uri,
+                    contentType,
+                    applicationContext = mockk<Context>(relaxed = true),
+                    mediaQuality = mediaQuality,
+                )
+
+            coVerify(exactly = 0) { Compressor.compress(any(), any(), any(), any()) }
+            assertEquals(uri, result.uri)
+            assertEquals(contentType, result.contentType)
+            assertEquals(null, result.size)
+        }
+
+    @Test
     fun `Image compression should return back same uri on exception`() =
         runTest {
             // setup


### PR DESCRIPTION
## Summary

Addresses #837 by keeping AVIF uploads out of the generic JPEG image compression path and the EXIF metadata rewriting path.

- Detects `image/avif`, `image/avif-sequence`, and `.avif` / `.avif-sequence` filenames before image compression.
- Returns the original URI and MIME type for AVIF uploads so the upload pipeline does not re-encode them as JPEG.
- Skips EXIF metadata rewriting for AVIF files because `ExifInterface` does not reliably support rewriting AVIF containers.
- Adds regression coverage for AVIF compression bypass and metadata stripping bypass.

## Testing

- `git diff --check`
- Attempted `./gradlew.bat :amethyst:testDebugUnitTest --tests com.vitorpamplona.amethyst.ui.components.MediaCompressorTest --tests com.vitorpamplona.amethyst.service.uploads.MetadataStripperTest`, but this local Windows environment has no Java/JDK configured: `JAVA_HOME is not set and no 'java' command could be found in your PATH`.

I kept this intentionally narrow: display rendering is already supported, and this PR focuses on preserving AVIF files during upload.