### PR TITLE
Re-add Nostrcheck.me Blossom server to defaults

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/mediaServers/ServerName.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/mediaServers/ServerName.kt
@@ -38,6 +38,7 @@ enum class ServerType {
 val DEFAULT_MEDIA_SERVERS: List<ServerName> =
     listOf(
         ServerName("Nostr.Build", "https://blossom.band/", ServerType.Blossom),
+        ServerName("Nostrcheck.me", "https://cdn.nostrcheck.me", ServerType.Blossom),
         ServerName("24242.io", "https://24242.io/", ServerType.Blossom),
         ServerName("Azzamo", "https://blossom.azzamo.media", ServerType.Blossom),
         ServerName("YakiHonne", "https://blossom.yakihonne.com/", ServerType.Blossom),


### PR DESCRIPTION
## Summary

 Re-adds [Nostrcheck.me](https://nostrcheck.me) (`https://cdn.nostrcheck.me`) to the `DEFAULT_MEDIA_SERVERS` list as a Blossom option.

## Test plan

  The diff is a single entry in `DEFAULT_MEDIA_SERVERS`, no logic.

## Interop suites

- [x ] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## AI assistance

- [ x] Written by hand

## License

- [x ] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
