### PR TITLE
Fix test name grammar in LnZapRequestAnonTagTest

### DIFF
--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip57Zaps/LnZapRequestAnonTagTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip57Zaps/LnZapRequestAnonTagTest.kt
@@ -113,7 +113,7 @@ class LnZapRequestAnonTagTest {
         }
 
     @Test
-    fun `private zap request has anon tag, is private, and hides the sender key`() =
+    fun `private zap request has anon tag and is private and hides the sender key`() =
         runTest {
             val zapRequest = request(LnZapEvent.ZapType.PRIVATE)
 


### PR DESCRIPTION
## Summary

Improved test name readability by removing unnecessary commas from the test method name `private zap request has anon tag, is private, and hides the sender key` → `private zap request has anon tag and is private and hides the sender key`. This makes the test name flow more naturally as a single descriptive phrase.

## Test plan

- [x] N/A — change is a test name refactor with no functional impact

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01CmsQZYL9evoonwse7rupvt