### PR TITLE
Restore iOS test native-cache workaround dropped in dependency bump

### DIFF
--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -1,5 +1,23 @@
 
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.DisableCacheInKotlinVersion
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCacheApi
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.TestExecutable
+
+// Disables the Kotlin/Native compiler cache for an iOS test binary so the
+// Compose ui-uikit klib recompiles fresh instead of linking the broken prebuilt
+// cache (see the call site in the `kotlin {}` block). The version guard makes
+// Kotlin re-surface this workaround once we move past 2.4.0, so it can be
+// dropped when a newer Compose/Kotlin pairing fixes the cache. Wrapped in a
+// helper because @OptIn only applies to declarations, not bare statements.
+@OptIn(KotlinNativeCacheApi::class)
+fun TestExecutable.disableUiKitPrebuiltCache() =
+    disableNativeCache(
+        DisableCacheInKotlinVersion.`2_4_0`,
+        "Compose ui-uikit prebuilt cache references UIViewLayoutRegion (iOS 17+); " +
+            "linking the iOS test binary fails under Xcode 16.4.",
+    )
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -49,6 +67,22 @@ kotlin {
     // which commonMain files still reach for platform-only APIs.
     iosArm64()
     iosSimulatorArm64()
+
+    // Compose Multiplatform 1.11.x ships an `org.jetbrains.compose.ui:ui-uikit`
+    // prebuilt Kotlin/Native cache whose CMPLayoutRegion object hard-references
+    // the UIKit class `UIViewLayoutRegion` (introduced in iOS 17). Linking the
+    // iOS *test* executable against that cache under Xcode 16.4 fails with
+    //   ld: Undefined symbols: _OBJC_CLASS_$_UIViewLayoutRegion
+    // because the cached object was built for a newer simulator SDK (18.5) than
+    // the test binary is being linked for (14.0). Disabling the native cache for
+    // the iOS test binaries makes ui-uikit recompile against the active SDK,
+    // where the symbol resolves. See disableUiKitPrebuiltCache() above and
+    // https://kotl.in/disable-native-cache
+    targets.withType<KotlinNativeTarget>().configureEach {
+        binaries.withType<TestExecutable>().configureEach {
+            disableUiKitPrebuiltCache()
+        }
+    }
 
     sourceSets {
         commonMain {


### PR DESCRIPTION
## Problem

`main` is red on the `test-quartz-ios` job (step **Test Commons on iOS**) for every commit since `c7e25c5a9`. The `:commons:linkDebugTestIosSimulatorArm64` task fails at link time under CI's Xcode 16.4:

  > Task :commons:linkDebugTestIosSimulatorArm64 FAILED
  > e: ld invocation reported errors (Undefined symbols: _OBJC_CLASS_$_UIViewLayoutRegion)

  ## Root cause

  Bisecting the job history pins the first failure to `c7e25c5a9`. The culprit is `ece719445` ("Updates all dependencies"), which **deleted** the `disableUiKitPrebuiltCache()` workaround from `commons/build.gradle.kts`.

  Compose Multiplatform 1.11.x ships an `org.jetbrains.compose.ui:ui-uikit` prebuilt Kotlin/Native cache whose `CMPLayoutRegion` object hard-references the UIKit class `UIViewLayoutRegion` (introduced in iOS 17). Linking the
  iOS *test* executable against that cache under Xcode 16.4 fails because the cached object was built for a newer simulator SDK than the test binary is linked for. The workaround disabled the native cache for test binaries so `ui-uikit` recompiles against the active SDK, where the symbol resolves.

  The dependency bump moved Kotlin to 2.4.0, which removed the `DisableCacheInKotlinVersion.2_3_21` enum value the workaround referenced. Rather than bumping the guard, the whole block was deleted — reintroducing the link failure.

  ## Fix

  Restore the workaround using `DisableCacheInKotlinVersion.2_4_0`, the value that exists in KGP 2.4.0. The version guard will re-surface this workaround once Kotlin moves past 2.4.0, so it can be dropped when a newer
  Compose/Kotlin pairing fixes the cache.

  ## Verification

  Ran the exact failing task locally: `:commons:linkDebugTestIosSimulatorArm64` now succeeds, and the build log confirms the cache-disable is applied to the `debugTest` binary ("Kotlin/Native cache is disabled for Debug binary
  'debugTest'"). Local Xcode is 26.x so it can't reproduce the 16.4-specific red, but the fix path is proven applied and linking succeeds; CI on Xcode 16.4 will recompile ui-uikit against the active SDK.

## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
