### PR TITLE
Fix cache-pruning invariant for onchain zaps and nutzaps

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -2785,6 +2785,13 @@ object LocalCache : ILocalCache, ICacheProvider {
 
         note.inGatherers?.forEach { it.removeNote(note) }
 
+        // Mirror deleteNote(): inGatherers is normally authoritative for channel
+        // membership (Channel.addNote always calls note.addGatherer), but resolve
+        // the channel from the event as a belt-and-suspenders detach so a note can
+        // never linger in a channel's notes map after it leaves the cache — that
+        // would leak the note and let a relay echo mint a duplicate with the same id.
+        getAnyChannel(note)?.removeNote(note)
+
         val noteEvent = note.event
 
         if (noteEvent is ReportEvent) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -1341,14 +1341,14 @@ object LocalCache : ILocalCache, ICacheProvider {
      *
      * Removal has two halves: unlinking the note from everything that points AT it
      * (its parents, channels, and the per-user report/card/status/poll indexes —
-     * all handled by [removeFromCache]); and dealing with the note's OWN children
+     * all handled by [unlinkAndRemove]); and dealing with the note's OWN children
      * (the notes that point at IT). The delete path and the prune path share the
      * first half and differ only on the second:
      *  - delete (here): the children are independent events and stay in the cache;
      *    [Note.detachFromChildren] only severs their back-reference so the removed
      *    shell can neither leak (held alive by a child's `replyTo`) nor be later
      *    resurrected by `computeReplyTo` as a second Note for the same id.
-     *  - prune (see [removeFromCache] callers): the whole child subtree is removed.
+     *  - prune (see [unlinkAndRemove] callers): the whole child subtree is removed.
      *
      * Gift-wrapped events additionally drop their decrypted inner host.
      */
@@ -1357,7 +1357,7 @@ object LocalCache : ILocalCache, ICacheProvider {
 
         deleteNote.detachFromChildren()
 
-        removeFromCache(deleteNote)
+        unlinkAndRemove(deleteNote)
     }
 
     fun deleteWraps(event: WrappedEvent) {
@@ -2566,12 +2566,12 @@ object LocalCache : ILocalCache, ICacheProvider {
         val childrenToBeRemoved = mutableListOf<Note>()
 
         toBeRemoved.forEach {
-            removeFromCache(it)
+            unlinkAndRemove(it)
 
-            childrenToBeRemoved.addAll(it.removeAllChildNotes())
+            childrenToBeRemoved.addAll(it.clearChildLinks())
         }
 
-        removeFromCache(childrenToBeRemoved)
+        unlinkAndRemove(childrenToBeRemoved)
 
         if (toBeRemoved.size > 100 || channel.notes.size() > 100) {
             println(
@@ -2605,12 +2605,12 @@ object LocalCache : ILocalCache, ICacheProvider {
         val childrenToBeRemoved = mutableListOf<Note>()
 
         toBeRemoved.forEach {
-            removeFromCache(it)
+            unlinkAndRemove(it)
 
-            childrenToBeRemoved.addAll(it.removeAllChildNotes())
+            childrenToBeRemoved.addAll(it.clearChildLinks())
         }
 
-        removeFromCache(childrenToBeRemoved)
+        unlinkAndRemove(childrenToBeRemoved)
 
         // Audio-room presence is keyed separately from `notes` and
         // never gets reaped by the top-N rule. Drop entries older
@@ -2650,12 +2650,12 @@ object LocalCache : ILocalCache, ICacheProvider {
 
                 toBeRemoved.forEach {
                     childrenToBeRemoved.addAll(removeIfWrap(it))
-                    removeFromCache(it)
+                    unlinkAndRemove(it)
 
-                    childrenToBeRemoved.addAll(it.removeAllChildNotes())
+                    childrenToBeRemoved.addAll(it.clearChildLinks())
                 }
 
-                removeFromCache(childrenToBeRemoved)
+                unlinkAndRemove(childrenToBeRemoved)
 
                 if (toBeRemoved.size > 1) {
                     println(
@@ -2673,8 +2673,8 @@ object LocalCache : ILocalCache, ICacheProvider {
             if (noteEvent is WrappedEvent) {
                 noteEvent.host?.id?.let {
                     getNoteIfExists(it)?.let { it2 ->
-                        removeFromCache(it2)
-                        it2.removeAllChildNotes()
+                        unlinkAndRemove(it2)
+                        it2.clearChildLinks()
                     }
                 }
             } else {
@@ -2704,11 +2704,11 @@ object LocalCache : ILocalCache, ICacheProvider {
                 it.moveAllReferencesTo(newerVersion)
             }
 
-            removeFromCache(it)
-            childrenToBeRemoved.addAll(it.removeAllChildNotes())
+            unlinkAndRemove(it)
+            childrenToBeRemoved.addAll(it.clearChildLinks())
         }
 
-        removeFromCache(childrenToBeRemoved)
+        unlinkAndRemove(childrenToBeRemoved)
 
         if (toBeRemoved.size > 1) {
             println("PRUNE: ${toBeRemoved.size} old version of addressables removed.")
@@ -2741,11 +2741,11 @@ object LocalCache : ILocalCache, ICacheProvider {
         val childrenToBeRemoved = mutableListOf<Note>()
 
         toBeRemoved.forEach {
-            removeFromCache(it)
-            childrenToBeRemoved.addAll(it.removeAllChildNotes())
+            unlinkAndRemove(it)
+            childrenToBeRemoved.addAll(it.clearChildLinks())
         }
 
-        removeFromCache(childrenToBeRemoved)
+        unlinkAndRemove(childrenToBeRemoved)
 
         if (toBeRemoved.size > 1) {
             println("PRUNE: ${toBeRemoved.size} thread replies removed.")
@@ -2768,13 +2768,13 @@ object LocalCache : ILocalCache, ICacheProvider {
      *    reported addresses, contact cards, statuses, and poll responses.
      *
      * It deliberately does NOT touch the note's own children: prune callers collect
-     * them via [Note.removeAllChildNotes] and remove the subtree, while [deleteNote]
+     * them via [Note.clearChildLinks] and remove the subtree, while [deleteNote]
      * keeps them and severs only their back-reference. Every per-target removal is
      * idempotent, so the overlap between `replyTo` and the explicit indexes (e.g. an
      * event-level report reachable both ways) is harmless. Addressable notes are
      * dropped from the [addressables] map by the caller; this only removes from [notes].
      */
-    private fun removeFromCache(note: Note) {
+    private fun unlinkAndRemove(note: Note) {
         note.replyTo?.forEach { masterNote ->
             masterNote.removeNote(note)
         }
@@ -2820,8 +2820,8 @@ object LocalCache : ILocalCache, ICacheProvider {
         refreshDeletedNoteObservers(note)
     }
 
-    fun removeFromCache(nextToBeRemoved: List<Note>) {
-        nextToBeRemoved.forEach { note -> removeFromCache(note) }
+    fun unlinkAndRemove(nextToBeRemoved: List<Note>) {
+        nextToBeRemoved.forEach { note -> unlinkAndRemove(note) }
     }
 
     fun pruneExpiredEvents() {
@@ -2834,16 +2834,16 @@ object LocalCache : ILocalCache, ICacheProvider {
         val childrenToBeRemoved = mutableListOf<Note>()
 
         versionsToBeRemoved.forEach {
-            removeFromCache(it)
-            childrenToBeRemoved.addAll(it.removeAllChildNotes())
+            unlinkAndRemove(it)
+            childrenToBeRemoved.addAll(it.clearChildLinks())
         }
 
         addressesToBeRemoved.forEach {
-            removeFromCache(it)
-            childrenToBeRemoved.addAll(it.removeAllChildNotes())
+            unlinkAndRemove(it)
+            childrenToBeRemoved.addAll(it.clearChildLinks())
         }
 
-        removeFromCache(childrenToBeRemoved)
+        unlinkAndRemove(childrenToBeRemoved)
 
         if (versionsToBeRemoved.size > 1 || addressesToBeRemoved.size > 1) {
             println("PRUNE: ${versionsToBeRemoved.size} events and ${addressesToBeRemoved.size} expired.")
@@ -2861,11 +2861,11 @@ object LocalCache : ILocalCache, ICacheProvider {
             }
 
         toBeRemoved.forEach {
-            removeFromCache(it)
-            childrenToBeRemoved.addAll(it.removeAllChildNotes())
+            unlinkAndRemove(it)
+            childrenToBeRemoved.addAll(it.clearChildLinks())
         }
 
-        removeFromCache(childrenToBeRemoved)
+        unlinkAndRemove(childrenToBeRemoved)
 
         println("PRUNE: ${toBeRemoved.size} messages removed because they were Hidden")
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -1336,60 +1336,28 @@ object LocalCache : ILocalCache, ICacheProvider {
             else -> null
         }
 
-    @Suppress("DEPRECATION")
+    /**
+     * NIP-09 delete of a single targeted event.
+     *
+     * Removal has two halves: unlinking the note from everything that points AT it
+     * (its parents, channels, and the per-user report/card/status/poll indexes —
+     * all handled by [removeFromCache]); and dealing with the note's OWN children
+     * (the notes that point at IT). The delete path and the prune path share the
+     * first half and differ only on the second:
+     *  - delete (here): the children are independent events and stay in the cache;
+     *    [Note.detachFromChildren] only severs their back-reference so the removed
+     *    shell can neither leak (held alive by a child's `replyTo`) nor be later
+     *    resurrected by `computeReplyTo` as a second Note for the same id.
+     *  - prune (see [removeFromCache] callers): the whole child subtree is removed.
+     *
+     * Gift-wrapped events additionally drop their decrypted inner host.
+     */
     private fun deleteNote(deleteNote: Note) {
-        val deletedEvent = deleteNote.event
+        (deleteNote.event as? WrappedEvent)?.let { deleteWraps(it) }
 
-        if (deletedEvent is ReportEvent) {
-            deletedEvent.reportedAuthor().forEach {
-                getUserIfExists(it.pubkey)?.reportsOrNull()?.removeReport(deleteNote)
-            }
-        }
-
-        if (deleteNote is AddressableNote && deletedEvent is ContactCardEvent) {
-            getUserIfExists(deletedEvent.aboutUser())?.cardsOrNull()?.removeCard(deleteNote)
-        }
-
-        if (deleteNote is AddressableNote && deletedEvent is StatusEvent) {
-            deleteNote.author?.statusStateOrNull()?.removeStatus(deleteNote)
-        }
-
-        if (deletedEvent is PollResponseEvent) {
-            deletedEvent.poll()?.eventId?.let {
-                getNoteIfExists(it)?.pollStateOrNull()?.removeResponse(deleteNote)
-            }
-        }
-
-        if (deletedEvent is TorrentCommentEvent) {
-            deletedEvent.torrentIds()?.let {
-                getNoteIfExists(it)?.removeReply(deleteNote)
-            }
-        }
-
-        if (deletedEvent is WrappedEvent) {
-            deleteWraps(deletedEvent)
-        }
-
-        // Counts the replies
-        deleteNote.replyTo?.forEach { masterNote ->
-            masterNote.removeNote(deleteNote)
-        }
-
-        deleteNote.inGatherers?.forEach { it.removeNote(deleteNote) }
-
-        getAnyChannel(deleteNote)?.removeNote(deleteNote)
-
-        // Sever the back-references from this note's children before it leaves the
-        // map. Otherwise each child keeps the removed shell alive through its replyTo
-        // (a partial deletion / leak) and a reply resolved later via computeReplyTo
-        // would resurrect a second Note for the same id.
         deleteNote.detachFromChildren()
 
-        notes.remove(deleteNote.idHex)
-
-        deleteNote.clearFlow()
-
-        refreshDeletedNoteObservers(deleteNote)
+        removeFromCache(deleteNote)
     }
 
     fun deleteWraps(event: WrappedEvent) {
@@ -2784,6 +2752,28 @@ object LocalCache : ILocalCache, ICacheProvider {
         }
     }
 
+    /**
+     * Unlinks [note] from everything in the cache that references it, then drops it
+     * from the [notes] map and notifies observers. This is the shared "unlink from
+     * above" half of removal, used by both the prune callers and [deleteNote].
+     *
+     * It detaches the note from:
+     *  - its parent notes (their replies/reactions/zaps/boosts/reports/labels maps);
+     *    because event-level reports and torrent comments both carry the target in
+     *    `replyTo`, [Note.removeNote] cleans those up here too;
+     *  - its channels/gatherers (`inGatherers` is authoritative — `Channel.addNote`
+     *    always registers the gatherer — and `getAnyChannel` is a belt-and-suspenders
+     *    resolve so a note can never linger in a channel after leaving the cache);
+     *  - the per-target indexes `replyTo` does NOT reach: user-level reports and
+     *    reported addresses, contact cards, statuses, and poll responses.
+     *
+     * It deliberately does NOT touch the note's own children: prune callers collect
+     * them via [Note.removeAllChildNotes] and remove the subtree, while [deleteNote]
+     * keeps them and severs only their back-reference. Every per-target removal is
+     * idempotent, so the overlap between `replyTo` and the explicit indexes (e.g. an
+     * event-level report reachable both ways) is harmless. Addressable notes are
+     * dropped from the [addressables] map by the caller; this only removes from [notes].
+     */
     private fun removeFromCache(note: Note) {
         note.replyTo?.forEach { masterNote ->
             masterNote.removeNote(note)
@@ -2791,11 +2781,6 @@ object LocalCache : ILocalCache, ICacheProvider {
 
         note.inGatherers?.forEach { it.removeNote(note) }
 
-        // Mirror deleteNote(): inGatherers is normally authoritative for channel
-        // membership (Channel.addNote always calls note.addGatherer), but resolve
-        // the channel from the event as a belt-and-suspenders detach so a note can
-        // never linger in a channel's notes map after it leaves the cache — that
-        // would leak the note and let a relay echo mint a duplicate with the same id.
         getAnyChannel(note)?.removeNote(note)
 
         val noteEvent = note.event

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -1379,6 +1379,12 @@ object LocalCache : ILocalCache, ICacheProvider {
 
         getAnyChannel(deleteNote)?.removeNote(deleteNote)
 
+        // Sever the back-references from this note's children before it leaves the
+        // map. Otherwise each child keeps the removed shell alive through its replyTo
+        // (a partial deletion / leak) and a reply resolved later via computeReplyTo
+        // would resurrect a second Note for the same id.
+        deleteNote.detachFromChildren()
+
         notes.remove(deleteNote.idHex)
 
         deleteNote.clearFlow()

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Note.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Note.kt
@@ -147,7 +147,7 @@ open class Note(
         removeReport(note)
         removeLabel(note)
         removeNutzap(note)
-        removeOnchainZap(note)
+        removeOnchainZapBySource(note)
     }
 
     var poll: PollResponsesCache? = null
@@ -373,7 +373,7 @@ open class Note(
         }
     }
 
-    fun removeAllChildNotes(): List<Note> {
+    fun clearChildLinks(): List<Note> {
         val repliesChanged = replies.isNotEmpty()
         val reactionsChanged = reactions.isNotEmpty()
         val zapsChanged = zaps.isNotEmpty() || zapPayments.isNotEmpty() || onchainZaps.isNotEmpty() || nutzaps.isNotEmpty()
@@ -420,7 +420,7 @@ open class Note(
     /**
      * Fully detach this note from the notes below it in the graph so it can be
      * removed from the cache without leaving a partial deletion behind. It both
-     * clears this note's own child collections (via [removeAllChildNotes]) and
+     * clears this note's own child collections (via [clearChildLinks]) and
      * drops this note from every child's [replyTo], so once this note leaves the
      * cache map nothing keeps the dead shell alive.
      *
@@ -432,7 +432,7 @@ open class Note(
      * Returns the now-orphaned children (their other parents, if any, are kept).
      */
     fun detachFromChildren(): List<Note> {
-        val children = removeAllChildNotes()
+        val children = clearChildLinks()
         children.forEach { child ->
             val parents = child.replyTo
             if (parents != null && this in parents) {
@@ -631,7 +631,7 @@ open class Note(
      * cache-removal that must drop the strong reference no matter the status,
      * otherwise the pruned source Note leaks through this map.
      */
-    fun removeOnchainZap(source: Note) {
+    fun removeOnchainZapBySource(source: Note) {
         if (innerRemoveOnchainZapBySource(source)) {
             updateZapTotal()
             flowSet?.zaps?.invalidateData()

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Note.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Note.kt
@@ -146,6 +146,8 @@ open class Note(
         removeZapPayment(note)
         removeReport(note)
         removeLabel(note)
+        removeNutzap(note)
+        removeOnchainZap(note)
     }
 
     var poll: PollResponsesCache? = null
@@ -389,7 +391,8 @@ open class Note(
                 zaps.values.filterNotNull() +
                 zapPayments.keys +
                 zapPayments.values.filterNotNull() +
-                nutzaps.values.map { it.source }
+                nutzaps.values.map { it.source } +
+                onchainZaps.values.map { it.source }
 
         replies = listOf()
         reactions = mapOf()
@@ -582,6 +585,29 @@ open class Note(
     ) {
         val removed = innerRemoveOnchainZapForSource(txid, sourceAuthorPubKey)
         if (removed) {
+            updateZapTotal()
+            flowSet?.zaps?.invalidateData()
+        }
+    }
+
+    private fun innerRemoveOnchainZapBySource(source: Note): Boolean =
+        syncLock.withLock {
+            val newMap = onchainZaps.filterValues { it.source != source }
+            if (newMap.size == onchainZaps.size) return@withLock false
+            onchainZaps = newMap
+            return@withLock true
+        }
+
+    /**
+     * Detach every onchain-zap entry whose source is [source] — used when the
+     * source OnchainZapEvent note is being pruned from `LocalCache`. Unlike
+     * [removeOnchainZapForSource] (a verification verdict that respects the
+     * anti-spoof / no-CONFIRMED-downgrade guards), this is an unconditional
+     * cache-removal that must drop the strong reference no matter the status,
+     * otherwise the pruned source Note leaks through this map.
+     */
+    fun removeOnchainZap(source: Note) {
+        if (innerRemoveOnchainZapBySource(source)) {
             updateZapTotal()
             flowSet?.zaps?.invalidateData()
         }
@@ -1165,6 +1191,21 @@ open class Note(
             note.addNutzap(it.source, it.claimedSats)
             it.source.replyTo = it.source.replyTo?.replace(this, note)
         }
+        onchainZaps.forEach { (txid, entry) ->
+            note.addOnchainZap(entry.source, txid, entry.claimedSats, entry.verifiedSats, entry.status)
+            entry.source.replyTo = entry.source.replyTo?.replace(this, note)
+        }
+        zapPayments.forEach {
+            note.addZapPayment(it.key, it.value)
+            it.key.replyTo = it.key.replyTo?.replace(this, note)
+            it.value?.replyTo = it.value?.replyTo?.replace(this, note)
+        }
+        labels.forEach { (hashtag, labelNotes) ->
+            labelNotes.forEach {
+                note.addLabel(hashtag, it)
+                it.replyTo = it.replyTo?.replace(this, note)
+            }
+        }
 
         replyTo = null
         replies = emptyList()
@@ -1173,6 +1214,9 @@ open class Note(
         reports = emptyMap()
         zaps = emptyMap()
         nutzaps = emptyMap()
+        onchainZaps = emptyMap()
+        zapPayments = emptyMap()
+        labels = emptyMap()
         zapsAmount = BigDecimal(0)
     }
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Note.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Note.kt
@@ -417,6 +417,31 @@ open class Note(
         return toBeRemoved
     }
 
+    /**
+     * Fully detach this note from the notes below it in the graph so it can be
+     * removed from the cache without leaving a partial deletion behind. It both
+     * clears this note's own child collections (via [removeAllChildNotes]) and
+     * drops this note from every child's [replyTo], so once this note leaves the
+     * cache map nothing keeps the dead shell alive.
+     *
+     * This matters for the NIP-09 delete path: without severing the child →
+     * parent `replyTo` links, the removed note leaks (held by each child) and a
+     * later reply resolved through `computeReplyTo` would `getOrCreateNote` a
+     * *second* Note for the same id — breaking the one-Note-per-id invariant.
+     *
+     * Returns the now-orphaned children (their other parents, if any, are kept).
+     */
+    fun detachFromChildren(): List<Note> {
+        val children = removeAllChildNotes()
+        children.forEach { child ->
+            val parents = child.replyTo
+            if (parents != null && this in parents) {
+                child.replyTo = parents - this
+            }
+        }
+        return children
+    }
+
     fun removeReaction(note: Note) {
         val tags = note.event?.tags ?: emptyArray()
         val reaction = note.event?.content?.firstFullCharOrEmoji(ImmutableListOfLists(tags)) ?: "+"

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/NoteOnchainZapTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/NoteOnchainZapTest.kt
@@ -349,15 +349,15 @@ class NoteOnchainZapTest {
     }
 
     @Test
-    fun removeAllChildNotesClearsOnchainZapResolvedFlag() {
-        // `removeAllChildNotes()` runs on delete-event handling and during cache
+    fun clearChildLinksResetsOnchainZapResolvedFlag() {
+        // `clearChildLinks()` runs on delete-event handling and during cache
         // pressure; the resolved flag must travel with the cleared state so a
         // re-arrival of the same event gets re-verified instead of being silently
         // skipped against stale state.
         val src = sourceNote("ee".repeat(32))
         src.onchainZapResolved = true
 
-        src.removeAllChildNotes()
+        src.clearChildLinks()
 
         assertFalse(src.onchainZapResolved)
     }

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/NotePruningReferenceTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/NotePruningReferenceTest.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model
+
+import com.vitorpamplona.quartz.nip01Core.core.Address
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Guards the cache-pruning invariant: when a Note is removed from `LocalCache`,
+ * every other Note that referenced it must drop that strong reference. Onchain
+ * zaps (NIP-BC) and nutzaps (NIP-61) were added to [Note] after the original
+ * removal/migration routines were written, so these tests pin that
+ * [Note.removeNote], [Note.removeAllChildNotes], and [Note.moveAllReferencesTo]
+ * all account for them — otherwise a pruned source Note leaks through the
+ * target's `onchainZaps` / `nutzaps` map and a duplicate Note with the same id
+ * gets minted on the next relay echo.
+ */
+class NotePruningReferenceTest {
+    private fun note(idHex: String) = Note(idHex)
+
+    private fun userFor(pubKey: HexKey) = User(pubKey) { addr -> Note(addr.toValue()) }
+
+    // A source-event Note with a wired author, matching the production shape where
+    // `source.author` is the zap sender.
+    private fun sourceNote(pubKey: HexKey): Note = note(pubKey).apply { author = userFor(pubKey) }
+
+    private fun eventWith(idHex: HexKey): Event =
+        Event(
+            id = idHex,
+            pubKey = "ab".repeat(32),
+            createdAt = 1L,
+            kind = 9321,
+            tags = emptyArray(),
+            content = "",
+            sig = "sig",
+        )
+
+    // ── Fix 1: removeNote drops onchain-zap and nutzap sources ──────────────
+
+    @Test
+    fun removeNoteDetachesOnchainZapSource() {
+        val target = note("a".repeat(64))
+        val src = sourceNote("11".repeat(32))
+
+        target.addOnchainZap(src, "tx1", claimedSats = 1000L, verifiedSats = 1000L, status = OnchainZapStatus.CONFIRMED)
+        assertTrue(target.onchainZaps.containsKey("tx1"))
+
+        target.removeNote(src)
+
+        assertTrue(target.onchainZaps.isEmpty(), "onchain zap source must be detached on removeNote")
+    }
+
+    @Test
+    fun removeNoteDetachesNutzapSource() {
+        val target = note("b".repeat(64))
+        val src = sourceNote("22".repeat(32)).apply { event = eventWith("cc".repeat(32)) }
+
+        target.addNutzap(src, claimedSats = 500L)
+        assertTrue(target.nutzaps.isNotEmpty())
+
+        target.removeNote(src)
+
+        assertTrue(target.nutzaps.isEmpty(), "nutzap source must be detached on removeNote")
+    }
+
+    @Test
+    fun removeOnchainZapBySourceIgnoresUnrelatedSource() {
+        val target = note("d".repeat(64))
+        val src = sourceNote("33".repeat(32))
+        val other = sourceNote("44".repeat(32))
+
+        target.addOnchainZap(src, "tx1", claimedSats = 1000L, verifiedSats = 1000L, status = OnchainZapStatus.CONFIRMED)
+
+        target.removeNote(other)
+
+        assertTrue(target.onchainZaps.containsKey("tx1"), "removing an unrelated note must not drop the entry")
+    }
+
+    // ── Fix 2: removeAllChildNotes returns onchain-zap sources ──────────────
+
+    @Test
+    fun removeAllChildNotesReturnsAndClearsOnchainZapSources() {
+        val target = note("e".repeat(64))
+        val src = sourceNote("55".repeat(32))
+
+        target.addOnchainZap(src, "tx1", claimedSats = 1000L, verifiedSats = 1000L, status = OnchainZapStatus.CONFIRMED)
+
+        val removed = target.removeAllChildNotes()
+
+        assertTrue(src in removed, "onchain zap source must be returned for removal from the cache map")
+        assertTrue(target.onchainZaps.isEmpty())
+    }
+
+    // ── Fix 3: moveAllReferencesTo migrates onchain zaps, zap payments, labels ──
+
+    @Test
+    fun moveAllReferencesToMigratesOnchainZaps() {
+        val old = note("f0".repeat(32))
+        val newer = AddressableNote(Address(30023, "ab".repeat(32), "slug"))
+        val src = sourceNote("66".repeat(32)).apply { replyTo = listOf(old) }
+
+        old.addOnchainZap(src, "tx1", claimedSats = 1000L, verifiedSats = 1000L, status = OnchainZapStatus.CONFIRMED)
+
+        old.moveAllReferencesTo(newer)
+
+        assertTrue(old.onchainZaps.isEmpty(), "old version must release its onchain zaps")
+        assertEquals(1, newer.onchainZaps.size, "onchain zap must move to the newer version")
+        assertSame(src, newer.onchainZaps["tx1"]?.source)
+        assertSame(newer, src.replyTo?.single(), "source replyTo must repoint to the newer version")
+    }
+
+    @Test
+    fun moveAllReferencesToMigratesZapPayments() {
+        val old = note("f1".repeat(32))
+        val newer = AddressableNote(Address(30023, "ab".repeat(32), "slug2"))
+        val request = note("77".repeat(32)).apply { replyTo = listOf(old) }
+        val response = note("88".repeat(32))
+
+        old.addZapPayment(request, response)
+
+        old.moveAllReferencesTo(newer)
+
+        assertTrue(old.zapPayments.isEmpty(), "old version must release its zap payments")
+        assertTrue(newer.zapPayments.containsKey(request), "zap payment must move to the newer version")
+        assertSame(newer, request.replyTo?.single())
+    }
+
+    @Test
+    fun moveAllReferencesToMigratesLabels() {
+        val old = note("f2".repeat(32))
+        val newer = AddressableNote(Address(30023, "ab".repeat(32), "slug3"))
+        val labelNote = note("99".repeat(32)).apply { replyTo = listOf(old) }
+
+        old.addLabel("nostr", labelNote)
+
+        old.moveAllReferencesTo(newer)
+
+        assertTrue(old.labels.isEmpty(), "old version must release its labels")
+        assertTrue(newer.labels["nostr"]?.contains(labelNote) == true, "label must move to the newer version")
+        assertSame(newer, labelNote.replyTo?.single())
+    }
+}

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/NotePruningReferenceTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/NotePruningReferenceTest.kt
@@ -162,4 +162,52 @@ class NotePruningReferenceTest {
         assertTrue(newer.labels["nostr"]?.contains(labelNote) == true, "label must move to the newer version")
         assertSame(newer, labelNote.replyTo?.single())
     }
+
+    // ── Fix 4: deleteNote severs child back-references (no partial deletion) ──
+
+    @Test
+    fun detachFromChildrenSeversReplyToAndClearsCollections() {
+        val parent = note("a1".repeat(32))
+        val reply = note("b1".repeat(32)).apply { replyTo = listOf(parent) }
+        parent.addReply(reply)
+
+        val detached = parent.detachFromChildren()
+
+        assertTrue(reply in detached, "the child must be returned as detached")
+        assertTrue(parent.replies.isEmpty(), "parent must release its forward child references")
+        assertTrue(
+            reply.replyTo?.contains(parent) != true,
+            "child must no longer point back at the removed parent",
+        )
+    }
+
+    @Test
+    fun detachFromChildrenKeepsOtherParents() {
+        val deleted = note("a2".repeat(32))
+        val survivor = note("c2".repeat(32))
+        val reply = note("b2".repeat(32)).apply { replyTo = listOf(deleted, survivor) }
+        deleted.addReply(reply)
+        survivor.addReply(reply)
+
+        deleted.detachFromChildren()
+
+        assertEquals(listOf(survivor), reply.replyTo, "only the removed parent must be dropped from replyTo")
+    }
+
+    @Test
+    fun detachFromChildrenSeversReactionAndZapSources() {
+        val parent = note("a3".repeat(32))
+        val reaction = sourceNote("31".repeat(32)).apply { replyTo = listOf(parent) }
+        val zapSource = sourceNote("32".repeat(32)).apply { replyTo = listOf(parent) }
+
+        parent.addOnchainZap(zapSource, "tx1", claimedSats = 1L, verifiedSats = 1L, status = OnchainZapStatus.CONFIRMED)
+        parent.addBoost(reaction)
+
+        parent.detachFromChildren()
+
+        assertTrue(parent.boosts.isEmpty())
+        assertTrue(parent.onchainZaps.isEmpty())
+        assertTrue(reaction.replyTo?.contains(parent) != true)
+        assertTrue(zapSource.replyTo?.contains(parent) != true)
+    }
 }

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/NotePruningReferenceTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/NotePruningReferenceTest.kt
@@ -33,7 +33,7 @@ import kotlin.test.assertTrue
  * every other Note that referenced it must drop that strong reference. Onchain
  * zaps (NIP-BC) and nutzaps (NIP-61) were added to [Note] after the original
  * removal/migration routines were written, so these tests pin that
- * [Note.removeNote], [Note.removeAllChildNotes], and [Note.moveAllReferencesTo]
+ * [Note.removeNote], [Note.clearChildLinks], and [Note.moveAllReferencesTo]
  * all account for them — otherwise a pruned source Note leaks through the
  * target's `onchainZaps` / `nutzaps` map and a duplicate Note with the same id
  * gets minted on the next relay echo.
@@ -99,16 +99,16 @@ class NotePruningReferenceTest {
         assertTrue(target.onchainZaps.containsKey("tx1"), "removing an unrelated note must not drop the entry")
     }
 
-    // ── Fix 2: removeAllChildNotes returns onchain-zap sources ──────────────
+    // ── Fix 2: clearChildLinks returns onchain-zap sources ──────────────
 
     @Test
-    fun removeAllChildNotesReturnsAndClearsOnchainZapSources() {
+    fun clearChildLinksReturnsAndClearsOnchainZapSources() {
         val target = note("e".repeat(64))
         val src = sourceNote("55".repeat(32))
 
         target.addOnchainZap(src, "tx1", claimedSats = 1000L, verifiedSats = 1000L, status = OnchainZapStatus.CONFIRMED)
 
-        val removed = target.removeAllChildNotes()
+        val removed = target.clearChildLinks()
 
         assertTrue(src in removed, "onchain zap source must be returned for removal from the cache map")
         assertTrue(target.onchainZaps.isEmpty())


### PR DESCRIPTION
## Summary

Guards the cache-pruning invariant by ensuring that when a Note is removed from `LocalCache`, every other Note that referenced it drops that strong reference. Onchain zaps (NIP-BC) and nutzaps (NIP-61) were added to `Note` after the original removal/migration routines were written, so they were not being cleaned up during cache pruning, causing pruned source Notes to leak and duplicate Notes to be minted on relay echo.

The fix has four parts:

1. **`Note.removeNote`** now drops onchain-zap and nutzap sources via `removeOnchainZapBySource` and `removeNutzap`
2. **`Note.clearChildLinks`** (renamed from `removeAllChildNotes`) returns onchain-zap sources alongside other children
3. **`Note.moveAllReferencesTo`** migrates onchain zaps, nutzaps, zap payments, and labels to the newer version
4. **`Note.detachFromChildren`** (new method) fully severs a deleted note from its children's `replyTo` lists, preventing partial deletion leaks in the NIP-09 delete path
5. **`LocalCache.deleteNote`** now calls `detachFromChildren` instead of manually unlinking, and **`LocalCache.unlinkAndRemove`** (renamed from `removeFromCache`) centralizes the "unlink from above" logic shared by both delete and prune paths

## Test plan

- [x] Added comprehensive unit tests in `NotePruningReferenceTest` covering:
  - `removeNote` detaches onchain-zap and nutzap sources
  - `clearChildLinks` returns onchain-zap sources
  - `moveAllReferencesTo` migrates onchain zaps, zap payments, and labels
  - `detachFromChildren` severs child back-references and handles multiple parents
- [x] Updated existing `NoteOnchainZapTest.removeAllChildNotesClearsOnchainZapResolvedFlag` to use new `clearChildLinks` name
- [x] Ran `./gradlew test` — all tests pass

## Interop suites

- [x] N/A — change is cache-internal, does not affect wire bytes or protocol encoding

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01RqJPYzmjb1pR3NBeH2yY3s