### PR TITLE
Add URL discussion feeds

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/RelaySubscriptionsCoordinator.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/RelaySubscriptionsCoordinator.kt
@@ -60,6 +60,7 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.relay.datasource.RelayFeedF
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.datasource.RelayInfoNip66FilterAssembler
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.shorts.datasource.ShortsFilterAssembler
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.threadview.datasources.ThreadFilterAssembler
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.url.datasource.UrlFilterAssembler
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.video.datasource.VideoFilterAssembler
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.wallet.datasource.OnchainZapsFilterAssembler
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
@@ -104,6 +105,7 @@ class RelaySubscriptionsCoordinator(
     val profile = UserProfileFilterAssembler(client)
     val hashtags = HashtagFilterAssembler(client)
     val geohashes = GeoHashFilterAssembler(client)
+    val urls = UrlFilterAssembler(client)
     val relayFeed = RelayFeedFilterAssembler(client)
     val relayInfoNip66 = RelayInfoNip66FilterAssembler(client)
     val followPacks = FollowPackFeedFilterAssembler(client)
@@ -170,6 +172,7 @@ class RelaySubscriptionsCoordinator(
             profile,
             hashtags,
             geohashes,
+            urls,
             relayFeed,
             relayInfoNip66,
             chess,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -183,6 +183,8 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.UserSettingsScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.VideoPlayerSettingsScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.shorts.ShortsScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.threadview.ThreadScreen
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.url.UrlPostScreen
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.url.UrlScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.video.VideoScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.video.hls.NewHlsVideoScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.wallet.AddWalletScreen
@@ -374,6 +376,7 @@ fun BuildNavigation(
         composableFromEndArgs<Route.ContactListUsers> { ContactListUsersScreen(it.noteId, accountViewModel, nav) }
         composableFromEndArgs<Route.Hashtag> { HashtagScreen(it, accountViewModel, nav) }
         composableFromEndArgs<Route.Geohash> { GeoHashScreen(it, accountViewModel, nav) }
+        composableFromEndArgs<Route.Url> { UrlScreen(it, accountViewModel, nav) }
         composableFromEndArgs<Route.RelayFeed> { RelayFeedScreen(it, accountViewModel, nav) }
         composableFromEndArgs<Route.ChessGame> { ChessGameScreen(it.gameId, accountViewModel, nav) }
         composableFromEndArgs<Route.RelayInfo> { RelayInformationScreen(it.url, accountViewModel, nav) }
@@ -465,6 +468,19 @@ fun BuildNavigation(
         composableFromBottomArgs<Route.HashtagPost> {
             HashtagPostScreen(
                 hashtag = it.hashtag,
+                message = it.message,
+                attachment = it.attachment,
+                replyId = it.replyTo,
+                quoteId = it.quote,
+                draftId = it.draft,
+                accountViewModel,
+                nav,
+            )
+        }
+
+        composableFromBottomArgs<Route.UrlPost> {
+            UrlPostScreen(
+                url = it.url,
                 message = it.message,
                 attachment = it.attachment,
                 replyId = it.replyTo,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/RouteMaker.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/RouteMaker.kt
@@ -54,6 +54,7 @@ import com.vitorpamplona.quartz.nip59Giftwrap.wraps.GiftWrapEvent
 import com.vitorpamplona.quartz.nip72ModCommunities.definition.CommunityDefinitionEvent
 import com.vitorpamplona.quartz.nip73ExternalIds.location.isGeohashedScoped
 import com.vitorpamplona.quartz.nip73ExternalIds.topics.isHashtagScoped
+import com.vitorpamplona.quartz.nip73ExternalIds.urls.isUrlScoped
 import com.vitorpamplona.quartz.nip88Polls.poll.PollEvent
 import com.vitorpamplona.quartz.nip89AppHandlers.definition.AppDefinitionEvent
 import com.vitorpamplona.quartz.nip99Classifieds.ClassifiedsEvent
@@ -329,6 +330,8 @@ fun routeReplyTo(
                 Route.GeoPost(replyTo = note.idHex)
             } else if (noteEvent.isHashtagScoped()) {
                 Route.HashtagPost(replyTo = note.idHex)
+            } else if (noteEvent.isUrlScoped()) {
+                Route.UrlPost(replyTo = note.idHex)
             } else {
                 Route.GenericCommentPost(replyTo = note.idHex)
             }
@@ -399,6 +402,8 @@ suspend fun routeEditDraftTo(
                 Route.GeoPost(draft = note.idHex)
             } else if (draft.isHashtagScoped()) {
                 Route.HashtagPost(draft = note.idHex)
+            } else if (draft.isUrlScoped()) {
+                Route.UrlPost(draft = note.idHex)
             } else {
                 Route.GenericCommentPost(draft = note.idHex)
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
@@ -358,6 +358,10 @@ sealed class Route {
         val hashtag: String,
     ) : Route()
 
+    @Serializable data class Url(
+        val url: String,
+    ) : Route()
+
     @Serializable data class Geohash(
         val geohash: String,
     ) : Route()
@@ -542,6 +546,16 @@ sealed class Route {
     @Serializable
     data class HashtagPost(
         val hashtag: String? = null,
+        val message: String? = null,
+        val attachment: String? = null,
+        val replyTo: String? = null,
+        val quote: String? = null,
+        val draft: String? = null,
+    ) : Route()
+
+    @Serializable
+    data class UrlPost(
+        val url: String? = null,
         val message: String? = null,
         val attachment: String? = null,
         val replyTo: String? = null,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DropDownMenu.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DropDownMenu.kt
@@ -55,10 +55,14 @@ import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.Size24Modifier
 import com.vitorpamplona.quartz.nip01Core.jackson.JacksonMapper
 import com.vitorpamplona.quartz.nip01Core.tags.aTag.isTaggedAddressableNote
+import com.vitorpamplona.quartz.nip01Core.tags.references.HttpUrlFormatter
+import com.vitorpamplona.quartz.nip01Core.tags.references.references
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
+import com.vitorpamplona.quartz.nip10Notes.content.findURLs
 import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
 import com.vitorpamplona.quartz.nip30CustomEmoji.pack.EmojiPackEvent
 import com.vitorpamplona.quartz.nip36SensitiveContent.isSensitiveOrNSFW
+import com.vitorpamplona.quartz.nip73ExternalIds.urls.UrlId
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
@@ -158,6 +162,7 @@ fun NoteDropDownMenu(
         val clipboardManager = LocalClipboard.current
         val actContext = LocalContext.current
         val scope = rememberCoroutineScope()
+        val discussionUrls = remember(note) { note.discussionUrls() }
 
         // Follow section
         M3ActionSection {
@@ -229,6 +234,20 @@ fun NoteDropDownMenu(
                 val shareIntent = Intent.createChooser(sendIntent, stringRes(actContext, R.string.quick_action_share))
                 actContext.startActivity(shareIntent)
                 onDismiss()
+            }
+        }
+
+        if (discussionUrls.isNotEmpty()) {
+            M3ActionSection {
+                discussionUrls.take(5).forEach { url ->
+                    M3ActionRow(
+                        icon = MaterialSymbols.Link,
+                        text = stringRes(R.string.link_discussion_for, HttpUrlFormatter.displayUrl(url)),
+                    ) {
+                        nav.nav(Route.Url(url))
+                        onDismiss()
+                    }
+                }
             }
         }
 
@@ -366,6 +385,22 @@ fun NoteDropDownMenu(
             onDismiss()
         }
     }
+}
+
+private fun Note.discussionUrls(): List<String> {
+    val event = event ?: return emptyList()
+    val references = event.tags.references()
+    val urlsInContent =
+        if (event.isContentEncoded()) {
+            emptyList()
+        } else {
+            findURLs(event.content)
+        }
+
+    return (references + urlsInContent)
+        .mapNotNull { url ->
+            runCatching { UrlId.toScope(url) }.getOrNull()
+        }.distinct()
 }
 
 @Composable

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/DisplayExternalId.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/DisplayExternalId.kt
@@ -30,7 +30,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.LinkInteractionListener
 import androidx.compose.ui.text.buildAnnotatedString
@@ -43,6 +42,7 @@ import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbol
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.StdHorzSpacer
@@ -68,7 +68,7 @@ fun DisplayExternalId(
         }
 
         is UrlId -> {
-            DisplayUrlExternalId(externalId)
+            DisplayUrlExternalId(externalId, nav)
         }
 
         else -> {
@@ -78,13 +78,15 @@ fun DisplayExternalId(
 }
 
 @Composable
-fun DisplayUrlExternalId(externalId: UrlId) {
-    val uriHandler = LocalUriHandler.current
+fun DisplayUrlExternalId(
+    externalId: UrlId,
+    nav: INav,
+) {
     DisplayExternalIdChip(
         symbol = MaterialSymbols.Link,
         contentDescription = stringRes(id = R.string.external_url_scope),
         label = externalId.url,
-        linkInteractionListener = { runCatching { uriHandler.openUri(externalId.url) } },
+        linkInteractionListener = { nav.nav(Route.Url(externalId.url)) },
     )
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/url/NewUrlNoteButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/url/NewUrlNoteButton.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.url
+
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.routes.Route
+import com.vitorpamplona.amethyst.ui.painterRes
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.amethyst.ui.theme.Size26Modifier
+import com.vitorpamplona.amethyst.ui.theme.Size55Modifier
+
+@Composable
+fun NewUrlPostButton(
+    url: String,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    FloatingActionButton(
+        onClick = {
+            nav.nav(Route.UrlPost(url))
+        },
+        modifier = Size55Modifier,
+        shape = CircleShape,
+        containerColor = MaterialTheme.colorScheme.primary,
+    ) {
+        Icon(
+            painter = painterRes(R.drawable.ic_compose, 3),
+            contentDescription = stringRes(id = R.string.new_community_note),
+            modifier = Size26Modifier,
+            tint = Color.White,
+        )
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/url/UrlPostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/url/UrlPostScreen.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.url
+
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.net.toUri
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
+import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
+import com.vitorpamplona.amethyst.ui.note.nip22Comments.CommentPostViewModel
+import com.vitorpamplona.amethyst.ui.note.nip22Comments.GenericCommentPostScreen
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip73ExternalIds.urls.UrlId
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@Composable
+fun UrlPostScreen(
+    url: String? = null,
+    message: String? = null,
+    attachment: String? = null,
+    replyId: HexKey? = null,
+    quoteId: HexKey? = null,
+    draftId: HexKey? = null,
+    accountViewModel: AccountViewModel,
+    nav: Nav,
+) {
+    val postViewModel: CommentPostViewModel = viewModel()
+    postViewModel.init(accountViewModel)
+
+    val context = LocalContext.current
+
+    LaunchedEffect(postViewModel, accountViewModel) {
+        url?.let {
+            postViewModel.newPostFor(UrlId(UrlId.toScope(it)))
+        }
+        replyId?.let { accountViewModel.getNoteIfExists(it) }?.let {
+            postViewModel.reply(it)
+        }
+        draftId?.let { accountViewModel.getNoteIfExists(it) }?.let {
+            postViewModel.editFromDraft(it)
+        }
+        quoteId?.let { accountViewModel.getNoteIfExists(it) }?.let {
+            postViewModel.quote(it)
+        }
+        message?.ifBlank { null }?.let {
+            postViewModel.message.setTextAndPlaceCursorAtEnd(it)
+            postViewModel.onMessageChanged()
+        }
+        attachment?.ifBlank { null }?.toUri()?.let {
+            withContext(Dispatchers.IO) {
+                val mediaType = context.contentResolver.getType(it)
+                postViewModel.selectImage(persistentListOf(SelectedMedia(it, mediaType)))
+            }
+        }
+    }
+
+    GenericCommentPostScreen(postViewModel, accountViewModel, nav)
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/url/UrlScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/url/UrlScreen.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.url
+
+import android.annotation.SuppressLint
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.vitorpamplona.amethyst.ui.feeds.WatchLifecycleAndUpdateModel
+import com.vitorpamplona.amethyst.ui.layouts.DisappearingScaffold
+import com.vitorpamplona.amethyst.ui.navigation.bottombars.FabBottomBarPadded
+import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.routes.Route
+import com.vitorpamplona.amethyst.ui.navigation.topbars.TopBarExtensibleWithBackButton
+import com.vitorpamplona.amethyst.ui.screen.RefresheableFeedView
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.url.dal.UrlFeedViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.url.datasource.UrlFilterAssemblerSubscription
+import com.vitorpamplona.quartz.nip01Core.tags.references.HttpUrlFormatter
+import com.vitorpamplona.quartz.nip73ExternalIds.urls.UrlId
+
+@Composable
+fun UrlScreen(
+    route: Route.Url,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    if (route.url.isEmpty()) return
+
+    PrepareViewModelsUrlScreen(route, accountViewModel, nav)
+}
+
+@SuppressLint("StateFlowValueCalledInComposition")
+@Composable
+fun PrepareViewModelsUrlScreen(
+    route: Route.Url,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    val normalizedUrl = UrlId.toScope(route.url)
+    val urlFeedViewModel: UrlFeedViewModel =
+        viewModel(
+            key = normalizedUrl + "UrlFeedViewModel",
+            factory =
+                UrlFeedViewModel.Factory(
+                    normalizedUrl,
+                    accountViewModel.account.followOutboxesOrProxy.flow.value,
+                    accountViewModel.account,
+                ),
+        )
+
+    UrlScreen(route, urlFeedViewModel, accountViewModel, nav)
+}
+
+@Composable
+fun UrlScreen(
+    route: Route.Url,
+    feedViewModel: UrlFeedViewModel,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    val normalizedUrl = UrlId.toScope(route.url)
+
+    WatchLifecycleAndUpdateModel(feedViewModel)
+    UrlFilterAssemblerSubscription(Route.Url(normalizedUrl), accountViewModel)
+
+    DisappearingScaffold(
+        isInvertedLayout = false,
+        topBar = {
+            TopBarExtensibleWithBackButton(
+                title = {
+                    Text(
+                        HttpUrlFormatter.displayUrl(normalizedUrl),
+                        modifier = Modifier.weight(1f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                },
+                popBack = nav::popBack,
+            )
+        },
+        floatingButton = {
+            FabBottomBarPadded(nav) {
+                NewUrlPostButton(normalizedUrl, accountViewModel, nav)
+            }
+        },
+        accountViewModel = accountViewModel,
+    ) {
+        RefresheableFeedView(
+            feedViewModel,
+            null,
+            accountViewModel = accountViewModel,
+            nav = nav,
+        )
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/url/dal/UrlFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/url/dal/UrlFeedFilter.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.url.dal
+
+import com.vitorpamplona.amethyst.model.Account
+import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.model.Note
+import com.vitorpamplona.amethyst.ui.dal.AdditiveFeedFilter
+import com.vitorpamplona.amethyst.ui.dal.DefaultFeedOrder
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip01Core.tags.references.HttpUrlFormatter
+import com.vitorpamplona.quartz.nip01Core.tags.references.isTaggedReferences
+import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
+import com.vitorpamplona.quartz.nip18Reposts.GenericRepostEvent
+import com.vitorpamplona.quartz.nip18Reposts.RepostEvent
+import com.vitorpamplona.quartz.nip22Comments.CommentEvent
+import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
+import com.vitorpamplona.quartz.nip28PublicChat.message.ChannelMessageEvent
+import com.vitorpamplona.quartz.nip54Wiki.WikiNoteEvent
+import com.vitorpamplona.quartz.nip73ExternalIds.urls.UrlId
+import com.vitorpamplona.quartz.nip84Highlights.HighlightEvent
+
+class UrlFeedFilter(
+    val url: String,
+    val relays: Set<NormalizedRelayUrl>,
+    val account: Account,
+    val cache: LocalCache,
+) : AdditiveFeedFilter<Note>() {
+    private val normalizedUrl = UrlId.toScope(url)
+    private val referenceUrls = setOf(normalizedUrl, HttpUrlFormatter.normalize(url))
+
+    override fun feedKey(): String = account.userProfile().pubkeyHex + "-" + normalizedUrl
+
+    override fun feed(): List<Note> {
+        val notes =
+            cache.notes.filterIntoSet { _, note ->
+                acceptableEvent(note)
+            }
+
+        return sort(notes)
+    }
+
+    override fun applyFilter(newItems: Set<Note>): Set<Note> = newItems.filterTo(HashSet()) { acceptableEvent(it) }
+
+    private fun acceptableEvent(note: Note): Boolean =
+        (acceptableViaReference(note.event) || acceptableViaScope(note.event)) &&
+            !note.isHiddenFor(account.hiddenUsers.flow.value) &&
+            account.isAcceptable(note)
+
+    private fun acceptableViaReference(event: Event?): Boolean =
+        (
+            event is TextNoteEvent ||
+                event is RepostEvent ||
+                event is GenericRepostEvent ||
+                event is LongTextNoteEvent ||
+                event is WikiNoteEvent ||
+                event is ChannelMessageEvent ||
+                event is CommentEvent ||
+                event is HighlightEvent
+        ) &&
+            event.tags.isTaggedReferences(referenceUrls)
+
+    private fun acceptableViaScope(event: Event?): Boolean = event is CommentEvent && event.isTaggedScope(normalizedUrl, UrlId::match)
+
+    override fun sort(items: Set<Note>): List<Note> = items.sortedWith(DefaultFeedOrder)
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/url/dal/UrlFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/url/dal/UrlFeedViewModel.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.url.dal
+
+import androidx.compose.runtime.Stable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.vitorpamplona.amethyst.model.Account
+import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.ui.screen.AndroidFeedViewModel
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+
+@Stable
+class UrlFeedViewModel(
+    val url: String,
+    val relays: Set<NormalizedRelayUrl>,
+    val account: Account,
+) : AndroidFeedViewModel(
+        UrlFeedFilter(url, relays, account, LocalCache),
+    ) {
+    @Suppress("UNCHECKED_CAST")
+    class Factory(
+        val url: String,
+        val relays: Set<NormalizedRelayUrl>,
+        val account: Account,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T = UrlFeedViewModel(url, relays, account) as T
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/url/datasource/FilterPostsByUrls.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/url/datasource/FilterPostsByUrls.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.url.datasource
+
+import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip22Comments.CommentKinds
+import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
+import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip01Core.tags.references.HttpUrlFormatter
+import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
+import com.vitorpamplona.quartz.nip18Reposts.GenericRepostEvent
+import com.vitorpamplona.quartz.nip18Reposts.RepostEvent
+import com.vitorpamplona.quartz.nip22Comments.CommentEvent
+import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
+import com.vitorpamplona.quartz.nip28PublicChat.message.ChannelMessageEvent
+import com.vitorpamplona.quartz.nip54Wiki.WikiNoteEvent
+import com.vitorpamplona.quartz.nip73ExternalIds.urls.UrlId
+import com.vitorpamplona.quartz.nip84Highlights.HighlightEvent
+
+val PostsByUrlReferenceKinds =
+    listOf(
+        TextNoteEvent.KIND,
+        RepostEvent.KIND,
+        GenericRepostEvent.KIND,
+        ChannelMessageEvent.KIND,
+        LongTextNoteEvent.KIND,
+        WikiNoteEvent.KIND,
+        CommentEvent.KIND,
+        HighlightEvent.KIND,
+    )
+
+fun filterPostsByUrls(
+    url: String,
+    relays: Set<NormalizedRelayUrl>,
+    since: SincePerRelayMap?,
+): List<RelayBasedFilter> {
+    val normalizedUrl = UrlId.toScope(url)
+    val referenceUrls = listOf(normalizedUrl, HttpUrlFormatter.normalize(url)).distinct()
+
+    return relays.flatMap { relay ->
+        val since = since?.get(relay)?.time
+        listOf(
+            RelayBasedFilter(
+                relay = relay,
+                filter =
+                    Filter(
+                        tags = mapOf("r" to referenceUrls),
+                        kinds = PostsByUrlReferenceKinds,
+                        limit = 200,
+                        since = since,
+                    ),
+            ),
+            RelayBasedFilter(
+                relay = relay,
+                filter =
+                    Filter(
+                        tags = mapOf("I" to listOf(normalizedUrl)),
+                        kinds = CommentKinds,
+                        limit = 200,
+                        since = since,
+                    ),
+            ),
+        )
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/url/datasource/UrlFeedFilterSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/url/datasource/UrlFeedFilterSubAssembler.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.url.datasource
+
+import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUniqueIdEoseManager
+import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
+import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
+import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
+
+class UrlFeedFilterSubAssembler(
+    client: INostrClient,
+    allKeys: () -> Set<UrlQueryState>,
+) : PerUniqueIdEoseManager<UrlQueryState, String>(client, allKeys) {
+    override fun updateFilter(
+        key: UrlQueryState,
+        since: SincePerRelayMap?,
+    ): List<RelayBasedFilter> = filterPostsByUrls(key.url, key.relays, since)
+
+    override fun id(key: UrlQueryState) = key.normalizedUrl
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/url/datasource/UrlFilterAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/url/datasource/UrlFilterAssembler.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.url.datasource
+
+import com.vitorpamplona.amethyst.commons.relayClient.composeSubscriptionManagers.ComposeSubscriptionManager
+import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip73ExternalIds.urls.UrlId
+
+class UrlQueryState(
+    val url: String,
+    val relays: Set<NormalizedRelayUrl>,
+) {
+    val normalizedUrl = UrlId.toScope(url)
+}
+
+class UrlFilterAssembler(
+    client: INostrClient,
+) : ComposeSubscriptionManager<UrlQueryState>() {
+    val group =
+        listOf(
+            UrlFeedFilterSubAssembler(client, ::allKeys),
+        )
+
+    override fun invalidateKeys() = invalidateFilters()
+
+    override fun invalidateFilters() = group.forEach { it.invalidateFilters() }
+
+    override fun destroy() = group.forEach { it.destroy() }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/url/datasource/UrlFilterAssemblerSubscription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/url/datasource/UrlFilterAssemblerSubscription.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.url.datasource
+
+import android.annotation.SuppressLint
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.LifecycleAwareKeyDataSourceSubscription
+import com.vitorpamplona.amethyst.ui.navigation.routes.Route
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+
+@SuppressLint("StateFlowValueCalledInComposition")
+@Composable
+fun UrlFilterAssemblerSubscription(
+    route: Route.Url,
+    accountViewModel: AccountViewModel,
+) {
+    val state =
+        remember(route) {
+            UrlQueryState(route.url, accountViewModel.account.followOutboxesOrProxy.flow.value)
+        }
+
+    LifecycleAwareKeyDataSourceSubscription(state, accountViewModel.dataSources().urls)
+}

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -392,6 +392,7 @@
     <string name="quick_action_select">Select</string>
     <string name="quick_action_share_browser_link">Share Browser Link</string>
     <string name="quick_action_share">Share</string>
+    <string name="link_discussion_for">Discuss %1$s</string>
     <string name="quick_action_copy_user_id">Author ID</string>
     <string name="quick_action_copy_note_id">Note ID</string>
     <string name="quick_action_copy_text">Copy Text</string>


### PR DESCRIPTION
## Summary

Adds URL discussion feeds for issue #304. Amethyst can now open a dedicated discussion feed for URLs referenced by notes, load both legacy URL `r` references and current NIP-22/NIP-73 URL `i`-scoped comments, and compose new URL-scoped comments from that feed.

The note actions menu now lists discovered URL discussions from `r` tags and URLs in note content. Existing URL external-id chips on NIP-22 comments now open the URL discussion feed instead of leaving the app.

Closes #304.

Bounty payout address, if accepted: `bc1qa5acxqc3wldzxwjhe8a65gjp6n7dxmafm6qs4j`

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes / screenshots:

No Android device or emulator was available in this environment, so I could not capture UI screenshots or exercise the flow on-device. Local build/test verification run on Amazon Linux 2023 with JDK 21 and Android SDK 37:

```text
./gradlew :amethyst:compilePlayDebugKotlin
BUILD SUCCESSFUL in 3m 19s
58 actionable tasks: 58 executed
```

```text
./gradlew :amethyst:compileFdroidDebugKotlin
BUILD SUCCESSFUL in 1m 9s
58 actionable tasks: 9 executed, 6 from cache, 43 up-to-date
```

```text
./gradlew :amethyst:assemblePlayBenchmark
BUILD SUCCESSFUL in 5m
134 actionable tasks: 87 executed, 2 from cache, 45 up-to-date
```

The pre-commit hook also passed `spotlessCheck`, and the pre-push hook passed:

```text
:quartz:jvmTest :commons:jvmTest :nestsClient:jvmTest :quic:jvmTest :amethyst:testPlayDebugUnitTest :cli:test :desktopApp:test --quiet
All test passed.
```

### Feature test plan

- Open a note with one or more URL references in `r` tags or visible URL content.
- Open note actions and tap `Discuss <url>`.
- Confirm the URL feed opens, requests `#r` references and NIP-22 `#I` URL scopes, and shows matching notes/comments.
- Tap the compose FAB in that URL feed and publish a comment.
- Confirm the created comment is a NIP-22 comment scoped to the NIP-73 URL external identity.
- Open an existing URL-scoped NIP-22 comment and tap the URL scope chip.
- Confirm it navigates to the same URL discussion feed.

### Regression test plan

- Existing hashtag/geohash comment routes are unchanged and still use their dedicated post screens.
- Generic NIP-22 comments still route to `GenericCommentPost` when they are not URL/hashtag/geohash scoped.
- The URL feed uses the existing lifecycle-aware subscription manager pattern rather than opening ad-hoc relay subscriptions.
- Interop suites are not run because this change does not alter MLS, DM envelopes, audio-room transport, MoQ-lite, or QUIC code paths.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes
- [ ] Marmot / MLS — `cli/tests/marmot/marmot-interop-headless.sh` (NIP-EE / `whitenoise-rs`)
- [ ] NIP-17 DM — `cli/tests/dm/dm-interop-headless.sh`
- [ ] Audio rooms manual — `cli/tests/nests/nests-interop.sh` (Amethyst ↔ nostrnests.com)
- [ ] MoQ-lite hang-tier — `:nestsClient:jvmTest -DnestsHangInterop=true`
- [ ] MoQ-lite browser-tier — `:nestsClient:jvmTest -DnestsBrowserInterop=true`
- [ ] QUIC interop-runner — `quic/interop/run-matrix.sh -s {aioquic,picoquic,quic-go,quinn}`

## AI assistance

- [x] Drafted with AI assistance, manually reviewed and tested
- [ ] Written by hand

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.
