### PR TITLE
feat(relays): add simple relay mode

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
@@ -98,6 +98,7 @@ private object PrefKeys {
     const val USE_LOCAL_BLOSSOM_CACHE = "useLocalBlossomCache"
     const val LOCAL_BLOSSOM_CACHE_PROFILE_PICTURES_ONLY = "localBlossomCacheProfilePicturesOnly"
     const val HIDE_COMMUNITY_RULES_VIOLATIONS = "hideCommunityRulesViolations"
+    const val SIMPLE_RELAY_MODE = "simpleRelayMode"
     const val DEFAULT_HOME_FOLLOW_LIST = "defaultHomeFollowList"
     const val DEFAULT_STORIES_FOLLOW_LIST = "defaultStoriesFollowList"
     const val DEFAULT_NOTIFICATION_FOLLOW_LIST = "defaultNotificationFollowList"
@@ -362,6 +363,7 @@ object LocalPreferences {
                     putBoolean(PrefKeys.USE_LOCAL_BLOSSOM_CACHE, settings.useLocalBlossomCache.value)
                     putBoolean(PrefKeys.LOCAL_BLOSSOM_CACHE_PROFILE_PICTURES_ONLY, settings.localBlossomCacheProfilePicturesOnly.value)
                     putBoolean(PrefKeys.HIDE_COMMUNITY_RULES_VIOLATIONS, settings.hideCommunityRulesViolations.value)
+                    putBoolean(PrefKeys.SIMPLE_RELAY_MODE, settings.simpleRelayMode.value)
 
                     putString(PrefKeys.DEFAULT_HOME_FOLLOW_LIST, JsonMapper.toJson(settings.defaultHomeFollowList.value))
                     putString(PrefKeys.DEFAULT_STORIES_FOLLOW_LIST, JsonMapper.toJson(settings.defaultStoriesFollowList.value))
@@ -535,6 +537,7 @@ object LocalPreferences {
                     val useLocalBlossomCache = getBoolean(PrefKeys.USE_LOCAL_BLOSSOM_CACHE, true)
                     val localBlossomCacheProfilePicturesOnly = getBoolean(PrefKeys.LOCAL_BLOSSOM_CACHE_PROFILE_PICTURES_ONLY, false)
                     val hideCommunityRulesViolations = getBoolean(PrefKeys.HIDE_COMMUNITY_RULES_VIOLATIONS, false)
+                    val simpleRelayMode = getBoolean(PrefKeys.SIMPLE_RELAY_MODE, false)
                     val hideDeleteRequestDialog = getBoolean(PrefKeys.HIDE_DELETE_REQUEST_DIALOG, false)
                     val hideBlockAlertDialog = getBoolean(PrefKeys.HIDE_BLOCK_ALERT_DIALOG, false)
                     val hideNIP17WarningDialog = getBoolean(PrefKeys.HIDE_NIP_17_WARNING_DIALOG, false)
@@ -646,6 +649,7 @@ object LocalPreferences {
                         useLocalBlossomCache = MutableStateFlow(useLocalBlossomCache),
                         localBlossomCacheProfilePicturesOnly = MutableStateFlow(localBlossomCacheProfilePicturesOnly),
                         hideCommunityRulesViolations = MutableStateFlow(hideCommunityRulesViolations),
+                        simpleRelayMode = MutableStateFlow(simpleRelayMode),
                         defaultHomeFollowList = MutableStateFlow(followListPrefs.home),
                         defaultStoriesFollowList = MutableStateFlow(followListPrefs.stories),
                         defaultNotificationFollowList = MutableStateFlow(followListPrefs.notification),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -408,7 +408,7 @@ class Account(
     val trustedRelays = TrustedRelayListsState(nip65RelayList, privateStorageRelayList, localRelayList, dmRelayList, searchRelayList, indexerRelayList, proxyRelayList, trustedRelayList, broadcastRelayList, scope)
 
     // Follows Relays
-    val followOutboxesOrProxy = FollowListOutboxOrProxyRelays(kind3FollowList, blockedRelayList, proxyRelayList, cache, scope)
+    val followOutboxesOrProxy = FollowListOutboxOrProxyRelays(kind3FollowList, blockedRelayList, proxyRelayList, settings.simpleRelayMode, cache, scope)
 
     // only follow relays that are declared in more than one user.
     val followSharedOutboxesOrProxy = FollowListReusedOutboxOrProxyRelays(kind3FollowList, blockedRelayList, proxyRelayList, cache, scope)
@@ -422,7 +422,7 @@ class Account(
     val declaredFollowsPerUsingRelay = DeclaredFollowsPerUsingRelay(kind3FollowList, cache, scope).flow
 
     // keeps a cache of the outbox relays for each author
-    val followsPerRelay = FollowsPerOutboxRelay(kind3FollowList, blockedRelayList, proxyRelayList, cache, scope).flow
+    val followsPerRelay = FollowsPerOutboxRelay(kind3FollowList, blockedRelayList, proxyRelayList, settings.simpleRelayMode, cache, scope).flow
 
     // Merges all follow lists to create a single All Follows feed.
     val allFollows = MergedFollowListsState(kind3FollowList, peopleLists, followLists, hashtagList, geohashList, communityList, scope)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -182,6 +182,7 @@ class AccountSettings(
     var hideNIP17WarningDialog: Boolean = false,
     val alwaysOnNotificationService: MutableStateFlow<Boolean> = MutableStateFlow(false),
     val splitNotificationsEnabled: MutableStateFlow<Boolean> = MutableStateFlow(false),
+    val simpleRelayMode: MutableStateFlow<Boolean> = MutableStateFlow(false),
     var backupUserMetadata: MetadataEvent? = null,
     var backupContactList: ContactListEvent? = null,
     var backupDMRelayList: ChatMessageRelayListEvent? = null,
@@ -243,6 +244,15 @@ class AccountSettings(
         splitNotificationsEnabled.tryEmit(newValue)
         saveAccountSettings()
         return newValue
+    }
+
+    fun changeSimpleRelayMode(newValue: Boolean): Boolean {
+        if (simpleRelayMode.value != newValue) {
+            simpleRelayMode.tryEmit(newValue)
+            saveAccountSettings()
+            return true
+        }
+        return false
     }
 
     // ---

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip02FollowLists/FollowListOutboxOrProxyRelays.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip02FollowLists/FollowListOutboxOrProxyRelays.kt
@@ -24,6 +24,7 @@ import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.nip51Lists.blockedRelays.BlockedRelayListState
 import com.vitorpamplona.amethyst.model.nip51Lists.proxyRelays.ProxyRelayListState
 import com.vitorpamplona.amethyst.model.topNavFeeds.OutboxRelayLoader
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -45,21 +46,30 @@ class FollowListOutboxOrProxyRelays(
     kind3Follows: Kind3FollowListState,
     blockedRelayList: BlockedRelayListState,
     proxyRelayList: ProxyRelayListState,
+    simpleRelayMode: StateFlow<Boolean>,
     val cache: LocalCache,
     scope: CoroutineScope,
 ) {
     @OptIn(ExperimentalCoroutinesApi::class)
     val outboxRelayFlow: StateFlow<Set<NormalizedRelayUrl>> =
-        kind3Follows.flow
-            .transformLatest { follows ->
+        combine(kind3Follows.flow, simpleRelayMode) { follows, isSimpleRelayMode ->
+            follows to isSimpleRelayMode
+        }
+            .transformLatest { (follows, isSimpleRelayMode) ->
                 emitAll(
-                    OutboxRelayLoader(true).toAuthorsPerRelayFlow(follows.authors, cache) { it.keys },
+                    OutboxRelayLoader(true).toAuthorsPerRelayFlow(follows.authors, cache) {
+                        selectOutboxRelays(it, isSimpleRelayMode)
+                    },
                 )
-            }.onStart {
+            }
+            .onStart {
                 emit(
-                    OutboxRelayLoader(true).authorsPerRelaySnapshot(kind3Follows.flow.value.authors, cache) { it.keys },
+                    OutboxRelayLoader(true).authorsPerRelaySnapshot(kind3Follows.flow.value.authors, cache) {
+                        selectOutboxRelays(it, simpleRelayMode.value)
+                    },
                 )
-            }.distinctUntilChanged()
+            }
+            .distinctUntilChanged()
             .flowOn(Dispatchers.IO)
             .stateIn(
                 scope,
@@ -114,4 +124,16 @@ class FollowListOutboxOrProxyRelays(
                 SharingStarted.Eagerly,
                 emptySet(),
             )
+
+    private fun selectOutboxRelays(
+        authorsPerRelay: Map<NormalizedRelayUrl, Set<HexKey>>,
+        isSimpleRelayMode: Boolean,
+    ): Set<NormalizedRelayUrl> =
+        if (isSimpleRelayMode) {
+            authorsPerRelay.mapNotNullTo(mutableSetOf()) { (relay, authors) ->
+                if (authors.size > 1) relay else null
+            }
+        } else {
+            authorsPerRelay.keys
+        }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip02FollowLists/FollowsPerOutboxRelay.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip02FollowLists/FollowsPerOutboxRelay.kt
@@ -45,21 +45,30 @@ class FollowsPerOutboxRelay(
     kind3Follows: Kind3FollowListState,
     blockedRelayList: BlockedRelayListState,
     proxyRelayList: ProxyRelayListState,
+    simpleRelayMode: StateFlow<Boolean>,
     val cache: LocalCache,
     scope: CoroutineScope,
 ) {
     @OptIn(ExperimentalCoroutinesApi::class)
     val outboxPerRelayFlow: StateFlow<Map<NormalizedRelayUrl, Set<HexKey>>> =
-        kind3Follows.flow
-            .transformLatest {
+        combine(kind3Follows.flow, simpleRelayMode) { follows, isSimpleRelayMode ->
+            follows to isSimpleRelayMode
+        }
+            .transformLatest { (follows, isSimpleRelayMode) ->
                 emitAll(
-                    OutboxRelayLoader().toAuthorsPerRelayFlow(it.authors, cache) { it },
+                    OutboxRelayLoader().toAuthorsPerRelayFlow(follows.authors, cache) {
+                        selectOutboxRelays(it, isSimpleRelayMode)
+                    },
                 )
-            }.onStart {
+            }
+            .onStart {
                 emit(
-                    OutboxRelayLoader().authorsPerRelaySnapshot(kind3Follows.flow.value.authors, cache) { it },
+                    OutboxRelayLoader().authorsPerRelaySnapshot(kind3Follows.flow.value.authors, cache) {
+                        selectOutboxRelays(it, simpleRelayMode.value)
+                    },
                 )
-            }.distinctUntilChanged()
+            }
+            .distinctUntilChanged()
             .flowOn(Dispatchers.IO)
             .stateIn(
                 scope,
@@ -102,4 +111,14 @@ class FollowsPerOutboxRelay(
                 SharingStarted.Eagerly,
                 emptyMap(),
             )
+
+    private fun selectOutboxRelays(
+        authorsPerRelay: Map<NormalizedRelayUrl, Set<HexKey>>,
+        isSimpleRelayMode: Boolean,
+    ): Map<NormalizedRelayUrl, Set<HexKey>> =
+        if (isSimpleRelayMode) {
+            authorsPerRelay.filterValues { it.size > 1 }
+        } else {
+            authorsPerRelay
+        }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/AllRelayListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/AllRelayListScreen.kt
@@ -20,10 +20,12 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.relays
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -32,6 +34,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -39,8 +42,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.Role
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
@@ -349,9 +354,21 @@ fun MappedAllRelayListView(
         ) {
             item {
                 SettingsCategory(
+                    R.string.simple_relay_mode_section,
+                    R.string.simple_relay_mode_section_explainer,
+                    SettingsCategoryFirstWithHorzBorderModifier,
+                )
+            }
+
+            item {
+                SimpleRelayModeSwitch(accountViewModel)
+            }
+
+            item {
+                SettingsCategory(
                     R.string.public_home_section,
                     R.string.public_home_section_explainer,
-                    SettingsCategoryFirstWithHorzBorderModifier,
+                    SettingsCategorySpacingWithHorzBorderModifier,
                 )
             }
             renderNip65HomeItems(homeFeedState, nip65ViewModel, accountViewModel, nav, outboxCounts, homeDragState)
@@ -480,6 +497,40 @@ fun MappedAllRelayListView(
             }
             renderConnectedItems(connectedRelays, connectedViewModel, accountViewModel, nav)
         }
+    }
+}
+
+@Composable
+private fun SimpleRelayModeSwitch(accountViewModel: AccountViewModel) {
+    val enabled by accountViewModel.account.settings.simpleRelayMode.collectAsStateWithLifecycle()
+
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(role = Role.Switch) {
+                    accountViewModel.account.settings.changeSimpleRelayMode(!enabled)
+                }
+                .padding(horizontal = 10.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f).padding(end = 16.dp)) {
+            Text(
+                text = stringRes(R.string.simple_relay_mode_title),
+                color = MaterialTheme.colorScheme.onSurface,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Text(
+                text = stringRes(R.string.simple_relay_mode_description),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.grayText,
+            )
+        }
+
+        Switch(
+            checked = enabled,
+            onCheckedChange = { accountViewModel.account.settings.changeSimpleRelayMode(it) },
+        )
     }
 }
 

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -2210,6 +2210,11 @@
     <string name="proxy_section">Proxy Relays</string>
     <string name="proxy_section_explainer">Aggregator relays the app must use to download your feeds from, like filter.nostr.wine. This replaces the outbox model and will make the app connect to only the relays in your lists.</string>
 
+    <string name="simple_relay_mode_section">Connection Mode</string>
+    <string name="simple_relay_mode_section_explainer">Choose how aggressively Amethyst follows outbox relays for your feed subscriptions.</string>
+    <string name="simple_relay_mode_title">Simple relay mode</string>
+    <string name="simple_relay_mode_description">Use only followed outbox relays shared by more than one person. This reduces relay connections but can miss posts from people who publish to unique relays.</string>
+
     <string name="broadcast_relays_title">Broadcast Relays</string>
     <string name="broadcast_section">Broadcast Relays</string>
     <string name="broadcast_section_explainer">Relays that specialize in pushing your notes to all of the other relays, like sendit.nosflare.com. Amethyst will add this relay to all new events made by you</string>


### PR DESCRIPTION
Closes #1487.

## Summary

- Adds a persisted, local `simpleRelayMode` account setting, defaulting off.
- Uses the existing shared/reused outbox-relay heuristic when the setting is enabled, so follow-feed subscriptions keep only followed outbox relays used by more than one followed account.
- Keeps proxy relays as the highest-priority path: if proxy relays are configured, they still replace the outbox model.
- Adds a switch at the top of Relay Settings so users can opt into the reduced-connection mode with the trade-off visible in the UI.

## Notes

This intentionally preserves current behaviour by default. The reduced mode is opt-in because it can miss posts from people who publish only to unique relays.

## Testing

- `git diff --check`
- Not run: Gradle compile/spotless/install. This local machine initially had only Java 8; I prepared Java 17 but stopped before continuing environment setup, so I do not have the required `BUILD SUCCESSFUL` tails to paste.

## AI assistance

Codex was used to prepare this patch. I checked that the issue is still open and did not find an open duplicate PR for the simple relay toggle before opening this.

## Bounty note

For the 5 EUR PayPal bounty offered in #1487, if this PR is accepted and the offer still stands: https://paypal.me/ShaimaaElkadi
