### PR TITLE
Add NIP-78 AppDataEvent (kind 78) and refactor AppSpecificDataEvent

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip78AppSpecific/AppSpecificState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip78AppSpecific/AppSpecificState.kt
@@ -54,11 +54,11 @@ class AppSpecificState(
 
     suspend fun saveNewAppSpecificData(): AppSpecificDataEvent {
         val toInternal = settings.syncedSettings.toInternal()
-        return AppSpecificDataEvent.create(
-            dTag = APP_SPECIFIC_DATA_D_TAG,
-            description = signer.nip44Encrypt(JsonMapper.toJson(toInternal), signer.pubKey),
-            otherTags = emptyArray(),
-            signer = signer,
+        return signer.sign(
+            AppSpecificDataEvent.build(
+                dTag = APP_SPECIFIC_DATA_D_TAG,
+                description = signer.nip44Encrypt(JsonMapper.toJson(toInternal), signer.pubKey),
+            ),
         )
     }
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip78AppData/AppDataEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip78AppData/AppDataEvent.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip78AppData
+
+import androidx.compose.runtime.Immutable
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
+import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
+import com.vitorpamplona.quartz.nip31Alts.AltTag
+import com.vitorpamplona.quartz.utils.TimeUtils
+
+/**
+ * NIP-78 — Arbitrary custom app data, normal-event flavor.
+ *
+ * Kind 78 is the non-replaceable counterpart to [AppSpecificDataEvent] (kind
+ * 30078). Use it when an app needs to store and query multiple events of the
+ * same type. The spec recommends using unique tags (including `d` tags) for
+ * grouping related events; the `d` tag here does NOT make the event
+ * addressable, it is just a free-form grouping key.
+ */
+@Immutable
+class AppDataEvent(
+    id: HexKey,
+    pubKey: HexKey,
+    createdAt: Long,
+    tags: Array<Array<String>>,
+    content: String,
+    sig: HexKey,
+) : Event(id, pubKey, createdAt, KIND, tags, content, sig) {
+    fun dTag(): String = tags.dTag()
+
+    companion object {
+        const val KIND = 78
+        const val ALT = "Arbitrary app data"
+
+        suspend fun create(
+            content: String,
+            dTag: String? = null,
+            otherTags: Array<Array<String>> = emptyArray(),
+            signer: NostrSigner,
+            createdAt: Long = TimeUtils.now(),
+        ): AppDataEvent {
+            val withD =
+                if (dTag == null) {
+                    otherTags
+                } else if (otherTags.any { it.size > 1 && it[0] == "d" && it[1] == dTag }) {
+                    otherTags
+                } else {
+                    otherTags.filter { it.isEmpty() || it[0] != "d" }.toTypedArray() + arrayOf(arrayOf("d", dTag))
+                }
+
+            val newTags =
+                if (withD.none { it.isNotEmpty() && it[0] == "alt" }) {
+                    withD + arrayOf(AltTag.assemble(ALT))
+                } else {
+                    withD
+                }
+
+            return signer.sign(createdAt, KIND, newTags, content)
+        }
+    }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip78AppData/AppDataEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip78AppData/AppDataEvent.kt
@@ -23,9 +23,11 @@ package com.vitorpamplona.quartz.nip78AppData
 import androidx.compose.runtime.Immutable
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
-import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
+import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
+import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
+import com.vitorpamplona.quartz.nip01Core.tags.dTag.DTag
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
-import com.vitorpamplona.quartz.nip31Alts.AltTag
+import com.vitorpamplona.quartz.nip31Alts.alt
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 /**
@@ -52,30 +54,15 @@ class AppDataEvent(
         const val KIND = 78
         const val ALT = "Arbitrary app data"
 
-        suspend fun create(
+        fun build(
             content: String,
             dTag: String? = null,
-            otherTags: Array<Array<String>> = emptyArray(),
-            signer: NostrSigner,
             createdAt: Long = TimeUtils.now(),
-        ): AppDataEvent {
-            val withD =
-                if (dTag == null) {
-                    otherTags
-                } else if (otherTags.any { it.size > 1 && it[0] == "d" && it[1] == dTag }) {
-                    otherTags
-                } else {
-                    otherTags.filter { it.isEmpty() || it[0] != "d" }.toTypedArray() + arrayOf(arrayOf("d", dTag))
-                }
-
-            val newTags =
-                if (withD.none { it.isNotEmpty() && it[0] == "alt" }) {
-                    withD + arrayOf(AltTag.assemble(ALT))
-                } else {
-                    withD
-                }
-
-            return signer.sign(createdAt, KIND, newTags, content)
+            initializer: TagArrayBuilder<AppDataEvent>.() -> Unit = {},
+        ) = eventTemplate<AppDataEvent>(KIND, content, createdAt) {
+            alt(ALT)
+            dTag?.let { addUnique(DTag.assemble(it)) }
+            initializer()
         }
     }
 }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip78AppData/AppSpecificDataEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip78AppData/AppSpecificDataEvent.kt
@@ -23,9 +23,11 @@ package com.vitorpamplona.quartz.nip78AppData
 import com.vitorpamplona.quartz.nip01Core.core.Address
 import com.vitorpamplona.quartz.nip01Core.core.BaseAddressableEvent
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
-import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
+import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
+import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.aTag.ATag
-import com.vitorpamplona.quartz.nip31Alts.AltTag
+import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
+import com.vitorpamplona.quartz.nip31Alts.alt
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 class AppSpecificDataEvent(
@@ -52,28 +54,15 @@ class AppSpecificDataEvent(
             dTag: String,
         ): ATag = ATag(KIND, pubkey, dTag, null)
 
-        suspend fun create(
+        fun build(
             dTag: String,
             description: String,
-            otherTags: Array<Array<String>>,
-            signer: NostrSigner,
             createdAt: Long = TimeUtils.now(),
-        ): AppSpecificDataEvent {
-            val withD =
-                if (otherTags.any { it.size > 1 && it[0] == "d" && it[1] == dTag }) {
-                    otherTags
-                } else {
-                    otherTags.filter { it.size > 0 && it[0] != "d" }.toTypedArray() + arrayOf("d", dTag)
-                }
-
-            val newTags =
-                if (withD.none { it.size > 0 && it[0] == "alt" }) {
-                    withD + AltTag.assemble(ALT)
-                } else {
-                    withD
-                }
-
-            return signer.sign(createdAt, KIND, newTags, description)
+            initializer: TagArrayBuilder<AppSpecificDataEvent>.() -> Unit = {},
+        ) = eventTemplate<AppSpecificDataEvent>(KIND, description, createdAt) {
+            alt(ALT)
+            dTag(dTag)
+            initializer()
         }
     }
 }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/utils/EventFactory.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/utils/EventFactory.kt
@@ -218,6 +218,7 @@ import com.vitorpamplona.quartz.nip72ModCommunities.approval.CommunityPostApprov
 import com.vitorpamplona.quartz.nip72ModCommunities.definition.CommunityDefinitionEvent
 import com.vitorpamplona.quartz.nip72ModCommunities.follow.CommunityListEvent
 import com.vitorpamplona.quartz.nip75ZapGoals.GoalEvent
+import com.vitorpamplona.quartz.nip78AppData.AppDataEvent
 import com.vitorpamplona.quartz.nip78AppData.AppSpecificDataEvent
 import com.vitorpamplona.quartz.nip7DThreads.ThreadEvent
 import com.vitorpamplona.quartz.nip84Highlights.HighlightEvent
@@ -322,6 +323,7 @@ class EventFactory {
                 AppCurationSetEvent.KIND -> AppCurationSetEvent(id, pubKey, createdAt, tags, content, sig)
                 AppDefinitionEvent.KIND -> AppDefinitionEvent(id, pubKey, createdAt, tags, content, sig)
                 AppRecommendationEvent.KIND -> AppRecommendationEvent(id, pubKey, createdAt, tags, content, sig)
+                AppDataEvent.KIND -> AppDataEvent(id, pubKey, createdAt, tags, content, sig)
                 AppSpecificDataEvent.KIND -> AppSpecificDataEvent(id, pubKey, createdAt, tags, content, sig)
                 AttestationEvent.KIND -> AttestationEvent(id, pubKey, createdAt, tags, content, sig)
                 AttestationRequestEvent.KIND -> AttestationRequestEvent(id, pubKey, createdAt, tags, content, sig)


### PR DESCRIPTION
## Summary

Implements NIP-78 support for non-replaceable arbitrary app data (kind 78) alongside the existing replaceable variant (kind 30078). Refactors `AppSpecificDataEvent` to use the new `eventTemplate` builder pattern for consistency with other event types, eliminating manual tag assembly and signer integration.

## Changes

- **New `AppDataEvent` class** (kind 78): Non-replaceable counterpart to `AppSpecificDataEvent`. Supports multiple events of the same type with optional `d` tag grouping (non-addressable, unlike kind 30078).
- **Refactored `AppSpecificDataEvent`**: Replaced `suspend create()` method with `build()` that returns an event template, delegating signing to the caller. Simplifies tag management using `alt()` and `dTag()` helpers.
- **Updated `AppSpecificState`**: Adapted to new builder pattern by wrapping `build()` result with `signer.sign()`.
- **EventFactory registration**: Added `AppDataEvent` to the kind-to-class mapping for deserialization.

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes: Existing event factory tests cover deserialization. The builder pattern is consistent with other event types in the codebase (e.g., `GoalEvent`, `CommunityDefinitionEvent`). No new test coverage required beyond existing factory tests.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

(Event serialization format unchanged; only internal builder API refactored.)

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

https://claude.ai/code/session_0161KH7PifyYpdPuXmjWauLV