### PR TITLE
feat(profile): toast when no app handles a payment target scheme

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/DisplayPaymentTargets.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/header/DisplayPaymentTargets.kt
@@ -89,7 +89,7 @@ fun DisplayPaymentTargets(
                     verticalArrangement = Arrangement.spacedBy(6.dp),
                     modifier = Modifier.padding(vertical = 4.dp),
                 ) {
-                    targets.forEach { target -> PaymentTargetChip(target) }
+                    targets.forEach { target -> PaymentTargetChip(target, accountViewModel) }
                 }
             }
         }
@@ -97,7 +97,10 @@ fun DisplayPaymentTargets(
 }
 
 @Composable
-private fun PaymentTargetChip(target: PaymentTarget) {
+private fun PaymentTargetChip(
+    target: PaymentTarget,
+    accountViewModel: AccountViewModel,
+) {
     val style = remember(target.type) { paymentTargetStyleFor(target.type) }
     val uriHandler = LocalUriHandler.current
     val context = LocalContext.current
@@ -114,6 +117,13 @@ private fun PaymentTargetChip(target: PaymentTarget) {
             Modifier.combinedClickable(
                 onClick = {
                     runCatching { uriHandler.openUri(style.uriFor(target.authority)) }
+                        .onFailure {
+                            accountViewModel.toastManager.toast(
+                                R.string.error_dialog_payment_error,
+                                R.string.no_payment_app_found_for_type,
+                                style.label,
+                            )
+                        }
                 },
                 onLongClick = {
                     scope.launch {

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -950,6 +950,7 @@
     <string name="payment_target_authority">Address</string>
     <string name="delete_payment_target">Delete payment target</string>
     <string name="no_payment_app_found">No app found to handle this payment. Please install a compatible wallet.</string>
+    <string name="no_payment_app_found_for_type">No app installed to handle %1$s payments. Please install a compatible wallet.</string>
     <string name="error_dialog_payment_error">Unable to open payment</string>
 
     <string name="uploading_state_ready">Not Started</string>


### PR DESCRIPTION
feat(profile): toast when no app handles a payment target scheme
Tapping a chip silently failed if no installed app handled the
type-specific URI scheme (bitcoin:, ethereum:, monero:, etc.).
Surface that case through the existing toastManager so users know
to install a compatible wallet.