### PR TITLE
Add fallback relay logic for abandoned users in metadata queries

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -404,7 +404,7 @@ class Account(
     val dmRelays = DmInboxRelayState(dmRelayList, nip65RelayList, privateStorageRelayList, localRelayList, scope)
     val notificationRelays = NotificationInboxRelayState(nip65RelayList, localRelayList, scope)
 
-    val trustedRelays = TrustedRelayListsState(nip65RelayList, privateStorageRelayList, localRelayList, dmRelayList, searchRelayList, trustedRelayList, broadcastRelayList, scope)
+    val trustedRelays = TrustedRelayListsState(nip65RelayList, privateStorageRelayList, localRelayList, dmRelayList, searchRelayList, indexerRelayList, proxyRelayList, trustedRelayList, broadcastRelayList, scope)
 
     // Follows Relays
     val followOutboxesOrProxy = FollowListOutboxOrProxyRelays(kind3FollowList, blockedRelayList, proxyRelayList, cache, scope)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/serverList/TrustedRelayListsState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/serverList/TrustedRelayListsState.kt
@@ -24,6 +24,8 @@ import com.vitorpamplona.amethyst.model.edits.PrivateStorageRelayListState
 import com.vitorpamplona.amethyst.model.localRelays.LocalRelayListState
 import com.vitorpamplona.amethyst.model.nip17Dms.DmRelayListState
 import com.vitorpamplona.amethyst.model.nip51Lists.broadcastRelays.BroadcastRelayListState
+import com.vitorpamplona.amethyst.model.nip51Lists.indexerRelays.IndexerRelayListState
+import com.vitorpamplona.amethyst.model.nip51Lists.proxyRelays.ProxyRelayListState
 import com.vitorpamplona.amethyst.model.nip51Lists.searchRelays.SearchRelayListState
 import com.vitorpamplona.amethyst.model.nip51Lists.trustedRelays.TrustedRelayListState
 import com.vitorpamplona.amethyst.model.nip65RelayList.Nip65RelayListState
@@ -43,6 +45,8 @@ class TrustedRelayListsState(
     val localRelayList: LocalRelayListState,
     val dmRelayList: DmRelayListState,
     val searchRelayListState: SearchRelayListState,
+    val indexerRelayList: IndexerRelayListState,
+    val proxyRelayList: ProxyRelayListState,
     val trustedRelayList: TrustedRelayListState,
     val broadcastRelayList: BroadcastRelayListState,
     val scope: CoroutineScope,
@@ -57,6 +61,8 @@ class TrustedRelayListsState(
                 localRelayList.flow,
                 dmRelayList.flow,
                 searchRelayListState.flowNoDefaults,
+                indexerRelayList.flowNoDefaults,
+                proxyRelayList.flow,
                 trustedRelayList.flow,
                 broadcastRelayList.flow,
             ),
@@ -70,6 +76,8 @@ class TrustedRelayListsState(
                         localRelayList.flow.value,
                         dmRelayList.flow.value,
                         searchRelayListState.flowNoDefaults.value,
+                        indexerRelayList.flowNoDefaults.value,
+                        proxyRelayList.flow.value,
                         trustedRelayList.flow.value,
                         broadcastRelayList.flow.value,
                     ),
@@ -86,6 +94,8 @@ class TrustedRelayListsState(
                         localRelayList.flow.value,
                         dmRelayList.flow.value,
                         searchRelayListState.flowNoDefaults.value,
+                        indexerRelayList.flowNoDefaults.value,
+                        proxyRelayList.flow.value,
                         trustedRelayList.flow.value,
                         broadcastRelayList.flow.value,
                     ),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/user/UserFinderFilterAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/user/UserFinderFilterAssembler.kt
@@ -48,7 +48,7 @@ class UserFinderFilterAssembler(
     val group =
         listOf(
             UserOutboxFinderSubAssembler(client, cache, failureTracker, ::allKeys),
-            UserWatcherSubAssembler(client, cache, ::allKeys),
+            UserWatcherSubAssembler(client, cache, failureTracker, ::allKeys),
             UserReportsSubAssembler(client, cache, ::allKeys),
             UserCardsSubAssembler(client, cache, ::allKeys),
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/user/loaders/UserOutboxFinderSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/user/loaders/UserOutboxFinderSubAssembler.kt
@@ -20,12 +20,15 @@
  */
 package com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.loaders
 
+import com.vitorpamplona.amethyst.commons.defaults.DefaultIndexerRelayList
+import com.vitorpamplona.amethyst.commons.defaults.DefaultSearchRelayList
 import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.BaseEoseManager
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.follows.pickRelaysToLoadUsers
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinderQueryState
 import com.vitorpamplona.amethyst.service.relays.EOSEAccountFast
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.RelayOfflineTracker
@@ -107,16 +110,46 @@ class UserOutboxFinderSubAssembler(
                 hasTried,
             )
 
-        return perRelayKeysBoth.mapNotNull {
-            val sortedUsers = it.value.sorted()
-            if (sortedUsers.isNotEmpty()) {
-                RelayBasedFilter(
-                    relay = it.key,
-                    filter = Filter(kinds = relayListKinds, authors = sortedUsers),
-                )
-            } else {
-                null
+        val activeFilters =
+            perRelayKeysBoth.mapNotNull {
+                val sortedUsers = it.value.sorted()
+                if (sortedUsers.isNotEmpty()) {
+                    RelayBasedFilter(
+                        relay = it.key,
+                        filter = Filter(kinds = relayListKinds, authors = sortedUsers),
+                    )
+                } else {
+                    null
+                }
             }
-        }
+
+        // Users that pickRelaysToLoadUsers could not place anywhere this pass:
+        // every candidate relay tier (outbox/hints/index/search/connected/common)
+        // is already in hasTried. Without a fallback they'd be silently dropped
+        // and a late-published kind 10002 would never reach the UI.
+        val placedPubkeys =
+            perRelayKeysBoth.values
+                .asSequence()
+                .flatten()
+                .toSet()
+        val abandonedPubkeys =
+            noOutboxList.mapNotNullTo(mutableSetOf<HexKey>()) { user ->
+                user.pubkeyHex.takeIf { it !in placedPubkeys }
+            }
+
+        if (abandonedPubkeys.isEmpty()) return activeFilters
+
+        val sortedAbandoned = abandonedPubkeys.sorted()
+        val fallbackRelays =
+            (DefaultIndexerRelayList + DefaultSearchRelayList) - failureTracker.cannotConnectRelays
+        val fallbackFilters =
+            fallbackRelays.map { relay ->
+                RelayBasedFilter(
+                    relay = relay,
+                    filter = Filter(kinds = relayListKinds, authors = sortedAbandoned),
+                )
+            }
+
+        return activeFilters + fallbackFilters
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/user/watchers/FilterUserMetadataForKey.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/user/watchers/FilterUserMetadataForKey.kt
@@ -48,6 +48,7 @@ val UserMetadataForKeyKinds =
 fun filterUserMetadataForKey(
     authors: Set<User>,
     indexRelays: Set<NormalizedRelayUrl>,
+    cannotConnectRelays: Set<NormalizedRelayUrl>,
     since: EOSEAccountFast<User>,
 ): List<RelayBasedFilter> {
     val perRelayUsers =
@@ -57,7 +58,7 @@ fun filterUserMetadataForKey(
                     key.outboxRelays()
                         ?: (key.allUsedRelays() + LocalCache.relayHints.hintsForKey(key.pubkeyHex) + indexRelays)
 
-                relays.forEach {
+                (relays - cannotConnectRelays).forEach {
                     add(it, key)
                 }
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/user/watchers/UserWatcherSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/user/watchers/UserWatcherSubAssembler.kt
@@ -28,6 +28,7 @@ import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinder
 import com.vitorpamplona.amethyst.service.relays.EOSEAccountFast
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
+import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.RelayOfflineTracker
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.groupByRelay
 import com.vitorpamplona.quartz.nip01Core.relay.client.reqs.SubscriptionListener
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
@@ -37,6 +38,7 @@ import com.vitorpamplona.quartz.utils.TimeUtils
 class UserWatcherSubAssembler(
     client: INostrClient,
     val cache: LocalCache,
+    val failureTracker: RelayOfflineTracker,
     allKeys: () -> Set<UserFinderQueryState>,
 ) : BaseEoseManager<UserFinderQueryState>(client, allKeys) {
     /**
@@ -99,7 +101,13 @@ class UserWatcherSubAssembler(
             )
         }
 
-        val newFilters = filterUserMetadataForKey(users, indexRelays, latestEOSEs).ifEmpty { null }
+        val newFilters =
+            filterUserMetadataForKey(
+                users,
+                indexRelays,
+                failureTracker.cannotConnectRelays,
+                latestEOSEs,
+            ).ifEmpty { null }
 
         sub.updateFilters(newFilters?.groupByRelay())
     }


### PR DESCRIPTION
## Summary

Improves user metadata discovery by adding a fallback mechanism for users that cannot be placed on any preferred relay tier. When `pickRelaysToLoadUsers` exhausts all candidate relays (outbox/hints/indexer/search/connected/common) for a user, the query now falls back to indexer + search relays (excluding offline relays) to ensure late-published kind 10002 events are still discovered. Also integrates indexer and proxy relay lists into the trusted relays state flow.

## Changes

**UserOutboxFinderSubAssembler.kt:**
- Refactored filter assembly to track which pubkeys were successfully placed on relays
- Added fallback logic: users not placed anywhere are queried against indexer + search relays (minus offline relays)
- Prevents silent dropping of users when all preferred relay tiers are exhausted

**FilterUserMetadataForKey.kt:**
- Added `cannotConnectRelays` parameter to filter out offline relays from metadata queries
- Prevents wasted queries to relays known to be offline

**UserWatcherSubAssembler.kt:**
- Injected `RelayOfflineTracker` dependency
- Passes offline relay set to `filterUserMetadataForKey` for filtering

**TrustedRelayListsState.kt:**
- Added `indexerRelayList` and `proxyRelayList` to the combined relay state flow
- Ensures these relay lists are included in trusted relay aggregation

**Account.kt:**
- Updated `TrustedRelayListsState` instantiation to include indexer and proxy relay lists

**UserFinderFilterAssembler.kt:**
- Passed `failureTracker` to `UserWatcherSubAssembler` constructor

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes: The change improves robustness of user metadata discovery by ensuring users are not silently dropped when preferred relays are unavailable. Existing relay selection logic and EOSE handling remain unchanged. The fallback only activates when primary relay selection fails to place a user.

## Interop suites

- [x] N/A — change affects relay query assembly only, not wire bytes or event encoding

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_0188RNKyKr6YJ4yCNnrtLp4A