### PR TITLE
Complete Phase 2 KMP migration to unblock iOS CI

### DIFF
--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/blurhash/Base83.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/blurhash/Base83.kt
@@ -37,7 +37,7 @@ object Base83 {
     ): String {
         val buffer = CharArray(length)
         encode(value, length, buffer, 0)
-        return String(buffer)
+        return buffer.concatToString()
     }
 
     fun encode(

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/blurhash/BlurHashEncoder.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/blurhash/BlurHashEncoder.kt
@@ -27,6 +27,7 @@ import kotlin.math.floor
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.pow
+import kotlin.math.roundToLong
 import kotlin.math.withSign
 
 class BlurHashEncoder {
@@ -42,7 +43,7 @@ class BlurHashEncoder {
         val quantR = floor(max(0.0, min(18.0, floor(signPow(value[0] / maximumValue, 0.5) * 9 + 9.5))))
         val quantG = floor(max(0.0, min(18.0, floor(signPow(value[1] / maximumValue, 0.5) * 9 + 9.5))))
         val quantB = floor(max(0.0, min(18.0, floor(signPow(value[2] / maximumValue, 0.5) * 9 + 9.5))))
-        return Math.round(quantR * 19 * 19 + quantG * 19 + quantB)
+        return (quantR * 19 * 19 + quantG * 19 + quantB).roundToLong()
     }
 
     private fun encodeDC(value: DoubleArray): Long {
@@ -126,7 +127,7 @@ class BlurHashEncoder {
             val actualMaximumValue = max(factors, 1, factors.size)
             val quantisedMaximumValue = floor(max(0.0, min(82.0, floor(actualMaximumValue * 166 - 0.5))))
             maximumValue = (quantisedMaximumValue + 1) / 166
-            encode(Math.round(quantisedMaximumValue), 1, hash, 1)
+            encode(quantisedMaximumValue.roundToLong(), 1, hash, 1)
         } else {
             maximumValue = 1.0
             encode(0, 1, hash, 1)
@@ -138,6 +139,6 @@ class BlurHashEncoder {
         for (i in 1 until factors.size) {
             encode(encodeAC(factors[i], maximumValue), 2, hash, 6 + 2 * (i - 1))
         }
-        return String(hash)
+        return hash.concatToString()
     }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/PeerSessionManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/call/PeerSessionManager.kt
@@ -20,6 +20,8 @@
  */
 package com.vitorpamplona.amethyst.commons.call
 
+import com.vitorpamplona.amethyst.commons.util.KmpLock
+import com.vitorpamplona.amethyst.commons.util.withLock
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 
 /**
@@ -46,7 +48,7 @@ class PeerSessionManager(
         val pendingIceCandidates: MutableList<IceCandidateData> = mutableListOf(),
     )
 
-    private val lock = Any()
+    private val lock = KmpLock()
     private val sessions = mutableMapOf<HexKey, SessionEntry>()
 
     /** Candidates received before a session exists for the sender. */
@@ -58,7 +60,7 @@ class PeerSessionManager(
         peerPubKey: HexKey,
         session: PeerSession,
     ): SessionEntry =
-        synchronized(lock) {
+        lock.withLock {
             val globalPending = globalPendingIce.remove(peerPubKey) ?: emptyList()
             val entry = SessionEntry(session)
             entry.pendingIceCandidates.addAll(globalPending)
@@ -66,17 +68,17 @@ class PeerSessionManager(
             entry
         }
 
-    fun getSession(peerPubKey: HexKey): SessionEntry? = synchronized(lock) { sessions[peerPubKey] }
+    fun getSession(peerPubKey: HexKey): SessionEntry? = lock.withLock { sessions[peerPubKey] }
 
-    fun hasSession(peerPubKey: HexKey): Boolean = synchronized(lock) { sessions.containsKey(peerPubKey) }
+    fun hasSession(peerPubKey: HexKey): Boolean = lock.withLock { sessions.containsKey(peerPubKey) }
 
     fun removeSession(peerPubKey: HexKey): SessionEntry? =
-        synchronized(lock) {
+        lock.withLock {
             globalPendingIce.remove(peerPubKey)
             sessions.remove(peerPubKey)
         }
 
-    fun allSessionKeys(): Set<HexKey> = synchronized(lock) { sessions.keys.toSet() }
+    fun allSessionKeys(): Set<HexKey> = lock.withLock { sessions.keys.toSet() }
 
     // ---- ICE candidate routing (two-layer buffering) ----
 
@@ -92,7 +94,7 @@ class PeerSessionManager(
         senderPubKey: HexKey,
         candidate: IceCandidateData,
     ): IceRouteAction =
-        synchronized(lock) {
+        lock.withLock {
             val entry = sessions[senderPubKey]
             when {
                 entry != null && entry.remoteDescriptionSet -> {
@@ -117,21 +119,21 @@ class PeerSessionManager(
      * Called after setRemoteDescription succeeds.
      */
     fun flushPendingIceCandidates(peerPubKey: HexKey): Int {
-        val candidates: List<IceCandidateData>
-        val entry: SessionEntry
-        synchronized(lock) {
-            entry = sessions[peerPubKey] ?: return 0
-            entry.remoteDescriptionSet = true
-            candidates = entry.pendingIceCandidates.toList()
-            entry.pendingIceCandidates.clear()
-        }
+        val (entry, candidates) =
+            lock.withLock {
+                val entry = sessions[peerPubKey] ?: return@withLock null
+                entry.remoteDescriptionSet = true
+                val candidates = entry.pendingIceCandidates.toList()
+                entry.pendingIceCandidates.clear()
+                entry to candidates
+            } ?: return 0
         candidates.forEach { entry.session.addIceCandidate(it) }
         return candidates.size
     }
 
-    fun globalPendingCount(peerPubKey: HexKey): Int = synchronized(lock) { globalPendingIce[peerPubKey]?.size ?: 0 }
+    fun globalPendingCount(peerPubKey: HexKey): Int = lock.withLock { globalPendingIce[peerPubKey]?.size ?: 0 }
 
-    fun sessionPendingCount(peerPubKey: HexKey): Int = synchronized(lock) { sessions[peerPubKey]?.pendingIceCandidates?.size ?: 0 }
+    fun sessionPendingCount(peerPubKey: HexKey): Int = lock.withLock { sessions[peerPubKey]?.pendingIceCandidates?.size ?: 0 }
 
     // ---- Renegotiation glare handling ----
 
@@ -147,7 +149,7 @@ class PeerSessionManager(
         remoteSdpOffer: String,
         onAcceptRemote: (SessionEntry) -> Unit,
     ): GlareResolution {
-        val entry = synchronized(lock) { sessions[peerPubKey] } ?: return GlareResolution.NO_SESSION
+        val entry = lock.withLock { sessions[peerPubKey] } ?: return GlareResolution.NO_SESSION
 
         val signalingState = entry.session.getSignalingState()
         if (signalingState != SignalingState.HAVE_LOCAL_OFFER) {
@@ -184,7 +186,7 @@ class PeerSessionManager(
         peerPubKey: HexKey,
         sdpAnswer: String,
     ): AnswerRouteAction {
-        val entry = synchronized(lock) { sessions[peerPubKey] } ?: return AnswerRouteAction.NO_SESSION
+        val entry = lock.withLock { sessions[peerPubKey] } ?: return AnswerRouteAction.NO_SESSION
 
         val signalingState = entry.session.getSignalingState()
         if (signalingState != SignalingState.HAVE_LOCAL_OFFER) {
@@ -199,12 +201,13 @@ class PeerSessionManager(
     // ---- Cleanup ----
 
     fun disposeAll() {
-        val entries: List<SessionEntry>
-        synchronized(lock) {
-            entries = sessions.values.toList()
-            sessions.clear()
-            globalPendingIce.clear()
-        }
+        val entries =
+            lock.withLock {
+                val snapshot = sessions.values.toList()
+                sessions.clear()
+                globalPendingIce.clear()
+                snapshot
+            }
         for (entry in entries) {
             entry.session.dispose()
         }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/AcceptedGamesRegistry.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/chess/AcceptedGamesRegistry.kt
@@ -20,6 +20,9 @@
  */
 package com.vitorpamplona.amethyst.commons.chess
 
+import com.vitorpamplona.amethyst.commons.util.KmpLock
+import com.vitorpamplona.amethyst.commons.util.withLock
+
 /**
  * Global registry of accepted game IDs.
  *
@@ -29,28 +32,28 @@ package com.vitorpamplona.amethyst.commons.chess
  */
 object AcceptedGamesRegistry {
     private val acceptedGameIds = mutableSetOf<String>()
-    private val lock = Any()
+    private val lock = KmpLock()
 
     fun markAsAccepted(gameId: String) {
-        synchronized(lock) {
+        lock.withLock {
             acceptedGameIds.add(gameId)
         }
     }
 
     fun wasAccepted(gameId: String): Boolean =
-        synchronized(lock) {
+        lock.withLock {
             acceptedGameIds.contains(gameId)
         }
 
     fun clear() {
-        synchronized(lock) {
+        lock.withLock {
             acceptedGameIds.clear()
         }
     }
 
     /** Remove old entries - call periodically to prevent memory leak */
     fun clearOldEntries(keepGameIds: Set<String>) {
-        synchronized(lock) {
+        lock.withLock {
             acceptedGameIds.retainAll(keepGameIds)
         }
     }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/emojicoder/EmojiCoder.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/emojicoder/EmojiCoder.kt
@@ -20,6 +20,10 @@
  */
 package com.vitorpamplona.amethyst.commons.emojicoder
 
+import com.vitorpamplona.amethyst.commons.util.codePointAtKmp
+import com.vitorpamplona.amethyst.commons.util.codePointCharCount
+import com.vitorpamplona.amethyst.commons.util.codePointToChars
+
 object EmojiCoder {
     // Variation selectors block https://unicode.org/charts/nameslist/n_FE00.html
     // VS1..=VS16
@@ -35,8 +39,8 @@ object EmojiCoder {
         Array<CharArray>(256) {
             // converts to UTF-16. Always char[2] back
             when (it) {
-                in 0..15 -> Character.toChars(VARIATION_SELECTOR_START + it)
-                in 16..255 -> Character.toChars(VARIATION_SELECTOR_SUPPLEMENT_START + it - 16)
+                in 0..15 -> codePointToChars(VARIATION_SELECTOR_START + it)
+                in 16..255 -> codePointToChars(VARIATION_SELECTOR_SUPPLEMENT_START + it - 16)
                 else -> throw RuntimeException("This should never happen")
             }
         }
@@ -55,11 +59,11 @@ object EmojiCoder {
     fun isCoded(text: String): Boolean {
         if (text.length <= 3) return false
 
-        if (!isVariationChar(text.codePointAt(text.length - 2))) {
+        if (!isVariationChar(text.codePointAtKmp(text.length - 2))) {
             return false
         }
 
-        if (text.length > 4 && !isVariationChar(text.codePointAt(text.length - 4))) {
+        if (text.length > 4 && !isVariationChar(text.codePointAtKmp(text.length - 4))) {
             return false
         }
 
@@ -70,7 +74,7 @@ object EmojiCoder {
         emoji: String,
         text: String,
     ): String {
-        val input = text.toByteArray(Charsets.UTF_8)
+        val input = text.encodeToByteArray()
         val out = CharArray(input.size * 2)
         var outIdx = 0
         for (i in 0 until input.size) {
@@ -78,51 +82,34 @@ object EmojiCoder {
             out[outIdx++] = chars[0]
             out[outIdx++] = chars[1]
         }
-        return emoji + String(out)
+        return emoji + out.concatToString()
+    }
+
+    /**
+     * Scans [text] collecting variation-selector bytes until a non-selector is found
+     * after at least one byte has been collected.
+     * Returns the end index (exclusive) in [text] and the collected byte values.
+     */
+    private fun scanVariationBytes(text: String): Pair<Int, List<Int>> {
+        val bytes = mutableListOf<Int>()
+        var i = 0
+        while (i < text.length) {
+            val codePoint = text.codePointAtKmp(i)
+            val byte = fromVariationSelector(codePoint)
+            if (byte == null && bytes.isNotEmpty()) break
+            i += codePointCharCount(codePoint) // Advance by correct char count
+            if (byte != null) bytes.add(byte)
+        }
+        return i to bytes
     }
 
     fun decode(text: String): String {
-        val decoded = mutableListOf<Int>()
-
-        var i = 0
-        while (i < text.length) {
-            val codePoint = text.codePointAt(i)
-            val byte = fromVariationSelector(codePoint)
-
-            if (byte == null && decoded.isNotEmpty()) {
-                break
-            } else if (byte == null) {
-                i += Character.charCount(codePoint) // Advance index by correct number of chars
-                continue
-            }
-
-            decoded.add(byte)
-            i += Character.charCount(codePoint) // Advance index by correct number of chars
-        }
-
-        val decodedArray = ByteArray(decoded.size) { decoded[it].toByte() }
-        return String(decodedArray, Charsets.UTF_8)
+        val (_, bytes) = scanVariationBytes(text)
+        return ByteArray(bytes.size) { bytes[it].toByte() }.decodeToString()
     }
 
     fun cropToFirstMessage(text: String): String {
-        val decoded = mutableListOf<Int>()
-
-        var i = 0
-        while (i < text.length) {
-            val codePoint = text.codePointAt(i)
-            val byte = fromVariationSelector(codePoint)
-
-            if (byte == null && decoded.isNotEmpty()) {
-                break
-            } else if (byte == null) {
-                i += Character.charCount(codePoint) // Advance index by correct number of chars
-                continue
-            }
-
-            decoded.add(byte)
-            i += Character.charCount(codePoint) // Advance index by correct number of chars
-        }
-
-        return text.substring(0, i)
+        val (endIndex, _) = scanVariationBytes(text)
+        return text.substring(0, endIndex)
     }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Channel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Channel.kt
@@ -70,12 +70,9 @@ abstract class Channel : NotesGatherer {
     abstract fun toBestDisplayName(): String
 
     open fun relays(): Set<NormalizedRelayUrl> =
-        relays.keys
-            .toSortedSet { o1, o2 ->
-                val o1Count = relays[o1]?.number ?: 0
-                val o2Count = relays[o2]?.number ?: 0
-                o2Count.compareTo(o1Count) // descending
-            }
+        relays.entries
+            .sortedByDescending { it.value.number }
+            .mapTo(LinkedHashSet(relays.size)) { it.key }
 
     fun updateChannelInfo() {
         flowSet?.metadata?.invalidateData()

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/emphChat/EphemeralChatListState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/emphChat/EphemeralChatListState.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flowOn

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip02FollowList/Kind3FollowListState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip02FollowList/Kind3FollowListState.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip23LongContent/LongFormPublishAction.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip23LongContent/LongFormPublishAction.kt
@@ -58,7 +58,7 @@ object LongFormPublishAction {
             throw IllegalStateException("Cannot publish: signer is not writeable")
         }
 
-        if (content.toByteArray().size > MAX_CONTENT_BYTES) {
+        if (content.encodeToByteArray().size > MAX_CONTENT_BYTES) {
             throw IllegalArgumentException("Content exceeds maximum size of $MAX_CONTENT_BYTES bytes")
         }
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip28PublicChats/PublicChatListState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip28PublicChats/PublicChatListState.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flowOn

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip30CustomEmojis/EmojiPackState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip30CustomEmojis/EmojiPackState.kt
@@ -31,6 +31,7 @@ import com.vitorpamplona.quartz.nip30CustomEmoji.selection.EmojiPackSelectionEve
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combineTransform

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip51Lists/BookmarkListState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip51Lists/BookmarkListState.kt
@@ -35,6 +35,7 @@ import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.EventBookmark
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combineTransform

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip51Lists/OldBookmarkListState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip51Lists/OldBookmarkListState.kt
@@ -34,6 +34,7 @@ import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.EventBookmark
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combineTransform

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip65RelayList/Nip65RelayListState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip65RelayList/Nip65RelayListState.kt
@@ -31,6 +31,7 @@ import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flowOn

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/observables/CreatedAtComparator.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/observables/CreatedAtComparator.kt
@@ -22,14 +22,12 @@ package com.vitorpamplona.amethyst.commons.model.observables
 
 import com.vitorpamplona.amethyst.commons.model.AddressableNote
 import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.quartz.nip01Core.core.Event
 
 val CreatedAtIdHexComparator: Comparator<Note> =
     Comparator { note1, note2 ->
         // Sort by created_at and idhex, but define uniqueness by reference
         if (note1 === note2) return@Comparator 0
-
-        if (note1 == null) return@Comparator 1 // null is greater, moves to last
-        if (note2 == null) return@Comparator -1 // null is greater, moves to last
 
         val createdAt1 = note1.createdAt()
         val createdAt2 = note2.createdAt()
@@ -49,42 +47,31 @@ val CreatedAtIdHexComparator: Comparator<Note> =
         }
     }
 
+private inline fun <T> compareByCreatedAt(
+    a: T,
+    b: T,
+    eventOf: (T) -> Event?,
+): Int {
+    val firstEvent = eventOf(a)
+    val secondEvent = eventOf(b)
+    return when {
+        firstEvent == null && secondEvent == null -> 0
+        firstEvent == null -> 1
+        secondEvent == null -> -1
+        else -> firstEvent.createdAt.compareTo(secondEvent.createdAt)
+    }
+}
+
 object CreatedAtComparator : Comparator<Note> {
     override fun compare(
-        first: Note?,
-        second: Note?,
-    ): Int {
-        val firstEvent = first?.event
-        val secondEvent = second?.event
-
-        return if (firstEvent == null && secondEvent == null) {
-            0
-        } else if (firstEvent == null) {
-            1
-        } else if (secondEvent == null) {
-            -1
-        } else {
-            firstEvent.createdAt.compareTo(secondEvent.createdAt)
-        }
-    }
+        a: Note,
+        b: Note,
+    ): Int = compareByCreatedAt(a, b) { it.event }
 }
 
 object CreatedAtComparatorAddresses : Comparator<AddressableNote> {
     override fun compare(
-        first: AddressableNote?,
-        second: AddressableNote?,
-    ): Int {
-        val firstEvent = first?.event
-        val secondEvent = second?.event
-
-        return if (firstEvent == null && secondEvent == null) {
-            0
-        } else if (firstEvent == null) {
-            1
-        } else if (secondEvent == null) {
-            -1
-        } else {
-            firstEvent.createdAt.compareTo(secondEvent.createdAt)
-        }
-    }
+        a: AddressableNote,
+        b: AddressableNote,
+    ): Int = compareByCreatedAt(a, b) { it.event }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/trustedAssertions/UserCardsCache.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/trustedAssertions/UserCardsCache.kt
@@ -27,6 +27,7 @@ import com.vitorpamplona.amethyst.commons.relays.EOSERelayList
 import com.vitorpamplona.amethyst.commons.util.PlatformNumberFormatter
 import com.vitorpamplona.quartz.nip85TrustedAssertions.users.ContactCardEvent
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combineTransform
 import kotlinx.coroutines.flow.emitAll

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/eoseManagers/BaseEoseManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/eoseManagers/BaseEoseManager.kt
@@ -26,6 +26,7 @@ import com.vitorpamplona.quartz.nip01Core.relay.client.reqs.SubscriptionListener
 import com.vitorpamplona.quartz.nip01Core.relay.client.single.newSubId
 import com.vitorpamplona.quartz.nip01Core.relay.client.subscriptions.SubscriptionController
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 
 abstract class BaseEoseManager<T>(
     val client: INostrClient,

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relays/EOSECache.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relays/EOSECache.kt
@@ -20,6 +20,8 @@
  */
 package com.vitorpamplona.amethyst.commons.relays
 
+import com.vitorpamplona.amethyst.commons.util.KmpLock
+import com.vitorpamplona.amethyst.commons.util.withLock
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 
 /**
@@ -33,14 +35,14 @@ open class EOSECache<K : Any>(
     private val maxSize: Int = 200,
 ) {
     private val cache = linkedMapOf<K, EOSERelayList>()
-    private val lock = Any()
+    private val lock = KmpLock()
 
     fun addOrUpdate(
         key: K,
         relayUrl: NormalizedRelayUrl,
         time: Long,
     ) {
-        synchronized(lock) {
+        lock.withLock {
             val relayList = cache[key]
             if (relayList == null) {
                 // Evict oldest if at capacity
@@ -57,7 +59,7 @@ open class EOSECache<K : Any>(
     }
 
     fun since(key: K): SincePerRelayMap? =
-        synchronized(lock) {
+        lock.withLock {
             cache[key]?.relayList?.toMutableMap()
         }
 
@@ -68,18 +70,18 @@ open class EOSECache<K : Any>(
     ) = addOrUpdate(key, relayUrl, time)
 
     fun remove(key: K) {
-        synchronized(lock) {
+        lock.withLock {
             cache.remove(key)
         }
     }
 
     fun clear() {
-        synchronized(lock) {
+        lock.withLock {
             cache.clear()
         }
     }
 
-    fun size(): Int = synchronized(lock) { cache.size }
+    fun size(): Int = lock.withLock { cache.size }
 }
 
 /**
@@ -91,7 +93,7 @@ open class EOSETwoLevelCache<K1 : Any, K2 : Any>(
     private val innerMaxSize: Int = 200,
 ) {
     private val cache = linkedMapOf<K1, EOSECache<K2>>()
-    private val lock = Any()
+    private val lock = KmpLock()
 
     fun addOrUpdate(
         outerKey: K1,
@@ -99,7 +101,7 @@ open class EOSETwoLevelCache<K1 : Any, K2 : Any>(
         relayUrl: NormalizedRelayUrl,
         time: Long,
     ) {
-        synchronized(lock) {
+        lock.withLock {
             val innerCache = cache[outerKey]
             if (innerCache == null) {
                 // Evict oldest if at capacity
@@ -119,7 +121,7 @@ open class EOSETwoLevelCache<K1 : Any, K2 : Any>(
         outerKey: K1,
         innerKey: K2,
     ): SincePerRelayMap? =
-        synchronized(lock) {
+        lock.withLock {
             cache[outerKey]?.since(innerKey)
         }
 
@@ -131,13 +133,13 @@ open class EOSETwoLevelCache<K1 : Any, K2 : Any>(
     ) = addOrUpdate(outerKey, innerKey, relayUrl, time)
 
     fun removeOuter(key: K1) {
-        synchronized(lock) {
+        lock.withLock {
             cache.remove(key)
         }
     }
 
     fun clear() {
-        synchronized(lock) {
+        lock.withLock {
             cache.clear()
         }
     }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/robohash/RobohashAssembler.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/robohash/RobohashAssembler.kt
@@ -168,7 +168,7 @@ class RobohashAssembler {
                 Hex.decode(msg)
             } else {
                 Log.w("Robohash") { "$msg is not a hex" }
-                sha256(msg.toByteArray())
+                sha256(msg.encodeToByteArray())
             }
 
         val bgColor = SolidColor(bytesToColor(hash[0], hash[1], hash[2], isLightTheme))

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/service/BundledUpdate.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/service/BundledUpdate.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/thumbhash/ThumbHashDecoder.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/thumbhash/ThumbHashDecoder.kt
@@ -21,6 +21,8 @@
 package com.vitorpamplona.amethyst.commons.thumbhash
 
 import com.vitorpamplona.amethyst.commons.blurhash.PlatformImage
+import com.vitorpamplona.amethyst.commons.util.KmpLock
+import com.vitorpamplona.amethyst.commons.util.withLock
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.math.PI
@@ -50,14 +52,14 @@ object ThumbHashDecoder {
     // (size, components) pairs across the entire app lifetime, each table is
     // a few KB, so the memory ceiling is tiny.
     private val cosineCache = HashMap<Long, DoubleArray>()
-    private val cosineCacheLock = Any()
+    private val cosineCacheLock = KmpLock()
 
     /**
      * Clear the cosine table cache. Tables are tiny but callers under memory
      * pressure can release them; they will be recomputed on demand.
      */
     fun clearCache() {
-        synchronized(cosineCacheLock) { cosineCache.clear() }
+        cosineCacheLock.withLock { cosineCache.clear() }
     }
 
     private fun cosTable(
@@ -65,9 +67,8 @@ object ThumbHashDecoder {
         components: Int,
     ): DoubleArray {
         val key = (size.toLong() shl 32) or components.toLong()
-        synchronized(cosineCacheLock) {
-            cosineCache[key]?.let { return it }
-        }
+        val cached = cosineCacheLock.withLock { cosineCache[key] }
+        if (cached != null) return cached
         val table = DoubleArray(size * components)
         val piOverSize = PI / size
         for (i in 0 until size) {
@@ -77,10 +78,7 @@ object ThumbHashDecoder {
                 table[rowOffset + c] = cos(phase * c)
             }
         }
-        synchronized(cosineCacheLock) {
-            cosineCache.getOrPut(key) { table }
-        }
-        return table
+        return cosineCacheLock.withLock { cosineCache.getOrPut(key) { table } }
     }
 
     /**

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/LoadingState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/LoadingState.kt
@@ -175,7 +175,7 @@ fun FeedErrorState(
     modifier: Modifier = Modifier,
     onRetry: (() -> Unit)? = null,
 ) {
-    val formattedMessage = stringResource(Res.string.error_loading_feed).format(errorMessage)
+    val formattedMessage = stringResource(Res.string.error_loading_feed, errorMessage)
 
     ErrorState(
         message = formattedMessage,

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/FeedContentState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/FeedContentState.kt
@@ -35,6 +35,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/signing/SigningState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/signing/SigningState.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.vitorpamplona.quartz.nip01Core.signers.SignerExceptions
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.ExperimentalAtomicApi

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/util/CodePoints.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/util/CodePoints.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.util
+
+// KMP code-point helpers — replacements for `java.lang.Character.*` and the
+// JVM-only `String.codePointAt(Int)` / `String.offsetByCodePoints(Int, Int)`
+// extensions. UTF-16 surrogate-pair aware so emoji and other supplementary
+// code points are handled correctly on Native targets.
+
+/** Number of UTF-16 code units (1 or 2) needed for [codePoint]. */
+fun codePointCharCount(codePoint: Int): Int = if (codePoint >= 0x10000) 2 else 1
+
+/**
+ * Encode [codePoint] as UTF-16. Returns a 1-char array for BMP code points and
+ * a high+low surrogate pair for supplementary code points (≥ U+10000).
+ */
+fun codePointToChars(codePoint: Int): CharArray =
+    if (codePoint < 0x10000) {
+        charArrayOf(codePoint.toChar())
+    } else {
+        val offset = codePoint - 0x10000
+        charArrayOf(
+            (0xD800 + (offset ushr 10)).toChar(),
+            (0xDC00 + (offset and 0x3FF)).toChar(),
+        )
+    }
+
+/**
+ * Decode the Unicode code point that starts at [index]. Mirrors
+ * `java.lang.Character.codePointAt(CharSequence, int)`: returns the
+ * supplementary code point when [index] points at a well-formed high surrogate
+ * followed by a low surrogate; otherwise returns the raw `Char.code`.
+ */
+fun String.codePointAtKmp(index: Int): Int {
+    val high = this[index]
+    if (high.isHighSurrogate() && index + 1 < length) {
+        val low = this[index + 1]
+        if (low.isLowSurrogate()) {
+            return 0x10000 + ((high.code - 0xD800) shl 10) + (low.code - 0xDC00)
+        }
+    }
+    return high.code
+}
+
+/**
+ * Return the index that is [codePointOffset] code points away from [index].
+ * Negative offsets are not supported (matches the only call site usage today).
+ */
+fun String.offsetByCodePointsKmp(
+    index: Int,
+    codePointOffset: Int,
+): Int {
+    var i = index
+    repeat(codePointOffset) {
+        i += codePointCharCount(codePointAtKmp(i))
+    }
+    return i
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/util/EmojiUtils.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/util/EmojiUtils.kt
@@ -23,7 +23,7 @@ package com.vitorpamplona.amethyst.commons.util
 import com.vitorpamplona.amethyst.commons.emojicoder.EmojiCoder
 import com.vitorpamplona.amethyst.commons.model.ImmutableListOfLists
 
-fun String.isUTF16Char(pos: Int): Boolean = Character.charCount(this.codePointAt(pos)) == 2
+fun String.isUTF16Char(pos: Int): Boolean = codePointCharCount(this.codePointAtKmp(pos)) == 2
 
 fun String.firstFullCharOld(): String {
     return when (this.length) {
@@ -64,11 +64,11 @@ fun String.firstFullChar(): String {
     var i = 0
 
     while (i < this.length) {
-        codePoint = codePointAt(i)
+        codePoint = codePointAtKmp(i)
 
         // Skips if it starts with the join char 0x200D
         if (codePoint == 0x200D && previousCharLength == 0) {
-            next = offsetByCodePoints(i, 1)
+            next = offsetByCodePointsKmp(i, 1)
             start = next
         } else {
             // If join, searches for the next char
@@ -78,7 +78,7 @@ fun String.firstFullChar(): String {
             } else {
                 // stops when two chars are not joined together
                 if (previousCharLength > 0 && !isInJoin) {
-                    if (Character.charCount(codePoint) == 1 || hasHadSecondChance) {
+                    if (codePointCharCount(codePoint) == 1 || hasHadSecondChance) {
                         break
                     } else {
                         hasHadSecondChance = true
@@ -91,7 +91,7 @@ fun String.firstFullChar(): String {
             }
 
             // next char to evaluate
-            next = offsetByCodePoints(i, 1)
+            next = offsetByCodePointsKmp(i, 1)
             previousCharLength += (next - i)
         }
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/FeedViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/FeedViewModel.kt
@@ -30,6 +30,7 @@ import com.vitorpamplona.amethyst.commons.ui.feeds.FeedFilter
 import com.vitorpamplona.amethyst.commons.ui.feeds.InvalidatableContent
 import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.launch
 
 @Stable

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/ListChangeFeedViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/ListChangeFeedViewModel.kt
@@ -31,6 +31,7 @@ import com.vitorpamplona.amethyst.commons.ui.feeds.FeedContentState
 import com.vitorpamplona.amethyst.commons.ui.feeds.InvalidatableContent
 import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.launch
 
 @Stable

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/LiveStreamTopZappersViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/LiveStreamTopZappersViewModel.kt
@@ -33,6 +33,7 @@ import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
 import com.vitorpamplona.quartz.nip57Zaps.LnZapRequestEvent
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/thread/LevelFeedViewModel.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/thread/LevelFeedViewModel.kt
@@ -35,6 +35,7 @@ import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
 import com.vitorpamplona.amethyst.commons.viewmodels.FeedViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/ChannelRelaysTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/ChannelRelaysTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model
+
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Lock in the descending-by-usage ordering and equal-count preservation of
+ * [Channel.relays]. Phase 2 KMP migration replaced the JVM `toSortedSet`
+ * (TreeSet) implementation — which silently dropped duplicates whose
+ * comparator returned 0 — with a LinkedHashSet built from a pre-sorted list.
+ * That keeps every distinct relay even when usage counts tie.
+ */
+class ChannelRelaysTest {
+    /** Minimal concrete subclass — the base [Channel] is abstract. */
+    private class TestChannel : Channel() {
+        override fun toBestDisplayName(): String = "test"
+    }
+
+    private val relayA = NormalizedRelayUrl("wss://a.example/")
+    private val relayB = NormalizedRelayUrl("wss://b.example/")
+    private val relayC = NormalizedRelayUrl("wss://c.example/")
+
+    @Test
+    fun emptyWhenNoRelaysAdded() {
+        assertEquals(emptySet<NormalizedRelayUrl>(), TestChannel().relays())
+    }
+
+    @Test
+    fun singleRelayIsReturned() {
+        val channel = TestChannel()
+        channel.addRelay(relayA)
+        assertEquals(setOf(relayA), channel.relays())
+    }
+
+    @Test
+    fun relaysAreOrderedDescendingByUsageCount() {
+        val channel = TestChannel()
+        // C will end up with the highest count.
+        channel.addRelay(relayA) // A: 1
+        channel.addRelay(relayB) // B: 1
+        channel.addRelay(relayB) // B: 2
+        channel.addRelay(relayC) // C: 1
+        channel.addRelay(relayC) // C: 2
+        channel.addRelay(relayC) // C: 3
+
+        // LinkedHashSet preserves insertion order, which is the
+        // descending-by-count order produced by sortedByDescending.
+        assertEquals(listOf(relayC, relayB, relayA), channel.relays().toList())
+    }
+
+    /**
+     * Behavioural change from the JVM-only implementation: the previous
+     * `toSortedSet` returned a [java.util.TreeSet] whose membership uses the
+     * comparator for equality. Two relays with equal counts would be treated
+     * as duplicates by the TreeSet and one would be silently dropped. The
+     * KMP-friendly replacement uses [LinkedHashSet], whose membership uses
+     * `equals`, so every distinct relay is preserved regardless of count.
+     */
+    @Test
+    fun relaysWithEqualUsageCountsAreAllPreserved() {
+        val channel = TestChannel()
+        channel.addRelay(relayA) // A: 1
+        channel.addRelay(relayB) // B: 1
+        channel.addRelay(relayC) // C: 1
+
+        // All three relays share count 1. The old behaviour would return
+        // exactly one of them; the new behaviour returns all three.
+        assertEquals(setOf(relayA, relayB, relayC), channel.relays())
+        assertEquals(3, channel.relays().size)
+    }
+}

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/util/CodePointsTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/util/CodePointsTest.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.util
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CodePointsTest {
+    // ---- codePointCharCount ----
+
+    @Test
+    fun charCountIsOneForBmp() {
+        assertEquals(1, codePointCharCount(0x0041)) // 'A'
+        assertEquals(1, codePointCharCount(0xFFFF)) // last BMP code point
+    }
+
+    @Test
+    fun charCountIsTwoForSupplementary() {
+        assertEquals(2, codePointCharCount(0x10000)) // first supplementary code point
+        assertEquals(2, codePointCharCount(0x1F600)) // 😀 grinning face
+        assertEquals(2, codePointCharCount(0x10FFFF)) // last valid code point
+    }
+
+    // ---- codePointToChars ----
+
+    @Test
+    fun toCharsRoundTripsAscii() {
+        assertArrayEquals(charArrayOf('A'), codePointToChars(0x0041))
+    }
+
+    @Test
+    fun toCharsRoundTripsLastBmp() {
+        assertArrayEquals(charArrayOf('￿'), codePointToChars(0xFFFF))
+    }
+
+    @Test
+    fun toCharsProducesSurrogatePairForGrinningFace() {
+        // U+1F600 (😀) is encoded as the surrogate pair (0xD83D, 0xDE00).
+        assertArrayEquals(charArrayOf('\uD83D', '\uDE00'), codePointToChars(0x1F600))
+    }
+
+    @Test
+    fun toCharsProducesSurrogatePairForFirstSupplementary() {
+        // U+10000 -> (0xD800, 0xDC00).
+        assertArrayEquals(charArrayOf('\uD800', '\uDC00'), codePointToChars(0x10000))
+    }
+
+    @Test
+    fun toCharsProducesSurrogatePairForLastCodePoint() {
+        // U+10FFFF -> (0xDBFF, 0xDFFF).
+        assertArrayEquals(charArrayOf('\uDBFF', '\uDFFF'), codePointToChars(0x10FFFF))
+    }
+
+    // ---- String.codePointAtKmp ----
+
+    @Test
+    fun codePointAtReturnsAsciiCodeForBmp() {
+        assertEquals(0x0041, "Aa".codePointAtKmp(0))
+        assertEquals(0x0061, "Aa".codePointAtKmp(1))
+    }
+
+    @Test
+    fun codePointAtDecodesSurrogatePair() {
+        // "😀X" — surrogate pair followed by 'X'.
+        val s = "😀X"
+        assertEquals(0x1F600, s.codePointAtKmp(0))
+    }
+
+    @Test
+    fun codePointAtReturnsLowSurrogateWhenIndexIsOnLowHalf() {
+        // Indexing into the middle of a surrogate pair returns the low surrogate's raw code unit.
+        val s = "😀"
+        assertEquals(0xDE00, s.codePointAtKmp(1))
+    }
+
+    @Test
+    fun codePointAtReturnsHighSurrogateWhenStringEndsOnLoneHighSurrogate() {
+        // Lone high surrogate at end of string: `index + 1 < length` is false, so we
+        // fall back to returning the surrogate's raw code unit. This matches
+        // java.lang.Character.codePointAt(CharSequence, int).
+        val s = "\uD83D"
+        assertEquals(0xD83D, s.codePointAtKmp(0))
+    }
+
+    @Test
+    fun codePointAtReturnsHighSurrogateWhenFollowedByNonSurrogate() {
+        // High surrogate followed by a non-low-surrogate char: return the high surrogate raw.
+        val s = "\uD83DA"
+        assertEquals(0xD83D, s.codePointAtKmp(0))
+        assertEquals(0x0041, s.codePointAtKmp(1))
+    }
+
+    // ---- String.offsetByCodePointsKmp ----
+
+    @Test
+    fun offsetByOneStepsOverBmp() {
+        // Two ASCII chars; offset 1 from index 0 lands on index 1.
+        assertEquals(1, "Aa".offsetByCodePointsKmp(0, 1))
+    }
+
+    @Test
+    fun offsetByOneStepsOverSupplementaryPair() {
+        // 😀 is 2 UTF-16 code units; offset 1 from index 0 lands on index 2.
+        val s = "😀X"
+        assertEquals(2, s.offsetByCodePointsKmp(0, 1))
+        // Then a single step lands on the end of the string.
+        assertEquals(3, s.offsetByCodePointsKmp(2, 1))
+    }
+
+    @Test
+    fun offsetByZeroIsIdentity() {
+        assertEquals(0, "Aa".offsetByCodePointsKmp(0, 0))
+        assertEquals(2, "Aa".offsetByCodePointsKmp(2, 0))
+    }
+
+    // ---- Round-trip ----
+
+    @Test
+    fun encodeDecodeRoundTripCoversFullCodePointRange() {
+        // Spot-check a handful of code points across BMP and supplementary planes.
+        val samples = intArrayOf(0x0001, 0x0041, 0x00FF, 0x4F60, 0xFFFF, 0x10000, 0x1F600, 0x10FFFF)
+        for (cp in samples) {
+            val chars = codePointToChars(cp)
+            val asString = chars.concatToString()
+            assertEquals("round-trip code point U+${cp.toString(16).uppercase()}", cp, asString.codePointAtKmp(0))
+            assertEquals(
+                "char count for U+${cp.toString(16).uppercase()}",
+                chars.size,
+                codePointCharCount(cp),
+            )
+        }
+    }
+}

--- a/commons/src/iosMain/kotlin/com/vitorpamplona/amethyst/commons/blurhash/PlatformImage.ios.kt
+++ b/commons/src/iosMain/kotlin/com/vitorpamplona/amethyst/commons/blurhash/PlatformImage.ios.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.blurhash
+
+// Phase 2 compile-only iOS actual. Holds an ARGB pixel buffer + size. Phase 3
+// will swap to a UIImage/CGImage-backed implementation when the iosApp module
+// lands and BlurHash/ThumbHash output needs to render to UIKit.
+actual class PlatformImage internal constructor(
+    private val pixels: IntArray,
+    actual val width: Int,
+    actual val height: Int,
+) {
+    actual fun getPixels(
+        pixels: IntArray,
+        offset: Int,
+        stride: Int,
+        x: Int,
+        y: Int,
+        width: Int,
+        height: Int,
+    ) {
+        for (row in 0 until height) {
+            val srcStart = (y + row) * this.width + x
+            val dstStart = offset + row * stride
+            this.pixels.copyInto(
+                destination = pixels,
+                destinationOffset = dstStart,
+                startIndex = srcStart,
+                endIndex = srcStart + width,
+            )
+        }
+    }
+
+    actual fun scale(
+        width: Int,
+        height: Int,
+    ): PlatformImage {
+        // Nearest-neighbour resample. Adequate for the Phase 2 compile-only target;
+        // Phase 3 should swap to CoreGraphics scaling for production quality.
+        val out = IntArray(width * height)
+        for (j in 0 until height) {
+            val srcY = (j.toLong() * this.height / height).toInt().coerceAtMost(this.height - 1)
+            for (i in 0 until width) {
+                val srcX = (i.toLong() * this.width / width).toInt().coerceAtMost(this.width - 1)
+                out[j * width + i] = pixels[srcY * this.width + srcX]
+            }
+        }
+        return PlatformImage(out, width, height)
+    }
+
+    actual companion object {
+        actual fun create(
+            pixels: IntArray,
+            width: Int,
+            height: Int,
+        ): PlatformImage = PlatformImage(pixels.copyOf(), width, height)
+    }
+}

--- a/commons/src/iosMain/kotlin/com/vitorpamplona/amethyst/commons/chess/ChessDismissedGamesStorage.ios.kt
+++ b/commons/src/iosMain/kotlin/com/vitorpamplona/amethyst/commons/chess/ChessDismissedGamesStorage.ios.kt
@@ -18,20 +18,27 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.search
+package com.vitorpamplona.amethyst.commons.chess
 
-import com.vitorpamplona.amethyst.commons.util.KmpLock
-import com.vitorpamplona.amethyst.commons.util.withLock
+// Phase 2 compile-only iOS actual. In-memory only; persistence via
+// NSUserDefaults arrives with the iosApp module in Phase 3.
+actual class ChessDismissedGamesStorage private actual constructor() {
+    private val dismissed = mutableMapOf<String, Set<String>>()
 
-class EventDeduplicator {
-    private val lock = KmpLock()
-    private val seenIds = mutableSetOf<String>()
+    actual companion object {
+        actual fun create(context: Any?): ChessDismissedGamesStorage = ChessDismissedGamesStorage()
+    }
 
-    fun tryAdd(id: String): Boolean = lock.withLock { seenIds.add(id) }
+    actual fun load(userPubkey: String): Set<String> = dismissed[userPubkey] ?: emptySet()
 
-    fun contains(id: String): Boolean = lock.withLock { id in seenIds }
-
-    fun clear() = lock.withLock { seenIds.clear() }
-
-    val size: Int get() = lock.withLock { seenIds.size }
+    actual fun save(
+        userPubkey: String,
+        ids: Set<String>,
+    ) {
+        if (ids.isEmpty()) {
+            dismissed.remove(userPubkey)
+        } else {
+            dismissed[userPubkey] = ids
+        }
+    }
 }

--- a/commons/src/iosMain/kotlin/com/vitorpamplona/amethyst/commons/keystorage/SecureKeyStorage.ios.kt
+++ b/commons/src/iosMain/kotlin/com/vitorpamplona/amethyst/commons/keystorage/SecureKeyStorage.ios.kt
@@ -18,20 +18,23 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.search
+package com.vitorpamplona.amethyst.commons.keystorage
 
-import com.vitorpamplona.amethyst.commons.util.KmpLock
-import com.vitorpamplona.amethyst.commons.util.withLock
+// Phase 2 compile-only iOS actual. Keychain Services wiring lands in Phase 4
+// (write paths: signing, posting, settings) per amethyst/plans/2026-05-24-ios-support.md.
+actual class SecureKeyStorage private actual constructor() {
+    actual companion object {
+        actual fun create(context: Any?): SecureKeyStorage = SecureKeyStorage()
+    }
 
-class EventDeduplicator {
-    private val lock = KmpLock()
-    private val seenIds = mutableSetOf<String>()
+    actual suspend fun savePrivateKey(
+        npub: String,
+        privKeyHex: String,
+    ): Unit = throw SecureStorageException("Keychain Services binding pending (iOS Phase 4)")
 
-    fun tryAdd(id: String): Boolean = lock.withLock { seenIds.add(id) }
+    actual suspend fun getPrivateKey(npub: String): String? = throw SecureStorageException("Keychain Services binding pending (iOS Phase 4)")
 
-    fun contains(id: String): Boolean = lock.withLock { id in seenIds }
+    actual suspend fun deletePrivateKey(npub: String): Boolean = throw SecureStorageException("Keychain Services binding pending (iOS Phase 4)")
 
-    fun clear() = lock.withLock { seenIds.clear() }
-
-    val size: Int get() = lock.withLock { seenIds.size }
+    actual suspend fun hasPrivateKey(npub: String): Boolean = throw SecureStorageException("Keychain Services binding pending (iOS Phase 4)")
 }

--- a/commons/src/iosMain/kotlin/com/vitorpamplona/amethyst/commons/model/ThreadLevelCalculator.ios.kt
+++ b/commons/src/iosMain/kotlin/com/vitorpamplona/amethyst/commons/model/ThreadLevelCalculator.ios.kt
@@ -18,20 +18,25 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.search
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
 
-import com.vitorpamplona.amethyst.commons.util.KmpLock
-import com.vitorpamplona.amethyst.commons.util.withLock
+package com.vitorpamplona.amethyst.commons.model
 
-class EventDeduplicator {
-    private val lock = KmpLock()
-    private val seenIds = mutableSetOf<String>()
+import platform.Foundation.NSDate
+import platform.Foundation.NSDateFormatter
+import platform.Foundation.NSLocale
+import platform.Foundation.NSTimeZone
+import platform.Foundation.dateWithTimeIntervalSince1970
+import platform.Foundation.localTimeZone
 
-    fun tryAdd(id: String): Boolean = lock.withLock { seenIds.add(id) }
+// Format pattern matches the JVM actual ("uuuu-MM-dd-HH:mm:ss"). For the
+// post-1970 timestamps Nostr events use, `yyyy` and `uuuu` are equivalent
+// (proleptic Gregorian, year >= 1), so NSDateFormatter's `yyyy` is fine.
+private val levelFormatter: NSDateFormatter =
+    NSDateFormatter().apply {
+        dateFormat = "yyyy-MM-dd-HH:mm:ss"
+        timeZone = NSTimeZone.localTimeZone
+        locale = NSLocale("en_US_POSIX")
+    }
 
-    fun contains(id: String): Boolean = lock.withLock { id in seenIds }
-
-    fun clear() = lock.withLock { seenIds.clear() }
-
-    val size: Int get() = lock.withLock { seenIds.size }
-}
+actual fun formattedDateTime(timestamp: Long): String = levelFormatter.stringFromDate(NSDate.dateWithTimeIntervalSince1970(timestamp.toDouble()))

--- a/commons/src/iosMain/kotlin/com/vitorpamplona/amethyst/commons/model/ThreadLevelCalculator.ios.kt
+++ b/commons/src/iosMain/kotlin/com/vitorpamplona/amethyst/commons/model/ThreadLevelCalculator.ios.kt
@@ -22,6 +22,8 @@
 
 package com.vitorpamplona.amethyst.commons.model
 
+import com.vitorpamplona.amethyst.commons.util.KmpLock
+import com.vitorpamplona.amethyst.commons.util.withLock
 import platform.Foundation.NSDate
 import platform.Foundation.NSDateFormatter
 import platform.Foundation.NSLocale
@@ -39,4 +41,14 @@ private val levelFormatter: NSDateFormatter =
         locale = NSLocale("en_US_POSIX")
     }
 
-actual fun formattedDateTime(timestamp: Long): String = levelFormatter.stringFromDate(NSDate.dateWithTimeIntervalSince1970(timestamp.toDouble()))
+// NSDateFormatter is not thread-safe for concurrent stringFromDate calls
+// (Apple docs). ThreadLevelCalculator.replyLevelSignature runs under
+// Dispatchers.IO via LevelFeedViewModel, so multiple threads can hit
+// formattedDateTime simultaneously. Guard the shared formatter rather than
+// allocating one per call (cheaper for the O(notes-per-thread-sort) call rate).
+private val levelFormatterLock = KmpLock()
+
+actual fun formattedDateTime(timestamp: Long): String =
+    levelFormatterLock.withLock {
+        levelFormatter.stringFromDate(NSDate.dateWithTimeIntervalSince1970(timestamp.toDouble()))
+    }

--- a/commons/src/iosMain/kotlin/com/vitorpamplona/amethyst/commons/threading/Threading.ios.kt
+++ b/commons/src/iosMain/kotlin/com/vitorpamplona/amethyst/commons/threading/Threading.ios.kt
@@ -18,20 +18,11 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.search
+package com.vitorpamplona.amethyst.commons.threading
 
-import com.vitorpamplona.amethyst.commons.util.KmpLock
-import com.vitorpamplona.amethyst.commons.util.withLock
-
-class EventDeduplicator {
-    private val lock = KmpLock()
-    private val seenIds = mutableSetOf<String>()
-
-    fun tryAdd(id: String): Boolean = lock.withLock { seenIds.add(id) }
-
-    fun contains(id: String): Boolean = lock.withLock { id in seenIds }
-
-    fun clear() = lock.withLock { seenIds.clear() }
-
-    val size: Int get() = lock.withLock { seenIds.size }
+// Mirrors the jvmMain no-op. The iosApp module (Phase 3) can swap this for an
+// `NSThread.isMainThread` check if iOS-specific main-thread restrictions need
+// enforcement; today there are none.
+actual fun checkNotInMainThread() {
+    // No-op
 }

--- a/commons/src/iosMain/kotlin/com/vitorpamplona/amethyst/commons/util/PlatformNumberFormatter.ios.kt
+++ b/commons/src/iosMain/kotlin/com/vitorpamplona/amethyst/commons/util/PlatformNumberFormatter.ios.kt
@@ -18,20 +18,20 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.search
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
 
-import com.vitorpamplona.amethyst.commons.util.KmpLock
-import com.vitorpamplona.amethyst.commons.util.withLock
+package com.vitorpamplona.amethyst.commons.util
 
-class EventDeduplicator {
-    private val lock = KmpLock()
-    private val seenIds = mutableSetOf<String>()
+import platform.Foundation.NSNumber
+import platform.Foundation.NSNumberFormatter
+import platform.Foundation.NSNumberFormatterDecimalStyle
+import platform.Foundation.numberWithLongLong
 
-    fun tryAdd(id: String): Boolean = lock.withLock { seenIds.add(id) }
+actual class PlatformNumberFormatter {
+    private val formatter: NSNumberFormatter =
+        NSNumberFormatter().apply {
+            numberStyle = NSNumberFormatterDecimalStyle
+        }
 
-    fun contains(id: String): Boolean = lock.withLock { id in seenIds }
-
-    fun clear() = lock.withLock { seenIds.clear() }
-
-    val size: Int get() = lock.withLock { seenIds.size }
+    actual fun format(value: Long): String = formatter.stringFromNumber(NSNumber.numberWithLongLong(value)) ?: value.toString()
 }

--- a/commons/src/iosMain/kotlin/com/vitorpamplona/amethyst/commons/util/WeakReference.ios.kt
+++ b/commons/src/iosMain/kotlin/com/vitorpamplona/amethyst/commons/util/WeakReference.ios.kt
@@ -18,6 +18,14 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+@file:OptIn(kotlin.experimental.ExperimentalNativeApi::class)
+
 package com.vitorpamplona.amethyst.commons.util
 
-actual typealias WeakReference<T> = kotlin.native.ref.WeakReference<T>
+actual class WeakReference<T : Any> actual constructor(
+    referent: T,
+) {
+    private val ref = kotlin.native.ref.WeakReference(referent)
+
+    actual fun get(): T? = ref.get()
+}

--- a/commons/src/iosMain/kotlin/com/vitorpamplona/amethyst/commons/utils/DebugUtils.ios.kt
+++ b/commons/src/iosMain/kotlin/com/vitorpamplona/amethyst/commons/utils/DebugUtils.ios.kt
@@ -18,20 +18,8 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.commons.search
+package com.vitorpamplona.amethyst.commons.utils
 
-import com.vitorpamplona.amethyst.commons.util.KmpLock
-import com.vitorpamplona.amethyst.commons.util.withLock
-
-class EventDeduplicator {
-    private val lock = KmpLock()
-    private val seenIds = mutableSetOf<String>()
-
-    fun tryAdd(id: String): Boolean = lock.withLock { seenIds.add(id) }
-
-    fun contains(id: String): Boolean = lock.withLock { id in seenIds }
-
-    fun clear() = lock.withLock { seenIds.clear() }
-
-    val size: Int get() = lock.withLock { seenIds.size }
-}
+// iosApp (Phase 3) can flip this from a build flag (`DEBUG` Swift compile
+// condition surfaced through the framework). Compile-only target ships false.
+actual val isDebug: Boolean = false


### PR DESCRIPTION
@vitorpamplona Would this CI build fix help or are you currently working on it?

## Summary

Unblock the `:commons:compileKotlinIosSimulatorArm64` CI gate that has been failing on every `main` build since PR #3047 (commit `e02972e1b`) enabled iOS Kotlin/Native targets on `:commons` without completing the Phase 2 KMP migration. 39 files touched, 3 commits.

## ⚠️ One real behavior change to review carefully

**`Channel.relays()`** (`commons/.../model/Channel.kt:72-75`) — the only change here that isn't a mechanical translation.

The old code used `toSortedSet { o1, o2 -> ... }`, which returned a `java.util.TreeSet`. `TreeSet` uses its `Comparator` for *equality*, not just ordering — so two relays whose comparator returned `0` (same usage count) were treated as duplicates and the second one was silently dropped.

The new code uses `LinkedHashSet` built from a pre-sorted list. `LinkedHashSet` uses `NormalizedRelayUrl.equals()` for membership, so every distinct relay is preserved regardless of count.

**Implication:** users who had two or more relays for the same channel with identical usage counters will now see all of them in the relay list. Previously they'd have seen only one. The new behavior is arguably more correct (the old behavior was a quiet bug), but it is observable.

If a bug report comes in along the lines of "a relay disappeared from channel X" or "more relays showing up than expected," this is the first place to look. Locked in by `ChannelRelaysTest.relaysWithEqualUsageCountsAreAllPreserved`.

## Mechanical changes (commit `ae71bb819`)

All JVM-only API → KMP-stdlib equivalents. No behavior change on JVM/Android.

<table>
  <thead>
    <tr><th>Category</th><th>Files</th><th>Translation</th></tr>
  </thead>
  <tbody>
    <tr>
      <td><code>Dispatchers.IO</code> on Native</td>
      <td>16 files</td>
      <td>Add <code>import kotlinx.coroutines.IO</code> (matches <code>quartz/NostrClient.kt</code> precedent; no-op on JVM)</td>
    </tr>
    <tr>
      <td><code>synchronized(lock)</code> → <code>KmpLock.withLock</code></td>
      <td>5 files</td>
      <td>Use the existing <code>KmpLock</code> (<code>ReentrantLock</code> on JVM, <code>NSRecursiveLock</code> on iOS) — drop-in semantic equivalent</td>
    </tr>
    <tr>
      <td><code>java.lang.Character</code> + <code>String.codePointAt</code> / <code>offsetByCodePoints</code></td>
      <td><code>EmojiCoder.kt</code>, <code>EmojiUtils.kt</code></td>
      <td>New <code>commons/util/CodePoints.kt</code> with surrogate-pair-aware KMP helpers</td>
    </tr>
    <tr>
      <td><code>String(bytes, Charsets.UTF_8)</code> / <code>String(charArray)</code> / <code>text.toByteArray()</code></td>
      <td>5 files</td>
      <td><code>ByteArray.decodeToString()</code> / <code>CharArray.concatToString()</code> / <code>String.encodeToByteArray()</code> (all UTF-8)</td>
    </tr>
    <tr>
      <td><code>Math.round(Double)</code></td>
      <td><code>BlurHashEncoder.kt</code></td>
      <td><code>Double.roundToLong()</code> from <code>kotlin.math</code></td>
    </tr>
    <tr>
      <td><code>String.format</code></td>
      <td><code>LoadingState.kt</code></td>
      <td>Compose Resources <code>stringResource(res, vararg args)</code> overload</td>
    </tr>
    <tr>
      <td><code>toSortedSet</code></td>
      <td><code>Channel.kt</code></td>
      <td>See ⚠️ section above — <code>sortedByDescending { ... }.mapTo(LinkedHashSet)</code></td>
    </tr>
    <tr>
      <td><code>Comparator&lt;T?&gt;</code> params</td>
      <td><code>CreatedAtComparator.kt</code></td>
      <td><code>kotlin.Comparator&lt;T&gt;</code> on Native is non-null; aligned signatures to <code>compare(a: T, b: T)</code></td>
    </tr>
    <tr>
      <td><code>WeakReference.ios.kt</code> param-name mismatch</td>
      <td>iosMain</td>
      <td>Replaced typealias with explicit <code>actual class</code> wrapping <code>kotlin.native.ref.WeakReference</code></td>
    </tr>
    <tr>
      <td>Missing iOS actuals</td>
      <td>7 new files in <code>commons/src/iosMain/</code></td>
      <td>Stubs for <code>PlatformImage</code>, <code>ChessDismissedGamesStorage</code>, <code>SecureKeyStorage</code>, <code>formattedDateTime</code>, <code>checkNotInMainThread</code>, <code>PlatformNumberFormatter</code>, <code>isDebug</code>. Stub-vs-functional split documented in each file — UI/Compose iOS bring-up is Phase 3, signer/key bring-up is Phase 4 per <code>amethyst/plans/2026-05-24-ios-support.md</code>.</td>
    </tr>
  </tbody>
</table>

### Follow-up fix from kotlin-review (commit `2444a8dab`)

`formattedDateTime` iOS actual was holding a single `NSDateFormatter` as a module-level `private val`, called from `Dispatchers.IO` via `LevelFeedViewModel.flowOn(Dispatchers.IO)`. `NSDateFormatter` is not thread-safe for concurrent `stringFromDate` calls per Apple docs. Guarded with `KmpLock` (cheaper than per-call allocation for the O(notes-per-thread-sort) call rate).

## Testing

### Local verification

<table>
  <thead>
    <tr><th>Command</th><th>Result</th></tr>
  </thead>
  <tbody>
    <tr><td><code>./gradlew :commons:compileKotlinIosSimulatorArm64 :commons:compileKotlinIosArm64</code></td><td>✅ pass</td></tr>
    <tr><td><code>./gradlew :quartz:iosSimulatorArm64Test</code></td><td>✅ pass</td></tr>
    <tr><td><code>./gradlew :commons:jvmTest :quartz:jvmTest</code></td><td>✅ pass (+20 new tests)</td></tr>
    <tr><td><code>./gradlew :quartz:verifyKmpPurity :commons:verifyKmpPurity spotlessCheck</code> (mirrors CI <code>lint</code> job)</td><td>✅ pass</td></tr>
    <tr><td><code>./gradlew clean &amp;&amp; ./gradlew :amethyst:installPlayBenchmark</code></td><td>✅ installed on Pixel 9a (Android 16) in 5m 48s</td></tr>
<tr><td><code>Manual on device smoke test</td><td>✅ pass</td></tr>
  </tbody>
</table>

### New tests (commit `1f74c4b35`)

<table>
  <thead>
    <tr><th>Test class</th><th>Count</th><th>Coverage</th></tr>
  </thead>
  <tbody>
    <tr>
      <td><code>CodePointsTest</code></td>
      <td>16 tests</td>
      <td>BMP / supplementary plane boundaries (U+0001 through U+10FFFF); <code>codePointToChars</code> producing correct surrogate pairs (e.g. U+1F600 😀 → <code>(0xD83D, 0xDE00)</code>); <code>String.codePointAtKmp</code> on ASCII, surrogate pairs, lone high surrogate at end-of-string (matches <code>java.lang.Character.codePointAt</code> behaviour), and low-half-of-pair indexing; <code>String.offsetByCodePointsKmp</code> advancing over BMP and supplementary characters; full round-trip across the code-point range.</td>
    </tr>
    <tr>
      <td><code>ChannelRelaysTest</code></td>
      <td>4 tests</td>
      <td>Locks in the behavior change in the ⚠️ section: empty channel returns empty set; single relay; multiple relays ordered descending by usage count; <strong>multiple relays with identical counts are all preserved</strong> (the new behavior; the old TreeSet would have dropped duplicates). Uses an inline <code>TestChannel</code> subclass since <code>Channel</code> is abstract.</td>
    </tr>
  </tbody>
</table>

### Test coverage gaps (acknowledged, not addressed in this PR)

<table>
  <thead>
    <tr><th>Area</th><th>Why skipped</th></tr>
  </thead>
  <tbody>
    <tr>
      <td><code>RobohashAssembler</code> / <code>LongFormPublishAction</code> <code>encodeToByteArray</code> swap</td>
      <td>Byte-identical to <code>toByteArray()</code> for UTF-8 on JVM. <code>LongFormPublishAction</code> testing requires a fake <code>NostrSigner</code>; <code>RobohashAssembler</code> output is an <code>ImageVector</code>. Low marginal value.</td>
    </tr>
    <tr>
      <td><code>FeedErrorState</code> <code>stringResource(res, args)</code> substitution</td>
      <td>Needs Compose UI test infrastructure not currently set up for <code>:commons</code>. Easy to verify manually by triggering a feed-load error.</td>
    </tr>
  </tbody>
</table>

## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.