### PR TITLE
fix(playback): hide video controls while the error overlay is shown

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/RenderVideoPlayer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/RenderVideoPlayer.kt
@@ -142,7 +142,7 @@ fun RenderVideoPlayer(
             hasBlurhash = hasBlurhash,
         )
 
-        if (showControls) {
+        if (showControls && controllerState.playbackError.value == null) {
             TopGradientOverlay(
                 controllerVisible = controllerVisible,
                 modifier = Modifier.align(Alignment.TopCenter),


### PR DESCRIPTION
Tapping the player while the codec-not-supported overlay is up would still
toggle the gradients/buttons in. Gate the controls block on a clear error
state so the overlay stays the only thing on screen.