### PR TITLE
Add profile lists tab

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/ProfileScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/ProfileScreen.kt
@@ -92,6 +92,9 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.header.ProfileHeade
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.header.ProfileTopBar
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.header.apps.UserAppRecommendationsFeedViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.header.identity.UserExternalIdentitiesViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.lists.ProfileListsTabHeader
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.lists.TabProfileLists
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.lists.dal.UserProfileListsFeedViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.mutual.TabMutualConversations
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.mutual.dal.UserProfileMutualFeedViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.newthreads.TabNotesNewThreads
@@ -193,6 +196,16 @@ fun PrepareViewModels(
                 UserProfileZapsViewModel.Factory(baseUser, accountViewModel.account),
         )
 
+    val listsFeedViewModel: UserProfileListsFeedViewModel =
+        viewModel(
+            key = baseUser.pubkeyHex + "UserProfileListsFeedViewModel",
+            factory =
+                UserProfileListsFeedViewModel.Factory(
+                    baseUser,
+                    accountViewModel.account,
+                ),
+        )
+
     val threadsViewModel: UserProfileNewThreadsFeedViewModel =
         viewModel(
             key = baseUser.pubkeyHex + "UserProfileNewThreadsFeedViewModel",
@@ -263,6 +276,7 @@ fun PrepareViewModels(
         appRecommendations,
         externalIdentities,
         zapFeedViewModel,
+        listsFeedViewModel,
         bookmarksFeedViewModel,
         pinnedNotesFeedViewModel,
         galleryFeedViewModel,
@@ -283,6 +297,7 @@ fun ProfileScreen(
     appRecommendations: UserAppRecommendationsFeedViewModel,
     externalIdentities: UserExternalIdentitiesViewModel,
     zapFeedViewModel: UserProfileZapsViewModel,
+    listsFeedViewModel: UserProfileListsFeedViewModel,
     bookmarksFeedViewModel: UserProfileBookmarksFeedViewModel,
     pinnedNotesFeedViewModel: UserProfilePinnedNotesFeedViewModel,
     galleryFeedViewModel: UserProfileGalleryFeedViewModel,
@@ -302,6 +317,7 @@ fun ProfileScreen(
         WatchLifecycleAndUpdateModel(appRecommendations)
     }
     WatchLifecycleAndUpdateModel(bookmarksFeedViewModel)
+    WatchLifecycleAndUpdateModel(listsFeedViewModel)
     WatchLifecycleAndUpdateModel(pinnedNotesFeedViewModel)
     WatchLifecycleAndUpdateModel(galleryFeedViewModel)
 
@@ -348,6 +364,7 @@ fun ProfileScreen(
                     followsFeedViewModel,
                     followersFeedViewModel,
                     zapFeedViewModel,
+                    listsFeedViewModel,
                     bookmarksFeedViewModel,
                     pinnedNotesFeedViewModel,
                     galleryFeedViewModel,
@@ -447,6 +464,7 @@ private fun RenderScreen(
     followsFeedViewModel: UserProfileFollowsUserFeedViewModel,
     followersFeedViewModel: UserProfileFollowersUserFeedViewModel,
     zapFeedViewModel: UserProfileZapsViewModel,
+    listsFeedViewModel: UserProfileListsFeedViewModel,
     bookmarksFeedViewModel: UserProfileBookmarksFeedViewModel,
     pinnedNotesFeedViewModel: UserProfilePinnedNotesFeedViewModel,
     galleryFeedViewModel: UserProfileGalleryFeedViewModel,
@@ -468,6 +486,7 @@ private fun RenderScreen(
                 add(ProfileTab.Follows)
                 if (showFollowersTab) add(ProfileTab.Followers)
                 if (showZapsTab) add(ProfileTab.Zaps)
+                add(ProfileTab.Lists)
                 add(ProfileTab.Bookmarks)
                 add(ProfileTab.FollowedTags)
                 add(ProfileTab.Reports)
@@ -515,6 +534,7 @@ private fun RenderScreen(
                     followsFeedViewModel,
                     followersFeedViewModel,
                     zapFeedViewModel,
+                    listsFeedViewModel,
                     bookmarksFeedViewModel,
                     galleryFeedViewModel,
                     reportsFeedViewModel,
@@ -534,6 +554,7 @@ private fun RenderScreen(
                     followsFeedViewModel,
                     followersFeedViewModel,
                     zapFeedViewModel,
+                    listsFeedViewModel,
                     bookmarksFeedViewModel,
                     pinnedNotesFeedViewModel,
                     galleryFeedViewModel,
@@ -554,6 +575,7 @@ private enum class ProfileTab {
     Follows,
     Followers,
     Zaps,
+    Lists,
     Bookmarks,
     FollowedTags,
     Reports,
@@ -574,6 +596,7 @@ private fun CreateAndRenderPages(
     followsFeedViewModel: UserProfileFollowsUserFeedViewModel,
     followersFeedViewModel: UserProfileFollowersUserFeedViewModel,
     zapFeedViewModel: UserProfileZapsViewModel,
+    listsFeedViewModel: UserProfileListsFeedViewModel,
     bookmarksFeedViewModel: UserProfileBookmarksFeedViewModel,
     pinnedNotesFeedViewModel: UserProfilePinnedNotesFeedViewModel,
     galleryFeedViewModel: UserProfileGalleryFeedViewModel,
@@ -596,6 +619,7 @@ private fun CreateAndRenderPages(
         ProfileTab.Follows -> TabFollows(followsFeedViewModel, accountViewModel, nav)
         ProfileTab.Followers -> TabFollowers(followersFeedViewModel, accountViewModel, nav)
         ProfileTab.Zaps -> TabReceivedZaps(baseUser, zapFeedViewModel, accountViewModel, nav)
+        ProfileTab.Lists -> TabProfileLists(listsFeedViewModel, accountViewModel, nav)
         ProfileTab.Bookmarks -> TabBookmarks(bookmarksFeedViewModel, accountViewModel, nav)
         ProfileTab.FollowedTags -> TabFollowedTags(baseUser, accountViewModel, nav)
         ProfileTab.Reports -> TabReports(baseUser, reportsFeedViewModel, accountViewModel, nav)
@@ -629,6 +653,7 @@ private fun CreateAndRenderTabs(
     followsFeedViewModel: UserProfileFollowsUserFeedViewModel,
     followersFeedViewModel: UserProfileFollowersUserFeedViewModel,
     zapFeedViewModel: UserProfileZapsViewModel,
+    listsFeedViewModel: UserProfileListsFeedViewModel,
     bookmarksFeedViewModel: UserProfileBookmarksFeedViewModel,
     galleryFeedViewModel: UserProfileGalleryFeedViewModel,
     reportsFeedViewModel: UserProfileReportFeedViewModel,
@@ -649,6 +674,7 @@ private fun CreateAndRenderTabs(
                     ProfileTab.Follows -> FollowTabHeader(followsFeedViewModel, accountViewModel)
                     ProfileTab.Followers -> FollowersTabHeader(baseUser, followersFeedViewModel, accountViewModel)
                     ProfileTab.Zaps -> ZapTabHeader(zapFeedViewModel, accountViewModel)
+                    ProfileTab.Lists -> ProfileListsTabHeader()
                     ProfileTab.Bookmarks -> BookmarkTabHeader(baseUser, accountViewModel)
                     ProfileTab.FollowedTags -> FollowedTagsTabHeader(baseUser, accountViewModel)
                     ProfileTab.Reports -> ReportsTabHeader(baseUser, reportsFeedViewModel, accountViewModel)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/lists/ProfileListsTabHeader.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/lists/ProfileListsTabHeader.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.lists
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.ui.stringRes
+
+@Composable
+fun ProfileListsTabHeader() {
+    Text(text = stringRes(R.string.feed_group_lists))
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/lists/TabProfileLists.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/lists/TabProfileLists.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.lists
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.screen.RefresheableFeedView
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.lists.dal.UserProfileListsFeedViewModel
+
+@Composable
+fun TabProfileLists(
+    feedViewModel: UserProfileListsFeedViewModel,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    LaunchedEffect(Unit) { feedViewModel.invalidateData() }
+
+    Column(Modifier.fillMaxHeight()) {
+        Column(
+            modifier = Modifier.padding(vertical = 0.dp),
+        ) {
+            RefresheableFeedView(
+                feedViewModel,
+                null,
+                enablePullRefresh = false,
+                accountViewModel = accountViewModel,
+                nav = nav,
+            )
+        }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/lists/dal/UserProfileListsFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/lists/dal/UserProfileListsFeedFilter.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.lists.dal
+
+import com.vitorpamplona.amethyst.model.Account
+import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.model.Note
+import com.vitorpamplona.amethyst.model.User
+import com.vitorpamplona.amethyst.model.filter
+import com.vitorpamplona.amethyst.ui.dal.FeedFilter
+import com.vitorpamplona.quartz.nip51Lists.followList.FollowListEvent
+import com.vitorpamplona.quartz.nip51Lists.peopleList.PeopleListEvent
+
+class UserProfileListsFeedFilter(
+    val user: User,
+    val account: Account,
+) : FeedFilter<Note>() {
+    override fun feedKey(): String = account.userProfile().pubkeyHex + "-" + user.pubkeyHex + "-lists"
+
+    override fun feed(): List<Note> =
+        (
+            LocalCache.addressables.filter(PeopleListEvent.KIND, user.pubkeyHex) +
+                LocalCache.addressables.filter(FollowListEvent.KIND, user.pubkeyHex)
+        ).filter { it.event != null }
+            .sortedWith(compareByDescending<Note> { it.createdAt() ?: 0L }.thenBy { it.idHex })
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/lists/dal/UserProfileListsFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/lists/dal/UserProfileListsFeedViewModel.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.profile.lists.dal
+
+import androidx.compose.runtime.Stable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.vitorpamplona.amethyst.model.Account
+import com.vitorpamplona.amethyst.model.User
+import com.vitorpamplona.amethyst.ui.screen.AndroidFeedViewModel
+
+@Stable
+class UserProfileListsFeedViewModel(
+    val user: User,
+    val account: Account,
+) : AndroidFeedViewModel(UserProfileListsFeedFilter(user, account)) {
+    class Factory(
+        val user: User,
+        val account: Account,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T = UserProfileListsFeedViewModel(user, account) as T
+    }
+}


### PR DESCRIPTION
Adds a Lists tab to profile pages so public people lists and follow packs published by that user can be browsed from the profile.

The profile subscription already loads these list event kinds; this adds a small feed filter/viewmodel and reuses the existing list note rendering in the profile pager.

Closes #616.

Testing:
- git diff --check
- ./gradlew :amethyst:compilePlayDebugKotlin --no-daemon
- git pre-commit hook (spotlessCheck)
- git pre-push hook (./gradlew test)