### PR TITLE
Remove write-only RelayStat liveness fields

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/stats/RelayStat.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/stats/RelayStat.kt
@@ -23,7 +23,6 @@ package com.vitorpamplona.quartz.nip01Core.relay.client.stats
 import androidx.collection.LruCache
 import androidx.compose.runtime.Stable
 import com.vitorpamplona.quartz.utils.TimeUtils
-import kotlin.concurrent.Volatile
 
 @Stable
 class RelayStat(
@@ -36,12 +35,6 @@ class RelayStat(
     var connectionTentatives: Int = 0,
     var connectionCompleted: Int = 0,
 ) {
-    // Best-effort liveness signals (epoch seconds, 0 = never). The enclosing RelayStats LruCache
-    // can evict; durable per-relay history lives in commons RelayHealthStore.
-    @Volatile var lastConnectAt: Long = 0
-
-    @Volatile var lastIncomingAt: Long = 0
-
     val messages = LruCache<IRelayDebugMessage, IRelayDebugMessage>(100)
 
     fun newNotice(notice: String?) {

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/stats/RelayStats.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/stats/RelayStats.kt
@@ -32,7 +32,6 @@ import com.vitorpamplona.quartz.nip01Core.relay.commands.toClient.OkMessage
 import com.vitorpamplona.quartz.nip01Core.relay.commands.toRelay.Command
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.utils.Log
-import com.vitorpamplona.quartz.utils.TimeUtils
 import com.vitorpamplona.quartz.utils.bytesUsedInMemory
 
 class RelayStats(
@@ -65,7 +64,6 @@ class RelayStats(
                     pingInMs = pingMillis
                     compression = compressed
                     connectionCompleted()
-                    lastConnectAt = TimeUtils.now()
                 }
             }
 
@@ -93,7 +91,6 @@ class RelayStats(
                 val stat = get(relay.url)
 
                 stat.addBytesReceived(msgStr.bytesUsedInMemory())
-                stat.lastIncomingAt = TimeUtils.now()
 
                 when (msg) {
                     is NoticeMessage -> {


### PR DESCRIPTION
 ## What
  
  Removes the `RelayStat.lastConnectAt` / `lastIncomingAt` fields and their writes, added in #3186 but never read.
  
  ## Why
  
  #3186 added two liveness timestamps to the quartz `RelayStat`, written on every connect (`onConnected`) and every incoming relay message (`onIncomingMessage`) — a `TimeUtils.now()` call plus a volatile store per message.
  Nothing reads them.
  
  The unhealthy-relay feature sources its data entirely from the commons chain `RelayHealthListener → RelayHealthStore → RelayHealthRecord/UnhealthyRelay`. `RelayHealthListener` registers its *own* `RelayConnectionListener`
  and captures the same `TimeUtils.now()` timestamps independently, so the quartz fields are a redundant, half-wired second mechanism.
  
  It's worst on Android: `RelayHealthListener` is installed on Desktop only (`Main.kt`), while `RelayStats` is wired on Android (`AppModules.kt`). So on Android the dead write was the *only* thing executing on the message hot
  path — feeding fields with zero consumers.
  
  The fields' own comment already noted the `RelayStats` `LruCache` can evict and that durable history lives in the commons store — i.e. they were superseded by the commons mechanism and left in by oversight. This drops them;
  the commons store remains the single source of truth.
  
  ## Changes
  
  - `RelayStat.kt`: remove the two `@Volatile` fields + now-unused `kotlin.concurrent.Volatile` import (kept `TimeUtils`, still used by the debug message classes).
  - `RelayStats.kt`: remove the two writes + now-unused `TimeUtils` import.
  
  Net: −10 lines, no functional change. Removes a per-message `TimeUtils.now()` + volatile store from the Android relay hot path.
  
  ## Verification
  
  - `:quartz:compileKotlinJvm` and `spotlessCheck` pass.
  - Repo-wide grep confirms no readers of the removed fields (the identically-named fields in commons `RelayHealthRecord`/`UnhealthyRelay` are separate classes and untouched).

## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
