### PR TITLE
fix(tor): set Active deterministically so the bootstrap callback can't race it

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorService.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/tor/TorService.kt
@@ -185,6 +185,11 @@ class TorService(
                 // setLogCallback and initialize are the first ArtiNative calls,
                 // which triggers System.loadLibrary on this IO thread.
                 if (initialized.compareAndSet(false, true)) {
+                    // Forward Arti's internal logs. The Active transition is NOT driven
+                    // from here: the "Sufficiently bootstrapped" line is emitted from a
+                    // tokio task that races startSocksProxy returning, so honoring it here
+                    // (gated on proxyRunning) intermittently dropped the transition. start()
+                    // now sets Active deterministically once the proxy is bound.
                     ArtiNative.setLogCallback { text ->
                         Log.d("TorService") {
                             val newLine = text.indexOf('\n')
@@ -192,21 +197,6 @@ class TorService(
                                 "Arti: ${text.substring(0, newLine)}"
                             } else {
                                 "Arti: $text"
-                            }
-                        }
-
-                        when {
-                            text.contains("Sufficiently bootstrapped", ignoreCase = true) -> {
-                                // Only honor the bootstrap signal while the proxy is
-                                // actually running. A reset/stop flips proxyRunning to
-                                // false; a late callback from a torn-down client must
-                                // not resurrect a stale Active status.
-                                if (proxyRunning.get()) {
-                                    _status.value = TorServiceStatus.Active(socksPort)
-                                    val startedAt = bootstrapStartedAtMs
-                                    val elapsed = if (startedAt > 0) System.currentTimeMillis() - startedAt else -1
-                                    Log.d("TorService") { "Arti SOCKS proxy active on port $socksPort (bootstrap took ${elapsed}ms)" }
-                                }
                             }
                         }
                     }
@@ -283,6 +273,22 @@ class TorService(
                 }
 
                 proxyRunning.set(true)
+
+                // Transition to Active deterministically here rather than relying on
+                // the "Sufficiently bootstrapped" log callback. That callback is emitted
+                // from a tokio task spawned inside the native startSocksProxy (see
+                // arti-android-wrapper lib.rs), which races the native call returning and
+                // this `proxyRunning.set(true)` above. When the task wins the race, the
+                // callback's `proxyRunning.get()` guard is still false, the Active
+                // transition is dropped, and status stays Connecting until the 60s
+                // connection-failure dialog fires. The client is bootstrapped (initialize
+                // returned 0) and the SOCKS proxy is bound, so this is the correct point
+                // to declare Active — and we hold lifecycleMutex, so a concurrent
+                // reset/stop can't clobber it.
+                val startedAt = bootstrapStartedAtMs
+                val elapsed = if (startedAt > 0) System.currentTimeMillis() - startedAt else -1
+                _status.value = TorServiceStatus.Active(socksPort)
+                Log.d("TorService") { "Arti SOCKS proxy active on port $socksPort (bootstrap took ${elapsed}ms)" }
             }
         }
 


### PR DESCRIPTION
## Problem

On internal Tor, the app intermittently showed the 60s **\"can't connect to Tor\"** screen even though Arti had bootstrapped fine and the SOCKS proxy was bound. The downstream symptom was a flood of `ECONNREFUSED` on `127.0.0.1:9050` — but that's only because, while status never reached `Active`, `proxyPortProvider = torManager.activePortOrNull` is null and the relay OkHttp client falls back to `DEFAULT_SOCKS_PORT = 9050` (the external/Orbot port), which nothing is listening on. Guards were healthy (20/20 usable), so this is **not** the older poisoned-guards bug.

## Root cause — a race

`TorService.start()` drove the `Connecting → Active` transition off Arti's `"Sufficiently bootstrapped"` log line, gated on `proxyRunning.get()`. That line is emitted from a tokio task spawned **inside** the native `startSocksProxy` (`arti-android-wrapper/lib.rs:282`), which races the native call returning to Kotlin and `start()` setting `proxyRunning = true`. Two orderings observed in one session:

- **Worked:** `SOCKS proxy started` logged before `Sufficiently bootstrapped` → guard true → `Active` set.
- **Failed:** `Sufficiently bootstrapped` logged first → guard false → transition silently dropped → stuck `Connecting` → 60s failure screen.

The `proxyRunning` guard was added in bdfc56cf23 (prevent a torn-down client resurrecting stale `Active`); it introduced this happy-path race.

## Fix

Set `_status.value = Active(socksPort)` deterministically in `start()` right after the proxy binds and `proxyRunning` is set — under the `lifecycleMutex` that `start()` already holds, so a concurrent reset/stop can't clobber it. The client is bootstrapped (`initialize()` returned 0) and the SOCKS proxy is bound, so this is the correct readiness point. The log callback is reduced to plain log forwarding now that it no longer drives status.

## Verification (emulator-5554, installed debug build)

- `Arti SOCKS proxy active on port 17392` now logged from `start()` **before** the `Sufficiently bootstrapped` callback — transition no longer depends on it.
- **Zero** `ECONNREFUSED` on the `9050` fallback after relaunch (vs. a continuous flood before).
- Relays connecting through Tor: multiple `OnOpen` successes (`relay.dergigi.com`, `haven.dergigi.com`, `filter.nostr.wine`, …).

## Out of scope

Same device still shows unrelated flaky-network behavior (`onTorCircuitsDead` self-heals, occasional native bootstrap timeouts) — that's the emulator's degraded network, a separate layer from this race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)