### PR TITLE
Optimize string resource loading in WalletScreen

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletScreen.kt
@@ -218,6 +218,8 @@ private fun MultiWalletHomeContent(
 ) {
     val walletInfoList by walletViewModel.walletInfoList.collectAsState()
     val context = LocalContext.current
+    val budgetApprovedMsg = stringRes(R.string.clink_budget_approved)
+    val debitNoResponseMsg = stringRes(R.string.clink_debit_no_response)
 
     LaunchedEffect(Unit) {
         walletViewModel.fetchAllBalances()
@@ -261,9 +263,9 @@ private fun MultiWalletHomeContent(
                                 val error = response?.failureDetail()
                                 val msg =
                                     when {
-                                        response?.isOk() == true -> context.getString(R.string.clink_budget_approved)
+                                        response?.isOk() == true -> budgetApprovedMsg
                                         !error.isNullOrBlank() -> error
-                                        else -> context.getString(R.string.clink_debit_no_response)
+                                        else -> debitNoResponseMsg
                                     }
                                 Toast.makeText(context, msg, Toast.LENGTH_LONG).show()
                             }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/Nip05Test.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/Nip05Test.kt
@@ -56,7 +56,7 @@ class Nip05Test {
         }
 
     @Test
-    fun `parse clink_offer as a flat top-level string (bridgelet shape)`() =
+    fun `parse clink_offer as a flat top-level bridgelet-shaped string`() =
         runTest {
             val noffer = "noffer1qqsexampleclinkoffer"
             val json = """{ "names": { "bob": "abc" }, "clink_offer": "$noffer" }"""


### PR DESCRIPTION
## Summary

Refactored `MultiWalletHomeContent` to load string resources once at composition time instead of repeatedly calling `context.getString()` within the response handler. This improves performance by avoiding redundant resource lookups and reduces the number of context method calls in the hot path.

Also improved a test name in `Nip05Test` for clarity.

## Changes

- **amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletScreen.kt**
  - Moved `budgetApprovedMsg` and `debitNoResponseMsg` string resource loads to the top of `MultiWalletHomeContent` composition
  - Replaced inline `context.getString()` calls with pre-loaded string variables in the response handler

- **quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/Nip05Test.kt**
  - Improved test name clarity: `parse clink_offer as a flat top-level string (bridgelet shape)` → `parse clink_offer as a flat top-level bridgelet-shaped string`

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Ran `./gradlew test` — existing tests pass
- [x] N/A — change is a performance optimization with no behavioral changes; no manual testing needed

https://claude.ai/code/session_01UgP8ErzBbQYkTDtkJx5nrt