### PR TITLE
feat: tighten the zap UI

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettingsInternal.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettingsInternal.kt
@@ -38,7 +38,7 @@ val DefaultReactions =
     )
 
 val DefaultZapAmounts = listOf(100L, 500L, 1000L)
-val DefaultOnchainZapAmounts = listOf(10_000L, 50_000L, 250_000L)
+val DefaultOnchainZapAmounts = listOf(10_000L)
 val DefaultReportWarningThreshold = 5
 
 @Serializable

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/ReactionsRow.kt
@@ -1976,66 +1976,40 @@ fun ZapAmountChoicePopupContent(
             elevation = CardDefaults.elevatedCardElevation(defaultElevation = 8.dp),
             colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
         ) {
-            Column {
-                FlowRow(
-                    modifier = Modifier.padding(horizontal = 5.dp, vertical = 5.dp),
-                    horizontalArrangement = Arrangement.Center,
-                    verticalArrangement = Arrangement.Center,
-                    itemVerticalAlignment = CenterVertically,
-                ) {
-                    zapAmountChoices.forEach { amountInSats ->
-                        ZapAmountChip(
-                            amountInSats = amountInSats,
-                            onClick = { onZap(amountInSats) },
-                            onLongClick = onChangeAmount,
-                        )
-                    }
-                    ClickableBox(
-                        modifier =
-                            Modifier
-                                .padding(horizontal = 4.dp, vertical = 6.dp)
-                                .size(32.dp)
-                                .padding(7.dp),
-                        onClick = onChangeAmount,
-                    ) {
-                        Icon(
-                            symbol = MaterialSymbols.Tune,
-                            contentDescription = stringRes(R.string.quick_zap_amounts),
-                            modifier = Size18Modifier,
-                            tint = MaterialTheme.colorScheme.placeholderText,
-                        )
-                    }
+            FlowRow(
+                modifier = Modifier.padding(horizontal = 5.dp, vertical = 5.dp),
+                horizontalArrangement = Arrangement.Center,
+                verticalArrangement = Arrangement.Center,
+                itemVerticalAlignment = CenterVertically,
+            ) {
+                zapAmountChoices.forEach { amountInSats ->
+                    ZapAmountChip(
+                        amountInSats = amountInSats,
+                        onClick = { onZap(amountInSats) },
+                        onLongClick = onChangeAmount,
+                    )
                 }
-                if (onchainZapAmountChoices.isNotEmpty()) {
-                    FlowRow(
-                        modifier = Modifier.padding(horizontal = 5.dp, vertical = 5.dp),
-                        horizontalArrangement = Arrangement.Center,
-                        verticalArrangement = Arrangement.Center,
-                        itemVerticalAlignment = CenterVertically,
-                    ) {
-                        onchainZapAmountChoices.forEach { amountInSats ->
-                            OnchainZapAmountChip(
-                                amountInSats = amountInSats,
-                                onClick = { onOnchainAmount(amountInSats) },
-                                onLongClick = onChangeAmount,
-                            )
-                        }
-                        ClickableBox(
-                            modifier =
-                                Modifier
-                                    .padding(horizontal = 4.dp, vertical = 6.dp)
-                                    .size(32.dp)
-                                    .padding(7.dp),
-                            onClick = { onOnchainAmount(null) },
-                        ) {
-                            Icon(
-                                symbol = MaterialSymbols.Tune,
-                                contentDescription = stringRes(R.string.quick_zap_amounts_onchain),
-                                modifier = Size18Modifier,
-                                tint = MaterialTheme.colorScheme.placeholderText,
-                            )
-                        }
-                    }
+                onchainZapAmountChoices.forEach { amountInSats ->
+                    OnchainZapAmountChip(
+                        amountInSats = amountInSats,
+                        onClick = { onOnchainAmount(amountInSats) },
+                        onLongClick = onChangeAmount,
+                    )
+                }
+                ClickableBox(
+                    modifier =
+                        Modifier
+                            .padding(horizontal = 4.dp, vertical = 6.dp)
+                            .size(32.dp)
+                            .padding(7.dp),
+                    onClick = onChangeAmount,
+                ) {
+                    Icon(
+                        symbol = MaterialSymbols.Tune,
+                        contentDescription = stringRes(R.string.quick_zap_amounts),
+                        modifier = Size18Modifier,
+                        tint = MaterialTheme.colorScheme.placeholderText,
+                    )
                 }
             }
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/UpdateZapAmountDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/UpdateZapAmountDialog.kt
@@ -306,7 +306,40 @@ fun UpdateZapAmountContent(
             )
         }
 
-        // ── Section 2: Quick On-chain Zap Amounts ─────────────────────────────
+        // ── Section 2: Zap Privacy ────────────────────────────────────────────
+
+        Text(
+            text = stringRes(R.string.zap_privacy_section),
+            color = MaterialTheme.colorScheme.primary,
+            style = MaterialTheme.typography.titleSmall,
+            modifier = SettingsCategorySpacingModifier,
+        )
+        Text(
+            text = stringRes(R.string.zap_type_section_explainer),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.placeholderText,
+            modifier = Modifier.padding(bottom = 8.dp),
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            TextSpinner(
+                label = stringRes(id = R.string.zap_type_explainer),
+                placeholder =
+                    zapTypes
+                        .firstOrNull { it.first == accountViewModel.defaultZapType() }
+                        ?.second
+                        ?: zapTypes.firstOrNull()?.second
+                        ?: "",
+                options = zapOptions,
+                onSelect = { postViewModel.selectedZapType = zapTypes[it].first },
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+
+        // ── Section 3: Quick On-chain Zap Amounts ─────────────────────────────
 
         Text(
             text = stringRes(R.string.quick_zap_amounts_onchain),
@@ -395,40 +428,7 @@ fun UpdateZapAmountContent(
             )
         }
 
-        // ── Section 3: Zap Privacy ────────────────────────────────────────────
-
-        Text(
-            text = stringRes(R.string.zap_privacy_section),
-            color = MaterialTheme.colorScheme.primary,
-            style = MaterialTheme.typography.titleSmall,
-            modifier = SettingsCategorySpacingModifier,
-        )
-        Text(
-            text = stringRes(R.string.zap_type_section_explainer),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.placeholderText,
-            modifier = Modifier.padding(bottom = 8.dp),
-        )
-
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            TextSpinner(
-                label = stringRes(id = R.string.zap_type_explainer),
-                placeholder =
-                    zapTypes
-                        .firstOrNull { it.first == accountViewModel.defaultZapType() }
-                        ?.second
-                        ?: zapTypes.firstOrNull()?.second
-                        ?: "",
-                options = zapOptions,
-                onSelect = { postViewModel.selectedZapType = zapTypes[it].first },
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
-
-        // ── Section 3: Nostr Wallet Connect ───────────────────────────────────
+        // ── Section 4: Nostr Wallet Connect ───────────────────────────────────
 
         HorizontalDivider(
             modifier = Modifier.padding(vertical = 16.dp),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/OnchainZapSendDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/OnchainZapSendDialog.kt
@@ -608,18 +608,7 @@ private fun AmountSection(
 ) {
     SectionLabel("Amount")
 
-    OutlinedTextField(
-        value = amountInput,
-        onValueChange = { onAmountChange(it.filter(Char::isDigit)) },
-        singleLine = true,
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-        placeholder = { Text("0") },
-        suffix = { Text("sats", color = MaterialTheme.colorScheme.onSurfaceVariant) },
-        modifier = Modifier.fillMaxWidth(),
-    )
-
     if (presetAmounts.isNotEmpty()) {
-        Spacer(Modifier.height(8.dp))
         FlowRow(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -632,7 +621,18 @@ private fun AmountSection(
                 )
             }
         }
+        Spacer(Modifier.height(8.dp))
     }
+
+    OutlinedTextField(
+        value = amountInput,
+        onValueChange = { onAmountChange(it.filter(Char::isDigit)) },
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        placeholder = { Text("0") },
+        suffix = { Text("sats", color = MaterialTheme.colorScheme.onSurfaceVariant) },
+        modifier = Modifier.fillMaxWidth(),
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)


### PR DESCRIPTION
ReactionsRow zap popup
- Merge the Lightning and on-chain chips into a single FlowRow so all amounts wrap together instead of stacking on two lines.
- Drop the on-chain row's own Tune (settings) button; the Lightning row's Tune is the single entry point to the settings screen.

UpdateZapAmountDialog
- Reorder sections: Quick Zap Amounts, Zap Privacy, Quick On-chain Zap Amounts, Nostr Wallet Connect — privacy now sits next to the Lightning amounts it actually applies to, and on-chain (which has no privacy concept) is grouped further down.

OnchainZapSendDialog
- Move the preset amount chips above the sats text field in AmountSection so the user sees the quick picks first and the free-form input second.

Defaults
- DefaultOnchainZapAmounts is now [10_000] (just one chip) so a fresh install / first-upgrade shows 4 chips total in the popup (3 Lightning defaults + 1 on-chain default), not 6. kotlinx serialization defaults handle the back-compat for existing users who never set their on-chain choices explicitly.

<!--
Thanks for contributing to Amethyst! Before opening this PR, please skim
CONTRIBUTING.md — especially the "Proof of testing" and "Interoperability
tests" sections if you are not a regular contributor to this repo.

Delete any section below that doesn't apply.
-->

## Summary

<!-- 1–3 sentences. What changed and why. Not "what files changed" — the
diff already shows that. -->

## Test plan

<!-- Required. What did you actually run, on what platform, with what result?
"CI is green" is necessary but not sufficient — show the new path firing.

For UI changes, attach screenshots (light + dark) or a short recording.
For Android: device model + Android version. For Desktop: OS + window size.
For build/packaging changes: paste the `./gradlew` command + tail of output.

If you are NOT a regular contributor to this repo, this section is required
regardless of how small the change is — see CONTRIBUTING.md § Proof of
testing. -->

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes / screenshots:

<!-- paste here -->

## Interop suites

<!-- The interop suites listed in CONTRIBUTING.md § Interoperability tests
are NOT run in CI. If your change touches the relevant code paths, run them
locally and tick the box. If your change can't possibly affect them
(docs-only, UI-only on unrelated screens, etc.), tick "N/A". -->

- [ ] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes
- [ ] Marmot / MLS — `cli/tests/marmot/marmot-interop-headless.sh` (NIP-EE / `whitenoise-rs`)
- [ ] NIP-17 DM — `cli/tests/dm/dm-interop-headless.sh`
- [ ] Audio rooms manual — `cli/tests/nests/nests-interop.sh` (Amethyst ↔ nostrnests.com)
- [ ] MoQ-lite hang-tier — `:nestsClient:jvmTest -DnestsHangInterop=true`
- [ ] MoQ-lite browser-tier — `:nestsClient:jvmTest -DnestsBrowserInterop=true`
- [ ] QUIC interop-runner — `quic/interop/run-matrix.sh -s {aioquic,picoquic,quic-go,quinn}`

## AI assistance

<!-- Optional disclosure. We accept AI-assisted PRs (Claude Code, Copilot,
Cursor, Codex, etc.) under the same rules as human PRs — see
CONTRIBUTING.md § Human and AI contributions. A one-line note here is
appreciated when an assistant did the bulk of the diff. -->

- [ ] Drafted with AI assistance, manually reviewed and tested
- [ ] Written by hand

If "Drafted with AI assistance" is ticked, also read
[`CONTRIBUTING-WITH-AI.md`](CONTRIBUTING-WITH-AI.md) for the additional
gates that apply to AI-authored PRs.

## License

- [ ] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
