### PR TITLE
Preserve AVIF uploads

### DIFF
--- a/amethyst/src/androidTest/java/com/vitorpamplona/amethyst/service/uploads/AvifUploadPipelineInstrumentedTest.kt
+++ b/amethyst/src/androidTest/java/com/vitorpamplona/amethyst/service/uploads/AvifUploadPipelineInstrumentedTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.uploads
+
+import android.net.Uri
+import android.os.Build
+import android.util.Base64
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class AvifUploadPipelineInstrumentedTest {
+    private val tinyAvifBase64 =
+        "AAAAIGZ0eXBhdmlmAAAAAGF2aWZtaWYxbWlhZk1BMUIAAADrbWV0YQAAAAAAAAAhaGRscgAAAAAAAAAAcGljdAAAAAAAAAAAAAAAAAAAAAAOcGl0bQAAAAAAAQAAAB5pbG9jAAAAAEQAAAEAAQAAAAEAAAETAAAAPAAAAChpaW5mAAAAAAABAAAAGmluZmUCAAAAAAEAAGF2MDFDb2xvcgAAAABqaXBycAAAAEtpcGNvAAAAFGlzcGUAAAAAAAAACAAAAAgAAAAQcGl4aQAAAAADCAgIAAAADGF2MUOBAAwAAAAAE2NvbHJuY2x4AAEADQAGgAAAABdpcG1hAAAAAAAAAAEAAQQBAoMEAAAARG1kYXQSAAoFGAi/YEIyMRQAAwwwxAA89itlZz4hWO2B4vIBcLfFyXWnEefrmHux78818I4WywDTVsW1Fx3+VNA="
+
+    @Test
+    fun avifUploadPipelinePreservesAvifAndComputesPreviewMetadata() =
+        runBlocking {
+            assumeTrue("AVIF decoding requires Android 12+", Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
+
+            val context = InstrumentationRegistry.getInstrumentation().targetContext
+            val avifFile = File.createTempFile("amethyst_tiny_", ".avif", context.cacheDir)
+            avifFile.writeBytes(Base64.decode(tinyAvifBase64, Base64.DEFAULT))
+
+            val avifUri = Uri.fromFile(avifFile)
+            try {
+                val compressed =
+                    MediaCompressor()
+                        .compress(
+                            uri = avifUri,
+                            contentType = "image/avif",
+                            mediaQuality = CompressorQuality.MEDIUM,
+                            applicationContext = context,
+                        )
+
+                assertEquals(avifUri, compressed.uri)
+                assertEquals("image/avif", compressed.contentType)
+                assertNull(compressed.size)
+
+                val previewMetadata =
+                    PreviewMetadataCalculator.computeFromUri(
+                        context = context,
+                        uri = avifUri,
+                        mimeType = "image/avif",
+                    )
+
+                assertNotNull(previewMetadata)
+                assertEquals(8, previewMetadata?.dim?.width)
+                assertEquals(8, previewMetadata?.dim?.height)
+                assertNotNull(previewMetadata?.blurhash)
+                assertNotNull(previewMetadata?.thumbhash)
+
+                val stripped =
+                    MetadataStripper.strip(
+                        uri = avifUri,
+                        mimeType = "image/avif",
+                        context = context,
+                    )
+
+                assertEquals(avifUri, stripped.uri)
+                assertEquals(true, stripped.stripped)
+            } finally {
+                avifFile.delete()
+            }
+        }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/MediaCompressor.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/MediaCompressor.kt
@@ -78,7 +78,8 @@ class MediaCompressor {
 
             contentType?.startsWith("image", ignoreCase = true) == true &&
                 !contentType.contains("gif") &&
-                !contentType.contains("svg") -> {
+                !contentType.contains("svg") &&
+                !contentType.isAvifMimeType() -> {
                 compressImage(uri, contentType, applicationContext, mediaQuality)
             }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/MediaMimeTypes.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/MediaMimeTypes.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.uploads
+
+internal const val AVIF_MIME_TYPE = "image/avif"
+internal const val AVIF_SEQUENCE_MIME_TYPE = "image/avif-sequence"
+
+internal fun String?.isAvifMimeType(): Boolean =
+    when (this?.substringBefore(";")?.trim()?.lowercase()) {
+        AVIF_MIME_TYPE,
+        AVIF_SEQUENCE_MIME_TYPE,
+        -> true
+        else -> false
+    }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/MetadataStripper.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/MetadataStripper.kt
@@ -27,6 +27,7 @@ import android.media.MediaFormat
 import android.media.MediaMetadataRetriever
 import android.media.MediaMuxer
 import android.net.Uri
+import android.os.Build
 import androidx.core.net.toUri
 import androidx.exifinterface.media.ExifInterface
 import com.vitorpamplona.quartz.utils.Log
@@ -298,6 +299,49 @@ object MetadataStripper {
         }
     }
 
+    fun stripAvifMetadata(
+        uri: Uri,
+        context: Context,
+    ): StrippingResult {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return StrippingResult(uri, false)
+
+        var tempFile: File? = null
+        return try {
+            tempFile = File.createTempFile("checked_avif_", ".avif", context.cacheDir)
+
+            val inputStream =
+                context.contentResolver.openInputStream(uri)
+                    ?: run {
+                        if (!tempFile.delete()) {
+                            Log.w("MetadataStripper") { "Failed to delete temp file: ${tempFile.absolutePath}" }
+                        }
+                        return StrippingResult(uri, false)
+                    }
+            inputStream.use { input ->
+                tempFile.outputStream().use { output ->
+                    input.copyTo(output)
+                }
+            }
+
+            val exif = ExifInterface(tempFile.absolutePath)
+            val hasSensitiveExif = SENSITIVE_EXIF_TAGS.any { !exif.getAttribute(it).isNullOrBlank() }
+
+            if (!tempFile.delete()) {
+                Log.w("MetadataStripper") { "Failed to delete temp file: ${tempFile.absolutePath}" }
+            }
+            tempFile = null
+
+            StrippingResult(uri, !hasSensitiveExif)
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            if (tempFile?.delete() == false) {
+                Log.w("MetadataStripper") { "Failed to delete temp file: ${tempFile.absolutePath}" }
+            }
+            Log.d("MetadataStripper") { "Failed to inspect AVIF metadata: ${e.message}" }
+            StrippingResult(uri, false)
+        }
+    }
+
     fun stripMp3Metadata(
         uri: Uri,
         context: Context,
@@ -398,6 +442,7 @@ object MetadataStripper {
         context: Context,
     ): StrippingResult =
         when {
+            mimeType.isAvifMimeType() -> stripAvifMetadata(uri, context)
             mimeType?.startsWith("image/", ignoreCase = true) == true -> stripImageMetadata(uri, context)
             mimeType?.startsWith("video/", ignoreCase = true) == true -> stripVideoMetadata(uri, context)
             mimeType?.equals("audio/mpeg", ignoreCase = true) == true -> stripMp3Metadata(uri, context)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/PreviewMetadataCalculator.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/PreviewMetadataCalculator.kt
@@ -23,14 +23,17 @@ package com.vitorpamplona.amethyst.service.uploads
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.ImageDecoder
 import android.media.MediaMetadataRetriever
 import android.net.Uri
+import android.os.Build
 import com.vitorpamplona.amethyst.commons.blurhash.toBlurhash
 import com.vitorpamplona.amethyst.commons.thumbhash.toThumbhash
 import com.vitorpamplona.amethyst.service.images.BlurhashWrapper
 import com.vitorpamplona.amethyst.service.images.ThumbhashWrapper
 import com.vitorpamplona.quartz.nip94FileMetadata.tags.DimensionTag
 import com.vitorpamplona.quartz.utils.Log
+import java.nio.ByteBuffer
 
 /**
  * Result of precomputing placeholder metadata during an upload. The bitmap or video thumbnail is
@@ -61,6 +64,33 @@ object PreviewMetadataCalculator {
             inPreferredConfig = Bitmap.Config.ARGB_8888
         }
 
+    private fun decodeImageBitmapFromBytes(
+        data: ByteArray,
+        mimeType: String?,
+    ): Bitmap? =
+        if (mimeType.isAvifMimeType() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            ImageDecoder.decodeBitmap(ImageDecoder.createSource(ByteBuffer.wrap(data))) { decoder, _, _ ->
+                decoder.allocator = ImageDecoder.ALLOCATOR_SOFTWARE
+            }
+        } else {
+            BitmapFactory.decodeByteArray(data, 0, data.size, createBitmapOptions())
+        }
+
+    private fun decodeImageBitmapFromUri(
+        context: Context,
+        uri: Uri,
+        mimeType: String?,
+    ): Bitmap? =
+        if (mimeType.isAvifMimeType() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            ImageDecoder.decodeBitmap(ImageDecoder.createSource(context.contentResolver, uri)) { decoder, _, _ ->
+                decoder.allocator = ImageDecoder.ALLOCATOR_SOFTWARE
+            }
+        } else {
+            context.contentResolver.openInputStream(uri)?.use { stream ->
+                BitmapFactory.decodeStream(stream, null, createBitmapOptions())
+            }
+        }
+
     fun computeFromBytes(
         data: ByteArray,
         mimeType: String?,
@@ -68,7 +98,7 @@ object PreviewMetadataCalculator {
     ): PreviewHashes =
         when {
             isImage(mimeType) -> {
-                val bitmap = BitmapFactory.decodeByteArray(data, 0, data.size, createBitmapOptions())
+                val bitmap = decodeImageBitmapFromBytes(data, mimeType)
                 processImage(bitmap, dimPrecomputed)
             }
 
@@ -98,10 +128,7 @@ object PreviewMetadataCalculator {
         return try {
             when {
                 isImage(mimeType) -> {
-                    context.contentResolver.openInputStream(uri)?.use { stream ->
-                        val bitmap = BitmapFactory.decodeStream(stream, null, createBitmapOptions())
-                        processImage(bitmap, dimPrecomputed)
-                    } ?: PreviewHashes(dim = dimPrecomputed)
+                    processImage(decodeImageBitmapFromUri(context, uri, mimeType), dimPrecomputed)
                 }
 
                 isVideo(mimeType) -> {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/nip96/Nip96Uploader.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/uploads/nip96/Nip96Uploader.kt
@@ -30,6 +30,8 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.service.HttpStatusMessages
 import com.vitorpamplona.amethyst.service.checkNotInMainThread
+import com.vitorpamplona.amethyst.service.uploads.AVIF_MIME_TYPE
+import com.vitorpamplona.amethyst.service.uploads.AVIF_SEQUENCE_MIME_TYPE
 import com.vitorpamplona.amethyst.service.uploads.MediaUploadResult
 import com.vitorpamplona.amethyst.service.uploads.PreviewMetadataCalculator
 import com.vitorpamplona.amethyst.ui.stringRes
@@ -239,7 +241,9 @@ class Nip96Uploader {
     // carries a real extension — otherwise the server gets "name." and echoes it back, which
     // breaks HLS URL rewriting.
     private fun fallbackExtensionForMimeType(mimeType: String): String? =
-        when (mimeType.lowercase()) {
+        when (mimeType.substringBefore(";").trim().lowercase()) {
+            AVIF_MIME_TYPE -> "avif"
+            AVIF_SEQUENCE_MIME_TYPE -> "avif"
             "application/vnd.apple.mpegurl", "application/x-mpegurl", "audio/x-mpegurl", "audio/mpegurl" -> "m3u8"
             "video/mp2t" -> "ts"
             "video/iso.segment", "video/mp4" -> "mp4"

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/components/MediaCompressorTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/components/MediaCompressorTest.kt
@@ -154,6 +154,38 @@ class MediaCompressorTest {
         }
 
     @Test
+    fun `AVIF images should not be converted to JPEG compressor output`() =
+        runTest {
+            val mediaQuality = CompressorQuality.MEDIUM
+            val uri = mockk<Uri>()
+            val contentTypes =
+                listOf(
+                    "image/avif",
+                    "image/avif; codecs=avif",
+                    "image/avif-sequence",
+                )
+
+            mockkObject(MediaCompressorFileUtils)
+            every { MediaCompressorFileUtils.from(any(), any()) } returns File("test")
+            coEvery { Compressor.compress(any(), any(), any(), any()) } returns File("compressed")
+
+            contentTypes.forEach { contentType ->
+                val result =
+                    MediaCompressor().compress(
+                        uri,
+                        contentType,
+                        applicationContext = mockk<Context>(relaxed = true),
+                        mediaQuality = mediaQuality,
+                    )
+
+                assertEquals(uri, result.uri)
+                assertEquals(contentType, result.contentType)
+                assertEquals(null, result.size)
+            }
+            coVerify(exactly = 0) { Compressor.compress(any(), any(), any(), any()) }
+        }
+
+    @Test
     fun `Image compression should return back same uri on exception`() =
         runTest {
             // setup


### PR DESCRIPTION
## Summary

Fixes vitorpamplona/amethyst#837 by preserving AVIF uploads through the Android upload pipeline instead of sending them through the generic JPEG compressor path.

This keeps still AVIF and animated AVIF MIME types intact for upload, filename fallback, metadata inspection, and local preview metadata generation.

## Changes

- Skip JPEG recompression for `image/avif` and `image/avif-sequence`.
- Add shared AVIF MIME helpers so upload/compression paths agree on still and animated AVIF handling.
- Preserve `.avif` multipart filenames when Android's `MimeTypeMap` does not provide an extension.
- Decode AVIF upload previews with `ImageDecoder` on supported Android versions so blurhash, thumbhash, and dimensions can still be generated.
- Inspect AVIF EXIF metadata without rewriting the file; uploads fail closed if sensitive metadata cannot be ruled out.
- Add regression coverage proving AVIF MIME variants are not converted to JPEG compressor output.

## Validation

- `git diff --check HEAD`
- `./gradlew.bat :amethyst:testPlayDebugUnitTest --tests "com.vitorpamplona.amethyst.ui.components.MediaCompressorTest"`
- `./gradlew.bat :amethyst:compileFdroidDebugKotlin`
- `./gradlew.bat :amethyst:installPlayDebug` on `Medium_Phone_API_35`
- Launched `com.vitorpamplona.amethyst.debug/com.vitorpamplona.amethyst.ui.MainActivity` on the API 35 emulator and confirmed the process started.
- Pre-push hook passed: `:quartz:jvmTest :commons:jvmTest :nestsClient:jvmTest :quic:jvmTest :amethyst:testPlayDebugUnitTest :cli:test :desktopApp:test --quiet`

Note: I did not use a live signed-in account or upload to a production media server during the emulator check.

## Bounty / payout

This is submitted for the 150,000 sats bounty on #837. A Lightning invoice can be provided if accepted.
