### PR TITLE
fix(math): collapse over-escaped backslashes in inline equations

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/LatexEquation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/LatexEquation.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.TextUnitType
 import androidx.compose.ui.unit.sp
+import com.vitorpamplona.amethyst.commons.richtext.MathParser
 import ru.noties.jlatexmath.JLatexMathDrawable
 
 /**
@@ -58,6 +59,11 @@ fun LatexEquation(
     val density = LocalDensity.current
     val fontSize = LocalTextStyle.current.fontSize
 
+    // Inline math has no legitimate `\\` line break, so a doubled backslash is an
+    // over-escaped command (`\\ldots` → `\ldots`). Without this JLaTeXMath would
+    // read `\\` as a line break and render `ldots`/`cdots` as literal letters.
+    val formula = if (displayMode) latex else MathParser.collapseDoubledBackslashes(latex)
+
     // Display math renders a touch larger than the surrounding prose, matching
     // the visual weight KaTeX gives block equations.
     val textSizePx =
@@ -67,10 +73,10 @@ fun LatexEquation(
         }
 
     val drawable =
-        remember(latex, color, textSizePx) {
+        remember(formula, color, textSizePx) {
             runCatching {
                 JLatexMathDrawable
-                    .builder(latex)
+                    .builder(formula)
                     .textSize(textSizePx)
                     .color(color)
                     .align(JLatexMathDrawable.ALIGN_LEFT)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/MathParser.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/MathParser.kt
@@ -70,6 +70,20 @@ object MathParser {
     }
 
     /**
+     * Collapses doubled backslashes (`\\cmd` → `\cmd`).
+     *
+     * Some sources over-escape their LaTeX (every `\` written as `\\`). In inline
+     * math a `\\` is a TeX forced line break that is never intended, so `\\ldots`
+     * really means `\ldots`. Left as-is, a renderer like JLaTeXMath reads `\\` as
+     * a line break — splitting the equation across two lines — and the trailing
+     * command name (`ldots`, `cdots`) as literal letters, so the symbol is lost.
+     *
+     * No-op when the input isn't over-escaped. Only meant for inline math; display
+     * math (`$$…$$`) may use `\\` as a genuine line break in aligned/matrix forms.
+     */
+    fun collapseDoubledBackslashes(latex: String): String = if (latex.contains("\\\\")) latex.replace("\\\\", "\\") else latex
+
+    /**
      * Splits [line] on spaces into [Token.Word]s, with any whitespace-delimited
      * math span surfaced as a [Token.Math].
      */

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/MathParserTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/MathParserTest.kt
@@ -123,6 +123,19 @@ class MathParserTest {
     }
 
     @Test
+    fun collapsesOverEscapedBackslashes() {
+        // `\\ldots` (over-escaped) -> `\ldots`; otherwise JLaTeXMath sees a line
+        // break plus the literal letters "ldots".
+        assertEquals("A_1, ${bs}ldots, A_n", MathParser.collapseDoubledBackslashes("A_1, $bs$bs" + "ldots, A_n"))
+        assertEquals("x_1 = ${bs}cdots = x_n", MathParser.collapseDoubledBackslashes("x_1 = $bs$bs" + "cdots = x_n"))
+    }
+
+    @Test
+    fun singleBackslashLatexIsLeftAlone() {
+        assertEquals("${bs}frac{1}{2} + ${bs}sqrt{x}", MathParser.collapseDoubledBackslashes("${bs}frac{1}{2} + ${bs}sqrt{x}"))
+    }
+
+    @Test
     fun gluedMathStaysPlainWord() {
         // Math without a separating space is not whitespace-delimited, so it
         // remains a single literal word rather than three rendered pieces.


### PR DESCRIPTION
Some sources (e.g. the math-academy posts) over-escape their LaTeX, so the content carries `\\ldots` / `\\cdots` instead of `\ldots` / `\cdots`. JLaTeXMath reads the `\\` as a forced TeX line break — splitting every inline equation across two lines — and renders the trailing command name as the literal letters "ldots"/"cdots", so the ellipsis symbol is lost.

Collapse doubled backslashes (`\\cmd` -> `\cmd`) before rendering inline math; display math is left untouched since `\\` can be a genuine line break there. No-op when the content isn't over-escaped.

<!--
Thanks for contributing to Amethyst! Before opening this PR, please skim
CONTRIBUTING.md — especially the "Proof of testing" and "Interoperability
tests" sections if you are not a regular contributor to this repo.

Delete any section below that doesn't apply.
-->

## Summary

<!-- 1–3 sentences. What changed and why. Not "what files changed" — the
diff already shows that. -->

## Test plan

<!-- Required. What did you actually run, on what platform, with what result?
"CI is green" is necessary but not sufficient — show the new path firing.

For UI changes, attach screenshots (light + dark) or a short recording.
For Android: device model + Android version. For Desktop: OS + window size.
For build/packaging changes: paste the `./gradlew` command + tail of output.

If you are NOT a regular contributor to this repo, this section is required
regardless of how small the change is — see CONTRIBUTING.md § Proof of
testing. -->

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes / screenshots:

<!-- paste here -->

## Interop suites

<!-- The interop suites listed in CONTRIBUTING.md § Interoperability tests
are NOT run in CI. If your change touches the relevant code paths, run them
locally and tick the box. If your change can't possibly affect them
(docs-only, UI-only on unrelated screens, etc.), tick "N/A". -->

- [ ] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes
- [ ] Marmot / MLS — `cli/tests/marmot/marmot-interop-headless.sh` (NIP-EE / `whitenoise-rs`)
- [ ] NIP-17 DM — `cli/tests/dm/dm-interop-headless.sh`
- [ ] Audio rooms manual — `cli/tests/nests/nests-interop.sh` (Amethyst ↔ nostrnests.com)
- [ ] MoQ-lite hang-tier — `:nestsClient:jvmTest -DnestsHangInterop=true`
- [ ] MoQ-lite browser-tier — `:nestsClient:jvmTest -DnestsBrowserInterop=true`
- [ ] QUIC interop-runner — `quic/interop/run-matrix.sh -s {aioquic,picoquic,quic-go,quinn}`

## AI assistance

<!-- Optional disclosure. We accept AI-assisted PRs (Claude Code, Copilot,
Cursor, Codex, etc.) under the same rules as human PRs — see
CONTRIBUTING.md § Human and AI contributions. A one-line note here is
appreciated when an assistant did the bulk of the diff. -->

- [ ] Drafted with AI assistance, manually reviewed and tested
- [ ] Written by hand

If "Drafted with AI assistance" is ticked, also read
[`CONTRIBUTING-WITH-AI.md`](CONTRIBUTING-WITH-AI.md) for the additional
gates that apply to AI-authored PRs.

## License

- [ ] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
