### PR TITLE
docs: Add v1.12.0 release notes

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -2,6 +2,7 @@
 
 Release notes for Amethyst, one file per version. Files are named with zero-padded version numbers so they sort correctly in any file browser. Use [`TEMPLATE.md`](TEMPLATE.md) as the starting point for the next release.
 
+- [v1.12.0 — Payments, Private Posts & Workouts](v1.12.00.md)
 - [v1.11.0 — NIP-52 Calendars, On-Chain Zap Polish](v1.11.00.md)
 - [v1.10.0 — On-Chain zaps](v1.10.00.md)
 - [v1.09.2 — Fixes](v1.09.02.md)

--- a/docs/changelog/v1.12.00.md
+++ b/docs/changelog/v1.12.00.md
@@ -1,0 +1,116 @@
+# v1.12.0: Payments, Private Posts & Workouts
+
+Highlights:
+- **CLINK payments** — a new Lightning payment rail built on Offers and Debits, with spending budgets, NIP-05 offer discovery, and a unified Send Payment screen that brings Lightning, CLINK, on-chain and Cashu together in one place.
+- **Private posts & reactions** — compose private replies and posts, react/un-react privately, and force-private zaps, all delivered end-to-end encrypted via NIP-17 gift wraps.
+- **Workouts** — record and browse NIP-101e workout records (kind 1301) in a dedicated Workouts feed.
+- **Math in notes** — write inline and block LaTeX (`$...$` and `$$...$$`) and have it render right in the timeline.
+- **Activity cards** — likes, zaps and nutzaps now render as rich gradient "activity cards" that embed the post they reacted to, tappable straight to the thread.
+- **App recommendations** — editable NIP-89 app recommendations on your profile, with richer app cards, screenshots and author attribution.
+- **Pinned DMs** — pin your most important conversations to the top of the chat list, synced across your devices.
+- **Desktop** — image-compression pipeline on upload, a new media player, group-DM parity with Android, a Replies tab, and a refreshed feed.
+
+## New Features
+
+### Payments
+- **CLINK — a new Lightning payment rail.** Pay and get paid through CLINK Offers and Debits, an interoperable Lightning-over-Nostr scheme. Profiles can show a tappable CLINK Offer chip, and you can pay a contact directly from their profile.
+- **Spending budgets for CLINK debits** — set one-time or recurring spending limits so a debit connection can pull funds up to a cap you control.
+- **Discover offers by NIP-05** — resolve a person's payment offer straight from their `name@domain` address.
+- **Unified Send Payment screen** — Lightning, CLINK, on-chain Bitcoin and Cashu/nutzaps are now all reachable from one screen, with a "Pay from" wallet selector to choose which wallet the money leaves.
+- **Pay Bitcoin payment targets from the in-app on-chain wallet**, and pay a contact's on-chain "Bit" recipient directly.
+- **Unified payment-rail chips** on the profile header — long-press any chip to copy that destination.
+- **Nutzap send progress bar** that matches the Lightning experience, plus a Cashu mint top-up screen and per-mint balances.
+
+### Posting & Privacy
+- **Compose private replies and private posts** delivered as NIP-17 gift wraps, with an editable "Notify" block so you choose exactly who can read a private post.
+- **Private reactions and private un-react** — react and remove reactions privately, with safeguards that prevent private content from leaking publicly.
+- **Force-private zaps on private notes**, and replies to private zaps are routed into the sender's DM room.
+- **NIP-32 hashtag labels** — add first-class hashtag labels to posts; follow-hashtag labels are published through your outbox relays and surface in the hashtag feed.
+- **Richer notify chips** in the new-post screen, modernized inline payment cards that surface their descriptions, and quote-reposts (NIP-18) now counted in the repost counter.
+
+### Chat & DMs
+- **Pin DM conversations** to the top of your chat list — synced across devices via a NIP-78 app-data event.
+- **@-mention search in Marmot (MLS) group chats** — search and tag users in the group composer, with conversation participants ranked first and marked with an "In this chat" chip.
+- **Quoted chat messages** now render inside chat bubbles with the proper chat-reply design, and the redundant reply row is skipped when the message is already quoted inline.
+- **MLS unread state now persists across app restarts**, and the kind:445 backlog is no longer refetched on every launch.
+
+### Reading & Feeds
+- **Render LaTeX math** in notes with `$...$` (inline) and `$$...$$` (block) delimiters.
+- **Activity cards** — reactions, zaps, likes and nutzaps render as gradient cards that embed the post they're about; a single tap on a like/zap chip opens that event's thread.
+- **NIP-101e Workouts** — a dedicated feed for workout records (kind 1301).
+- **Editable NIP-89 app recommendations** on your profile, with screenshots shown in app feed cards, an "by &lt;author&gt;" attribution line, and a full app detail screen.
+- New community renderers: **Birdex species collections** (kind 12473) and **Agora fundraiser campaigns** (kind 33863).
+- **Reactions and zaps anchor their own thread** view, and reposts whose boosted kind isn't supported are now hidden instead of showing blank cards.
+- **Brightness/volume swipe gestures** in fullscreen video, and tap a podcast to open a show screen listing all its episodes.
+
+### Settings
+- **Searchable settings** — a search box filters settings rows by title and curated keywords, with prefix matching and an empty-state.
+
+## Performance
+
+- Pinned-DM state reads are deferred to the individual row and menu so the chat list stays smooth.
+- Parsed CLINK offers are cached for NIP-05 lookups (case-insensitive keys).
+- The "fix missing spaces" rich-text pass now indexes URLs by their first character to avoid repeated scans.
+
+## Improvements and Bug fixes
+
+- **Notifications:** likes/zaps replies now correctly reach the "Curated" feed; the legacy "Global" filter migrates once to "Curated"; replies to a like/zap no longer drag in the original liked post's whole thread.
+- **Note search** no longer matches on `p`, `e`, `a`, `alt` or `client` tags, so searches return cleaner results.
+- **Anonymous posting:** profile zaps that should be anonymous are no longer accidentally encrypted as private zaps; media uploads in anonymous posts use an ephemeral signer.
+- **Wallet:** the Cashu wallet row now shows the Cashu logo instead of a generic icon; own on-chain zaps highlight the bolt and show as pending in the counter; tidied wallet screen layout.
+- **Zap settings:** preset amounts are de-duplicated so drag-to-reorder keeps working, and the chip-drag interaction was fixed.
+- **Cashu top-up** is now crash-safe on retry — funds are checkpointed the instant they leave the wallet and never re-moved on a retry.
+- **Tor:** relay backoff is honored during Tor bootstrap; a new "money operations" relay category keeps payment traffic on the right transport.
+- **Metadata:** a non-spec birthday value can no longer drop an entire profile.
+- **Deletions (NIP-09):** deleting a note now properly severs child back-references and detaches on-chain-zap, nutzap and channel sources from the cache.
+- Numerous audit and hardening fixes across the private-posts, CLINK, and MLS paths (off-main-thread crypto, leak prevention, share/bookmark hidden on private notes).
+- Reduced runtime log noise and fixed several edge-case crashes.
+
+## Desktop
+
+- **Image compression on upload** — a new compression pipeline with an Image Compression settings panel, per-post quality presets, batch progress in the composer, a preview-then-publish gate, and a fail-loud dialog if compression fails.
+- **New media player** — replaced vlcj with kdroidFilter's ComposeMediaPlayer (JCodec/FFmpeg backend) for video playback.
+- **Group DM parity with Android** — desktop now handles group direct messages the same way.
+- **Replies tab** on the user profile, plus reply context (parent embed + label) shown inline in feeds.
+- **Feed refresh** — inline card expansion, a "New posts" chip that slides in from the top, stick-to-top on prepend, and wired-up like/zap/comment actions.
+- Copy a Blossom image URL on click with a hover tooltip and snackbar; collapsed-sidebar polish (tighter ripple + hover tooltips); Amethyst logo on the Tor and account-loading splashes.
+- Restored inter-word spacing in rich text with mentions/hashtags, and fixed parent-author metadata loading.
+- **Namecoin diagnostics** card ported from the Android settings.
+
+## Cli
+
+- `amy offer` — CLINK offer info and request, including `--payer-data`.
+- `amy debit` — CLINK debit info, pay and budget.
+- `amy zap --with <ndebit>` — settle a zap invoice via a CLINK debit.
+- `amy offer discover <nip05>` — resolve a profile's offer through NIP-05.
+- Closed CLINK parity gaps (profile offer, follow, offer pay, GFY detail) and added a clink-headless interop harness.
+
+## Quartz
+
+- **Relay-server toolkit** — major work toward running a relay from Quartz: a `Flow<Event>` REQ-responder SPI with a storage-free dispatch engine, NIP-50 search parsing, suspendable auth hooks, and split engine/backend/policy packages.
+- **NIP-45 approximate COUNT** via HyperLogLog construction, with wire support.
+- **NIP-11** improvements — the missing `banner` field, relay limits as a single source of truth served over NIP-11.
+- **Connection observability** — stable per-connection ids and a per-connection `RequestContext` threaded into the event source; auth identity moved from policy into connection scope.
+- **NIP-46** bunker fix for double-resume and retry id-reuse races.
+- Fixed `q` (quote) tags being dropped by an inverted guard, and registered `CommunityRulesEvent` / CLINK DTO serializers (incl. Kotlin/Native targets).
+
+## Build & Documentation
+
+- Updated all dependencies (Kotlin, Compose Multiplatform 1.11.1, Coil 5, OkHttp 5, Jackson, AndroidX, Firebase, and more); the Blossom interceptor test was adapted to OkHttp 5's `Interceptor.Chain`.
+- `commons` `commonTest` now compiles and runs on iOS targets, and CI runs the shared `commonTest` on iOS for `:commons`.
+- Split the monolithic CHANGELOG into per-version files under `docs/changelog/`.
+- A large SonarQube cleanup pass (S1871) merging duplicate `when`/`if` arms across the codebase, plus `Log` lambda-overload migrations.
+- Documented an Amethyst→commons migration plan and target package hierarchy, refreshed several Claude skills and the Namecoin design doc, and added a rule requiring a license check when introducing any new dependency.
+- `versionName` branch detection now sets the git cwd so it works inside git worktrees.
+
+## Contributors
+
+- Vitor Pamplona (@npub1gcxzte5zlkncx26j68ez60fzkvtkm9e0vrwdcvsjakxf9mu9qewqlfnj5z)
+- davotoula
+- nrobi144
+- mstrofnone
+- Daneul Kim
+
+## Translations
+
+Community translations contributed through Crowdin across 50+ locales, including Arabic, Bengali, Catalan, Czech, German, Greek, Spanish, Persian, Finnish, French, Gujarati, Hindi, Croatian, Hungarian, Indonesian, Italian, Hebrew, Japanese, Kazakh, Korean, Lithuanian, Latvian, Dutch, Polish, Portuguese (BR/PT), Russian, Slovenian, Serbian, Swedish, Swahili, Tamil, Thai, Turkish, Ukrainian, Vietnamese, and Chinese (Simplified/Traditional/Hong Kong). New CLINK, Send Payment, workouts, chat-history, reply-search and on-chain-failure strings (cs, de, sv, pt-BR) were added directly.

--- a/docs/changelog/v1.12.00.md
+++ b/docs/changelog/v1.12.00.md
@@ -93,6 +93,9 @@ Highlights:
 - **Reply to zaps from the notification screen.**
   - Reply directly to a zap from Notifications.
   - Nutzap chips reply on long-press.
+- **Group DM subjects (NIP-14).**
+  - Set a subject line on group conversations.
+  - A smoother flow for creating a new group DM.
 
 ### Reading & Feeds
 
@@ -171,6 +174,7 @@ Highlights:
   - The Cashu wallet row shows the Cashu logo instead of a generic icon.
   - Own on-chain zaps highlight the bolt and show as pending in the counter.
   - Tidied the wallet screen layout.
+  - Removed the wallet reordering drag-and-drop UI.
 - **Zap settings.**
   - Preset amounts are de-duplicated, so drag-to-reorder keeps working.
   - Fixed the chip-drag interaction.
@@ -182,7 +186,8 @@ Highlights:
   - The payment rails now appear live as they resolve.
 - **Tor.**
   - Relay backoff is honored during Tor bootstrap.
-  - A new "money operations" relay category keeps payment traffic on the right transport.
+  - Payment and wallet relay connections now honor the "Money operations via Tor" setting.
+  - Previously they were forced over Tor, which broke NIP-47 and CLINK on Tor-blocking services.
   - Sockets opened on the wrong transport are rebuilt.
 - **DM history loading.**
   - Per-relay download windows realign when DMs are pruned.
@@ -273,6 +278,7 @@ Highlights:
 - **Other.**
   - Fixed `q` (quote) tags being dropped by an inverted guard.
   - Registered `CommunityRulesEvent` and CLINK DTO serializers (incl. Kotlin/Native).
+  - Relay failure logs are now diagnosable (exception class on null message, correct NIP-11 error label).
 
 ## Build & Documentation
 

--- a/docs/changelog/v1.12.00.md
+++ b/docs/changelog/v1.12.00.md
@@ -163,6 +163,15 @@ Highlights:
 - **Tor.**
   - Relay backoff is honored during Tor bootstrap.
   - A new "money operations" relay category keeps payment traffic on the right transport.
+- **DM history loading.**
+  - Per-relay download windows realign when DMs are pruned.
+  - A slow Tor connect is no longer mislabeled as "stalled".
+  - The paused-history card shows parked relays, and the sync marker is tappable.
+- **Live streams.** Fixed the live-stream chat relay fallback.
+- **Polls.** Zap and non-zap polls now share the same option text.
+- **Video.** Legacy NIP-71 videos now resolve their address from the real `d` tag.
+- **Media server.** The default media server no longer resets on every launch.
+- **Accounts.** Deleting an account now clears its cached entry.
 - **Metadata.** A non-spec birthday value can no longer drop an entire profile.
 - **Deletions (NIP-09).**
   - Deleting a note now severs child back-references.
@@ -241,6 +250,8 @@ Highlights:
   - The link-preview fetcher, relay broadcast tracker, and CLI-safe util extensions.
   - `HtmlParser` made KMP (dropped its Java `Charset` dependency).
   - A consolidated package taxonomy with a new architecture doc.
+- **Licensing.** Replaced the GPLv3 `TarsosDSP` dependency with an in-house pitch shifter for the voice anonymizer, keeping the project MIT-clean.
+- Added a monochrome outline Cashu icon to the Material Symbols set.
 - Renamed `ReplaceableVideoEvent` to `AddressableVideoEvent` for spec accuracy.
 - Split the monolithic CHANGELOG into per-version files under `docs/changelog/`.
 - **SonarQube cleanup (S1871).**

--- a/docs/changelog/v1.12.00.md
+++ b/docs/changelog/v1.12.00.md
@@ -2,14 +2,14 @@
 
 Highlights:
 
-- **CLINK payments.** A new Lightning rail built on Offers and Debits. Includes spending budgets, NIP-05 offer discovery, and a unified Send Payment screen.
-- **Private posts & reactions.** Post, reply, react, and zap privately. Everything is end-to-end encrypted via NIP-17 gift wraps.
-- **Workouts.** Record and browse NIP-101e workout records (kind 1301) in a dedicated feed.
-- **Math in notes.** Write inline and block LaTeX. It renders right in the timeline.
-- **Activity cards.** Likes, zaps, and nutzaps now render as rich gradient cards. Each card embeds the post it reacted to and taps through to the thread.
-- **App recommendations.** Editable NIP-89 recommendations on your profile, with richer cards, screenshots, and author names.
-- **Pinned DMs.** Pin important conversations to the top of the chat list. The pins sync across your devices.
-- **Desktop.** Image compression on upload, a new media player, group-DM parity, a Replies tab, and a refreshed feed.
+- **CLINK payments** — a new Lightning rail with spending budgets, NIP-05 offer discovery, and a unified Send Payment screen.
+- **Private posts & reactions** — post, reply, react, and zap privately, all end-to-end encrypted via NIP-17 gift wraps.
+- **Workouts** — record and browse NIP-101e workout records (kind 1301) in a dedicated feed.
+- **Math in notes** — write inline and block LaTeX that renders right in the timeline.
+- **Activity cards** — likes, zaps, and nutzaps render as rich gradient cards that tap through to the thread.
+- **App recommendations** — editable NIP-89 recommendations on your profile, with richer cards and screenshots.
+- **Pinned DMs** — pin important conversations to the top of the chat list, synced across devices.
+- **Desktop** — image compression on upload, a new media player, group-DM parity, a Replies tab, and a refreshed feed.
 
 ## New Features
 
@@ -18,13 +18,18 @@ Highlights:
 - **CLINK — a new Lightning payment rail.** Pay and get paid through CLINK Offers and Debits, an interoperable Lightning-over-Nostr scheme.
   - Profiles can show a tappable CLINK Offer chip.
   - You can pay a contact directly from their profile.
-- **Spending budgets for CLINK debits.** Set one-time or recurring limits. A debit connection can then pull funds up to the cap you set.
+- **Spending budgets for CLINK debits.**
+  - Set one-time or recurring limits.
+  - A debit connection pulls funds only up to the cap you set.
 - **Discover offers by NIP-05.** Resolve a person's payment offer straight from their `name@domain` address.
 - **Unified Send Payment screen.** Reach every rail from one place:
   - Lightning, CLINK, on-chain Bitcoin, and Cashu/nutzaps.
   - A "Pay from" selector chooses which wallet the money leaves.
-- **On-chain payments.** Pay Bitcoin payment targets from the in-app on-chain wallet. You can also pay a contact's on-chain "Bit" recipient directly.
-- **Unified payment-rail chips** on the profile header. Long-press any chip to copy that destination.
+- **On-chain payments.**
+  - Pay Bitcoin payment targets from the in-app on-chain wallet.
+  - Pay a contact's on-chain "Bit" recipient directly.
+- **Unified payment-rail chips** on the profile header.
+  - Long-press any chip to copy that destination.
 - **Cashu improvements.**
   - A send progress bar that matches the Lightning experience.
   - A new mint top-up screen.
@@ -32,9 +37,15 @@ Highlights:
 
 ### Posting & Privacy
 
-- **Private posts and replies.** Composed and delivered as NIP-17 gift wraps. An editable "Notify" block lets you choose exactly who can read a private post.
-- **Private reactions.** React and un-react privately. Safeguards prevent private content from leaking publicly.
-- **Private zaps.** Zaps on private notes are forced private. Replies to a private zap route into the sender's DM room.
+- **Private posts and replies.**
+  - Composed and delivered as NIP-17 gift wraps.
+  - An editable "Notify" block lets you choose exactly who can read a private post.
+- **Private reactions.**
+  - React and un-react privately.
+  - Safeguards prevent private content from leaking publicly.
+- **Private zaps.**
+  - Zaps on private notes are forced private.
+  - Replies to a private zap route into the sender's DM room.
 - **NIP-32 hashtag labels.** Add first-class hashtag labels to posts.
   - Follow-hashtag labels publish through your outbox relays.
   - They surface in the hashtag feed.
@@ -45,19 +56,26 @@ Highlights:
 
 ### Chat & DMs
 
-- **Pin DM conversations** to the top of your chat list. Pins sync across devices via a NIP-78 app-data event.
+- **Pin DM conversations** to the top of your chat list.
+  - Pins sync across devices via a NIP-78 app-data event.
 - **@-mention search in Marmot (MLS) group chats.** Search and tag users in the group composer.
   - Conversation participants rank first.
   - They are marked with an "In this chat" chip.
-- **Quoted chat messages** now render inside chat bubbles with the proper chat-reply design. The redundant reply row is skipped when the message is already quoted inline.
+- **Quoted chat messages** now render inside chat bubbles with the proper chat-reply design.
+  - The redundant reply row is skipped when the message is already quoted inline.
 - **MLS reliability.**
   - Unread state now persists across app restarts.
   - The kind:445 backlog is no longer refetched on every launch.
 
 ### Reading & Feeds
 
-- **Render LaTeX math** in notes. Use `$...$` for inline and `$$...$$` for block equations.
-- **Activity cards.** Reactions, zaps, likes, and nutzaps render as gradient cards that embed the post they're about. A single tap on a like/zap chip opens that event's thread.
+- **Render LaTeX math** in notes.
+  - Use `$...$` for inline equations.
+  - Use `$$...$$` for block equations.
+- **Activity cards.**
+  - Reactions, zaps, likes, and nutzaps render as gradient cards.
+  - Each card embeds the post it's about.
+  - A single tap on a like/zap chip opens that event's thread.
 - **Workouts feed.** A dedicated feed for NIP-101e workout records (kind 1301).
 - **App recommendations.** Editable NIP-89 recommendations on your profile.
   - Screenshots show in app feed cards.
@@ -66,18 +84,24 @@ Highlights:
 - **New community renderers.**
   - Birdex species collections (kind 12473).
   - Agora fundraiser campaigns (kind 33863).
-- **Cleaner feeds.** Reactions and zaps anchor their own thread view. Reposts whose boosted kind isn't supported are now hidden instead of showing blank cards.
-- **Media.** Swipe for brightness and volume in fullscreen video. Tap a podcast to open a show screen listing all its episodes.
+- **Cleaner feeds.**
+  - Reactions and zaps anchor their own thread view.
+  - Reposts whose boosted kind isn't supported are hidden instead of showing blank cards.
+- **Media.**
+  - Swipe for brightness and volume in fullscreen video.
+  - Tap a podcast to open a show screen listing all its episodes.
 
 ### Settings
 
-- **Searchable settings.** A search box filters rows by title and curated keywords. Supports prefix matching and an empty-state.
+- **Searchable settings.**
+  - A search box filters rows by title and curated keywords.
+  - Supports prefix matching and an empty-state.
 
 ## Performance
 
-- Pinned-DM state reads are deferred to the row and menu. The chat list stays smooth.
+- Pinned-DM state reads are deferred to the row and menu, keeping the chat list smooth.
 - Parsed CLINK offers are cached for NIP-05 lookups, using case-insensitive keys.
-- The "fix missing spaces" rich-text pass indexes URLs by their first character. This avoids repeated scans.
+- The "fix missing spaces" pass indexes URLs by their first character to avoid repeated scans.
 
 ## Improvements and Bug fixes
 
@@ -85,7 +109,9 @@ Highlights:
   - Replies to likes/zaps now reach the "Curated" feed.
   - The legacy "Global" filter migrates once to "Curated".
   - A reply to a like/zap no longer drags in the original post's whole thread.
-- **Note search.** Searches no longer match on `p`, `e`, `a`, `alt`, or `client` tags. Results are cleaner.
+- **Note search.**
+  - No longer matches on `p`, `e`, `a`, `alt`, or `client` tags.
+  - Results are cleaner.
 - **Anonymous posting.**
   - Profile zaps that should be anonymous are no longer encrypted as private zaps.
   - Media uploads in anonymous posts use an ephemeral signer.
@@ -93,15 +119,24 @@ Highlights:
   - The Cashu wallet row now shows the Cashu logo instead of a generic icon.
   - Own on-chain zaps highlight the bolt and show as pending in the counter.
   - Tidied the wallet screen layout.
-- **Zap settings.** Preset amounts are de-duplicated so drag-to-reorder keeps working. The chip-drag interaction was fixed.
-- **Cashu top-up** is now crash-safe on retry. Funds are checkpointed the instant they leave the wallet and never re-moved.
+- **Zap settings.**
+  - Preset amounts are de-duplicated, so drag-to-reorder keeps working.
+  - Fixed the chip-drag interaction.
+- **Cashu top-up** is now crash-safe on retry.
+  - Funds are checkpointed the instant they leave the wallet.
+  - They are never re-moved on a retry.
 - **Tor.**
   - Relay backoff is honored during Tor bootstrap.
   - A new "money operations" relay category keeps payment traffic on the right transport.
 - **Metadata.** A non-spec birthday value can no longer drop an entire profile.
-- **Deletions (NIP-09).** Deleting a note now severs child back-references. It also detaches on-chain-zap, nutzap, and channel sources from the cache.
-- **Hardening.** Many audit fixes across the private-posts, CLINK, and MLS paths. Covers off-main-thread crypto, leak prevention, and hiding share/bookmark on private notes.
-- Reduced runtime log noise and fixed several edge-case crashes.
+- **Deletions (NIP-09).**
+  - Deleting a note now severs child back-references.
+  - It detaches on-chain-zap, nutzap, and channel sources from the cache.
+- **Hardening.**
+  - Many audit fixes across the private-posts, CLINK, and MLS paths.
+  - Covers off-main-thread crypto, leak prevention, and hiding share/bookmark on private notes.
+- Reduced runtime log noise.
+- Fixed several edge-case crashes.
 
 ## Desktop
 
@@ -113,7 +148,8 @@ Highlights:
   - A fail-loud dialog if compression fails.
 - **New media player.** Replaced vlcj with kdroidFilter's ComposeMediaPlayer (JCodec/FFmpeg backend).
 - **Group DM parity with Android.** Desktop now handles group direct messages the same way.
-- **Replies tab** on the user profile. Feeds also show reply context (parent embed plus label) inline.
+- **Replies tab** on the user profile.
+  - Feeds also show reply context (parent embed plus label) inline.
 - **Feed refresh.**
   - Inline card expansion.
   - A "New posts" chip that slides in from the top.
@@ -133,7 +169,8 @@ Highlights:
 - `amy debit` — CLINK debit info, pay, and budget.
 - `amy zap --with <ndebit>` — settle a zap invoice via a CLINK debit.
 - `amy offer discover <nip05>` — resolve a profile's offer through NIP-05.
-- Closed CLINK parity gaps (profile offer, follow, offer pay, GFY detail). Added a clink-headless interop harness.
+- Closed CLINK parity gaps (profile offer, follow, offer pay, GFY detail).
+- Added a clink-headless interop harness.
 
 ## Quartz
 
@@ -143,18 +180,33 @@ Highlights:
   - Suspendable auth hooks.
   - Split engine/backend/policy packages.
 - **NIP-45 approximate COUNT** via HyperLogLog construction, with wire support.
-- **NIP-11.** Added the missing `banner` field. Relay limits are now a single source of truth served over NIP-11.
-- **Connection observability.** Stable per-connection ids and a per-connection `RequestContext` threaded into the event source. Auth identity moved from policy into connection scope.
+- **NIP-11.**
+  - Added the missing `banner` field.
+  - Relay limits are now a single source of truth served over NIP-11.
+- **Connection observability.**
+  - Stable per-connection ids.
+  - A per-connection `RequestContext` threaded into the event source.
+  - Auth identity moved from policy into connection scope.
 - **NIP-46.** Fixed a bunker double-resume and retry id-reuse race.
-- Fixed `q` (quote) tags being dropped by an inverted guard. Registered `CommunityRulesEvent` and CLINK DTO serializers (including Kotlin/Native targets).
+- Fixed `q` (quote) tags being dropped by an inverted guard.
+- Registered `CommunityRulesEvent` and CLINK DTO serializers (including Kotlin/Native targets).
 
 ## Build & Documentation
 
-- **Dependency updates.** Bumped Kotlin, Compose Multiplatform 1.11.1, Coil 5, OkHttp 5, Jackson, AndroidX, Firebase, and more. The Blossom interceptor test was adapted to OkHttp 5's `Interceptor.Chain`.
-- **iOS CI.** `commons` `commonTest` now compiles and runs on iOS targets. CI runs the shared `commonTest` on iOS for `:commons`.
+- **Dependency updates.**
+  - Bumped Kotlin, Compose Multiplatform 1.11.1, Coil 5, OkHttp 5, Jackson, AndroidX, Firebase, and more.
+  - The Blossom interceptor test was adapted to OkHttp 5's `Interceptor.Chain`.
+- **iOS CI.**
+  - `commons` `commonTest` now compiles and runs on iOS targets.
+  - CI runs the shared `commonTest` on iOS for `:commons`.
 - Split the monolithic CHANGELOG into per-version files under `docs/changelog/`.
-- A large SonarQube cleanup pass (S1871) merged duplicate `when`/`if` arms. Also migrated `Log` calls to the lambda overload.
-- Documented an Amethyst→commons migration plan and target package hierarchy. Refreshed several Claude skills and the Namecoin design doc. Added a rule requiring a license check when adding any new dependency.
+- **SonarQube cleanup (S1871).**
+  - Merged duplicate `when`/`if` arms across the codebase.
+  - Migrated `Log` calls to the lambda overload.
+- **Documentation.**
+  - Documented an Amethyst→commons migration plan and target package hierarchy.
+  - Refreshed several Claude skills and the Namecoin design doc.
+  - Added a rule requiring a license check when adding any new dependency.
 - `versionName` branch detection now sets the git cwd, so it works inside git worktrees.
 
 ## Contributors

--- a/docs/changelog/v1.12.00.md
+++ b/docs/changelog/v1.12.00.md
@@ -6,13 +6,10 @@ Highlights:
 - **CLINK payments** — a new Lightning rail with budgets and a unified Send Payment screen.
 - **Private posts & reactions** — post, reply, react, and zap privately via NIP-17.
 - **Workouts** — record and browse NIP-101e workouts in a dedicated feed.
-- **Math in notes** — write inline and block LaTeX in the timeline.
-- **Audio visualizer** — a live, styleable visualizer for audio-only notes.
 - **Activity cards** — likes, zaps, and nutzaps render as rich gradient cards.
 - **Software Apps** — a browsable NIP-82 app directory.
 - **Music** — publish and browse music tracks and playlists.
 - **Podcasts** — a new NIP-F4 podcast feed with favorites and an inline player.
-- **Pinned DMs** — pin conversations to the top of the chat list.
 - **Desktop** — image compression, a new media player, group DMs, and a refreshed feed.
 
 ## New Features

--- a/docs/changelog/v1.12.00.md
+++ b/docs/changelog/v1.12.00.md
@@ -2,60 +2,67 @@
 
 Highlights:
 
-- **Cashu wallet** — a new in-app NIP-60 ecash wallet with mint management, top-ups, and NIP-61 nutzaps.
-- **CLINK payments** — a new Lightning rail with spending budgets, NIP-05 offer discovery, and a unified Send Payment screen.
-- **Private posts & reactions** — post, reply, react, and zap privately, all end-to-end encrypted via NIP-17 gift wraps.
-- **Workouts** — record and browse NIP-101e workout records (kind 1301) in a dedicated feed.
-- **Math in notes** — write inline and block LaTeX that renders right in the timeline.
-- **Audio visualizer** — a live, styleable visualizer that reacts to whatever audio is playing.
-- **Activity cards** — likes, zaps, and nutzaps render as rich gradient cards that tap through to the thread.
-- **Software Apps** — a browsable NIP-82 app directory, plus editable NIP-89 app recommendations on your profile.
-- **Music** — publish and browse music tracks and playlists, with their own feeds.
-- **Pinned DMs** — pin important conversations to the top of the chat list, synced across devices.
-- **Desktop** — image compression on upload, a new media player, group-DM parity, a Replies tab, and a refreshed feed.
+- **Cashu wallet** — a new in-app NIP-60 ecash wallet.
+- **CLINK payments** — a new Lightning rail with budgets and a unified Send Payment screen.
+- **Private posts & reactions** — post, reply, react, and zap privately via NIP-17.
+- **Workouts** — record and browse NIP-101e workouts in a dedicated feed.
+- **Math in notes** — write inline and block LaTeX in the timeline.
+- **Audio visualizer** — a live, styleable visualizer for whatever audio is playing.
+- **Activity cards** — likes, zaps, and nutzaps render as rich gradient cards.
+- **Software Apps** — a browsable NIP-82 app directory.
+- **Music** — publish and browse music tracks and playlists.
+- **Pinned DMs** — pin conversations to the top of the chat list.
+- **Desktop** — image compression, a new media player, group DMs, and a refreshed feed.
 
 ## New Features
 
 ### Payments
 
-- **CLINK — a new Lightning payment rail.** Pay and get paid through CLINK Offers and Debits, an interoperable Lightning-over-Nostr scheme.
+- **CLINK — a new Lightning payment rail.**
+  - Pay and get paid through CLINK Offers and Debits.
+  - An interoperable Lightning-over-Nostr scheme.
   - Profiles can show a tappable CLINK Offer chip.
-  - You can pay a contact directly from their profile.
+  - Pay a contact directly from their profile.
 - **Spending budgets for CLINK debits.**
   - Set one-time or recurring limits.
   - A debit connection pulls funds only up to the cap you set.
-- **Discover offers by NIP-05.** Resolve a person's payment offer straight from their `name@domain` address.
-- **Unified Send Payment screen.** Reach every rail from one place:
-  - Lightning, CLINK, on-chain Bitcoin, and Cashu/nutzaps.
+- **Discover offers by NIP-05.**
+  - Resolve a person's payment offer from their `name@domain` address.
+- **Unified Send Payment screen.**
+  - Reach Lightning, CLINK, on-chain Bitcoin, and Cashu/nutzaps from one place.
   - A "Pay from" selector chooses which wallet the money leaves.
 - **On-chain payments.**
   - Pay Bitcoin payment targets from the in-app on-chain wallet.
   - Pay a contact's on-chain "Bit" recipient directly.
 - **Unified payment-rail chips** on the profile header.
   - Long-press any chip to copy that destination.
-- **Manage multiple wallets.** Add and pick between wallet types from the payment flow.
+- **Manage multiple wallets.**
   - Add an NWC (Nostr Wallet Connect) wallet.
   - Add a CLINK debit wallet.
   - Add a Cashu wallet.
-- **Cashu ecash wallet (new, NIP-60).** A full in-app ecash wallet, beyond the previous redeem-only support.
-  - Create and add a Cashu wallet, with a dedicated wallet screen and settings.
+  - Pick between them from the payment flow.
+- **Cashu ecash wallet (new, NIP-60).**
+  - A full in-app ecash wallet, beyond the previous redeem-only support.
+  - Create and add a Cashu wallet, with its own screen and settings.
   - Browse and pick mints from a mint directory.
-  - A standalone mint top-up screen.
-  - Per-mint balances on the wallet.
-  - Send NIP-61 nutzaps from the wallet, with a send progress bar that matches the Lightning experience.
+  - Top up a mint from a standalone screen.
+  - See per-mint balances on the wallet.
+  - Send NIP-61 nutzaps from the wallet.
+  - A send progress bar that matches the Lightning experience.
 
 ### Posting & Privacy
 
 - **Private posts and replies.**
   - Composed and delivered as NIP-17 gift wraps.
-  - An editable "Notify" block lets you choose exactly who can read a private post.
+  - An editable "Notify" block picks exactly who can read a private post.
 - **Private reactions.**
   - React and un-react privately.
   - Safeguards prevent private content from leaking publicly.
 - **Private zaps.**
   - Zaps on private notes are forced private.
   - Replies to a private zap route into the sender's DM room.
-- **NIP-32 hashtag labels.** Add first-class hashtag labels to posts.
+- **NIP-32 hashtag labels.**
+  - Add first-class hashtag labels to posts.
   - Follow-hashtag labels publish through your outbox relays.
   - They surface in the hashtag feed.
 - **Compose polish.**
@@ -70,17 +77,19 @@ Highlights:
 
 - **Pin DM conversations** to the top of your chat list.
   - Pins sync across devices via a NIP-78 app-data event.
-- **@-mention search in Marmot (MLS) group chats.** Search and tag users in the group composer.
+- **@-mention search in Marmot (MLS) group chats.**
+  - Search and tag users in the group composer.
   - Conversation participants rank first.
   - They are marked with an "In this chat" chip.
-- **Quoted chat messages** now render inside chat bubbles with the proper chat-reply design.
-  - The redundant reply row is skipped when the message is already quoted inline.
+- **Quoted chat messages in bubbles.**
+  - Quotes render inside chat bubbles with the proper chat-reply design.
+  - The redundant reply row is skipped when the quote is already inline.
 - **MLS reliability.**
   - Unread state now persists across app restarts.
   - The kind:445 backlog is no longer refetched on every launch.
 - **Share to DM.**
   - A new "Share to DM" route sends content straight into a conversation.
-  - The room screen accepts a shared attachment so the draft opens pre-filled.
+  - The room screen accepts a shared attachment, so the draft opens pre-filled.
 - **Reply to zaps from the notification screen.**
   - Reply directly to a zap from Notifications.
   - Nutzap chips reply on long-press.
@@ -94,16 +103,20 @@ Highlights:
   - Reactions, zaps, likes, and nutzaps render as gradient cards.
   - Each card embeds the post it's about.
   - A single tap on a like/zap chip opens that event's thread.
-- **Workouts feed.** A dedicated feed for NIP-101e workout records (kind 1301).
-- **Music (new).** Tracks (kind 36787) and playlists get first-class support.
+- **Workouts feed.**
+  - A dedicated feed for NIP-101e workout records (kind 1301).
+- **Music (new).**
+  - First-class support for tracks (kind 36787) and playlists.
   - Browse Music Tracks and Music Playlists feeds.
   - Publish a new track and create playlists.
   - Add a track to a playlist from a bottom sheet.
-- **Software Apps directory (new, NIP-82).** Browse software applications (kind 32267).
+- **Software Apps directory (new, NIP-82).**
+  - Browse software applications (kind 32267).
   - Filter by follows, author, hashtag, or global.
   - An app detail screen shows screenshots and the author.
   - Tap a screenshot to open it fullscreen.
-- **App recommendations (NIP-89).** Editable recommendations on your profile.
+- **App recommendations (NIP-89).**
+  - Editable recommendations on your profile.
   - Tiered ordering in the recommendations editor.
   - Richer app cards with author attribution.
 - **New community renderers.**
@@ -111,11 +124,13 @@ Highlights:
   - Agora fundraiser campaigns (kind 33863).
 - **Cleaner feeds.**
   - Reactions and zaps anchor their own thread view.
-  - Reposts whose boosted kind isn't supported are hidden instead of showing blank cards.
-- **Audio visualizer (new).** A live visualizer that reacts to the audio you're playing.
+  - Reposts of an unsupported kind are hidden instead of showing blank cards.
+- **Audio visualizer (new).**
+  - A live visualizer that reacts to the audio you're playing.
   - Real-time FFT spectrum driven from the playback PCM stream.
   - Selectable styles: Classic, Static, Aurora, Waves, and Radial.
-  - A settings screen with live previews; your choice syncs via NIP-78.
+  - A settings screen with live previews.
+  - Your choice syncs via NIP-78.
   - Fills the height in fullscreen and shows a fixed strip in the feed.
 - **Podcasts.**
   - Tap a podcast to open a show screen listing all its episodes.
@@ -132,9 +147,12 @@ Highlights:
 
 ## Performance
 
-- Pinned-DM state reads are deferred to the row and menu, keeping the chat list smooth.
-- Parsed CLINK offers are cached for NIP-05 lookups, using case-insensitive keys.
-- The "fix missing spaces" pass indexes URLs by their first character to avoid repeated scans.
+- Pinned-DM state reads are deferred to the row and menu.
+  - The chat list stays smooth.
+- Parsed CLINK offers are cached for NIP-05 lookups.
+  - Uses case-insensitive keys.
+- The "fix missing spaces" pass indexes URLs by their first character.
+  - Avoids repeated scans.
 
 ## Improvements and Bug fixes
 
@@ -150,7 +168,7 @@ Highlights:
   - Profile zaps that should be anonymous are no longer encrypted as private zaps.
   - Media uploads in anonymous posts use an ephemeral signer.
 - **Wallet.**
-  - The Cashu wallet row now shows the Cashu logo instead of a generic icon.
+  - The Cashu wallet row shows the Cashu logo instead of a generic icon.
   - Own on-chain zaps highlight the bolt and show as pending in the counter.
   - Tidied the wallet screen layout.
 - **Zap settings.**
@@ -159,39 +177,54 @@ Highlights:
 - **Cashu top-up** is now crash-safe on retry.
   - Funds are checkpointed the instant they leave the wallet.
   - They are never re-moved on a retry.
-- **Zap popup.** It now reacts to Lightning-address and Cashu/nutzap info loading, so the payment rails appear live as they resolve.
+- **Zap popup.**
+  - Reacts to Lightning-address and Cashu/nutzap info as it loads.
+  - The payment rails now appear live as they resolve.
 - **Tor.**
   - Relay backoff is honored during Tor bootstrap.
   - A new "money operations" relay category keeps payment traffic on the right transport.
+  - Sockets opened on the wrong transport are rebuilt.
 - **DM history loading.**
   - Per-relay download windows realign when DMs are pruned.
   - A slow Tor connect is no longer mislabeled as "stalled".
-  - The paused-history card shows parked relays, and the sync marker is tappable.
-- **Live streams.** Fixed the live-stream chat relay fallback.
-- **Polls.** Zap and non-zap polls now share the same option text.
-- **Video.** Legacy NIP-71 videos now resolve their address from the real `d` tag.
-- **Media server.** The default media server no longer resets on every launch.
-- **Accounts.** Deleting an account now clears its cached entry.
-- **Metadata.** A non-spec birthday value can no longer drop an entire profile.
+  - The paused-history card shows parked relays.
+  - The sync marker is now tappable.
+- **Live streams.**
+  - Fixed the live-stream chat relay fallback.
+- **Polls.**
+  - Zap and non-zap polls now share the same option text.
+- **Video.**
+  - Legacy NIP-71 videos resolve their address from the real `d` tag.
+- **Media server.**
+  - The default media server no longer resets on every launch.
+- **Accounts.**
+  - Deleting an account now clears its cached entry.
+- **Metadata.**
+  - A non-spec birthday value can no longer drop an entire profile.
 - **Deletions (NIP-09).**
   - Deleting a note now severs child back-references.
   - It detaches on-chain-zap, nutzap, and channel sources from the cache.
 - **Hardening.**
   - Many audit fixes across the private-posts, CLINK, and MLS paths.
-  - Covers off-main-thread crypto, leak prevention, and hiding share/bookmark on private notes.
-- Reduced runtime log noise.
-- Fixed several edge-case crashes.
+  - Covers off-main-thread crypto and leak prevention.
+  - Hides share/bookmark on private notes.
+- **General.**
+  - Reduced runtime log noise.
+  - Fixed several edge-case crashes.
 
 ## Desktop
 
-- **Image compression on upload.** A new compression pipeline with:
+- **Image compression on upload.**
   - An Image Compression settings panel.
   - Per-post quality presets.
   - Batch progress in the composer.
   - A preview-then-publish gate.
   - A fail-loud dialog if compression fails.
-- **New media player.** Replaced vlcj with kdroidFilter's ComposeMediaPlayer (JCodec/FFmpeg backend).
-- **Group DM parity with Android.** Desktop now handles group direct messages the same way.
+- **New media player.**
+  - Replaced vlcj with kdroidFilter's ComposeMediaPlayer.
+  - Uses a JCodec/FFmpeg backend.
+- **Group DM parity with Android.**
+  - Desktop now handles group direct messages the same way.
 - **Replies tab** on the user profile.
   - Feeds also show reply context (parent embed plus label) inline.
 - **Feed refresh.**
@@ -205,8 +238,10 @@ Highlights:
   - Amethyst logo on the Tor and account-loading splashes.
   - Restored inter-word spacing in rich text with mentions/hashtags.
   - Fixed parent-author metadata loading.
-- **Unhealthy-relay review.** A banner and popup that flag relays behaving poorly.
-- **Namecoin diagnostics** card ported from the Android settings.
+- **Unhealthy-relay review.**
+  - A banner and popup that flag relays behaving poorly.
+- **Namecoin diagnostics.**
+  - The diagnostics card was ported from the Android settings.
 
 ## Cli
 
@@ -219,12 +254,13 @@ Highlights:
 
 ## Quartz
 
-- **Relay-server toolkit.** Major work toward running a relay from Quartz:
+- **Relay-server toolkit.**
   - A `Flow<Event>` REQ-responder SPI with a storage-free dispatch engine.
   - NIP-50 search parsing.
   - Suspendable auth hooks.
   - Split engine/backend/policy packages.
-- **NIP-45 approximate COUNT** via HyperLogLog construction, with wire support.
+- **NIP-45 approximate COUNT.**
+  - HyperLogLog construction, with wire support.
 - **NIP-11.**
   - Added the missing `banner` field.
   - Relay limits are now a single source of truth served over NIP-11.
@@ -232,28 +268,35 @@ Highlights:
   - Stable per-connection ids.
   - A per-connection `RequestContext` threaded into the event source.
   - Auth identity moved from policy into connection scope.
-- **NIP-46.** Fixed a bunker double-resume and retry id-reuse race.
-- Fixed `q` (quote) tags being dropped by an inverted guard.
-- Registered `CommunityRulesEvent` and CLINK DTO serializers (including Kotlin/Native targets).
+- **NIP-46.**
+  - Fixed a bunker double-resume and retry id-reuse race.
+- **Other.**
+  - Fixed `q` (quote) tags being dropped by an inverted guard.
+  - Registered `CommunityRulesEvent` and CLINK DTO serializers (incl. Kotlin/Native).
 
 ## Build & Documentation
 
 - **Dependency updates.**
   - Bumped Kotlin, Compose Multiplatform 1.11.1, Coil 5, OkHttp 5, Jackson, AndroidX, Firebase, and more.
-  - The Blossom interceptor test was adapted to OkHttp 5's `Interceptor.Chain`.
+  - Adapted the Blossom interceptor test to OkHttp 5's `Interceptor.Chain`.
 - **iOS CI.**
   - `commons` `commonTest` now compiles and runs on iOS targets.
   - CI runs the shared `commonTest` on iOS for `:commons`.
-- **Amethyst → commons migration (KMP/iOS).** A large effort moving shared, CLI-safe code out of the Android app into `commons` so it works on every front end:
+- **Amethyst → commons migration (KMP/iOS).**
+  - Moves shared, CLI-safe code out of the Android app into `commons`.
   - Decryption caches (Mute/People/Community, Hashtag, Favorite-algo, Trust-provider).
   - Models: InterestSet, LabeledBookmarkList, NwcWalletEntry, CashuToken, OwnedEmojiPack.
   - The link-preview fetcher, relay broadcast tracker, and CLI-safe util extensions.
   - `HtmlParser` made KMP (dropped its Java `Charset` dependency).
   - A consolidated package taxonomy with a new architecture doc.
-- **Licensing.** Replaced the GPLv3 `TarsosDSP` dependency with an in-house pitch shifter for the voice anonymizer, keeping the project MIT-clean.
-- Added a monochrome outline Cashu icon to the Material Symbols set.
-- Renamed `ReplaceableVideoEvent` to `AddressableVideoEvent` for spec accuracy.
-- Split the monolithic CHANGELOG into per-version files under `docs/changelog/`.
+- **Licensing.**
+  - Replaced the GPLv3 `TarsosDSP` dependency with an in-house pitch shifter for the voice anonymizer.
+  - Keeps the project MIT-clean.
+- **Misc.**
+  - Added a monochrome outline Cashu icon to the Material Symbols set.
+  - Renamed `ReplaceableVideoEvent` to `AddressableVideoEvent` for spec accuracy.
+  - Split the monolithic CHANGELOG into per-version files under `docs/changelog/`.
+  - `versionName` branch detection sets the git cwd, so it works inside git worktrees.
 - **SonarQube cleanup (S1871).**
   - Merged duplicate `when`/`if` arms across the codebase.
   - Migrated `Log` calls to the lambda overload.
@@ -261,7 +304,6 @@ Highlights:
   - Documented an Amethyst→commons migration plan and target package hierarchy.
   - Refreshed several Claude skills and the Namecoin design doc.
   - Added a rule requiring a license check when adding any new dependency.
-- `versionName` branch detection now sets the git cwd, so it works inside git worktrees.
 
 ## Contributors
 

--- a/docs/changelog/v1.12.00.md
+++ b/docs/changelog/v1.12.00.md
@@ -53,6 +53,9 @@ Highlights:
   - Richer notify chips in the new-post screen.
   - Modernized inline payment cards that show their descriptions.
   - Quote-reposts (NIP-18) now count in the repost counter.
+- **Hidden Words moderation.**
+  - A per-row unblock button on the Hidden Words screen.
+  - Remove a single muted word without clearing the whole list.
 
 ### Chat & DMs
 
@@ -66,6 +69,12 @@ Highlights:
 - **MLS reliability.**
   - Unread state now persists across app restarts.
   - The kind:445 backlog is no longer refetched on every launch.
+- **Share to DM.**
+  - A new "Share to DM" route sends content straight into a conversation.
+  - The room screen accepts a shared attachment so the draft opens pre-filled.
+- **Reply to zaps from the notification screen.**
+  - Reply directly to a zap from Notifications.
+  - Nutzap chips reply on long-press.
 
 ### Reading & Feeds
 
@@ -87,9 +96,13 @@ Highlights:
 - **Cleaner feeds.**
   - Reactions and zaps anchor their own thread view.
   - Reposts whose boosted kind isn't supported are hidden instead of showing blank cards.
-- **Media.**
-  - Swipe for brightness and volume in fullscreen video.
+- **Podcasts.**
   - Tap a podcast to open a show screen listing all its episodes.
+  - Translatable show and episode descriptions on the feed cards.
+  - A synthetic playback waveform while audio plays.
+  - The episode audio player is now squared so the controls get room.
+- **Video.**
+  - Swipe for brightness and volume in fullscreen video.
 
 ### Settings
 
@@ -106,6 +119,7 @@ Highlights:
 ## Improvements and Bug fixes
 
 - **Notifications.**
+  - The old "Global" tab is split into "Selected" (curated) and a raw "Global".
   - Replies to likes/zaps now reach the "Curated" feed.
   - The legacy "Global" filter migrates once to "Curated".
   - A reply to a like/zap no longer drags in the original post's whole thread.
@@ -125,6 +139,7 @@ Highlights:
 - **Cashu top-up** is now crash-safe on retry.
   - Funds are checkpointed the instant they leave the wallet.
   - They are never re-moved on a retry.
+- **Zap popup.** It now reacts to Lightning-address and Cashu/nutzap info loading, so the payment rails appear live as they resolve.
 - **Tor.**
   - Relay backoff is honored during Tor bootstrap.
   - A new "money operations" relay category keeps payment traffic on the right transport.
@@ -161,6 +176,7 @@ Highlights:
   - Amethyst logo on the Tor and account-loading splashes.
   - Restored inter-word spacing in rich text with mentions/hashtags.
   - Fixed parent-author metadata loading.
+- **Unhealthy-relay review.** A banner and popup that flag relays behaving poorly.
 - **Namecoin diagnostics** card ported from the Android settings.
 
 ## Cli
@@ -199,6 +215,13 @@ Highlights:
 - **iOS CI.**
   - `commons` `commonTest` now compiles and runs on iOS targets.
   - CI runs the shared `commonTest` on iOS for `:commons`.
+- **Amethyst → commons migration (KMP/iOS).** A large effort moving shared, CLI-safe code out of the Android app into `commons` so it works on every front end:
+  - Decryption caches (Mute/People/Community, Hashtag, Favorite-algo, Trust-provider).
+  - Models: InterestSet, LabeledBookmarkList, NwcWalletEntry, CashuToken, OwnedEmojiPack.
+  - The link-preview fetcher, relay broadcast tracker, and CLI-safe util extensions.
+  - `HtmlParser` made KMP (dropped its Java `Charset` dependency).
+  - A consolidated package taxonomy with a new architecture doc.
+- Renamed `ReplaceableVideoEvent` to `AddressableVideoEvent` for spec accuracy.
 - Split the monolithic CHANGELOG into per-version files under `docs/changelog/`.
 - **SonarQube cleanup (S1871).**
   - Merged duplicate `when`/`if` arms across the codebase.

--- a/docs/changelog/v1.12.00.md
+++ b/docs/changelog/v1.12.00.md
@@ -7,10 +7,11 @@ Highlights:
 - **Private posts & reactions** — post, reply, react, and zap privately via NIP-17.
 - **Workouts** — record and browse NIP-101e workouts in a dedicated feed.
 - **Math in notes** — write inline and block LaTeX in the timeline.
-- **Audio visualizer** — a live, styleable visualizer for whatever audio is playing.
+- **Audio visualizer** — a live, styleable visualizer for audio-only notes.
 - **Activity cards** — likes, zaps, and nutzaps render as rich gradient cards.
 - **Software Apps** — a browsable NIP-82 app directory.
 - **Music** — publish and browse music tracks and playlists.
+- **Podcasts** — a new NIP-F4 podcast feed with favorites and an inline player.
 - **Pinned DMs** — pin conversations to the top of the chat list.
 - **Desktop** — image compression, a new media player, group DMs, and a refreshed feed.
 
@@ -19,6 +20,7 @@ Highlights:
 ### Payments
 
 - **CLINK — a new Lightning payment rail.**
+  - CLINK = Common Lightning Interface for Nostr Keys.
   - Pay and get paid through CLINK Offers and Debits.
   - An interoperable Lightning-over-Nostr scheme.
   - Profiles can show a tappable CLINK Offer chip.
@@ -45,10 +47,11 @@ Highlights:
   - A full in-app ecash wallet, beyond the previous redeem-only support.
   - Create and add a Cashu wallet, with its own screen and settings.
   - Browse and pick mints from a mint directory.
+  - Mint ecash from Lightning and melt it back to Lightning.
+  - Send and receive ecash tokens.
   - Top up a mint from a standalone screen.
   - See per-mint balances on the wallet.
-  - Send NIP-61 nutzaps from the wallet.
-  - A send progress bar that matches the Lightning experience.
+  - Send NIP-61 nutzaps from the wallet, with a Lightning-style send progress bar.
 
 ### Posting & Privacy
 
@@ -87,15 +90,18 @@ Highlights:
 - **MLS reliability.**
   - Unread state now persists across app restarts.
   - The kind:445 backlog is no longer refetched on every launch.
-- **Share to DM.**
-  - A new "Share to DM" route sends content straight into a conversation.
-  - The room screen accepts a shared attachment, so the draft opens pre-filled.
+- **Share to DM ("Send as DM").**
+  - A new Android share-sheet target, alongside "New Post".
+  - Share text, an image, or a video from another app into a DM.
+  - Pick a recent conversation; the chat composer opens pre-filled and editable.
 - **Reply to zaps from the notification screen.**
   - Reply directly to a zap from Notifications.
   - Nutzap chips reply on long-press.
-- **Group DM subjects (NIP-14).**
-  - Set a subject line on group conversations.
-  - A smoother flow for creating a new group DM.
+- **Group DMs (NIP-14 subjects).**
+  - Set and update a group name (subject) on encrypted group chats.
+  - Create a group by selecting multiple recipients in the New DM dialog.
+  - Rooms are marked read when opened.
+  - Messages from muted authors no longer mark a room unread.
 
 ### Reading & Feeds
 
@@ -106,8 +112,10 @@ Highlights:
   - Reactions, zaps, likes, and nutzaps render as gradient cards.
   - Each card embeds the post it's about.
   - A single tap on a like/zap chip opens that event's thread.
-- **Workouts feed.**
-  - A dedicated feed for NIP-101e workout records (kind 1301).
+- **Workouts (new, NIP-101e).**
+  - Create and publish workout records (kind 1301), interoperable with the RUNSTR dialect.
+  - Browse a dedicated Workouts feed.
+  - Filter by exercise type, author, community, or hashtag.
 - **Music (new).**
   - First-class support for tracks (kind 36787) and playlists.
   - Browse Music Tracks and Music Playlists feeds.
@@ -129,16 +137,18 @@ Highlights:
   - Reactions and zaps anchor their own thread view.
   - Reposts of an unsupported kind are hidden instead of showing blank cards.
 - **Audio visualizer (new).**
-  - A live visualizer that reacts to the audio you're playing.
-  - Real-time FFT spectrum driven from the playback PCM stream.
-  - Selectable styles: Classic, Static, Aurora, Waves, and Radial.
-  - A settings screen with live previews.
-  - Your choice syncs via NIP-78.
-  - Fills the height in fullscreen and shows a fixed strip in the feed.
-- **Podcasts.**
-  - Tap a podcast to open a show screen listing all its episodes.
+  - A live visualizer for audio-only notes.
+  - Real-time FFT spectrum from the track's decoded audio (no mic, no new permission).
+  - Styles: Classic (default), Spectrum Bars, Color Waves, Radial Ring, Aurora Glow, Static, and Off.
+  - Each style has a live preview in the settings picker.
+  - Your choice syncs across devices via NIP-78.
+  - Fills the art area in fullscreen and shows a fixed strip in the feed.
+- **Podcasts (new, NIP-F4).**
+  - Dedicated podcast and episode feeds, filterable by follows, authors, communities, or hashtags.
+  - Mark podcasts as favorites.
+  - Tap a podcast to open a show screen with all its episodes and an inline player.
   - Translatable show and episode descriptions on the feed cards.
-  - The episode audio player is now squared so the controls get room.
+  - The episode audio player is squared so the controls get room.
 - **Video.**
   - Swipe for brightness and volume in fullscreen video.
 

--- a/docs/changelog/v1.12.00.md
+++ b/docs/changelog/v1.12.00.md
@@ -2,12 +2,15 @@
 
 Highlights:
 
+- **Cashu wallet** — a new in-app NIP-60 ecash wallet with mint management, top-ups, and NIP-61 nutzaps.
 - **CLINK payments** — a new Lightning rail with spending budgets, NIP-05 offer discovery, and a unified Send Payment screen.
 - **Private posts & reactions** — post, reply, react, and zap privately, all end-to-end encrypted via NIP-17 gift wraps.
 - **Workouts** — record and browse NIP-101e workout records (kind 1301) in a dedicated feed.
 - **Math in notes** — write inline and block LaTeX that renders right in the timeline.
+- **Audio visualizer** — a live, styleable visualizer that reacts to whatever audio is playing.
 - **Activity cards** — likes, zaps, and nutzaps render as rich gradient cards that tap through to the thread.
-- **App recommendations** — editable NIP-89 recommendations on your profile, with richer cards and screenshots.
+- **Software Apps** — a browsable NIP-82 app directory, plus editable NIP-89 app recommendations on your profile.
+- **Music** — publish and browse music tracks and playlists, with their own feeds.
 - **Pinned DMs** — pin important conversations to the top of the chat list, synced across devices.
 - **Desktop** — image compression on upload, a new media player, group-DM parity, a Replies tab, and a refreshed feed.
 
@@ -30,10 +33,16 @@ Highlights:
   - Pay a contact's on-chain "Bit" recipient directly.
 - **Unified payment-rail chips** on the profile header.
   - Long-press any chip to copy that destination.
-- **Cashu improvements.**
-  - A send progress bar that matches the Lightning experience.
-  - A new mint top-up screen.
-  - Per-mint balances.
+- **Manage multiple wallets.** Add and pick between wallet types from the payment flow.
+  - Add an NWC (Nostr Wallet Connect) wallet.
+  - Add a CLINK debit wallet.
+  - Add a Cashu wallet.
+- **Cashu ecash wallet (new, NIP-60).** A full in-app ecash wallet, beyond the previous redeem-only support.
+  - Create and add a Cashu wallet, with a dedicated wallet screen and settings.
+  - Browse and pick mints from a mint directory.
+  - A standalone mint top-up screen.
+  - Per-mint balances on the wallet.
+  - Send NIP-61 nutzaps from the wallet, with a send progress bar that matches the Lightning experience.
 
 ### Posting & Privacy
 
@@ -86,20 +95,31 @@ Highlights:
   - Each card embeds the post it's about.
   - A single tap on a like/zap chip opens that event's thread.
 - **Workouts feed.** A dedicated feed for NIP-101e workout records (kind 1301).
-- **App recommendations.** Editable NIP-89 recommendations on your profile.
-  - Screenshots show in app feed cards.
-  - An "by &lt;author&gt;" line credits the author.
-  - A full app detail screen is available.
+- **Music (new).** Tracks (kind 36787) and playlists get first-class support.
+  - Browse Music Tracks and Music Playlists feeds.
+  - Publish a new track and create playlists.
+  - Add a track to a playlist from a bottom sheet.
+- **Software Apps directory (new, NIP-82).** Browse software applications (kind 32267).
+  - Filter by follows, author, hashtag, or global.
+  - An app detail screen shows screenshots and the author.
+  - Tap a screenshot to open it fullscreen.
+- **App recommendations (NIP-89).** Editable recommendations on your profile.
+  - Tiered ordering in the recommendations editor.
+  - Richer app cards with author attribution.
 - **New community renderers.**
   - Birdex species collections (kind 12473).
   - Agora fundraiser campaigns (kind 33863).
 - **Cleaner feeds.**
   - Reactions and zaps anchor their own thread view.
   - Reposts whose boosted kind isn't supported are hidden instead of showing blank cards.
+- **Audio visualizer (new).** A live visualizer that reacts to the audio you're playing.
+  - Real-time FFT spectrum driven from the playback PCM stream.
+  - Selectable styles: Classic, Static, Aurora, Waves, and Radial.
+  - A settings screen with live previews; your choice syncs via NIP-78.
+  - Fills the height in fullscreen and shows a fixed strip in the feed.
 - **Podcasts.**
   - Tap a podcast to open a show screen listing all its episodes.
   - Translatable show and episode descriptions on the feed cards.
-  - A synthetic playback waveform while audio plays.
   - The episode audio player is now squared so the controls get room.
 - **Video.**
   - Swipe for brightness and volume in fullscreen video.

--- a/docs/changelog/v1.12.00.md
+++ b/docs/changelog/v1.12.00.md
@@ -1,107 +1,161 @@
 # v1.12.0: Payments, Private Posts & Workouts
 
 Highlights:
-- **CLINK payments** — a new Lightning payment rail built on Offers and Debits, with spending budgets, NIP-05 offer discovery, and a unified Send Payment screen that brings Lightning, CLINK, on-chain and Cashu together in one place.
-- **Private posts & reactions** — compose private replies and posts, react/un-react privately, and force-private zaps, all delivered end-to-end encrypted via NIP-17 gift wraps.
-- **Workouts** — record and browse NIP-101e workout records (kind 1301) in a dedicated Workouts feed.
-- **Math in notes** — write inline and block LaTeX (`$...$` and `$$...$$`) and have it render right in the timeline.
-- **Activity cards** — likes, zaps and nutzaps now render as rich gradient "activity cards" that embed the post they reacted to, tappable straight to the thread.
-- **App recommendations** — editable NIP-89 app recommendations on your profile, with richer app cards, screenshots and author attribution.
-- **Pinned DMs** — pin your most important conversations to the top of the chat list, synced across your devices.
-- **Desktop** — image-compression pipeline on upload, a new media player, group-DM parity with Android, a Replies tab, and a refreshed feed.
+
+- **CLINK payments.** A new Lightning rail built on Offers and Debits. Includes spending budgets, NIP-05 offer discovery, and a unified Send Payment screen.
+- **Private posts & reactions.** Post, reply, react, and zap privately. Everything is end-to-end encrypted via NIP-17 gift wraps.
+- **Workouts.** Record and browse NIP-101e workout records (kind 1301) in a dedicated feed.
+- **Math in notes.** Write inline and block LaTeX. It renders right in the timeline.
+- **Activity cards.** Likes, zaps, and nutzaps now render as rich gradient cards. Each card embeds the post it reacted to and taps through to the thread.
+- **App recommendations.** Editable NIP-89 recommendations on your profile, with richer cards, screenshots, and author names.
+- **Pinned DMs.** Pin important conversations to the top of the chat list. The pins sync across your devices.
+- **Desktop.** Image compression on upload, a new media player, group-DM parity, a Replies tab, and a refreshed feed.
 
 ## New Features
 
 ### Payments
-- **CLINK — a new Lightning payment rail.** Pay and get paid through CLINK Offers and Debits, an interoperable Lightning-over-Nostr scheme. Profiles can show a tappable CLINK Offer chip, and you can pay a contact directly from their profile.
-- **Spending budgets for CLINK debits** — set one-time or recurring spending limits so a debit connection can pull funds up to a cap you control.
-- **Discover offers by NIP-05** — resolve a person's payment offer straight from their `name@domain` address.
-- **Unified Send Payment screen** — Lightning, CLINK, on-chain Bitcoin and Cashu/nutzaps are now all reachable from one screen, with a "Pay from" wallet selector to choose which wallet the money leaves.
-- **Pay Bitcoin payment targets from the in-app on-chain wallet**, and pay a contact's on-chain "Bit" recipient directly.
-- **Unified payment-rail chips** on the profile header — long-press any chip to copy that destination.
-- **Nutzap send progress bar** that matches the Lightning experience, plus a Cashu mint top-up screen and per-mint balances.
+
+- **CLINK — a new Lightning payment rail.** Pay and get paid through CLINK Offers and Debits, an interoperable Lightning-over-Nostr scheme.
+  - Profiles can show a tappable CLINK Offer chip.
+  - You can pay a contact directly from their profile.
+- **Spending budgets for CLINK debits.** Set one-time or recurring limits. A debit connection can then pull funds up to the cap you set.
+- **Discover offers by NIP-05.** Resolve a person's payment offer straight from their `name@domain` address.
+- **Unified Send Payment screen.** Reach every rail from one place:
+  - Lightning, CLINK, on-chain Bitcoin, and Cashu/nutzaps.
+  - A "Pay from" selector chooses which wallet the money leaves.
+- **On-chain payments.** Pay Bitcoin payment targets from the in-app on-chain wallet. You can also pay a contact's on-chain "Bit" recipient directly.
+- **Unified payment-rail chips** on the profile header. Long-press any chip to copy that destination.
+- **Cashu improvements.**
+  - A send progress bar that matches the Lightning experience.
+  - A new mint top-up screen.
+  - Per-mint balances.
 
 ### Posting & Privacy
-- **Compose private replies and private posts** delivered as NIP-17 gift wraps, with an editable "Notify" block so you choose exactly who can read a private post.
-- **Private reactions and private un-react** — react and remove reactions privately, with safeguards that prevent private content from leaking publicly.
-- **Force-private zaps on private notes**, and replies to private zaps are routed into the sender's DM room.
-- **NIP-32 hashtag labels** — add first-class hashtag labels to posts; follow-hashtag labels are published through your outbox relays and surface in the hashtag feed.
-- **Richer notify chips** in the new-post screen, modernized inline payment cards that surface their descriptions, and quote-reposts (NIP-18) now counted in the repost counter.
+
+- **Private posts and replies.** Composed and delivered as NIP-17 gift wraps. An editable "Notify" block lets you choose exactly who can read a private post.
+- **Private reactions.** React and un-react privately. Safeguards prevent private content from leaking publicly.
+- **Private zaps.** Zaps on private notes are forced private. Replies to a private zap route into the sender's DM room.
+- **NIP-32 hashtag labels.** Add first-class hashtag labels to posts.
+  - Follow-hashtag labels publish through your outbox relays.
+  - They surface in the hashtag feed.
+- **Compose polish.**
+  - Richer notify chips in the new-post screen.
+  - Modernized inline payment cards that show their descriptions.
+  - Quote-reposts (NIP-18) now count in the repost counter.
 
 ### Chat & DMs
-- **Pin DM conversations** to the top of your chat list — synced across devices via a NIP-78 app-data event.
-- **@-mention search in Marmot (MLS) group chats** — search and tag users in the group composer, with conversation participants ranked first and marked with an "In this chat" chip.
-- **Quoted chat messages** now render inside chat bubbles with the proper chat-reply design, and the redundant reply row is skipped when the message is already quoted inline.
-- **MLS unread state now persists across app restarts**, and the kind:445 backlog is no longer refetched on every launch.
+
+- **Pin DM conversations** to the top of your chat list. Pins sync across devices via a NIP-78 app-data event.
+- **@-mention search in Marmot (MLS) group chats.** Search and tag users in the group composer.
+  - Conversation participants rank first.
+  - They are marked with an "In this chat" chip.
+- **Quoted chat messages** now render inside chat bubbles with the proper chat-reply design. The redundant reply row is skipped when the message is already quoted inline.
+- **MLS reliability.**
+  - Unread state now persists across app restarts.
+  - The kind:445 backlog is no longer refetched on every launch.
 
 ### Reading & Feeds
-- **Render LaTeX math** in notes with `$...$` (inline) and `$$...$$` (block) delimiters.
-- **Activity cards** — reactions, zaps, likes and nutzaps render as gradient cards that embed the post they're about; a single tap on a like/zap chip opens that event's thread.
-- **NIP-101e Workouts** — a dedicated feed for workout records (kind 1301).
-- **Editable NIP-89 app recommendations** on your profile, with screenshots shown in app feed cards, an "by &lt;author&gt;" attribution line, and a full app detail screen.
-- New community renderers: **Birdex species collections** (kind 12473) and **Agora fundraiser campaigns** (kind 33863).
-- **Reactions and zaps anchor their own thread** view, and reposts whose boosted kind isn't supported are now hidden instead of showing blank cards.
-- **Brightness/volume swipe gestures** in fullscreen video, and tap a podcast to open a show screen listing all its episodes.
+
+- **Render LaTeX math** in notes. Use `$...$` for inline and `$$...$$` for block equations.
+- **Activity cards.** Reactions, zaps, likes, and nutzaps render as gradient cards that embed the post they're about. A single tap on a like/zap chip opens that event's thread.
+- **Workouts feed.** A dedicated feed for NIP-101e workout records (kind 1301).
+- **App recommendations.** Editable NIP-89 recommendations on your profile.
+  - Screenshots show in app feed cards.
+  - An "by &lt;author&gt;" line credits the author.
+  - A full app detail screen is available.
+- **New community renderers.**
+  - Birdex species collections (kind 12473).
+  - Agora fundraiser campaigns (kind 33863).
+- **Cleaner feeds.** Reactions and zaps anchor their own thread view. Reposts whose boosted kind isn't supported are now hidden instead of showing blank cards.
+- **Media.** Swipe for brightness and volume in fullscreen video. Tap a podcast to open a show screen listing all its episodes.
 
 ### Settings
-- **Searchable settings** — a search box filters settings rows by title and curated keywords, with prefix matching and an empty-state.
+
+- **Searchable settings.** A search box filters rows by title and curated keywords. Supports prefix matching and an empty-state.
 
 ## Performance
 
-- Pinned-DM state reads are deferred to the individual row and menu so the chat list stays smooth.
-- Parsed CLINK offers are cached for NIP-05 lookups (case-insensitive keys).
-- The "fix missing spaces" rich-text pass now indexes URLs by their first character to avoid repeated scans.
+- Pinned-DM state reads are deferred to the row and menu. The chat list stays smooth.
+- Parsed CLINK offers are cached for NIP-05 lookups, using case-insensitive keys.
+- The "fix missing spaces" rich-text pass indexes URLs by their first character. This avoids repeated scans.
 
 ## Improvements and Bug fixes
 
-- **Notifications:** likes/zaps replies now correctly reach the "Curated" feed; the legacy "Global" filter migrates once to "Curated"; replies to a like/zap no longer drag in the original liked post's whole thread.
-- **Note search** no longer matches on `p`, `e`, `a`, `alt` or `client` tags, so searches return cleaner results.
-- **Anonymous posting:** profile zaps that should be anonymous are no longer accidentally encrypted as private zaps; media uploads in anonymous posts use an ephemeral signer.
-- **Wallet:** the Cashu wallet row now shows the Cashu logo instead of a generic icon; own on-chain zaps highlight the bolt and show as pending in the counter; tidied wallet screen layout.
-- **Zap settings:** preset amounts are de-duplicated so drag-to-reorder keeps working, and the chip-drag interaction was fixed.
-- **Cashu top-up** is now crash-safe on retry — funds are checkpointed the instant they leave the wallet and never re-moved on a retry.
-- **Tor:** relay backoff is honored during Tor bootstrap; a new "money operations" relay category keeps payment traffic on the right transport.
-- **Metadata:** a non-spec birthday value can no longer drop an entire profile.
-- **Deletions (NIP-09):** deleting a note now properly severs child back-references and detaches on-chain-zap, nutzap and channel sources from the cache.
-- Numerous audit and hardening fixes across the private-posts, CLINK, and MLS paths (off-main-thread crypto, leak prevention, share/bookmark hidden on private notes).
+- **Notifications.**
+  - Replies to likes/zaps now reach the "Curated" feed.
+  - The legacy "Global" filter migrates once to "Curated".
+  - A reply to a like/zap no longer drags in the original post's whole thread.
+- **Note search.** Searches no longer match on `p`, `e`, `a`, `alt`, or `client` tags. Results are cleaner.
+- **Anonymous posting.**
+  - Profile zaps that should be anonymous are no longer encrypted as private zaps.
+  - Media uploads in anonymous posts use an ephemeral signer.
+- **Wallet.**
+  - The Cashu wallet row now shows the Cashu logo instead of a generic icon.
+  - Own on-chain zaps highlight the bolt and show as pending in the counter.
+  - Tidied the wallet screen layout.
+- **Zap settings.** Preset amounts are de-duplicated so drag-to-reorder keeps working. The chip-drag interaction was fixed.
+- **Cashu top-up** is now crash-safe on retry. Funds are checkpointed the instant they leave the wallet and never re-moved.
+- **Tor.**
+  - Relay backoff is honored during Tor bootstrap.
+  - A new "money operations" relay category keeps payment traffic on the right transport.
+- **Metadata.** A non-spec birthday value can no longer drop an entire profile.
+- **Deletions (NIP-09).** Deleting a note now severs child back-references. It also detaches on-chain-zap, nutzap, and channel sources from the cache.
+- **Hardening.** Many audit fixes across the private-posts, CLINK, and MLS paths. Covers off-main-thread crypto, leak prevention, and hiding share/bookmark on private notes.
 - Reduced runtime log noise and fixed several edge-case crashes.
 
 ## Desktop
 
-- **Image compression on upload** — a new compression pipeline with an Image Compression settings panel, per-post quality presets, batch progress in the composer, a preview-then-publish gate, and a fail-loud dialog if compression fails.
-- **New media player** — replaced vlcj with kdroidFilter's ComposeMediaPlayer (JCodec/FFmpeg backend) for video playback.
-- **Group DM parity with Android** — desktop now handles group direct messages the same way.
-- **Replies tab** on the user profile, plus reply context (parent embed + label) shown inline in feeds.
-- **Feed refresh** — inline card expansion, a "New posts" chip that slides in from the top, stick-to-top on prepend, and wired-up like/zap/comment actions.
-- Copy a Blossom image URL on click with a hover tooltip and snackbar; collapsed-sidebar polish (tighter ripple + hover tooltips); Amethyst logo on the Tor and account-loading splashes.
-- Restored inter-word spacing in rich text with mentions/hashtags, and fixed parent-author metadata loading.
+- **Image compression on upload.** A new compression pipeline with:
+  - An Image Compression settings panel.
+  - Per-post quality presets.
+  - Batch progress in the composer.
+  - A preview-then-publish gate.
+  - A fail-loud dialog if compression fails.
+- **New media player.** Replaced vlcj with kdroidFilter's ComposeMediaPlayer (JCodec/FFmpeg backend).
+- **Group DM parity with Android.** Desktop now handles group direct messages the same way.
+- **Replies tab** on the user profile. Feeds also show reply context (parent embed plus label) inline.
+- **Feed refresh.**
+  - Inline card expansion.
+  - A "New posts" chip that slides in from the top.
+  - Stick-to-top on prepend.
+  - Wired-up like/zap/comment actions.
+- **Smaller fixes.**
+  - Copy a Blossom image URL on click, with a hover tooltip and snackbar.
+  - Collapsed-sidebar polish: tighter ripple and hover tooltips.
+  - Amethyst logo on the Tor and account-loading splashes.
+  - Restored inter-word spacing in rich text with mentions/hashtags.
+  - Fixed parent-author metadata loading.
 - **Namecoin diagnostics** card ported from the Android settings.
 
 ## Cli
 
 - `amy offer` — CLINK offer info and request, including `--payer-data`.
-- `amy debit` — CLINK debit info, pay and budget.
+- `amy debit` — CLINK debit info, pay, and budget.
 - `amy zap --with <ndebit>` — settle a zap invoice via a CLINK debit.
 - `amy offer discover <nip05>` — resolve a profile's offer through NIP-05.
-- Closed CLINK parity gaps (profile offer, follow, offer pay, GFY detail) and added a clink-headless interop harness.
+- Closed CLINK parity gaps (profile offer, follow, offer pay, GFY detail). Added a clink-headless interop harness.
 
 ## Quartz
 
-- **Relay-server toolkit** — major work toward running a relay from Quartz: a `Flow<Event>` REQ-responder SPI with a storage-free dispatch engine, NIP-50 search parsing, suspendable auth hooks, and split engine/backend/policy packages.
+- **Relay-server toolkit.** Major work toward running a relay from Quartz:
+  - A `Flow<Event>` REQ-responder SPI with a storage-free dispatch engine.
+  - NIP-50 search parsing.
+  - Suspendable auth hooks.
+  - Split engine/backend/policy packages.
 - **NIP-45 approximate COUNT** via HyperLogLog construction, with wire support.
-- **NIP-11** improvements — the missing `banner` field, relay limits as a single source of truth served over NIP-11.
-- **Connection observability** — stable per-connection ids and a per-connection `RequestContext` threaded into the event source; auth identity moved from policy into connection scope.
-- **NIP-46** bunker fix for double-resume and retry id-reuse races.
-- Fixed `q` (quote) tags being dropped by an inverted guard, and registered `CommunityRulesEvent` / CLINK DTO serializers (incl. Kotlin/Native targets).
+- **NIP-11.** Added the missing `banner` field. Relay limits are now a single source of truth served over NIP-11.
+- **Connection observability.** Stable per-connection ids and a per-connection `RequestContext` threaded into the event source. Auth identity moved from policy into connection scope.
+- **NIP-46.** Fixed a bunker double-resume and retry id-reuse race.
+- Fixed `q` (quote) tags being dropped by an inverted guard. Registered `CommunityRulesEvent` and CLINK DTO serializers (including Kotlin/Native targets).
 
 ## Build & Documentation
 
-- Updated all dependencies (Kotlin, Compose Multiplatform 1.11.1, Coil 5, OkHttp 5, Jackson, AndroidX, Firebase, and more); the Blossom interceptor test was adapted to OkHttp 5's `Interceptor.Chain`.
-- `commons` `commonTest` now compiles and runs on iOS targets, and CI runs the shared `commonTest` on iOS for `:commons`.
+- **Dependency updates.** Bumped Kotlin, Compose Multiplatform 1.11.1, Coil 5, OkHttp 5, Jackson, AndroidX, Firebase, and more. The Blossom interceptor test was adapted to OkHttp 5's `Interceptor.Chain`.
+- **iOS CI.** `commons` `commonTest` now compiles and runs on iOS targets. CI runs the shared `commonTest` on iOS for `:commons`.
 - Split the monolithic CHANGELOG into per-version files under `docs/changelog/`.
-- A large SonarQube cleanup pass (S1871) merging duplicate `when`/`if` arms across the codebase, plus `Log` lambda-overload migrations.
-- Documented an Amethyst→commons migration plan and target package hierarchy, refreshed several Claude skills and the Namecoin design doc, and added a rule requiring a license check when introducing any new dependency.
-- `versionName` branch detection now sets the git cwd so it works inside git worktrees.
+- A large SonarQube cleanup pass (S1871) merged duplicate `when`/`if` arms. Also migrated `Log` calls to the lambda overload.
+- Documented an Amethyst→commons migration plan and target package hierarchy. Refreshed several Claude skills and the Namecoin design doc. Added a rule requiring a license check when adding any new dependency.
+- `versionName` branch detection now sets the git cwd, so it works inside git worktrees.
 
 ## Contributors
 
@@ -113,4 +167,14 @@ Highlights:
 
 ## Translations
 
-Community translations contributed through Crowdin across 50+ locales, including Arabic, Bengali, Catalan, Czech, German, Greek, Spanish, Persian, Finnish, French, Gujarati, Hindi, Croatian, Hungarian, Indonesian, Italian, Hebrew, Japanese, Kazakh, Korean, Lithuanian, Latvian, Dutch, Polish, Portuguese (BR/PT), Russian, Slovenian, Serbian, Swedish, Swahili, Tamil, Thai, Turkish, Ukrainian, Vietnamese, and Chinese (Simplified/Traditional/Hong Kong). New CLINK, Send Payment, workouts, chat-history, reply-search and on-chain-failure strings (cs, de, sv, pt-BR) were added directly.
+Community translations contributed through Crowdin across 50+ locales. Languages updated include:
+
+- Arabic, Bengali, Catalan, Czech, German, Greek
+- Spanish, Persian, Finnish, French, Gujarati, Hindi
+- Croatian, Hungarian, Indonesian, Italian, Hebrew, Japanese
+- Kazakh, Korean, Lithuanian, Latvian, Dutch, Polish
+- Portuguese (BR/PT), Russian, Slovenian, Serbian, Swedish, Swahili
+- Tamil, Thai, Turkish, Ukrainian, Vietnamese
+- Chinese (Simplified/Traditional/Hong Kong)
+
+New CLINK, Send Payment, workouts, chat-history, reply-search, and on-chain-failure strings (cs, de, sv, pt-BR) were added directly.

--- a/docs/changelog/v1.12.00.md
+++ b/docs/changelog/v1.12.00.md
@@ -167,14 +167,11 @@ Highlights:
 
 ## Translations
 
-Community translations contributed through Crowdin across 50+ locales. Languages updated include:
-
-- Arabic, Bengali, Catalan, Czech, German, Greek
-- Spanish, Persian, Finnish, French, Gujarati, Hindi
-- Croatian, Hungarian, Indonesian, Italian, Hebrew, Japanese
-- Kazakh, Korean, Lithuanian, Latvian, Dutch, Polish
-- Portuguese (BR/PT), Russian, Slovenian, Serbian, Swedish, Swahili
-- Tamil, Thai, Turkish, Ukrainian, Vietnamese
-- Chinese (Simplified/Traditional/Hong Kong)
-
-New CLINK, Send Payment, workouts, chat-history, reply-search, and on-chain-failure strings (cs, de, sv, pt-BR) were added directly.
+- Czech, German, Swedish, and Portuguese by @npub1e2yuky03caw4ke3zy68lg0fz3r4gkt94hx4fjmlelacyljgyk79svn3eef
+- Hungarian by @npub1dnvslq0vvrs8d603suykc4harv94yglcxwna9sl2xu8grt2afm3qgfh0tp
+- Dutch by @npub1w4la29u3zv09r6crx5u8yxax0ffxgekzdm2egzjkjckef7xc83fs0ftxcd
+- Polish by @npub16gjyljum0ksrrm28zzvejydgxwfm7xse98zwc4hlgq8epxeuggushqwyrm
+- Hindi by @npub1ww6huwu3xye6r05n3qkjeq62wds5pq0jswhl7uc59lchc0n0ns4sdtw5e6
+- Slovenian by @npub1qqqqqqz7nhdqz3uuwmzlflxt46lyu7zkuqhcapddhgz66c4ddynswreecw
+- Spanish by @npub1luhyzgce7qtcs6r6v00ryjxza8av8u4dzh3avg0zks38tjktnmxspxq903
+- Chinese by hypnotichemionus4 and @npub1gd8e0xfkylc7v8c5a6hkpj4gelwwcy99jt90lqjseqjj2t253s2s6ch58h


### PR DESCRIPTION
## Summary

Added comprehensive release notes for v1.12.0, documenting major features across payments (CLINK, Cashu wallet), private posts/reactions (NIP-17), workouts (NIP-101e), music, podcasts, software apps directory, and significant improvements to chat, feeds, desktop, CLI, and the Quartz relay toolkit.

## Test plan

- [x] N/A — documentation-only change, no code logic affected

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

https://claude.ai/code/session_01Y8cDkDRV48GYdQd3CR4kuV