### PR TITLE
Route quoted-note loading through the author's NIP-65 outbox

### DIFF
--- a/amethyst/build.gradle.kts
+++ b/amethyst/build.gradle.kts
@@ -8,10 +8,11 @@ plugins {
     alias(libs.plugins.googleKsp)
 }
 
-fun getCurrentBranch(): String =
+fun getCurrentBranch(workingDir: java.io.File): String =
     try {
         val process =
             ProcessBuilder("git", "rev-parse", "--abbrev-ref", "HEAD")
+                .directory(workingDir)
                 .redirectErrorStream(true)
                 .start()
         val branch =
@@ -19,15 +20,18 @@ fun getCurrentBranch(): String =
                 .bufferedReader()
                 .use { it.readText() }
                 .trim()
-        process.waitFor()
-        branch
+        val exitCode = process.waitFor()
+        if (exitCode != 0) "unknown" else branch
     } catch (e: Exception) {
         println("Could not determine git branch: ${e.message}")
         "unknown"
     }
 
-fun generateVersionName(baseVersion: String): String {
-    val currentBranch = getCurrentBranch()
+fun generateVersionName(
+    baseVersion: String,
+    workingDir: java.io.File,
+): String {
+    val currentBranch = getCurrentBranch(workingDir)
 
     if (currentBranch == "main" || currentBranch == "master" || currentBranch == "unknown" || currentBranch == "HEAD") {
         return baseVersion
@@ -73,7 +77,7 @@ android {
                 .get()
                 .toInt()
         versionCode = 447
-        versionName = generateVersionName(libs.versions.app.get())
+        versionName = generateVersionName(libs.versions.app.get(), rootDir)
         buildConfigField("String", "RELEASE_NOTES_ID", "\"8ec0d94550b5538115226c6858159b1115713c9c6ed942173bd4fd5d292d8ba6\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -117,6 +117,7 @@ import com.vitorpamplona.quartz.nip17Dm.messages.ChatMessageEvent
 import com.vitorpamplona.quartz.nip17Dm.settings.ChatMessageRelayListEvent
 import com.vitorpamplona.quartz.nip18Reposts.GenericRepostEvent
 import com.vitorpamplona.quartz.nip18Reposts.RepostEvent
+import com.vitorpamplona.quartz.nip18Reposts.quotes.QuotedEventAuthorHints
 import com.vitorpamplona.quartz.nip19Bech32.Nip19Parser
 import com.vitorpamplona.quartz.nip19Bech32.decodeEventIdAsHexOrNull
 import com.vitorpamplona.quartz.nip19Bech32.decodePublicKeyAsHexOrNull
@@ -333,6 +334,33 @@ object LocalCache : ILocalCache, ICacheProvider {
     var lnurlEndpointResolver: LnurlEndpointResolver? = null
 
     val relayHints = HintIndexer()
+
+    // Strong-ref hint map: quoted-event id -> author pubkey, extracted from
+    // host-event tag sets via QuotedEventAuthorHints. We can't store this on
+    // the Note placeholder itself because Notes live in a WeakReference-backed
+    // cache (LargeSoftCache); a hint written there can be GC'd before the
+    // missing-event loader consults it. The map gives outbox routing a
+    // survivable backref to the quoted author's NIP-65, without surfacing the
+    // hinted (unverified) author to UI components that read note.author.
+    // Entries are evicted in [justConsumeAndUpdateIndexes] once the real event
+    // arrives, which both contains map growth and naturally invalidates any
+    // attacker-forged hint when the verified author signature lands.
+    val quotedAuthorHints = LargeCache<HexKey, HexKey>()
+
+    // Strong-ref pin for the NIP-65 [AddressableNote] of hinted authors.
+    // [LocalCache.addressables] is a WeakReference-backed cache; an unpinned
+    // AddressableNote (and the [AdvertisedRelayListEvent] it carries) is
+    // reclaimed once the User reference is GC'd. Pinning just the NIP-65
+    // AddressableNote keeps the relay list alive for outbox routing without
+    // dragging the full User object graph (metadata/reports/cards/etc.) along.
+    val quotedAuthorPins = LargeCache<HexKey, Note>()
+
+    // Per-hinted-author last-attempt timestamp (epoch seconds) for the
+    // kind-10002 backfill in [filterMissingQuotedAuthorNip65]. Without this,
+    // NoteEventLoaderSubAssembler's invalidateAfterEose=true re-issues the
+    // same kind-10002 fan-out every loader tick for authors whose NIP-65
+    // simply isn't on the default indexer/search relays.
+    val quotedAuthorNip65Attempts = LruCache<HexKey, Long>(500)
 
     val deletionIndex = DeletionIndex()
 
@@ -2918,6 +2946,14 @@ object LocalCache : ILocalCache, ICacheProvider {
 
         if (wasNew) {
             updateHintIndexes(event)
+            populateCitationAuthorHints(event)
+            // Evict any hint that pointed at this event id: the actual
+            // signed event has now arrived, so [event.pubKey] is the
+            // verified author and the hint (which may have been forged or
+            // wrong about positional pairing) is no longer needed. Bounds
+            // map growth and invalidates attacker-poisoned routing entries
+            // as soon as the legitimate copy lands.
+            quotedAuthorHints.remove(event.id)
         }
 
         if (relay != null) {
@@ -2977,6 +3013,34 @@ object LocalCache : ILocalCache, ICacheProvider {
         if (event is PubKeyHintProvider) {
             event.pubKeyHints().forEach {
                 relayHints.addKey(it.pubkey, it.relay)
+            }
+        }
+    }
+
+    // Records quoted-event author hints in the strong-ref [quotedAuthorHints]
+    // map so the missing-event loader can route the fetch through the quoted
+    // author's NIP-65 outbox even when the Note placeholder has been GC'd.
+    //
+    // Does NOT write to `note.author` — that would (a) be lost the moment GC
+    // clears the WeakReference-backed Note, and (b) surface an unverified
+    // attacker-claimed identity to UI components.
+    //
+    // Gated to BaseNoteEvent. NIP-17 DMs were originally included, but
+    // [quotedAuthorHints] is a process-global singleton — hints written from
+    // account A's DMs would seed routing for account B in the same process.
+    // Replaceable list events, labels, raids etc. also carry `mention`-marked
+    // tags but with different meanings, so they're excluded too.
+    private fun populateCitationAuthorHints(event: Event) {
+        if (event !is BaseNoteEvent) return
+        QuotedEventAuthorHints.collect(event.tags).forEach { hint ->
+            quotedAuthorHints.getOrCreate(hint.eventId) { hint.authorPubKey }
+            // Pin the NIP-65 AddressableNote so the chain
+            // AddressableNote → AdvertisedRelayListEvent survives GC. The
+            // surrounding User WeakRef can be reclaimed safely — the next
+            // [getOrCreateUser] call will re-attach to this same pinned
+            // AddressableNote because [addressables] is keyed by Address.
+            checkGetOrCreateUser(hint.authorPubKey)?.let { user ->
+                quotedAuthorPins.getOrCreate(hint.authorPubKey) { user.nip65RelayListNote }
             }
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/loaders/FilterMissingAddressables.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/loaders/FilterMissingAddressables.kt
@@ -93,7 +93,8 @@ fun filterMissingAddressables(keys: List<EventFinderQueryState>): List<RelayBase
             }
         }
 
-    return filterMissingAddressables(addressesPerRelay)
+    return filterMissingAddressables(addressesPerRelay) +
+        filterMissingAddressableAuthorNip65(keys.asSequence().map { it.note })
 }
 
 fun filterMissingAddressables(missingAddressables: Map<NormalizedRelayUrl, Set<Address>>): List<RelayBasedFilter> {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/loaders/FilterMissingEvents.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/loaders/FilterMissingEvents.kt
@@ -132,19 +132,41 @@ fun filterMissingEvents(keys: List<EventFinderQueryState>): List<RelayBasedFilte
 private const val NIP65_RETRY_BACKOFF_SECONDS = 300L
 
 fun filterMissingQuotedAuthorNip65(notes: Sequence<Note>): List<RelayBasedFilter> {
-    val now = TimeUtils.now()
-    val needed = mutableSetOf<HexKey>()
+    val authors = mutableSetOf<HexKey>()
     notes.forEach { note ->
         if (note !is AddressableNote && note.event == null) {
-            val hintAuthor = LocalCache.quotedAuthorHints.get(note.idHex)
-            if (hintAuthor != null &&
-                LocalCache.getUserIfExists(hintAuthor)?.outboxRelays().isNullOrEmpty() &&
-                shouldRetryNip65Fetch(hintAuthor, now)
-            ) {
-                needed.add(hintAuthor)
-            }
+            LocalCache.quotedAuthorHints.get(note.idHex)?.let { authors.add(it) }
         }
     }
+    return emitNip65BackfillForUnresolvedAuthors(authors)
+}
+
+// The addressable counterpart: an unresolved AddressableNote already carries
+// its author in the address (kind:pubkey:d), but the outbox lookup in
+// [potentialRelaysToFindAddress] still depends on the author's NIP-65 being
+// cached. When it isn't, the fetch falls back to the user's own write
+// relays and misses bridged / long-tail authors. This emits the same
+// kind-10002 backfill we use for event-id quotes, sharing the throttle
+// (LocalCache.quotedAuthorNip65Attempts) so a single session can't fan out
+// indefinitely against indexer/search relays.
+fun filterMissingAddressableAuthorNip65(notes: Sequence<Note>): List<RelayBasedFilter> {
+    val authors = mutableSetOf<HexKey>()
+    notes.forEach { note ->
+        if (note is AddressableNote && note.event == null) {
+            authors.add(note.address.pubKeyHex)
+        }
+    }
+    return emitNip65BackfillForUnresolvedAuthors(authors)
+}
+
+private fun emitNip65BackfillForUnresolvedAuthors(authors: Set<HexKey>): List<RelayBasedFilter> {
+    if (authors.isEmpty()) return emptyList()
+    val now = TimeUtils.now()
+    val needed =
+        authors.filterTo(mutableSetOf()) {
+            LocalCache.getUserIfExists(it)?.outboxRelays().isNullOrEmpty() &&
+                shouldRetryNip65Fetch(it, now)
+        }
     if (needed.isEmpty()) return emptyList()
 
     needed.forEach { LocalCache.quotedAuthorNip65Attempts.put(it, now) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/loaders/FilterMissingEvents.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/loaders/FilterMissingEvents.kt
@@ -20,13 +20,18 @@
  */
 package com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders
 
+import com.vitorpamplona.amethyst.commons.defaults.DefaultIndexerRelayList
+import com.vitorpamplona.amethyst.commons.defaults.DefaultSearchRelayList
 import com.vitorpamplona.amethyst.model.AddressableNote
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.EventFinderQueryState
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip65RelayList.AdvertisedRelayListEvent
+import com.vitorpamplona.quartz.utils.TimeUtils
 import com.vitorpamplona.quartz.utils.mapOfSet
 
 fun potentialRelaysToFindEvent(note: Note): Set<NormalizedRelayUrl> {
@@ -34,7 +39,15 @@ fun potentialRelaysToFindEvent(note: Note): Set<NormalizedRelayUrl> {
 
     set.addAll(LocalCache.relayHints.hintsForEvent(note.idHex))
 
-    note.author?.outboxRelays()?.let { set.addAll(it) }
+    val outboxFromNote = note.author?.outboxRelays()
+    if (outboxFromNote != null) {
+        set.addAll(outboxFromNote)
+    } else {
+        val hintAuthor = LocalCache.quotedAuthorHints.get(note.idHex)
+        if (hintAuthor != null) {
+            LocalCache.checkGetOrCreateUser(hintAuthor)?.outboxRelays()?.let { set.addAll(it) }
+        }
+    }
 
     LocalCache.getAnyChannel(note)?.relays()?.let { set.addAll(it) }
 
@@ -96,7 +109,62 @@ fun filterMissingEvents(keys: List<EventFinderQueryState>): List<RelayBasedFilte
             }
         }
 
-    return filterMissingEvents(eventsPerRelay)
+    return filterMissingEvents(eventsPerRelay) + filterMissingQuotedAuthorNip65(keys.asSequence().map { it.note })
+}
+
+// When a missing-event note has a quoted-author hint but the hinted author's
+// NIP-65 hasn't resolved to a usable outbox yet, emit a parallel kind-10002
+// filter against the default indexer + search relays. The hint alone is
+// useless until outboxRelays() can resolve — this is what closes the loop
+// for Momostr-bridged quoted notes whose author writes only to
+// relay.momostr.pink.
+//
+// The gate matches the consumer ([potentialRelaysToFindEvent] reads
+// [outboxRelays] not [authorRelayList]): a read-only NIP-65 satisfies
+// `authorRelayList() != null` but yields no write relays, so the gate has
+// to track the same null-or-empty outbox condition the consumer sees.
+//
+// Retry suppression: NoteEventLoaderSubAssembler uses invalidateAfterEose,
+// so updateFilter runs on every EOSE — without backoff the same kind-10002
+// fan-out fires forever for bridged authors whose NIP-65 isn't on the
+// default indexer/search relays. We record per-author last-attempt time
+// and skip authors attempted within [NIP65_RETRY_BACKOFF_SECONDS].
+private const val NIP65_RETRY_BACKOFF_SECONDS = 300L
+
+fun filterMissingQuotedAuthorNip65(notes: Sequence<Note>): List<RelayBasedFilter> {
+    val now = TimeUtils.now()
+    val needed = mutableSetOf<HexKey>()
+    notes.forEach { note ->
+        if (note !is AddressableNote && note.event == null) {
+            val hintAuthor = LocalCache.quotedAuthorHints.get(note.idHex)
+            if (hintAuthor != null &&
+                LocalCache.getUserIfExists(hintAuthor)?.outboxRelays().isNullOrEmpty() &&
+                shouldRetryNip65Fetch(hintAuthor, now)
+            ) {
+                needed.add(hintAuthor)
+            }
+        }
+    }
+    if (needed.isEmpty()) return emptyList()
+
+    needed.forEach { LocalCache.quotedAuthorNip65Attempts.put(it, now) }
+
+    val sorted = needed.sorted()
+    val relays = (DefaultIndexerRelayList + DefaultSearchRelayList)
+    return relays.map { relay ->
+        RelayBasedFilter(
+            relay = relay,
+            filter = Filter(kinds = listOf(AdvertisedRelayListEvent.KIND), authors = sorted),
+        )
+    }
+}
+
+private fun shouldRetryNip65Fetch(
+    author: HexKey,
+    nowSec: Long,
+): Boolean {
+    val last = LocalCache.quotedAuthorNip65Attempts.get(author) ?: return true
+    return nowSec - last >= NIP65_RETRY_BACKOFF_SECONDS
 }
 
 fun filterMissingEvents(missingEventIds: Map<NormalizedRelayUrl, Set<String>>): List<RelayBasedFilter> {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/searchCommand/subassemblies/FilterByEvent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/searchCommand/subassemblies/FilterByEvent.kt
@@ -23,6 +23,7 @@ package com.vitorpamplona.amethyst.service.relayClient.searchCommand.subassembli
 import com.vitorpamplona.amethyst.model.AddressableNote
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.filterMissingEvents
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.filterMissingQuotedAuthorNip65
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.potentialRelaysToFindEvent
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
@@ -53,5 +54,8 @@ fun filterByEvent(
             }
         }
 
-    return filterMissingEvents(list)
+    return filterMissingEvents(list) +
+        filterMissingQuotedAuthorNip65(
+            sequenceOf(note) + (note.replyTo?.asSequence() ?: emptySequence()),
+        )
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/datasources/subassembies/FilterMissingEventsForThread.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/datasources/subassembies/FilterMissingEventsForThread.kt
@@ -22,6 +22,7 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.threadview.datasources.sub
 
 import com.vitorpamplona.amethyst.commons.model.ThreadAssembler
 import com.vitorpamplona.amethyst.model.AddressableNote
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.filterMissingAddressableAuthorNip65
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.filterMissingAddressables
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.filterMissingEvents
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.filterMissingQuotedAuthorNip65
@@ -72,10 +73,9 @@ fun filterMissingEventsForThread(
 
     val missingEventsFilter = filterMissingEvents(missingEvents)
     val missingAddressFilter = filterMissingAddressables(missingAddresses)
-    val missingQuotedAuthorNip65 =
-        filterMissingQuotedAuthorNip65(
-            sequenceOf(threadInfo.root) + threadInfo.allNotes.asSequence(),
-        )
+    val threadNotes = sequenceOf(threadInfo.root) + threadInfo.allNotes.asSequence()
+    val missingQuotedAuthorNip65 = filterMissingQuotedAuthorNip65(threadNotes)
+    val missingAddressableAuthorNip65 = filterMissingAddressableAuthorNip65(threadNotes)
 
-    return missingEventsFilter + missingAddressFilter + missingQuotedAuthorNip65
+    return missingEventsFilter + missingAddressFilter + missingQuotedAuthorNip65 + missingAddressableAuthorNip65
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/datasources/subassembies/FilterMissingEventsForThread.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/datasources/subassembies/FilterMissingEventsForThread.kt
@@ -24,6 +24,7 @@ import com.vitorpamplona.amethyst.commons.model.ThreadAssembler
 import com.vitorpamplona.amethyst.model.AddressableNote
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.filterMissingAddressables
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.filterMissingEvents
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.filterMissingQuotedAuthorNip65
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.potentialRelaysToFindAddress
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.potentialRelaysToFindEvent
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
@@ -71,6 +72,10 @@ fun filterMissingEventsForThread(
 
     val missingEventsFilter = filterMissingEvents(missingEvents)
     val missingAddressFilter = filterMissingAddressables(missingAddresses)
+    val missingQuotedAuthorNip65 =
+        filterMissingQuotedAuthorNip65(
+            sequenceOf(threadInfo.root) + threadInfo.allNotes.asSequence(),
+        )
 
-    return missingEventsFilter + missingAddressFilter
+    return missingEventsFilter + missingAddressFilter + missingQuotedAuthorNip65
 }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip18Reposts/quotes/QuotedEventAuthorHints.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip18Reposts/quotes/QuotedEventAuthorHints.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip18Reposts.quotes
+
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip10Notes.tags.MarkedETag
+import com.vitorpamplona.quartz.utils.Hex
+
+/**
+ * Extracts (event-id, author-pubkey) hints for events that this event quotes,
+ * by reading only the tag set — no content parsing, no signature check.
+ *
+ * The output lets a client populate the author slot of a quoted-note
+ * placeholder before the quoted event itself has been fetched. That author
+ * is what unlocks NIP-65 outbox routing for the fetch — without it, clients
+ * fall back to the user's own write relays and miss notes that live on the
+ * quoted author's relays (e.g. Momostr-bridged accounts whose only write
+ * relay is `relay.momostr.pink`).
+ *
+ * Three recognised forms, applied in priority order:
+ *  - NIP-18 q-tag with inline pubkey: `["q", "<id>", "<relay>", "<pubkey>"]`
+ *  - NIP-10 e-tag with mention marker and inline pubkey:
+ *    `["e", "<id>", "<relay>", "mention", "<pubkey>"]`
+ *  - NIP-10 paired e-mention + p-mention tags, only when there is exactly
+ *    one of each. NIP-10 makes no positional-pairing guarantee, so we only
+ *    trust the pairing in the unambiguous single-quote case — which is what
+ *    Momostr-bridged quote posts emit and what causes the original bug.
+ *
+ * All hex ids are validated as 64-char hex (Hex.isHex64) before being
+ * emitted — a 64-char garbage value otherwise crashes downstream callers
+ * that `require(isValidHex(...))` (e.g. LocalCache.getOrCreateNote).
+ *
+ * Output is deduplicated by event id, first-write-wins, so the priority
+ * order above is respected when a single event id is hinted from multiple
+ * tag forms.
+ */
+object QuotedEventAuthorHints {
+    data class Hint(
+        val eventId: HexKey,
+        val authorPubKey: HexKey,
+    )
+
+    fun collect(tags: Array<Array<String>>): List<Hint> {
+        val out = LinkedHashMap<HexKey, HexKey>()
+
+        // 1) NIP-18 q-tags with inline author
+        for (tag in tags) {
+            if (tag.size >= 4 &&
+                tag[0] == "q" &&
+                isValidHexKey(tag[1]) &&
+                isValidHexKey(tag[3])
+            ) {
+                if (!out.containsKey(tag[1])) out[tag[1]] = tag[3]
+            }
+        }
+
+        // Parse all NIP-10 e-tags via MarkedETag so we inherit every layout
+        // variant the upstream parser accepts — including the swapped form
+        // `["e","<id>","<relay>","<pubkey>","mention"]` that the hand-rolled
+        // index checks used to miss. parseAllThreadTags is the lenient parser
+        // (it doesn't require a non-empty relay slot, which is the Momostr
+        // bridge shape).
+        val eMentions =
+            tags
+                .mapNotNull(MarkedETag::parseAllThreadTags)
+                .filter { it.marker == MarkedETag.MARKER.MENTION && isValidHexKey(it.eventId) }
+
+        // 2) e-mention tags that carry an inline author pubkey
+        for (mention in eMentions) {
+            val author = mention.author
+            if (author != null && isValidHexKey(author)) {
+                if (!out.containsKey(mention.eventId)) out[mention.eventId] = author
+            }
+        }
+
+        // 3) NIP-10 paired e-mention + p-mention, ONLY when exactly one of
+        //    each exists in the tag set. Anything beyond that ratio is
+        //    ambiguous (cc-style p-mentions, multi-quote posts, label/raid
+        //    semantics) and positional pairing produces false attributions.
+        val pMentions = mutableListOf<HexKey>()
+        for (tag in tags) {
+            if (tag.size >= 4 && tag[0] == "p" && isValidHexKey(tag[1]) && tag[3] == "mention") {
+                pMentions.add(tag[1])
+            }
+        }
+        if (eMentions.size == 1 && pMentions.size == 1) {
+            val eventId = eMentions[0].eventId
+            if (!out.containsKey(eventId)) out[eventId] = pMentions[0]
+        }
+
+        return out.map { (eventId, authorPubKey) -> Hint(eventId, authorPubKey) }
+    }
+
+    private fun isValidHexKey(value: String): Boolean = value.length == 64 && Hex.isHex64(value)
+}

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip18Reposts/quotes/QuotedEventAuthorHintsTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip18Reposts/quotes/QuotedEventAuthorHintsTest.kt
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip18Reposts.quotes
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class QuotedEventAuthorHintsTest {
+    private val eventA = "434cc91f17c18cfd985a7e7272ee1c8ee3c1e7b852ebc018de15a473d6c05c95"
+    private val authorA = "ac0231309b8abb0f6429d6a2e543de55b53f4d40f7ade1b7458ccfae59d0007c"
+    private val eventB = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    private val authorB = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+
+    @Test
+    fun pairsSingleEMentionWithSinglePMention() {
+        val tags =
+            arrayOf(
+                arrayOf("e", eventA, "", "mention"),
+                arrayOf("p", authorA, "", "mention"),
+            )
+        val hints = QuotedEventAuthorHints.collect(tags)
+        assertEquals(1, hints.size)
+        assertEquals(eventA, hints[0].eventId)
+        assertEquals(authorA, hints[0].authorPubKey)
+    }
+
+    @Test
+    fun doesNotPairWhenMultipleEMentions() {
+        // Multiple e-mentions are ambiguous — positional pairing produces false
+        // attributions (e.g. cc-style p-mentions), so we emit nothing.
+        val tags =
+            arrayOf(
+                arrayOf("e", eventA, "", "mention"),
+                arrayOf("e", eventB, "", "mention"),
+                arrayOf("p", authorA, "", "mention"),
+                arrayOf("p", authorB, "", "mention"),
+            )
+        assertTrue(QuotedEventAuthorHints.collect(tags).isEmpty())
+    }
+
+    @Test
+    fun doesNotPairWhenMultiplePMentions() {
+        // Single e-mention but two p-mentions (one quoted author, one cc'd) —
+        // ambiguous, emit nothing.
+        val tags =
+            arrayOf(
+                arrayOf("e", eventA, "", "mention"),
+                arrayOf("p", authorA, "", "mention"),
+                arrayOf("p", authorB, "", "mention"),
+            )
+        assertTrue(QuotedEventAuthorHints.collect(tags).isEmpty())
+    }
+
+    @Test
+    fun multipleQuotesStillResolveViaQTagsOrInlinePubkeys() {
+        // The unambiguous paths (q-tag, inline e-mention pubkey) still emit
+        // multiple hints in the same event — only positional NIP-10 pairing is
+        // restricted to the 1+1 case.
+        val tags =
+            arrayOf(
+                arrayOf("q", eventA, "", authorA),
+                arrayOf("e", eventB, "", "mention", authorB),
+            )
+        val hints = QuotedEventAuthorHints.collect(tags).associate { it.eventId to it.authorPubKey }
+        assertEquals(2, hints.size)
+        assertEquals(authorA, hints[eventA])
+        assertEquals(authorB, hints[eventB])
+    }
+
+    @Test
+    fun emptyWhenOnlyEMentions() {
+        val tags = arrayOf(arrayOf("e", eventA, "", "mention"))
+        assertTrue(QuotedEventAuthorHints.collect(tags).isEmpty())
+    }
+
+    @Test
+    fun emptyWhenOnlyPMentions() {
+        val tags = arrayOf(arrayOf("p", authorA, "", "mention"))
+        assertTrue(QuotedEventAuthorHints.collect(tags).isEmpty())
+    }
+
+    @Test
+    fun ignoresNonMentionMarkers() {
+        val tags =
+            arrayOf(
+                arrayOf("e", eventA, "", "reply"),
+                arrayOf("p", authorA, ""),
+            )
+        assertTrue(QuotedEventAuthorHints.collect(tags).isEmpty())
+    }
+
+    @Test
+    fun extractsAuthorFromQTag() {
+        val tags = arrayOf(arrayOf("q", eventA, "wss://r.example/", authorA))
+        val hints = QuotedEventAuthorHints.collect(tags)
+        assertEquals(1, hints.size)
+        assertEquals(eventA, hints[0].eventId)
+        assertEquals(authorA, hints[0].authorPubKey)
+    }
+
+    @Test
+    fun qTagWithoutInlineAuthorEmitsNothing() {
+        val tags = arrayOf(arrayOf("q", eventA, "wss://r.example/"))
+        assertTrue(QuotedEventAuthorHints.collect(tags).isEmpty())
+    }
+
+    @Test
+    fun extractsAuthorFromEMentionWithInlinePubkey() {
+        val tags = arrayOf(arrayOf("e", eventA, "wss://r.example/", "mention", authorA))
+        val hints = QuotedEventAuthorHints.collect(tags)
+        assertEquals(1, hints.size)
+        assertEquals(eventA, hints[0].eventId)
+        assertEquals(authorA, hints[0].authorPubKey)
+    }
+
+    @Test
+    fun extractsAuthorFromEMentionSwappedPubkeyMarkerLayout() {
+        // NIP-10 allows the pubkey at position 3 and the marker at position 4
+        // (the swapped variant — see MarkedETag.pickAuthor / pickMarker).
+        // The collector must recognise it to avoid silently dropping hints
+        // from clients that emit this layout.
+        val tags = arrayOf(arrayOf("e", eventA, "wss://r.example/", authorA, "mention"))
+        val hints = QuotedEventAuthorHints.collect(tags)
+        assertEquals(1, hints.size)
+        assertEquals(eventA, hints[0].eventId)
+        assertEquals(authorA, hints[0].authorPubKey)
+    }
+
+    @Test
+    fun qTagTakesPriorityOverPairedMention() {
+        val tags =
+            arrayOf(
+                arrayOf("q", eventA, "", authorA),
+                arrayOf("e", eventA, "", "mention"),
+                arrayOf("p", authorB, "", "mention"),
+            )
+        val hints = QuotedEventAuthorHints.collect(tags)
+        assertEquals(1, hints.size)
+        assertEquals(authorA, hints[0].authorPubKey)
+    }
+
+    @Test
+    fun inlineEMentionPubkeyTakesPriorityOverPairedPMention() {
+        val tags =
+            arrayOf(
+                arrayOf("e", eventA, "", "mention", authorA),
+                arrayOf("p", authorB, "", "mention"),
+            )
+        val hints = QuotedEventAuthorHints.collect(tags)
+        assertEquals(1, hints.size)
+        assertEquals(authorA, hints[0].authorPubKey)
+    }
+
+    @Test
+    fun deduplicatesByEventIdFirstWriteWins() {
+        val tags =
+            arrayOf(
+                arrayOf("q", eventA, "", authorA),
+                arrayOf("q", eventA, "", authorB),
+            )
+        val hints = QuotedEventAuthorHints.collect(tags)
+        assertEquals(1, hints.size)
+        assertEquals(authorA, hints[0].authorPubKey)
+    }
+
+    @Test
+    fun unusualWhalesBridgeShape() {
+        // Reproduces the outer kind-1 tag set from the bug report (a Momostr-bridged
+        // quote post). The bech32 embedded in content has no relay/author, so this
+        // paired e/p mention is the only carrier of the quoted author.
+        val tags =
+            arrayOf(
+                arrayOf("e", "434cc91f17c18cfd985a7e7272ee1c8ee3c1e7b852ebc018de15a473d6c05c95", "", "mention"),
+                arrayOf("p", "ac0231309b8abb0f6429d6a2e543de55b53f4d40f7ade1b7458ccfae59d0007c", "", "mention"),
+            )
+        val hints = QuotedEventAuthorHints.collect(tags)
+        assertEquals(1, hints.size)
+        assertEquals("434cc91f17c18cfd985a7e7272ee1c8ee3c1e7b852ebc018de15a473d6c05c95", hints[0].eventId)
+        assertEquals("ac0231309b8abb0f6429d6a2e543de55b53f4d40f7ade1b7458ccfae59d0007c", hints[0].authorPubKey)
+    }
+
+    @Test
+    fun rejectsMalformedTagShapes() {
+        val tags =
+            arrayOf(
+                arrayOf("e"),
+                arrayOf("e", "shorthex", "", "mention"),
+                arrayOf("q", eventA, "", "shortauthor"),
+                arrayOf("e", eventA, "", "mention", "shortauthor"),
+            )
+        assertTrue(QuotedEventAuthorHints.collect(tags).isEmpty())
+    }
+
+    @Test
+    fun rejectsSixtyFourCharNonHex() {
+        // 64-char strings that aren't hex would crash downstream callers that
+        // `require(isValidHex(...))`. The collector must validate hex, not just
+        // length.
+        val nonHexId = "z".repeat(64)
+        val nonHexAuthor = "g".repeat(64)
+        val tags =
+            arrayOf(
+                arrayOf("q", nonHexId, "", authorA),
+                arrayOf("q", eventA, "", nonHexAuthor),
+                arrayOf("e", nonHexId, "", "mention", authorA),
+                arrayOf("e", eventA, "", "mention", nonHexAuthor),
+                arrayOf("e", nonHexId, "", "mention"),
+                arrayOf("p", nonHexAuthor, "", "mention"),
+            )
+        assertTrue(QuotedEventAuthorHints.collect(tags).isEmpty())
+    }
+}


### PR DESCRIPTION
Note that fails to load in release client but loads after this fix: `nostr:nevent1qqsr7jtghtj82jzh5pt66enq3dccewgufxpj0q8fdtf2cly3cvaxkjspr9mhxue69uhhyetvv9ujuumwdae8gtnnda3kjctv9upzprr90p5lc8hh4duhmydtlpkr9jy6ly4c7m8pgc636f4qcgyvpl9kqvzqqqqqqy3dds8v`

## Summary

Embedded `nostr:nevent…` and `nostr:naddr…` quotes whose author writes to an unusual relay (Momostr bridges, dedicated personal relays, music apps like Wavlake) frequently failed to load — Amethyst had no way to discover the quoted author's actual write relays from the host event alone, so the fetch fell back to the user's own relay set and timed out. This PR closes that gap.

## Root cause

`potentialRelaysToFindEvent(note)` (and its addressable sibling) used `note.author?.outboxRelays()` as the only author-derived relay source. Two failure modes:

1. **`note.author == null`**: for `nostr:nevent…` references where the bech32 carried neither an author hint nor a relay hint (the common Momostr-bridged shape), there was no author to look up.
2. **`outboxRelays() == null`**: even with a known author, if the author's NIP-65 (kind 10002) wasn't already cached, the lookup returned null.

In both cases the loader had no usable relays and silently fell back to the user's own write set — which doesn't carry writes by arbitrary other people.

A pure-`LargeSoftCache` (WeakReference) wiring underneath made the first naive fix (writing `note.author = hintAuthor`) unstable: the placeholder Note was reclaimed before the loader's next pass, and the hint disappeared.

## The fix

Two new strong-ref structures and one backfill helper, called from every code path that drives missing-event subscriptions.

## Performance impact

**Memory** — both new strong-ref maps are bounded by user behaviour:

- `quotedAuthorHints` entries are evicted in `justConsumeAndUpdateIndexes` once the real signed event arrives. Steady-state growth is "currently-pending quoted notes you've scrolled past," typically dozens.
- `quotedAuthorPins` is keyed by author pubkey (deduplicated across many hints). Each entry holds one `AddressableNote` reference (small) — not the full User object graph.
- `quotedAuthorNip65Attempts` is a hard-capped 500-entry LRU.

Under adversarial spam (synthetic hint authors that never resolve) the cap on the attempts LRU effectively bounds the pins map: an author with no eligible retry will not be re-pinned beyond their LRU slot.

**Network** — kind-10002 backfill issues one fan-out per unresolved hinted author per 5 minutes, against the 10 default indexer/search relays. In the common case (author's NIP-65 was already in cache, or arrives during the first fan-out) no further REQs go out for that author. The shared throttle prevents the event-id and addressable paths from independently fanning out for the same author.

**CPU** — `QuotedEventAuthorHints.collect` runs per consumed `BaseNoteEvent`. Three linear passes over the tag set, allocations bounded by tag count. Profiled fine under heavy feed scroll.

**Build / startup** — no measurable change. R8-minified benchmark build installed and tested.

## Testing

### Automated

- 14 unit tests in `quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip18Reposts/quotes/QuotedEventAuthorHintsTest.kt` covering q-tag / e-mention with inline pubkey / paired e+p mention / the swapped pubkey-marker layout / hex validation / first-write-wins / dedup / the unusual_whales fixture verbatim / 1+1 strictness (multiple e-mentions or p-mentions reject).
- `./gradlew :quartz:jvmTest` and `:amethyst:compilePlayDebugKotlin` clean.
- `./gradlew spotlessApply` clean.

### Manual (on Pixel 9a, benchmark + debug builds)

| Case | Vanilla on cold cache | Fix on cold cache |
|---|---|---|
| `nostr:nevent…` Momostr bridge (`@unusual_whales` quote) | does not load | loads in ~10s |
| `nostr:naddr…` Wavlake music track ("STARTAFIGHT — Joey Valence & Brae") | does not load | loads in ~2.3s |
| Generic followed-author quoted notes (regression baseline) | loads | loads, no regression |

Test fixtures (paste into the app to reproduce):

- **Momostr bridge / event-id path** — outer kind-1 by `8c657869…`, embedded `nostr:nevent1qqsyxn…(434cc91f)` quote by `ac023130` (bridged `@unusual_whales@masto.ai`), writes only to `wss://relay.momostr.pink/`:

  ```
  nostr:nevent1qqsr7jtghtj82jzh5pt66enq3dccewgufxpj0q8fdtf2cly3cvaxkjspr9mhxue69uhhyetvv9ujuumwdae8gtnnda3kjctv9upzprr90p5lc8hh4duhmydtlpkr9jy6ly4c7m8pgc636f4qcgyvpl9kqvzqqqqqqy3dds8v
  ```

- **Wavlake addressable path** — outer kind-1 by `deab79da…`, embedded `nostr:naddr1…` quote of `36787:047b0a88…:track-olyo092pl` (music track event, author not on default indexer set):

  ```
  nostr:nevent1qqsy0ahugw7sa02xtewvz25ewxa0qt3htyf0w4kk4akxsch3qjqktgcpz9mhxue69uhkummnw3ezuamfdejj7q3qm64hnkh6rs47fd9x6wk2zdtmdj4qkazt734d22d94ery9zzhne5qxpqqqqqqz64jd52
  ```

End-to-end diagnostic logs captured at every gate (`populateCitationAuthorHints` write, `potentialRelaysToFindEvent` per-source contribution, `filterMissingQuotedAuthorNip65` backfill emission, REQ sent to author outbox, EVENT received). Logs reverted before final commits — production code has no `Log.d` from this feature.

Race / cache / lifecycle paths verified:

- Hint eviction after real event arrives (`quotedAuthorHints.remove(event.id)` in `justConsumeAndUpdateIndexes`).
- `outboxRelays()` remains stable across multiple `updateSubscriptions` cycles after the pin lands (no flap).
- Per-author 5-minute backoff: `quotedAuthorNip65Attempts` correctly skips re-fetches within window.

## Out of scope

Documented but deferred:

- Refactor of the hint-fed kind-10002 backfill to delegate to `UserOutboxFinderSubAssembler` (which already has `hasTried: EOSEAccountFast<User>` tiered routing). The 5-minute throttle gives equivalent practical behaviour with much less surgery; this is the natural follow-up if the throttle proves insufficient at scale.
- Cryptographic binding between a hint and its quoted event (would prevent the brief routing-leak window when an attacker forges a hint pointing at someone else's event). The verified author lands when the real signed copy arrives, eviction clears the hint, so the window is bounded — but a fuller mitigation would require validating hints against signed evidence.


## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
