### PR TITLE
docs: add Zapstore metadata and publishing relay guidance

### DIFF
--- a/RELEASE_OPS.md
+++ b/RELEASE_OPS.md
@@ -122,9 +122,10 @@ few days): <https://f-droid.org/packages/com.vitorpamplona.amethyst/>.
 ### Zapstore — `zsp publish` with Amethyst's nsec
 [Zapstore](https://zapstore.dev/) is a Nostr-native app store. The `zsp` CLI
 reads [`zapstore.yaml`](zapstore.yaml) at the repo root (name, summary,
-description, tags, license, screenshots, and the `variants` regexes that match
-our `*-fdroid-*.apk` / `*-googleplay-*.apk` GH-release assets), then publishes a
-signed software-release event to Nostr relays.
+description, tags, license, `icon`, screenshots, `supported_nips`, and the
+`variants` regexes that match our `*-fdroid-*.apk` / `*-googleplay-*.apk`
+GH-release assets), then publishes a signed software-release event to Nostr
+relays.
 
 ```bash
 # from the repo root, after the GH Release assets exist
@@ -132,7 +133,20 @@ zsp publish
 ```
 
 It signs with **Amethyst's nsec** — provide the key the way `zsp` expects
-(env var / prompt / its own config), never commit it.
+(`SIGN_WITH` env var / prompt / its own config), never commit it.
+
+**Relays.** `zsp` does *not* take relays from `zapstore.yaml`; it reads the
+`RELAY_URLS` env var (comma-separated) and defaults to `wss://relay.zapstore.dev`
+when unset. To fan the release event out to more relays for discoverability,
+set `RELAY_URLS` for the run:
+
+```bash
+RELAY_URLS="wss://relay.zapstore.dev,wss://relay.damus.io,wss://nos.lol,wss://relay.nostr.band" \
+  SIGN_WITH=<amethyst-nsec> zsp publish
+```
+
+Keep `wss://relay.zapstore.dev` in the list — that is the relay the Zapstore app
+itself reads from.
 
 ### Homebrew + Winget — automatic
 `bump-homebrew.yml` and `bump-winget.yml` fire on stable tags and open PRs

--- a/RELEASE_OPS.md
+++ b/RELEASE_OPS.md
@@ -141,7 +141,7 @@ when unset. To fan the release event out to more relays for discoverability,
 set `RELAY_URLS` for the run:
 
 ```bash
-RELAY_URLS="wss://relay.zapstore.dev,wss://relay.damus.io,wss://nos.lol,wss://relay.nostr.band" \
+RELAY_URLS="wss://relay.zapstore.dev,wss://relay.damus.io,wss://nos.lol,wss://vitor.nostr1.com" \
   SIGN_WITH=<amethyst-nsec> zsp publish
 ```
 

--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -34,12 +34,107 @@ website: https://amethyst.social/
 # ═══════════════════════════════════════════════════════════════════
 # MEDIA
 # ═══════════════════════════════════════════════════════════════════
+
+# App icon (local path or URL). 512x512 Play Store launcher icon.
+icon: ./amethyst/src/main/ic_launcher-playstore.png
+
 # Screenshots (local paths or URLs)
 images:
   - ./docs/screenshots/home.png
   - ./docs/screenshots/messages.png
   - ./docs/screenshots/notifications.png
   - ./docs/screenshots/replies.png
+
+# ═══════════════════════════════════════════════════════════════════
+# NOSTR METADATA
+# ═══════════════════════════════════════════════════════════════════
+
+# NIPs implemented by the app (shown on the Zapstore listing). Kept in sync
+# with the "Supported NIPs" checklist in README.md (only the checked items).
+supported_nips:
+  - "01" # Basic protocol flow
+  - "02" # Follow List
+  - "03" # OpenTimestamps Attestations
+  - "04" # Encrypted Direct Message
+  - "05" # DNS-based Identifiers
+  - "06" # Key Derivation from Mnemonic
+  - "08" # Handling Mentions
+  - "09" # Event Deletion Request
+  - "10" # Text Notes and Threads
+  - "11" # Relay Information Document
+  - "13" # Proof of Work
+  - "14" # Subject Tag in Text Events
+  - "15" # Nostr Marketplace
+  - "17" # Private Direct Messages
+  - "18" # Reposts
+  - "19" # bech32-encoded Entities
+  - "21" # nostr: URI Scheme
+  - "22" # Comment
+  - "23" # Long-form Content
+  - "24" # Extra Metadata Fields and Tags
+  - "25" # Reactions
+  - "26" # Delegated Event Signing
+  - "27" # Text Note References
+  - "28" # Public Chat
+  - "29" # Relay-based Groups
+  - "30" # Custom Emoji
+  - "31" # Dealing with Unknown Events
+  - "32" # Labeling
+  - "34" # git stuff
+  - "35" # Torrents
+  - "36" # Sensitive Content
+  - "37" # Draft Events
+  - "38" # User Statuses
+  - "39" # External Identities in Profiles
+  - "40" # Expiration Timestamp
+  - "42" # Authentication of Clients to Relays
+  - "43" # Relay Access Metadata and Requests
+  - "44" # Encrypted Payloads / Versioned
+  - "45" # Counting Results
+  - "46" # Nostr Remote Signing
+  - "47" # Nostr Wallet Connect
+  - "48" # Proxy Tags
+  - "49" # Private Key Encryption
+  - "50" # Search Capability
+  - "51" # Lists
+  - "52" # Calendar Events
+  - "53" # Live Activities
+  - "54" # Wiki
+  - "55" # Android Signer Application
+  - "56" # Reporting
+  - "57" # Lightning Zaps
+  - "58" # Badges
+  - "59" # Gift Wrap
+  - "5A" # Pubkey Static Websites
+  - "60" # Cashu Wallet
+  - "61" # Nutzaps
+  - "62" # Request to Vanish
+  - "64" # Chess / PGN
+  - "65" # Relay List Metadata
+  - "66" # Relay Discovery and Liveness Monitoring
+  - "68" # Picture-first Feeds
+  - "69" # Peer-to-peer Order Events
+  - "70" # Protected Events
+  - "71" # Video Events
+  - "72" # Moderated Communities
+  - "73" # External Content IDs
+  - "75" # Zap Goals
+  - "77" # Negentropy Syncing
+  - "78" # Application-specific Data
+  - "7D" # Threads
+  - "84" # Highlights
+  - "85" # Trusted Assertions
+  - "86" # Relay Management API
+  - "87" # Ecash Mint Discoverability
+  - "88" # Polls
+  - "89" # Recommended Application Handlers
+  - "90" # Data Vending Machines
+  - "92" # Media Attachments
+  - "94" # File Metadata
+  - "95" # Binary Blobs (Draft)
+  - "96" # HTTP File Storage Integration
+  - "98" # HTTP Auth
+  - "99" # Classified Listings
 
 # ═══════════════════════════════════════════════════════════════════
 # VARIANTS
@@ -49,3 +144,16 @@ images:
 variants:
   fdroid: ".*-fdroid-.*\\.apk$"
   google: ".*-googleplay-.*\\.apk$"
+
+# ═══════════════════════════════════════════════════════════════════
+# PUBLISHING RELAYS
+# ═══════════════════════════════════════════════════════════════════
+# Relays are NOT configured in this file. `zsp` reads them from the
+# RELAY_URLS environment variable (comma-separated) and falls back to
+# wss://relay.zapstore.dev when it is unset. To publish the release event
+# to additional relays, set RELAY_URLS before running `zsp publish`, e.g.:
+#
+#   RELAY_URLS="wss://relay.zapstore.dev,wss://relay.damus.io,wss://nos.lol" \
+#     SIGN_WITH=<amethyst-nsec> zsp publish
+#
+# See RELEASE_OPS.md for the maintainer publishing checklist.


### PR DESCRIPTION
## Summary

Updated `zapstore.yaml` to include the app icon and a comprehensive list of supported NIPs (Nostr Improvement Proposals) that Amethyst implements. Added documentation in `RELEASE_OPS.md` clarifying how `zsp publish` reads relay configuration from the `RELAY_URLS` environment variable rather than the config file, with examples of fanning out release events to multiple relays for better discoverability.

## Test plan

- [ ] N/A — documentation and configuration metadata only; no code changes

The changes are purely informational:
- `zapstore.yaml` additions are read by the `zsp` CLI tool (external to this repo)
- `RELEASE_OPS.md` updates document existing behavior and best practices for the maintainer publishing workflow

No testing needed beyond verifying the YAML is syntactically valid (which `zsp` will catch on next publish).

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01VK27apdHs4Yzxa54qx44oJ