### PR TITLE
Hide Android system bars in immersive scroll and full-screen media

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentDialog.kt
@@ -53,6 +53,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
@@ -71,10 +72,13 @@ import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.util.lerp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.core.net.toUri
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
@@ -204,6 +208,19 @@ fun ZoomableImageDialog(
             attributes.flags = attributes.flags and WindowManager.LayoutParams.FLAG_DIM_BEHIND.inv()
             attributes.screenBrightness = currentBrightness
             dialogWindow.attributes = attributes
+        }
+
+        // Go fully immersive while the full-screen media viewer is open: hide both OS bars and
+        // restore them when the dialog closes. BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE lets the user
+        // swipe to peek the bars. Applies to full-screen images and video alike (shared dialog).
+        val dialogView = LocalView.current
+        DisposableEffect(dialogWindow, dialogView) {
+            val controller = dialogWindow?.let { WindowInsetsControllerCompat(it, dialogView) }
+            controller?.apply {
+                systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+                hide(WindowInsetsCompat.Type.systemBars())
+            }
+            onDispose { controller?.show(WindowInsetsCompat.Type.systemBars()) }
         }
 
         Box(modifier = Modifier.fillMaxSize()) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/DisappearingScaffold.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/DisappearingScaffold.kt
@@ -34,22 +34,30 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.vitorpamplona.amethyst.ui.components.getActivityWindow
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.theme.DividerThickness
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
+import kotlin.math.max
 
 private enum class DisappearingSlot { Top, Bottom, Content, Fab }
 
@@ -87,8 +95,11 @@ fun DisappearingScaffold(
             )
         }
 
-    // Only wire the lifecycle observer when the scaffold actually moves its bars.
-    if (allowBarHide) ResetBarsOnResume(state)
+    // Only wire the lifecycle observer + system-bar control when the scaffold actually moves its bars.
+    if (allowBarHide) {
+        ResetBarsOnResume(state)
+        ImmersiveStatusBarEffect(state)
+    }
 
     // When bars are pinned, skip attaching the nested-scroll connection entirely.
     // The outer Surface provides the Material container color + onBackground as
@@ -253,5 +264,45 @@ private fun ResetBarsOnResume(state: DisappearingBarState) {
             }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+}
+
+/** Fraction at which the in-app bars are considered fully settled into the hidden edge. */
+private const val STATUS_BAR_HIDE_THRESHOLD = 0.999f
+
+/**
+ * Hides the OS status bar once the in-app bars have settled into the hidden edge, and shows it the
+ * moment they start coming back. The OS status bar is binary (cannot slide), so it is driven off the
+ * collapse fraction with a near-1 threshold, which means it toggles on settle rather than mid-drag.
+ *
+ * Only the top status bar is touched; the bottom OS navigation bar is left alone.
+ * BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE lets the user swipe to peek the status bar while immersed.
+ * The status bar is always restored on dispose so leaving an immersive screen can never strand a
+ * hidden bar.
+ */
+@Composable
+private fun ImmersiveStatusBarEffect(state: DisappearingBarState) {
+    val view = LocalView.current
+    if (view.isInEditMode) return
+    val window = getActivityWindow() ?: return
+    val controller = remember(window, view) { WindowInsetsControllerCompat(window, view) }
+
+    LaunchedEffect(controller, state) {
+        snapshotFlow {
+            max(state.topCollapsedFraction, state.bottomCollapsedFraction) >= STATUS_BAR_HIDE_THRESHOLD
+        }.distinctUntilChanged()
+            .collect { shouldHide ->
+                controller.systemBarsBehavior =
+                    WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+                if (shouldHide) {
+                    controller.hide(WindowInsetsCompat.Type.statusBars())
+                } else {
+                    controller.show(WindowInsetsCompat.Type.statusBars())
+                }
+            }
+    }
+
+    DisposableEffect(controller) {
+        onDispose { controller.show(WindowInsetsCompat.Type.statusBars()) }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/DisappearingScaffold.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/DisappearingScaffold.kt
@@ -57,7 +57,6 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.theme.DividerThickness
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
-import kotlin.math.max
 
 private enum class DisappearingSlot { Top, Bottom, Content, Fab }
 
@@ -267,13 +266,20 @@ private fun ResetBarsOnResume(state: DisappearingBarState) {
     }
 }
 
-/** Fraction at which the in-app bars are considered fully settled into the hidden edge. */
+/** Fraction at which the tracked in-app bar is considered fully settled into the hidden edge. */
 private const val STATUS_BAR_HIDE_THRESHOLD = 0.999f
 
 /**
- * Hides the OS status bar once the in-app bars have settled into the hidden edge, and shows it the
- * moment they start coming back. The OS status bar is binary (cannot slide), so it is driven off the
- * collapse fraction with a near-1 threshold, which means it toggles on settle rather than mid-drag.
+ * Hides the OS status bar once the tracked in-app bar has settled into the hidden edge, and shows it
+ * the moment it starts coming back. The OS status bar is binary (cannot slide), so it is driven off
+ * the collapse fraction with a near-1 threshold, which means it toggles on settle rather than
+ * mid-drag.
+ *
+ * The status bar sits with the top in-app bar, so it tracks the top bar's collapse. The top and
+ * bottom bars can collapse at different rates (each clamps to its own height), so tracking the top
+ * fraction keeps the status bar in step with the chrome directly beneath it. On screens with no top
+ * bar (topHeightLimit == 0) it falls back to the bottom bar, so the status bar still hides in sync
+ * with the bottom navigation.
  *
  * Only the top status bar is touched; the bottom OS navigation bar is left alone.
  * BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE lets the user swipe to peek the status bar while immersed.
@@ -288,12 +294,13 @@ private fun ImmersiveStatusBarEffect(state: DisappearingBarState) {
     val controller = remember(window, view) { WindowInsetsControllerCompat(window, view) }
 
     LaunchedEffect(controller, state) {
+        controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
         snapshotFlow {
-            max(state.topCollapsedFraction, state.bottomCollapsedFraction) >= STATUS_BAR_HIDE_THRESHOLD
+            val fraction =
+                if (state.topHeightLimit > 0f) state.topCollapsedFraction else state.bottomCollapsedFraction
+            fraction >= STATUS_BAR_HIDE_THRESHOLD
         }.distinctUntilChanged()
             .collect { shouldHide ->
-                controller.systemBarsBehavior =
-                    WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
                 if (shouldHide) {
                     controller.hide(WindowInsetsCompat.Type.statusBars())
                 } else {


### PR DESCRIPTION
Not sure why we never hid android system bar when watching full screen video, it always annoyed me 😆 Also hide system bar when immersive scrolling is on in UI preferences (I've left the navigation bar when scrolling, happy to remove if it's better UX).

## What
  
  Two places where the Android OS system bars used to stay painted now go immersive:
  
  1. **Scroll immersive mode** — when the in-app top/bottom chrome slides away on scroll, the OS **status bar** now hides too, and reappears the moment the chrome comes back. Only the top status bar is touched; the bottom OS
  navigation bar is left alone so gesture nav is unaffected.
  2. **Full-screen media** — opening the full-screen image/video viewer now hides **both** OS bars for the duration, with swipe-to-reveal, restoring them on close.
  
  ## Why
  
  The app is edge-to-edge, so the OS bars are drawn permanently over content. During immersive scroll the status bar lingered over the feed, and full-screen video/images played underneath a visible status + navigation bar.
  Neither was ever programmatically hidden — there has never been a `WindowInsetsControllerCompat.hide(...)`, `SYSTEM_UI_FLAG_*`, Accompanist `SystemUiController`, or `FLAG_FULLSCREEN` anywhere in the app's history — so this adds that behavior for the first time rather than restoring it. 
  
  ## How
  
  `DisappearingScaffold` gains a small `ImmersiveStatusBarEffect` that drives the activity window's status-bar visibility from the bar collapse fraction via `WindowInsetsControllerCompat`. It is gated on the existing
  `allowBarHide` path, so it is naturally governed by the current "automatically hide navigation bars" setting (the bars only collapse when immersive scrolling is active).
  
  The status bar is binary (it cannot slide), so it toggles on settle: it hides only once the tracked in-app bar reaches the fully-collapsed edge. It tracks the **top** bar's collapse fraction — the top and bottom bars clamp
  to their own heights and so collapse at different rates, and keying off the top keeps the status bar in step with the chrome directly beneath it. On screens with no top bar it falls back to the bottom bar so the status bar
  still hides in sync with the bottom navigation. The bar is always restored on dispose, so leaving an immersive screen can never strand a hidden bar. 
  
  `ZoomableContentDialog` (the shared full-screen media dialog) gains a `DisposableEffect` on its own dialog window that hides both system bars with `BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE` and restores them when the dialog
  closes.
  
  No new dependencies, no new settings, and no changes to the platform-neutral scroll-math classes (`DisappearingBarState` / `DisappearingBarNestedScroll`).
  
  ## Testing
  
  Verified on a Pixel 9a (Android 16, `playBenchmark` build):
  
  - Scroll a feed down → status bar hides once the chrome settles; scroll up → it returns together. With "automatically hide navigation bars" off, the status bar stays visible while scrolling.
  - Full-screen a video and an image → both OS bars hide, an edge swipe peeks them transiently, exit restores them.
  - Background/foreground while immersed → status bar restored; navigating away never leaves a hidden bar.


## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
