### PR TITLE
fix(user-metadata): fall back to indexer relays when outbox is exhausted

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/user/watchers/FilterUserMetadataForKey.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/user/watchers/FilterUserMetadataForKey.kt
@@ -56,9 +56,20 @@ fun filterUserMetadataForKey(
     val perRelayUsers =
         mapOfSet {
             authors.forEach { key ->
+                val outbox = key.outboxRelays()
                 val relays =
-                    key.outboxRelays()
-                        ?: (key.allUsedRelays() + LocalCache.relayHints.hintsForKey(key.pubkeyHex) + indexRelays)
+                    when {
+                        outbox == null ->
+                            key.allUsedRelays() + LocalCache.relayHints.hintsForKey(key.pubkeyHex) + indexRelays
+                        // Outbox is published but exhausted (every relay either EOSE'd
+                        // or is known-unreachable) and metadata is still missing —
+                        // widen to indexers so a misconfigured outbox doesn't strand
+                        // the user's profile.
+                        key.metadataOrNull()?.flow?.value == null &&
+                            outbox.all { it in cannotConnectRelays || since.since(key)?.get(it) != null } ->
+                            outbox + indexRelays
+                        else -> outbox
+                    }
 
                 (relays - cannotConnectRelays).forEach {
                     add(it, key)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/user/watchers/UserWatcherSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/user/watchers/UserWatcherSubAssembler.kt
@@ -59,6 +59,9 @@ class UserWatcherSubAssembler(
                 }
             }
         }
+        // Re-evaluate filters: filterUserMetadataForKey may widen to indexer
+        // relays once a user's outbox is exhausted without yielding metadata.
+        invalidateFilters()
     }
 
     val sub =


### PR DESCRIPTION
If a user's NIP-65 outbox advertises only relays that don't hold their
kind 0, profile fetching used to give up after EOSE on those relays.
filterUserMetadataForKey now widens to the account's indexer relays
once every outbox relay has either EOSE'd or is in cannotConnectRelays
and metadata is still missing. UserWatcherSubAssembler invalidates
filters on EOSE so the fallback re-evaluates without waiting for an
unrelated trigger.