### PR TITLE
Replace String.format with toString(16).padStart in test helpers

### DIFF
--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/RoomReactionsStateTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/RoomReactionsStateTest.kt
@@ -37,7 +37,7 @@ class RoomReactionsStateTest {
         to: String?,
         content: String,
         createdAt: Long,
-        id: String = "%064x".format(nextEventId++),
+        id: String = (nextEventId++).toString(16).padStart(64, '0'),
     ): ReactionEvent {
         val tags =
             buildList<Array<String>> {

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/RoomZapsStateTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/viewmodels/RoomZapsStateTest.kt
@@ -45,7 +45,7 @@ class RoomZapsStateTest {
         from: String,
         to: String?,
         createdAt: Long,
-        id: String = "%064x".format(nextEventId++),
+        id: String = (nextEventId++).toString(16).padStart(64, '0'),
     ): LnZapEvent {
         val tags =
             buildList<Array<String>> {


### PR DESCRIPTION
## Summary

Replace deprecated `String.format("%064x")` calls with `toString(16).padStart(64, '0')` in test helper functions for generating event IDs. This improves compatibility and uses more idiomatic Kotlin for hexadecimal formatting.

## Test plan

- [x] Ran `./gradlew test` — existing unit tests pass
- [x] N/A — change is test-only and doesn't affect production code paths

The changes are in test helper methods (`createReactionEvent` and `createLnZapEvent`) that generate mock event IDs. Both implementations produce identical output (64-character zero-padded hexadecimal strings), so existing tests continue to pass without modification.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

This is a test-only refactor with no impact on protocol or wire format.

https://claude.ai/code/session_01QJ876DV7FpYVP6XwsiRM7u