### PR TITLE
Square the feed audio player

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/AudioPlayerSquare.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/AudioPlayerSquare.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.unit.dp
  * [tracksAreAudio] (covers bare-URL audio once tracks resolve). Voice notes keep their seek-bar strip,
  * and the full-screen dialog fills the screen, so both opt out.
  */
-fun shouldSquareAudioPlayer(
+internal fun shouldSquareAudioPlayer(
     isFullscreen: Boolean,
     isVoiceNote: Boolean,
     isAudioMime: Boolean,
@@ -44,10 +44,10 @@ fun shouldSquareAudioPlayer(
  * Maximum height of the square. The player is always full width; below this height it is a true
  * square (1:1), and above it the height is capped (full width, shorter than square).
  */
-val AUDIO_SQUARE_MAX_HEIGHT: Dp = 400.dp
+internal val AUDIO_SQUARE_MAX_HEIGHT: Dp = 400.dp
 
 /** Square side in px: the full width, but never taller than the cap. */
-fun audioSquareSide(
+internal fun audioSquareSide(
     widthPx: Int,
     maxHeightPx: Int,
 ): Int = minOf(widthPx, maxHeightPx)
@@ -57,21 +57,16 @@ fun audioSquareSide(
  * bounded incoming width (the feed cell); with an unbounded width it measures normally and does
  * nothing, so it is safe to leave in the chain unconditionally if ever needed.
  */
-fun Modifier.audioSquare(maxHeight: Dp = AUDIO_SQUARE_MAX_HEIGHT): Modifier =
+internal fun Modifier.audioSquare(maxHeight: Dp = AUDIO_SQUARE_MAX_HEIGHT): Modifier =
     layout { measurable, constraints ->
-        if (!constraints.hasBoundedWidth) {
+        val width = constraints.maxWidth
+        // Unbounded width, or first layout pass before the cell has a width: measure normally and let
+        // the next pass impose the square once a real width arrives.
+        if (!constraints.hasBoundedWidth || width == 0) {
             val placeable = measurable.measure(constraints)
-            layout(placeable.width, placeable.height) { placeable.placeRelative(0, 0) }
-        } else {
-            val width = constraints.maxWidth
-            if (width == 0) {
-                // First layout pass before the cell has a width: measure normally, size next pass.
-                val placeable = measurable.measure(constraints)
-                layout(placeable.width, placeable.height) { placeable.placeRelative(0, 0) }
-            } else {
-                val side = audioSquareSide(width, maxHeight.roundToPx())
-                val placeable = measurable.measure(Constraints.fixed(width, side))
-                layout(width, side) { placeable.placeRelative(0, 0) }
-            }
+            return@layout layout(placeable.width, placeable.height) { placeable.placeRelative(0, 0) }
         }
+        val side = audioSquareSide(width, maxHeight.roundToPx())
+        val placeable = measurable.measure(Constraints.fixed(width, side))
+        layout(width, side) { placeable.placeRelative(0, 0) }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/AudioPlayerSquare.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/AudioPlayerSquare.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.playback.composable
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * True when the inline-feed audio player should be sized as a square.
+ *
+ * Audio is detected two ways: the imeta [isAudioMime] (known up front, no resize) and the runtime
+ * [tracksAreAudio] (covers bare-URL audio once tracks resolve). Voice notes keep their seek-bar strip,
+ * and the full-screen dialog fills the screen, so both opt out.
+ */
+fun shouldSquareAudioPlayer(
+    isFullscreen: Boolean,
+    isVoiceNote: Boolean,
+    isAudioMime: Boolean,
+    tracksAreAudio: Boolean,
+): Boolean = !isFullscreen && !isVoiceNote && (isAudioMime || tracksAreAudio)
+
+/**
+ * Maximum height of the square. The player is always full width; below this height it is a true
+ * square (1:1), and above it the height is capped (full width, shorter than square).
+ */
+val AUDIO_SQUARE_MAX_HEIGHT: Dp = 400.dp
+
+/** Square side in px: the full width, but never taller than the cap. */
+fun audioSquareSide(
+    widthPx: Int,
+    maxHeightPx: Int,
+): Int = minOf(widthPx, maxHeightPx)
+
+/**
+ * Sizes the player as a square: full width, height = min(width, [maxHeight]). Only meaningful with a
+ * bounded incoming width (the feed cell); with an unbounded width it measures normally and does
+ * nothing, so it is safe to leave in the chain unconditionally if ever needed.
+ */
+fun Modifier.audioSquare(maxHeight: Dp = AUDIO_SQUARE_MAX_HEIGHT): Modifier =
+    layout { measurable, constraints ->
+        if (!constraints.hasBoundedWidth) {
+            val placeable = measurable.measure(constraints)
+            layout(placeable.width, placeable.height) { placeable.placeRelative(0, 0) }
+        } else {
+            val width = constraints.maxWidth
+            if (width == 0) {
+                // First layout pass before the cell has a width: measure normally, size next pass.
+                val placeable = measurable.measure(constraints)
+                layout(placeable.width, placeable.height) { placeable.placeRelative(0, 0) }
+            } else {
+                val side = audioSquareSide(width, maxHeight.roundToPx())
+                val placeable = measurable.measure(Constraints.fixed(width, side))
+                layout(width, side) { placeable.placeRelative(0, 0) }
+            }
+        }
+    }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/RenderVideoPlayer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/RenderVideoPlayer.kt
@@ -202,6 +202,7 @@ fun RenderVideoPlayer(
             waveform = mediaItem.src.waveformData,
             mediaId = mediaItem.src.videoUri,
             style = visualizerStyle,
+            isAudio = tracksAreAudio,
             modifier = Modifier.fillMaxSize().align(Alignment.Center),
             hasBlurhash = hasBlurhash,
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/RenderVideoPlayer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/RenderVideoPlayer.kt
@@ -54,6 +54,7 @@ import com.vitorpamplona.amethyst.service.playback.composable.controls.TopGradie
 import com.vitorpamplona.amethyst.service.playback.composable.controls.fullscreenSwipeControls
 import com.vitorpamplona.amethyst.service.playback.composable.mediaitem.LoadedMediaItem
 import com.vitorpamplona.amethyst.service.playback.composable.wavefront.AudioPlayingAnimation
+import com.vitorpamplona.amethyst.service.playback.composable.wavefront.rememberIsAudioTrack
 import com.vitorpamplona.amethyst.service.playback.diskCache.isLiveStreaming
 import com.vitorpamplona.amethyst.ui.components.getDialogWindow
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -131,9 +132,22 @@ fun RenderVideoPlayer(
 
     WatchPlaybackErrors(controllerState)
 
+    // Audio files have no video dimensions, so without this the player collapses to a thin strip and
+    // the controls get crammed. Size it square (capped) so the visualizer and controls get room.
+    // Voice notes keep their seek-bar strip; the full-screen dialog fills the screen.
+    val tracksAreAudio by rememberIsAudioTrack(controllerState.controller)
+    val squarePlayer =
+        shouldSquareAudioPlayer(
+            isFullscreen = isFullscreen,
+            isVoiceNote = mediaItem.src.waveformData != null,
+            isAudioMime = mediaItem.src.mimeType?.startsWith("audio/") == true,
+            tracksAreAudio = tracksAreAudio,
+        )
+    val playerModifier = if (squarePlayer) borderModifier.audioSquare() else borderModifier
+
     Box(
         modifier =
-            borderModifier
+            playerModifier
                 .onSizeChanged { containerWidth[0] = it.width }
                 .pointerInput(isLive, controllerState) {
                     detectTapGestures(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/wavefront/AudioPlayingAnimation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/wavefront/AudioPlayingAnimation.kt
@@ -68,6 +68,8 @@ fun rememberIsAudioTrack(controller: Player): State<Boolean> {
                 }
             }
         controller.addListener(listener)
+        // Re-read after registering so a track change racing the initial remember{} read isn't missed.
+        isAudio.value = controller.currentTracks.isAudio()
         onDispose { controller.removeListener(listener) }
     }
     return isAudio
@@ -92,11 +94,10 @@ fun AudioPlayingAnimation(
     waveform: WaveformData?,
     mediaId: String,
     style: VisualizerStyle,
+    isAudio: Boolean,
     modifier: Modifier = Modifier,
     hasBlurhash: Boolean = false,
 ) {
-    val isAudio by rememberIsAudioTrack(controllerState.controller)
-
     if (!isAudio) return
 
     // Dim any blurhash/cover backdrop behind whatever we draw, for contrast and consistency across

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/wavefront/AudioPlayingAnimation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/wavefront/AudioPlayingAnimation.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layout
@@ -52,6 +51,27 @@ import com.vitorpamplona.amethyst.service.playback.playerPool.PcmTapRegistry
 import kotlinx.coroutines.flow.emptyFlow
 
 fun Tracks.isAudio() = groups.isNotEmpty() && groups.none { it.type == C.TRACK_TYPE_VIDEO }
+
+/**
+ * Observes whether the controller's current tracks are audio-only, updating live via the player's
+ * track-change listener. Shared by [AudioPlayingAnimation] (to decide what to draw) and the player
+ * container (to decide whether to size the player as a square).
+ */
+@Composable
+fun rememberIsAudioTrack(controller: Player): State<Boolean> {
+    val isAudio = remember(controller) { mutableStateOf(controller.currentTracks.isAudio()) }
+    DisposableEffect(controller) {
+        val listener =
+            object : Player.Listener {
+                override fun onTracksChanged(tracks: Tracks) {
+                    isAudio.value = tracks.isAudio()
+                }
+            }
+        controller.addListener(listener)
+        onDispose { controller.removeListener(listener) }
+    }
+    return isAudio
+}
 
 // Output-latency compensation. The spectrum is tapped upstream of the AudioTrack output buffer (and,
 // over Bluetooth, the codec/transmission lag downstream of it), so the visual leads the speaker and
@@ -75,19 +95,7 @@ fun AudioPlayingAnimation(
     modifier: Modifier = Modifier,
     hasBlurhash: Boolean = false,
 ) {
-    var isAudio by remember { mutableStateOf(controllerState.controller.currentTracks.isAudio()) }
-
-    DisposableEffect(controllerState.controller) {
-        val listener =
-            object : Player.Listener {
-                override fun onTracksChanged(tracks: Tracks) {
-                    super.onTracksChanged(tracks)
-                    isAudio = tracks.isAudio()
-                }
-            }
-        controllerState.controller.addListener(listener)
-        onDispose { controllerState.controller.removeListener(listener) }
-    }
+    val isAudio by rememberIsAudioTrack(controllerState.controller)
 
     if (!isAudio) return
 
@@ -102,6 +110,7 @@ fun AudioPlayingAnimation(
     }
 
     when (style) {
+        // CLASSIC keeps its compact fixed-height wave (it does not stretch to fill the square).
         VisualizerStyle.CLASSIC -> FakeWaveformAnimation(mediaControllerState = controllerState, modifier = drawModifier)
         VisualizerStyle.STATIC -> {
             // StaticRenderer ignores the flow and shows a frozen frame.

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/service/playback/composable/AudioPlayerSquareTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/service/playback/composable/AudioPlayerSquareTest.kt
@@ -65,4 +65,9 @@ class AudioPlayerSquareTest {
     fun sideEqualsCapAtBoundary() {
         assertEquals(1000, audioSquareSide(widthPx = 1000, maxHeightPx = 1000))
     }
+
+    @Test
+    fun sideIsZeroWhenWidthIsZero() {
+        assertEquals(0, audioSquareSide(widthPx = 0, maxHeightPx = 1000))
+    }
 }

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/service/playback/composable/AudioPlayerSquareTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/service/playback/composable/AudioPlayerSquareTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.playback.composable
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AudioPlayerSquareTest {
+    @Test
+    fun squareWhenMimeSaysAudio() {
+        assertTrue(shouldSquareAudioPlayer(isFullscreen = false, isVoiceNote = false, isAudioMime = true, tracksAreAudio = false))
+    }
+
+    @Test
+    fun squareWhenTracksResolveAudio() {
+        assertTrue(shouldSquareAudioPlayer(isFullscreen = false, isVoiceNote = false, isAudioMime = false, tracksAreAudio = true))
+    }
+
+    @Test
+    fun noSquareForVideo() {
+        assertFalse(shouldSquareAudioPlayer(isFullscreen = false, isVoiceNote = false, isAudioMime = false, tracksAreAudio = false))
+    }
+
+    @Test
+    fun noSquareForVoiceNoteEvenIfAudio() {
+        assertFalse(shouldSquareAudioPlayer(isFullscreen = false, isVoiceNote = true, isAudioMime = true, tracksAreAudio = true))
+    }
+
+    @Test
+    fun noSquareInFullscreen() {
+        assertFalse(shouldSquareAudioPlayer(isFullscreen = true, isVoiceNote = false, isAudioMime = true, tracksAreAudio = true))
+    }
+
+    @Test
+    fun sideIsWidthBelowCap() {
+        assertEquals(360, audioSquareSide(widthPx = 360, maxHeightPx = 1000))
+    }
+
+    @Test
+    fun sideIsCappedAboveCap() {
+        assertEquals(1000, audioSquareSide(widthPx = 1800, maxHeightPx = 1000))
+    }
+
+    @Test
+    fun sideEqualsCapAtBoundary() {
+        assertEquals(1000, audioSquareSide(widthPx = 1000, maxHeightPx = 1000))
+    }
+}


### PR DESCRIPTION

<img width="300" alt="Screenshot_20260608-224630" src="https://github.com/user-attachments/assets/c7c11a06-8a65-49f2-9946-92b7ac95f28f" />

Summary
  
  Audio files have no video dimensions, so in the feed the player collapsed to a thin strip — the new visualizer looked tiny and the playback controls (play/pause, seek bar, top buttons) were crammed into ~48–72dp. This sizes
  the inline-feed audio player as a square so the visualizer and the controls get room.
  
  What changed

  - The player Box (the one already holding both the visualizer and the controls) is sized full width, height = min(width, 400dp) via a small Modifier.audioSquare() layout modifier — a true square on phones, height-capped on
  wide/tablet layouts.
  - Audio is detected with two signals: the imeta mimeType (audio/…, known up front → no resize) plus the runtime Tracks.isAudio() fallback for bare-URL audio. Extracted into a shared rememberIsAudioTrack so the container and
  the visualizer observe one signal (one Player.Listener per player, not two).
  - Excluded: voice notes (NIP-A0 keep their seek-bar strip) and full-screen (still fills the screen).
  - Per style: the spectrum visualizers (BARS/WAVES/RADIAL/AURORA/STATIC) fill the square; CLASSIC keeps its compact 48dp wave centered inside the square (it does not stretch); OFF shows the cover/blurhash with roomy controls.

  Performance

  Layout-only. No new per-frame work: the square is a single layout {} measure (integer math, no per-frame state reads), and the listener consolidation removed a duplicate Player.Listener + MutableState per audio player. Pure
  decision/size helpers are split out and unit-tested.

  Testing
  
  - 9 unit tests for the square decision + side math (AudioPlayerSquareTest).
  - Manual on-device (Pixel 9a, benchmark build): each style square with roomy controls; CLASSIC small wave centered; voice notes stay a strip; full-screen fills; landscape height-capped.


## License

- [ ] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
