### PR TITLE
Eagerly preload thread for replies visible in feed

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Text.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Text.kt
@@ -48,6 +48,7 @@ import com.vitorpamplona.amethyst.ui.note.ReplyNoteComposition
 import com.vitorpamplona.amethyst.ui.note.elements.DisplayUncitedHashtags
 import com.vitorpamplona.amethyst.ui.note.nip22Comments.DisplayExternalId
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.threadview.datasources.PreloadThreadForReply
 import com.vitorpamplona.amethyst.ui.theme.HalfVertSpacer
 import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
 import com.vitorpamplona.amethyst.ui.theme.placeholderText
@@ -82,6 +83,10 @@ fun RenderTextEvent(
     val noteEvent = note.event ?: return
 
     if (unPackReply != ReplyRenderType.NONE) {
+        // Eagerly pull the rest of this reply's thread while it's on screen, so opening
+        // the conversation finds it already loaded. No-op when the note is a root itself.
+        PreloadThreadForReply(note, accountViewModel)
+
         val canShowReply by
             remember(note) {
                 derivedStateOf {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/datasources/ThreadFilterAssemblerSubscription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/datasources/ThreadFilterAssemblerSubscription.kt
@@ -22,10 +22,8 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.threadview.datasources
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import com.vitorpamplona.amethyst.commons.model.ThreadAssembler
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.LifecycleAwareKeyDataSourceSubscription
 import com.vitorpamplona.amethyst.model.Account
-import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -59,25 +57,20 @@ fun ThreadFilterAssemblerSubscription(
 /**
  * Eagerly pre-loads the whole thread of a reply that is visible in a feed.
  *
- * When a reply shows up in `NoteCompose`, this resolves the thread root and opens
- * the same root subscription the thread screen uses (a filter on the root's `e`/`a`
- * tag, covering NIP-10 and NIP-22 event/addressable roots), so tapping into the
- * conversation finds it already loaded. Keying on the resolved root id means every
- * visible reply that shares a root collapses onto a single subscription, and a note
- * that is itself a root (no parent) is skipped — nothing to pre-load.
+ * When a reply shows up in `NoteCompose`, this opens the same root subscription the
+ * thread screen uses: `ThreadFilterSubAssembler` resolves the thread root from this
+ * id and subscribes to the root's `e`/`a` tag (covering NIP-10 and NIP-22 event /
+ * addressable roots), so tapping into the conversation finds it already loaded.
+ *
+ * Only replies are pre-loaded — a root post (empty `replyTo`) has no ancestor thread
+ * to pull, and pure quotes are excluded because citations don't populate `replyTo`.
  */
 @Composable
 fun PreloadThreadForReply(
     note: Note,
     accountViewModel: AccountViewModel,
 ) {
-    val rootId =
-        remember(note) {
-            val root = ThreadAssembler(LocalCache).findRoot(note.idHex)
-            if (root != null && root != note) root.idHex else null
-        }
-
-    if (rootId != null) {
-        ThreadFilterAssemblerSubscription(rootId, accountViewModel)
+    if (note.replyTo?.isNotEmpty() == true) {
+        ThreadFilterAssemblerSubscription(note.idHex, accountViewModel)
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/datasources/ThreadFilterAssemblerSubscription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/datasources/ThreadFilterAssemblerSubscription.kt
@@ -22,8 +22,11 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.threadview.datasources
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import com.vitorpamplona.amethyst.commons.model.ThreadAssembler
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.LifecycleAwareKeyDataSourceSubscription
 import com.vitorpamplona.amethyst.model.Account
+import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 
@@ -51,4 +54,30 @@ fun ThreadFilterAssemblerSubscription(
         }
 
     LifecycleAwareKeyDataSourceSubscription(state, filterAssembler)
+}
+
+/**
+ * Eagerly pre-loads the whole thread of a reply that is visible in a feed.
+ *
+ * When a reply shows up in `NoteCompose`, this resolves the thread root and opens
+ * the same root subscription the thread screen uses (a filter on the root's `e`/`a`
+ * tag, covering NIP-10 and NIP-22 event/addressable roots), so tapping into the
+ * conversation finds it already loaded. Keying on the resolved root id means every
+ * visible reply that shares a root collapses onto a single subscription, and a note
+ * that is itself a root (no parent) is skipped — nothing to pre-load.
+ */
+@Composable
+fun PreloadThreadForReply(
+    note: Note,
+    accountViewModel: AccountViewModel,
+) {
+    val rootId =
+        remember(note) {
+            val root = ThreadAssembler(LocalCache).findRoot(note.idHex)
+            if (root != null && root != note) root.idHex else null
+        }
+
+    if (rootId != null) {
+        ThreadFilterAssemblerSubscription(rootId, accountViewModel)
+    }
 }


### PR DESCRIPTION
## Summary

Add thread preloading for replies visible in the feed. When a reply appears in `NoteCompose`, this opens the same root subscription that the thread screen uses, so tapping into the conversation finds the thread already loaded. Only replies are preloaded — root posts and pure quotes are excluded since they have no ancestor thread to pull.

## Changes

- **`ThreadFilterAssemblerSubscription.kt`**: Added `PreloadThreadForReply()` composable that conditionally triggers thread loading for notes with `replyTo` populated
- **`Text.kt`**: Call `PreloadThreadForReply()` in `RenderTextEvent()` when rendering replies, with a comment explaining the optimization

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes: This is a performance optimization that preloads thread context while a reply is on screen. Verify by:
1. Opening a feed with replies visible
2. Tapping into a reply's conversation — the thread should load faster since it was preloaded while the reply was visible in the feed
3. Confirm root posts and quotes don't trigger unnecessary subscriptions (no-op when `replyTo` is empty)

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

https://claude.ai/code/session_01LWk6sf7QWsPvW4rnTKp45p