### PR TITLE
Add followed bookmarks home feed

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -93,6 +93,9 @@ sealed class TopFilter(
     object DefaultFollows : TopFilter(" Main User Follows ")
 
     @Serializable
+    object FollowedBookmarks : TopFilter(" Followed Bookmarks ")
+
+    @Serializable
     object AroundMe : TopFilter(" Around Me ")
 
     @Serializable

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/FeedTopNavFilterState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/FeedTopNavFilterState.kt
@@ -30,6 +30,7 @@ import com.vitorpamplona.amethyst.model.topNavFeeds.allUserFollows.AllUserFollow
 import com.vitorpamplona.amethyst.model.topNavFeeds.allUserFollows.Kind3UserFollowsFeedFlow
 import com.vitorpamplona.amethyst.model.topNavFeeds.aroundMe.AroundMeFeedFlow
 import com.vitorpamplona.amethyst.model.topNavFeeds.aroundMe.GeohashFeedFlow
+import com.vitorpamplona.amethyst.model.topNavFeeds.bookmarks.PublicBookmarksFeedFlow
 import com.vitorpamplona.amethyst.model.topNavFeeds.favoriteAlgoFeeds.AllFavoriteAlgoFeedsFlow
 import com.vitorpamplona.amethyst.model.topNavFeeds.favoriteAlgoFeeds.FavoriteAlgoFeedFlow
 import com.vitorpamplona.amethyst.model.topNavFeeds.global.GlobalFeedFlow
@@ -86,6 +87,10 @@ class FeedTopNavFilterState(
 
             TopFilter.DefaultFollows -> {
                 Kind3UserFollowsFeedFlow(kind3Follows, followsRelays, blockedRelays, proxyRelays)
+            }
+
+            TopFilter.FollowedBookmarks -> {
+                PublicBookmarksFeedFlow(kind3Follows, followsRelays, blockedRelays, proxyRelays, LocalCache)
             }
 
             TopFilter.AroundMe -> {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/bookmarks/PublicBookmarkFeedSnapshot.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/bookmarks/PublicBookmarkFeedSnapshot.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.model.topNavFeeds.bookmarks
+
+import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.quartz.nip01Core.core.Address
+import com.vitorpamplona.quartz.nip01Core.core.AddressableEvent
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
+import com.vitorpamplona.quartz.nip51Lists.bookmarkList.BookmarkListEvent
+import com.vitorpamplona.quartz.nip51Lists.bookmarkList.OldBookmarkListEvent
+import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.AddressBookmark
+import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.BookmarkIdTag
+import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.EventBookmark
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+
+@Immutable
+data class PublicBookmarkFeedSnapshot(
+    val eventIds: Set<HexKey> = emptySet(),
+    val addresses: Set<Address> = emptySet(),
+) {
+    fun matches(event: Event): Boolean =
+        event.id in eventIds ||
+            (event as? AddressableEvent)?.address() in addresses
+}
+
+val PublicBookmarkListKinds = listOf(BookmarkListEvent.KIND, OldBookmarkListEvent.KIND)
+
+fun publicBookmarkSnapshotForAuthors(
+    authors: Set<HexKey>,
+    cache: LocalCache,
+): PublicBookmarkFeedSnapshot {
+    if (authors.isEmpty()) return PublicBookmarkFeedSnapshot()
+
+    val eventIds = mutableSetOf<HexKey>()
+    val addresses = mutableSetOf<Address>()
+
+    authors.forEach { pubkey ->
+        val bookmarkList = cache.getOrCreateAddressableNote(BookmarkListEvent.createBookmarkAddress(pubkey)).event as? BookmarkListEvent
+        bookmarkList?.publicBookmarks()?.collectInto(eventIds, addresses)
+
+        val oldBookmarkList = cache.getOrCreateAddressableNote(OldBookmarkListEvent.createBookmarkAddress(pubkey)).event as? OldBookmarkListEvent
+        oldBookmarkList?.publicBookmarks()?.collectInto(eventIds, addresses)
+    }
+
+    return PublicBookmarkFeedSnapshot(eventIds, addresses)
+}
+
+fun publicBookmarkSnapshotFlow(
+    authors: Set<HexKey>,
+    cache: LocalCache,
+): kotlinx.coroutines.flow.Flow<PublicBookmarkFeedSnapshot> {
+    if (authors.isEmpty()) {
+        return flowOf(PublicBookmarkFeedSnapshot())
+    }
+
+    return cache
+        .observeEvents<Event>(
+            Filter(
+                kinds = PublicBookmarkListKinds,
+                authors = authors.sorted(),
+            ),
+        ).map {
+            publicBookmarkSnapshotForAuthors(authors, cache)
+        }.onStart {
+            emit(publicBookmarkSnapshotForAuthors(authors, cache))
+        }.distinctUntilChanged()
+}
+
+private fun List<BookmarkIdTag>.collectInto(
+    eventIds: MutableSet<HexKey>,
+    addresses: MutableSet<Address>,
+) {
+    forEach {
+        when (it) {
+            is EventBookmark -> eventIds.add(it.eventId)
+            is AddressBookmark -> addresses.add(it.address)
+        }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/bookmarks/PublicBookmarksFeedFlow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/bookmarks/PublicBookmarksFeedFlow.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.model.topNavFeeds.bookmarks
+
+import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.model.nip02FollowLists.Kind3FollowListState
+import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedFlowsType
+import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.transformLatest
+
+class PublicBookmarksFeedFlow(
+    val kind3Follows: StateFlow<Kind3FollowListState.Kind3Follows>,
+    val defaultRelays: StateFlow<Set<NormalizedRelayUrl>>,
+    val blockedRelays: StateFlow<Set<NormalizedRelayUrl>>,
+    val proxyRelays: StateFlow<Set<NormalizedRelayUrl>>,
+    val cache: LocalCache,
+) : IFeedFlowsType {
+    fun convert(
+        authors: Set<HexKey>,
+        proxyRelays: Set<NormalizedRelayUrl>,
+        snapshot: PublicBookmarkFeedSnapshot,
+    ): IFeedTopNavFilter =
+        if (proxyRelays.isEmpty()) {
+            PublicBookmarksByOutboxTopNavFilter(
+                authors = authors,
+                snapshot = snapshot,
+                defaultRelays = defaultRelays,
+                blockedRelays = blockedRelays,
+            )
+        } else {
+            PublicBookmarksByProxyTopNavFilter(
+                authors = authors,
+                snapshot = snapshot,
+                proxyRelays = proxyRelays,
+            )
+        }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun flow() =
+        combine(kind3Follows, proxyRelays) { follows, proxyRelays ->
+            follows.authors to proxyRelays
+        }.transformLatest { (authors, proxyRelays) ->
+            publicBookmarkSnapshotFlow(authors, cache).collect { snapshot ->
+                emit(convert(authors, proxyRelays, snapshot))
+            }
+        }
+
+    override fun startValue(): IFeedTopNavFilter =
+        convert(
+            authors = kind3Follows.value.authors,
+            proxyRelays = proxyRelays.value,
+            snapshot = publicBookmarkSnapshotForAuthors(kind3Follows.value.authors, cache),
+        )
+
+    override suspend fun startValue(collector: FlowCollector<IFeedTopNavFilter>) {
+        collector.emit(startValue())
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/bookmarks/PublicBookmarksTopNavFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/topNavFeeds/bookmarks/PublicBookmarksTopNavFilter.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.model.topNavFeeds.bookmarks
+
+import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
+import com.vitorpamplona.amethyst.model.topNavFeeds.OutboxRelayLoader
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+
+@Immutable
+class PublicBookmarksByOutboxTopNavFilter(
+    val authors: Set<HexKey>,
+    val snapshot: PublicBookmarkFeedSnapshot,
+    val defaultRelays: StateFlow<Set<NormalizedRelayUrl>>,
+    val blockedRelays: StateFlow<Set<NormalizedRelayUrl>>,
+) : IFeedTopNavFilter {
+    override fun matchAuthor(pubkey: HexKey): Boolean = false
+
+    override fun match(noteEvent: Event): Boolean = snapshot.matches(noteEvent)
+
+    override fun toPerRelayFlow(cache: LocalCache): Flow<PublicBookmarksTopNavPerRelayFilterSet> {
+        val authorsPerRelay = OutboxRelayLoader().toAuthorsPerRelayFlow(authors, cache) { it }
+
+        return combine(authorsPerRelay, defaultRelays, blockedRelays) { perRelayAuthors, default, blocked ->
+            convert(perRelayAuthors.minus(blocked).ifEmpty { default.associateWith { authors } })
+        }
+    }
+
+    override fun startValue(cache: LocalCache): PublicBookmarksTopNavPerRelayFilterSet {
+        val authorsPerRelay = OutboxRelayLoader().authorsPerRelaySnapshot(authors, cache) { it }
+
+        return convert(authorsPerRelay.minus(blockedRelays.value).ifEmpty { defaultRelays.value.associateWith { authors } })
+    }
+
+    private fun convert(authorsPerRelay: Map<NormalizedRelayUrl, Set<HexKey>>) =
+        PublicBookmarksTopNavPerRelayFilterSet(
+            authorsPerRelay.mapValues {
+                PublicBookmarksTopNavPerRelayFilter(
+                    bookmarkAuthors = it.value,
+                    eventIds = snapshot.eventIds,
+                    addresses = snapshot.addresses,
+                )
+            },
+        )
+}
+
+@Immutable
+class PublicBookmarksByProxyTopNavFilter(
+    val authors: Set<HexKey>,
+    val snapshot: PublicBookmarkFeedSnapshot,
+    val proxyRelays: Set<NormalizedRelayUrl>,
+) : IFeedTopNavFilter {
+    override fun matchAuthor(pubkey: HexKey): Boolean = false
+
+    override fun match(noteEvent: Event): Boolean = snapshot.matches(noteEvent)
+
+    override fun toPerRelayFlow(cache: LocalCache): Flow<PublicBookmarksTopNavPerRelayFilterSet> = kotlinx.coroutines.flow.flowOf(startValue(cache))
+
+    override fun startValue(cache: LocalCache): PublicBookmarksTopNavPerRelayFilterSet =
+        PublicBookmarksTopNavPerRelayFilterSet(
+            proxyRelays.associateWith {
+                PublicBookmarksTopNavPerRelayFilter(
+                    bookmarkAuthors = authors,
+                    eventIds = snapshot.eventIds,
+                    addresses = snapshot.addresses,
+                )
+            },
+        )
+}
+
+@Immutable
+class PublicBookmarksTopNavPerRelayFilterSet(
+    val set: Map<NormalizedRelayUrl, PublicBookmarksTopNavPerRelayFilter>,
+) : com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavPerRelayFilterSet
+
+@Immutable
+class PublicBookmarksTopNavPerRelayFilter(
+    val bookmarkAuthors: Set<HexKey>,
+    val eventIds: Set<HexKey>,
+    val addresses: Set<com.vitorpamplona.quartz.nip01Core.core.Address>,
+) : com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavPerRelayFilter

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/FeedFilterSpinner.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/FeedFilterSpinner.kt
@@ -533,6 +533,10 @@ private fun FeedIcon(
                 MaterialSymbols.Groups
             }
 
+            is TopFilter.FollowedBookmarks -> {
+                MaterialSymbols.Bookmark
+            }
+
             is TopFilter.MuteList -> {
                 MaterialSymbols.AutoMirrored.VolumeOff
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/TopNavFilterState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/TopNavFilterState.kt
@@ -76,6 +76,12 @@ class TopNavFilterState(
             name = ResourceName(R.string.follow_list_kind3_follows_users_only),
         )
 
+    val followedBookmarks =
+        FeedDefinition(
+            code = TopFilter.FollowedBookmarks,
+            name = ResourceName(R.string.follow_list_followed_bookmarks),
+        )
+
     val globalFollow =
         FeedDefinition(
             code = TopFilter.Global,
@@ -106,7 +112,7 @@ class TopNavFilterState(
             name = ResourceName(R.string.follow_list_all_favorite_dvms),
         )
 
-    val defaultLists = persistentListOf(allFollows, userFollows, kind3Follows, aroundMe, globalFollow, muteListFollow)
+    val defaultLists = persistentListOf(allFollows, userFollows, kind3Follows, followedBookmarks, aroundMe, globalFollow, muteListFollow)
 
     fun mergePeopleLists(
         peopleLists: List<AddressableNote>,
@@ -250,7 +256,7 @@ class TopNavFilterState(
             checkNotInMainThread()
             emit(
                 listOf(
-                    listOf(allFollows, userFollows, kind3Follows, aroundMe, globalFollow),
+                    listOf(allFollows, userFollows, kind3Follows, followedBookmarks, aroundMe, globalFollow),
                     peopleLists,
                     interests,
                     listOf(muteListFollow),
@@ -287,7 +293,7 @@ class TopNavFilterState(
             checkNotInMainThread()
             emit(
                 listOf(
-                    listOf(allFollows, userFollows, kind3Follows, aroundMe, globalFollow),
+                    listOf(allFollows, userFollows, kind3Follows, followedBookmarks, aroundMe, globalFollow),
                     peopleLists,
                     listOf(muteListFollow),
                 ).flatten().toImmutableList(),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/dal/HomeConversationsFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/dal/HomeConversationsFeedFilter.kt
@@ -42,7 +42,10 @@ import com.vitorpamplona.quartz.nipA4PublicMessages.PublicMessageEvent
 class HomeConversationsFeedFilter(
     val account: Account,
 ) : AdditiveFeedFilter<Note>() {
-    override fun feedKey(): String = account.userProfile().pubkeyHex + "-" + account.settings.defaultHomeFollowList.value
+    override fun feedKey(): String =
+        account.userProfile().pubkeyHex +
+            "-" + account.settings.defaultHomeFollowList.value.code +
+            "-" + account.liveHomeFollowLists.value.hashCode()
 
     override fun showHiddenKey(): Boolean =
         account.liveHomeFollowLists.value is MutedAuthorsByOutboxTopNavFilter ||

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/dal/HomeEverythingFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/dal/HomeEverythingFeedFilter.kt
@@ -39,7 +39,10 @@ class HomeEverythingFeedFilter(
     private val newThreads = HomeNewThreadFeedFilter(account)
     private val conversations = HomeConversationsFeedFilter(account)
 
-    override fun feedKey(): String = account.userProfile().pubkeyHex + "-" + account.settings.defaultHomeFollowList.value
+    override fun feedKey(): String =
+        account.userProfile().pubkeyHex +
+            "-" + account.settings.defaultHomeFollowList.value.code +
+            "-" + account.liveHomeFollowLists.value.hashCode()
 
     override fun showHiddenKey(): Boolean =
         account.liveHomeFollowLists.value is MutedAuthorsByOutboxTopNavFilter ||

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/dal/HomeLiveFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/dal/HomeLiveFilter.kt
@@ -48,7 +48,10 @@ import com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.tags.StatusTag
 class HomeLiveFilter(
     val account: Account,
 ) : AdditiveComplexFeedFilter<Channel, Note>() {
-    override fun feedKey(): String = account.userProfile().pubkeyHex + "-" + account.settings.defaultHomeFollowList.value
+    override fun feedKey(): String =
+        account.userProfile().pubkeyHex +
+            "-" + account.settings.defaultHomeFollowList.value.code +
+            "-" + account.liveHomeFollowLists.value.hashCode()
 
     override fun showHiddenKey(): Boolean = false
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/dal/HomeNewThreadFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/dal/HomeNewThreadFeedFilter.kt
@@ -66,7 +66,10 @@ class HomeNewThreadFeedFilter(
             )
     }
 
-    override fun feedKey(): String = account.userProfile().pubkeyHex + "-" + account.settings.defaultHomeFollowList.value
+    override fun feedKey(): String =
+        account.userProfile().pubkeyHex +
+            "-" + account.settings.defaultHomeFollowList.value.code +
+            "-" + account.liveHomeFollowLists.value.hashCode()
 
     override fun showHiddenKey(): Boolean =
         account.liveHomeFollowLists.value is MutedAuthorsByOutboxTopNavFilter ||

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/datasource/nip51Bookmarks/FilterHomePostsByPublicBookmarks.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/datasource/nip51Bookmarks/FilterHomePostsByPublicBookmarks.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip51Bookmarks
+
+import com.vitorpamplona.amethyst.model.topNavFeeds.bookmarks.PublicBookmarkListKinds
+import com.vitorpamplona.amethyst.model.topNavFeeds.bookmarks.PublicBookmarksTopNavPerRelayFilterSet
+import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
+import com.vitorpamplona.quartz.nip01Core.core.Address
+import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
+import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+
+private const val ID_CHUNK_SIZE = 200
+
+fun filterHomePostsByPublicBookmarks(
+    bookmarkSet: PublicBookmarksTopNavPerRelayFilterSet,
+    since: SincePerRelayMap?,
+): List<RelayBasedFilter> {
+    if (bookmarkSet.set.isEmpty()) return emptyList()
+
+    return bookmarkSet.set.flatMap { (relay, filter) ->
+        val relaySince = since?.get(relay)?.time
+
+        filterBookmarkLists(relay, filter.bookmarkAuthors, relaySince) +
+            filterBookmarkEvents(relay, filter.eventIds) +
+            filterBookmarkAddressables(relay, filter.addresses)
+    }
+}
+
+private fun filterBookmarkLists(
+    relay: NormalizedRelayUrl,
+    authors: Set<String>,
+    since: Long?,
+): List<RelayBasedFilter> {
+    if (authors.isEmpty()) return emptyList()
+
+    return listOf(
+        RelayBasedFilter(
+            relay = relay,
+            filter =
+                Filter(
+                    kinds = PublicBookmarkListKinds,
+                    authors = authors.sorted(),
+                    since = since,
+                    limit = authors.size * PublicBookmarkListKinds.size,
+                ),
+        ),
+    )
+}
+
+private fun filterBookmarkEvents(
+    relay: NormalizedRelayUrl,
+    ids: Set<String>,
+): List<RelayBasedFilter> =
+    ids
+        .sorted()
+        .chunked(ID_CHUNK_SIZE)
+        .map {
+            RelayBasedFilter(
+                relay = relay,
+                filter =
+                    Filter(
+                        ids = it,
+                        limit = it.size,
+                    ),
+            )
+        }
+
+private fun filterBookmarkAddressables(
+    relay: NormalizedRelayUrl,
+    addresses: Set<Address>,
+): List<RelayBasedFilter> =
+    addresses.map { address ->
+        RelayBasedFilter(
+            relay = relay,
+            filter =
+                if (address.kind < 25000 && address.dTag.isBlank()) {
+                    Filter(
+                        kinds = listOf(address.kind),
+                        authors = listOf(address.pubKeyHex),
+                        limit = 1,
+                    )
+                } else {
+                    Filter(
+                        kinds = listOf(address.kind),
+                        tags = mapOf("d" to listOf(address.dTag)),
+                        authors = listOf(address.pubKeyHex),
+                        limit = 1,
+                    )
+                },
+        )
+    }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/datasource/nip65Follows/HomeOutboxEventsEoseManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/datasource/nip65Follows/HomeOutboxEventsEoseManager.kt
@@ -24,6 +24,7 @@ import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.model.topNavFeeds.allFollows.AllFollowsTopNavPerRelayFilterSet
 import com.vitorpamplona.amethyst.model.topNavFeeds.aroundMe.LocationTopNavPerRelayFilterSet
+import com.vitorpamplona.amethyst.model.topNavFeeds.bookmarks.PublicBookmarksTopNavPerRelayFilterSet
 import com.vitorpamplona.amethyst.model.topNavFeeds.favoriteAlgoFeeds.FavoriteAlgoFeedTopNavPerRelayFilterSet
 import com.vitorpamplona.amethyst.model.topNavFeeds.global.GlobalTopNavPerRelayFilterSet
 import com.vitorpamplona.amethyst.model.topNavFeeds.hashtag.HashtagTopNavPerRelayFilterSet
@@ -39,6 +40,7 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip01Core.f
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip01Core.filterHomePostsByGlobal
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip01Core.filterHomePostsByHashtags
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip01Core.filterHomePostsByRelay
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip51Bookmarks.filterHomePostsByPublicBookmarks
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip72Communities.filterHomePostsByAllCommunities
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip72Communities.filterHomePostsByCommunity
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.home.datasource.nip90AlgoFeeds.filterHomePostsByAlgoFeedIds
@@ -71,6 +73,7 @@ class HomeOutboxEventsEoseManager(
             is HashtagTopNavPerRelayFilterSet -> filterHomePostsByHashtags(feedSettings, since, newThreadSince)
             is LocationTopNavPerRelayFilterSet -> filterHomePostsByGeohashes(feedSettings, since, newThreadSince)
             is MutedAuthorsTopNavPerRelayFilterSet -> filterHomePostsByAuthors(feedSettings, since, newThreadSince, repliesSince)
+            is PublicBookmarksTopNavPerRelayFilterSet -> filterHomePostsByPublicBookmarks(feedSettings, since)
             is RelayTopNavPerRelayFilterSet -> filterHomePostsByRelay(feedSettings, since, newThreadSince, repliesSince)
             is SingleCommunityTopNavPerRelayFilterSet -> filterHomePostsByCommunity(feedSettings, since, newThreadSince)
             is FavoriteAlgoFeedTopNavPerRelayFilterSet -> filterHomePostsByAlgoFeedIds(feedSettings, since, newThreadSince)

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -982,6 +982,7 @@
     <string name="follow_list_kind3follows_users_only">All User Follows</string>
     <string name="follow_list_kind3_follows_users_only">Default Follow List</string>
     <string name="follow_list_kind3follows_proxy">Follows via Proxy</string>
+    <string name="follow_list_followed_bookmarks">Follows\' Bookmarks</string>
     <string name="follow_list_aroundme">Around Me</string>
     <string name="follow_list_global">Global</string>
     <string name="follow_list_chess">Chess</string>


### PR DESCRIPTION
## Summary
- Add a home top-nav feed for public notes bookmarked by followed users.
- Load followed users public NIP-51 bookmark lists and match bookmarked event IDs/addressable notes locally.
- Query bookmark lists and bookmarked targets per relay so the feed can hydrate missing notes.

Fixes #1342

## Validation
- Pre-commit Spotless check passed.
- F-Droid debug Kotlin compile passed: ./gradlew :amethyst:compileFdroidDebugKotlin.
- Pre-push tests passed.

Bounty note: this addresses the 5k sats request in #1342. I can provide a Lightning invoice if accepted.