### PR TITLE
fix: surface Pay row in Reaction Settings for existing accounts

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettings.kt
@@ -35,7 +35,7 @@ class AccountSyncedSettings(
     val reactions =
         AccountReactionPreferences(
             MutableStateFlow(internalSettings.reactions.reactionChoices.toImmutableList()),
-            MutableStateFlow(internalSettings.reactions.reactionRowItems.toImmutableList()),
+            MutableStateFlow(mergeWithDefaultReactionRowItems(internalSettings.reactions.reactionRowItems).toImmutableList()),
         )
     val zaps =
         AccountZapPreferences(
@@ -96,7 +96,8 @@ class AccountSyncedSettings(
             reactions.reactionChoices.tryEmit(newReactionChoices)
         }
 
-        val newReactionRowItems = syncedSettingsInternal.reactions.reactionRowItems.toImmutableList()
+        val newReactionRowItems =
+            mergeWithDefaultReactionRowItems(syncedSettingsInternal.reactions.reactionRowItems).toImmutableList()
         if (!equalImmutableLists(reactions.reactionRowItems.value, newReactionRowItems)) {
             reactions.reactionRowItems.tryEmit(newReactionRowItems)
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettingsInternal.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettingsInternal.kt
@@ -67,6 +67,16 @@ val DefaultReactionRowItems =
         ReactionRowItem(ReactionRowAction.Share, showCounter = false),
     )
 
+// Existing accounts have a reaction-row list serialized before some actions
+// existed (e.g. Pay was added later). Append any default items the saved list
+// is missing so new actions surface without forcing a settings reset — the
+// user's existing order/toggles for actions they already have are preserved.
+fun mergeWithDefaultReactionRowItems(saved: List<ReactionRowItem>): List<ReactionRowItem> {
+    val knownActions = saved.mapTo(mutableSetOf()) { it.action }
+    val missing = DefaultReactionRowItems.filter { it.action !in knownActions }
+    return if (missing.isEmpty()) saved else saved + missing
+}
+
 @Serializable
 enum class VideoPlayerAction {
     Fullscreen,


### PR DESCRIPTION
Accounts whose `reactionRowItems` were persisted before `ReactionRowAction.Pay` existed still load a 5-item list, so the **Pay** row never appears in Settings → Reactions for those users.

This mirrors the existing fix used for `VideoPlayerButtonItem.Cast`:

- Add `mergeWithDefaultReactionRowItems` in `AccountSyncedSettingsInternal.kt` — appends any default actions missing from the saved list while preserving the user's existing order and enabled/showCounter toggles.
- Wire it into the two entry points in `AccountSyncedSettings.kt` (constructor + `updateFrom`), exactly matching how `mergeWithDefaultVideoPlayerButtons` is called for video-player buttons.

No migration or settings reset is required — the next read repairs the list in place. Forward-compatible: any future `ReactionRowAction` added to `DefaultReactionRowItems` will auto-surface for existing users.

## Test plan

- [x] `./gradlew :amethyst:compilePlayDebugKotlin` passes
- [x] `./gradlew spotlessCheck` passes
- [x] On an account whose persisted `reactionRowItems` predates Pay, Settings → Reactions lists all six rows: Reply, Boost, Like, Zap, Pay (disabled by default), Share
- [x] Toggling Pay → enabled persists across app restart
- [x] Existing order/toggles for other reaction rows are preserved (non-destructive merge)