### PR TITLE
Fix route hint re-firing on activity recreation

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/AccountScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/AccountScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -119,10 +120,14 @@ fun LoggedInSetup(
     state: AccountState.LoggedIn,
     accountSessionManager: AccountSessionManager,
 ) {
+    // Consume the one-shot route hint set by sign-in/account-switch so it
+    // can't re-fire when LoggedInPage re-composes after activity recreation
+    // (rotation, dark-mode toggle, returning from background).
+    val initialRoute = remember(state) { state.route.also { state.route = null } }
     SetAccountCentricViewModelStore(state) {
         LoggedInPage(
             account = state.account,
-            route = state.route,
+            route = initialRoute,
             accountSessionManager = accountSessionManager,
         )
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/LoggedInPage.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/LoggedInPage.kt
@@ -75,7 +75,9 @@ fun LoggedInPage(
                 ),
         )
 
-    accountViewModel.firstRoute = route
+    LaunchedEffect(Unit) {
+        accountViewModel.firstRoute = route
+    }
 
     // Adds this account to the authentication procedures for relays.
     RelayAuthSubscription(accountViewModel)


### PR DESCRIPTION
## Summary

Fix a bug where navigation route hints set during sign-in or account-switch would re-fire when `LoggedInPage` recomposes after activity recreation (rotation, dark-mode toggle, returning from background). The route is now consumed once in `LoggedInSetup` using `remember`, and passed as a stable parameter to `LoggedInPage`. The assignment to `accountViewModel.firstRoute` is also moved into a `LaunchedEffect` to ensure it only runs once per route change.

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes / screenshots:

1. Sign in or switch accounts and verify the initial route (e.g., deep link or specific screen) fires once
2. Rotate the device or toggle dark mode while on the routed screen — verify the route does not re-fire and the app stays on the current screen
3. Return from background — verify the route does not re-fire

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

https://claude.ai/code/session_01SaWh5gVk3GZsuNh8sdTbQa