### PR TITLE
Make relay failure logs diagnosable (exception class on null message, correct NIP-11 error label)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip11RelayInfo/Nip11Retriever.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip11RelayInfo/Nip11Retriever.kt
@@ -47,14 +47,21 @@ class Nip11Retriever(
         onError: (NormalizedRelayUrl, ErrorCode, String?) -> Unit,
     ) = withContext(Dispatchers.IO) {
         val url = relay.toHttp()
-        try {
-            val request: Request =
+        val request =
+            try {
                 Request
                     .Builder()
                     .header("Accept", "application/nostr+json")
                     .url(url)
                     .build()
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                Log.e("RelayInfoFail", "Invalid URL ${relay.url}", e)
+                onError(relay, ErrorCode.FAIL_TO_ASSEMBLE_URL, e.message)
+                return@withContext
+            }
 
+        try {
             val client = okHttpClient(relay)
 
             client.newCall(request).executeAsync().use { response ->
@@ -81,8 +88,8 @@ class Nip11Retriever(
             }
         } catch (e: Exception) {
             if (e is CancellationException) throw e
-            Log.e("RelayInfoFail", "Invalid URL ${relay.url}", e)
-            onError(relay, ErrorCode.FAIL_TO_ASSEMBLE_URL, e.message)
+            Log.e("RelayInfoFail", "Failed to fetch NIP-11 from ${relay.url}", e)
+            onError(relay, ErrorCode.FAIL_TO_REACH_SERVER, e.message ?: e::class.simpleName)
         }
     }
 }

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/model/nip11RelayInfo/Nip11RetrieverTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/model/nip11RelayInfo/Nip11RetrieverTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.model.nip11RelayInfo
+
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+import java.net.ConnectException
+
+class Nip11RetrieverTest {
+    @Test
+    fun unreachableServerReportsFailToReachServer() =
+        runBlocking {
+            // Inject a fake client that simulates connection refused without building
+            // a real OkHttpClient (which fails in amethyst JVM unit tests because
+            // the Android OkHttp variant tries to detect Android via android.util.Log).
+            val retriever =
+                Nip11Retriever { _ ->
+                    throw ConnectException("Connection refused")
+                }
+            val relay = NormalizedRelayUrl("ws://127.0.0.1:14591/")
+
+            var errorCode: Nip11Retriever.ErrorCode? = null
+            retriever.loadRelayInfo(
+                relay = relay,
+                onInfo = { fail("Expected an error, got relay info") },
+                onError = { _, code, _ -> errorCode = code },
+            )
+
+            assertEquals(Nip11Retriever.ErrorCode.FAIL_TO_REACH_SERVER, errorCode)
+        }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/single/basic/BasicRelayClient.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/single/basic/BasicRelayClient.kt
@@ -167,9 +167,9 @@ open class BasicRelayClient(
                     )
                 ) {
                     if (code != null || response != null) {
-                        listener.onCannotConnect(this@BasicRelayClient, "Server Misconfigured. Response: $code $response. Exception: ${t.message}")
+                        listener.onCannotConnect(this@BasicRelayClient, "Server Misconfigured. Response: $code $response. Exception: ${t.message ?: t::class.simpleName}")
                     } else {
-                        listener.onCannotConnect(this@BasicRelayClient, "WebSocket Failure: ${t.message}")
+                        listener.onCannotConnect(this@BasicRelayClient, "WebSocket Failure: ${t.message ?: t::class.simpleName}")
                     }
                 } else {
                     // ignore local disconnect requests and tor errors

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/single/basic/BasicRelayClient.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/single/basic/BasicRelayClient.kt
@@ -103,7 +103,7 @@ open class BasicRelayClient(
             socket?.connect()
         } catch (e: Exception) {
             if (e is CancellationException) throw e
-            listener.onCannotConnect(this, "Error when trying to connect: ${e.message}")
+            listener.onCannotConnect(this, "Error when trying to connect: ${e.message ?: e::class.simpleName}")
             listener.onDisconnected(this)
             dontTryAgainForALongTime()
             markConnectionAsClosed()
@@ -154,7 +154,9 @@ open class BasicRelayClient(
             } else {
                 socket?.disconnect()
 
+                // suppression rules below must match the raw message; displayMsg is for listener output only
                 val msg = t.message
+                val displayMsg = msg ?: t::class.simpleName
 
                 // checks if this is an actual failure. Closing the socket generates an onFailure as well.
                 // ignore tor errors.
@@ -167,9 +169,9 @@ open class BasicRelayClient(
                     )
                 ) {
                     if (code != null || response != null) {
-                        listener.onCannotConnect(this@BasicRelayClient, "Server Misconfigured. Response: $code $response. Exception: ${t.message ?: t::class.simpleName}")
+                        listener.onCannotConnect(this@BasicRelayClient, "Server Misconfigured. Response: $code $response. Exception: $displayMsg")
                     } else {
-                        listener.onCannotConnect(this@BasicRelayClient, "WebSocket Failure: ${t.message ?: t::class.simpleName}")
+                        listener.onCannotConnect(this@BasicRelayClient, "WebSocket Failure: $displayMsg")
                     }
                 } else {
                     // ignore local disconnect requests and tor errors

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/single/basic/BasicRelayClientTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/single/basic/BasicRelayClientTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.relay.client.single.basic
+
+import com.vitorpamplona.quartz.nip01Core.relay.client.listeners.RelayConnectionListener
+import com.vitorpamplona.quartz.nip01Core.relay.client.single.IRelayClient
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip01Core.relay.sockets.WebSocket
+import com.vitorpamplona.quartz.nip01Core.relay.sockets.WebSocketListener
+import com.vitorpamplona.quartz.nip01Core.relay.sockets.WebsocketBuilder
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class BasicRelayClientTest {
+    private class FakeWebSocket : WebSocket {
+        override fun needsReconnect() = false
+
+        override fun connect() {}
+
+        override fun disconnect() {}
+
+        override fun send(msg: String) = true
+    }
+
+    private class FakeWebsocketBuilder : WebsocketBuilder {
+        var capturedListener: WebSocketListener? = null
+
+        override fun build(
+            url: NormalizedRelayUrl,
+            out: WebSocketListener,
+        ): WebSocket {
+            capturedListener = out
+            return FakeWebSocket()
+        }
+    }
+
+    private class RecordingConnectionListener : RelayConnectionListener {
+        val cannotConnectMessages = mutableListOf<String>()
+
+        override fun onCannotConnect(
+            relay: IRelayClient,
+            errorMessage: String,
+        ) {
+            cannotConnectMessages.add(errorMessage)
+        }
+    }
+
+    private class MessagelessException : Exception()
+
+    private fun connectAndCapture(
+        builder: FakeWebsocketBuilder,
+        listener: RecordingConnectionListener,
+    ): WebSocketListener {
+        val client =
+            BasicRelayClient(
+                NormalizedRelayUrl("wss://relay.example.com/"),
+                builder,
+                listener,
+            )
+        client.connect()
+        val socketListener = builder.capturedListener
+        assertNotNull(socketListener)
+        return socketListener
+    }
+
+    @Test
+    fun onFailureWithNullMessageReportsExceptionClassName() {
+        val builder = FakeWebsocketBuilder()
+        val listener = RecordingConnectionListener()
+
+        connectAndCapture(builder, listener).onFailure(MessagelessException(), null, null)
+
+        assertEquals(
+            listOf("WebSocket Failure: MessagelessException"),
+            listener.cannotConnectMessages,
+        )
+    }
+
+    @Test
+    fun onFailureWithMessageKeepsExistingFormat() {
+        val builder = FakeWebsocketBuilder()
+        val listener = RecordingConnectionListener()
+
+        connectAndCapture(builder, listener).onFailure(Exception("Connection reset"), null, null)
+
+        assertEquals(
+            listOf("WebSocket Failure: Connection reset"),
+            listener.cannotConnectMessages,
+        )
+    }
+
+    @Test
+    fun serverMisconfiguredWithNullMessageReportsExceptionClassName() {
+        val builder = FakeWebsocketBuilder()
+        val listener = RecordingConnectionListener()
+
+        connectAndCapture(builder, listener).onFailure(MessagelessException(), 200, "OK")
+
+        assertEquals(
+            listOf("Server Misconfigured. Response: 200 OK. Exception: MessagelessException"),
+            listener.cannotConnectMessages,
+        )
+    }
+}

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/single/basic/BasicRelayClientTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/single/basic/BasicRelayClientTest.kt
@@ -66,10 +66,14 @@ class BasicRelayClientTest {
 
     private class MessagelessException : Exception()
 
-    private fun connectAndCapture(
-        builder: FakeWebsocketBuilder,
-        listener: RecordingConnectionListener,
-    ): WebSocketListener {
+    private data class Harness(
+        val socketListener: WebSocketListener,
+        val connectionListener: RecordingConnectionListener,
+    )
+
+    private fun connectAndCapture(): Harness {
+        val builder = FakeWebsocketBuilder()
+        val listener = RecordingConnectionListener()
         val client =
             BasicRelayClient(
                 NormalizedRelayUrl("wss://relay.example.com/"),
@@ -79,15 +83,14 @@ class BasicRelayClientTest {
         client.connect()
         val socketListener = builder.capturedListener
         assertNotNull(socketListener)
-        return socketListener
+        return Harness(socketListener, listener)
     }
 
     @Test
     fun onFailureWithNullMessageReportsExceptionClassName() {
-        val builder = FakeWebsocketBuilder()
-        val listener = RecordingConnectionListener()
+        val (socket, listener) = connectAndCapture()
 
-        connectAndCapture(builder, listener).onFailure(MessagelessException(), null, null)
+        socket.onFailure(MessagelessException(), null, null)
 
         assertEquals(
             listOf("WebSocket Failure: MessagelessException"),
@@ -97,10 +100,9 @@ class BasicRelayClientTest {
 
     @Test
     fun onFailureWithMessageKeepsExistingFormat() {
-        val builder = FakeWebsocketBuilder()
-        val listener = RecordingConnectionListener()
+        val (socket, listener) = connectAndCapture()
 
-        connectAndCapture(builder, listener).onFailure(Exception("Connection reset"), null, null)
+        socket.onFailure(Exception("Connection reset"), null, null)
 
         assertEquals(
             listOf("WebSocket Failure: Connection reset"),
@@ -110,10 +112,9 @@ class BasicRelayClientTest {
 
     @Test
     fun serverMisconfiguredWithNullMessageReportsExceptionClassName() {
-        val builder = FakeWebsocketBuilder()
-        val listener = RecordingConnectionListener()
+        val (socket, listener) = connectAndCapture()
 
-        connectAndCapture(builder, listener).onFailure(MessagelessException(), 200, "OK")
+        socket.onFailure(MessagelessException(), 200, "OK")
 
         assertEquals(
             listOf("Server Misconfigured. Response: 200 OK. Exception: MessagelessException"),


### PR DESCRIPTION
## Symptom
  
  A 40-minute read-only log audit of the benchmark build surfaced two diagnostics problems:

  1. **`WebSocket Failure: null`** — 908 of the session's relay error lines carried a literal `null` instead of any indication of what failed (12% of all app W/E lines).
  2. **`RelayInfoFail: Invalid URL wss://relay.nostr.band/`** — a perfectly valid relay URL reported as invalid. The actual failure underneath was a `SocketTimeoutException` connecting to the relay's HTTP endpoint during the
  NIP-11 fetch.

  ## Root cause
  
  1. `BasicRelayClient`'s failure paths build error strings from `t.message` alone, and the `Throwable` itself never leaves the handler — `onCannotConnect` carries only a String. Exceptions that ship a null message (EOF,
  connection reset) therefore lose their type entirely.
  2. `Nip11Retriever.loadRelayInfo` wrapped request assembly **and** the network call in a single `try`; every exception — including network timeouts — landed in a catch that logged "Invalid URL" and reported
  `ErrorCode.FAIL_TO_ASSEMBLE_URL`. The enum's `FAIL_TO_REACH_SERVER` existed but was never used.

  ## Fixes applied
  
  - `BasicRelayClient`: error strings now fall back to the exception class name when the message is null (`t.message ?: t::class.simpleName`) — applied to the `WebSocket Failure` and `Server Misconfigured` branches of
  `onFailure`, and to `connect()`'s catch which had the same gap. The null-message suppression rules still match on the raw message, and reconnect/backoff logic is untouched.
  - `Nip11Retriever`: request assembly and network execution now have separate catch scopes — assembly failures keep `FAIL_TO_ASSEMBLE_URL`/"Invalid URL", network failures log `Failed to fetch NIP-11 from …` with the throwable
  attached and report `FAIL_TO_REACH_SERVER`. The parse-failure path is unchanged, and no caller branches on specific `ErrorCode` values, so behavior beyond classification is identical.

  ## Testing

  - New `BasicRelayClientTest` (quartz commonTest, 3 tests): drives the real `onFailure` path through fake socket/builder/listener — null-message → class name, non-null message → format unchanged, Server Misconfigured branch
  covered. Written TDD (failed pre-fix with `WebSocket Failure: null`).
  - New `Nip11RetrieverTest` (1 test): asserts a connection failure during the fetch yields `FAIL_TO_REACH_SERVER`, via an injected throwing `okHttpClient` lambda (a real `OkHttpClient` can't be constructed in this module's
  JVM unit tests). Failed pre-fix with `FAIL_TO_ASSEMBLE_URL`.
  - Full `:quartz:jvmTest` and `:amethyst:testPlayDebugUnitTest` suites pass; spotless clean.

  ## Verification on device

  Installed the benchmark build (Pixel 9a) and captured PID-filtered W/E logcat:

  - **Zero** `WebSocket Failure: null` lines; the former nulls now read `WebSocket Failure: EOFException` (30× in a 4-minute window), while message-carrying failures (`timeout`, `Broken pipe`, cert errors) are unchanged.
  - The audit's exact case reproduced: `relay.nostr.band` timed out its NIP-11 fetch again and now logs `Failed to fetch NIP-11 from wss://relay.nostr.band/` with the full `java.net.SocketTimeoutException` stack trace — same
  relay, same IP, previously mislabeled as "Invalid URL". Zero `Invalid URL` lines in the capture.

## License

- [ ] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
