### PR TITLE
Stop media-server default from resetting on every launch

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nipB7Blossom/BlossomServerListState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nipB7Blossom/BlossomServerListState.kt
@@ -89,8 +89,8 @@ class BlossomServerListState(
             }.onStart {
                 emit(mergeServerList(flow.value))
             }.onEach { servers ->
-                if (servers.none { it == settings.defaultFileServer }) {
-                    settings.changeDefaultFileServer(servers.firstOrNull() ?: DEFAULT_MEDIA_SERVERS[0])
+                resetTargetOrNull(flow.value, servers, settings.defaultFileServer)?.let {
+                    settings.changeDefaultFileServer(it)
                 }
             }.flowOn(Dispatchers.IO)
             .stateIn(
@@ -127,3 +127,25 @@ class BlossomServerListState(
         alt: String,
     ): BlossomAuthorizationEvent = BlossomAuthorizationEvent.createDeleteAuth(hash, alt, signer)
 }
+
+/**
+ * Decides whether the persisted default file server must be reset, and to what.
+ *
+ * Returns the new default server, or `null` when no change should happen.
+ *
+ * The guard on [rawList] being non-empty is what prevents the startup race: before the user's
+ * [BlossomServersEvent] (kind 10063) loads from cache/relay, [rawList] is empty and [merged] is the
+ * transient [DEFAULT_MEDIA_SERVERS] fallback. Resetting against that fallback would clobber the
+ * locally-saved pick on every launch. Only reset once a real, loaded list is in hand and it no
+ * longer contains the current pick (e.g. the user removed it from their list).
+ */
+fun resetTargetOrNull(
+    rawList: List<String>,
+    merged: List<ServerName>,
+    current: ServerName,
+): ServerName? =
+    if (rawList.isNotEmpty() && merged.none { it == current }) {
+        merged.firstOrNull() ?: DEFAULT_MEDIA_SERVERS[0]
+    } else {
+        null
+    }

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/model/nipB7Blossom/BlossomServerListResetTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/model/nipB7Blossom/BlossomServerListResetTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.model.nipB7Blossom
+
+import com.vitorpamplona.amethyst.ui.actions.mediaServers.ServerName
+import com.vitorpamplona.amethyst.ui.actions.mediaServers.ServerType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class BlossomServerListResetTest {
+    private fun server(host: String) = ServerName(host, "https://$host/", ServerType.Blossom)
+
+    private val a = server("a.example")
+    private val b = server("b.example")
+    private val c = server("c.example")
+    private val custom = server("my-custom.example")
+
+    @Test
+    fun transientDefaultEmissionDoesNotClobberSavedPick() {
+        // Regression guard: before the user's BlossomServersEvent loads, the raw
+        // published list is empty and `merged` is the DEFAULT_MEDIA_SERVERS fallback.
+        // The saved custom pick must NOT be reset.
+        val result =
+            resetTargetOrNull(
+                rawList = emptyList(),
+                merged = listOf(a, b, c),
+                current = custom,
+            )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun loadedListWithoutCurrentResetsToFirst() {
+        // The user removed their current default from the published list -> reset.
+        val result =
+            resetTargetOrNull(
+                rawList = listOf("a.example", "b.example", "c.example"),
+                merged = listOf(a, b, c),
+                current = custom,
+            )
+
+        assertEquals(a, result)
+    }
+
+    @Test
+    fun loadedListContainingCurrentDoesNotReset() {
+        val result =
+            resetTargetOrNull(
+                rawList = listOf("a.example", "b.example", "c.example"),
+                merged = listOf(a, b, c),
+                current = b,
+            )
+
+        assertNull(result)
+    }
+}


### PR DESCRIPTION
I have a faulty test media server first in my list so this issue was very obvious to me on every restart. Have you noticed this issue? (default media server being reset between restarts).

Default media server isn't persisted to relays so on re-install it still defaults to first media server. 

## Problem
  
  After picking a non-default Blossom media server, the choice didn't stick — on the next app launch the upload server reverted to the top of the built-in fallback list (`blossom.band`). Users had to re-pick their server every launch, for both post and profile-picture uploads.
  
  ## Root cause
  
  `BlossomServerListState.hostNameFlow` resets the persisted default (`AccountSettings.defaultFileServer`) whenever the current list doesn't contain it. The defect is a startup race:
  
  1. On a fresh process the user's `BlossomServersEvent` (kind 10063) hasn't loaded yet, so the underlying `flow` is still `emptyList()`.
  2. `mergeServerList(emptyList())` falls back to `DEFAULT_MEDIA_SERVERS`, so `hostNameFlow`'s first emission is the default list, not the user's real one.
  3. `onEach` sees the saved pick isn't in `DEFAULT_MEDIA_SERVERS` and resets it to `blossom.band`, persisting it locally.
  
  The locally-saved pick was destroyed on every launch by this transient default emission, before the real list ever loaded. (`defaultFileServer` is local-only — never published to relays.)
  
  ## Fix
  
  Only reset once a real, loaded list is in hand. The decision is extracted into a pure `resetTargetOrNull` helper, guarded on the raw published list (`flow.value`) being non-empty:
  
  ```kotlin
  fun resetTargetOrNull(rawList, merged, current): ServerName? =
      if (rawList.isNotEmpty() && merged.none { it == current })
          merged.firstOrNull() ?: DEFAULT_MEDIA_SERVERS[0]
      else null
```
      
  flow.value is empty exactly during the transient default emission and non-empty once the user's event has loaded, so the spurious reset is suppressed while the legitimate one (user removes their current default from the list) still fires.

  Testing
  
  - New unit test BlossomServerListResetTest — covers the regression guard (empty raw list → no reset), the reset path, and the no-op path.
  - Manual on-device (Pixel 9a, Play benchmark/R8 build):
    - Pick a non-default server → force-stop → relaunch → pick is preserved.
    - Remove the current default from Media Servers → falls back to first-in-list (legitimate reset still works).

  Scope / known limitation

  Restores persistence of the local pick across restarts. It does not restore the pick after a reinstall — defaultFileServer is local-only, so a wiped install starts at the default and resets to first-in-list once the relay list loads. Making first-in-list the relay-synced source of truth is separate follow-up work (the media-server reorder feature).

## License

- [ ] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
