### PR TITLE
Register CommunityRulesEvent in EventFactory for kind 34551

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/utils/EventFactory.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/utils/EventFactory.kt
@@ -217,6 +217,7 @@ import com.vitorpamplona.quartz.nip71Video.VideoVerticalEvent
 import com.vitorpamplona.quartz.nip72ModCommunities.approval.CommunityPostApprovalEvent
 import com.vitorpamplona.quartz.nip72ModCommunities.definition.CommunityDefinitionEvent
 import com.vitorpamplona.quartz.nip72ModCommunities.follow.CommunityListEvent
+import com.vitorpamplona.quartz.nip72ModCommunities.rules.CommunityRulesEvent
 import com.vitorpamplona.quartz.nip75ZapGoals.GoalEvent
 import com.vitorpamplona.quartz.nip78AppData.AppDataEvent
 import com.vitorpamplona.quartz.nip78AppData.AppSpecificDataEvent
@@ -400,6 +401,7 @@ class EventFactory {
                 CommunityDefinitionEvent.KIND -> CommunityDefinitionEvent(id, pubKey, createdAt, tags, content, sig)
                 CommunityListEvent.KIND -> CommunityListEvent(id, pubKey, createdAt, tags, content, sig)
                 CommunityPostApprovalEvent.KIND -> CommunityPostApprovalEvent(id, pubKey, createdAt, tags, content, sig)
+                CommunityRulesEvent.KIND -> CommunityRulesEvent(id, pubKey, createdAt, tags, content, sig)
                 ContactListEvent.KIND -> ContactListEvent(id, pubKey, createdAt, tags, content, sig)
                 DeletionEvent.KIND -> DeletionEvent(id, pubKey, createdAt, tags, content, sig)
                 DraftWrapEvent.KIND -> DraftWrapEvent(id, pubKey, createdAt, tags, content, sig)

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip72ModCommunities/rules/CommunityRulesEventFactoryTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip72ModCommunities/rules/CommunityRulesEventFactoryTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip72ModCommunities.rules
+
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.utils.EventFactory
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class CommunityRulesEventFactoryTest {
+    /**
+     * Regression test for the ClassCastException seen in production when
+     * publishing community rules: the factory used to fall back to the generic
+     * [Event] for kind 34551 because [CommunityRulesEvent] was never registered,
+     * so `signer.sign(...)` produced an [Event] that couldn't be cast back to
+     * [CommunityRulesEvent] in `Account.sendCommunityRules`.
+     */
+    @Test
+    fun factoryBuildsCommunityRulesEventForKind34551() {
+        val event: Event =
+            EventFactory.create(
+                id = "00".repeat(32),
+                pubKey = "11".repeat(32),
+                createdAt = 1_700_000_000L,
+                kind = CommunityRulesEvent.KIND,
+                tags = arrayOf(arrayOf("d", "my-community")),
+                content = "",
+                sig = "22".repeat(64),
+            )
+
+        assertTrue(
+            event is CommunityRulesEvent,
+            "Expected a CommunityRulesEvent but got ${event::class.simpleName}",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a `ClassCastException` that occurred in production when publishing community rules. The `EventFactory` was falling back to the generic `Event` class for kind 34551 because `CommunityRulesEvent` was never registered in the factory's kind-to-class mapping. This caused `signer.sign(...)` to produce a generic `Event` that couldn't be cast back to `CommunityRulesEvent` in `Account.sendCommunityRules`.

## Changes

- Added `CommunityRulesEvent` import to `EventFactory.kt`
- Registered kind 34551 (`CommunityRulesEvent.KIND`) in the factory's `when` statement to instantiate `CommunityRulesEvent` instead of falling back to generic `Event`
- Added regression test `CommunityRulesEventFactoryTest` to verify the factory correctly builds `CommunityRulesEvent` instances for kind 34551

## Test plan

- [x] Added unit test `CommunityRulesEventFactoryTest.factoryBuildsCommunityRulesEventForKind34551()` that verifies `EventFactory.create()` returns a `CommunityRulesEvent` instance (not generic `Event`) when given kind 34551
- [x] Ran `./gradlew test` — new test passes, existing tests unaffected

## Interop suites

- [x] N/A — change only affects event deserialization in the factory; no wire format or protocol changes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_016gBkGHQ61fzZrxmS3JeQaH