### PR TITLE
Fix account cache race condition in setDefaultAccount

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
@@ -323,8 +323,16 @@ object LocalPreferences {
     }
 
     suspend fun setDefaultAccount(accountSettings: AccountSettings) {
-        setCurrentAccount(accountSettings)
+        // Save the per-npub file before emitting onto the savedAccounts flow.
+        // Otherwise a collector (e.g. AlwaysOnNotificationServiceManager) can race in
+        // and call loadAccountConfigFromEncryptedStorage(npub) before NOSTR_PUBKEY is
+        // written, get null back, and poison `cachedAccounts[npub] = null` for the
+        // rest of the session — making every later switch to this account land on
+        // LoggedOff instead of LoggedIn.
         saveToEncryptedStorage(accountSettings)
+        val npub = accountSettings.keyPair.pubKey.toNpub()
+        mutex.withLock { cachedAccounts.put(npub, accountSettings) }
+        setCurrentAccount(accountSettings)
     }
 
     suspend fun allSavedAccounts(): List<AccountInfo> = savedAccounts()
@@ -489,19 +497,20 @@ object LocalPreferences {
 
     suspend fun loadAccountConfigFromEncryptedStorage(npub: String): AccountSettings? {
         // if already loaded, return right away
-        if (cachedAccounts.containsKey(npub)) {
-            return cachedAccounts[npub]
-        }
+        cachedAccounts[npub]?.let { return it }
 
         return withContext(Dispatchers.IO) {
             mutex.withLock {
-                if (cachedAccounts.containsKey(npub)) {
-                    return@withContext cachedAccounts.get(npub)
-                }
+                cachedAccounts[npub]?.let { return@withContext it }
 
                 val accountSettings = innerLoadCurrentAccountFromEncryptedStorage(npub)
 
-                cachedAccounts.put(npub, accountSettings)
+                // Only cache successful loads. Caching null would leave the account
+                // permanently unreachable for the rest of the session if a reader
+                // raced in before the per-npub file finished being written.
+                if (accountSettings != null) {
+                    cachedAccounts.put(npub, accountSettings)
+                }
 
                 return@withContext accountSettings
             }


### PR DESCRIPTION
## Summary

Fix a race condition in `setDefaultAccount()` where concurrent readers could cache `null` for an account before its encrypted storage file was fully written. This would permanently poison the cache for the rest of the session, causing account switches to land on `LoggedOff` instead of `LoggedIn`.

The fix ensures the in-memory cache is populated *before* emitting to the `savedAccounts` flow (which triggers collectors like `AlwaysOnNotificationServiceManager`), and prevents caching `null` values from incomplete reads.

## Changes

- **`setDefaultAccount()`**: Reorder operations to cache the account settings before calling `setCurrentAccount()`, ensuring the cache is ready before any collector tries to load it
- **`loadAccountConfigFromEncryptedStorage()`**: 
  - Simplify early-exit checks using `?.let` 
  - Only cache successful (non-null) loads to prevent poisoning the cache with incomplete reads
  - Add explanatory comments about the race condition

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes: This is a concurrency fix in account initialization. The change is defensive — it prevents a subtle race that would only manifest under specific timing conditions (rapid account switches during startup). Existing account switching flows should continue to work normally.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_015877w5PiwvsRzLKgnhqLgJ