### PR TITLE
Gate Tor-routed relay dials until Tor is ready

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/AppModules.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/AppModules.kt
@@ -427,10 +427,19 @@ class AppModules(
 
     // Connects the INostrClient class with okHttp
     val websocketBuilder =
-        OkHttpWebSocket.Builder { url ->
-            val useTor = torEvaluatorFlow.shouldUseTorForRelay(url)
-            okHttpClientForRelays.getHttpClient(useTor)
-        }
+        OkHttpWebSocket.Builder(
+            httpClient = { url ->
+                val useTor = torEvaluatorFlow.shouldUseTorForRelay(url)
+                okHttpClientForRelays.getHttpClient(useTor)
+            },
+            // Don't dial Tor-routed relays until Tor's SOCKS port is up. Otherwise the
+            // whole Tor-routed relay set is hammered with doomed dials against the dead
+            // proxy during bootstrap. RelayProxyClientConnector reconnects them (with
+            // ignoreRetryDelays=true) the instant Tor flips to Active.
+            canDial = { url ->
+                !torEvaluatorFlow.shouldUseTorForRelay(url) || torManager.isSocksReady()
+            },
+        )
 
     // Caches all events in Memory
     val cache: LocalCache = LocalCache

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/okhttp/OkHttpWebSocket.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/okhttp/OkHttpWebSocket.kt
@@ -133,12 +133,16 @@ class OkHttpWebSocket(
 
     class Builder(
         val httpClient: (NormalizedRelayUrl) -> OkHttpClient,
+        val canDial: (NormalizedRelayUrl) -> Boolean = { true },
     ) : WebsocketBuilder {
         // Called when connecting.
         override fun build(
             url: NormalizedRelayUrl,
             out: WebSocketListener,
         ) = OkHttpWebSocket(url, httpClient, out)
+
+        // Gates the dial — false skips it (e.g. a Tor-routed relay before Tor is ready).
+        override fun canConnect(url: NormalizedRelayUrl) = canDial(url)
     }
 
     override fun disconnect() {

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/relays/health/RelayHealthStoreCloseTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/relays/health/RelayHealthStoreCloseTest.kt
@@ -27,7 +27,9 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.concurrent.Volatile
 import kotlin.test.Test
@@ -87,7 +89,12 @@ class RelayHealthStoreCloseTest {
                     ioDispatcher = dispatcher,
                 )
 
-            advanceUntilIdle()
+            // NB: the store's init launches an always-on `while(true){ reclassify(); delay(60s) }`
+            // ticker on this shared test scheduler. advanceUntilIdle() would chase that periodic
+            // delay forever (livelock). Advance just past the persist debounce instead so init's
+            // debounced save fires while the ticker stays parked at its 60s mark.
+            advanceTimeBy(RelayHealthStore.PERSIST_DEBOUNCE_MS + 1)
+            runCurrent()
             val baseline = persistence.saves
 
             store.close()

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/single/basic/BasicRelayClient.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/single/basic/BasicRelayClient.kt
@@ -103,6 +103,12 @@ open class BasicRelayClient(
     override fun needsToReconnect() = socket?.needsReconnect() ?: true
 
     override fun connect() {
+        // Transport gate: skip the dial when the builder reports this relay's transport
+        // isn't ready (e.g. a Tor-routed relay while Tor's SOCKS port isn't up). Returning
+        // here before the mutex/socket/onConnecting means no doomed dial and no backoff
+        // growth; a later reconnect pass (fired when the transport becomes ready) will dial.
+        if (!socketBuilder.canConnect(url)) return
+
         // If there is a connection, don't wait.
         if (connectingMutex.exchange(true)) {
             return

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/sockets/WebsocketBuilder.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/sockets/WebsocketBuilder.kt
@@ -27,4 +27,19 @@ interface WebsocketBuilder {
         url: NormalizedRelayUrl,
         out: WebSocketListener,
     ): WebSocket
+
+    /**
+     * Whether the transport for [url] is ready to dial right now. Returning false makes
+     * [com.vitorpamplona.quartz.nip01Core.relay.client.single.basic.BasicRelayClient.connect]
+     * skip the dial entirely — no socket, no backoff growth — until a later reconnect pass
+     * finds it ready.
+     *
+     * The motivating case: a Tor-routed relay while Tor's SOCKS proxy isn't up yet. Without
+     * this gate the pool hammers the dead proxy with doomed dials during the whole Tor
+     * bootstrap window. The caller is responsible for re-triggering a reconnect once the
+     * transport becomes ready (e.g. on the Tor status flipping to Active).
+     *
+     * Defaults to true so non-proxied builders need no change.
+     */
+    fun canConnect(url: NormalizedRelayUrl): Boolean = true
 }


### PR DESCRIPTION
**PR:** https://github.com/vitorpamplona/amethyst/pull/3223

## Summary

Two commits:

1. **`fix: gate Tor-routed relay dials until Tor's SOCKS port is ready`** — Before Tor finishes bootstrapping, the relay pool dialed every Tor-routed relay against the not-yet-listening SOCKS proxy. On a cold start that was **~580 doomed dials** (all `SOCKS: Connection refused`) in the seconds before Tor went Active, churning sockets/CPU and inflating each relay's backoff — and the same storm recurred on **every network switch** (which resets and re-bootstraps Arti).

   Adds an optional `WebsocketBuilder.canConnect(url)` gate (defaults to `true`, so other implementors are untouched), checked at the top of `BasicRelayClient.connect()` before the mutex / `onConnecting` / socket build — so a gated relay opens no socket, fires no listener events, and grows no backoff. The Android builder gates Tor-routed relays on `torManager.isSocksReady()`; `RelayProxyClientConnector` already reconnects them with `ignoreRetryDelays=true` the instant Tor flips to Active, so they dial as soon as the transport is usable.

2. **`fix(commons): stop RelayHealthStoreCloseTest livelocking the test suite`** — `recordIncoming_after_close_does_not_schedule_persist` called `advanceUntilIdle()` while `RelayHealthStore`'s init ticker (`while(true){ reclassify(); delay(60s) }`) was still live on the shared test scheduler, so it spun forever and wedged `:commons:jvmTest` (and the pre-push hook). Pre-existing on `main` via #3221; unblocks the hook. Advances past the persist debounce + `runCurrent()` instead.

## Verification (on-device, Android emulator)

Measured cold starts and WiFi↔Mobile switches with a temporary timing logger (removed before commit):

| metric | before | after gate |
|---|---|---|
| doomed pre-ready Tor dials (cold start) | **581** | **0** |
| doomed dials during network-switch re-bootstrap | storm | **0** |
| clearnet connections at Tor-ready | preserved | preserved |
| Tor relays connected after Tor Active | ~155 | ~158 |

Tor walks `Active → Off → Connecting → Active` on a network switch; the gate suppresses dials during each re-bootstrap window and the relays self-heal (via the existing `transportChanged=true` reconnect) the moment Tor is Active again. `:quartz:jvmTest` (BasicRelayClient + backoff) and the full pre-push matrix pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
