### PR TITLE
docs: add Material Symbols font subset regeneration guide

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -306,6 +306,29 @@ actual fun openExternalUrl(url: String) {
 }
 ```
 
+## Icons
+
+The Material Symbols font bundled at
+`commons/src/commonMain/composeResources/font/material_symbols_outlined.ttf`
+is a **subset** that only contains the glyphs referenced from
+`commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/icons/symbols/MaterialSymbols.kt`.
+
+**MANDATORY:** Whenever you add a new icon — i.e. introduce a
+`MaterialSymbol("\uXXXX")` codepoint that wasn't already referenced anywhere in
+`MaterialSymbols.kt` — you MUST regenerate the subset font by running:
+
+```bash
+./tools/material-symbols-subset/subset.sh
+```
+
+Commit the regenerated `material_symbols_outlined.ttf` alongside your
+`MaterialSymbols.kt` change. Without this step the new icon renders as tofu (□)
+at runtime because the glyph is not in the bundled font.
+
+Reusing a codepoint already present in `MaterialSymbols.kt` does NOT require
+regenerating. See `tools/material-symbols-subset/README.md` for details and
+prerequisites (`pip install fonttools brotli`).
+
 ## Code Formatting
 After completing any task that modifies Kotlin files, always run:
 ```


### PR DESCRIPTION
## Summary

Added documentation to `CLAUDE.md` explaining the Material Symbols font subset workflow. The bundled font file is a subset containing only glyphs referenced in `MaterialSymbols.kt`, and developers must regenerate it when adding new icon codepoints to avoid rendering as tofu (□) at runtime.

## Details

This change documents:
- The location and purpose of the Material Symbols font subset
- **Mandatory** regeneration step when adding new icons: `./tools/material-symbols-subset/subset.sh`
- That reusing existing codepoints does NOT require regeneration
- Prerequisites and reference to the subset tool's README

This is a documentation-only change with no code modifications.

## Test plan

- [x] N/A — documentation only, no code changes

https://claude.ai/code/session_01C5SpDeTaYAeC1qvv2baEm1