### PR TITLE
Use distinct icons for password visibility toggle

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/NamecoinSettingsSection.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/NamecoinSettingsSection.kt
@@ -1028,7 +1028,7 @@ private fun NamecoinCoreRpcSection(
             trailingIcon = {
                 IconButton(onClick = { passVisible = !passVisible }) {
                     Icon(
-                        if (passVisible) MaterialSymbols.Lock else MaterialSymbols.Lock,
+                        if (passVisible) MaterialSymbols.VisibilityOff else MaterialSymbols.Visibility,
                         contentDescription = null,
                     )
                 }


### PR DESCRIPTION
@mstrofnone was this a bug?

The trailing icon used MaterialSymbols.Lock in both branches of the visibility conditional, making it a no-op. Switch to Visibility / VisibilityOff to match the AccountBackupScreen convention.

## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
