### PR TITLE
Switch Java distribution from Zulu to Temurin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: 21
 
       # Remote Gradle build cache: writes on push to main, reads on PRs and
@@ -71,7 +71,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: 21
 
       - name: Set up Gradle
@@ -203,7 +203,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: 21
 
       - name: Set up Gradle
@@ -256,7 +256,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: 21
 
       - name: Set up Gradle

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: 21
 
       - name: Resolve tag + version
@@ -223,7 +223,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: 21
 
       - name: Resolve tag + version
@@ -346,7 +346,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: 21
 
       - name: Cache gradle

--- a/.github/workflows/smoke-test-desktop.yml
+++ b/.github/workflows/smoke-test-desktop.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: 21
 
       - name: Set up Gradle
@@ -60,7 +60,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: 21
 
       - name: Set up Gradle


### PR DESCRIPTION
## Summary

Updated all GitHub Actions workflows to use the Temurin JDK distribution instead of Zulu for Java 21. This change affects the build, release, and smoke test workflows across the project.

## Test plan

- [ ] N/A — CI configuration change with no source code impact

The change is a straightforward distribution swap in the `actions/setup-java` action configuration. All workflows will continue to use Java 21; only the underlying JDK provider changes from Zulu to Temurin (both are certified OpenJDK distributions). CI will validate the change on next run.

## Interop suites

- [ ] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [ ] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

https://claude.ai/code/session_01Y4BBvKJRuVYkgXRNxmJwjY