### PR TITLE
Unify payment card UI with PaymentCard component

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/cashu/v3/V3Parser.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/cashu/v3/V3Parser.kt
@@ -50,7 +50,7 @@ class V3Parser {
                             totalAmount += proof.amount
                         }
 
-                        CashuToken(cashuToken, mint, totalAmount, proofs)
+                        CashuToken(cashuToken, mint, totalAmount, proofs, cashu.unit, cashu.memo?.takeIf { it.isNotBlank() })
                     }
 
                 return GenericLoadable.Loaded(converted.toImmutableList())

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/cashu/v4/V4Parser.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/cashu/v4/V4Parser.kt
@@ -60,7 +60,7 @@ class V4Parser {
                             totalAmount += proof.amount
                         }
 
-                        CashuToken(cashuToken, mint, totalAmount, proofs)
+                        CashuToken(cashuToken, mint, totalAmount, proofs, v4Token.u, v4Token.d?.takeIf { it.isNotBlank() })
                     }
 
                 return GenericLoadable.Loaded(converted.toImmutableList())

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/lnurl/CachedLnInvoice.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/lnurl/CachedLnInvoice.kt
@@ -30,6 +30,10 @@ import java.text.NumberFormat
 data class InvoiceAmount(
     val invoice: String,
     val amount: String?,
+    /** Free-text BOLT-11 description, when the invoice carries one. */
+    val description: String? = null,
+    /** Expiration as epoch seconds, when the invoice decodes. */
+    val expiresAt: Long? = null,
 )
 
 object CachedLnInvoiceParser {
@@ -49,7 +53,8 @@ object CachedLnInvoiceParser {
                     null
                 }
 
-            val lnInvoice = InvoiceAmount(myInvoice, myInvoiceAmount)
+            val details = LnInvoiceUtil.parseDetails(myInvoice)
+            val lnInvoice = InvoiceAmount(myInvoice, myInvoiceAmount, details?.description, details?.expiresAt())
 
             lnInvoicesCache.put(lnbcWord, lnInvoice)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/CashuRedeem.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/CashuRedeem.kt
@@ -22,14 +22,12 @@ package com.vitorpamplona.amethyst.ui.components
 
 import android.content.Context
 import android.content.Intent
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Card
+import androidx.compose.material3.Button
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
@@ -40,17 +38,16 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDirection
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.hashtags.Cashu
@@ -58,23 +55,20 @@ import com.vitorpamplona.amethyst.commons.hashtags.CustomHashTagIcons
 import com.vitorpamplona.amethyst.commons.model.nip60Cashu.CashuToken
 import com.vitorpamplona.amethyst.service.cashu.CachedCashuParser
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
-import com.vitorpamplona.amethyst.ui.components.util.setText
-import com.vitorpamplona.amethyst.ui.note.CopyIcon
 import com.vitorpamplona.amethyst.ui.note.OpenInNewIcon
 import com.vitorpamplona.amethyst.ui.note.ZapIcon
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
-import com.vitorpamplona.amethyst.ui.theme.CashuCardBorders
+import com.vitorpamplona.amethyst.ui.theme.ButtonBorder
 import com.vitorpamplona.amethyst.ui.theme.Size18Modifier
 import com.vitorpamplona.amethyst.ui.theme.Size20Modifier
-import com.vitorpamplona.amethyst.ui.theme.SmallishBorder
 import com.vitorpamplona.amethyst.ui.theme.StdHorzSpacer
 import com.vitorpamplona.amethyst.ui.theme.ThemeComparisonColumn
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.text.NumberFormat
 
 @Composable
 fun CashuPreview(
@@ -129,10 +123,29 @@ fun CashuPreview(
 fun CashuPreviewPreview() {
     ThemeComparisonColumn {
         CashuPreviewNew(
-            token = CashuToken("token", "mint", 32400, listOf()),
+            token = CashuToken("token", "https://mint.example.com", 32400, listOf(), "sat", "Thanks for the coffee!"),
             melt = { _, _, _ -> },
             toast = { _, _ -> },
         )
+    }
+}
+
+/**
+ * Formats the token amount with its NUT-00 unit: sats stay sats, fiat units
+ * (denominated in minor units, e.g. usd = cents) are shown with two decimals,
+ * anything unknown is rendered verbatim rather than mislabeled as sats.
+ */
+private fun cashuAmountLabel(
+    token: CashuToken,
+    satsLabel: String,
+): Pair<String, String> {
+    val unit = token.unit
+    return when (unit) {
+        null, "sat" -> NumberFormat.getIntegerInstance().format(token.totalAmount) to satsLabel
+        "usd", "eur" ->
+            NumberFormat.getInstance().apply { minimumFractionDigits = 2 }.format(token.totalAmount / 100.0) to
+                unit.uppercase()
+        else -> NumberFormat.getIntegerInstance().format(token.totalAmount) to unit
     }
 }
 
@@ -144,107 +157,88 @@ fun CashuPreviewNew(
 ) {
     val context = LocalContext.current
 
-    Card(
-        modifier = CashuCardBorders,
+    PaymentCard(
+        title = stringRes(R.string.cashu),
+        icon = {
+            Icon(
+                imageVector = CustomHashTagIcons.Cashu,
+                contentDescription = null,
+                modifier = Size18Modifier,
+                tint = Color.Unspecified,
+            )
+        },
+        copyValue = token.token,
     ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
+        val satsLabel = stringRes(R.string.sats)
+        val (amount, unit) = remember(token) { cashuAmountLabel(token, satsLabel) }
+
+        PaymentCardAmount(amount = amount, unit = unit)
+
+        token.memo?.let {
+            PaymentCardDescription(it)
+        }
+
+        Text(
+            text = stringRes(R.string.cashu_mint_label, token.mint.removePrefix("https://")),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .padding(10.dp),
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    imageVector = CustomHashTagIcons.Cashu,
-                    null,
-                    modifier = Modifier.size(13.dp),
-                )
+                    .padding(top = 6.dp),
+        )
 
-                Text(
-                    text = stringRes(R.string.cashu),
-                    fontSize = 12.sp,
-                    modifier = Modifier.padding(start = 5.dp, bottom = 1.dp),
-                )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center,
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(top = 12.dp),
+        ) {
+            var isRedeeming by remember { mutableStateOf(false) }
+
+            Button(
+                onClick = {
+                    isRedeeming = true
+                    melt(token, context) { title, message ->
+                        toast(title, message)
+                        isRedeeming = false
+                    }
+                },
+                shape = ButtonBorder,
+                modifier = Modifier.weight(1f),
+            ) {
+                if (isRedeeming) {
+                    LoadingAnimation()
+                } else {
+                    ZapIcon(Size20Modifier, tint = MaterialTheme.colorScheme.onPrimary)
+                }
+                Spacer(StdHorzSpacer)
+
+                Text(stringRes(R.string.cashu_redeem))
             }
 
-            Text(
-                text = "${token.totalAmount} ${stringRes(id = R.string.sats)}",
-                fontSize = 20.sp,
-                modifier = Modifier.padding(top = 5.dp),
-            )
-            Text(
-                text = "Mint: " + token.mint.replace("https://", ""),
-                fontSize = 7.sp,
-                color = Color.Gray,
-                modifier = Modifier.padding(start = 5.dp, bottom = 1.dp),
-            )
+            Spacer(modifier = StdHorzSpacer)
 
-            Row(modifier = Modifier.padding(top = 5.dp)) {
-                var isRedeeming by remember { mutableStateOf(false) }
+            FilledTonalButton(
+                onClick = {
+                    try {
+                        val intent = Intent(Intent.ACTION_VIEW, "cashu://${token.token}".toUri())
+                        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
 
-                FilledTonalButton(
-                    onClick = {
-                        isRedeeming = true
-                        melt(token, context) { title, message ->
-                            toast(title, message)
-                            isRedeeming = false
-                        }
-                    },
-                    shape = SmallishBorder,
-                ) {
-                    if (isRedeeming) {
-                        LoadingAnimation()
-                    } else {
-                        ZapIcon(Size20Modifier, tint = MaterialTheme.colorScheme.onBackground)
+                        context.startActivity(intent)
+                    } catch (e: Exception) {
+                        if (e is CancellationException) throw e
+                        toast(stringRes(context, R.string.cashu), stringRes(context, R.string.cashu_no_wallet_found))
                     }
-                    Spacer(StdHorzSpacer)
-
-                    Text(
-                        "Redeem",
-                        fontSize = 16.sp,
-                    )
-                }
-
-                Spacer(modifier = StdHorzSpacer)
-
-                FilledTonalButton(
-                    onClick = {
-                        try {
-                            val intent = Intent(Intent.ACTION_VIEW, "cashu://${token.token}".toUri())
-                            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-
-                            context.startActivity(intent)
-                        } catch (e: Exception) {
-                            if (e is CancellationException) throw e
-                            toast(stringRes(context, R.string.cashu), stringRes(context, R.string.cashu_no_wallet_found))
-                        }
-                    },
-                    shape = SmallishBorder,
-                    contentPadding = PaddingValues(0.dp),
-                ) {
-                    OpenInNewIcon(Size18Modifier)
-                }
-
-                Spacer(modifier = StdHorzSpacer)
-
-                val clipboardManager = LocalClipboard.current
-                val scope = rememberCoroutineScope()
-
-                FilledTonalButton(
-                    onClick = {
-                        scope.launch {
-                            // Copying the token to clipboard
-                            clipboardManager.setText(token.token)
-                        }
-                    },
-                    shape = SmallishBorder,
-                    contentPadding = PaddingValues(0.dp),
-                ) {
-                    CopyIcon(Size18Modifier)
-                }
+                },
+                shape = ButtonBorder,
+            ) {
+                OpenInNewIcon(Size18Modifier)
             }
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/PaymentCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/PaymentCard.kt
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.components
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
+import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
+import com.vitorpamplona.amethyst.ui.components.util.setText
+import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.amethyst.ui.theme.QuoteBorder
+import com.vitorpamplona.amethyst.ui.theme.Size18Modifier
+import kotlinx.coroutines.launch
+
+/**
+ * Shared scaffold for the inline payment cards rendered in the middle of a post
+ * (Lightning invoices, CLINK Offers, Cashu tokens): a tonal card with a small
+ * icon + label header, an optional copy-to-clipboard action, and the
+ * payment-specific body underneath.
+ */
+@Composable
+fun PaymentCard(
+    title: String,
+    icon: @Composable () -> Unit,
+    copyValue: String? = null,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Card(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(vertical = 10.dp),
+        shape = QuoteBorder,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, end = 16.dp, top = 10.dp, bottom = 16.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                icon()
+
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(start = 8.dp),
+                )
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                if (copyValue != null) {
+                    CopyToClipboardButton(copyValue)
+                }
+            }
+
+            content()
+        }
+    }
+}
+
+@Composable
+private fun CopyToClipboardButton(value: String) {
+    val context = LocalContext.current
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
+    val copiedMessage = stringRes(R.string.copied_to_clipboard)
+
+    IconButton(
+        onClick = {
+            scope.launch {
+                clipboard.setText(value)
+                Toast.makeText(context, copiedMessage, Toast.LENGTH_SHORT).show()
+            }
+        },
+        modifier = Modifier.size(28.dp),
+    ) {
+        Icon(
+            symbol = MaterialSymbols.ContentCopy,
+            contentDescription = stringRes(R.string.copy_to_clipboard),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Size18Modifier,
+        )
+    }
+}
+
+/** Centered headline amount with the unit rendered smaller on the same baseline. */
+@Composable
+fun PaymentCardAmount(
+    amount: String,
+    unit: String,
+) {
+    Row(
+        horizontalArrangement = Arrangement.Center,
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(top = 10.dp),
+    ) {
+        Text(
+            text = amount,
+            fontSize = 30.sp,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.alignByBaseline(),
+        )
+        Text(
+            text = unit,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier =
+                Modifier
+                    .alignByBaseline()
+                    .padding(start = 6.dp),
+        )
+    }
+}
+
+/** Free-text description/memo attached to the payment. */
+@Composable
+fun PaymentCardDescription(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Center,
+        maxLines = 3,
+        overflow = TextOverflow.Ellipsis,
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(top = 6.dp),
+    )
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/RichTextViewer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/RichTextViewer.kt
@@ -507,7 +507,7 @@ private fun RenderWordWithoutPreview(
 
         // Decoding is local and the network round-trip only fires on the Pay tap,
         // so the offer card is safe to render even in the no-preview path.
-        is ClinkOfferSegment -> ClinkOfferPreview(word.offer, accountViewModel)
+        is ClinkOfferSegment -> ClinkOfferPreview(word.offer, accountViewModel, nav)
 
         is EmailSegment -> ClickableEmail(word.segmentText)
 
@@ -555,7 +555,7 @@ private fun RenderWordWithPreview(
         is InvoiceSegment -> MayBeInvoicePreview(word.segmentText, accountViewModel)
         is WithdrawSegment -> MayBeWithdrawal(word.segmentText, accountViewModel)
         is CashuSegment -> CashuPreview(word.segmentText, accountViewModel)
-        is ClinkOfferSegment -> ClinkOfferPreview(word.offer, accountViewModel)
+        is ClinkOfferSegment -> ClinkOfferPreview(word.offer, accountViewModel, nav)
         is EmailSegment -> ClickableEmail(word.segmentText)
         is SecretEmoji -> DisplaySecretEmoji(word, state, callbackUri, true, quotesLeft, backgroundColor, accountViewModel, nav)
         is MathSegment -> LatexEquation(word.latex, word.displayMode, word.leading, word.trailing)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/invoice/ClinkOfferPreview.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/invoice/ClinkOfferPreview.kt
@@ -20,19 +20,14 @@
  */
 package com.vitorpamplona.amethyst.ui.note.creators.invoice
 
-import android.widget.Toast
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -46,32 +41,35 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.hashtags.CustomHashTagIcons
 import com.vitorpamplona.amethyst.commons.hashtags.Lightning
-import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
-import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
 import com.vitorpamplona.amethyst.service.ClinkOfferPayer
-import com.vitorpamplona.amethyst.ui.components.util.setText
+import com.vitorpamplona.amethyst.ui.components.PaymentCard
+import com.vitorpamplona.amethyst.ui.components.PaymentCardAmount
+import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.routes.routeFor
+import com.vitorpamplona.amethyst.ui.note.ClickableUserPicture
 import com.vitorpamplona.amethyst.ui.note.ErrorMessageDialog
+import com.vitorpamplona.amethyst.ui.note.UsernameDisplay
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.LoadUser
 import com.vitorpamplona.amethyst.ui.stringRes
-import com.vitorpamplona.amethyst.ui.theme.DividerThickness
-import com.vitorpamplona.amethyst.ui.theme.QuoteBorder
-import com.vitorpamplona.amethyst.ui.theme.Size20Modifier
-import com.vitorpamplona.amethyst.ui.theme.subtleBorder
+import com.vitorpamplona.amethyst.ui.theme.ButtonBorder
+import com.vitorpamplona.amethyst.ui.theme.Size18Modifier
+import com.vitorpamplona.amethyst.ui.theme.Size25dp
+import com.vitorpamplona.amethyst.ui.theme.SmallBorder
+import com.vitorpamplona.amethyst.ui.theme.StdHorzSpacer
 import com.vitorpamplona.quartz.experimental.clink.common.SatRange
 import com.vitorpamplona.quartz.experimental.clink.offers.OfferErrorCode
 import com.vitorpamplona.quartz.experimental.clink.pointers.ClinkPointerParser
 import com.vitorpamplona.quartz.experimental.clink.pointers.NOffer
 import com.vitorpamplona.quartz.experimental.clink.pointers.OfferPriceType
 import kotlinx.coroutines.launch
+import java.text.NumberFormat
 
 /**
  * Inline card for a CLINK Offers pointer (`noffer1…`) found in a note. Tapping "Pay"
@@ -83,10 +81,10 @@ import kotlinx.coroutines.launch
 fun ClinkOfferPreview(
     offer: NOffer,
     accountViewModel: AccountViewModel,
+    nav: INav,
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
-    val clipboard = LocalClipboard.current
 
     var requesting by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
@@ -113,174 +111,157 @@ fun ClinkOfferPreview(
         onError = { errorMessage = it },
     )
 
-    Column(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(start = 20.dp, end = 20.dp, top = 10.dp, bottom = 10.dp)
-                .clip(shape = QuoteBorder)
-                .border(1.dp, MaterialTheme.colorScheme.subtleBorder, QuoteBorder),
+    PaymentCard(
+        title = stringRes(R.string.clink_lightning_offer),
+        icon = {
+            Icon(
+                imageVector = CustomHashTagIcons.Lightning,
+                contentDescription = null,
+                modifier = Size18Modifier,
+                tint = Color.Unspecified,
+            )
+        },
+        copyValue = activeOffer.encode(),
     ) {
-        Column(
+        // Who gets paid: the offer pointer carries the recipient's pubkey.
+        OfferRecipientRow(activeOffer.pubKey, accountViewModel, nav)
+
+        // FIXED offers display their preset price; SPONTANEOUS offers (and the default
+        // when the pointer omits a price type) require the payer to enter an amount.
+        // Reflect the pointer actually being charged (which may have changed if the
+        // service redirected us to a replacement noffer via "Expired or Moved").
+        if (activeOffer.priceType == OfferPriceType.FIXED) {
+            activeOffer.price?.let {
+                PaymentCardAmount(
+                    amount = NumberFormat.getIntegerInstance().format(it),
+                    unit = stringRes(R.string.sats),
+                )
+            }
+        }
+
+        if (needsAmount) {
+            OutlinedTextField(
+                value = amountInput,
+                onValueChange = { new -> amountInput = new.filter(Char::isDigit) },
+                label = { Text(stringRes(R.string.clink_offer_amount_sats)) },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                supportingText =
+                    amountRange?.let { range ->
+                        val min = range.min
+                        val max = range.max
+                        if (min != null && max != null) {
+                            { Text(stringRes(R.string.clink_offer_amount_range, min.toString(), max.toString())) }
+                        } else {
+                            null
+                        }
+                    },
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(top = 10.dp),
+            )
+        }
+
+        val amountRequired = needsAmount
+
+        suspend fun runOfferRequest(
+            useOffer: NOffer,
+            followMoved: Boolean,
+        ) {
+            val amount = if (amountRequired) amountInput.toLongOrNull() else useOffer.price
+
+            val response = ClinkOfferPayer.requestInvoice(accountViewModel.account, useOffer, amountSats = amount)
+
+            val bolt11 = response?.bolt11
+            val movedTo =
+                if (response?.code == OfferErrorCode.EXPIRED_OR_MOVED && followMoved) {
+                    response.latest?.let { ClinkPointerParser.parse(it) as? NOffer }
+                } else {
+                    null
+                }
+
+            when {
+                bolt11 != null -> {
+                    requesting = false
+                    payingInvoice = bolt11
+                }
+                // Follow a relocated offer once, paying the replacement pointer.
+                movedTo != null -> {
+                    activeOffer = movedTo
+                    runOfferRequest(movedTo, followMoved = false)
+                }
+                response?.code == OfferErrorCode.INVALID_AMOUNT -> {
+                    // Reveal the amount field (or refine it) with the service's range.
+                    requesting = false
+                    needsAmount = true
+                    amountRange = response.range
+                    errorMessage =
+                        response.error?.takeIf { it.isNotBlank() }
+                            ?: stringRes(context, R.string.clink_offer_invalid_amount)
+                }
+                else -> {
+                    requesting = false
+                    errorMessage =
+                        response?.error?.takeIf { it.isNotBlank() }
+                            ?: stringRes(context, R.string.error_dialog_pay_invoice_error)
+                }
+            }
+        }
+
+        Button(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .padding(20.dp),
+                    .padding(top = 12.dp),
+            enabled = !requesting && (!amountRequired || (amountInput.toLongOrNull() ?: 0L) > 0L),
+            onClick = {
+                requesting = true
+                scope.launch { runOfferRequest(activeOffer, followMoved = true) }
+            },
+            shape = ButtonBorder,
         ) {
+            Text(text = stringRes(if (requesting) R.string.clink_requesting_invoice else R.string.pay))
+        }
+    }
+}
+
+/** Avatar + name of the offer's payee, tappable to open their profile. */
+@Composable
+private fun OfferRecipientRow(
+    pubKey: String,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    LoadUser(baseUserHex = pubKey, accountViewModel) { user ->
+        if (user != null) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .padding(bottom = 10.dp),
-            ) {
-                Icon(
-                    imageVector = CustomHashTagIcons.Lightning,
-                    contentDescription = null,
-                    modifier = Size20Modifier,
-                    tint = Color.Unspecified,
-                )
-
-                Text(
-                    text = stringRes(R.string.clink_lightning_offer),
-                    fontSize = 20.sp,
-                    fontWeight = FontWeight.W500,
-                    modifier = Modifier.padding(start = 10.dp),
-                )
-
-                Spacer(modifier = Modifier.weight(1f))
-
-                val copiedMessage = stringRes(R.string.copied_to_clipboard)
-                IconButton(
-                    onClick = {
-                        scope.launch {
-                            clipboard.setText(activeOffer.encode())
-                            Toast.makeText(context, copiedMessage, Toast.LENGTH_SHORT).show()
-                        }
-                    },
-                ) {
-                    Icon(
-                        symbol = MaterialSymbols.ContentCopy,
-                        contentDescription = stringRes(R.string.copy_to_clipboard),
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Size20Modifier,
-                    )
-                }
-            }
-
-            HorizontalDivider(thickness = DividerThickness)
-
-            // FIXED offers display their preset price; SPONTANEOUS offers (and the default
-            // when the pointer omits a price type) require the payer to enter an amount.
-            // Reflect the pointer actually being charged (which may have changed if the
-            // service redirected us to a replacement noffer via "Expired or Moved").
-            val effectiveType = activeOffer.priceType
-
-            if (effectiveType == OfferPriceType.FIXED) {
-                activeOffer.price?.let {
-                    Text(
-                        text = "$it ${stringRes(id = R.string.sats)}",
-                        fontSize = 25.sp,
-                        fontWeight = FontWeight.W500,
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 10.dp),
-                    )
-                }
-            }
-
-            if (needsAmount) {
-                OutlinedTextField(
-                    value = amountInput,
-                    onValueChange = { new -> amountInput = new.filter(Char::isDigit) },
-                    label = { Text(stringRes(R.string.clink_offer_amount_sats)) },
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                    supportingText =
-                        amountRange?.let { range ->
-                            val min = range.min
-                            val max = range.max
-                            if (min != null && max != null) {
-                                { Text(stringRes(R.string.clink_offer_amount_range, min.toString(), max.toString())) }
-                            } else {
-                                null
-                            }
-                        },
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 10.dp),
-                )
-            }
-
-            val amountRequired = needsAmount
-
-            suspend fun runOfferRequest(
-                useOffer: NOffer,
-                followMoved: Boolean,
-            ) {
-                val amount = if (amountRequired) amountInput.toLongOrNull() else useOffer.price
-
-                val response = ClinkOfferPayer.requestInvoice(accountViewModel.account, useOffer, amountSats = amount)
-
-                val bolt11 = response?.bolt11
-                val movedTo =
-                    if (response?.code == OfferErrorCode.EXPIRED_OR_MOVED && followMoved) {
-                        response.latest?.let { ClinkPointerParser.parse(it) as? NOffer }
-                    } else {
-                        null
-                    }
-
-                when {
-                    bolt11 != null -> {
-                        requesting = false
-                        payingInvoice = bolt11
-                    }
-                    // Follow a relocated offer once, paying the replacement pointer.
-                    movedTo != null -> {
-                        activeOffer = movedTo
-                        runOfferRequest(movedTo, followMoved = false)
-                    }
-                    response?.code == OfferErrorCode.INVALID_AMOUNT -> {
-                        // Reveal the amount field (or refine it) with the service's range.
-                        requesting = false
-                        needsAmount = true
-                        amountRange = response.range
-                        errorMessage =
-                            response.error?.takeIf { it.isNotBlank() }
-                                ?: stringRes(context, R.string.clink_offer_invalid_amount)
-                    }
-                    else -> {
-                        requesting = false
-                        errorMessage =
-                            response?.error?.takeIf { it.isNotBlank() }
-                                ?: stringRes(context, R.string.error_dialog_pay_invoice_error)
-                    }
-                }
-            }
-
-            Button(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 10.dp),
-                enabled = !requesting && (!amountRequired || (amountInput.toLongOrNull() ?: 0L) > 0L),
-                onClick = {
-                    requesting = true
-                    scope.launch { runOfferRequest(activeOffer, followMoved = true) }
-                },
-                shape = QuoteBorder,
-                colors =
-                    ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                    ),
+                        .padding(top = 8.dp)
+                        .clip(SmallBorder)
+                        .clickable { nav.nav(routeFor(user)) }
+                        .padding(4.dp),
             ) {
                 Text(
-                    text = stringRes(if (requesting) R.string.clink_requesting_invoice else R.string.pay),
-                    color = Color.White,
-                    fontSize = 20.sp,
+                    text = stringRes(R.string.clink_offer_pay_to),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(end = 8.dp),
                 )
+
+                ClickableUserPicture(
+                    baseUser = user,
+                    size = Size25dp,
+                    accountViewModel = accountViewModel,
+                    onClick = { nav.nav(routeFor(it)) },
+                )
+
+                Spacer(modifier = StdHorzSpacer)
+
+                UsernameDisplay(user, accountViewModel = accountViewModel)
             }
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/invoice/InvoicePreview.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/invoice/InvoicePreview.kt
@@ -20,14 +20,9 @@
  */
 package com.vitorpamplona.amethyst.ui.note.creators.invoice
 
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
@@ -38,28 +33,27 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.hashtags.CustomHashTagIcons
 import com.vitorpamplona.amethyst.commons.hashtags.Lightning
 import com.vitorpamplona.amethyst.service.lnurl.CachedLnInvoiceParser
 import com.vitorpamplona.amethyst.service.lnurl.InvoiceAmount
 import com.vitorpamplona.amethyst.ui.actions.CrossfadeIfEnabled
+import com.vitorpamplona.amethyst.ui.components.PaymentCard
+import com.vitorpamplona.amethyst.ui.components.PaymentCardAmount
+import com.vitorpamplona.amethyst.ui.components.PaymentCardDescription
 import com.vitorpamplona.amethyst.ui.note.ErrorMessageDialog
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
-import com.vitorpamplona.amethyst.ui.theme.DividerThickness
-import com.vitorpamplona.amethyst.ui.theme.QuoteBorder
-import com.vitorpamplona.amethyst.ui.theme.Size20Modifier
-import com.vitorpamplona.amethyst.ui.theme.subtleBorder
+import com.vitorpamplona.amethyst.ui.theme.ButtonBorder
+import com.vitorpamplona.amethyst.ui.theme.Size18Modifier
+import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -88,7 +82,7 @@ fun MayBeInvoicePreview(
     LoadValueFromInvoice(lnbcWord = lnbcWord) { invoiceAmount ->
         CrossfadeIfEnabled(targetState = invoiceAmount, label = "MayBeInvoicePreview", accountViewModel = accountViewModel) {
             if (it != null) {
-                InvoicePreview(it.invoice, it.amount, accountViewModel)
+                InvoicePreview(it.invoice, it.amount, it.description, it.expiresAt, accountViewModel)
             } else {
                 Text(
                     text = lnbcWord,
@@ -103,6 +97,8 @@ fun MayBeInvoicePreview(
 fun InvoicePreview(
     lnInvoice: String,
     amount: String?,
+    description: String?,
+    expiresAt: Long?,
     accountViewModel: AccountViewModel,
 ) {
     val context = LocalContext.current
@@ -125,70 +121,53 @@ fun InvoicePreview(
         onError = { showErrorMessageDialog = it },
     )
 
-    Column(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(start = 20.dp, end = 20.dp, top = 10.dp, bottom = 10.dp)
-                .clip(shape = QuoteBorder)
-                .border(1.dp, MaterialTheme.colorScheme.subtleBorder, QuoteBorder),
+    // Snapshot at composition: enough to flag clearly stale invoices without
+    // ticking a clock while the card is on screen.
+    val isExpired = remember(expiresAt) { expiresAt != null && expiresAt < TimeUtils.now() }
+
+    PaymentCard(
+        title = stringRes(R.string.lightning_invoice),
+        icon = {
+            Icon(
+                imageVector = CustomHashTagIcons.Lightning,
+                contentDescription = null,
+                modifier = Size18Modifier,
+                tint = Color.Unspecified,
+            )
+        },
+        copyValue = lnInvoice,
     ) {
-        Column(
+        amount?.let {
+            PaymentCardAmount(amount = it, unit = stringRes(R.string.sats))
+        }
+
+        description?.let {
+            PaymentCardDescription(it)
+        }
+
+        if (isExpired) {
+            Text(
+                text = stringRes(R.string.invoice_expired),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.error,
+                textAlign = TextAlign.Center,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(top = 6.dp),
+            )
+        }
+
+        Button(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .padding(20.dp),
+                    .padding(top = 12.dp),
+            enabled = !isExpired,
+            onClick = { payingInvoice = lnInvoice },
+            shape = ButtonBorder,
         ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(bottom = 10.dp),
-            ) {
-                Icon(
-                    imageVector = CustomHashTagIcons.Lightning,
-                    null,
-                    modifier = Size20Modifier,
-                    tint = Color.Unspecified,
-                )
-
-                Text(
-                    text = stringRes(R.string.lightning_invoice),
-                    fontSize = 20.sp,
-                    fontWeight = FontWeight.W500,
-                    modifier = Modifier.padding(start = 10.dp),
-                )
-            }
-
-            HorizontalDivider(thickness = DividerThickness)
-
-            amount?.let {
-                Text(
-                    text = "$it ${stringRes(id = R.string.sats)}",
-                    fontSize = 25.sp,
-                    fontWeight = FontWeight.W500,
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 10.dp),
-                )
-            }
-
-            Button(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 10.dp),
-                onClick = { payingInvoice = lnInvoice },
-                shape = QuoteBorder,
-                colors =
-                    ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                    ),
-            ) {
-                Text(text = stringRes(R.string.pay), color = Color.White, fontSize = 20.sp)
-            }
+            Text(text = stringRes(R.string.pay))
         }
     }
 }

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -112,7 +112,9 @@
     <string name="log_out">Logout</string>
     <string name="show_more">Show More</string>
     <string name="lightning_invoice">Lightning Invoice</string>
+    <string name="invoice_expired">Expired</string>
     <string name="clink_lightning_offer">CLINK Offer</string>
+    <string name="clink_offer_pay_to">To</string>
     <string name="clink_requesting_invoice">Requesting invoice…</string>
     <string name="clink_debit_no_response">The debit service did not complete the payment.</string>
     <string name="clink_confirm_payment_title">Confirm payment</string>
@@ -1554,6 +1556,7 @@
     <string name="default_limit">Default Limit (Events Returning)</string>
     <string name="max_subid_length">Max SubID Length</string>
     <string name="cashu">Cashu Token</string>
+    <string name="cashu_mint_label">Mint: %1$s</string>
     <string name="cashu_redeem">Redeem</string>
     <string name="cashu_redeem_to_zap">Send to Zap Wallet</string>
     <string name="cashu_redeem_to_cashu">Open in Cashu Wallet</string>

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/CashuV4ParserTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/CashuV4ParserTest.kt
@@ -22,6 +22,7 @@ package com.vitorpamplona.amethyst
 
 import com.vitorpamplona.amethyst.service.cashu.v4.V4Parser
 import com.vitorpamplona.amethyst.ui.components.GenericLoadable
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
@@ -41,7 +42,9 @@ class CashuV4ParserTest {
                 val list = outcome.loaded
                 assertTrue("Expected at least one CashuToken", list.isNotEmpty())
                 val first = list.first()
-                println("mint=${first.mint} totalAmount=${first.totalAmount} proofs=${first.proofs.size}")
+                assertEquals("https://mint.minibits.cash/Bitcoin", first.mint)
+                assertEquals("sat", first.unit)
+                assertEquals("TEST", first.memo)
             }
             is GenericLoadable.Error -> fail("V4Parser failed: ${outcome.errorMessage}")
             else -> fail("V4Parser returned $outcome")

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip60Cashu/CashuToken.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip60Cashu/CashuToken.kt
@@ -29,6 +29,10 @@ data class CashuToken(
     val mint: String,
     val totalAmount: Long,
     val proofs: List<Proof>,
+    /** NUT-00 currency unit ("sat" when absent). Non-sat units are denominated in minor units (e.g. usd = cents). */
+    val unit: String? = null,
+    /** Free-text memo the sender attached to the token. */
+    val memo: String? = null,
 )
 
 @Serializable

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/note/DesktopRichTextViewer.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/note/DesktopRichTextViewer.kt
@@ -484,6 +484,10 @@ private fun RenderInvoiceCard(
         remember(invoice) {
             runCatching { LnInvoiceUtil.getAmountInSats(invoice) }.getOrNull()
         }
+    val description =
+        remember(invoice) {
+            LnInvoiceUtil.getDescription(invoice)
+        }
     Card(
         modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
@@ -501,6 +505,16 @@ private fun RenderInvoiceCard(
                     text = if (amount != null) "$amount sats" else "Lightning Invoice",
                     style = MaterialTheme.typography.titleSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (description != null) {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
             Spacer(Modifier.height(8.dp))

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/lightning/LnInvoiceUtil.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/lightning/LnInvoiceUtil.kt
@@ -283,6 +283,112 @@ object LnInvoiceUtil {
 
     fun getAmountInSats(invoice: String): BigDecimal = getAmount(invoice).multiply(OneHundredK)
 
+    /** Tagged-field types from BOLT-11 (the bech32 value of the tag character). */
+    private const val TAG_DESCRIPTION = 13 // 'd'
+    private const val TAG_EXPIRY = 6 // 'x'
+
+    /** Default expiry per BOLT-11 when the `x` field is absent. */
+    private const val DEFAULT_EXPIRY_SECONDS = 3600L
+
+    /**
+     * The human-relevant tagged fields of a BOLT-11 invoice: when it was created,
+     * the free-text description (absent when the payee used a description hash),
+     * and how long it stays valid.
+     */
+    class Bolt11Details(
+        val timestamp: Long,
+        val description: String?,
+        val expirySeconds: Long?,
+    ) {
+        fun expiresAt(): Long = timestamp + (expirySeconds ?: DEFAULT_EXPIRY_SECONDS)
+    }
+
+    /**
+     * Parses the data part of a BOLT-11 invoice and returns its timestamp, description
+     * and expiry. Returns null if the string is not a checksum-valid invoice.
+     */
+    fun parseDetails(invoice: String): Bolt11Details? {
+        try {
+            decodeUnlimitedLength(invoice) // checksum must match
+        } catch (e: AddressFormatException) {
+            return null
+        }
+
+        val pos = invoice.lastIndexOf('1')
+        val dataPart = invoice.substring(pos + 1).lowercase()
+        // 7 chars of timestamp + 104 chars of signature + 6 chars of checksum is the minimum.
+        if (dataPart.length < 7 + 104 + 6) return null
+
+        val values = ByteArray(dataPart.length)
+        for (i in dataPart.indices) {
+            val code = dataPart[i].code
+            if (code >= CHARSET_REV.size || CHARSET_REV[code].toInt() == -1) return null
+            values[i] = CHARSET_REV[code]
+        }
+
+        var timestamp = 0L
+        for (i in 0 until 7) {
+            timestamp = (timestamp shl 5) or values[i].toLong()
+        }
+
+        // Tagged fields run from after the timestamp to before the 520-bit signature
+        // + recovery id (104 values) and the checksum (6 values).
+        val fieldsEnd = values.size - 104 - 6
+        var description: String? = null
+        var expiry: Long? = null
+
+        var i = 7
+        while (i + 3 <= fieldsEnd) {
+            val type = values[i].toInt()
+            val dataLength = values[i + 1].toInt() * 32 + values[i + 2].toInt()
+            val dataStart = i + 3
+            val dataEnd = dataStart + dataLength
+            if (dataEnd > fieldsEnd) break
+
+            when (type) {
+                TAG_DESCRIPTION -> description = fiveBitsToBytes(values, dataStart, dataEnd).decodeToString()
+                TAG_EXPIRY -> {
+                    var seconds = 0L
+                    for (j in dataStart until dataEnd) {
+                        seconds = (seconds shl 5) or values[j].toLong()
+                    }
+                    expiry = seconds
+                }
+            }
+
+            i = dataEnd
+        }
+
+        return Bolt11Details(timestamp, description?.takeIf { it.isNotBlank() }, expiry)
+    }
+
+    /**
+     * Returns the free-text description (`d` tagged field) of a BOLT-11 invoice, or null
+     * when the invoice is invalid, has no description, or carries only a description hash.
+     */
+    fun getDescription(invoice: String): String? = parseDetails(invoice)?.description
+
+    /** Regroups 5-bit bech32 values into 8-bit bytes, discarding incomplete trailing bits. */
+    private fun fiveBitsToBytes(
+        values: ByteArray,
+        from: Int,
+        to: Int,
+    ): ByteArray {
+        val result = ByteArray((to - from) * 5 / 8)
+        var acc = 0
+        var bits = 0
+        var index = 0
+        for (i in from until to) {
+            acc = (acc shl 5) or values[i].toInt()
+            bits += 5
+            if (bits >= 8) {
+                bits -= 8
+                result[index++] = ((acc ushr bits) and 0xFF).toByte()
+            }
+        }
+        return result
+    }
+
     private fun multiplier(multiplier: String): BigDecimal =
         when (multiplier.lowercase()) {
             "m" -> OneMili

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/lightning/LnInvoiceDetailsTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/lightning/LnInvoiceDetailsTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.lightning
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/** Tagged-field parsing against the BOLT-11 spec example invoices. */
+class LnInvoiceDetailsTest {
+    // "Please consider supporting this project", no amount, no expiry.
+    val donation =
+        "lnbc1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq9qrsgq357wnc5r2ueh7ck6q93dj32dlqnls087fxdwk8qakdyafkq3yap9us6v52vjjsrvywa6rt52cm9r9zqt8r2t7mlcwspyetp5h2tztugp9lfyql"
+
+    // "1 cup coffee", 2500u, expiry 60s.
+    val coffee =
+        "lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpu9qrsgquk0rl77nj30yxdy8j9vdx85fkpmdla2087ne0xh8nhedh8w27kyke0lp53ut353s06fv3qfegext0eh0ymjpf39tuven09sam30g4vgpfna3rh"
+
+    // Description hash only (`h` field), no free-text description.
+    val hashedDescription =
+        "lnbc20m1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqs9qrsgq7ea976txfraylvgzuxs8kgcw23ezlrszfnh8r6qtfpr6cxga50aj6txm9rxrydzd06dfeawfk6swupvz4erwnyutnjq7x39ymw6j38gp7ynn44"
+
+    // UTF-8 description "ナンセンス 1杯", expiry 60s.
+    val japanese =
+        "lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpu9qrsgqhtjpauu9ur7fw2thcl4y9vfvh4m9wlfyz2gem29g5ghe2aak2pm3ps8fdhtceqsaagty2vph7utlgj48u0ged6a337aewvraedendscp573dxr"
+
+    @Test
+    fun parsesPlainDescription() {
+        val details = LnInvoiceUtil.parseDetails(donation)
+        assertNotNull(details)
+        assertEquals("Please consider supporting this project", details.description)
+        assertEquals(1496314658L, details.timestamp)
+        assertNull(details.expirySeconds)
+        // Falls back to the BOLT-11 default of one hour.
+        assertEquals(1496314658L + 3600L, details.expiresAt())
+    }
+
+    @Test
+    fun parsesDescriptionWithExplicitExpiry() {
+        val details = LnInvoiceUtil.parseDetails(coffee)
+        assertNotNull(details)
+        assertEquals("1 cup coffee", details.description)
+        assertEquals(60L, details.expirySeconds)
+        assertEquals(1496314658L + 60L, details.expiresAt())
+    }
+
+    @Test
+    fun hashedDescriptionYieldsNoText() {
+        val details = LnInvoiceUtil.parseDetails(hashedDescription)
+        assertNotNull(details)
+        assertNull(details.description)
+    }
+
+    @Test
+    fun parsesUtf8Description() {
+        assertEquals("ナンセンス 1杯", LnInvoiceUtil.getDescription(japanese))
+    }
+
+    @Test
+    fun rejectsCorruptedInvoice() {
+        assertNull(LnInvoiceUtil.parseDetails(coffee.dropLast(1) + "q"))
+        assertNull(LnInvoiceUtil.parseDetails("lnbc1notanInvoice"))
+    }
+}


### PR DESCRIPTION
## Summary

Refactored Lightning invoices, CLINK offers, and Cashu tokens to share a common `PaymentCard` composable scaffold. This eliminates duplicate card styling, header layouts, and copy-to-clipboard logic across three payment preview components.

Added BOLT-11 parsing to extract description and expiry metadata from Lightning invoices, surfacing this information in the invoice preview card. Updated Cashu token parsing to carry unit and memo fields, enabling proper amount formatting (sats as integers, fiat with two decimals).

## Changes

**New component:**
- `PaymentCard.kt`: Shared card scaffold with icon + title header, optional copy button, and content slot. Includes `PaymentCardAmount` (centered amount + unit) and `PaymentCardDescription` (memo text) helper composables.

**Updated payment previews:**
- `InvoicePreview.kt`: Now displays description and expiry status; uses `PaymentCard` instead of custom Column/border layout.
- `ClinkOfferPreview.kt`: Refactored to use `PaymentCard`; added `OfferRecipientRow` composable for recipient display; added `nav` parameter for navigation.
- `CashuRedeem.kt`: Refactored to use `PaymentCard`; added `cashuAmountLabel()` helper to format amounts by unit (sats, fiat with decimals, etc.).

**BOLT-11 parsing:**
- `LnInvoiceUtil.kt`: Added `parseDetails()` to extract timestamp, description, and expiry from BOLT-11 data section; added `getDescription()` convenience method.
- `LnInvoiceDetailsTest.kt`: Unit tests covering plain descriptions, explicit expiry, hashed descriptions, and UTF-8 text.

**Data model updates:**
- `InvoiceAmount.kt`: Added `description` and `expiresAt` fields.
- `CashuToken.kt`: Added `unit` and `memo` fields.
- `V3Parser.kt` & `V4Parser.kt`: Updated to pass unit and memo when constructing `CashuToken`.

**UI strings:**
- Added `invoice_expired` string resource.

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Ran `./gradlew test` — all tests pass, including new `LnInvoiceDetailsTest`
- [x] Manually exercised the change:
  - Verified Lightning invoice cards display description and expiry status
  - Verified CLINK offer cards render with recipient info and proper amount formatting
  - Verified Cashu token cards display unit-aware amounts (sats, fiat with decimals)
  - Confirmed copy-to-clipboard button works on all three card types
  - Tested with invoices lacking descriptions (no crash, graceful fallback)

## Interop suites

- [x] N/A — change is UI-only; no wire bytes, protocol, or state affected

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_019VuZ4y3ij6Ly4VVExE1W1W