### PR TITLE
Support measurement system detection on Android API <28

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/workouts/MeasurementSystem.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/workouts/MeasurementSystem.kt
@@ -22,7 +22,11 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.workouts
 
 import android.icu.util.LocaleData
 import android.icu.util.ULocale
+import android.os.Build
 import java.util.Locale
+
+/** Countries that use miles for road distance (imperial / US customary). */
+private val MILES_COUNTRIES = setOf("US", "GB", "LR", "MM")
 
 /**
  * Whether the phone's measurement preference favours miles for distance.
@@ -31,7 +35,8 @@ import java.util.Locale
  * which the platform surfaces through the default locale's Unicode `-u-ms-`
  * extension (`metric` / `ussystem` / `uksystem`). When no explicit override is
  * set it falls back to ICU's locale-derived measurement system (US and UK both
- * use miles for distance), available since API 24.
+ * use miles for distance), available since API 28; on older releases it falls
+ * back to a country-code check.
  */
 fun phonePrefersMiles(): Boolean {
     val locale = Locale.getDefault(Locale.Category.FORMAT)
@@ -40,8 +45,12 @@ fun phonePrefersMiles(): Boolean {
         return ms == "ussystem" || ms == "uksystem"
     }
 
-    return when (LocaleData.getMeasurementSystem(ULocale.forLocale(locale))) {
-        LocaleData.MeasurementSystem.US, LocaleData.MeasurementSystem.UK -> true
-        else -> false
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        when (LocaleData.getMeasurementSystem(ULocale.forLocale(locale))) {
+            LocaleData.MeasurementSystem.US, LocaleData.MeasurementSystem.UK -> true
+            else -> false
+        }
+    } else {
+        locale.country.uppercase(Locale.ROOT) in MILES_COUNTRIES
     }
 }


### PR DESCRIPTION
## Summary

Add fallback support for detecting miles preference on Android versions before API 28, which lack `LocaleData.getMeasurementSystem()`. The function now checks the Android version and falls back to a country-code lookup for older devices, ensuring consistent behavior across all supported API levels.

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes:
The change is a straightforward API-level guard with a fallback country-code check. Existing unit tests for `phonePrefersMiles()` should continue to pass. Manual verification on devices/emulators running API <28 would confirm the fallback path fires correctly, though this is a low-risk change (simple conditional + set membership lookup).

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

https://claude.ai/code/session_01JDcx7i1VDRyT7rDcuSB5Co