### PR TITLE
fix(cashu): NUT-02 per-keyset input fees in melt/swap (fixes coinos send-LN)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip60Cashu/CashuWalletOps.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip60Cashu/CashuWalletOps.kt
@@ -409,15 +409,22 @@ class CashuWalletOps(
 
         val ops = ops(mintUrl)
         val required = quote.amount + quote.feeReserve
+        // The melt mints its inputs on the active keyset (via the swap-down
+        // below) and the mint then charges a NUT-02 input fee on them on top
+        // of amount + fee_reserve. Reserve it up front so neither proof
+        // selection nor the swap-down leaves the melt short — otherwise
+        // meltProofs throws "Inputs total X < required Y" the moment the
+        // active keyset charges a per-input fee (e.g. mint.coinos.io).
+        val target = required + ops.activeKeysetInputFeeFor(required)
 
-        val (selected, _) = selectProofsCovering(available, required)
+        val (selected, _) = selectProofsCovering(available, target)
         val spendingProofs = selected.flatMap { it.content.proofs }
         val total = spendingProofs.sumOf { it.amount }
 
-        // If the selected proofs overshoot, swap them down to (required) first.
-        val (inputs, prePaidChangeEvent) =
-            if (total > required) {
-                val swap = ops.swap(spendingProofs, targetSplit = required)
+        // If the selected proofs overshoot, swap them down to (target) first.
+        val (inputs, prePaidChangeEvent, prePaidChangeAmount) =
+            if (total > target) {
+                val swap = ops.swap(spendingProofs, targetSplit = target)
                 // The keep-side from the pre-swap is the "extra change" we
                 // didn't burn into the melt — publish it now so a crashed
                 // melt doesn't lose those proofs.
@@ -431,9 +438,9 @@ class CashuWalletOps(
                     } else {
                         null
                     }
-                swap.send to keepEvent
+                Triple(swap.send, keepEvent, swap.keep.sumOf { it.amount })
             } else {
-                spendingProofs to null
+                Triple(spendingProofs, null, 0L)
             }
 
         val meltResult = ops.meltProofs(quote, inputs)
@@ -485,7 +492,11 @@ class CashuWalletOps(
         return MeltCompleted(
             preimage = meltResult.preimage,
             paidAmount = quote.amount,
-            fees = total - meltResult.changeProofs.sumOf { it.amount } - quote.amount,
+            // Fee = proofs we spent − change we got back (both the pre-paid
+            // swap keep and the melt's own change) − the invoice amount. The
+            // pre-paid keep was split off before the melt and never burned,
+            // so it must not be counted as a fee.
+            fees = total - prePaidChangeAmount - meltResult.changeProofs.sumOf { it.amount } - quote.amount,
             historyEvent = historyEvent,
             deleteEvent = deleteEvent,
             newTokenEvent = finalChangeEvent,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/cashu/melt/MeltProcessor.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/cashu/melt/MeltProcessor.kt
@@ -21,22 +21,30 @@
 package com.vitorpamplona.amethyst.service.cashu.melt
 
 import android.content.Context
-import com.fasterxml.jackson.databind.node.JsonNodeFactory
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.model.nip60Cashu.CashuToken
 import com.vitorpamplona.amethyst.service.lnurl.LightningAddressResolver
 import com.vitorpamplona.amethyst.ui.stringRes
-import com.vitorpamplona.quartz.utils.asTextOrNull
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import okhttp3.MediaType.Companion.toMediaType
+import com.vitorpamplona.quartz.nip60Cashu.mintApi.CashuMintOperations
+import com.vitorpamplona.quartz.nip60Cashu.mintApi.MintHttpClient
+import com.vitorpamplona.quartz.nip60Cashu.token.CashuProof
 import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.coroutines.executeAsync
 import kotlin.coroutines.cancellation.CancellationException
 
+/**
+ * Redeems an externally-received cashu token straight to a Lightning address
+ * via NUT-05 melt (`POST /v1/melt/quote/bolt11` + `POST /v1/melt/bolt11`).
+ *
+ * This is the "Redeem" button on a received cashu token preview — distinct
+ * from the NIP-60 wallet's own send-LN flow ([com.vitorpamplona.amethyst.model.nip60Cashu.CashuWalletOps.meltToLightning]),
+ * which spends the user's stored proofs and rolls change back into the wallet.
+ * Here there is no wallet: the proofs come straight off the pasted token and
+ * any leftover stays with the mint.
+ *
+ * Migrated off the deprecated pre-v1 `/melt` + `/checkfees` endpoints (gone on
+ * CDK and other modern mints) onto the same NUT-05 client the wallet uses, so
+ * it also picks up NUT-02 per-input fee handling for free.
+ */
 class MeltProcessor {
     suspend fun melt(
         token: CashuToken,
@@ -44,187 +52,66 @@ class MeltProcessor {
         okHttpClient: (String) -> OkHttpClient,
         context: Context,
     ): MeltResult {
-        val baseInvoice =
-            LightningAddressResolver().lnAddressInvoice(
-                lnAddress = lud16,
-                // Make invoice and leave room for fees
-                milliSats = token.totalAmount * 1000,
-                message = "Calculate Fees for Cashu",
-                okHttpClient = okHttpClient,
-                onProgress = {},
-                context = context,
-            )
-
-        val fees =
-            feeCalculator(
-                mintAddress = token.mint,
-                invoice = baseInvoice,
-                okHttpClient = okHttpClient,
-                context = context,
-            )
-
-        val invoice =
-            LightningAddressResolver().lnAddressInvoice(
-                lnAddress = lud16,
-                // Make invoice and leave room for fees
-                milliSats = (token.totalAmount - fees) * 1000,
-                message = "Redeem Cashu",
-                okHttpClient = okHttpClient,
-                onProgress = {},
-                context = context,
-            )
-
-        meltInvoice(token, invoice, okHttpClient, context)
-
-        return MeltResult(
-            token = token,
-            invoice = invoice,
-            fees = fees,
-        )
-    }
-
-    fun melt(
-        token: CashuToken,
-        lud16: String,
-        okHttpClient: (String) -> OkHttpClient,
-        onSuccess: (String, String) -> Unit,
-        onError: (String, String) -> Unit,
-        context: Context,
-    ) {
-        // TODO: Implement Cashu token melting via Lightning invoice
-    }
-
-    suspend fun feeCalculator(
-        mintAddress: String,
-        invoice: String,
-        okHttpClient: (String) -> OkHttpClient,
-        context: Context,
-    ): Int =
         try {
-            val url = "$mintAddress/checkfees" // Melt cashu tokens at Mint
-            val client = okHttpClient(url)
-
-            val factory = JsonNodeFactory.instance
-
-            val jsonObject = factory.objectNode()
-            jsonObject.put("pr", invoice)
-
-            val mediaType = "application/json; charset=utf-8".toMediaType()
-            val requestBody = jsonObject.toString().toRequestBody(mediaType)
-            val request =
-                Request
-                    .Builder()
-                    .url(url)
-                    .post(requestBody)
-                    .build()
-
-            client.newCall(request).executeAsync().use { response ->
-                withContext(Dispatchers.IO) {
-                    val body = response.body.string()
-                    val tree = jacksonObjectMapper().readTree(body)
-
-                    val feeCost = tree?.get("fee")?.asInt()
-
-                    if (feeCost == null) {
-                        val msg =
-                            tree
-                                ?.get("detail")
-                                ?.asTextOrNull()
-                                ?.split('.')
-                                ?.getOrNull(0)
-                                ?.ifBlank { null }
-
-                        throw LightningAddressResolver.LightningAddressError(
-                            stringRes(context, R.string.cashu_failed_redemption),
-                            if (msg != null) {
-                                stringRes(context, R.string.cashu_failed_redemption_explainer_error_msg, msg)
-                            } else {
-                                stringRes(context, R.string.cashu_failed_redemption_explainer_error_msg)
-                            },
-                        )
-                    }
-
-                    feeCost
+            val ops = CashuMintOperations(MintHttpClient(token.mint, okHttpClient))
+            val proofs =
+                token.proofs.map {
+                    CashuProof(id = it.id, amount = it.amount.toLong(), secret = it.secret, c = it.C)
                 }
+
+            // A Lightning address must commit to an amount before we know the
+            // fees, so probe with an invoice for the full token value to learn
+            // the LN fee_reserve, then add the NUT-02 input fee the mint
+            // charges on these proofs.
+            val probeInvoice =
+                LightningAddressResolver().lnAddressInvoice(
+                    lnAddress = lud16,
+                    milliSats = token.totalAmount * 1000,
+                    message = "Calculate Fees for Cashu",
+                    okHttpClient = okHttpClient,
+                    onProgress = {},
+                    context = context,
+                )
+            val probeQuote = ops.requestMeltQuote(probeInvoice)
+            val fees = probeQuote.feeReserve + ops.inputFeeFor(proofs)
+
+            val sendable = token.totalAmount - fees
+            if (sendable <= 0) {
+                throw LightningAddressResolver.LightningAddressError(
+                    stringRes(context, R.string.cashu_failed_redemption),
+                    stringRes(
+                        context,
+                        R.string.cashu_failed_redemption_explainer_error_msg,
+                        "Token value ${token.totalAmount} does not cover fees $fees",
+                    ),
+                )
             }
+
+            // Real invoice for (total − fees), quote it, then melt without
+            // requesting change — there is no wallet to hold leftover proofs,
+            // so the unused fee_reserve stays with the mint.
+            val invoice =
+                LightningAddressResolver().lnAddressInvoice(
+                    lnAddress = lud16,
+                    milliSats = sendable * 1000,
+                    message = "Redeem Cashu",
+                    okHttpClient = okHttpClient,
+                    onProgress = {},
+                    context = context,
+                )
+            val quote = ops.requestMeltQuote(invoice)
+            ops.meltProofs(quote, proofs, requestChange = false)
+
+            return MeltResult(
+                token = token,
+                invoice = invoice,
+                fees = fees.toInt(),
+            )
         } catch (e: Exception) {
             if (e is CancellationException) throw e
+            if (e is LightningAddressResolver.LightningAddressError) throw e
             throw LightningAddressResolver.LightningAddressError(
                 stringRes(context, R.string.cashu_failed_redemption),
-                stringRes(context, R.string.cashu_failed_redemption_explainer_error_msg, e.message),
-            )
-        }
-
-    private suspend fun meltInvoice(
-        token: CashuToken,
-        invoice: String,
-        okHttpClient: (String) -> OkHttpClient,
-        context: Context,
-    ) {
-        try {
-            val url = token.mint + "/melt" // Melt cashu tokens at Mint
-            val client = okHttpClient(url)
-
-            val factory = JsonNodeFactory.instance
-
-            val jsonObject = factory.objectNode()
-
-            jsonObject.replace(
-                "proofs",
-                factory.arrayNode(token.proofs.size).apply {
-                    token.proofs.forEach {
-                        addObject().apply {
-                            put("amount", it.amount)
-                            put("id", it.id)
-                            put("secret", it.secret)
-                            put("C", it.C)
-                        }
-                    }
-                },
-            )
-
-            jsonObject.put("pr", invoice)
-
-            val mediaType = "application/json; charset=utf-8".toMediaType()
-            val requestBody = jsonObject.toString().toRequestBody(mediaType)
-            val request =
-                Request
-                    .Builder()
-                    .url(url)
-                    .post(requestBody)
-                    .build()
-
-            client.newCall(request).executeAsync().use { response ->
-                withContext(Dispatchers.IO) {
-                    val body = response.body.string()
-                    val tree = jacksonObjectMapper().readTree(body)
-
-                    val successful = tree?.get("paid")?.asText() == "true"
-
-                    if (!successful) {
-                        val msg =
-                            tree
-                                ?.get("detail")
-                                ?.asTextOrNull()
-                                ?.split('.')
-                                ?.getOrNull(0)
-                                ?.ifBlank { null }
-
-                        throw LightningAddressResolver.LightningAddressError(
-                            stringRes(context, R.string.cashu_failed_redemption),
-                            if (msg != null) {
-                                stringRes(context, R.string.cashu_failed_redemption_explainer_error_msg, msg)
-                            } else {
-                                stringRes(context, R.string.cashu_failed_redemption_explainer_error_msg)
-                            },
-                        )
-                    }
-                }
-            }
-        } catch (e: Exception) {
-            if (e is CancellationException) throw e
-            throw LightningAddressResolver.LightningAddressError(
-                stringRes(context, R.string.cashu_successful_redemption),
                 stringRes(context, R.string.cashu_failed_redemption_explainer_error_msg, e.message),
             )
         }

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip60Cashu/mintApi/CashuMintOperations.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip60Cashu/mintApi/CashuMintOperations.kt
@@ -301,6 +301,14 @@ class CashuMintOperations(
     }
 
     /**
+     * NUT-02 input fee the mint would charge to spend [proofs], priced per
+     * each proof's own keyset (active or inactive). Lets a caller size an LN
+     * invoice / target amount so the subsequent [meltProofs] or [swap] isn't
+     * left short by the fee.
+     */
+    suspend fun inputFeeFor(proofs: List<CashuProof>): Long = computeInputFee(proofs, fetchInputFeePpkByKeyset())
+
+    /**
      * Pay the bolt11 invoice. Spends [inputs], which must total at least
      * `quote.amount + quote.fee_reserve`. Any change is returned blinded so the
      * mint signs unused fee proofs that the wallet can later spend.
@@ -308,6 +316,15 @@ class CashuMintOperations(
     suspend fun meltProofs(
         quote: MeltQuoteBolt11ResponseDto,
         inputs: List<CashuProof>,
+        /**
+         * NUT-08: whether to send blinded change outputs so the mint can
+         * return the unused portion of the fee_reserve as fresh proofs.
+         * The NIP-60 wallet keeps this on (default) and rolls the change
+         * into a new kind:7375. A one-shot redemption with nowhere to store
+         * proofs (e.g. melting a received token straight to a Lightning
+         * address) sets it false and lets the mint keep the unused reserve.
+         */
+        requestChange: Boolean = true,
     ): MeltResult {
         val total = inputs.sumOf { it.amount }
         val keyset = fetchKeyset()
@@ -326,7 +343,7 @@ class CashuMintOperations(
         // excludes the (already-paid) NUT-02 input fee.
         val changeAmount = total - quote.amount - inputFee
         val changeOutputs =
-            if (changeAmount > 0) secretOutputsFor(splitAmounts(changeAmount), keyset) else emptyList()
+            if (requestChange && changeAmount > 0) secretOutputsFor(splitAmounts(changeAmount), keyset) else emptyList()
 
         val response =
             client.meltBolt11(

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip60Cashu/mintApi/CashuMintOperations.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip60Cashu/mintApi/CashuMintOperations.kt
@@ -139,9 +139,15 @@ class CashuMintOperations(
 
         val keyset = fetchKeyset()
 
-        // NUT-02: reserve per-input fees from the output total. Without
-        // this, fee-charging mints reject the swap with "amount mismatch".
-        val feeAtoms = computeInputFee(proofs.size, keyset.inputFeePpk)
+        // NUT-02: reserve per-input fees from the output total. Fees are
+        // charged per the keyset of EACH input proof — which may be an
+        // inactive, rotated-out keyset whose fee differs from the active
+        // output keyset — so price them from /v1/keysets, not from
+        // `keyset.inputFeePpk`. Without this, a wallet holding proofs on a
+        // 0-fee keyset against a mint whose active keyset charges a fee
+        // (e.g. mint.coinos.io) reserves a fee the mint doesn't take and
+        // the mint rejects the swap as "inputs/outputs not balanced".
+        val feeAtoms = computeInputFee(proofs, fetchInputFeePpkByKeyset())
         val outputTotal = total - feeAtoms
         if (targetSplit != null && targetSplit > outputTotal) {
             throw IllegalArgumentException("Target split $targetSplit exceeds outputs after fee ($outputTotal)")
@@ -228,9 +234,10 @@ class CashuMintOperations(
         if (targetSplit > total) throw IllegalArgumentException("Target split exceeds available proofs")
 
         val keyset = fetchKeyset()
-        // NUT-02: reserve per-input fees; change shrinks by the fee, send
-        // amount stays whole (the recipient gets exactly targetSplit sats).
-        val feeAtoms = computeInputFee(proofs.size, keyset.inputFeePpk)
+        // NUT-02: reserve per-input fees (priced per each input proof's own
+        // keyset — see [swap]); change shrinks by the fee, send amount stays
+        // whole (the recipient gets exactly targetSplit sats).
+        val feeAtoms = computeInputFee(proofs, fetchInputFeePpkByKeyset())
         val keepAmount = total - targetSplit - feeAtoms
         if (keepAmount < 0L) {
             throw IllegalArgumentException("Inputs $total don't cover send $targetSplit + fee $feeAtoms")
@@ -289,8 +296,11 @@ class CashuMintOperations(
         val keyset = fetchKeyset()
         // NUT-02 input fee — separate from quote.feeReserve, which is the
         // upper bound on LN routing fees. The mint subtracts both from
-        // inputs before paying the invoice; we must reserve both.
-        val inputFee = computeInputFee(inputs.size, keyset.inputFeePpk)
+        // inputs before paying the invoice; we must reserve both. Fees are
+        // priced per each input proof's own keyset (which may be an
+        // inactive, rotated-out keyset — see [swap]), so read them from
+        // /v1/keysets rather than the active output keyset.
+        val inputFee = computeInputFee(inputs, fetchInputFeePpkByKeyset())
         val required = quote.amount + quote.feeReserve + inputFee
         if (total < required) throw IllegalArgumentException("Inputs total $total < required $required")
 
@@ -581,6 +591,18 @@ class CashuMintOperations(
             ?: throw IllegalStateException("Mint exposes no keysets")
     }
 
+    /**
+     * NUT-02 per-keyset input fees from /v1/keysets. Unlike /v1/keys
+     * (active keysets only), /v1/keysets lists EVERY keyset the mint has
+     * ever published — active and inactive — each with its own
+     * `input_fee_ppk`. That distinction matters: input proofs are
+     * frequently minted under a keyset the mint has since rotated out,
+     * and the fee charged on a spend follows the proof's own keyset, not
+     * whatever keyset is active now. Maps keyset id → input_fee_ppk
+     * (absent / null → 0).
+     */
+    private suspend fun fetchInputFeePpkByKeyset(): Map<String, Long> = client.keysets().keysets.associate { it.id to (it.inputFeePpk ?: 0L) }
+
     private fun createBlindedOutputs(
         amount: Long,
         keyset: KeysetDto,
@@ -746,6 +768,28 @@ class CashuMintOperations(
             val ppk = inputFeePpk ?: 0L
             if (ppk <= 0L || numInputs <= 0) return 0L
             return (numInputs.toLong() * ppk + 999L) / 1000L
+        }
+
+        /**
+         * NUT-02 input-fee math for a heterogeneous set of input proofs.
+         *
+         * Each proof is charged the `input_fee_ppk` of *its own* keyset —
+         * NOT the wallet's currently-active keyset. A mint that rotated
+         * keysets and changed its fee policy (mint.coinos.io: old keyset
+         * 0 ppk, new keyset 100 ppk) charges per the keyset the proof was
+         * minted under. The total fee is `ceil(sum(input_fee_ppk_i) / 1000)`,
+         * with the ceiling applied once to the SUM (per spec), not per input.
+         *
+         * [feePpkByKeyset] maps keyset id → its `input_fee_ppk`; a proof
+         * whose keyset is absent (mint dropped it entirely) contributes 0.
+         */
+        fun computeInputFee(
+            proofs: List<CashuProof>,
+            feePpkByKeyset: Map<String, Long>,
+        ): Long {
+            val sumPpk = proofs.sumOf { (feePpkByKeyset[it.id] ?: 0L).coerceAtLeast(0L) }
+            if (sumPpk <= 0L) return 0L
+            return (sumPpk + 999L) / 1000L
         }
     }
 

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip60Cashu/mintApi/CashuMintOperations.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip60Cashu/mintApi/CashuMintOperations.kt
@@ -284,6 +284,23 @@ class CashuMintOperations(
     suspend fun meltQuoteStatus(quote: String): MeltQuoteBolt11ResponseDto = client.meltQuoteBolt11Status(quote)
 
     /**
+     * NUT-02 input fee the active (output) keyset would charge to spend a
+     * proof set worth [amount] sats once it's split into power-of-two
+     * denominations.
+     *
+     * [CashuWalletOps.meltToLightning] swaps its inputs down onto the
+     * active keyset and the mint then charges this fee on top of
+     * `amount + fee_reserve`. Sizing selection + the swap-down with this
+     * fee included keeps the subsequent [meltProofs] from coming up short
+     * ("Inputs total X < required Y").
+     */
+    suspend fun activeKeysetInputFeeFor(amount: Long): Long {
+        if (amount <= 0L) return 0L
+        val keyset = fetchKeyset()
+        return computeInputFee(splitAmounts(amount).size, keyset.inputFeePpk)
+    }
+
+    /**
      * Pay the bolt11 invoice. Spends [inputs], which must total at least
      * `quote.amount + quote.fee_reserve`. Any change is returned blinded so the
      * mint signs unused fee proofs that the wallet can later spend.

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip60Cashu/mintApi/NutTwoInputFeeTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip60Cashu/mintApi/NutTwoInputFeeTest.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.quartz.nip60Cashu.mintApi
 
+import com.vitorpamplona.quartz.nip60Cashu.token.CashuProof
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -89,5 +90,63 @@ class NutTwoInputFeeTest {
     @Test
     fun `negative ppk treated as zero — defensive against bad mint payloads`() {
         assertEquals(0L, CashuMintOperations.computeInputFee(numInputs = 10, inputFeePpk = -5L))
+    }
+
+    // --- Per-keyset variant: fees follow each input proof's OWN keyset ---
+
+    private fun proof(
+        keysetId: String,
+        amount: Long,
+    ) = CashuProof(id = keysetId, amount = amount, secret = "s-$keysetId-$amount", c = "c")
+
+    @Test
+    fun `proofs on a zero-fee keyset cost nothing even when another keyset charges`() {
+        // Reproduces the mint.coinos.io report: the wallet's proofs sit on the
+        // mint's old keyset (0 ppk) while the active keyset charges 100 ppk.
+        // The fee must be priced from the proofs' own keyset, so it is 0 — not
+        // ceil(N*100/1000). Pricing from the active keyset reserved a fee the
+        // mint never took, leaving outputs one sat short ("inputs 84 - fees 0
+        // vs output (83) are not balanced").
+        val oldKeyset = "004f7adf2a04356c"
+        val activeKeyset = "007311aa2fa58cc8"
+        val feePpkByKeyset = mapOf(oldKeyset to 0L, activeKeyset to 100L)
+        val inputs = List(20) { proof(oldKeyset, 4L) } // 80 sat across 20 proofs on the 0-fee keyset
+
+        assertEquals(0L, CashuMintOperations.computeInputFee(inputs, feePpkByKeyset))
+    }
+
+    @Test
+    fun `proofs on a fee-charging keyset are billed per spec ceiling`() {
+        val activeKeyset = "007311aa2fa58cc8"
+        val feePpkByKeyset = mapOf(activeKeyset to 100L)
+        // 11 inputs * 100 ppk = 1100 → ceil(1100/1000) = 2
+        val inputs = List(11) { proof(activeKeyset, 1L) }
+
+        assertEquals(2L, CashuMintOperations.computeInputFee(inputs, feePpkByKeyset))
+    }
+
+    @Test
+    fun `mixed keysets sum per-input ppk then ceil once`() {
+        val zeroKeyset = "004f7adf2a04356c"
+        val feeKeyset = "007311aa2fa58cc8"
+        val feePpkByKeyset = mapOf(zeroKeyset to 0L, feeKeyset to 100L)
+        // 5 fee-charging inputs (5*100=500 ppk) + 5 zero-fee inputs (0) = 500 ppk
+        // ceil(500/1000) = 1. Ceiling is applied once to the SUM, not per input.
+        val inputs = List(5) { proof(feeKeyset, 1L) } + List(5) { proof(zeroKeyset, 1L) }
+
+        assertEquals(1L, CashuMintOperations.computeInputFee(inputs, feePpkByKeyset))
+    }
+
+    @Test
+    fun `unknown keyset (mint dropped it) contributes zero`() {
+        val feePpkByKeyset = mapOf("known" to 100L)
+        val inputs = List(50) { proof("rotated-out-and-gone", 1L) }
+
+        assertEquals(0L, CashuMintOperations.computeInputFee(inputs, feePpkByKeyset))
+    }
+
+    @Test
+    fun `empty inputs cost nothing`() {
+        assertEquals(0L, CashuMintOperations.computeInputFee(emptyList(), mapOf("k" to 100L)))
     }
 }

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip60Cashu/mintApi/NutTwoInputFeeTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip60Cashu/mintApi/NutTwoInputFeeTest.kt
@@ -149,4 +149,38 @@ class NutTwoInputFeeTest {
     fun `empty inputs cost nothing`() {
         assertEquals(0L, CashuMintOperations.computeInputFee(emptyList(), mapOf("k" to 100L)))
     }
+
+    // --- Melt headroom: the fee the active keyset charges on the swapped-down
+    //     send proofs, which meltToLightning must reserve on top of
+    //     amount + fee_reserve. Mirrors CashuMintOperations.activeKeysetInputFeeFor,
+    //     which is `computeInputFee(splitAmounts(amount).size, activePpk)`. ---
+
+    private fun activeKeysetFeeFor(
+        amount: Long,
+        ppk: Long,
+    ) = CashuMintOperations.computeInputFee(
+        numInputs = CashuMintOperations.splitAmounts(amount).size,
+        inputFeePpk = ppk,
+    )
+
+    @Test
+    fun `melt headroom on a zero-fee active keyset is zero`() {
+        assertEquals(0L, activeKeysetFeeFor(amount = 83, ppk = 0L))
+    }
+
+    @Test
+    fun `melt headroom reserves the active keyset fee — coinos case`() {
+        // splitAmounts(83) = [1,2,16,64] → 4 proofs → ceil(4*100/1000) = 1.
+        // Without this 1-sat headroom, swapping down to exactly 83 leaves the
+        // melt one sat short of amount+fee_reserve+input_fee.
+        assertEquals(4, CashuMintOperations.splitAmounts(83).size)
+        assertEquals(1L, activeKeysetFeeFor(amount = 83, ppk = 100L))
+    }
+
+    @Test
+    fun `melt headroom grows with proof count on a fee keyset`() {
+        // splitAmounts(1023) = 10 set bits → 10 proofs → ceil(10*100/1000) = 1.
+        assertEquals(10, CashuMintOperations.splitAmounts(1023).size)
+        assertEquals(1L, activeKeysetFeeFor(amount = 1023, ppk = 100L))
+    }
 }


### PR DESCRIPTION
## Problem

Sending Lightning from the Cashu wallet against **mint.coinos.io** failed with:

> Mint Error (HTTP 400), inputs 84 - fees 0 vs output (83) are not balanced

## Root cause

NUT-02 charges the input fee **per the keyset each input proof was minted under**, but the code priced it from the mint's single *active* keyset. coinos has rotated keysets:

| keyset | state | `input_fee_ppk` |
|--------|-------|-----------------|
| `004f7adf2a04356c` | inactive | **0** |
| `007311aa2fa58cc8` | active | **100** |

The user's proofs sit on the old **0-fee** keyset, but the wallet reserved a fee using the active keyset's 100 ppk → built swap outputs one sat short → mint rejected as unbalanced.

## What changed

**1. Per-keyset NUT-02 fees** (`32a3045`) — fees are now `ceil(Σ input_fee_ppk_i / 1000)` over each input proof's *own* keyset, read from `/v1/keysets` (which lists inactive keysets too, unlike `/v1/keys`). Applied in `swap`, `swapToLocked`, and `meltProofs`.

**2. Reserve the melt's own input fee** (`d9a9ecd`) — `meltToLightning` swaps inputs down onto the active keyset, and the melt then charges *its* NUT-02 fee on them. The swap-down target and proof selection didn't account for it, so fix #1 alone just moved the failure from the swap to `meltProofs` (`Inputs total 83 < required 84`). Now reserves `activeKeysetInputFeeFor(required)` on top of `amount + fee_reserve`. Also corrects `MeltCompleted.fees`, which counted the pre-paid swap "keep" as a fee in the swap path.

**3. Migrate token-redeem melt to NUT-05** (`2cbdfe74`) — `MeltProcessor` (the **Redeem received cashu token → Lightning address** button) was hand-coded against the deprecated pre-v1 `/melt` + `/checkfees` endpoints (gone on CDK / non-Nutshell mints) and had the same missing-fee bug. It now uses the same NUT-05 `CashuMintOperations` (`requestMeltQuote` + `meltProofs`), picking up per-keyset fees for free. Adds `meltProofs(requestChange=…)` (the redeem path has no wallet to hold change) and a public `inputFeeFor(proofs)` for invoice sizing; removes a dead empty `melt(...)` stub.

## Verification

- Diagnosis confirmed against the **live coinos keyset data** and traced by hand on the exact reported numbers.
- New unit tests in `NutTwoInputFeeTest` cover mixed-keyset fees, the unknown/dropped-keyset case, and the melt-fee headroom math.
- `:quartz:jvmTest`, `:commons:jvmTest`, `:nestsClient:jvmTest`, `:quic:jvmTest`, `:amethyst:testPlayDebugUnitTest`, `:cli:test`, `:desktopApp:test` and `spotlessApply` all green. Branch merged up to date with `main`.

## Notes for the reviewer

- **Token redemption stays lossy by design:** with no NIP-60 wallet to hold change, `MeltProcessor` melts with `requestChange=false` and the mint keeps the unused fee reserve — same trade-off the legacy path made. Non-`sat` tokens remain unsupported, as before.
- **Pre-existing, unrelated test failure:** `geode/KtorRelayTest > nip11_returnsInfoDocOnHttpGetWithNostrAcceptHeader` fails on `main` too (`expected:<geode> but was:<Geode>`, a relay-name casing mismatch). It's outside the pre-push test set so it didn't block this branch, but `./gradlew test` will trip on it. Happy to fix in a separate one-line PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ffjz3doZ5CtFtAWSpvmqR

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ffjz3doZ5CtFtAWSpvmqR)_