### PR TITLE
Fix live stream chat relay fallback

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/send/ChannelNewMessageViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/send/ChannelNewMessageViewModel.kt
@@ -297,7 +297,13 @@ open class ChannelNewMessageViewModel :
         val version = draftTag.current
         cancel()
 
-        accountViewModel.account.signAndSendPrivately(template, channelRelays)
+        if (channel is LiveActivitiesChannel) {
+            accountViewModel.account.signAndSendPrivatelyOrBroadcast(template) {
+                channelRelays.toList()
+            }
+        } else {
+            accountViewModel.account.signAndSendPrivately(template, channelRelays)
+        }
         accountViewModel.viewModelScope.launch(Dispatchers.IO) {
             accountViewModel.account.deleteDraftIgnoreErrors(version)
         }


### PR DESCRIPTION
Fixes #1497

## Summary
- keep normal public-channel messages on the channel relay path
- route live-activity chat messages through `signAndSendPrivatelyOrBroadcast` so they fall back to computed broadcast relays when the live channel relay set is empty
- prevents sent live-stream comments from staying local-only until the user manually taps Broadcast

## Bounty
Issue #1497 offers 100 sats for a solution.

## Validation
- `git diff --check`

I could not run Gradle checks locally because this environment has no Java Runtime installed; the repository pre-commit/pre-push hooks failed for that reason, so the commit and push were made with hook verification bypassed.