### PR TITLE
Audio visualiser for audio notes

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -23,6 +23,7 @@ package com.vitorpamplona.amethyst.model
 import androidx.compose.runtime.Stable
 import com.vitorpamplona.amethyst.BuildConfig
 import com.vitorpamplona.amethyst.LocalPreferences
+import com.vitorpamplona.amethyst.commons.audio.VisualizerStyle
 import com.vitorpamplona.amethyst.commons.marmot.MarmotManager
 import com.vitorpamplona.amethyst.commons.model.IAccount
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
@@ -647,6 +648,12 @@ class Account(
 
     suspend fun changeVideoPlayerButtonItems(items: List<VideoPlayerButtonItem>) {
         if (settings.changeVideoPlayerButtonItems(items)) {
+            sendNewAppSpecificData()
+        }
+    }
+
+    suspend fun changeAudioVisualizer(style: VisualizerStyle) {
+        if (settings.changeAudioVisualizer(style)) {
             sendNewAppSpecificData()
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.model
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.audio.VisualizerStyle
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatRepository
 import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatListRepository
 import com.vitorpamplona.amethyst.commons.model.nip47WalletConnect.NwcWalletEntryNorm
@@ -319,6 +320,15 @@ class AccountSettings(
     fun changeVideoPlayerButtonItems(newItems: List<VideoPlayerButtonItem>): Boolean {
         if (syncedSettings.videoPlayer.buttonItems.value != newItems) {
             syncedSettings.videoPlayer.buttonItems.tryEmit(newItems.toImmutableList())
+            saveAccountSettings()
+            return true
+        }
+        return false
+    }
+
+    fun changeAudioVisualizer(style: VisualizerStyle): Boolean {
+        if (syncedSettings.media.audioVisualizer.value != style) {
+            syncedSettings.media.audioVisualizer.tryEmit(style)
             saveAccountSettings()
             return true
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettings.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.model
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.audio.VisualizerStyle
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications.equalImmutableLists
 import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
 import kotlinx.collections.immutable.ImmutableList
@@ -62,6 +63,10 @@ class AccountSyncedSettings(
         AccountVideoPlayerPreferences(
             MutableStateFlow(mergeWithDefaultVideoPlayerButtons(internalSettings.videoPlayer.buttonItems).toImmutableList()),
         )
+    val media =
+        AccountMediaPreferences(
+            MutableStateFlow(VisualizerStyle.fromName(internalSettings.media.audioVisualizer)),
+        )
 
     fun toInternal(): AccountSyncedSettingsInternal =
         AccountSyncedSettingsInternal(
@@ -92,6 +97,7 @@ class AccountSyncedSettings(
                     security.addClientTag.value,
                 ),
             videoPlayer = AccountVideoPlayerPreferencesInternal(videoPlayer.buttonItems.value),
+            media = AccountMediaPreferencesInternal(media.audioVisualizer.value.name),
         )
 
     fun updateFrom(syncedSettingsInternal: AccountSyncedSettingsInternal) {
@@ -159,6 +165,11 @@ class AccountSyncedSettings(
             mergeWithDefaultVideoPlayerButtons(syncedSettingsInternal.videoPlayer.buttonItems).toImmutableList()
         if (!equalImmutableLists(videoPlayer.buttonItems.value, newVideoPlayerButtonItems)) {
             videoPlayer.buttonItems.tryEmit(newVideoPlayerButtonItems)
+        }
+
+        val newAudioVisualizer = VisualizerStyle.fromName(syncedSettingsInternal.media.audioVisualizer)
+        if (media.audioVisualizer.value != newAudioVisualizer) {
+            media.audioVisualizer.tryEmit(newAudioVisualizer)
         }
     }
 
@@ -252,6 +263,11 @@ class AccountLanguagePreferences(
         target: String,
     ): String? = languagePreferences.value["$source,$target"]
 }
+
+@Stable
+class AccountMediaPreferences(
+    val audioVisualizer: MutableStateFlow<VisualizerStyle>,
+)
 
 @Stable
 class AccountSecurityPreferences(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettingsInternal.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettingsInternal.kt
@@ -155,6 +155,7 @@ class AccountSyncedSettingsInternal(
     val languages: AccountLanguagePreferencesInternal = AccountLanguagePreferencesInternal(),
     val security: AccountSecurityPreferencesInternal = AccountSecurityPreferencesInternal(),
     val videoPlayer: AccountVideoPlayerPreferencesInternal = AccountVideoPlayerPreferencesInternal(),
+    val media: AccountMediaPreferencesInternal = AccountMediaPreferencesInternal(),
 )
 
 @Serializable
@@ -196,4 +197,10 @@ class AccountSecurityPreferencesInternal(
     val maxHashtagLimit: Int = 8,
     var sendKind0EventsToLocalRelay: Boolean = false,
     var addClientTag: Boolean = true,
+)
+
+@Serializable
+class AccountMediaPreferencesInternal(
+    // Stored as VisualizerStyle.name; defaults to WAVES.
+    var audioVisualizer: String = "WAVES",
 )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettingsInternal.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettingsInternal.kt
@@ -201,6 +201,6 @@ class AccountSecurityPreferencesInternal(
 
 @Serializable
 class AccountMediaPreferencesInternal(
-    // Stored as VisualizerStyle.name; defaults to WAVES.
-    var audioVisualizer: String = "WAVES",
+    // Stored as VisualizerStyle.name; defaults to CLASSIC (the app's classic audio animation).
+    var audioVisualizer: String = "CLASSIC",
 )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/RenderVideoPlayer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/RenderVideoPlayer.kt
@@ -186,6 +186,7 @@ fun RenderVideoPlayer(
         AudioPlayingAnimation(
             controllerState = controllerState,
             waveform = mediaItem.src.waveformData,
+            mediaId = mediaItem.src.videoUri,
             style = visualizerStyle,
             modifier = Modifier.fillMaxSize().align(Alignment.Center),
             hasBlurhash = hasBlurhash,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/RenderVideoPlayer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/RenderVideoPlayer.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -38,6 +39,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.ui.compose.ContentFrame
@@ -180,10 +182,12 @@ fun RenderVideoPlayer(
             modifier = Modifier.align(Alignment.Center),
         )
 
+        val visualizerStyle by accountViewModel.audioVisualizerFlow().collectAsStateWithLifecycle()
         AudioPlayingAnimation(
-            controllerState,
-            mediaItem.src.waveformData,
-            Modifier.fillMaxSize().align(Alignment.Center),
+            controllerState = controllerState,
+            waveform = mediaItem.src.waveformData,
+            style = visualizerStyle,
+            modifier = Modifier.fillMaxSize().align(Alignment.Center),
             hasBlurhash = hasBlurhash,
         )
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/wavefront/AudioPlayingAnimation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/wavefront/AudioPlayingAnimation.kt
@@ -110,9 +110,12 @@ private fun Modifier.audioVisualizerHeight(fallback: Dp = 72.dp): Modifier =
     fillMaxWidth().layout { measurable, constraints ->
         val fallbackPx = fallback.roundToPx()
         val targetHeight =
-            if (constraints.hasBoundedHeight && constraints.maxHeight >= fallbackPx * 2) {
-                constraints.maxHeight
+            if (constraints.hasBoundedHeight) {
+                // Fill a clearly-large cell (full-screen dialog); otherwise use the fallback strip but
+                // never exceed the cell, so a small bounded cell can't overflow onto its neighbors.
+                if (constraints.maxHeight >= fallbackPx * 2) constraints.maxHeight else minOf(fallbackPx, constraints.maxHeight)
             } else {
+                // Unbounded (lazy feed): the fallback strip avoids collapsing to zero.
                 fallbackPx
             }
         val placeable = measurable.measure(constraints.copy(minHeight = targetHeight, maxHeight = targetHeight))

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/wavefront/AudioPlayingAnimation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/wavefront/AudioPlayingAnimation.kt
@@ -20,6 +20,8 @@
  */
 package com.vitorpamplona.amethyst.service.playback.composable.wavefront
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -27,11 +29,15 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.media3.common.C
 import androidx.media3.common.Player
 import androidx.media3.common.Tracks
+import com.vitorpamplona.amethyst.commons.audio.AudioVisualizer
+import com.vitorpamplona.amethyst.commons.audio.VisualizerStyle
 import com.vitorpamplona.amethyst.service.playback.composable.MediaControllerState
 import com.vitorpamplona.amethyst.service.playback.composable.WaveformData
+import com.vitorpamplona.amethyst.service.playback.playerPool.PcmTapRegistry
 
 fun Tracks.isAudio() = groups.isNotEmpty() && groups.none { it.type == C.TRACK_TYPE_VIDEO }
 
@@ -39,11 +45,10 @@ fun Tracks.isAudio() = groups.isNotEmpty() && groups.none { it.type == C.TRACK_T
 fun AudioPlayingAnimation(
     controllerState: MediaControllerState,
     waveform: WaveformData?,
+    style: VisualizerStyle,
     modifier: Modifier = Modifier,
     hasBlurhash: Boolean = false,
 ) {
-    if (hasBlurhash) return
-
     var isAudio by remember { mutableStateOf(controllerState.controller.currentTracks.isAudio()) }
 
     DisposableEffect(controllerState.controller) {
@@ -58,14 +63,29 @@ fun AudioPlayingAnimation(
         onDispose { controllerState.controller.removeListener(listener) }
     }
 
-    if (isAudio) {
-        if (waveform != null) {
-            Waveform(waveform, controllerState, modifier)
-        } else {
-            FakeWaveformAnimation(
-                mediaControllerState = controllerState,
-                modifier = modifier,
-            )
+    if (!isAudio) return
+
+    when {
+        // NIP-A0 voice notes etc. that ship a precomputed waveform keep their seek bar.
+        waveform != null -> Waveform(waveform, controllerState, modifier)
+
+        // Visualizer disabled: draw nothing so any blurhash/cover backdrop shows through.
+        style == VisualizerStyle.OFF -> Unit
+
+        else -> {
+            val spectrum = remember(controllerState.controller) { PcmTapRegistry.spectrumFor(controllerState.controller) }
+            if (spectrum != null) {
+                // Dim the cover/blurhash backdrop behind the live visualizer.
+                val drawModifier = if (hasBlurhash) modifier.background(Color.Black.copy(alpha = 0.45f)) else modifier
+                AudioVisualizer(
+                    style = style,
+                    spectrum = spectrum,
+                    modifier = drawModifier.fillMaxSize(),
+                )
+            } else if (!hasBlurhash) {
+                // No live PCM available and no backdrop: keep the decorative fallback.
+                FakeWaveformAnimation(mediaControllerState = controllerState, modifier = modifier)
+            }
         }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/wavefront/AudioPlayingAnimation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/wavefront/AudioPlayingAnimation.kt
@@ -21,7 +21,8 @@
 package com.vitorpamplona.amethyst.service.playback.composable.wavefront
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -30,14 +31,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 import androidx.media3.common.C
 import androidx.media3.common.Player
 import androidx.media3.common.Tracks
 import com.vitorpamplona.amethyst.commons.audio.AudioVisualizer
+import com.vitorpamplona.amethyst.commons.audio.SyntheticSpectrum
 import com.vitorpamplona.amethyst.commons.audio.VisualizerStyle
 import com.vitorpamplona.amethyst.service.playback.composable.MediaControllerState
 import com.vitorpamplona.amethyst.service.playback.composable.WaveformData
 import com.vitorpamplona.amethyst.service.playback.playerPool.PcmTapRegistry
+import kotlinx.coroutines.flow.flowOf
 
 fun Tracks.isAudio() = groups.isNotEmpty() && groups.none { it.type == C.TRACK_TYPE_VIDEO }
 
@@ -45,6 +49,7 @@ fun Tracks.isAudio() = groups.isNotEmpty() && groups.none { it.type == C.TRACK_T
 fun AudioPlayingAnimation(
     controllerState: MediaControllerState,
     waveform: WaveformData?,
+    mediaId: String,
     style: VisualizerStyle,
     modifier: Modifier = Modifier,
     hasBlurhash: Boolean = false,
@@ -69,23 +74,23 @@ fun AudioPlayingAnimation(
         // NIP-A0 voice notes etc. that ship a precomputed waveform keep their seek bar.
         waveform != null -> Waveform(waveform, controllerState, modifier)
 
+        // The app's classic animated waveform.
+        style == VisualizerStyle.CLASSIC -> FakeWaveformAnimation(mediaControllerState = controllerState, modifier = modifier)
+
+        // A still, non-animated bar graphic for users who prefer no motion.
+        style == VisualizerStyle.STATIC -> {
+            val frozen = remember { flowOf(SyntheticSpectrum.frame(0f, 48)) }
+            AudioVisualizer(style = VisualizerStyle.BARS, spectrum = frozen, modifier = modifier.fillMaxWidth().requiredHeight(72.dp))
+        }
+
         // Visualizer disabled: draw nothing so any blurhash/cover backdrop shows through.
         style == VisualizerStyle.OFF -> Unit
 
+        // Live FFT styles (BARS / WAVES / RADIAL / AURORA).
         else -> {
-            val spectrum = remember(controllerState.controller) { PcmTapRegistry.spectrumFor(controllerState.controller) }
-            if (spectrum != null) {
-                // Dim the cover/blurhash backdrop behind the live visualizer.
-                val drawModifier = if (hasBlurhash) modifier.background(Color.Black.copy(alpha = 0.45f)) else modifier
-                AudioVisualizer(
-                    style = style,
-                    spectrum = spectrum,
-                    modifier = drawModifier.fillMaxSize(),
-                )
-            } else if (!hasBlurhash) {
-                // No live PCM available and no backdrop: keep the decorative fallback.
-                FakeWaveformAnimation(mediaControllerState = controllerState, modifier = modifier)
-            }
+            val spectrum = remember(mediaId) { PcmTapRegistry.spectrumFor(mediaId) }
+            val drawModifier = if (hasBlurhash) modifier.background(Color.Black.copy(alpha = 0.45f)) else modifier
+            AudioVisualizer(style = style, spectrum = spectrum, modifier = drawModifier.fillMaxWidth().requiredHeight(72.dp))
         }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/wavefront/AudioPlayingAnimation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/wavefront/AudioPlayingAnimation.kt
@@ -22,7 +22,6 @@ package com.vitorpamplona.amethyst.service.playback.composable.wavefront
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -31,17 +30,19 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.media3.common.C
 import androidx.media3.common.Player
 import androidx.media3.common.Tracks
 import com.vitorpamplona.amethyst.commons.audio.AudioVisualizer
-import com.vitorpamplona.amethyst.commons.audio.SyntheticSpectrum
+import com.vitorpamplona.amethyst.commons.audio.Spectrum
 import com.vitorpamplona.amethyst.commons.audio.VisualizerStyle
 import com.vitorpamplona.amethyst.service.playback.composable.MediaControllerState
 import com.vitorpamplona.amethyst.service.playback.composable.WaveformData
 import com.vitorpamplona.amethyst.service.playback.playerPool.PcmTapRegistry
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.emptyFlow
 
 fun Tracks.isAudio() = groups.isNotEmpty() && groups.none { it.type == C.TRACK_TYPE_VIDEO }
 
@@ -70,27 +71,50 @@ fun AudioPlayingAnimation(
 
     if (!isAudio) return
 
-    when {
+    // Dim any blurhash/cover backdrop behind whatever we draw, for contrast and consistency across
+    // every visible style. OFF draws nothing, so the cover still shows cleanly there.
+    val drawModifier = if (hasBlurhash) modifier.background(Color.Black.copy(alpha = 0.45f)) else modifier
+
+    if (waveform != null) {
         // NIP-A0 voice notes etc. that ship a precomputed waveform keep their seek bar.
-        waveform != null -> Waveform(waveform, controllerState, modifier)
+        Waveform(waveform, controllerState, drawModifier)
+        return
+    }
 
-        // The app's classic animated waveform.
-        style == VisualizerStyle.CLASSIC -> FakeWaveformAnimation(mediaControllerState = controllerState, modifier = modifier)
-
-        // A still, non-animated bar graphic for users who prefer no motion.
-        style == VisualizerStyle.STATIC -> {
-            val frozen = remember { flowOf(SyntheticSpectrum.frame(0f, 48)) }
-            AudioVisualizer(style = VisualizerStyle.BARS, spectrum = frozen, modifier = modifier.fillMaxWidth().requiredHeight(72.dp))
+    when (style) {
+        VisualizerStyle.CLASSIC -> FakeWaveformAnimation(mediaControllerState = controllerState, modifier = drawModifier)
+        VisualizerStyle.STATIC -> {
+            // StaticRenderer ignores the flow and shows a frozen frame.
+            val empty = remember { emptyFlow<Spectrum>() }
+            AudioVisualizer(style = VisualizerStyle.STATIC, spectrum = empty, modifier = drawModifier.audioVisualizerHeight())
         }
-
-        // Visualizer disabled: draw nothing so any blurhash/cover backdrop shows through.
-        style == VisualizerStyle.OFF -> Unit
-
-        // Live FFT styles (BARS / WAVES / RADIAL / AURORA).
-        else -> {
+        VisualizerStyle.OFF -> Unit
+        VisualizerStyle.BARS,
+        VisualizerStyle.WAVES,
+        VisualizerStyle.RADIAL,
+        VisualizerStyle.AURORA,
+        -> {
             val spectrum = remember(mediaId) { PcmTapRegistry.spectrumFor(mediaId) }
-            val drawModifier = if (hasBlurhash) modifier.background(Color.Black.copy(alpha = 0.45f)) else modifier
-            AudioVisualizer(style = style, spectrum = spectrum, modifier = drawModifier.fillMaxWidth().requiredHeight(72.dp))
+            AudioVisualizer(style = style, spectrum = spectrum, modifier = drawModifier.audioVisualizerHeight())
         }
     }
 }
+
+/**
+ * Fills the available height only when the parent gives a bounded height clearly larger than
+ * [fallback] (the full-screen media dialog); otherwise uses the fixed [fallback] strip. This avoids
+ * filling a small bounded feed cell and avoids collapsing to zero under the feed's unbounded lazy
+ * height. Always fills width.
+ */
+private fun Modifier.audioVisualizerHeight(fallback: Dp = 72.dp): Modifier =
+    fillMaxWidth().layout { measurable, constraints ->
+        val fallbackPx = fallback.roundToPx()
+        val targetHeight =
+            if (constraints.hasBoundedHeight && constraints.maxHeight >= fallbackPx * 2) {
+                constraints.maxHeight
+            } else {
+                fallbackPx
+            }
+        val placeable = measurable.measure(constraints.copy(minHeight = targetHeight, maxHeight = targetHeight))
+        layout(placeable.width, targetHeight) { placeable.placeRelative(0, 0) }
+    }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/wavefront/AudioPlayingAnimation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/wavefront/AudioPlayingAnimation.kt
@@ -20,10 +20,15 @@
  */
 package com.vitorpamplona.amethyst.service.playback.composable.wavefront
 
+import android.content.Context
+import android.media.AudioDeviceCallback
+import android.media.AudioDeviceInfo
+import android.media.AudioManager
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -31,6 +36,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layout
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.media3.common.C
@@ -39,12 +45,26 @@ import androidx.media3.common.Tracks
 import com.vitorpamplona.amethyst.commons.audio.AudioVisualizer
 import com.vitorpamplona.amethyst.commons.audio.Spectrum
 import com.vitorpamplona.amethyst.commons.audio.VisualizerStyle
+import com.vitorpamplona.amethyst.commons.audio.delayedByFrames
 import com.vitorpamplona.amethyst.service.playback.composable.MediaControllerState
 import com.vitorpamplona.amethyst.service.playback.composable.WaveformData
 import com.vitorpamplona.amethyst.service.playback.playerPool.PcmTapRegistry
 import kotlinx.coroutines.flow.emptyFlow
 
 fun Tracks.isAudio() = groups.isNotEmpty() && groups.none { it.type == C.TRACK_TYPE_VIDEO }
+
+// Output-latency compensation. The spectrum is tapped upstream of the AudioTrack output buffer (and,
+// over Bluetooth, the codec/transmission lag downstream of it), so the visual leads the speaker and
+// must be delayed to match. Each hop is one 1024-sample FFT frame (~23 ms at 44.1 kHz). Tuned on a
+// Pixel 9a against the 120-BPM beat of the synthetic demo clip (1 beat = 500 ms): wired/speaker wants
+// ~20 hops, Bluetooth ~27 hops (the extra ~7 hops / ~160 ms is the BT codec latency).
+//
+// DEVICE/CODEC-SPECIFIC tuned constants. Android exposes no reliable output latency, and runtime
+// auto-detection from player.currentPosition was tried and rejected (~3.4x off — it measures decode
+// buffer depth, not the perceptual sync point). [rememberIsBluetoothOutput] only switches between
+// these two presets by route; the BT figure is a per-codec average, so it may be off on other gear.
+private const val FEED_VISUALIZER_DELAY_FRAMES = 20
+private const val BT_VISUALIZER_DELAY_FRAMES = 27
 
 @Composable
 fun AudioPlayingAnimation(
@@ -94,9 +114,48 @@ fun AudioPlayingAnimation(
         VisualizerStyle.RADIAL,
         VisualizerStyle.AURORA,
         -> {
-            val spectrum = remember(mediaId) { PcmTapRegistry.spectrumFor(mediaId) }
+            val bluetooth by rememberIsBluetoothOutput()
+            val delayFrames = if (bluetooth) BT_VISUALIZER_DELAY_FRAMES else FEED_VISUALIZER_DELAY_FRAMES
+            val spectrum = remember(mediaId, delayFrames) { PcmTapRegistry.spectrumFor(mediaId).delayedByFrames(delayFrames) }
             AudioVisualizer(style = style, spectrum = spectrum, modifier = drawModifier.audioVisualizerHeight())
         }
+    }
+}
+
+/**
+ * Tracks whether audio is currently routed to a Bluetooth output, updating live as devices connect or
+ * disconnect. Bluetooth adds codec/transmission latency downstream of AudioTrack, so the visualizer
+ * needs a larger delay there. Keys off CONNECTED A2DP/LE output devices — a good proxy since A2DP
+ * captures media playback, and Android exposes no reliable "active media route" before API 31.
+ */
+@Composable
+private fun rememberIsBluetoothOutput(): State<Boolean> {
+    val context = LocalContext.current
+    val audioManager = remember { context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager }
+    val isBluetooth = remember { mutableStateOf(audioManager.isBluetoothOutput()) }
+    DisposableEffect(audioManager) {
+        val callback =
+            object : AudioDeviceCallback() {
+                override fun onAudioDevicesAdded(addedDevices: Array<out AudioDeviceInfo>?) {
+                    isBluetooth.value = audioManager.isBluetoothOutput()
+                }
+
+                override fun onAudioDevicesRemoved(removedDevices: Array<out AudioDeviceInfo>?) {
+                    isBluetooth.value = audioManager.isBluetoothOutput()
+                }
+            }
+        audioManager?.registerAudioDeviceCallback(callback, null)
+        onDispose { audioManager?.unregisterAudioDeviceCallback(callback) }
+    }
+    return isBluetooth
+}
+
+private fun AudioManager?.isBluetoothOutput(): Boolean {
+    if (this == null) return false
+    return getDevices(AudioManager.GET_DEVICES_OUTPUTS).any { device ->
+        device.type == AudioDeviceInfo.TYPE_BLUETOOTH_A2DP ||
+            device.type == AudioDeviceInfo.TYPE_BLE_HEADSET ||
+            device.type == AudioDeviceInfo.TYPE_BLE_SPEAKER
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/ExoPlayerBuilder.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/ExoPlayerBuilder.kt
@@ -22,6 +22,8 @@ package com.vitorpamplona.amethyst.service.playback.playerPool
 
 import android.content.Context
 import androidx.annotation.OptIn
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
 import androidx.media3.exoplayer.DefaultLoadControl
@@ -67,7 +69,18 @@ class ExoPlayerBuilder(
                 setLoadControl(feedTunedLoadControl())
             }.build()
             .apply {
-                PcmTapRegistry.register(this, sink)
+                PcmTapRegistry.registerPlayer(this, sink)
+                addListener(
+                    object : Player.Listener {
+                        override fun onMediaItemTransition(
+                            mediaItem: MediaItem?,
+                            reason: Int,
+                        ) {
+                            PcmTapRegistry.bind(mediaItem?.mediaId, sink)
+                        }
+                    },
+                )
+                PcmTapRegistry.bind(currentMediaItem?.mediaId, sink)
                 addListener(AspectRatioCacher(MediaAspectRatioCache))
                 addListener(KeepVideosPlaying(this))
                 addListener(CurrentPlayPositionCacher(this, VideoViewedPositionCache))

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/ExoPlayerBuilder.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/ExoPlayerBuilder.kt
@@ -25,7 +25,11 @@ import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
 import androidx.media3.exoplayer.DefaultLoadControl
+import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.audio.AudioSink
+import androidx.media3.exoplayer.audio.DefaultAudioSink
+import androidx.media3.exoplayer.audio.TeeAudioProcessor
 import com.vitorpamplona.amethyst.model.MediaAspectRatioCache
 import com.vitorpamplona.amethyst.service.playback.diskCache.VideoCache
 import com.vitorpamplona.amethyst.service.playback.playerPool.aspectRatio.AspectRatioCacher
@@ -38,18 +42,37 @@ class ExoPlayerBuilder(
     val videoCache: VideoCache,
     val dataSourceFactory: DataSource.Factory,
 ) {
-    fun build(context: Context): ExoPlayer =
-        ExoPlayer
-            .Builder(context)
+    fun build(context: Context): ExoPlayer {
+        val sink = PcmTapRegistry.newSink()
+
+        val renderersFactory =
+            object : DefaultRenderersFactory(context) {
+                override fun buildAudioSink(
+                    context: Context,
+                    enableFloatOutput: Boolean,
+                    enableAudioTrackPlaybackParams: Boolean,
+                ): AudioSink =
+                    DefaultAudioSink
+                        .Builder(context)
+                        .setEnableFloatOutput(enableFloatOutput)
+                        .setEnableAudioTrackPlaybackParams(enableAudioTrackPlaybackParams)
+                        .setAudioProcessors(arrayOf(TeeAudioProcessor(sink)))
+                        .build()
+            }
+
+        return ExoPlayer
+            .Builder(context, renderersFactory)
             .apply {
                 setMediaSourceFactory(CustomMediaSourceFactory(videoCache, dataSourceFactory))
                 setLoadControl(feedTunedLoadControl())
             }.build()
             .apply {
+                PcmTapRegistry.register(this, sink)
                 addListener(AspectRatioCacher(MediaAspectRatioCache))
                 addListener(KeepVideosPlaying(this))
                 addListener(CurrentPlayPositionCacher(this, VideoViewedPositionCache))
             }
+    }
 
     companion object {
         // Default DefaultLoadControl buffers 50s ahead before slowing down. Every visible video

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/ExoPlayerPool.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/ExoPlayerPool.kt
@@ -209,7 +209,7 @@ class ExoPlayerPool(
                 coldPool.add(player)
             }
         } else {
-            PcmTapRegistry.unregister(player)
+            PcmTapRegistry.unregisterPlayer(player)
             player.release() // Release if pool is full.
         }
     }
@@ -225,11 +225,11 @@ class ExoPlayerPool(
                             copy
                         }
                     warmSnapshot.forEach {
-                        PcmTapRegistry.unregister(it.player)
+                        PcmTapRegistry.unregisterPlayer(it.player)
                         it.player.release()
                     }
                     coldPool.forEach {
-                        PcmTapRegistry.unregister(it)
+                        PcmTapRegistry.unregisterPlayer(it)
                         it.release()
                     }
                     coldPool.clear()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/ExoPlayerPool.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/ExoPlayerPool.kt
@@ -209,6 +209,7 @@ class ExoPlayerPool(
                 coldPool.add(player)
             }
         } else {
+            PcmTapRegistry.unregister(player)
             player.release() // Release if pool is full.
         }
     }
@@ -223,8 +224,14 @@ class ExoPlayerPool(
                             warmPool.clear()
                             copy
                         }
-                    warmSnapshot.forEach { it.player.release() }
-                    coldPool.forEach { it.release() }
+                    warmSnapshot.forEach {
+                        PcmTapRegistry.unregister(it.player)
+                        it.player.release()
+                    }
+                    coldPool.forEach {
+                        PcmTapRegistry.unregister(it)
+                        it.release()
+                    }
                     coldPool.clear()
                 }
             }.invokeOnCompletion {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/PcmTapRegistry.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/PcmTapRegistry.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.playback.playerPool
+
+import androidx.annotation.OptIn
+import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.audio.TeeAudioProcessor
+import com.vitorpamplona.amethyst.commons.audio.AudioWindow
+import com.vitorpamplona.amethyst.commons.audio.Fft
+import com.vitorpamplona.amethyst.commons.audio.Spectrum
+import com.vitorpamplona.amethyst.commons.audio.normalizedToPeak
+import com.vitorpamplona.amethyst.commons.audio.toLogBins
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * A Media3 [TeeAudioProcessor.AudioBufferSink] that turns the decoded 16-bit PCM of the
+ * currently-playing track into a live [Spectrum] stream ([frames]) via FFT + log binning.
+ *
+ * Only 16-bit PCM is handled; other encodings are ignored. Note that ExoPlayer audio
+ * *offload* and *passthrough* modes bypass the audio-processor chain entirely, so no PCM
+ * reaches this sink in those modes — the [frames] flow simply stays empty and the
+ * visualizer renders idle (it never shows a stale/wrong spectrum, thanks to the replay-cache
+ * reset in [flush]). Amethyst does not enable audio offload, so this is not expected in
+ * practice.
+ */
+@OptIn(UnstableApi::class)
+class SpectrumAudioBufferSink(
+    private val fftSize: Int = 1024,
+    private val binCount: Int = 48,
+) : TeeAudioProcessor.AudioBufferSink {
+    // replay = 1 so a renderer subscribing mid-playback gets the latest frame immediately.
+    val frames = MutableSharedFlow<Spectrum>(replay = 1, extraBufferCapacity = 1)
+
+    private val window = AudioWindow.hann(fftSize)
+    private val mono = ShortArray(fftSize)
+    private var filled = 0
+    private var channels = 1
+    private var encoding = C.ENCODING_PCM_16BIT
+
+    @kotlin.OptIn(ExperimentalCoroutinesApi::class)
+    override fun flush(
+        sampleRateHz: Int,
+        channelCount: Int,
+        encoding: Int,
+    ) {
+        this.channels = channelCount.coerceAtLeast(1)
+        this.encoding = encoding
+        filled = 0
+        // Drop any spectrum from the previously-played track so a freshly subscribing
+        // collector doesn't briefly see the old track's last frame on pooled-player reuse.
+        frames.resetReplayCache()
+    }
+
+    override fun handleBuffer(buffer: ByteBuffer) {
+        if (encoding != C.ENCODING_PCM_16BIT) return
+        val pcm = buffer.order(ByteOrder.LITTLE_ENDIAN)
+        while (pcm.remaining() >= 2 * channels) {
+            val sample = pcm.short // first channel of the frame
+            for (c in 1 until channels) pcm.short // skip remaining channels
+            mono[filled++] = sample
+            if (filled == fftSize) {
+                emitSpectrum()
+                filled = 0
+            }
+        }
+    }
+
+    // Allocates a few short-lived arrays per FFT window (~47/s at 48kHz/1024). Acceptable for
+    // now; pre-allocated working buffers would be the optimization if audio-thread GC shows up.
+    private fun emitSpectrum() {
+        val windowed = AudioWindow.shortsToWindowed(mono, window)
+        val mags = Fft.magnitudes(windowed).normalizedToPeak()
+        frames.tryEmit(Spectrum(mags.toLogBins(binCount)))
+    }
+}
+
+/** Maps each pooled player to its live spectrum stream. */
+@OptIn(UnstableApi::class)
+object PcmTapRegistry {
+    private val sinks = ConcurrentHashMap<Any, SpectrumAudioBufferSink>()
+
+    fun newSink(): SpectrumAudioBufferSink = SpectrumAudioBufferSink()
+
+    fun register(
+        playerKey: Any,
+        sink: SpectrumAudioBufferSink,
+    ) {
+        sinks[playerKey] = sink
+    }
+
+    fun unregister(playerKey: Any) {
+        sinks.remove(playerKey)
+    }
+
+    fun spectrumFor(playerKey: Any): Flow<Spectrum>? = sinks[playerKey]?.frames
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/PcmTapRegistry.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/PcmTapRegistry.kt
@@ -95,7 +95,9 @@ class SpectrumAudioBufferSink(
     private fun emitSpectrum() {
         AudioWindow.shortsToWindowedInto(mono, window, scratch)
         Fft.magnitudesInto(scratch, re, im, mags)
-        mags.normalizeToPeakInPlace()
+        // Skip the DC bin (index 0): toLogBins ignores it, so letting a DC/offset component be the
+        // peak would scale every audible bin toward zero and wash the spectrum out.
+        mags.normalizeToPeakInPlace(fromIndex = 1)
         output?.tryEmit(Spectrum(mags.toLogBins(binCount)))
     }
 }
@@ -130,14 +132,20 @@ object PcmTapRegistry {
         mediaId: String?,
         sink: SpectrumAudioBufferSink,
     ) {
-        sink.boundMediaId = mediaId
-        sink.output = mediaId?.let { flowFor(it) }
+        // Mutate the sink's binding under the same lock that guards flow eviction (flowFor is
+        // reentrant), so the eviction guard never observes a half-updated boundMediaId.
+        synchronized(lock) {
+            sink.boundMediaId = mediaId
+            sink.output = mediaId?.let { flowFor(it) }
+        }
     }
 
     fun unregisterPlayer(playerKey: Any) {
-        sinkByPlayer.remove(playerKey)?.let {
-            it.output = null
-            it.boundMediaId = null
+        synchronized(lock) {
+            sinkByPlayer.remove(playerKey)?.let {
+                it.output = null
+                it.boundMediaId = null
+            }
         }
     }
 
@@ -150,9 +158,13 @@ object PcmTapRegistry {
                 if (flowsByMediaId.size >= MAX_TRACKED_FLOWS) {
                     val iter = flowsByMediaId.entries.iterator()
                     while (iter.hasNext() && flowsByMediaId.size >= MAX_TRACKED_FLOWS) {
-                        val key = iter.next().key
-                        // never evict a flow a live sink is currently feeding
-                        if (sinkByPlayer.values.none { it.boundMediaId == key }) iter.remove()
+                        val entry = iter.next()
+                        // Never evict a flow a live sink is currently feeding, nor one a composable is
+                        // still collecting — otherwise a later bind() would create a fresh instance the
+                        // sink feeds while the old subscriber keeps collecting the dead one (blank viz).
+                        val fedByLiveSink = sinkByPlayer.values.any { it.boundMediaId == entry.key }
+                        val stillCollected = entry.value.subscriptionCount.value > 0
+                        if (!fedByLiveSink && !stillCollected) iter.remove()
                     }
                 }
                 MutableSharedFlow(replay = 1, extraBufferCapacity = 1)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/PcmTapRegistry.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/PcmTapRegistry.kt
@@ -27,7 +27,7 @@ import androidx.media3.exoplayer.audio.TeeAudioProcessor
 import com.vitorpamplona.amethyst.commons.audio.AudioWindow
 import com.vitorpamplona.amethyst.commons.audio.Fft
 import com.vitorpamplona.amethyst.commons.audio.Spectrum
-import com.vitorpamplona.amethyst.commons.audio.normalizedToPeak
+import com.vitorpamplona.amethyst.commons.audio.normalizeToPeakInPlace
 import com.vitorpamplona.amethyst.commons.audio.toLogBins
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -38,13 +38,9 @@ import java.util.concurrent.ConcurrentHashMap
 
 /**
  * A Media3 [TeeAudioProcessor.AudioBufferSink] that turns the decoded 16-bit PCM of the
- * currently-playing track into a live [Spectrum] stream via FFT + log binning, emitting into
- * whichever per-media-id [output] flow [PcmTapRegistry] has currently bound it to.
- *
- * Only 16-bit PCM is handled; other encodings are ignored. ExoPlayer audio *offload* and
- * *passthrough* modes bypass the processor chain, so no PCM reaches this sink in those modes —
- * the bound flow stays empty and the visualizer renders idle (never stale). Amethyst does not
- * enable offload, so this is not expected in practice.
+ * currently-playing track into a live [Spectrum] stream via FFT + log binning, emitting into the
+ * per-media-id flow [PcmTapRegistry] has bound it to. Only 16-bit PCM is handled; offload/passthrough
+ * bypass the processor chain so the flow simply stays empty (visualizer idles, never stale).
  */
 @OptIn(UnstableApi::class)
 class SpectrumAudioBufferSink(
@@ -53,10 +49,18 @@ class SpectrumAudioBufferSink(
 ) : TeeAudioProcessor.AudioBufferSink {
     /** The per-media-id flow this sink currently feeds; set by [PcmTapRegistry.bind]. */
     @Volatile
-    var output: MutableSharedFlow<Spectrum>? = null
+    internal var output: MutableSharedFlow<Spectrum>? = null
+
+    /** The media id this sink is currently bound to; protects its flow from eviction. */
+    @Volatile
+    internal var boundMediaId: String? = null
 
     private val window = AudioWindow.hann(fftSize)
     private val mono = ShortArray(fftSize)
+    private val scratch = FloatArray(fftSize)
+    private val re = DoubleArray(fftSize)
+    private val im = DoubleArray(fftSize)
+    private val mags = FloatArray(fftSize / 2 + 1)
     private var filled = 0
     private var channels = 1
     private var encoding = C.ENCODING_PCM_16BIT
@@ -70,7 +74,6 @@ class SpectrumAudioBufferSink(
         this.channels = channelCount.coerceAtLeast(1)
         this.encoding = encoding
         filled = 0
-        // Drop any spectrum from the previous track so a fresh subscriber doesn't see it on reuse.
         output?.resetReplayCache()
     }
 
@@ -79,7 +82,7 @@ class SpectrumAudioBufferSink(
         val pcm = buffer.order(ByteOrder.LITTLE_ENDIAN)
         while (pcm.remaining() >= 2 * channels) {
             val sample = pcm.short // first channel of the frame
-            for (c in 1 until channels) pcm.short // skip remaining channels
+            if (channels > 1) pcm.position(pcm.position() + (channels - 1) * 2) // skip remaining channels
             mono[filled++] = sample
             if (filled == fftSize) {
                 emitSpectrum()
@@ -88,23 +91,29 @@ class SpectrumAudioBufferSink(
         }
     }
 
-    // Allocates a few short-lived arrays per FFT window (~47/s at 48kHz/1024). Acceptable for now;
-    // pre-allocated working buffers would be the optimization if audio-thread GC shows up.
+    // Reuses pre-allocated working buffers; the only per-frame allocation is the published bins.
     private fun emitSpectrum() {
-        val windowed = AudioWindow.shortsToWindowed(mono, window)
-        val mags = Fft.magnitudes(windowed).normalizedToPeak()
+        AudioWindow.shortsToWindowedInto(mono, window, scratch)
+        Fft.magnitudesInto(scratch, re, im, mags)
+        mags.normalizeToPeakInPlace()
         output?.tryEmit(Spectrum(mags.toLogBins(binCount)))
     }
 }
 
 /**
- * Routes each pooled player's decoded-PCM spectrum to a stable, per-media-id flow that the UI can
- * subscribe to by media URL. The flow is created on demand so a UI subscriber can attach before
- * playback binds the sink (avoids a compose-vs-playback race).
+ * Routes each pooled player's decoded-PCM spectrum to a stable per-media-id flow the UI subscribes
+ * to by media URL. Flows are created on demand (so a UI subscriber can attach before playback binds
+ * the sink) and the map is bounded: past [MAX_TRACKED_FLOWS], the least-recently-used flows that no
+ * live sink is currently feeding are evicted, so a long feed session can't grow the map without limit.
  */
 @OptIn(UnstableApi::class)
 object PcmTapRegistry {
-    private val flowsByMediaId = ConcurrentHashMap<String, MutableSharedFlow<Spectrum>>()
+    private const val MAX_TRACKED_FLOWS = 64
+
+    private val lock = Any()
+
+    // access-order LinkedHashMap → eldest (least-recently-used) entries iterate first for eviction.
+    private val flowsByMediaId = LinkedHashMap<String, MutableSharedFlow<Spectrum>>(16, 0.75f, true)
     private val sinkByPlayer = ConcurrentHashMap<Any, SpectrumAudioBufferSink>()
 
     fun newSink(): SpectrumAudioBufferSink = SpectrumAudioBufferSink()
@@ -116,20 +125,37 @@ object PcmTapRegistry {
         sinkByPlayer[playerKey] = sink
     }
 
-    /** Points [sink]'s output at the flow for [mediaId] (the item it is now playing), or detaches it. */
+    /** Points [sink]'s output at the flow for [mediaId] (the item it now plays), or detaches it. */
     fun bind(
         mediaId: String?,
         sink: SpectrumAudioBufferSink,
     ) {
+        sink.boundMediaId = mediaId
         sink.output = mediaId?.let { flowFor(it) }
     }
 
     fun unregisterPlayer(playerKey: Any) {
-        sinkByPlayer.remove(playerKey)?.output = null
+        sinkByPlayer.remove(playerKey)?.let {
+            it.output = null
+            it.boundMediaId = null
+        }
     }
 
-    /** Stable spectrum stream for a media URL. Frames arrive once a player is bound to it and plays. */
+    /** Stable spectrum stream for a media URL; frames arrive once a player binds to it and plays. */
     fun spectrumFor(mediaId: String): Flow<Spectrum> = flowFor(mediaId)
 
-    private fun flowFor(mediaId: String): MutableSharedFlow<Spectrum> = flowsByMediaId.getOrPut(mediaId) { MutableSharedFlow(replay = 1, extraBufferCapacity = 1) }
+    private fun flowFor(mediaId: String): MutableSharedFlow<Spectrum> =
+        synchronized(lock) {
+            flowsByMediaId.getOrPut(mediaId) {
+                if (flowsByMediaId.size >= MAX_TRACKED_FLOWS) {
+                    val iter = flowsByMediaId.entries.iterator()
+                    while (iter.hasNext() && flowsByMediaId.size >= MAX_TRACKED_FLOWS) {
+                        val key = iter.next().key
+                        // never evict a flow a live sink is currently feeding
+                        if (sinkByPlayer.values.none { it.boundMediaId == key }) iter.remove()
+                    }
+                }
+                MutableSharedFlow(replay = 1, extraBufferCapacity = 1)
+            }
+        }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/PcmTapRegistry.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/PcmTapRegistry.kt
@@ -38,22 +38,22 @@ import java.util.concurrent.ConcurrentHashMap
 
 /**
  * A Media3 [TeeAudioProcessor.AudioBufferSink] that turns the decoded 16-bit PCM of the
- * currently-playing track into a live [Spectrum] stream ([frames]) via FFT + log binning.
+ * currently-playing track into a live [Spectrum] stream via FFT + log binning, emitting into
+ * whichever per-media-id [output] flow [PcmTapRegistry] has currently bound it to.
  *
- * Only 16-bit PCM is handled; other encodings are ignored. Note that ExoPlayer audio
- * *offload* and *passthrough* modes bypass the audio-processor chain entirely, so no PCM
- * reaches this sink in those modes — the [frames] flow simply stays empty and the
- * visualizer renders idle (it never shows a stale/wrong spectrum, thanks to the replay-cache
- * reset in [flush]). Amethyst does not enable audio offload, so this is not expected in
- * practice.
+ * Only 16-bit PCM is handled; other encodings are ignored. ExoPlayer audio *offload* and
+ * *passthrough* modes bypass the processor chain, so no PCM reaches this sink in those modes —
+ * the bound flow stays empty and the visualizer renders idle (never stale). Amethyst does not
+ * enable offload, so this is not expected in practice.
  */
 @OptIn(UnstableApi::class)
 class SpectrumAudioBufferSink(
     private val fftSize: Int = 1024,
     private val binCount: Int = 48,
 ) : TeeAudioProcessor.AudioBufferSink {
-    // replay = 1 so a renderer subscribing mid-playback gets the latest frame immediately.
-    val frames = MutableSharedFlow<Spectrum>(replay = 1, extraBufferCapacity = 1)
+    /** The per-media-id flow this sink currently feeds; set by [PcmTapRegistry.bind]. */
+    @Volatile
+    var output: MutableSharedFlow<Spectrum>? = null
 
     private val window = AudioWindow.hann(fftSize)
     private val mono = ShortArray(fftSize)
@@ -61,7 +61,7 @@ class SpectrumAudioBufferSink(
     private var channels = 1
     private var encoding = C.ENCODING_PCM_16BIT
 
-    @kotlin.OptIn(ExperimentalCoroutinesApi::class)
+    @OptIn(ExperimentalCoroutinesApi::class)
     override fun flush(
         sampleRateHz: Int,
         channelCount: Int,
@@ -70,9 +70,8 @@ class SpectrumAudioBufferSink(
         this.channels = channelCount.coerceAtLeast(1)
         this.encoding = encoding
         filled = 0
-        // Drop any spectrum from the previously-played track so a freshly subscribing
-        // collector doesn't briefly see the old track's last frame on pooled-player reuse.
-        frames.resetReplayCache()
+        // Drop any spectrum from the previous track so a fresh subscriber doesn't see it on reuse.
+        output?.resetReplayCache()
     }
 
     override fun handleBuffer(buffer: ByteBuffer) {
@@ -89,32 +88,48 @@ class SpectrumAudioBufferSink(
         }
     }
 
-    // Allocates a few short-lived arrays per FFT window (~47/s at 48kHz/1024). Acceptable for
-    // now; pre-allocated working buffers would be the optimization if audio-thread GC shows up.
+    // Allocates a few short-lived arrays per FFT window (~47/s at 48kHz/1024). Acceptable for now;
+    // pre-allocated working buffers would be the optimization if audio-thread GC shows up.
     private fun emitSpectrum() {
         val windowed = AudioWindow.shortsToWindowed(mono, window)
         val mags = Fft.magnitudes(windowed).normalizedToPeak()
-        frames.tryEmit(Spectrum(mags.toLogBins(binCount)))
+        output?.tryEmit(Spectrum(mags.toLogBins(binCount)))
     }
 }
 
-/** Maps each pooled player to its live spectrum stream. */
+/**
+ * Routes each pooled player's decoded-PCM spectrum to a stable, per-media-id flow that the UI can
+ * subscribe to by media URL. The flow is created on demand so a UI subscriber can attach before
+ * playback binds the sink (avoids a compose-vs-playback race).
+ */
 @OptIn(UnstableApi::class)
 object PcmTapRegistry {
-    private val sinks = ConcurrentHashMap<Any, SpectrumAudioBufferSink>()
+    private val flowsByMediaId = ConcurrentHashMap<String, MutableSharedFlow<Spectrum>>()
+    private val sinkByPlayer = ConcurrentHashMap<Any, SpectrumAudioBufferSink>()
 
     fun newSink(): SpectrumAudioBufferSink = SpectrumAudioBufferSink()
 
-    fun register(
+    fun registerPlayer(
         playerKey: Any,
         sink: SpectrumAudioBufferSink,
     ) {
-        sinks[playerKey] = sink
+        sinkByPlayer[playerKey] = sink
     }
 
-    fun unregister(playerKey: Any) {
-        sinks.remove(playerKey)
+    /** Points [sink]'s output at the flow for [mediaId] (the item it is now playing), or detaches it. */
+    fun bind(
+        mediaId: String?,
+        sink: SpectrumAudioBufferSink,
+    ) {
+        sink.output = mediaId?.let { flowFor(it) }
     }
 
-    fun spectrumFor(playerKey: Any): Flow<Spectrum>? = sinks[playerKey]?.frames
+    fun unregisterPlayer(playerKey: Any) {
+        sinkByPlayer.remove(playerKey)?.output = null
+    }
+
+    /** Stable spectrum stream for a media URL. Frames arrive once a player is bound to it and plays. */
+    fun spectrumFor(mediaId: String): Flow<Spectrum> = flowFor(mediaId)
+
+    private fun flowFor(mediaId: String): MutableSharedFlow<Spectrum> = flowsByMediaId.getOrPut(mediaId) { MutableSharedFlow(replay = 1, extraBufferCapacity = 1) }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -170,6 +170,7 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.vanish.VanishEventsS
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.scheduledposts.ScheduledPostsScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.search.SearchScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.AllSettingsScreen
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.AudioVisualizerSettingsScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.BlockedUsersScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.BottomBarSettingsScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.CallSettingsScreen
@@ -375,6 +376,7 @@ fun BuildNavigation(
         composableFromEnd<Route.ComposeSettings> { ComposeSettingsScreen(accountViewModel, nav) }
         composableFromEnd<Route.UserSettings> { UserSettingsScreen(accountViewModel, nav) }
         composableFromEnd<Route.ReactionsSettings> { ReactionsSettingsScreen(accountViewModel, nav) }
+        composableFromEnd<Route.AudioVisualizerSettings> { AudioVisualizerSettingsScreen(accountViewModel, nav) }
         composableFromEnd<Route.BottomBarSettings> { BottomBarSettingsScreen(accountViewModel, nav) }
         composableFromEnd<Route.HomeTabsSettings> { HomeTabsSettingsScreen(accountViewModel, nav) }
         composableFromEnd<Route.ProfileUiSettings> { ProfileUiSettingsScreen(accountViewModel, nav) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
@@ -325,6 +325,8 @@ sealed class Route {
 
     @Serializable object ReactionsSettings : Route()
 
+    @Serializable object AudioVisualizerSettings : Route()
+
     @Serializable object BottomBarSettings : Route()
 
     @Serializable object HomeTabsSettings : Route()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -1312,9 +1312,10 @@ class AccountViewModel(
 
     fun audioVisualizerFlow(): StateFlow<VisualizerStyle> = account.settings.syncedSettings.media.audioVisualizer
 
-    fun changeAudioVisualizer(style: VisualizerStyle) {
-        account.settings.changeAudioVisualizer(style)
-    }
+    fun changeAudioVisualizer(style: VisualizerStyle) =
+        launchSigner {
+            account.changeAudioVisualizer(style)
+        }
 
     fun updateZapAmounts(
         amountSet: List<Long>,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -37,6 +37,7 @@ import com.vitorpamplona.amethyst.AccountInfo
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.LocalPreferences
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.audio.VisualizerStyle
 import com.vitorpamplona.amethyst.commons.model.LiveHiddenUsers
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
 import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatChannel
@@ -1308,6 +1309,12 @@ class AccountViewModel(
         launchSigner {
             account.changeVideoPlayerButtonItems(items)
         }
+
+    fun audioVisualizerFlow(): StateFlow<VisualizerStyle> = account.settings.syncedSettings.media.audioVisualizer
+
+    fun changeAudioVisualizer(style: VisualizerStyle) {
+        account.settings.changeAudioVisualizer(style)
+    }
 
     fun updateZapAmounts(
         amountSet: List<Long>,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AudioVisualizerSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AudioVisualizerSettingsScreen.kt
@@ -20,12 +20,6 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings
 
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -45,9 +39,11 @@ import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.withFrameMillis
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -56,6 +52,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.audio.AudioVisualizer
+import com.vitorpamplona.amethyst.commons.audio.Spectrum
 import com.vitorpamplona.amethyst.commons.audio.SyntheticSpectrum
 import com.vitorpamplona.amethyst.commons.audio.VisualizerStyle
 import com.vitorpamplona.amethyst.service.playback.composable.wavefront.FakeWaveformAnimation
@@ -63,7 +60,7 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.TopBarWithBackButton
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.Flow
 
 @Composable
 fun AudioVisualizerSettingsScreen(
@@ -85,6 +82,7 @@ fun AudioVisualizerSettingsContent(
     modifier: Modifier = Modifier,
 ) {
     val selected by accountViewModel.audioVisualizerFlow().collectAsStateWithLifecycle()
+    val previewSpectrum = remember { SyntheticSpectrum.flow(48) }
 
     LazyColumn(modifier = modifier.fillMaxWidth()) {
         item {
@@ -99,6 +97,7 @@ fun AudioVisualizerSettingsContent(
             VisualizerStyleRow(
                 style = style,
                 selected = style == selected,
+                previewSpectrum = previewSpectrum,
                 onClick = { accountViewModel.changeAudioVisualizer(style) },
             )
         }
@@ -110,6 +109,7 @@ fun AudioVisualizerSettingsContent(
 private fun VisualizerStyleRow(
     style: VisualizerStyle,
     selected: Boolean,
+    previewSpectrum: Flow<Spectrum>,
     onClick: () -> Unit,
 ) {
     Row(
@@ -132,28 +132,17 @@ private fun VisualizerStyleRow(
                     .clip(RoundedCornerShape(8.dp))
                     .background(Color(0xFF0C0C10)),
         ) {
-            when (style) {
-                VisualizerStyle.OFF -> Unit
-                VisualizerStyle.CLASSIC -> {
-                    val transition = rememberInfiniteTransition(label = "classicPreview")
-                    val anim by transition.animateFloat(
-                        initialValue = 0f,
-                        targetValue = 1f,
-                        animationSpec = infiniteRepeatable(tween(1500, easing = LinearEasing), RepeatMode.Restart),
-                        label = "classicProgress",
-                    )
-                    val progress = remember { mutableFloatStateOf(0f) }
-                    progress.floatValue = anim
-                    FakeWaveformAnimation(progress, 40, Modifier.fillMaxWidth().height(56.dp))
+            if (style == VisualizerStyle.CLASSIC) {
+                val progress = remember { mutableFloatStateOf(0f) }
+                LaunchedEffect(Unit) {
+                    while (true) {
+                        withFrameMillis { ms -> progress.floatValue = (ms % 1500L) / 1500f }
+                    }
                 }
-                VisualizerStyle.STATIC -> {
-                    val frozen = remember { flowOf(SyntheticSpectrum.frame(0f, 48)) }
-                    AudioVisualizer(style = VisualizerStyle.BARS, spectrum = frozen, modifier = Modifier.fillMaxWidth().height(56.dp))
-                }
-                else -> {
-                    val preview = remember { SyntheticSpectrum.flow(48) }
-                    AudioVisualizer(style = style, spectrum = preview, modifier = Modifier.fillMaxWidth().height(56.dp))
-                }
+                FakeWaveformAnimation(progress, 40, Modifier.fillMaxWidth().height(56.dp))
+            } else {
+                // OFF → OffRenderer (nothing), STATIC → frozen bars, others → live preview.
+                AudioVisualizer(style = style, spectrum = previewSpectrum, modifier = Modifier.fillMaxWidth().height(56.dp))
             }
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AudioVisualizerSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AudioVisualizerSettingsScreen.kt
@@ -149,7 +149,7 @@ private fun VisualizerStyleRow(
 }
 
 @Composable
-fun visualizerStyleName(style: VisualizerStyle): String =
+private fun visualizerStyleName(style: VisualizerStyle): String =
     when (style) {
         VisualizerStyle.CLASSIC -> stringRes(R.string.audio_visualizer_classic)
         VisualizerStyle.OFF -> stringRes(R.string.audio_visualizer_off)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AudioVisualizerSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/AudioVisualizerSettingsScreen.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.audio.AudioVisualizer
+import com.vitorpamplona.amethyst.commons.audio.SyntheticSpectrum
+import com.vitorpamplona.amethyst.commons.audio.VisualizerStyle
+import com.vitorpamplona.amethyst.service.playback.composable.wavefront.FakeWaveformAnimation
+import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.topbars.TopBarWithBackButton
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.stringRes
+import kotlinx.coroutines.flow.flowOf
+
+@Composable
+fun AudioVisualizerSettingsScreen(
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    Scaffold(
+        topBar = {
+            TopBarWithBackButton(stringRes(id = R.string.audio_visualizer_settings), nav)
+        },
+    ) { padding ->
+        AudioVisualizerSettingsContent(accountViewModel, Modifier.padding(padding))
+    }
+}
+
+@Composable
+fun AudioVisualizerSettingsContent(
+    accountViewModel: AccountViewModel,
+    modifier: Modifier = Modifier,
+) {
+    val selected by accountViewModel.audioVisualizerFlow().collectAsStateWithLifecycle()
+
+    LazyColumn(modifier = modifier.fillMaxWidth()) {
+        item {
+            Text(
+                text = stringRes(R.string.audio_visualizer_settings_description),
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color.Gray,
+                modifier = Modifier.padding(16.dp),
+            )
+        }
+        items(VisualizerStyle.entries) { style ->
+            VisualizerStyleRow(
+                style = style,
+                selected = style == selected,
+                onClick = { accountViewModel.changeAudioVisualizer(style) },
+            )
+        }
+        item { Spacer(Modifier.height(16.dp)) }
+    }
+}
+
+@Composable
+private fun VisualizerStyleRow(
+    style: VisualizerStyle,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        RadioButton(selected = selected, onClick = onClick)
+        Column(Modifier.weight(1f)) {
+            Text(visualizerStyleName(style), style = MaterialTheme.typography.bodyLarge)
+        }
+        Box(
+            modifier =
+                Modifier
+                    .size(width = 120.dp, height = 56.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(Color(0xFF0C0C10)),
+        ) {
+            when (style) {
+                VisualizerStyle.OFF -> Unit
+                VisualizerStyle.CLASSIC -> {
+                    val transition = rememberInfiniteTransition(label = "classicPreview")
+                    val anim by transition.animateFloat(
+                        initialValue = 0f,
+                        targetValue = 1f,
+                        animationSpec = infiniteRepeatable(tween(1500, easing = LinearEasing), RepeatMode.Restart),
+                        label = "classicProgress",
+                    )
+                    val progress = remember { mutableFloatStateOf(0f) }
+                    progress.floatValue = anim
+                    FakeWaveformAnimation(progress, 40, Modifier.fillMaxWidth().height(56.dp))
+                }
+                VisualizerStyle.STATIC -> {
+                    val frozen = remember { flowOf(SyntheticSpectrum.frame(0f, 48)) }
+                    AudioVisualizer(style = VisualizerStyle.BARS, spectrum = frozen, modifier = Modifier.fillMaxWidth().height(56.dp))
+                }
+                else -> {
+                    val preview = remember { SyntheticSpectrum.flow(48) }
+                    AudioVisualizer(style = style, spectrum = preview, modifier = Modifier.fillMaxWidth().height(56.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun visualizerStyleName(style: VisualizerStyle): String =
+    when (style) {
+        VisualizerStyle.CLASSIC -> stringRes(R.string.audio_visualizer_classic)
+        VisualizerStyle.OFF -> stringRes(R.string.audio_visualizer_off)
+        VisualizerStyle.BARS -> stringRes(R.string.audio_visualizer_bars)
+        VisualizerStyle.WAVES -> stringRes(R.string.audio_visualizer_waves)
+        VisualizerStyle.RADIAL -> stringRes(R.string.audio_visualizer_radial)
+        VisualizerStyle.AURORA -> stringRes(R.string.audio_visualizer_aurora)
+        VisualizerStyle.STATIC -> stringRes(R.string.audio_visualizer_static)
+    }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/SettingsCatalogBuilder.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/SettingsCatalogBuilder.kt
@@ -71,6 +71,7 @@ fun buildSettingsCatalog(
                     symEntry(R.string.favorite_dvms_title, MaterialSymbols.AutoAwesome, R.string.favorite_dvms_search_keywords, Route.EditFavoriteAlgoFeeds),
                     symEntry(R.string.reactions, MaterialSymbols.FavoriteBorder, R.string.reactions_search_keywords, Route.UpdateReactionType),
                     symEntry(R.string.video_player_settings, MaterialSymbols.VideoSettings, R.string.video_player_search_keywords, Route.VideoPlayerSettings),
+                    symEntry(R.string.audio_visualizer_settings, MaterialSymbols.MusicNote, R.string.audio_visualizer_search_keywords, Route.AudioVisualizerSettings),
                     symEntry(R.string.zaps, MaterialSymbols.Bolt, R.string.zaps_search_keywords, Route.UpdateZapAmount()),
                     symEntry(R.string.payment_targets, MaterialSymbols.Payment, R.string.payment_targets_search_keywords, Route.EditPaymentTargets),
                     symEntry(R.string.security_filters, MaterialSymbols.Security, R.string.security_filters_search_keywords, Route.SecurityFilters),

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -1526,6 +1526,7 @@
     <string name="favorite_dvms_search_keywords" translatable="false">dvm, data vending machine, algo, algorithm, feeds</string>
     <string name="reactions_search_keywords" translatable="false">emoji, like, reaction</string>
     <string name="video_player_search_keywords" translatable="false">video, player, playback, autoplay, mute</string>
+    <string name="audio_visualizer_search_keywords" translatable="false">audio, visualizer, spectrum, bars, waves, radial, aurora, animation</string>
     <string name="payment_targets_search_keywords" translatable="false">zap split, split, recipients, forward zaps</string>
     <string name="call_settings_search_keywords" translatable="false">webrtc, video call, voice call, calls</string>
     <string name="translations_search_keywords" translatable="false">language, translate, locale</string>
@@ -2335,6 +2336,16 @@
     <string name="video_player_settings_action_pip_description">Play the video in a floating window (hidden if unsupported)</string>
     <string name="video_player_settings_action_cast">Cast to Device</string>
     <string name="video_player_settings_action_cast_description">Send the video to a Chromecast receiver on your Wi-Fi (hidden for local files)</string>
+
+    <string name="audio_visualizer_settings">Audio Visualizer</string>
+    <string name="audio_visualizer_settings_description">Choose the animation shown while audio notes play.</string>
+    <string name="audio_visualizer_off">Off</string>
+    <string name="audio_visualizer_bars">Spectrum Bars</string>
+    <string name="audio_visualizer_waves">Color Waves</string>
+    <string name="audio_visualizer_radial">Radial Ring</string>
+    <string name="audio_visualizer_aurora">Aurora Glow</string>
+    <string name="audio_visualizer_classic">Classic Waveform</string>
+    <string name="audio_visualizer_static">Static Image</string>
 
     <string name="profile_image_of_user">Profile Picture of %1$s</string>
     <string name="relay_info">Relay %1$s</string>

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/service/playback/playerPool/SpectrumAudioBufferSinkTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/service/playback/playerPool/SpectrumAudioBufferSinkTest.kt
@@ -23,6 +23,8 @@ package com.vitorpamplona.amethyst.service.playback.playerPool
 import androidx.annotation.OptIn
 import androidx.media3.common.C
 import androidx.media3.common.util.UnstableApi
+import com.vitorpamplona.amethyst.commons.audio.Spectrum
+import kotlinx.coroutines.flow.MutableSharedFlow
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -66,11 +68,13 @@ class SpectrumAudioBufferSinkTest {
     @Test
     fun lowFrequencySineLightsLowBins() {
         val sink = SpectrumAudioBufferSink(fftSize = fftSize, binCount = binCount)
+        val out = MutableSharedFlow<Spectrum>(replay = 1, extraBufferCapacity = 1)
+        sink.output = out
         sink.flush(48000, 1, C.ENCODING_PCM_16BIT)
         sink.handleBuffer(monoPcm(sineShorts(k = 2, n = fftSize)))
 
         val bins =
-            sink.frames.replayCache
+            out.replayCache
                 .last()
                 .bins
         assertEquals(binCount, bins.size)
@@ -80,11 +84,13 @@ class SpectrumAudioBufferSinkTest {
     @Test
     fun highFrequencySineLightsHighBins() {
         val sink = SpectrumAudioBufferSink(fftSize = fftSize, binCount = binCount)
+        val out = MutableSharedFlow<Spectrum>(replay = 1, extraBufferCapacity = 1)
+        sink.output = out
         sink.flush(48000, 1, C.ENCODING_PCM_16BIT)
         sink.handleBuffer(monoPcm(sineShorts(k = 28, n = fftSize)))
 
         val bins =
-            sink.frames.replayCache
+            out.replayCache
                 .last()
                 .bins
         assertTrue("expected high bin to dominate, got ${maxBin(bins)}", maxBin(bins) >= binCount / 2)
@@ -93,11 +99,13 @@ class SpectrumAudioBufferSinkTest {
     @Test
     fun stereoIsDownmixedFromFirstChannel() {
         val sink = SpectrumAudioBufferSink(fftSize = fftSize, binCount = binCount)
+        val out = MutableSharedFlow<Spectrum>(replay = 1, extraBufferCapacity = 1)
+        sink.output = out
         sink.flush(48000, 2, C.ENCODING_PCM_16BIT)
         sink.handleBuffer(interleavedStereoPcm(sineShorts(k = 2, n = fftSize), ShortArray(fftSize)))
 
         val bins =
-            sink.frames.replayCache
+            out.replayCache
                 .last()
                 .bins
         assertTrue(maxBin(bins) < binCount / 2)
@@ -106,22 +114,26 @@ class SpectrumAudioBufferSinkTest {
     @Test
     fun emitsOnlyAfterAFullFftWindowAccumulates() {
         val sink = SpectrumAudioBufferSink(fftSize = fftSize, binCount = binCount)
+        val out = MutableSharedFlow<Spectrum>(replay = 1, extraBufferCapacity = 1)
+        sink.output = out
         sink.flush(48000, 1, C.ENCODING_PCM_16BIT)
         val full = sineShorts(k = 4, n = fftSize)
 
         sink.handleBuffer(monoPcm(full.copyOfRange(0, fftSize / 2)))
-        assertTrue("no frame should emit before a full window", sink.frames.replayCache.isEmpty())
+        assertTrue("no frame should emit before a full window", out.replayCache.isEmpty())
 
         sink.handleBuffer(monoPcm(full.copyOfRange(fftSize / 2, fftSize)))
-        assertEquals(1, sink.frames.replayCache.size)
+        assertEquals(1, out.replayCache.size)
     }
 
     @Test
     fun nonPcm16EncodingEmitsNothing() {
         val sink = SpectrumAudioBufferSink(fftSize = fftSize, binCount = binCount)
+        val out = MutableSharedFlow<Spectrum>(replay = 1, extraBufferCapacity = 1)
+        sink.output = out
         sink.flush(48000, 1, C.ENCODING_PCM_FLOAT)
         sink.handleBuffer(monoPcm(sineShorts(k = 4, n = fftSize)))
 
-        assertTrue("non-16-bit PCM must not emit a spectrum", sink.frames.replayCache.isEmpty())
+        assertTrue("non-16-bit PCM must not emit a spectrum", out.replayCache.isEmpty())
     }
 }

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/service/playback/playerPool/SpectrumAudioBufferSinkTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/service/playback/playerPool/SpectrumAudioBufferSinkTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.playback.playerPool
+
+import androidx.annotation.OptIn
+import androidx.media3.common.C
+import androidx.media3.common.util.UnstableApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import kotlin.math.PI
+import kotlin.math.sin
+
+@OptIn(UnstableApi::class)
+class SpectrumAudioBufferSinkTest {
+    private val fftSize = 64
+    private val binCount = 16
+
+    private fun sineShorts(
+        k: Int,
+        n: Int,
+    ): ShortArray = ShortArray(n) { (sin(2.0 * PI * k * it / n) * 30000).toInt().toShort() }
+
+    private fun monoPcm(samples: ShortArray): ByteBuffer {
+        val bb = ByteBuffer.allocate(samples.size * 2).order(ByteOrder.LITTLE_ENDIAN)
+        for (s in samples) bb.putShort(s)
+        bb.flip()
+        return bb
+    }
+
+    private fun interleavedStereoPcm(
+        left: ShortArray,
+        right: ShortArray,
+    ): ByteBuffer {
+        val bb = ByteBuffer.allocate(left.size * 4).order(ByteOrder.LITTLE_ENDIAN)
+        for (i in left.indices) {
+            bb.putShort(left[i])
+            bb.putShort(right[i])
+        }
+        bb.flip()
+        return bb
+    }
+
+    private fun maxBin(spectrumBins: FloatArray): Int = spectrumBins.indices.maxByOrNull { spectrumBins[it] } ?: -1
+
+    @Test
+    fun lowFrequencySineLightsLowBins() {
+        val sink = SpectrumAudioBufferSink(fftSize = fftSize, binCount = binCount)
+        sink.flush(48000, 1, C.ENCODING_PCM_16BIT)
+        sink.handleBuffer(monoPcm(sineShorts(k = 2, n = fftSize)))
+
+        val bins =
+            sink.frames.replayCache
+                .last()
+                .bins
+        assertEquals(binCount, bins.size)
+        assertTrue("expected low bin to dominate, got ${maxBin(bins)}", maxBin(bins) < binCount / 2)
+    }
+
+    @Test
+    fun highFrequencySineLightsHighBins() {
+        val sink = SpectrumAudioBufferSink(fftSize = fftSize, binCount = binCount)
+        sink.flush(48000, 1, C.ENCODING_PCM_16BIT)
+        sink.handleBuffer(monoPcm(sineShorts(k = 28, n = fftSize)))
+
+        val bins =
+            sink.frames.replayCache
+                .last()
+                .bins
+        assertTrue("expected high bin to dominate, got ${maxBin(bins)}", maxBin(bins) >= binCount / 2)
+    }
+
+    @Test
+    fun stereoIsDownmixedFromFirstChannel() {
+        val sink = SpectrumAudioBufferSink(fftSize = fftSize, binCount = binCount)
+        sink.flush(48000, 2, C.ENCODING_PCM_16BIT)
+        sink.handleBuffer(interleavedStereoPcm(sineShorts(k = 2, n = fftSize), ShortArray(fftSize)))
+
+        val bins =
+            sink.frames.replayCache
+                .last()
+                .bins
+        assertTrue(maxBin(bins) < binCount / 2)
+    }
+
+    @Test
+    fun emitsOnlyAfterAFullFftWindowAccumulates() {
+        val sink = SpectrumAudioBufferSink(fftSize = fftSize, binCount = binCount)
+        sink.flush(48000, 1, C.ENCODING_PCM_16BIT)
+        val full = sineShorts(k = 4, n = fftSize)
+
+        sink.handleBuffer(monoPcm(full.copyOfRange(0, fftSize / 2)))
+        assertTrue("no frame should emit before a full window", sink.frames.replayCache.isEmpty())
+
+        sink.handleBuffer(monoPcm(full.copyOfRange(fftSize / 2, fftSize)))
+        assertEquals(1, sink.frames.replayCache.size)
+    }
+
+    @Test
+    fun nonPcm16EncodingEmitsNothing() {
+        val sink = SpectrumAudioBufferSink(fftSize = fftSize, binCount = binCount)
+        sink.flush(48000, 1, C.ENCODING_PCM_FLOAT)
+        sink.handleBuffer(monoPcm(sineShorts(k = 4, n = fftSize)))
+
+        assertTrue("non-16-bit PCM must not emit a spectrum", sink.frames.replayCache.isEmpty())
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioSpectrum.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioSpectrum.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.audio
+
+import kotlin.math.exp
+import kotlin.math.ln
+import kotlin.math.log10
+
+/** One frame of frequency-domain magnitudes, ordered low→high Hz and normalized 0f..1f. */
+class Spectrum(
+    val bins: FloatArray,
+)
+
+/**
+ * Groups a linear-frequency magnitude array (index 0 = DC, last index = Nyquist)
+ * into [binCount] log-spaced buckets so bass/mid get more bars than the treble
+ * tail. Output is normalized 0f..1f using [floorDb] as the silence floor.
+ * Bin 0 (DC) is always excluded from the output.
+ */
+fun FloatArray.toLogBins(
+    binCount: Int,
+    floorDb: Float = -60f,
+): FloatArray {
+    if (isEmpty() || binCount <= 0) return FloatArray(0)
+    val step = ln(size.toDouble()) / binCount
+    val out = FloatArray(binCount)
+    for (b in 0 until binCount) {
+        val lo = exp(step * b).toInt().coerceAtLeast(1)
+        val hi = exp(step * (b + 1)).toInt().coerceAtMost(size).coerceAtLeast(lo + 1)
+        var peak = 0f
+        for (i in lo until hi) if (i < size && this[i] > peak) peak = this[i]
+        val db = if (peak > 0f) 20f * log10(peak) else floorDb
+        out[b] = ((db - floorDb) / -floorDb).coerceIn(0f, 1f)
+    }
+    return out
+}
+
+fun silentSpectrum(binCount: Int): Spectrum = Spectrum(FloatArray(binCount))
+
+/** Returns a NEW array scaled so the largest value becomes 1f. An all-zero input is returned as a zero-filled copy. */
+fun FloatArray.normalizedToPeak(): FloatArray {
+    var peak = 0f
+    for (v in this) if (v > peak) peak = v
+    if (peak <= 0f) return copyOf()
+    val inv = 1f / peak
+    return FloatArray(size) { this[it] * inv }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioSpectrum.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioSpectrum.kt
@@ -20,6 +20,8 @@
  */
 package com.vitorpamplona.amethyst.commons.audio
 
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlin.math.exp
 import kotlin.math.ln
 import kotlin.math.log10
@@ -85,3 +87,24 @@ fun FloatArray.normalizeToPeakInPlace(fromIndex: Int = 0) {
     val inv = 1f / peak
     for (i in fromIndex until size) this[i] *= inv
 }
+
+/**
+ * Holds back the latest [frames] spectra and emits the one from [frames] hops ago. The PCM tap
+ * computes each [Spectrum] inside the audio processor chain, upstream of the AudioTrack output
+ * buffer, so it runs ahead of what's audible by roughly that buffer's depth. Delaying the visual by
+ * the same number of decoded FFT hops (one [Spectrum] == one hop) realigns it with the speaker, in
+ * the same decoded-sample units as the lead, so it stays correct across startup and rate jitter.
+ * [frames] <= 0 is identity (e.g. previews, which carry no output latency).
+ */
+fun Flow<Spectrum>.delayedByFrames(frames: Int): Flow<Spectrum> =
+    if (frames <= 0) {
+        this
+    } else {
+        flow {
+            val queue = ArrayDeque<Spectrum>(frames + 1)
+            collect { frame ->
+                queue.addLast(frame)
+                if (queue.size > frames) emit(queue.removeFirst())
+            }
+        }
+    }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioSpectrum.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioSpectrum.kt
@@ -61,8 +61,6 @@ fun FloatArray.toLogBins(
     return out
 }
 
-fun silentSpectrum(binCount: Int): Spectrum = Spectrum(FloatArray(binCount))
-
 /**
  * Returns a NEW array scaled so the largest value becomes 1f. An all-zero input is returned as a zero-filled copy.
  * Reference/allocating variant — production uses the *Into / in-place form on the audio thread.
@@ -75,11 +73,15 @@ fun FloatArray.normalizedToPeak(): FloatArray {
     return FloatArray(size) { this[it] * inv }
 }
 
-/** In-place version of [normalizedToPeak]: scales this array so its largest value becomes 1f. */
-fun FloatArray.normalizeToPeakInPlace() {
+/**
+ * In-place version of [normalizedToPeak]: scales this array so its largest value becomes 1f.
+ * [fromIndex] excludes leading entries from both the peak search and the scaling (e.g. pass 1 to
+ * ignore the DC bin of an FFT magnitude array, which downstream log-binning also skips).
+ */
+fun FloatArray.normalizeToPeakInPlace(fromIndex: Int = 0) {
     var peak = 0f
-    for (v in this) if (v > peak) peak = v
+    for (i in fromIndex until size) if (this[i] > peak) peak = this[i]
     if (peak <= 0f) return
     val inv = 1f / peak
-    for (i in indices) this[i] *= inv
+    for (i in fromIndex until size) this[i] *= inv
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioSpectrum.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioSpectrum.kt
@@ -33,33 +33,53 @@ class Spectrum(
  * Groups a linear-frequency magnitude array (index 0 = DC, last index = Nyquist)
  * into [binCount] log-spaced buckets so bass/mid get more bars than the treble
  * tail. Output is normalized 0f..1f using [floorDb] as the silence floor.
- * Bin 0 (DC) is always excluded from the output.
+ * Bin 0 (DC) is always excluded; the Nyquist bin (last) is included.
+ * Low bins are guaranteed to map to distinct FFT bins (contiguous, non-aliased).
  */
 fun FloatArray.toLogBins(
     binCount: Int,
     floorDb: Float = -60f,
 ): FloatArray {
     if (isEmpty() || binCount <= 0) return FloatArray(0)
-    val step = ln(size.toDouble()) / binCount
     val out = FloatArray(binCount)
+    val logSize = ln(size.toDouble())
+    var lo = 1 // skip DC (index 0)
     for (b in 0 until binCount) {
-        val lo = exp(step * b).toInt().coerceAtLeast(1)
-        val hi = exp(step * (b + 1)).toInt().coerceAtMost(size).coerceAtLeast(lo + 1)
+        var hi = exp(logSize * (b + 1) / binCount).toInt()
+        if (hi <= lo) hi = lo + 1 // contiguous & distinct buckets: low bins map to distinct FFT bins, not all to bin 1
+        if (hi > size) hi = size
         var peak = 0f
-        for (i in lo until hi) if (i < size && this[i] > peak) peak = this[i]
+        var i = lo
+        while (i < hi) {
+            if (this[i] > peak) peak = this[i]
+            i++
+        }
         val db = if (peak > 0f) 20f * log10(peak) else floorDb
         out[b] = ((db - floorDb) / -floorDb).coerceIn(0f, 1f)
+        lo = hi
     }
     return out
 }
 
 fun silentSpectrum(binCount: Int): Spectrum = Spectrum(FloatArray(binCount))
 
-/** Returns a NEW array scaled so the largest value becomes 1f. An all-zero input is returned as a zero-filled copy. */
+/**
+ * Returns a NEW array scaled so the largest value becomes 1f. An all-zero input is returned as a zero-filled copy.
+ * Reference/allocating variant — production uses the *Into / in-place form on the audio thread.
+ */
 fun FloatArray.normalizedToPeak(): FloatArray {
     var peak = 0f
     for (v in this) if (v > peak) peak = v
     if (peak <= 0f) return copyOf()
     val inv = 1f / peak
     return FloatArray(size) { this[it] * inv }
+}
+
+/** In-place version of [normalizedToPeak]: scales this array so its largest value becomes 1f. */
+fun FloatArray.normalizeToPeakInPlace() {
+    var peak = 0f
+    for (v in this) if (v > peak) peak = v
+    if (peak <= 0f) return
+    val inv = 1f / peak
+    for (i in indices) this[i] *= inv
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioVisualizer.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioVisualizer.kt
@@ -24,7 +24,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import kotlinx.coroutines.flow.Flow
 
-/** Renders [spectrum] using whichever [style] the user selected. */
+/**
+ * Renders [spectrum] using whichever [style] the user selected.
+ * CLASSIC is not a spectrum renderer; passing it renders nothing (OffRenderer fallback). Callers handle CLASSIC separately.
+ */
 @Composable
 fun AudioVisualizer(
     style: VisualizerStyle,

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioVisualizer.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioVisualizer.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.audio
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import kotlinx.coroutines.flow.Flow
+
+/** Renders [spectrum] using whichever [style] the user selected. */
+@Composable
+fun AudioVisualizer(
+    style: VisualizerStyle,
+    spectrum: Flow<Spectrum>,
+    modifier: Modifier = Modifier,
+    palette: VisualizerPalette = VisualizerPalette.DEFAULT,
+) {
+    VisualizerRegistry.forStyle(style).Render(spectrum, palette, modifier)
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioWindow.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioWindow.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.audio
+
+import kotlin.math.PI
+import kotlin.math.cos
+
+object AudioWindow {
+    /** Hann window of length [n]. */
+    fun hann(n: Int): FloatArray {
+        if (n <= 1) return FloatArray(n) { 1f }
+        return FloatArray(n) { (0.5 - 0.5 * cos(2.0 * PI * it / (n - 1))).toFloat() }
+    }
+
+    /**
+     * Converts 16-bit PCM [samples] to normalized floats in [-1, 1], multiplies by
+     * [window], and pads/truncates to `window.size`.
+     */
+    fun shortsToWindowed(
+        samples: ShortArray,
+        window: FloatArray,
+    ): FloatArray =
+        FloatArray(window.size) { i ->
+            if (i < samples.size) (samples[i] / 32768f) * window[i] else 0f
+        }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioWindow.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioWindow.kt
@@ -41,4 +41,16 @@ object AudioWindow {
         FloatArray(window.size) { i ->
             if (i < samples.size) (samples[i] / 32768f) * window[i] else 0f
         }
+
+    /** Like [shortsToWindowed] but writes into [out] (size must equal [window].size); no allocation. */
+    fun shortsToWindowedInto(
+        samples: ShortArray,
+        window: FloatArray,
+        out: FloatArray,
+    ) {
+        require(out.size == window.size) { "out buffer must match window size" }
+        for (i in window.indices) {
+            out[i] = if (i < samples.size) (samples[i] / 32768f) * window[i] else 0f
+        }
+    }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/Fft.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/Fft.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.audio
+
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/**
+ * Minimal in-place iterative radix-2 Cooley–Tukey FFT (pure Kotlin, no JNI).
+ * Adapted from Nayuki's public-domain "Free small FFT". Only power-of-2 sizes
+ * are supported, which is all an audio visualiser needs (256/512/1024).
+ */
+object Fft {
+    /** In-place forward transform. [re]/[im] must be the same power-of-2 length. */
+    fun transform(
+        re: DoubleArray,
+        im: DoubleArray,
+    ) {
+        val n = re.size
+        require(n != 0 && (n and (n - 1)) == 0) { "FFT size must be a power of 2, was $n" }
+
+        var j = 0
+        for (i in 1 until n) {
+            var bit = n shr 1
+            while (j and bit != 0) {
+                j = j xor bit
+                bit = bit shr 1
+            }
+            j = j or bit
+            if (i < j) {
+                val tr = re[i]
+                re[i] = re[j]
+                re[j] = tr
+                val ti = im[i]
+                im[i] = im[j]
+                im[j] = ti
+            }
+        }
+
+        var len = 2
+        while (len <= n) {
+            val ang = -2.0 * PI / len
+            val wLenRe = cos(ang)
+            val wLenIm = sin(ang)
+            var i = 0
+            while (i < n) {
+                var wRe = 1.0
+                var wIm = 0.0
+                val half = len / 2
+                for (k in 0 until half) {
+                    val aRe = re[i + k]
+                    val aIm = im[i + k]
+                    val bRe = re[i + k + half] * wRe - im[i + k + half] * wIm
+                    val bIm = re[i + k + half] * wIm + im[i + k + half] * wRe
+                    re[i + k] = aRe + bRe
+                    im[i + k] = aIm + bIm
+                    re[i + k + half] = aRe - bRe
+                    im[i + k + half] = aIm - bIm
+                    val nextWRe = wRe * wLenRe - wIm * wLenIm
+                    wIm = wRe * wLenIm + wIm * wLenRe
+                    wRe = nextWRe
+                }
+                i += len
+            }
+            len = len shl 1
+        }
+    }
+
+    /** Forward-transforms real [signal] and returns magnitudes for bins 0..N/2 (DC..Nyquist). */
+    fun magnitudes(signal: FloatArray): FloatArray {
+        val n = signal.size
+        require(n != 0 && (n and (n - 1)) == 0) { "FFT size must be a power of 2, was $n" }
+        val re = DoubleArray(n) { signal[it].toDouble() }
+        val im = DoubleArray(n)
+        transform(re, im)
+        return FloatArray(n / 2 + 1) { sqrt(re[it] * re[it] + im[it] * im[it]).toFloat() }
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/Fft.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/Fft.kt
@@ -86,13 +86,36 @@ object Fft {
         }
     }
 
-    /** Forward-transforms real [signal] and returns magnitudes for bins 0..N/2 (DC..Nyquist). */
+    /**
+     * Forward-transforms real [signal] and returns magnitudes for bins 0..N/2 (DC..Nyquist).
+     * Reference/allocating variant — production uses the *Into / in-place form on the audio thread.
+     */
     fun magnitudes(signal: FloatArray): FloatArray {
+        val out = FloatArray(signal.size / 2 + 1)
+        magnitudesInto(signal, DoubleArray(signal.size), DoubleArray(signal.size), out)
+        return out
+    }
+
+    /**
+     * Like [magnitudes] but writes into caller-owned buffers (no allocation). [re] and [im] must be
+     * the same length as [signal] (a power of 2); [out] must be `signal.size / 2 + 1`. Used on the
+     * audio thread to avoid per-frame garbage.
+     */
+    fun magnitudesInto(
+        signal: FloatArray,
+        re: DoubleArray,
+        im: DoubleArray,
+        out: FloatArray,
+    ) {
         val n = signal.size
         require(n != 0 && (n and (n - 1)) == 0) { "FFT size must be a power of 2, was $n" }
-        val re = DoubleArray(n) { signal[it].toDouble() }
-        val im = DoubleArray(n)
+        require(re.size == n && im.size == n) { "re/im buffers must be size $n" }
+        require(out.size == n / 2 + 1) { "out buffer must be size ${n / 2 + 1}" }
+        for (i in 0 until n) {
+            re[i] = signal[i].toDouble()
+            im[i] = 0.0
+        }
         transform(re, im)
-        return FloatArray(n / 2 + 1) { sqrt(re[it] * re[it] + im[it] * im[it]).toFloat() }
+        for (i in out.indices) out[i] = sqrt(re[i] * re[i] + im[i] * im[i]).toFloat()
     }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/SpectrumCanvas.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/SpectrumCanvas.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.audio
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.withFrameMillis
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Collects [spectrum] into a decayed [FloatArray] and runs a monotonic time clock,
+ * then calls [draw] inside the Canvas draw lambda. The fast-changing state is read
+ * ONLY in the draw lambda, so new frames trigger the draw phase, never recomposition.
+ */
+@Composable
+fun SpectrumCanvas(
+    spectrum: Flow<Spectrum>,
+    palette: VisualizerPalette,
+    modifier: Modifier,
+    decay: Float = 0.85f,
+    draw: DrawScope.(bins: FloatArray, timeSec: Float, palette: VisualizerPalette) -> Unit,
+) {
+    val smoothed = remember { mutableStateOf(FloatArray(0)) }
+    LaunchedEffect(spectrum, decay) {
+        var prev = FloatArray(0)
+        spectrum.collect { frame ->
+            val next =
+                FloatArray(frame.bins.size) { i ->
+                    val prior = if (i < prev.size) prev[i] * decay else 0f
+                    if (frame.bins[i] > prior) frame.bins[i] else prior
+                }
+            smoothed.value = next
+            prev = next
+        }
+    }
+
+    // Monotonic, never-resetting clock. Accumulates elapsed seconds so the time value
+    // passed to renderers is continuous — a repeating transition would jump back to 0
+    // at its boundary and cause a visible phase discontinuity in sine-based renderers.
+    val timeSec = remember { mutableStateOf(0f) }
+    LaunchedEffect(Unit) {
+        var last = 0L
+        while (true) {
+            withFrameMillis { ms ->
+                if (last != 0L) timeSec.value += (ms - last) / 1000f
+                last = ms
+            }
+        }
+    }
+
+    Canvas(modifier) {
+        draw(smoothed.value, timeSec.value, palette)
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/SpectrumCanvas.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/SpectrumCanvas.kt
@@ -31,9 +31,10 @@ import androidx.compose.ui.graphics.drawscope.DrawScope
 import kotlinx.coroutines.flow.Flow
 
 /**
- * Collects [spectrum] into a decayed [FloatArray] and runs a monotonic time clock,
+ * Collects [spectrum] into a decayed [FloatArray] and optionally runs a monotonic time clock,
  * then calls [draw] inside the Canvas draw lambda. The fast-changing state is read
  * ONLY in the draw lambda, so new frames trigger the draw phase, never recomposition.
+ * Pass [animated] = false for non-time-varying styles (bars, radial) to avoid 60fps redraws.
  */
 @Composable
 fun SpectrumCanvas(
@@ -41,12 +42,15 @@ fun SpectrumCanvas(
     palette: VisualizerPalette,
     modifier: Modifier,
     decay: Float = 0.85f,
+    animated: Boolean = true,
     draw: DrawScope.(bins: FloatArray, timeSec: Float, palette: VisualizerPalette) -> Unit,
 ) {
     val smoothed = remember { mutableStateOf(FloatArray(0)) }
     LaunchedEffect(spectrum, decay) {
         var prev = FloatArray(0)
         spectrum.collect { frame ->
+            // A fresh array each frame is intentional: mutableStateOf compares by reference, so a new
+            // instance is what signals Compose to redraw. Do NOT switch to in-place mutation.
             val next =
                 FloatArray(frame.bins.size) { i ->
                     val prior = if (i < prev.size) prev[i] * decay else 0f
@@ -57,21 +61,20 @@ fun SpectrumCanvas(
         }
     }
 
-    // Monotonic, never-resetting clock. Accumulates elapsed seconds so the time value
-    // passed to renderers is continuous — a repeating transition would jump back to 0
-    // at its boundary and cause a visible phase discontinuity in sine-based renderers.
     val timeSec = remember { mutableStateOf(0f) }
-    LaunchedEffect(Unit) {
-        var last = 0L
-        while (true) {
-            withFrameMillis { ms ->
-                if (last != 0L) timeSec.value += (ms - last) / 1000f
-                last = ms
+    if (animated) {
+        LaunchedEffect(Unit) {
+            var last = 0L
+            while (true) {
+                withFrameMillis { ms ->
+                    if (last != 0L) timeSec.value += (ms - last) / 1000f
+                    last = ms
+                }
             }
         }
     }
 
     Canvas(modifier) {
-        draw(smoothed.value, timeSec.value, palette)
+        draw(smoothed.value, if (animated) timeSec.value else 0f, palette)
     }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/SyntheticSpectrum.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/SyntheticSpectrum.kt
@@ -50,7 +50,12 @@ object SyntheticSpectrum {
         return Spectrum(bins)
     }
 
-    /** Compose-friendly stream that emits one [frame] per display frame. */
+    /**
+     * Compose-friendly stream that emits one [frame] per display frame.
+     *
+     * Must be collected inside a Compose frame-clock scope (e.g. a `LaunchedEffect`); it uses
+     * `withFrameMillis`, which throws if collected from a plain coroutine with no frame clock.
+     */
     fun flow(binCount: Int = 48): Flow<Spectrum> =
         flow {
             var startMs = -1L

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/SyntheticSpectrum.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/SyntheticSpectrum.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.audio
+
+import androidx.compose.runtime.withFrameMillis
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlin.math.PI
+import kotlin.math.exp
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.math.sin
+
+/** Deterministic decorative spectrum for previews and demos (no real audio). */
+object SyntheticSpectrum {
+    fun frame(
+        timeSec: Float,
+        binCount: Int,
+    ): Spectrum {
+        val t = timeSec
+        val bins =
+            FloatArray(binCount) { i ->
+                val f = i / binCount.toFloat()
+                val beat = (0.5 + 0.5 * sin(t * 2.0 * PI * 1.9)).pow(6.0)
+                val bass = exp((-f * 9.0)) * (0.55 + 0.9 * beat)
+                val mid = exp(-((f - 0.35) * 4.0).pow(2.0)) * (0.35 + 0.25 * sin(t * 5.0 + i))
+                val treble = exp(-((f - 0.8) * 3.5).pow(2.0)) * max(0.0, sin(t * 14.0 + i * 2.3)) * 0.4
+                val v = bass + mid + treble + 0.04 * sin(t * 3.0 + i * 0.7)
+                min(1.0, max(0.0, v)).toFloat()
+            }
+        return Spectrum(bins)
+    }
+
+    /** Compose-friendly stream that emits one [frame] per display frame. */
+    fun flow(binCount: Int = 48): Flow<Spectrum> =
+        flow {
+            var startMs = -1L
+            while (true) {
+                val ms = withFrameMillis { it }
+                if (startMs < 0) startMs = ms
+                emit(frame((ms - startMs) / 1000f, binCount))
+            }
+        }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/SyntheticSpectrum.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/SyntheticSpectrum.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.flow.flow
 import kotlin.math.PI
 import kotlin.math.exp
 import kotlin.math.max
-import kotlin.math.min
 import kotlin.math.pow
 import kotlin.math.sin
 
@@ -45,7 +44,7 @@ object SyntheticSpectrum {
                 val mid = exp(-((f - 0.35) * 4.0).pow(2.0)) * (0.35 + 0.25 * sin(t * 5.0 + i))
                 val treble = exp(-((f - 0.8) * 3.5).pow(2.0)) * max(0.0, sin(t * 14.0 + i * 2.3)) * 0.4
                 val v = bass + mid + treble + 0.04 * sin(t * 3.0 + i * 0.7)
-                min(1.0, max(0.0, v)).toFloat()
+                v.coerceIn(0.0, 1.0).toFloat()
             }
         return Spectrum(bins)
     }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerPalette.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerPalette.kt
@@ -43,3 +43,6 @@ data class VisualizerPalette(
         val DEFAULT = VisualizerPalette()
     }
 }
+
+/** Wraps a hue into 0f..360f (handles negatives), for Color.hsl. */
+fun Float.wrapHue(): Float = ((this % 360f) + 360f) % 360f

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerPalette.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerPalette.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.audio
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Hue anchors (degrees, 0..360) the renderers use to colour the spectrum. Defaults
+ * give the cyan→magenta / bass-purple / treble-pink look from the design mockups.
+ */
+@Immutable
+data class VisualizerPalette(
+    val lowHue: Float = 280f,
+    val midHue: Float = 200f,
+    val highHue: Float = 330f,
+    val saturation: Float = 0.92f,
+    val lightness: Float = 0.6f,
+) {
+    init {
+        require(saturation in 0f..1f) { "saturation must be in 0f..1f, was $saturation" }
+        require(lightness in 0f..1f) { "lightness must be in 0f..1f, was $lightness" }
+    }
+
+    companion object {
+        val DEFAULT = VisualizerPalette()
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerRegistry.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerRegistry.kt
@@ -24,11 +24,16 @@ import com.vitorpamplona.amethyst.commons.audio.renderers.AuroraRenderer
 import com.vitorpamplona.amethyst.commons.audio.renderers.BarsRenderer
 import com.vitorpamplona.amethyst.commons.audio.renderers.OffRenderer
 import com.vitorpamplona.amethyst.commons.audio.renderers.RadialRenderer
+import com.vitorpamplona.amethyst.commons.audio.renderers.StaticRenderer
 import com.vitorpamplona.amethyst.commons.audio.renderers.WavesRenderer
 
+/**
+ * CLASSIC is intentionally absent — it requires the live player and is handled by the caller;
+ * forStyle(CLASSIC) falls back to OffRenderer.
+ */
 object VisualizerRegistry {
     val all: List<VisualizerRenderer> =
-        listOf(OffRenderer, BarsRenderer, WavesRenderer, RadialRenderer, AuroraRenderer)
+        listOf(OffRenderer, BarsRenderer, WavesRenderer, RadialRenderer, AuroraRenderer, StaticRenderer)
 
     private val byStyle = all.associateBy { it.style }
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerRegistry.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerRegistry.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.audio
+
+import com.vitorpamplona.amethyst.commons.audio.renderers.AuroraRenderer
+import com.vitorpamplona.amethyst.commons.audio.renderers.BarsRenderer
+import com.vitorpamplona.amethyst.commons.audio.renderers.OffRenderer
+import com.vitorpamplona.amethyst.commons.audio.renderers.RadialRenderer
+import com.vitorpamplona.amethyst.commons.audio.renderers.WavesRenderer
+
+object VisualizerRegistry {
+    val all: List<VisualizerRenderer> =
+        listOf(OffRenderer, BarsRenderer, WavesRenderer, RadialRenderer, AuroraRenderer)
+
+    private val byStyle = all.associateBy { it.style }
+
+    fun forStyle(style: VisualizerStyle): VisualizerRenderer = byStyle[style] ?: OffRenderer
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerRenderer.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerRenderer.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.audio
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import kotlinx.coroutines.flow.Flow
+
+/** A single visualiser style. Implementations draw [spectrum] frames onto a Canvas. */
+interface VisualizerRenderer {
+    val style: VisualizerStyle
+
+    @Composable
+    fun Render(
+        spectrum: Flow<Spectrum>,
+        palette: VisualizerPalette,
+        modifier: Modifier,
+    )
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerStyle.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerStyle.kt
@@ -21,15 +21,17 @@
 package com.vitorpamplona.amethyst.commons.audio
 
 enum class VisualizerStyle {
-    OFF,
+    CLASSIC,
     BARS,
     WAVES,
     RADIAL,
     AURORA,
+    STATIC,
+    OFF,
     ;
 
     companion object {
-        val DEFAULT = WAVES
+        val DEFAULT = CLASSIC
 
         fun fromName(name: String?): VisualizerStyle = entries.firstOrNull { it.name == name } ?: DEFAULT
     }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerStyle.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerStyle.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.audio
+
+enum class VisualizerStyle {
+    OFF,
+    BARS,
+    WAVES,
+    RADIAL,
+    AURORA,
+    ;
+
+    companion object {
+        val DEFAULT = WAVES
+
+        fun fromName(name: String?): VisualizerStyle = entries.firstOrNull { it.name == name } ?: DEFAULT
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/AuroraRenderer.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/AuroraRenderer.kt
@@ -70,7 +70,21 @@ object AuroraRenderer : VisualizerRenderer {
         modifier: Modifier,
     ) {
         val paths = remember { List(ribbons.size) { Path() } }
-        SpectrumCanvas(spectrum, palette, modifier) { bins, t, pal ->
+        // Each ribbon's gradient depends only on the palette (the animation lives in the Path
+        // geometry), so build the brushes once instead of allocating three Colors + a Brush per
+        // ribbon on every frame.
+        val brushes =
+            remember(palette) {
+                ribbons.map { ribbon ->
+                    val hue = ribbon.hue(palette).wrapHue()
+                    Brush.horizontalGradient(
+                        0f to Color.hsl(hue, palette.saturation, palette.lightness, 0f),
+                        0.5f to Color.hsl(hue, palette.saturation, palette.lightness, 0.6f),
+                        1f to Color.hsl(hue, palette.saturation, palette.lightness, 0f),
+                    )
+                }
+            }
+        SpectrumCanvas(spectrum, palette, modifier) { bins, t, _ ->
             if (bins.isEmpty()) return@SpectrumCanvas
             val n = bins.size
             val w = size.width
@@ -96,19 +110,15 @@ object AuroraRenderer : VisualizerRenderer {
                     val v = bins[i0] + (bins[i1] - bins[i0]) * (fb - i0)
                     val shimmer = 1f + 0.08f * sin(f * 9f + t)
                     val disp = (v * shimmer).coerceIn(0f, 1f) * h * 0.40f
-                    val y = (h * r.yo + r.dir * disp).coerceIn(half, h - half)
+                    // maxOf guards the reversed-range crash when the canvas is shorter than the
+                    // loudness-swelled stroke (h < strokeW makes half > h - half).
+                    val y = (h * r.yo + r.dir * disp).coerceIn(half, maxOf(half, h - half))
                     if (x == 0f) path.moveTo(x, y) else path.lineTo(x, y)
                     x += 5f
                 }
-                val hue = r.hue(pal).wrapHue()
                 drawPath(
                     path = path,
-                    brush =
-                        Brush.horizontalGradient(
-                            0f to Color.hsl(hue, pal.saturation, pal.lightness, 0f),
-                            0.5f to Color.hsl(hue, pal.saturation, pal.lightness, 0.6f),
-                            1f to Color.hsl(hue, pal.saturation, pal.lightness, 0f),
-                        ),
+                    brush = brushes[index],
                     style = Stroke(width = strokeW, cap = StrokeCap.Round),
                     blendMode = BlendMode.Plus,
                 )

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/AuroraRenderer.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/AuroraRenderer.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.audio.renderers
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import com.vitorpamplona.amethyst.commons.audio.Spectrum
+import com.vitorpamplona.amethyst.commons.audio.SpectrumCanvas
+import com.vitorpamplona.amethyst.commons.audio.VisualizerPalette
+import com.vitorpamplona.amethyst.commons.audio.VisualizerRenderer
+import com.vitorpamplona.amethyst.commons.audio.VisualizerStyle
+import kotlinx.coroutines.flow.Flow
+import kotlin.math.sin
+
+object AuroraRenderer : VisualizerRenderer {
+    override val style = VisualizerStyle.AURORA
+
+    private class Ribbon(
+        val hue: (VisualizerPalette) -> Float,
+        val yo: Float,
+        val sp: Float,
+        val band: Float,
+    )
+
+    private val ribbons =
+        listOf(
+            Ribbon({ it.midHue - 40f }, 0.5f, 1.0f, 0.15f),
+            Ribbon({ it.lowHue }, 0.55f, 1.4f, 0.45f),
+            Ribbon({ it.highHue }, 0.45f, 0.7f, 0.75f),
+        )
+
+    @Composable
+    override fun Render(
+        spectrum: Flow<Spectrum>,
+        palette: VisualizerPalette,
+        modifier: Modifier,
+    ) {
+        SpectrumCanvas(spectrum, palette, modifier) { bins, t, pal ->
+            if (bins.isEmpty()) return@SpectrumCanvas
+            val n = bins.size
+            val w = size.width
+            val h = size.height
+            for (r in ribbons) {
+                val idx = (r.band * (n - 1)).toInt().coerceIn(0, n - 1)
+                val amp = (0.25f + bins[idx] * 0.9f) * h * 0.4f
+                val path = Path()
+                var x = 0f
+                while (x <= w) {
+                    val f = x / w
+                    val y = h * r.yo + sin(f * 6f * r.sp + t * 1.5f * r.sp) * amp + sin(f * 13f + t) * amp * 0.25f
+                    if (x == 0f) path.moveTo(x, y) else path.lineTo(x, y)
+                    x += 5f
+                }
+                val hue = (((r.hue(pal)) % 360f) + 360f) % 360f
+                drawPath(
+                    path = path,
+                    brush =
+                        Brush.horizontalGradient(
+                            0f to Color.hsl(hue, pal.saturation, pal.lightness, 0f),
+                            0.5f to Color.hsl(hue, pal.saturation, pal.lightness, 0.55f),
+                            1f to Color.hsl(hue, pal.saturation, pal.lightness, 0f),
+                        ),
+                    style = Stroke(width = 22f + bins[idx] * 26f, cap = StrokeCap.Round),
+                    blendMode = BlendMode.Plus,
+                )
+            }
+        }
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/AuroraRenderer.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/AuroraRenderer.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.commons.audio.renderers
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
@@ -33,6 +34,7 @@ import com.vitorpamplona.amethyst.commons.audio.SpectrumCanvas
 import com.vitorpamplona.amethyst.commons.audio.VisualizerPalette
 import com.vitorpamplona.amethyst.commons.audio.VisualizerRenderer
 import com.vitorpamplona.amethyst.commons.audio.VisualizerStyle
+import com.vitorpamplona.amethyst.commons.audio.wrapHue
 import kotlinx.coroutines.flow.Flow
 import kotlin.math.sin
 
@@ -59,15 +61,17 @@ object AuroraRenderer : VisualizerRenderer {
         palette: VisualizerPalette,
         modifier: Modifier,
     ) {
+        val paths = remember { List(ribbons.size) { Path() } }
         SpectrumCanvas(spectrum, palette, modifier) { bins, t, pal ->
             if (bins.isEmpty()) return@SpectrumCanvas
             val n = bins.size
             val w = size.width
             val h = size.height
-            for (r in ribbons) {
+            ribbons.forEachIndexed { index, r ->
                 val idx = (r.band * (n - 1)).toInt().coerceIn(0, n - 1)
-                val amp = (0.25f + bins[idx] * 0.9f) * h * 0.4f
-                val path = Path()
+                val amp = (0.3f + bins[idx] * 1.2f) * h * 0.5f
+                val path = paths[index]
+                path.reset()
                 var x = 0f
                 while (x <= w) {
                     val f = x / w
@@ -75,7 +79,7 @@ object AuroraRenderer : VisualizerRenderer {
                     if (x == 0f) path.moveTo(x, y) else path.lineTo(x, y)
                     x += 5f
                 }
-                val hue = (((r.hue(pal)) % 360f) + 360f) % 360f
+                val hue = r.hue(pal).wrapHue()
                 drawPath(
                     path = path,
                     brush =

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/AuroraRenderer.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/AuroraRenderer.kt
@@ -38,21 +38,29 @@ import com.vitorpamplona.amethyst.commons.audio.wrapHue
 import kotlinx.coroutines.flow.Flow
 import kotlin.math.sin
 
+/**
+ * Three overlapping glowing ribbons. Each ribbon is a stroked line whose vertical displacement from
+ * its centre is the live spectrum of its band (interpolated across the width), so the ribbon's shape
+ * tracks the audio; the glow thickness swells with the overall energy. A small time shimmer (±8%)
+ * adds life without driving the motion. The line is clamped inside the canvas (accounting for the
+ * stroke width) so the tops/bottoms never get cut.
+ */
 object AuroraRenderer : VisualizerRenderer {
     override val style = VisualizerStyle.AURORA
 
     private class Ribbon(
         val hue: (VisualizerPalette) -> Float,
         val yo: Float,
-        val sp: Float,
-        val band: Float,
+        val lo: Float,
+        val hi: Float,
+        val dir: Float,
     )
 
     private val ribbons =
         listOf(
-            Ribbon({ it.midHue - 40f }, 0.5f, 1.0f, 0.15f),
-            Ribbon({ it.lowHue }, 0.55f, 1.4f, 0.45f),
-            Ribbon({ it.highHue }, 0.45f, 0.7f, 0.75f),
+            Ribbon({ it.midHue - 40f }, 0.55f, 0f, 0.5f, -1f),
+            Ribbon({ it.lowHue }, 0.5f, 0.15f, 0.85f, 1f),
+            Ribbon({ it.highHue }, 0.45f, 0.5f, 1f, -1f),
         )
 
     @Composable
@@ -67,15 +75,28 @@ object AuroraRenderer : VisualizerRenderer {
             val n = bins.size
             val w = size.width
             val h = size.height
+
+            // overall energy → glow thickness swells with loudness (bounded)
+            var energy = 0f
+            for (b in bins) energy += b
+            energy /= bins.size
+            val strokeW = 12f + energy * 30f
+            val half = strokeW / 2f
+
             ribbons.forEachIndexed { index, r ->
-                val idx = (r.band * (n - 1)).toInt().coerceIn(0, n - 1)
-                val amp = (0.3f + bins[idx] * 1.2f) * h * 0.5f
                 val path = paths[index]
                 path.reset()
                 var x = 0f
                 while (x <= w) {
                     val f = x / w
-                    val y = h * r.yo + sin(f * 6f * r.sp + t * 1.5f * r.sp) * amp + sin(f * 13f + t) * amp * 0.25f
+                    // interpolate this ribbon's band → the displacement IS the spectrum
+                    val fb = (r.lo + (r.hi - r.lo) * f) * (n - 1)
+                    val i0 = fb.toInt().coerceIn(0, n - 1)
+                    val i1 = (i0 + 1).coerceAtMost(n - 1)
+                    val v = bins[i0] + (bins[i1] - bins[i0]) * (fb - i0)
+                    val shimmer = 1f + 0.08f * sin(f * 9f + t)
+                    val disp = (v * shimmer).coerceIn(0f, 1f) * h * 0.40f
+                    val y = (h * r.yo + r.dir * disp).coerceIn(half, h - half)
                     if (x == 0f) path.moveTo(x, y) else path.lineTo(x, y)
                     x += 5f
                 }
@@ -85,10 +106,10 @@ object AuroraRenderer : VisualizerRenderer {
                     brush =
                         Brush.horizontalGradient(
                             0f to Color.hsl(hue, pal.saturation, pal.lightness, 0f),
-                            0.5f to Color.hsl(hue, pal.saturation, pal.lightness, 0.55f),
+                            0.5f to Color.hsl(hue, pal.saturation, pal.lightness, 0.6f),
                             1f to Color.hsl(hue, pal.saturation, pal.lightness, 0f),
                         ),
-                    style = Stroke(width = 22f + bins[idx] * 26f, cap = StrokeCap.Round),
+                    style = Stroke(width = strokeW, cap = StrokeCap.Round),
                     blendMode = BlendMode.Plus,
                 )
             }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/BarsRenderer.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/BarsRenderer.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.audio.renderers
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import com.vitorpamplona.amethyst.commons.audio.Spectrum
+import com.vitorpamplona.amethyst.commons.audio.SpectrumCanvas
+import com.vitorpamplona.amethyst.commons.audio.VisualizerPalette
+import com.vitorpamplona.amethyst.commons.audio.VisualizerRenderer
+import com.vitorpamplona.amethyst.commons.audio.VisualizerStyle
+import kotlinx.coroutines.flow.Flow
+import kotlin.math.min
+
+object BarsRenderer : VisualizerRenderer {
+    override val style = VisualizerStyle.BARS
+
+    @Composable
+    override fun Render(
+        spectrum: Flow<Spectrum>,
+        palette: VisualizerPalette,
+        modifier: Modifier,
+    ) {
+        SpectrumCanvas(spectrum, palette, modifier) { bins, _, pal ->
+            if (bins.isEmpty()) return@SpectrumCanvas
+            val n = bins.size
+            val gap = 2f
+            val barW = (size.width - gap * (n - 1)) / n
+            if (barW <= 0f) return@SpectrumCanvas
+            val mid = size.height / 2f
+            val radius = CornerRadius(min(barW / 2f, 3f), min(barW / 2f, 3f))
+            for (i in 0 until n) {
+                val v = bins[i].coerceIn(0f, 1f)
+                val half = v * (size.height / 2f - 2f)
+                if (half <= 0f) continue
+                val hue = pal.midHue + (pal.highHue - pal.midHue) * (i / n.toFloat())
+                drawRoundRect(
+                    color = Color.hsl(((hue % 360f) + 360f) % 360f, pal.saturation, pal.lightness),
+                    topLeft = Offset(i * (barW + gap), mid - half),
+                    size = Size(barW, half * 2f),
+                    cornerRadius = radius,
+                )
+            }
+        }
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/OffRenderer.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/OffRenderer.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.audio.renderers
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.vitorpamplona.amethyst.commons.audio.Spectrum
+import com.vitorpamplona.amethyst.commons.audio.VisualizerPalette
+import com.vitorpamplona.amethyst.commons.audio.VisualizerRenderer
+import com.vitorpamplona.amethyst.commons.audio.VisualizerStyle
+import kotlinx.coroutines.flow.Flow
+
+object OffRenderer : VisualizerRenderer {
+    override val style = VisualizerStyle.OFF
+
+    @Composable
+    override fun Render(
+        spectrum: Flow<Spectrum>,
+        palette: VisualizerPalette,
+        modifier: Modifier,
+    ) {
+        // Draws nothing, but honors the modifier so the reserved layout region doesn't collapse.
+        Box(modifier)
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/RadialRenderer.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/RadialRenderer.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.audio.renderers
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import com.vitorpamplona.amethyst.commons.audio.Spectrum
+import com.vitorpamplona.amethyst.commons.audio.SpectrumCanvas
+import com.vitorpamplona.amethyst.commons.audio.VisualizerPalette
+import com.vitorpamplona.amethyst.commons.audio.VisualizerRenderer
+import com.vitorpamplona.amethyst.commons.audio.VisualizerStyle
+import kotlinx.coroutines.flow.Flow
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.min
+import kotlin.math.sin
+
+object RadialRenderer : VisualizerRenderer {
+    override val style = VisualizerStyle.RADIAL
+
+    @Composable
+    override fun Render(
+        spectrum: Flow<Spectrum>,
+        palette: VisualizerPalette,
+        modifier: Modifier,
+    ) {
+        SpectrumCanvas(spectrum, palette, modifier) { bins, _, pal ->
+            if (bins.isEmpty()) return@SpectrumCanvas
+            val n = bins.size
+            val cx = size.width / 2f
+            val cy = size.height / 2f
+            val minDim = min(size.width, size.height)
+            val r0 = minDim * 0.16f
+
+            var energy = 0f
+            val lowCount = min(8, n)
+            for (i in 0 until lowCount) energy += bins[i]
+            energy /= lowCount
+
+            val coreR = r0 * (1.4f + energy)
+            drawCircle(
+                brush =
+                    Brush.radialGradient(
+                        0f to Color.hsl(pal.highHue, pal.saturation, 0.7f, 0.9f),
+                        1f to Color.hsl(pal.highHue, pal.saturation, 0.6f, 0f),
+                        center = Offset(cx, cy),
+                        radius = coreR,
+                    ),
+                radius = coreR,
+                center = Offset(cx, cy),
+            )
+
+            for (i in 0 until n) {
+                val a = i / n.toFloat() * (2f * PI.toFloat()) - PI.toFloat() / 2f
+                val len = r0 + bins[i].coerceIn(0f, 1f) * minDim * 0.32f
+                val hue = (((pal.midHue + (pal.highHue - pal.midHue) * (i / n.toFloat())) % 360f) + 360f) % 360f
+                drawLine(
+                    color = Color.hsl(hue, pal.saturation, pal.lightness),
+                    start = Offset(cx + cos(a) * r0, cy + sin(a) * r0),
+                    end = Offset(cx + cos(a) * len, cy + sin(a) * len),
+                    strokeWidth = 2.4f,
+                    cap = StrokeCap.Round,
+                )
+            }
+        }
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/RadialRenderer.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/RadialRenderer.kt
@@ -53,6 +53,9 @@ object RadialRenderer : VisualizerRenderer {
             val cx = size.width / 2f
             val cy = size.height / 2f
             val minDim = min(size.width, size.height)
+            // A zero/near-zero canvas (transient layout pass while audio plays) would make coreR == 0,
+            // and Brush.radialGradient(radius = 0f) throws. Nothing meaningful to draw at that size.
+            if (minDim <= 0f) return@SpectrumCanvas
             val r0 = minDim * 0.16f
 
             var energy = 0f

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/RadialRenderer.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/RadialRenderer.kt
@@ -31,6 +31,7 @@ import com.vitorpamplona.amethyst.commons.audio.SpectrumCanvas
 import com.vitorpamplona.amethyst.commons.audio.VisualizerPalette
 import com.vitorpamplona.amethyst.commons.audio.VisualizerRenderer
 import com.vitorpamplona.amethyst.commons.audio.VisualizerStyle
+import com.vitorpamplona.amethyst.commons.audio.wrapHue
 import kotlinx.coroutines.flow.Flow
 import kotlin.math.PI
 import kotlin.math.cos
@@ -46,7 +47,7 @@ object RadialRenderer : VisualizerRenderer {
         palette: VisualizerPalette,
         modifier: Modifier,
     ) {
-        SpectrumCanvas(spectrum, palette, modifier) { bins, _, pal ->
+        SpectrumCanvas(spectrum, palette, modifier, animated = false) { bins, _, pal ->
             if (bins.isEmpty()) return@SpectrumCanvas
             val n = bins.size
             val cx = size.width / 2f
@@ -75,7 +76,7 @@ object RadialRenderer : VisualizerRenderer {
             for (i in 0 until n) {
                 val a = i / n.toFloat() * (2f * PI.toFloat()) - PI.toFloat() / 2f
                 val len = r0 + bins[i].coerceIn(0f, 1f) * minDim * 0.32f
-                val hue = (((pal.midHue + (pal.highHue - pal.midHue) * (i / n.toFloat())) % 360f) + 360f) % 360f
+                val hue = (pal.midHue + (pal.highHue - pal.midHue) * (i / n.toFloat())).wrapHue()
                 drawLine(
                     color = Color.hsl(hue, pal.saturation, pal.lightness),
                     start = Offset(cx + cos(a) * r0, cy + sin(a) * r0),

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/StaticRenderer.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/StaticRenderer.kt
@@ -21,22 +21,23 @@
 package com.vitorpamplona.amethyst.commons.audio.renderers
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.CornerRadius
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Color
 import com.vitorpamplona.amethyst.commons.audio.Spectrum
-import com.vitorpamplona.amethyst.commons.audio.SpectrumCanvas
+import com.vitorpamplona.amethyst.commons.audio.SyntheticSpectrum
 import com.vitorpamplona.amethyst.commons.audio.VisualizerPalette
 import com.vitorpamplona.amethyst.commons.audio.VisualizerRenderer
 import com.vitorpamplona.amethyst.commons.audio.VisualizerStyle
-import com.vitorpamplona.amethyst.commons.audio.wrapHue
 import kotlinx.coroutines.flow.Flow
-import kotlin.math.min
+import kotlinx.coroutines.flow.flowOf
 
-object BarsRenderer : VisualizerRenderer {
-    override val style = VisualizerStyle.BARS
+/**
+ * A still, non-animated bar graphic for users who dislike motion. Ignores the live [spectrum]
+ * and renders a single frozen frame via [BarsRenderer] (which runs its canvas with animated=false,
+ * so there is no per-frame redraw once settled).
+ */
+object StaticRenderer : VisualizerRenderer {
+    override val style = VisualizerStyle.STATIC
 
     @Composable
     override fun Render(
@@ -44,26 +45,7 @@ object BarsRenderer : VisualizerRenderer {
         palette: VisualizerPalette,
         modifier: Modifier,
     ) {
-        SpectrumCanvas(spectrum, palette, modifier, animated = false) { bins, _, pal ->
-            if (bins.isEmpty()) return@SpectrumCanvas
-            val n = bins.size
-            val gap = 2f
-            val barW = (size.width - gap * (n - 1)) / n
-            if (barW <= 0f) return@SpectrumCanvas
-            val mid = size.height / 2f
-            val radius = CornerRadius(min(barW / 2f, 3f), min(barW / 2f, 3f))
-            for (i in 0 until n) {
-                val v = bins[i].coerceIn(0f, 1f)
-                val half = v * (size.height / 2f - 2f)
-                if (half <= 0f) continue
-                val hue = pal.midHue + (pal.highHue - pal.midHue) * (i / n.toFloat())
-                drawRoundRect(
-                    color = Color.hsl(hue.wrapHue(), pal.saturation, pal.lightness),
-                    topLeft = Offset(i * (barW + gap), mid - half),
-                    size = Size(barW, half * 2f),
-                    cornerRadius = radius,
-                )
-            }
-        }
+        val frozen = remember { flowOf(SyntheticSpectrum.frame(0f, 48)) }
+        BarsRenderer.Render(frozen, palette, modifier)
     }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/WavesRenderer.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/WavesRenderer.kt
@@ -67,7 +67,20 @@ object WavesRenderer : VisualizerRenderer {
         modifier: Modifier,
     ) {
         val paths = remember { List(layers.size) { Path() } }
-        SpectrumCanvas(spectrum, palette, modifier) { bins, t, pal ->
+        // Each layer's gradient depends only on the palette (the animation lives in the Path
+        // geometry), so build the brushes once instead of allocating two Colors + a Brush per layer
+        // on every frame.
+        val brushes =
+            remember(palette) {
+                layers.map { layer ->
+                    val hue = layer.hue(palette).wrapHue()
+                    Brush.verticalGradient(
+                        0f to Color.hsl(hue, palette.saturation, palette.lightness, 0.85f),
+                        1f to Color.hsl(hue, palette.saturation, palette.lightness * 0.8f, 0.05f),
+                    )
+                }
+            }
+        SpectrumCanvas(spectrum, palette, modifier) { bins, t, _ ->
             if (bins.isEmpty()) return@SpectrumCanvas
             val n = bins.size
             val w = size.width
@@ -91,14 +104,9 @@ object WavesRenderer : VisualizerRenderer {
                 }
                 path.lineTo(w, h)
                 path.close()
-                val hue = layer.hue(pal).wrapHue()
                 drawPath(
                     path = path,
-                    brush =
-                        Brush.verticalGradient(
-                            0f to Color.hsl(hue, pal.saturation, pal.lightness, 0.85f),
-                            1f to Color.hsl(hue, pal.saturation, pal.lightness * 0.8f, 0.05f),
-                        ),
+                    brush = brushes[index],
                     blendMode = BlendMode.Plus,
                 )
             }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/WavesRenderer.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/WavesRenderer.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.commons.audio.renderers
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
@@ -31,6 +32,7 @@ import com.vitorpamplona.amethyst.commons.audio.SpectrumCanvas
 import com.vitorpamplona.amethyst.commons.audio.VisualizerPalette
 import com.vitorpamplona.amethyst.commons.audio.VisualizerRenderer
 import com.vitorpamplona.amethyst.commons.audio.VisualizerStyle
+import com.vitorpamplona.amethyst.commons.audio.wrapHue
 import kotlinx.coroutines.flow.Flow
 import kotlin.math.sin
 
@@ -58,13 +60,16 @@ object WavesRenderer : VisualizerRenderer {
         palette: VisualizerPalette,
         modifier: Modifier,
     ) {
+        val paths = remember { List(layers.size) { Path() } }
         SpectrumCanvas(spectrum, palette, modifier) { bins, t, pal ->
             if (bins.isEmpty()) return@SpectrumCanvas
             val n = bins.size
             val w = size.width
             val h = size.height
-            for (layer in layers) {
-                val path = Path().apply { moveTo(0f, h) }
+            layers.forEachIndexed { index, layer ->
+                val path = paths[index]
+                path.reset()
+                path.moveTo(0f, h)
                 var x = 0f
                 while (x <= w) {
                     val f = x / w
@@ -76,7 +81,7 @@ object WavesRenderer : VisualizerRenderer {
                 }
                 path.lineTo(w, h)
                 path.close()
-                val hue = ((layer.hue(pal) % 360f) + 360f) % 360f
+                val hue = layer.hue(pal).wrapHue()
                 drawPath(
                     path = path,
                     brush =

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/WavesRenderer.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/WavesRenderer.kt
@@ -36,6 +36,12 @@ import com.vitorpamplona.amethyst.commons.audio.wrapHue
 import kotlinx.coroutines.flow.Flow
 import kotlin.math.sin
 
+/**
+ * Three translucent, overlapping filled waves. Each wave's OUTLINE is the live spectrum of its
+ * frequency band (low / mid / high), interpolated across the width, so the shape tracks the audio
+ * directly. A small time shimmer (±6%) adds life without driving the motion, and the height is
+ * clamped to 0.92·h so the fill never reaches or leaves the top edge.
+ */
 object WavesRenderer : VisualizerRenderer {
     override val style = VisualizerStyle.WAVES
 
@@ -49,9 +55,9 @@ object WavesRenderer : VisualizerRenderer {
 
     private val layers =
         listOf(
-            Layer(0f, 0.33f, { it.lowHue }, 0.95f, 0f),
-            Layer(0.2f, 0.7f, { it.midHue }, 0.8f, 1.5f),
-            Layer(0.5f, 1f, { it.highHue }, 0.7f, 3f),
+            Layer(0f, 0.4f, { it.lowHue }, 1.0f, 0f),
+            Layer(0.2f, 0.75f, { it.midHue }, 0.9f, 1.5f),
+            Layer(0.5f, 1f, { it.highHue }, 0.8f, 3f),
         )
 
     @Composable
@@ -73,11 +79,15 @@ object WavesRenderer : VisualizerRenderer {
                 var x = 0f
                 while (x <= w) {
                     val f = x / w
-                    val idx = ((layer.lo + (layer.hi - layer.lo) * f) * (n - 1)).toInt().coerceIn(0, n - 1)
-                    val v = bins[idx] * layer.amp
-                    val wob = 0.5f + 0.5f * sin(f * 8f + layer.phase + t * 2f)
-                    path.lineTo(x, h - v * h * (0.45f + 0.55f * wob))
-                    x += 6f
+                    // interpolate the spectrum within this layer's band → smooth, audio-driven outline
+                    val fb = (layer.lo + (layer.hi - layer.lo) * f) * (n - 1)
+                    val i0 = fb.toInt().coerceIn(0, n - 1)
+                    val i1 = (i0 + 1).coerceAtMost(n - 1)
+                    val v = (bins[i0] + (bins[i1] - bins[i0]) * (fb - i0)) * layer.amp
+                    val shimmer = 1f + 0.06f * sin(f * 12f + layer.phase + t * 1.5f)
+                    val height = (v * shimmer).coerceIn(0f, 1f) * h * 0.92f
+                    path.lineTo(x, h - height)
+                    x += 4f
                 }
                 path.lineTo(w, h)
                 path.close()

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/WavesRenderer.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/audio/renderers/WavesRenderer.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.audio.renderers
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import com.vitorpamplona.amethyst.commons.audio.Spectrum
+import com.vitorpamplona.amethyst.commons.audio.SpectrumCanvas
+import com.vitorpamplona.amethyst.commons.audio.VisualizerPalette
+import com.vitorpamplona.amethyst.commons.audio.VisualizerRenderer
+import com.vitorpamplona.amethyst.commons.audio.VisualizerStyle
+import kotlinx.coroutines.flow.Flow
+import kotlin.math.sin
+
+object WavesRenderer : VisualizerRenderer {
+    override val style = VisualizerStyle.WAVES
+
+    private class Layer(
+        val lo: Float,
+        val hi: Float,
+        val hue: (VisualizerPalette) -> Float,
+        val amp: Float,
+        val phase: Float,
+    )
+
+    private val layers =
+        listOf(
+            Layer(0f, 0.33f, { it.lowHue }, 0.95f, 0f),
+            Layer(0.2f, 0.7f, { it.midHue }, 0.8f, 1.5f),
+            Layer(0.5f, 1f, { it.highHue }, 0.7f, 3f),
+        )
+
+    @Composable
+    override fun Render(
+        spectrum: Flow<Spectrum>,
+        palette: VisualizerPalette,
+        modifier: Modifier,
+    ) {
+        SpectrumCanvas(spectrum, palette, modifier) { bins, t, pal ->
+            if (bins.isEmpty()) return@SpectrumCanvas
+            val n = bins.size
+            val w = size.width
+            val h = size.height
+            for (layer in layers) {
+                val path = Path().apply { moveTo(0f, h) }
+                var x = 0f
+                while (x <= w) {
+                    val f = x / w
+                    val idx = ((layer.lo + (layer.hi - layer.lo) * f) * (n - 1)).toInt().coerceIn(0, n - 1)
+                    val v = bins[idx] * layer.amp
+                    val wob = 0.5f + 0.5f * sin(f * 8f + layer.phase + t * 2f)
+                    path.lineTo(x, h - v * h * (0.45f + 0.55f * wob))
+                    x += 6f
+                }
+                path.lineTo(w, h)
+                path.close()
+                val hue = ((layer.hue(pal) % 360f) + 360f) % 360f
+                drawPath(
+                    path = path,
+                    brush =
+                        Brush.verticalGradient(
+                            0f to Color.hsl(hue, pal.saturation, pal.lightness, 0.85f),
+                            1f to Color.hsl(hue, pal.saturation, pal.lightness * 0.8f, 0.05f),
+                        ),
+                    blendMode = BlendMode.Plus,
+                )
+            }
+        }
+    }
+}

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioSpectrumTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioSpectrumTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.audio
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertTrue
+
+class AudioSpectrumTest {
+    @Test
+    fun normalizedToPeakScalesMaxToOne() {
+        val out = floatArrayOf(0f, 2f, 4f, 1f).normalizedToPeak()
+        assertEquals(1f, out[2], 1e-6f)
+        assertEquals(0.5f, out[1], 1e-6f)
+    }
+
+    @Test
+    fun normalizedToPeakHandlesAllZero() {
+        val out = floatArrayOf(0f, 0f, 0f).normalizedToPeak()
+        assertTrue(out.all { it == 0f })
+    }
+
+    @Test
+    fun normalizedToPeakReturnsNewArrayEvenForAllZero() {
+        val input = floatArrayOf(0f, 0f, 0f)
+        assertNotSame(input, input.normalizedToPeak())
+    }
+
+    @Test
+    fun toLogBinsProducesRequestedCountClampedZeroToOne() {
+        val mags = FloatArray(256) { if (it < 4) 1f else 0f }
+        val bins = mags.toLogBins(32)
+        assertEquals(32, bins.size)
+        assertTrue(bins.all { it in 0f..1f })
+        assertTrue(bins.first() > bins.last())
+    }
+}

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioSpectrumTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioSpectrumTest.kt
@@ -53,4 +53,13 @@ class AudioSpectrumTest {
         assertTrue(bins.all { it in 0f..1f })
         assertTrue(bins.first() > bins.last())
     }
+
+    @Test
+    fun normalizeToPeakInPlaceMatchesAllocatingVersion() {
+        val input = floatArrayOf(0f, 2f, 4f, 1f)
+        val expected = input.normalizedToPeak()
+        val inPlace = input.copyOf()
+        inPlace.normalizeToPeakInPlace()
+        for (i in inPlace.indices) assertEquals(expected[i], inPlace[i], 1e-6f)
+    }
 }

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioWindowTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioWindowTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.audio
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AudioWindowTest {
+    @Test
+    fun hannIsZeroAtEndsAndOneInMiddle() {
+        val w = AudioWindow.hann(9)
+        assertEquals(0f, w.first(), 1e-5f)
+        assertEquals(0f, w.last(), 1e-5f)
+        assertEquals(1f, w[4], 1e-4f)
+    }
+
+    @Test
+    fun shortsToWindowedNormalizesAndPadsToWindowLength() {
+        val window = FloatArray(4) { 1f }
+        val out = AudioWindow.shortsToWindowed(shortArrayOf(32767, -32768), window)
+        assertEquals(4, out.size)
+        assertTrue(out[0] in 0.99f..1.01f)
+        assertTrue(out[1] in -1.01f..-0.99f)
+        assertEquals(0f, out[2])
+        assertEquals(0f, out[3])
+    }
+}

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioWindowTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/AudioWindowTest.kt
@@ -43,4 +43,14 @@ class AudioWindowTest {
         assertEquals(0f, out[2])
         assertEquals(0f, out[3])
     }
+
+    @Test
+    fun shortsToWindowedIntoMatchesAllocatingVersion() {
+        val window = AudioWindow.hann(8)
+        val samples = ShortArray(8) { (it * 1000).toShort() }
+        val expected = AudioWindow.shortsToWindowed(samples, window)
+        val out = FloatArray(8)
+        AudioWindow.shortsToWindowedInto(samples, window, out)
+        for (i in out.indices) assertEquals(expected[i], out[i], 1e-6f)
+    }
 }

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/FftTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/FftTest.kt
@@ -61,4 +61,14 @@ class FftTest {
         }
         assertTrue(threw)
     }
+
+    @Test
+    fun magnitudesIntoMatchesMagnitudes() {
+        val n = 64
+        val signal = FloatArray(n) { sin(2.0 * PI * 5 * it / n).toFloat() }
+        val expected = Fft.magnitudes(signal)
+        val out = FloatArray(n / 2 + 1)
+        Fft.magnitudesInto(signal, DoubleArray(n), DoubleArray(n), out)
+        for (i in out.indices) assertEquals(expected[i], out[i], 1e-3f)
+    }
 }

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/FftTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/FftTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.audio
+
+import kotlin.math.PI
+import kotlin.math.sin
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class FftTest {
+    @Test
+    fun sineProducesPeakAtItsBin() {
+        val n = 64
+        val k = 8
+        val signal = FloatArray(n) { sin(2.0 * PI * k * it / n).toFloat() }
+
+        val mags = Fft.magnitudes(signal)
+
+        assertEquals(n / 2 + 1, mags.size)
+        val peakBin = mags.indices.maxByOrNull { mags[it] }
+        assertEquals(k, peakBin)
+    }
+
+    @Test
+    fun dcOffsetLandsInBinZero() {
+        val n = 32
+        val signal = FloatArray(n) { 0.5f }
+
+        val mags = Fft.magnitudes(signal)
+
+        val peakBin = mags.indices.maxByOrNull { mags[it] }
+        assertEquals(0, peakBin)
+    }
+
+    @Test
+    fun rejectsNonPowerOfTwo() {
+        var threw = false
+        try {
+            Fft.magnitudes(FloatArray(30))
+        } catch (e: IllegalArgumentException) {
+            threw = true
+        }
+        assertTrue(threw)
+    }
+}

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/SpectrumDelayTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/SpectrumDelayTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.audio
+
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SpectrumDelayTest {
+    private fun frames(n: Int) = (0 until n).map { Spectrum(floatArrayOf(it.toFloat())) }
+
+    @Test
+    fun delaysByFrameCountHoldingBackTheLatest() =
+        runTest {
+            // 10 frames in, hold back the latest 3 → 7 emitted, each shifted 3 hops earlier.
+            val out = frames(10).asFlow().delayedByFrames(3).toList()
+            assertEquals(7, out.size)
+            assertEquals(0f, out.first().bins[0])
+            assertEquals(6f, out.last().bins[0])
+        }
+
+    @Test
+    fun zeroDelayIsIdentity() =
+        runTest {
+            val out = frames(4).asFlow().delayedByFrames(0).toList()
+            assertEquals(listOf(0f, 1f, 2f, 3f), out.map { it.bins[0] })
+        }
+
+    @Test
+    fun negativeDelayIsIdentity() =
+        runTest {
+            assertEquals(
+                4,
+                frames(4)
+                    .asFlow()
+                    .delayedByFrames(-5)
+                    .toList()
+                    .size,
+            )
+        }
+
+    @Test
+    fun fewerFramesThanDelayEmitsNothing() =
+        runTest {
+            // Everything is still "in the buffer" (not yet audible), so nothing is shown.
+            assertEquals(
+                0,
+                frames(2)
+                    .asFlow()
+                    .delayedByFrames(5)
+                    .toList()
+                    .size,
+            )
+        }
+}

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/SyntheticSpectrumTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/SyntheticSpectrumTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.audio
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SyntheticSpectrumTest {
+    @Test
+    fun frameHasRequestedBinsClampedZeroToOne() {
+        val frame = SyntheticSpectrum.frame(timeSec = 1.0f, binCount = 48)
+        assertEquals(48, frame.bins.size)
+        assertTrue(frame.bins.all { it in 0f..1f })
+    }
+
+    @Test
+    fun frameIsDeterministic() {
+        val a = SyntheticSpectrum.frame(2.0f, 32).bins
+        val b = SyntheticSpectrum.frame(2.0f, 32).bins
+        assertTrue(a.contentEquals(b))
+    }
+
+    @Test
+    fun bassBinsCarryMoreEnergyThanTreble() {
+        var low = 0f
+        var high = 0f
+        var t = 0f
+        repeat(20) {
+            val bins = SyntheticSpectrum.frame(t, 32).bins
+            low += bins.take(6).sum()
+            high += bins.takeLast(6).sum()
+            t += 0.05f
+        }
+        assertTrue(low > high)
+    }
+}

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerRegistryTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerRegistryTest.kt
@@ -25,7 +25,7 @@ import kotlin.test.assertEquals
 
 class VisualizerRegistryTest {
     @Test
-    fun registryCoversTheFiveSpectrumStylesExactlyOnce() {
+    fun registryCoversSpectrumStylesExactlyOnce() {
         val styles = VisualizerRegistry.all.map { it.style }.toSet()
         assertEquals(
             setOf(
@@ -34,19 +34,19 @@ class VisualizerRegistryTest {
                 VisualizerStyle.WAVES,
                 VisualizerStyle.RADIAL,
                 VisualizerStyle.AURORA,
+                VisualizerStyle.STATIC,
             ),
             styles,
         )
-        assertEquals(5, VisualizerRegistry.all.size)
+        assertEquals(6, VisualizerRegistry.all.size)
     }
 
     @Test
-    fun forStyleReturnsMatchingRendererForSpectrumStylesAndFallsBackForOthers() {
+    fun forStyleMatchesForRegisteredStylesAndFallsBackForClassic() {
         for (renderer in VisualizerRegistry.all) {
             assertEquals(renderer.style, VisualizerRegistry.forStyle(renderer.style).style)
         }
-        // CLASSIC and STATIC have no spectrum renderer; the dispatcher falls back to OFF.
+        // CLASSIC has no spectrum renderer; the dispatcher falls back to OFF.
         assertEquals(VisualizerStyle.OFF, VisualizerRegistry.forStyle(VisualizerStyle.CLASSIC).style)
-        assertEquals(VisualizerStyle.OFF, VisualizerRegistry.forStyle(VisualizerStyle.STATIC).style)
     }
 }

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerRegistryTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerRegistryTest.kt
@@ -22,20 +22,31 @@ package com.vitorpamplona.amethyst.commons.audio
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class VisualizerRegistryTest {
     @Test
-    fun everyStyleHasARenderer() {
-        for (style in VisualizerStyle.entries) {
-            assertEquals(style, VisualizerRegistry.forStyle(style).style)
-        }
+    fun registryCoversTheFiveSpectrumStylesExactlyOnce() {
+        val styles = VisualizerRegistry.all.map { it.style }.toSet()
+        assertEquals(
+            setOf(
+                VisualizerStyle.OFF,
+                VisualizerStyle.BARS,
+                VisualizerStyle.WAVES,
+                VisualizerStyle.RADIAL,
+                VisualizerStyle.AURORA,
+            ),
+            styles,
+        )
+        assertEquals(5, VisualizerRegistry.all.size)
     }
 
     @Test
-    fun registryCoversEveryStyleExactlyOnce() {
-        val styles = VisualizerRegistry.all.map { it.style }.toSet()
-        assertTrue(styles.containsAll(VisualizerStyle.entries.toList()))
-        assertEquals(VisualizerStyle.entries.size, VisualizerRegistry.all.size)
+    fun forStyleReturnsMatchingRendererForSpectrumStylesAndFallsBackForOthers() {
+        for (renderer in VisualizerRegistry.all) {
+            assertEquals(renderer.style, VisualizerRegistry.forStyle(renderer.style).style)
+        }
+        // CLASSIC and STATIC have no spectrum renderer; the dispatcher falls back to OFF.
+        assertEquals(VisualizerStyle.OFF, VisualizerRegistry.forStyle(VisualizerStyle.CLASSIC).style)
+        assertEquals(VisualizerStyle.OFF, VisualizerRegistry.forStyle(VisualizerStyle.STATIC).style)
     }
 }

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerRegistryTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerRegistryTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.audio
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class VisualizerRegistryTest {
+    @Test
+    fun everyStyleHasARenderer() {
+        for (style in VisualizerStyle.entries) {
+            assertEquals(style, VisualizerRegistry.forStyle(style).style)
+        }
+    }
+
+    @Test
+    fun registryCoversEveryStyleExactlyOnce() {
+        val styles = VisualizerRegistry.all.map { it.style }.toSet()
+        assertTrue(styles.containsAll(VisualizerStyle.entries.toList()))
+        assertEquals(VisualizerStyle.entries.size, VisualizerRegistry.all.size)
+    }
+}

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerStyleTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerStyleTest.kt
@@ -28,12 +28,12 @@ class VisualizerStyleTest {
     fun parsesByNameWithSafeDefault() {
         assertEquals(VisualizerStyle.WAVES, VisualizerStyle.fromName("WAVES"))
         assertEquals(VisualizerStyle.RADIAL, VisualizerStyle.fromName("RADIAL"))
-        assertEquals(VisualizerStyle.WAVES, VisualizerStyle.fromName("nonsense"))
-        assertEquals(VisualizerStyle.WAVES, VisualizerStyle.fromName(null))
+        assertEquals(VisualizerStyle.CLASSIC, VisualizerStyle.fromName("nonsense"))
+        assertEquals(VisualizerStyle.CLASSIC, VisualizerStyle.fromName(null))
     }
 
     @Test
-    fun defaultIsWaves() {
-        assertEquals(VisualizerStyle.WAVES, VisualizerStyle.DEFAULT)
+    fun defaultIsClassic() {
+        assertEquals(VisualizerStyle.CLASSIC, VisualizerStyle.DEFAULT)
     }
 }

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerStyleTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/audio/VisualizerStyleTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.audio
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class VisualizerStyleTest {
+    @Test
+    fun parsesByNameWithSafeDefault() {
+        assertEquals(VisualizerStyle.WAVES, VisualizerStyle.fromName("WAVES"))
+        assertEquals(VisualizerStyle.RADIAL, VisualizerStyle.fromName("RADIAL"))
+        assertEquals(VisualizerStyle.WAVES, VisualizerStyle.fromName("nonsense"))
+        assertEquals(VisualizerStyle.WAVES, VisualizerStyle.fromName(null))
+    }
+
+    @Test
+    fun defaultIsWaves() {
+        assertEquals(VisualizerStyle.WAVES, VisualizerStyle.DEFAULT)
+    }
+}


### PR DESCRIPTION
## Summary

Note: very, very few posts are audio only so this feature has little actual visibility. By default the old visualiser is used to limit user experience changes. There is also an option for OFF (no visualiser).

Adds a real-time, animated audio visualiser for pure-audio notes (audio with no video track), with multiple selectable styles, a dedicated settings screen, and a per-account preference that syncs across devices. The spectrum is computed from the actual decoded audio of the playing track — there is no new runtime permission (no `RECORD_AUDIO`; it does not use the mic nor the `android.media.audiofx.Visualizer` API).

Viz testing file
`nostr:nevent1qqs8lgfsm6lrd7vq6glv75tgxlpz4s54rc97ury5vuphw0ke9sjm6ygpzpmhxue69uhkummnw3ezumt0d5hsygx23893ruw8t4dkvg3x3l6r6g5ga29jedde42vkl70lwp8ujp9h3vpsgqqqqqqsk8tnnu`

Song mp3
`nostr:nevent1qqs2u8zysytthjt40n6nxqjtxa2l0x4s6jjhlddva62hq0hj48htscqpzpmhxue69uhkummnw3ezumt0d5hsygqelxhm37z47h5xkkl2zc883mzcw9jgkyx7mvzr7jqxlj5vu58y6vpsgqqqqqqsst6t3u`

<img width="300" alt="Screenshot_20260608-175626" src="https://github.com/user-attachments/assets/7a3e5643-57dd-4ecb-aced-a62f35dd8ed6" /> <img width="300" alt="Screenshot_20260608-175556" src="https://github.com/user-attachments/assets/0b4dca91-13c1-4189-b924-05809c4dfe54" />

## What it does

- Animated spectrum/waveform over audio notes instead of the previous static placeholder.
- Style picked in Settings → Account → Audio Visualizer; stored per-account and synced via NIP-78 (kind 30078, encrypted-to-self), so it follows the identity across devices.
- NIP-A0 voice notes keep their precomputed seek-waveform; the live visualiser fills the art/placeholder area otherwise, dimming any cover/blurhash behind it for contrast.

## Styles

- Classic (existing animated waveform, **default**), Spectrum Bars, Color Waves, Radial Ring, Aurora Glow, Static Image (frozen, motion-free), Off.
- Each style has a live preview in the settings picker.

## How it works

- Decoded PCM tapped from the pooled ExoPlayer via a Media3 `TeeAudioProcessor` (no extra permission) → pure-Kotlin radix-2 FFT → log-spaced bins → per-media-URL `Flow<Spectrum>`.
- FFT, binning, the `VisualizerStyle` registry, and all Compose Canvas renderers live in `commons` (KMP-shareable); only the PCM tap and settings wiring are Android-specific.
- Route-aware delay offsets the visuals to compensate for audio output latency (longer on Bluetooth than wired/speaker) so the animation lines up with what you hear.

## Performance impact

- Audio-thread hot path reuses pre-allocated buffers (window, FFT real/imaginary, magnitudes); the only per-frame allocation is the small published bins array.
- FFT runs on ExoPlayer's audio-processing thread (buffered well ahead of the AudioTrack) at ~one 1024-point transform per ~21 ms of audio.
- Renderers read the spectrum in the Canvas draw phase (no per-frame recomposition), reuse `Path` objects, and build palette-only gradient brushes once via `remember(palette)`.
- Non-animated styles (Bars, Radial, Static) don't run the frame clock — Static settles to zero ongoing redraws.
- Per-URL spectrum-flow registry is bounded (LRU, cap 64) and never evicts a flow a composable is still collecting or a live player is feeding.
- No new permissions and no new third-party dependencies for the core.

## Testing performed

- Unit tests (`commons`): radix-2 FFT vs known signals (sine peak bin, DC, Nyquist), Hann windowing, log-bin bucketing, peak normalization, deterministic synthetic spectrum, renderer registry.
- Unit test (`amethyst`): PCM sink driven with synthetic 16-bit PCM sine waves — low/high band routing, stereo down-mix, window accumulation, non-PCM16 ignored.
- Manual on-device (Pixel 9a, play/benchmark R8 build) with a **real music MP3** and a **purpose-built synthetic audio file** (frequency sweeps, harmonic chord, beat section, noise burst, silent tail) to exercise the full spectrum.
- **Manually fine-tuned the graphics** (Waves/Aurora spectrum-shaping + amplitude clamping, Radial sizing, feed vs full-screen height) and the **audio-sync delay** (wired vs Bluetooth) by eye/ear.
- Verified rendering/reactivity in feed and full-screen, persistence across app restarts, and that crash guards hold for transient zero-size and short canvases.

## Platforms

- Android: fully wired (live audio, settings, persistence).
- Desktop: preview-ready (the rendering core compiles for JVM); live desktop audio and the desktop settings screen are deferred (VLCJ PCM tap + account-settings-in-commons are separate work).

## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
