### PR TITLE
Keep search state across bottom tab switches

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/navs/Nav.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/navs/Nav.kt
@@ -55,7 +55,10 @@ class Nav(
     override fun nav(route: Route) {
         navigationScope.launch {
             if (getRouteWithArguments(route::class, controller) != route) {
-                controller.navigate(route)
+                controller.navigate(route) {
+                    launchSingleTop = true
+                    restoreState = route is Route.Search
+                }
             }
         }
     }
@@ -88,8 +91,10 @@ class Nav(
                 // Home and back-swipe from Home leaves the app.
                 popUpTo(Route.Home) {
                     inclusive = false
+                    saveState = true
                 }
                 launchSingleTop = true
+                restoreState = true
             }
             // Mark this entry as a tab root: hides the back arrow in canPop
             // and skips the horizontal slide in composableFromEnd.


### PR DESCRIPTION
Keeps the search route state around when switching through the bottom navigation, so returning to search can restore the previous query/list position instead of rebuilding the screen from scratch.

This uses the normal Navigation saveState/restoreState path for bottom-nav switches and restores saved state when the search route is opened again.

Closes #426.

Testing:
- git diff --check
- ./gradlew :amethyst:compilePlayDebugKotlin --no-daemon
- git pre-commit hook (spotlessCheck)
- git pre-push hook (./gradlew test)