### PR TITLE
Block background media-button resumes

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/AppForegroundState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/AppForegroundState.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service
+
+object AppForegroundState {
+    @Volatile
+    var isForeground: Boolean = false
+        private set
+
+    fun update(isForeground: Boolean) {
+        this.isForeground = isForeground
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/nests/AppForegroundRecycleHook.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/nests/AppForegroundRecycleHook.kt
@@ -24,6 +24,7 @@ import android.app.Activity
 import android.app.Application
 import android.os.Bundle
 import com.vitorpamplona.amethyst.commons.viewmodels.NestNetworkChangeBus
+import com.vitorpamplona.amethyst.service.AppForegroundState
 import com.vitorpamplona.quartz.utils.Log
 
 /**
@@ -42,6 +43,7 @@ class AppForegroundCounter(
     private val backgroundThresholdMs: Long = AppForegroundRecycleHook.DEFAULT_BACKGROUND_THRESHOLD_MS,
     private val publishEvent: () -> Unit = { NestNetworkChangeBus.publish() },
     private val nowMillis: () -> Long = { System.currentTimeMillis() },
+    private val updateForeground: (Boolean) -> Unit = {},
 ) {
     private var startedActivities = 0
     private var lastBackgroundedAtMillis: Long = -1L
@@ -65,6 +67,7 @@ class AppForegroundCounter(
         val wasBackgrounded = startedActivities == 0
         startedActivities++
         if (!wasBackgrounded) return
+        updateForeground(true)
         val backgroundedAt = lastBackgroundedAtMillis
         if (backgroundedAt < 0L) return
         val backgroundedFor = nowMillis() - backgroundedAt
@@ -91,6 +94,7 @@ class AppForegroundCounter(
         if (startedActivities <= 0) {
             startedActivities = 0
             lastBackgroundedAtMillis = nowMillis()
+            updateForeground(false)
         }
     }
 }
@@ -134,8 +138,9 @@ class AppForegroundRecycleHook(
     backgroundThresholdMs: Long = DEFAULT_BACKGROUND_THRESHOLD_MS,
     publishEvent: () -> Unit = { NestNetworkChangeBus.publish() },
     nowMillis: () -> Long = { System.currentTimeMillis() },
+    updateForeground: (Boolean) -> Unit = AppForegroundState::update,
 ) : Application.ActivityLifecycleCallbacks {
-    private val counter = AppForegroundCounter(backgroundThresholdMs, publishEvent, nowMillis)
+    private val counter = AppForegroundCounter(backgroundThresholdMs, publishEvent, nowMillis, updateForeground)
 
     override fun onActivityStarted(activity: Activity) {
         counter.onActivityStarted()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/MediaSessionPool.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/MediaSessionPool.kt
@@ -26,7 +26,9 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.util.LruCache
+import android.view.KeyEvent
 import androidx.annotation.OptIn
+import androidx.core.content.IntentCompat
 import androidx.core.net.toUri
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
@@ -37,7 +39,9 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.MediaSession
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
+import com.vitorpamplona.amethyst.service.AppForegroundState
 import com.vitorpamplona.amethyst.service.playback.composable.mediaitem.MediaItemCache
+import com.vitorpamplona.amethyst.service.playback.pip.BackgroundMedia
 import com.vitorpamplona.amethyst.ui.MainActivity
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
@@ -235,6 +239,30 @@ class MediaSessionPool(
         val pool: MediaSessionPool,
         val appContext: Context,
     ) : MediaSession.Callback {
+        override fun onMediaButtonEvent(
+            session: MediaSession,
+            controllerInfo: MediaSession.ControllerInfo,
+            intent: Intent,
+        ): Boolean {
+            val keyEvent =
+                IntentCompat.getParcelableExtra(intent, Intent.EXTRA_KEY_EVENT, KeyEvent::class.java)
+            if (keyEvent?.action != KeyEvent.ACTION_DOWN) return false
+
+            if (AppForegroundState.isForeground || BackgroundMedia.bgInstance?.id == session.id) {
+                return false
+            }
+
+            val isResumeButton =
+                keyEvent.keyCode == KeyEvent.KEYCODE_MEDIA_PLAY ||
+                    keyEvent.keyCode == KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE ||
+                    keyEvent.keyCode == KeyEvent.KEYCODE_HEADSETHOOK
+
+            if (!isResumeButton) return false
+
+            session.player.pause()
+            return true
+        }
+
         @OptIn(UnstableApi::class)
         override fun onAddMediaItems(
             mediaSession: MediaSession,

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/service/nests/AppForegroundRecycleHookTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/service/nests/AppForegroundRecycleHookTest.kt
@@ -147,6 +147,29 @@ class AppForegroundRecycleHookTest {
     }
 
     @Test
+    fun foregroundStateTracksOnlyZeroToOneAndOneToZeroTransitions() {
+        var fakeNow = 0L
+        val states = mutableListOf<Boolean>()
+        val counter =
+            AppForegroundCounter(
+                publishEvent = {},
+                nowMillis = { fakeNow },
+                updateForeground = { states.add(it) },
+            )
+
+        fakeNow = 1_000L
+        counter.onActivityStarted()
+        fakeNow = 2_000L
+        counter.onActivityStarted()
+        fakeNow = 3_000L
+        counter.onActivityStopped()
+        fakeNow = 4_000L
+        counter.onActivityStopped()
+
+        assertEquals(listOf(true, false), states)
+    }
+
+    @Test
     fun consecutiveLongBackgroundsEachPublishOnce() {
         // Two separate back-and-forth cycles must each fire exactly
         // one publish. A regression that misses to refresh the


### PR DESCRIPTION
## Summary
- Track app foreground/background state from the existing activity lifecycle counter.
- Consume Bluetooth/headset media-button resume events while Amethyst is backgrounded so normal feed video sessions do not restart from Android's media controls.
- Preserve explicit PiP/background playback by allowing the registered `BackgroundMedia` session to handle media buttons normally.

Fixes #971

BTC bounty address: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`

## Validation
- `git diff --check`
- Attempted `./gradlew :amethyst:testPlayDebugUnitTest --tests com.vitorpamplona.amethyst.service.nests.AppForegroundRecycleHookTest --no-daemon`, but Gradle failed before compilation while downloading Android/KSP artifacts with TLS handshake termination errors from Maven repositories.
