### PR TITLE
Fix scroll position restoration in feed lists on return

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/feeds/WatchScrollToTop.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/feeds/WatchScrollToTop.kt
@@ -137,6 +137,9 @@ fun StickToTopOnPrepend(
     stickToTopOnPrepend(
         stateKey = listState,
         firstItemKey = firstItemKey,
+        initialAtTop = {
+            listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
+        },
         sampler = {
             snapshotFlow {
                 listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
@@ -156,6 +159,9 @@ fun StickToTopOnPrepend(
     stickToTopOnPrepend(
         stateKey = gridState,
         firstItemKey = firstItemKey,
+        initialAtTop = {
+            gridState.firstVisibleItemIndex == 0 && gridState.firstVisibleItemScrollOffset == 0
+        },
         sampler = {
             snapshotFlow {
                 gridState.firstVisibleItemIndex == 0 && gridState.firstVisibleItemScrollOffset == 0
@@ -209,6 +215,7 @@ private fun rememberFirstItemIdHex(feedContentState: FeedContentState): String? 
 private fun stickToTopOnPrepend(
     stateKey: Any,
     firstItemKey: Any?,
+    initialAtTop: () -> Boolean,
     sampler: () -> Flow<Boolean>,
     isScrollInProgress: () -> Boolean,
     firstVisibleItemIndex: () -> Int,
@@ -216,7 +223,10 @@ private fun stickToTopOnPrepend(
 ) {
     // Plain holder instead of mutableStateOf — we only read this inside
     // effects, never in composition, so we don't need snapshot tracking.
-    val wasAtTop = remember { booleanArrayOf(true) }
+    // Seed from the actual restored scroll position: when the user returns
+    // to a feed via rememberForeverLazyListState, the saved offset is
+    // already in place, and a hardcoded `true` would mis-snap them to 0.
+    val wasAtTop = remember(stateKey) { booleanArrayOf(initialAtTop()) }
 
     LaunchedEffect(stateKey) {
         sampler().collect { atTop ->


### PR DESCRIPTION
## Summary

Fix a bug where returning to a feed via `rememberForeverLazyListState` would incorrectly snap the list to the top, even when the saved scroll position was elsewhere. The issue was that `wasAtTop` was hardcoded to `true` on initialization, ignoring the actual restored scroll state.

Now `wasAtTop` is seeded from the current scroll position via a new `initialAtTop` lambda, so the "stick to top on prepend" logic respects the user's saved position when they return to a feed.

## Changes

- Added `initialAtTop: () -> Boolean` parameter to `stickToTopOnPrepend()` 
- Updated both `LazyListState` and `LazyGridState` call sites to pass `initialAtTop` lambdas that check the actual current scroll position
- Changed `wasAtTop` initialization from hardcoded `booleanArrayOf(true)` to `booleanArrayOf(initialAtTop())` with proper `remember` key

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes: This is a targeted fix to the scroll state initialization logic. The change is minimal and localized to the `stickToTopOnPrepend` function and its call sites. Existing tests should cover the prepend behavior; the fix ensures the initial state matches the actual restored scroll position rather than forcing it to `true`.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_0113kvDS7UYNeY3oE9VMX5sd