### PR TITLE
[codex] Preserve bottom tab navigation state

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/navs/Nav.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/navs/Nav.kt
@@ -83,13 +83,16 @@ class Nav(
     override fun navBottomBar(route: Route) {
         navigationScope.launch {
             controller.navigate(route) {
-                // Clear sibling bottom-nav entries but keep Home (the start
-                // destination) below, so back-swipe from any tab returns to
-                // Home and back-swipe from Home leaves the app.
+                // Keep Home below tab roots, but save the popped tab stack so
+                // returning to Search/Notifications/etc resumes its input,
+                // scroll position, and nested detail route instead of
+                // rebuilding that tab from scratch.
                 popUpTo(Route.Home) {
                     inclusive = false
+                    saveState = true
                 }
                 launchSingleTop = true
+                restoreState = true
             }
             // Mark this entry as a tab root: hides the back arrow in canPop
             // and skips the horizontal slide in composableFromEnd.


### PR DESCRIPTION
## Summary
- Enable Android Navigation save/restore state for bottom-bar tab switches.
- Preserve Search tab input, scroll position, and nested routes when switching to another tab and coming back.
- Keep Home as the base destination while avoiding a full rebuild of popped tab stacks.

Fixes #426.

## Validation
- `git diff --check`
- pre-commit hook static analysis / Spotless: passed during commit
- Attempted `:amethyst:compileFdroidDebugKotlin`; local verification was blocked by environment/dependency resolution: this machine lacks Java 21 for the pre-push `./gradlew test` hook, and Maven/Google/JitPack dependency downloads intermittently failed with TLS handshake termination.

Bounty payout BTC address: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`