### PR TITLE
Implement NIP-50 full-text search for additional event kinds

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/agora/FundraiserEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/agora/FundraiserEvent.kt
@@ -31,6 +31,7 @@ import com.vitorpamplona.quartz.nip01Core.tags.publishedAt.PublishedAtProvider
 import com.vitorpamplona.quartz.nip23LongContent.tags.ImageTag
 import com.vitorpamplona.quartz.nip23LongContent.tags.PublishedAtTag
 import com.vitorpamplona.quartz.nip23LongContent.tags.TitleTag
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 
 /**
  * Agora fundraiser / crowdfunding campaign (kind 33863).
@@ -59,7 +60,10 @@ class FundraiserEvent(
     content: String,
     sig: HexKey,
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
-    PublishedAtProvider {
+    PublishedAtProvider,
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(title(), content).joinToString("\n")
+
     fun title() = tags.firstNotNullOfOrNull(TitleTag::parse)
 
     fun banner() = tags.firstNotNullOfOrNull(BannerTag::parse)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/attestations/proficiency/AttestorProficiencyEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/attestations/proficiency/AttestorProficiencyEvent.kt
@@ -27,6 +27,7 @@ import com.vitorpamplona.quartz.nip01Core.core.Kind
 import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 @Immutable
@@ -37,7 +38,10 @@ class AttestorProficiencyEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : BaseReplaceableEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : BaseReplaceableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(description()).joinToString("\n")
+
     fun kinds() = tags.kinds()
 
     fun description() = content.ifBlank { null }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/attestations/recommendation/AttestorRecommendationEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/attestations/recommendation/AttestorRecommendationEvent.kt
@@ -28,6 +28,7 @@ import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 @Immutable
@@ -38,7 +39,10 @@ class AttestorRecommendationEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(description()).joinToString("\n")
+
     fun kinds() = tags.kinds()
 
     fun description() = content.ifBlank { null }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/audio/header/AudioHeaderEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/audio/header/AudioHeaderEvent.kt
@@ -29,6 +29,7 @@ import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 @Immutable
@@ -39,7 +40,10 @@ class AudioHeaderEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : Event(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = content
+
     fun download() = tags.firstNotNullOfOrNull(DownloadUrlTag::parse)
 
     fun stream() = tags.firstNotNullOfOrNull(StreamUrlTag::parse)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/audio/track/AudioTrackEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/audio/track/AudioTrackEvent.kt
@@ -31,7 +31,9 @@ import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
+import com.vitorpamplona.quartz.nip14Subject.SubjectTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -44,7 +46,13 @@ class AudioTrackEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    // content is empty for audio tracks; the only free-text is the subject tag.
+    override fun indexableContent() = listOfNotNull(subject()).joinToString("\n")
+
+    fun subject() = tags.firstNotNullOfOrNull(SubjectTag::parse)
+
     fun participants() = tags.mapNotNull(ParticipantTag::parse)
 
     fun type() = tags.firstNotNullOfOrNull(TypeTag::parse)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/birdstar/BirdexEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/birdstar/BirdexEvent.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.quartz.nip01Core.core.BaseReplaceableEvent
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.firstTagValue
 import com.vitorpamplona.quartz.nip01Core.core.mapValueTagged
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 
 /**
  * Birdstar "Birdex" species collection (kind 12473).
@@ -54,7 +55,10 @@ class BirdexEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : BaseReplaceableEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : BaseReplaceableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(summary()).joinToString("\n")
+
     /** Scientific names of the collected species, in event order, from the `n` tags. */
     fun speciesNames() = tags.mapValueTagged("n") { it }
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/fitness/workout/WorkoutRecordEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/fitness/workout/WorkoutRecordEvent.kt
@@ -28,6 +28,7 @@ import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip22Comments.RootScope
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -48,7 +49,10 @@ class WorkoutRecordEvent(
     content: String,
     sig: HexKey,
 ) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
-    RootScope {
+    RootScope,
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(title(), content).joinToString("\n")
+
     fun title() = tags.title()
 
     fun exercise() = tags.exercise()

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/interactiveStories/InteractiveStoryBaseEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/interactiveStories/InteractiveStoryBaseEvent.kt
@@ -27,6 +27,7 @@ import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip23LongContent.tags.ImageTag
 import com.vitorpamplona.quartz.nip23LongContent.tags.SummaryTag
 import com.vitorpamplona.quartz.nip23LongContent.tags.TitleTag
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 
 @Stable
 open class InteractiveStoryBaseEvent(
@@ -37,7 +38,10 @@ open class InteractiveStoryBaseEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : BaseAddressableEvent(id, pubKey, createdAt, kind, tags, content, sig) {
+) : BaseAddressableEvent(id, pubKey, createdAt, kind, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(title(), summary(), content).joinToString("\n")
+
     fun title() = tags.firstNotNullOfOrNull(TitleTag::parse)
 
     fun summary() = tags.firstNotNullOfOrNull(SummaryTag::parse)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/music/playlist/MusicPlaylistEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/music/playlist/MusicPlaylistEvent.kt
@@ -88,12 +88,7 @@ class MusicPlaylistEvent(
             if (address.kind == MusicTrackEvent.KIND) address else null
         }
 
-    override fun indexableContent(): String =
-        buildString {
-            append("title: ").append(title().orEmpty()).append('\n')
-            description()?.let { append("description: ").append(it).append('\n') }
-            append(content)
-        }
+    override fun indexableContent(): String = listOfNotNull(title(), description(), content).joinToString("\n")
 
     companion object {
         const val KIND = 34139

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/music/track/MusicTrackEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/music/track/MusicTrackEvent.kt
@@ -59,13 +59,7 @@ class MusicTrackEvent(
     sig: HexKey,
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     SearchableEvent {
-    override fun indexableContent(): String =
-        buildString {
-            append("title: ").append(title().orEmpty()).append('\n')
-            append("artist: ").append(artist().orEmpty()).append('\n')
-            album()?.let { append("album: ").append(it).append('\n') }
-            append(content)
-        }
+    override fun indexableContent(): String = listOfNotNull(title(), artist(), album(), content).joinToString("\n")
 
     fun title() = tags.firstNotNullOfOrNull(TitleTag::parse)
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/nip82SoftwareApps/application/SoftwareApplicationEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/nip82SoftwareApps/application/SoftwareApplicationEvent.kt
@@ -29,6 +29,7 @@ import com.vitorpamplona.quartz.nip01Core.tags.aTag.ATag
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip01Core.tags.hashtags.HashtagTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 /**
@@ -46,7 +47,10 @@ class SoftwareApplicationEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(name(), summary(), content).joinToString("\n")
+
     fun appId() = dTag()
 
     fun name() = tags.name()

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/nip82SoftwareApps/release/SoftwareReleaseEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/nip82SoftwareApps/release/SoftwareReleaseEvent.kt
@@ -31,6 +31,7 @@ import com.vitorpamplona.quartz.nip01Core.hints.EventHintProvider
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 /**
@@ -55,7 +56,13 @@ class SoftwareReleaseEvent(
     content: String,
     sig: HexKey,
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
-    EventHintProvider {
+    EventHintProvider,
+    SearchableEvent {
+    // content carries the release notes (free-text). NOTE: kind 30063 collides
+    // with NIP-51 ReleaseArtifactSetEvent, which is what EventFactory builds for
+    // stored events — so in practice this override is not exercised at runtime.
+    override fun indexableContent() = content
+
     override fun eventHints() = tags.mapNotNull(AssetTag::parseAsHint)
 
     override fun linkedEventIds() = tags.mapNotNull(AssetTag::parseId)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/nip95/header/FileStorageHeaderEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/nip95/header/FileStorageHeaderEvent.kt
@@ -32,6 +32,7 @@ import com.vitorpamplona.quartz.nip01Core.tags.events.ETag
 import com.vitorpamplona.quartz.nip01Core.tags.events.eTag
 import com.vitorpamplona.quartz.nip01Core.tags.events.toETag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip94FileMetadata.tags.BlurhashTag
 import com.vitorpamplona.quartz.nip94FileMetadata.tags.DimensionTag
 import com.vitorpamplona.quartz.nip94FileMetadata.tags.FallbackTag
@@ -55,7 +56,12 @@ class FileStorageHeaderEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : Event(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    // Only the summary tag is indexed; the file payload is base64 binary stored
+    // in a separate FileStorageEvent and is intentionally never indexed.
+    override fun indexableContent() = listOfNotNull(summary()).joinToString("\n")
+
     fun dataEvent() = tags.mapNotNull(ETag::parse)
 
     fun dataEventIds() = tags.mapNotNull(ETag::parseId)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/nipsOnNostr/NipTextEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/nipsOnNostr/NipTextEvent.kt
@@ -66,7 +66,7 @@ class NipTextEvent(
     AddressHintProvider,
     IForkableEvent,
     SearchableEvent {
-    override fun indexableContent() = "title: " + title() + "\n" + content
+    override fun indexableContent() = listOfNotNull(title(), content).joinToString("\n")
 
     override fun dTag() = tags.dTag()
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/profileGallery/ProfileGalleryEntryEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/profileGallery/ProfileGalleryEntryEvent.kt
@@ -28,6 +28,7 @@ import com.vitorpamplona.quartz.nip01Core.core.any
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.events.ETag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip94FileMetadata.tags.BlurhashTag
 import com.vitorpamplona.quartz.nip94FileMetadata.tags.DimensionTag
 import com.vitorpamplona.quartz.nip94FileMetadata.tags.FallbackTag
@@ -52,7 +53,12 @@ class ProfileGalleryEntryEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : Event(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    // Only the optional summary caption is indexed; this event is otherwise a
+    // url/hash pointer with no natural-language body (content is empty).
+    override fun indexableContent() = listOfNotNull(summary()).joinToString("\n")
+
     fun url() = tags.firstNotNullOfOrNull(UrlTag::parse)
 
     fun urls() = tags.mapNotNull(UrlTag::parse)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/zapPolls/ZapPollEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/zapPolls/ZapPollEvent.kt
@@ -66,7 +66,7 @@ class ZapPollEvent(
     override fun indexableContent() =
         buildString {
             append(content)
-            pollOptionsArray().forEach { append("\nOption: ").append(it.descriptor) }
+            pollOptionsArray().forEach { append('\n').append(it.descriptor) }
         }
 
     override fun eventHints(): List<EventIdHint> {

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/zapPolls/ZapPollEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/zapPolls/ZapPollEvent.kt
@@ -63,7 +63,11 @@ class ZapPollEvent(
     AddressHintProvider,
     PubKeyHintProvider,
     SearchableEvent {
-    override fun indexableContent() = content + pollOptionsArray().map { "\nOption: " + it.descriptor }
+    override fun indexableContent() =
+        buildString {
+            append(content)
+            pollOptionsArray().forEach { append("\nOption: ").append(it.descriptor) }
+        }
 
     override fun eventHints(): List<EventIdHint> {
         val eHints = tags.mapNotNull(MarkedETag::parseAsHint)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/feedDefinition/FeedDefinitionEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/feedDefinition/FeedDefinitionEvent.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Immutable
 import com.vitorpamplona.quartz.nip01Core.core.BaseAddressableEvent
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.TagArray
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 
 /**
  * Kind 31890: Feed Definition Event (draft NIP, PR #1181).
@@ -40,7 +41,10 @@ class FeedDefinitionEvent(
     tags: TagArray,
     content: String,
     sig: HexKey,
-) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = "title: " + title().orEmpty()
+
     fun title(): String? = tags.firstOrNull { it.size >= 2 && it[0] == "title" }?.get(1)
 
     fun emoji(): String? = tags.firstOrNull { it.size >= 2 && it[0] == "emoji" }?.get(1)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/feedDefinition/FeedDefinitionEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/feedDefinition/FeedDefinitionEvent.kt
@@ -43,7 +43,7 @@ class FeedDefinitionEvent(
     sig: HexKey,
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     SearchableEvent {
-    override fun indexableContent() = "title: " + title().orEmpty()
+    override fun indexableContent() = title().orEmpty()
 
     fun title(): String? = tags.firstOrNull { it.size >= 2 && it[0] == "title" }?.get(1)
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/metadata/MetadataEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/metadata/MetadataEvent.kt
@@ -48,6 +48,7 @@ import com.vitorpamplona.quartz.nip39ExtIdentities.githubClaim
 import com.vitorpamplona.quartz.nip39ExtIdentities.mastodonClaim
 import com.vitorpamplona.quartz.nip39ExtIdentities.replaceClaims
 import com.vitorpamplona.quartz.nip39ExtIdentities.twitterClaim
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quartz.utils.TimeUtils
 import com.vitorpamplona.quartz.utils.text
@@ -64,8 +65,28 @@ class MetadataEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : BaseReplaceableEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : BaseReplaceableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
     override fun isContentEncoded() = true
+
+    // Profile content is JSON, so we parse it and index only the
+    // human-meaningful fields: names, bio, plus the addresses people search
+    // by (nip05 email, lightning addresses, website/picture/banner URLs).
+    // Mirrors the in-memory searchable set in UserMetadata.anyPropertyContains.
+    override fun indexableContent() =
+        contactMetaData()?.let {
+            listOfNotNull(
+                it.name,
+                it.displayName,
+                it.about,
+                it.nip05,
+                it.lud06,
+                it.lud16,
+                it.website,
+                it.picture,
+                it.banner,
+            ).joinToString(" ")
+        } ?: ""
 
     fun contactMetadataJson() =
         try {

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/FullTextSearchModule.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/FullTextSearchModule.kt
@@ -27,14 +27,7 @@ import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 
 class FullTextSearchModule : IModule {
     val tableName = "event_fts"
-
-    // We don't store the event_headers foreign key as its own indexed column —
-    // an FTS column is tokenized into the searchable text, so a numeric FK would
-    // pollute MATCH results and waste index space. Instead we align the FTS
-    // table's implicit rowid with event_headers.row_id at insert time and join
-    // on it. rowid joins are also the fastest possible, and `rowid` works across
-    // fts3/4/5 (fts4/3 expose it as `docid`, but `rowid` is accepted too).
-    val rowIdName = "rowid"
+    val eventHeaderRowIdName = "event_header_row_id"
     val contentName = "content"
 
     override fun create(db: SQLiteConnection) {
@@ -42,12 +35,11 @@ class FullTextSearchModule : IModule {
         db.execSQL(
             """
                     CREATE VIRTUAL TABLE $tableName
-                    USING fts$ftsVersion($contentName)
+                    USING fts$ftsVersion($eventHeaderRowIdName, $contentName)
                 """,
         )
 
-        // Foreign key cleanup for full text search. Because the FTS rowid is the
-        // event_headers.row_id, we can delete the matching row directly.
+        // Foreign key cleanup for full text search
         db.execSQL(
             """
                 CREATE TRIGGER fts_foreign_key
@@ -55,23 +47,19 @@ class FullTextSearchModule : IModule {
                 FOR EACH ROW
                 BEGIN
                     DELETE FROM $tableName
-                    WHERE $tableName.$rowIdName = old.row_id;
+                    WHERE old.row_id = $tableName.$eventHeaderRowIdName;
                 END;
             """,
         )
     }
 
     override fun drop(db: SQLiteConnection) {
-        // The trigger lives on event_headers, so dropping our table alone won't
-        // remove it. Drop it explicitly so drop() is self-contained and a later
-        // create() doesn't fail with "trigger already exists".
-        db.execSQL("DROP TRIGGER IF EXISTS fts_foreign_key")
         db.execSQL("DROP TABLE IF EXISTS $tableName")
     }
 
     val insertFTS =
         """
-        INSERT OR ROLLBACK INTO $tableName ($rowIdName, $contentName)
+        INSERT OR ROLLBACK INTO $tableName ($eventHeaderRowIdName, $contentName)
         VALUES (?, ?)
         """.trimIndent()
 
@@ -82,30 +70,6 @@ class FullTextSearchModule : IModule {
     ) {
         if (event is SearchableEvent) {
             db.prepare(insertFTS).use { stmt ->
-                stmt.bindLong(1, headerId)
-                stmt.bindText(2, event.indexableContent())
-                stmt.step()
-            }
-        }
-    }
-
-    // Idempotent variant used by the background reindex backfill: a row may
-    // already have been indexed by the live insert path (event_headers.row_id
-    // is monotonic, so freshly received events land above the backfill cursor),
-    // and re-indexing it must be a no-op rather than a constraint failure.
-    val insertIfAbsentFTS =
-        """
-        INSERT OR IGNORE INTO $tableName ($rowIdName, $contentName)
-        VALUES (?, ?)
-        """.trimIndent()
-
-    fun insertIfAbsent(
-        event: Event,
-        headerId: Long,
-        db: SQLiteConnection,
-    ) {
-        if (event is SearchableEvent) {
-            db.prepare(insertIfAbsentFTS).use { stmt ->
                 stmt.bindLong(1, headerId)
                 stmt.bindText(2, event.indexableContent())
                 stmt.step()

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/FullTextSearchModule.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/FullTextSearchModule.kt
@@ -27,7 +27,14 @@ import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 
 class FullTextSearchModule : IModule {
     val tableName = "event_fts"
-    val eventHeaderRowIdName = "event_header_row_id"
+
+    // We don't store the event_headers foreign key as its own indexed column —
+    // an FTS column is tokenized into the searchable text, so a numeric FK would
+    // pollute MATCH results and waste index space. Instead we align the FTS
+    // table's implicit rowid with event_headers.row_id at insert time and join
+    // on it. rowid joins are also the fastest possible, and `rowid` works across
+    // fts3/4/5 (fts4/3 expose it as `docid`, but `rowid` is accepted too).
+    val rowIdName = "rowid"
     val contentName = "content"
 
     override fun create(db: SQLiteConnection) {
@@ -35,11 +42,12 @@ class FullTextSearchModule : IModule {
         db.execSQL(
             """
                     CREATE VIRTUAL TABLE $tableName
-                    USING fts$ftsVersion($eventHeaderRowIdName, $contentName)
+                    USING fts$ftsVersion($contentName)
                 """,
         )
 
-        // Foreign key cleanup for full text search
+        // Foreign key cleanup for full text search. Because the FTS rowid is the
+        // event_headers.row_id, we can delete the matching row directly.
         db.execSQL(
             """
                 CREATE TRIGGER fts_foreign_key
@@ -47,19 +55,23 @@ class FullTextSearchModule : IModule {
                 FOR EACH ROW
                 BEGIN
                     DELETE FROM $tableName
-                    WHERE old.row_id = $tableName.$eventHeaderRowIdName;
+                    WHERE $tableName.$rowIdName = old.row_id;
                 END;
             """,
         )
     }
 
     override fun drop(db: SQLiteConnection) {
+        // The trigger lives on event_headers, so dropping our table alone won't
+        // remove it. Drop it explicitly so drop() is self-contained and a later
+        // create() doesn't fail with "trigger already exists".
+        db.execSQL("DROP TRIGGER IF EXISTS fts_foreign_key")
         db.execSQL("DROP TABLE IF EXISTS $tableName")
     }
 
     val insertFTS =
         """
-        INSERT OR ROLLBACK INTO $tableName ($eventHeaderRowIdName, $contentName)
+        INSERT OR ROLLBACK INTO $tableName ($rowIdName, $contentName)
         VALUES (?, ?)
         """.trimIndent()
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/FullTextSearchModule.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/FullTextSearchModule.kt
@@ -89,6 +89,30 @@ class FullTextSearchModule : IModule {
         }
     }
 
+    // Idempotent variant used by the background reindex backfill: a row may
+    // already have been indexed by the live insert path (event_headers.row_id
+    // is monotonic, so freshly received events land above the backfill cursor),
+    // and re-indexing it must be a no-op rather than a constraint failure.
+    val insertIfAbsentFTS =
+        """
+        INSERT OR IGNORE INTO $tableName ($rowIdName, $contentName)
+        VALUES (?, ?)
+        """.trimIndent()
+
+    fun insertIfAbsent(
+        event: Event,
+        headerId: Long,
+        db: SQLiteConnection,
+    ) {
+        if (event is SearchableEvent) {
+            db.prepare(insertIfAbsentFTS).use { stmt ->
+                stmt.bindLong(1, headerId)
+                stmt.bindText(2, event.indexableContent())
+                stmt.step()
+            }
+        }
+    }
+
     fun versionFinder(db: SQLiteConnection): Int {
         // Defensive cleanup in case a previous probe left these behind
         // (e.g. a partial create() during an upgrade) — without this,

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/QueryBuilder.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/QueryBuilder.kt
@@ -360,7 +360,7 @@ class QueryBuilder(
         val sql =
             buildString {
                 append("SELECT event_headers.id, event_headers.created_at FROM event_headers")
-                append("\nINNER JOIN ${fts.tableName} ON event_headers.row_id = ${fts.tableName}.${fts.rowIdName}")
+                append("\nINNER JOIN ${fts.tableName} ON event_headers.row_id = ${fts.tableName}.${fts.eventHeaderRowIdName}")
                 if (clause.conditions.isNotEmpty()) {
                     append("\nWHERE ${clause.conditions}")
                 }
@@ -678,13 +678,13 @@ class QueryBuilder(
                     }
 
                     if (mustJoinSearch) {
-                        append(" INNER JOIN ${fts.tableName} ON ${fts.tableName}.${fts.rowIdName} = event_tags.event_header_row_id")
+                        append(" INNER JOIN ${fts.tableName} ON ${fts.tableName}.${fts.eventHeaderRowIdName} = event_tags.event_header_row_id")
                     }
                 } else if (mustJoinSearch) {
-                    append("SELECT ${fts.tableName}.${fts.rowIdName} as row_id FROM ${fts.tableName}")
+                    append("SELECT ${fts.tableName}.${fts.eventHeaderRowIdName} as row_id FROM ${fts.tableName}")
 
                     if (hasHeaders) {
-                        append(" INNER JOIN event_headers ON event_headers.row_id = ${fts.tableName}.${fts.rowIdName}")
+                        append(" INNER JOIN event_headers ON event_headers.row_id = ${fts.tableName}.${fts.eventHeaderRowIdName}")
                     }
                 } else {
                     // no tags and no search.
@@ -864,7 +864,7 @@ class QueryBuilder(
         val sql =
             buildString {
                 append("SELECT event_headers.id, event_headers.pubkey, event_headers.created_at, event_headers.kind, event_headers.tags, event_headers.content, event_headers.sig FROM event_headers")
-                append("\nINNER JOIN ${fts.tableName} ON event_headers.row_id = ${fts.tableName}.${fts.rowIdName}")
+                append("\nINNER JOIN ${fts.tableName} ON event_headers.row_id = ${fts.tableName}.${fts.eventHeaderRowIdName}")
                 if (clause.conditions.isNotEmpty()) {
                     append("\nWHERE ${clause.conditions}")
                 }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/QueryBuilder.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/QueryBuilder.kt
@@ -360,7 +360,7 @@ class QueryBuilder(
         val sql =
             buildString {
                 append("SELECT event_headers.id, event_headers.created_at FROM event_headers")
-                append("\nINNER JOIN ${fts.tableName} ON event_headers.row_id = ${fts.tableName}.${fts.eventHeaderRowIdName}")
+                append("\nINNER JOIN ${fts.tableName} ON event_headers.row_id = ${fts.tableName}.${fts.rowIdName}")
                 if (clause.conditions.isNotEmpty()) {
                     append("\nWHERE ${clause.conditions}")
                 }
@@ -678,13 +678,13 @@ class QueryBuilder(
                     }
 
                     if (mustJoinSearch) {
-                        append(" INNER JOIN ${fts.tableName} ON ${fts.tableName}.${fts.eventHeaderRowIdName} = event_tags.event_header_row_id")
+                        append(" INNER JOIN ${fts.tableName} ON ${fts.tableName}.${fts.rowIdName} = event_tags.event_header_row_id")
                     }
                 } else if (mustJoinSearch) {
-                    append("SELECT ${fts.tableName}.${fts.eventHeaderRowIdName} as row_id FROM ${fts.tableName}")
+                    append("SELECT ${fts.tableName}.${fts.rowIdName} as row_id FROM ${fts.tableName}")
 
                     if (hasHeaders) {
-                        append(" INNER JOIN event_headers ON event_headers.row_id = ${fts.tableName}.${fts.eventHeaderRowIdName}")
+                        append(" INNER JOIN event_headers ON event_headers.row_id = ${fts.tableName}.${fts.rowIdName}")
                     }
                 } else {
                     // no tags and no search.
@@ -864,7 +864,7 @@ class QueryBuilder(
         val sql =
             buildString {
                 append("SELECT event_headers.id, event_headers.pubkey, event_headers.created_at, event_headers.kind, event_headers.tags, event_headers.content, event_headers.sig FROM event_headers")
-                append("\nINNER JOIN ${fts.tableName} ON event_headers.row_id = ${fts.tableName}.${fts.eventHeaderRowIdName}")
+                append("\nINNER JOIN ${fts.tableName} ON event_headers.row_id = ${fts.tableName}.${fts.rowIdName}")
                 if (clause.conditions.isNotEmpty()) {
                     append("\nWHERE ${clause.conditions}")
                 }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/SQLiteEventStore.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/SQLiteEventStore.kt
@@ -44,7 +44,7 @@ class SQLiteEventStore(
     val numReaders: Int = 4,
 ) {
     companion object {
-        const val DATABASE_VERSION = 2
+        const val DATABASE_VERSION = 3
     }
 
     val seedModule = SeedModule()
@@ -164,6 +164,41 @@ class SQLiteEventStore(
                     modules.reversed().forEach { it.drop(db) }
                     modules.forEach { it.create(db) }
                 }
+                2 -> {
+                    // Upgrade from version 2 to 3
+                    // The full-text index dropped its dedicated foreign-key
+                    // column and now aligns the FTS rowid with
+                    // event_headers.row_id. Rebuild only the FTS index in place
+                    // so the cached events themselves survive the upgrade.
+                    fullTextSearchModule.drop(db)
+                    fullTextSearchModule.create(db)
+                    reindexFullText(db)
+                }
+            }
+        }
+    }
+
+    /**
+     * Repopulates [FullTextSearchModule] from the events already stored in
+     * event_headers. Used by migrations that recreate the FTS table without
+     * touching the source events. Reading event_headers while inserting into
+     * event_fts is safe because they are different tables.
+     */
+    private fun reindexFullText(db: SQLiteConnection) {
+        db.prepare("SELECT row_id, id, pubkey, created_at, kind, tags, content, sig FROM event_headers").use { stmt ->
+            while (stmt.step()) {
+                val rowId = stmt.getLong(0)
+                val event =
+                    EventFactory.create<Event>(
+                        stmt.getText(1),
+                        stmt.getText(2),
+                        stmt.getLong(3),
+                        stmt.getInt(4),
+                        OptimizedJsonMapper.fromJsonToTagArray(stmt.getText(5)),
+                        stmt.getText(6),
+                        stmt.getText(7),
+                    )
+                fullTextSearchModule.insert(event, rowId, db)
             }
         }
     }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/SQLiteEventStore.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/SQLiteEventStore.kt
@@ -35,6 +35,12 @@ import com.vitorpamplona.quartz.nip01Core.store.IEventStore
 import com.vitorpamplona.quartz.nip01Core.store.IdAndTime
 import com.vitorpamplona.quartz.nip40Expiration.isExpired
 import com.vitorpamplona.quartz.utils.EventFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
 
 class SQLiteEventStore(
     val driver: SQLiteDriver = BundledSQLiteDriver(),
@@ -45,6 +51,11 @@ class SQLiteEventStore(
 ) {
     companion object {
         const val DATABASE_VERSION = 3
+
+        // Rows per background-reindex batch. Each batch is one writer
+        // transaction; the writer mutex is released between batches so live
+        // inserts/queries interleave instead of waiting for the whole reindex.
+        const val REINDEX_BATCH_SIZE = 500
     }
 
     val seedModule = SeedModule()
@@ -131,6 +142,26 @@ class SQLiteEventStore(
         )
     }
 
+    // Background worker for one-off maintenance that must not block app
+    // startup — currently the post-migration full-text reindex backfill.
+    private val maintenanceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    init {
+        // Kicked off asynchronously: it returns immediately when there is no
+        // pending reindex (the common case), and otherwise backfills the FTS
+        // index in the background while the rest of the app runs normally.
+        maintenanceScope.launch {
+            try {
+                reindexFullTextIfPending()
+            } catch (_: Throwable) {
+                // Best-effort maintenance. A failure here only leaves search
+                // degraded until the next launch retries; it must never crash
+                // the store. (CancellationException from close() lands here too
+                // and is intentionally swallowed.)
+            }
+        }
+    }
+
     private fun getUserVersion(db: SQLiteConnection): Int =
         db.prepare("PRAGMA user_version").use { stmt ->
             stmt.step()
@@ -168,40 +199,154 @@ class SQLiteEventStore(
                     // Upgrade from version 2 to 3
                     // The full-text index dropped its dedicated foreign-key
                     // column and now aligns the FTS rowid with
-                    // event_headers.row_id. Rebuild only the FTS index in place
-                    // so the cached events themselves survive the upgrade.
+                    // event_headers.row_id. Recreate the (now empty) FTS table
+                    // structure cheaply inside the migration and record a
+                    // persistent marker; the actual repopulation from
+                    // event_headers happens later in the background via
+                    // [reindexFullTextIfPending] so the migration — and app
+                    // startup — never blocks on a large reindex.
                     fullTextSearchModule.drop(db)
                     fullTextSearchModule.create(db)
-                    reindexFullText(db)
+                    createReindexMarker(db)
                 }
             }
         }
     }
 
-    /**
-     * Repopulates [FullTextSearchModule] from the events already stored in
-     * event_headers. Used by migrations that recreate the FTS table without
-     * touching the source events. Reading event_headers while inserting into
-     * event_fts is safe because they are different tables.
-     */
-    private fun reindexFullText(db: SQLiteConnection) {
-        db.prepare("SELECT row_id, id, pubkey, created_at, kind, tags, content, sig FROM event_headers").use { stmt ->
-            while (stmt.step()) {
-                val rowId = stmt.getLong(0)
-                val event =
-                    EventFactory.create<Event>(
-                        stmt.getText(1),
-                        stmt.getText(2),
-                        stmt.getLong(3),
-                        stmt.getInt(4),
-                        OptimizedJsonMapper.fromJsonToTagArray(stmt.getText(5)),
-                        stmt.getText(6),
-                        stmt.getText(7),
-                    )
-                fullTextSearchModule.insert(event, rowId, db)
-            }
+    // ------------------------------------------------------------------
+    // Background full-text reindex
+    //
+    // When a migration recreates the FTS table it leaves a persistent
+    // `fts_reindex` marker holding a progress cursor (the highest
+    // event_headers.row_id already backfilled). The backfill walks
+    // event_headers in row_id order in small committed batches, so it
+    // interleaves with normal relay inserts/queries and survives process
+    // death: the cursor is persisted, and on the next launch the marker is
+    // still present so the work resumes where it stopped. Search is merely
+    // degraded (partial results) until it finishes — never blocked.
+    // ------------------------------------------------------------------
+
+    private val reindexMarkerTable = "fts_reindex"
+
+    private fun createReindexMarker(db: SQLiteConnection) {
+        db.execSQL("CREATE TABLE IF NOT EXISTS $reindexMarkerTable (next_row_id INTEGER NOT NULL)")
+        db.execSQL("DELETE FROM $reindexMarkerTable")
+        // row_id is AUTOINCREMENT starting at 1, so 0 means "nothing done yet".
+        db.execSQL("INSERT INTO $reindexMarkerTable (next_row_id) VALUES (0)")
+    }
+
+    private fun hasReindexMarker(db: SQLiteConnection): Boolean = db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '$reindexMarkerTable'").use { it.step() }
+
+    private fun getReindexCursor(db: SQLiteConnection): Long =
+        db.prepare("SELECT next_row_id FROM $reindexMarkerTable LIMIT 1").use {
+            if (it.step()) it.getLong(0) else 0L
+        }
+
+    private fun setReindexCursor(
+        db: SQLiteConnection,
+        value: Long,
+    ) {
+        db.prepare("UPDATE $reindexMarkerTable SET next_row_id = ?").use {
+            it.bindLong(1, value)
+            it.step()
         }
     }
+
+    private fun dropReindexMarker(db: SQLiteConnection) {
+        db.execSQL("DROP TABLE IF EXISTS $reindexMarkerTable")
+    }
+
+    /**
+     * Drives the background backfill loop while a reindex marker exists.
+     * Each iteration processes one batch in its own writer transaction, then
+     * releases the writer mutex so other writes get a turn. [yield] makes the
+     * loop cancellation-aware (see [close]).
+     */
+    internal suspend fun reindexFullTextIfPending() {
+        if (!pool.useReader { hasReindexMarker(it) }) return
+
+        while (true) {
+            val done = pool.useWriter { db -> reindexNextBatch(db, REINDEX_BATCH_SIZE) }
+            if (done) break
+            yield()
+        }
+    }
+
+    /**
+     * Indexes up to [limit] not-yet-processed events (row_id greater than the
+     * persisted cursor) into the FTS table and advances the cursor. Returns
+     * true once there is nothing left, after dropping the marker. A single
+     * malformed cached row is skipped — the cursor still moves past it, so the
+     * backfill can never get stuck retrying the same row.
+     */
+    private fun reindexNextBatch(
+        db: SQLiteConnection,
+        limit: Int,
+    ): Boolean =
+        db.transaction {
+            // The marker may have been dropped by a previous batch (or, in
+            // theory, another backfiller) — treat its absence as "done" rather
+            // than reading a cursor from a missing table.
+            if (!hasReindexMarker(db)) {
+                true
+            } else {
+                val cursor = getReindexCursor(db)
+                var lastRowId = cursor
+                var count = 0
+
+                db
+                    .prepare(
+                        "SELECT row_id, id, pubkey, created_at, kind, tags, content, sig FROM event_headers " +
+                            "WHERE row_id > ? ORDER BY row_id LIMIT ?",
+                    ).use { stmt ->
+                        stmt.bindLong(1, cursor)
+                        stmt.bindLong(2, limit.toLong())
+                        while (stmt.step()) {
+                            val rowId = stmt.getLong(0)
+                            try {
+                                val event =
+                                    EventFactory.create<Event>(
+                                        stmt.getText(1),
+                                        stmt.getText(2),
+                                        stmt.getLong(3),
+                                        stmt.getInt(4),
+                                        OptimizedJsonMapper.fromJsonToTagArray(stmt.getText(5)),
+                                        stmt.getText(6),
+                                        stmt.getText(7),
+                                    )
+                                fullTextSearchModule.insertIfAbsent(event, rowId, db)
+                            } catch (_: Throwable) {
+                                // Skip a row that fails to parse/index; advancing the
+                                // cursor below guarantees forward progress regardless.
+                            }
+                            lastRowId = rowId
+                            count++
+                        }
+                    }
+
+                if (count == 0) {
+                    dropReindexMarker(db)
+                    true
+                } else {
+                    setReindexCursor(db, lastRowId)
+                    false
+                }
+            }
+        }
+
+    /**
+     * Test hook: simulates the post-migration state by clearing the FTS table
+     * and arming the reindex marker, so a test can then drive
+     * [reindexFullTextIfPending] deterministically.
+     */
+    internal suspend fun dropFtsAndMarkPendingForTest() =
+        pool.useWriter { db ->
+            db.transaction {
+                fullTextSearchModule.drop(db)
+                fullTextSearchModule.create(db)
+                createReindexMarker(db)
+            }
+        }
 
     suspend fun clearDB() =
         pool.useWriter { db ->
@@ -375,7 +520,10 @@ class SQLiteEventStore(
 
     suspend fun deleteExpiredEvents() = pool.useWriter { expirationModule.deleteExpiredEvents(it) }
 
-    fun close() = pool.close()
+    fun close() {
+        maintenanceScope.cancel()
+        pool.close()
+    }
 }
 
 class RawEvent(

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/SQLiteEventStore.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/SQLiteEventStore.kt
@@ -35,12 +35,6 @@ import com.vitorpamplona.quartz.nip01Core.store.IEventStore
 import com.vitorpamplona.quartz.nip01Core.store.IdAndTime
 import com.vitorpamplona.quartz.nip40Expiration.isExpired
 import com.vitorpamplona.quartz.utils.EventFactory
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.yield
 
 class SQLiteEventStore(
     val driver: SQLiteDriver = BundledSQLiteDriver(),
@@ -50,12 +44,7 @@ class SQLiteEventStore(
     val numReaders: Int = 4,
 ) {
     companion object {
-        const val DATABASE_VERSION = 3
-
-        // Rows per background-reindex batch. Each batch is one writer
-        // transaction; the writer mutex is released between batches so live
-        // inserts/queries interleave instead of waiting for the whole reindex.
-        const val REINDEX_BATCH_SIZE = 500
+        const val DATABASE_VERSION = 2
     }
 
     val seedModule = SeedModule()
@@ -142,26 +131,6 @@ class SQLiteEventStore(
         )
     }
 
-    // Background worker for one-off maintenance that must not block app
-    // startup — currently the post-migration full-text reindex backfill.
-    private val maintenanceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-
-    init {
-        // Kicked off asynchronously: it returns immediately when there is no
-        // pending reindex (the common case), and otherwise backfills the FTS
-        // index in the background while the rest of the app runs normally.
-        maintenanceScope.launch {
-            try {
-                reindexFullTextIfPending()
-            } catch (_: Throwable) {
-                // Best-effort maintenance. A failure here only leaves search
-                // degraded until the next launch retries; it must never crash
-                // the store. (CancellationException from close() lands here too
-                // and is intentionally swallowed.)
-            }
-        }
-    }
-
     private fun getUserVersion(db: SQLiteConnection): Int =
         db.prepare("PRAGMA user_version").use { stmt ->
             stmt.step()
@@ -195,158 +164,9 @@ class SQLiteEventStore(
                     modules.reversed().forEach { it.drop(db) }
                     modules.forEach { it.create(db) }
                 }
-                2 -> {
-                    // Upgrade from version 2 to 3
-                    // The full-text index dropped its dedicated foreign-key
-                    // column and now aligns the FTS rowid with
-                    // event_headers.row_id. Recreate the (now empty) FTS table
-                    // structure cheaply inside the migration and record a
-                    // persistent marker; the actual repopulation from
-                    // event_headers happens later in the background via
-                    // [reindexFullTextIfPending] so the migration — and app
-                    // startup — never blocks on a large reindex.
-                    fullTextSearchModule.drop(db)
-                    fullTextSearchModule.create(db)
-                    createReindexMarker(db)
-                }
             }
         }
     }
-
-    // ------------------------------------------------------------------
-    // Background full-text reindex
-    //
-    // When a migration recreates the FTS table it leaves a persistent
-    // `fts_reindex` marker holding a progress cursor (the highest
-    // event_headers.row_id already backfilled). The backfill walks
-    // event_headers in row_id order in small committed batches, so it
-    // interleaves with normal relay inserts/queries and survives process
-    // death: the cursor is persisted, and on the next launch the marker is
-    // still present so the work resumes where it stopped. Search is merely
-    // degraded (partial results) until it finishes — never blocked.
-    // ------------------------------------------------------------------
-
-    private val reindexMarkerTable = "fts_reindex"
-
-    private fun createReindexMarker(db: SQLiteConnection) {
-        db.execSQL("CREATE TABLE IF NOT EXISTS $reindexMarkerTable (next_row_id INTEGER NOT NULL)")
-        db.execSQL("DELETE FROM $reindexMarkerTable")
-        // row_id is AUTOINCREMENT starting at 1, so 0 means "nothing done yet".
-        db.execSQL("INSERT INTO $reindexMarkerTable (next_row_id) VALUES (0)")
-    }
-
-    private fun hasReindexMarker(db: SQLiteConnection): Boolean = db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '$reindexMarkerTable'").use { it.step() }
-
-    private fun getReindexCursor(db: SQLiteConnection): Long =
-        db.prepare("SELECT next_row_id FROM $reindexMarkerTable LIMIT 1").use {
-            if (it.step()) it.getLong(0) else 0L
-        }
-
-    private fun setReindexCursor(
-        db: SQLiteConnection,
-        value: Long,
-    ) {
-        db.prepare("UPDATE $reindexMarkerTable SET next_row_id = ?").use {
-            it.bindLong(1, value)
-            it.step()
-        }
-    }
-
-    private fun dropReindexMarker(db: SQLiteConnection) {
-        db.execSQL("DROP TABLE IF EXISTS $reindexMarkerTable")
-    }
-
-    /**
-     * Drives the background backfill loop while a reindex marker exists.
-     * Each iteration processes one batch in its own writer transaction, then
-     * releases the writer mutex so other writes get a turn. [yield] makes the
-     * loop cancellation-aware (see [close]).
-     */
-    internal suspend fun reindexFullTextIfPending() {
-        if (!pool.useReader { hasReindexMarker(it) }) return
-
-        while (true) {
-            val done = pool.useWriter { db -> reindexNextBatch(db, REINDEX_BATCH_SIZE) }
-            if (done) break
-            yield()
-        }
-    }
-
-    /**
-     * Indexes up to [limit] not-yet-processed events (row_id greater than the
-     * persisted cursor) into the FTS table and advances the cursor. Returns
-     * true once there is nothing left, after dropping the marker. A single
-     * malformed cached row is skipped — the cursor still moves past it, so the
-     * backfill can never get stuck retrying the same row.
-     */
-    private fun reindexNextBatch(
-        db: SQLiteConnection,
-        limit: Int,
-    ): Boolean =
-        db.transaction {
-            // The marker may have been dropped by a previous batch (or, in
-            // theory, another backfiller) — treat its absence as "done" rather
-            // than reading a cursor from a missing table.
-            if (!hasReindexMarker(db)) {
-                true
-            } else {
-                val cursor = getReindexCursor(db)
-                var lastRowId = cursor
-                var count = 0
-
-                db
-                    .prepare(
-                        "SELECT row_id, id, pubkey, created_at, kind, tags, content, sig FROM event_headers " +
-                            "WHERE row_id > ? ORDER BY row_id LIMIT ?",
-                    ).use { stmt ->
-                        stmt.bindLong(1, cursor)
-                        stmt.bindLong(2, limit.toLong())
-                        while (stmt.step()) {
-                            val rowId = stmt.getLong(0)
-                            try {
-                                val event =
-                                    EventFactory.create<Event>(
-                                        stmt.getText(1),
-                                        stmt.getText(2),
-                                        stmt.getLong(3),
-                                        stmt.getInt(4),
-                                        OptimizedJsonMapper.fromJsonToTagArray(stmt.getText(5)),
-                                        stmt.getText(6),
-                                        stmt.getText(7),
-                                    )
-                                fullTextSearchModule.insertIfAbsent(event, rowId, db)
-                            } catch (_: Throwable) {
-                                // Skip a row that fails to parse/index; advancing the
-                                // cursor below guarantees forward progress regardless.
-                            }
-                            lastRowId = rowId
-                            count++
-                        }
-                    }
-
-                if (count == 0) {
-                    dropReindexMarker(db)
-                    true
-                } else {
-                    setReindexCursor(db, lastRowId)
-                    false
-                }
-            }
-        }
-
-    /**
-     * Test hook: simulates the post-migration state by clearing the FTS table
-     * and arming the reindex marker, so a test can then drive
-     * [reindexFullTextIfPending] deterministically.
-     */
-    internal suspend fun dropFtsAndMarkPendingForTest() =
-        pool.useWriter { db ->
-            db.transaction {
-                fullTextSearchModule.drop(db)
-                fullTextSearchModule.create(db)
-                createReindexMarker(db)
-            }
-        }
 
     suspend fun clearDB() =
         pool.useWriter { db ->
@@ -520,10 +340,7 @@ class SQLiteEventStore(
 
     suspend fun deleteExpiredEvents() = pool.useWriter { expirationModule.deleteExpiredEvents(it) }
 
-    fun close() {
-        maintenanceScope.cancel()
-        pool.close()
-    }
+    fun close() = pool.close()
 }
 
 class RawEvent(

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip10Notes/TextNoteEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip10Notes/TextNoteEvent.kt
@@ -66,7 +66,7 @@ class TextNoteEvent(
     PubKeyHintProvider,
     IForkableEvent,
     SearchableEvent {
-    override fun indexableContent() = "Subject: " + subject() + "\n" + content
+    override fun indexableContent() = listOfNotNull(subject(), content).joinToString("\n")
 
     override fun eventHints(): List<EventIdHint> {
         val eHints = tags.mapNotNull(MarkedETag::parseAsHint)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip17Dm/messages/ChatMessageEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip17Dm/messages/ChatMessageEvent.kt
@@ -30,6 +30,7 @@ import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip01Core.tags.people.toPTag
 import com.vitorpamplona.quartz.nip17Dm.base.BaseDMGroupEvent
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 @Immutable
@@ -40,7 +41,11 @@ class ChatMessageEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : BaseDMGroupEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : BaseDMGroupEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    // content is the decrypted (plaintext) direct-message body.
+    override fun indexableContent() = content
+
     fun replyTo() = tags.mapNotNull(ETag::parseId)
 
     companion object {

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip23LongContent/LongTextNoteEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip23LongContent/LongTextNoteEvent.kt
@@ -71,7 +71,7 @@ class LongTextNoteEvent(
     PublishedAtProvider,
     RootScope,
     SearchableEvent {
-    override fun indexableContent() = "title: " + title() + "\nsummary: " + summary() + "\n" + content
+    override fun indexableContent() = listOfNotNull(title(), summary(), content).joinToString("\n")
 
     override fun eventHints(): List<EventIdHint> {
         val qHints = tags.mapNotNull(QTag::parseEventAsHint)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip28PublicChat/admin/ChannelCreateEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip28PublicChat/admin/ChannelCreateEvent.kt
@@ -32,6 +32,7 @@ import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip28PublicChat.base.ChannelData
 import com.vitorpamplona.quartz.nip28PublicChat.base.ChannelDataNorm
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.CancellationException
@@ -45,7 +46,10 @@ class ChannelCreateEvent(
     content: String,
     sig: HexKey,
 ) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
-    EventHintProvider {
+    EventHintProvider,
+    SearchableEvent {
+    override fun indexableContent() = channelInfo().let { listOfNotNull(it.name, it.about, it.picture).joinToString(" ") }
+
     @kotlinx.serialization.Transient
     @kotlin.jvm.Transient
     var cache: ChannelDataNorm? = null

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip28PublicChat/admin/ChannelMetadataEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip28PublicChat/admin/ChannelMetadataEvent.kt
@@ -35,6 +35,7 @@ import com.vitorpamplona.quartz.nip28PublicChat.base.ChannelData
 import com.vitorpamplona.quartz.nip28PublicChat.base.ChannelDataNorm
 import com.vitorpamplona.quartz.nip28PublicChat.base.channel
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.CancellationException
@@ -48,7 +49,10 @@ class ChannelMetadataEvent(
     content: String,
     sig: HexKey,
 ) : BasePublicChatEvent(id, pubKey, createdAt, KIND, tags, content, sig),
-    EventHintProvider {
+    EventHintProvider,
+    SearchableEvent {
+    override fun indexableContent() = channelInfo().let { listOfNotNull(it.name, it.about, it.picture).joinToString(" ") }
+
     @kotlinx.serialization.Transient
     @kotlin.jvm.Transient
     var cache: ChannelDataNorm? = null

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip29RelayGroups/metadata/GroupMetadataEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip29RelayGroups/metadata/GroupMetadataEvent.kt
@@ -29,6 +29,7 @@ import com.vitorpamplona.quartz.nip01Core.core.hasTagWithContent
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 @Immutable
@@ -39,7 +40,10 @@ class GroupMetadataEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(name(), about()).joinToString("\n")
+
     fun groupId() = dTag()
 
     fun name() = tags.firstTagValue("name")

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip30CustomEmoji/pack/EmojiPackEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip30CustomEmoji/pack/EmojiPackEvent.kt
@@ -29,6 +29,7 @@ import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip30CustomEmoji.EmojiUrlTag
 import com.vitorpamplona.quartz.nip30CustomEmoji.emojis
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip51Lists.PrivateTagArrayEvent
 import com.vitorpamplona.quartz.nip51Lists.tags.DescriptionTag
 import com.vitorpamplona.quartz.nip51Lists.tags.ImageTag
@@ -46,7 +47,10 @@ class EmojiPackEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : PrivateTagArrayEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : PrivateTagArrayEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = "title: " + titleOrName().orEmpty() + "\ndescription: " + description().orEmpty() + "\n" + content
+
     @Deprecated("NIP-51 has deprecated name. Use title instead", ReplaceWith("title()"))
     fun name() = tags.firstNotNullOfOrNull(NameTag::parse)
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip30CustomEmoji/pack/EmojiPackEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip30CustomEmoji/pack/EmojiPackEvent.kt
@@ -49,7 +49,7 @@ class EmojiPackEvent(
     sig: HexKey,
 ) : PrivateTagArrayEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     SearchableEvent {
-    override fun indexableContent() = "title: " + titleOrName().orEmpty() + "\ndescription: " + description().orEmpty() + "\n" + content
+    override fun indexableContent() = listOfNotNull(titleOrName(), description(), content).joinToString("\n")
 
     @Deprecated("NIP-51 has deprecated name. Use title instead", ReplaceWith("title()"))
     fun name() = tags.firstNotNullOfOrNull(NameTag::parse)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip34Git/issue/GitIssueEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip34Git/issue/GitIssueEvent.kt
@@ -61,7 +61,7 @@ class GitIssueEvent(
     EventHintProvider,
     AddressHintProvider,
     SearchableEvent {
-    override fun indexableContent() = "Subject: " + subject() + "\n" + content
+    override fun indexableContent() = listOfNotNull(subject(), content).joinToString("\n")
 
     override fun eventHints(): List<EventIdHint> {
         val qHints = tags.mapNotNull(QTag::parseEventAsHint)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip34Git/patch/GitPatchEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip34Git/patch/GitPatchEvent.kt
@@ -44,6 +44,7 @@ import com.vitorpamplona.quartz.nip34Git.patch.tags.Committer
 import com.vitorpamplona.quartz.nip34Git.patch.tags.CommitterTag
 import com.vitorpamplona.quartz.nip34Git.patch.tags.ParentCommitTag
 import com.vitorpamplona.quartz.nip34Git.repository.GitRepositoryEvent
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 @Immutable
@@ -57,7 +58,10 @@ class GitPatchEvent(
 ) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
     PubKeyHintProvider,
     EventHintProvider,
-    AddressHintProvider {
+    AddressHintProvider,
+    SearchableEvent {
+    override fun indexableContent() = content
+
     override fun pubKeyHints() = tags.mapNotNull(PTag::parseAsHint)
 
     override fun linkedPubKeys() = tags.mapNotNull(PTag::parseKey)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip34Git/pr/GitPullRequestEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip34Git/pr/GitPullRequestEvent.kt
@@ -66,7 +66,7 @@ class GitPullRequestEvent(
     EventHintProvider,
     AddressHintProvider,
     SearchableEvent {
-    override fun indexableContent() = "Subject: " + subject().orEmpty() + "\n" + content
+    override fun indexableContent() = listOfNotNull(subject(), content).joinToString("\n")
 
     override fun pubKeyHints() = tags.mapNotNull(PTag::parseAsHint)
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip34Git/pr/GitPullRequestEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip34Git/pr/GitPullRequestEvent.kt
@@ -42,6 +42,7 @@ import com.vitorpamplona.quartz.nip34Git.pr.tags.CurrentCommitTag
 import com.vitorpamplona.quartz.nip34Git.pr.tags.MergeBaseTag
 import com.vitorpamplona.quartz.nip34Git.repository.GitRepositoryEvent
 import com.vitorpamplona.quartz.nip34Git.repository.tags.CloneTag
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 /**
@@ -63,7 +64,10 @@ class GitPullRequestEvent(
 ) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
     PubKeyHintProvider,
     EventHintProvider,
-    AddressHintProvider {
+    AddressHintProvider,
+    SearchableEvent {
+    override fun indexableContent() = "Subject: " + subject().orEmpty() + "\n" + content
+
     override fun pubKeyHints() = tags.mapNotNull(PTag::parseAsHint)
 
     override fun linkedPubKeys() = tags.mapNotNull(PTag::parseKey)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip34Git/reply/GitReplyEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip34Git/reply/GitReplyEvent.kt
@@ -47,6 +47,7 @@ import com.vitorpamplona.quartz.nip19Bech32.pubKeyHints
 import com.vitorpamplona.quartz.nip19Bech32.pubKeys
 import com.vitorpamplona.quartz.nip34Git.issue.GitIssueEvent
 import com.vitorpamplona.quartz.nip34Git.patch.GitPatchEvent
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 import com.vitorpamplona.quartz.utils.lastNotNullOfOrNull
 
@@ -62,7 +63,10 @@ class GitReplyEvent(
 ) : BaseThreadedEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     PubKeyHintProvider,
     EventHintProvider,
-    AddressHintProvider {
+    AddressHintProvider,
+    SearchableEvent {
+    override fun indexableContent() = content
+
     override fun eventHints(): List<EventIdHint> {
         val eHints = tags.mapNotNull(ETag::parseAsHint)
         val qHints = tags.mapNotNull(QTag::parseEventAsHint)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip34Git/repository/GitRepositoryEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip34Git/repository/GitRepositoryEvent.kt
@@ -52,7 +52,7 @@ class GitRepositoryEvent(
     sig: HexKey,
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     SearchableEvent {
-    override fun indexableContent() = "name: " + name().orEmpty() + "\ndescription: " + description().orEmpty() + "\n" + content
+    override fun indexableContent() = listOfNotNull(name(), description(), content).joinToString("\n")
 
     fun name() = tags.firstNotNullOfOrNull(NameTag::parse)
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip34Git/repository/GitRepositoryEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip34Git/repository/GitRepositoryEvent.kt
@@ -37,6 +37,7 @@ import com.vitorpamplona.quartz.nip34Git.repository.tags.MaintainersTag
 import com.vitorpamplona.quartz.nip34Git.repository.tags.NameTag
 import com.vitorpamplona.quartz.nip34Git.repository.tags.RelaysTag
 import com.vitorpamplona.quartz.nip34Git.repository.tags.WebTag
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -49,7 +50,10 @@ class GitRepositoryEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = "name: " + name().orEmpty() + "\ndescription: " + description().orEmpty() + "\n" + content
+
     fun name() = tags.firstNotNullOfOrNull(NameTag::parse)
 
     fun description() = tags.firstNotNullOfOrNull(DescriptionTag::parse)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip35Torrents/TorrentCommentEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip35Torrents/TorrentCommentEvent.kt
@@ -48,6 +48,7 @@ import com.vitorpamplona.quartz.nip19Bech32.eventIds
 import com.vitorpamplona.quartz.nip19Bech32.pubKeyHints
 import com.vitorpamplona.quartz.nip19Bech32.pubKeys
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 @Immutable
@@ -62,7 +63,10 @@ class TorrentCommentEvent(
 ) : BaseThreadedEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     EventHintProvider,
     PubKeyHintProvider,
-    AddressHintProvider {
+    AddressHintProvider,
+    SearchableEvent {
+    override fun indexableContent() = content
+
     override fun eventHints(): List<EventIdHint> {
         val eHints = tags.mapNotNull(MarkedETag::parseAsHint)
         val qHints = tags.mapNotNull(QTag::parseEventAsHint)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip35Torrents/TorrentEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip35Torrents/TorrentEvent.kt
@@ -38,6 +38,7 @@ import com.vitorpamplona.quartz.nip35Torrents.tags.FileTag
 import com.vitorpamplona.quartz.nip35Torrents.tags.InfoHashTag
 import com.vitorpamplona.quartz.nip35Torrents.tags.TrackerTag
 import com.vitorpamplona.quartz.nip36SensitiveContent.contentWarning
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 import com.vitorpamplona.quartz.utils.UrlEncoder
 
@@ -49,7 +50,10 @@ class TorrentEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : Event(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = "title: " + title().orEmpty() + "\n" + content
+
     fun title() = tags.firstNotNullOfOrNull(TitleTag::parse)
 
     fun btih() = tags.firstNotNullOfOrNull(BtihTag::parse)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip35Torrents/TorrentEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip35Torrents/TorrentEvent.kt
@@ -52,7 +52,7 @@ class TorrentEvent(
     sig: HexKey,
 ) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
     SearchableEvent {
-    override fun indexableContent() = "title: " + title().orEmpty() + "\n" + content
+    override fun indexableContent() = listOfNotNull(title(), content).joinToString("\n")
 
     fun title() = tags.firstNotNullOfOrNull(TitleTag::parse)
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip38UserStatus/StatusEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip38UserStatus/StatusEvent.kt
@@ -29,6 +29,7 @@ import com.vitorpamplona.quartz.nip01Core.tags.aTag.ATag
 import com.vitorpamplona.quartz.nip01Core.tags.events.ETag
 import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip30CustomEmoji.EmojiUrlTag
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 @Immutable
@@ -39,7 +40,10 @@ class StatusEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = content
+
     fun firstTaggedUrl() = tags.firstTagValue("r")
 
     companion object {

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/appCurationSet/AppCurationSetEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/appCurationSet/AppCurationSetEvent.kt
@@ -33,6 +33,7 @@ import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip31Alts.AltTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.AddressBookmark
 import com.vitorpamplona.quartz.nip51Lists.remove
 import com.vitorpamplona.quartz.nip51Lists.tags.DescriptionTag
@@ -51,7 +52,10 @@ class AppCurationSetEvent(
     content: String,
     sig: HexKey,
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
-    AddressHintProvider {
+    AddressHintProvider,
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(title(), description()).joinToString("\n")
+
     override fun addressHints() = tags.mapNotNull(AddressBookmark::parseAsHint)
 
     override fun linkedAddressIds() = tags.mapNotNull(AddressBookmark::parseAddressId)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/articleCurationSet/ArticleCurationSetEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/articleCurationSet/ArticleCurationSetEvent.kt
@@ -34,6 +34,7 @@ import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip31Alts.AltTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip51Lists.PrivateTagArrayEvent
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.AddressBookmark
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.BookmarkIdTag
@@ -57,7 +58,10 @@ class ArticleCurationSetEvent(
     sig: HexKey,
 ) : PrivateTagArrayEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     EventHintProvider,
-    AddressHintProvider {
+    AddressHintProvider,
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(title(), description()).joinToString("\n")
+
     override fun eventHints() = tags.mapNotNull(EventBookmark::parseAsHint)
 
     override fun linkedEventIds() = tags.mapNotNull(EventBookmark::parseId)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/bookmarkList/BookmarkListEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/bookmarkList/BookmarkListEvent.kt
@@ -33,6 +33,7 @@ import com.vitorpamplona.quartz.nip01Core.signers.SignerExceptions
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip31Alts.AltTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip51Lists.PrivateReplaceableTagArrayEvent
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.AddressBookmark
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.BookmarkIdTag
@@ -52,7 +53,12 @@ class BookmarkListEvent(
     sig: HexKey,
 ) : PrivateReplaceableTagArrayEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     EventHintProvider,
-    AddressHintProvider {
+    AddressHintProvider,
+    SearchableEvent {
+    // Only the public list title is indexed; bookmarks live in NIP-44
+    // encrypted content and are intentionally never indexed.
+    override fun indexableContent() = listOfNotNull(title()).joinToString("\n")
+
     override fun eventHints() = tags.mapNotNull(EventBookmark::parseAsHint)
 
     override fun linkedEventIds() = tags.mapNotNull(EventBookmark::parseId)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/bookmarkList/OldBookmarkListEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/bookmarkList/OldBookmarkListEvent.kt
@@ -34,6 +34,7 @@ import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip31Alts.AltTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip51Lists.PrivateTagArrayEvent
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.AddressBookmark
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.BookmarkIdTag
@@ -53,7 +54,12 @@ class OldBookmarkListEvent(
     sig: HexKey,
 ) : PrivateTagArrayEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     EventHintProvider,
-    AddressHintProvider {
+    AddressHintProvider,
+    SearchableEvent {
+    // Only the public list title is indexed; bookmarks live in NIP-44
+    // encrypted content and are intentionally never indexed.
+    override fun indexableContent() = listOfNotNull(title()).joinToString("\n")
+
     override fun eventHints() = tags.mapNotNull(EventBookmark::parseAsHint)
 
     override fun linkedEventIds() = tags.mapNotNull(EventBookmark::parseId)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/followList/FollowListEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/followList/FollowListEvent.kt
@@ -32,6 +32,7 @@ import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip31Alts.AltTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip51Lists.muteList.tags.UserTag
 import com.vitorpamplona.quartz.nip51Lists.remove
 import com.vitorpamplona.quartz.nip51Lists.tags.DescriptionTag
@@ -50,7 +51,10 @@ class FollowListEvent(
     content: String,
     sig: HexKey,
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
-    PubKeyHintProvider {
+    PubKeyHintProvider,
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(title(), description()).joinToString("\n")
+
     override fun pubKeyHints() = tags.mapNotNull(UserTag::parseAsHint)
 
     override fun linkedPubKeys() = tags.mapNotNull(UserTag::parseKey)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/interestSet/InterestSetEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/interestSet/InterestSetEvent.kt
@@ -33,10 +33,13 @@ import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip01Core.tags.hashtags.HashtagTag
 import com.vitorpamplona.quartz.nip31Alts.AltTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip51Lists.PrivateTagArrayEvent
 import com.vitorpamplona.quartz.nip51Lists.encryption.PrivateTagsInContent
 import com.vitorpamplona.quartz.nip51Lists.removeAny
 import com.vitorpamplona.quartz.nip51Lists.removeIgnoreCase
+import com.vitorpamplona.quartz.nip51Lists.tags.DescriptionTag
+import com.vitorpamplona.quartz.nip51Lists.tags.TitleTag
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -49,7 +52,16 @@ class InterestSetEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : PrivateTagArrayEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : PrivateTagArrayEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    // Public title/description plus the public-interest hashtags. Private
+    // hashtags live in NIP-44 encrypted content and are never indexed.
+    override fun indexableContent() = (listOfNotNull(title(), description()) + publicHashtags()).joinToString("\n")
+
+    fun title() = tags.firstNotNullOfOrNull(TitleTag::parse)
+
+    fun description() = tags.firstNotNullOfOrNull(DescriptionTag::parse)
+
     fun publicHashtags() = tags.mapNotNull(HashtagTag::parse)
 
     suspend fun privateHashtags(signer: NostrSigner) = privateTags(signer)?.mapNotNull(HashtagTag::parse)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/labeledBookmarkList/LabeledBookmarkListEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/labeledBookmarkList/LabeledBookmarkListEvent.kt
@@ -34,6 +34,7 @@ import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip31Alts.AltTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip51Lists.PrivateTagArrayEvent
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.AddressBookmark
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.BookmarkIdTag
@@ -59,7 +60,12 @@ class LabeledBookmarkListEvent(
     sig: HexKey,
 ) : PrivateTagArrayEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     EventHintProvider,
-    AddressHintProvider {
+    AddressHintProvider,
+    SearchableEvent {
+    // Only the public label/description is indexed; bookmarks live in NIP-44
+    // encrypted content and are intentionally never indexed.
+    override fun indexableContent() = listOfNotNull(titleOrName(), description()).joinToString("\n")
+
     override fun eventHints() = tags.mapNotNull(EventBookmark::parseAsHint)
 
     override fun linkedEventIds() = tags.mapNotNull(EventBookmark::parseId)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/mediaStarterPack/MediaStarterPackEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/mediaStarterPack/MediaStarterPackEvent.kt
@@ -32,6 +32,7 @@ import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip31Alts.AltTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip51Lists.followList.followIdSet
 import com.vitorpamplona.quartz.nip51Lists.followList.followIds
 import com.vitorpamplona.quartz.nip51Lists.followList.follows
@@ -53,7 +54,10 @@ class MediaStarterPackEvent(
     content: String,
     sig: HexKey,
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
-    PubKeyHintProvider {
+    PubKeyHintProvider,
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(title(), description()).joinToString("\n")
+
     override fun pubKeyHints() = tags.mapNotNull(UserTag::parseAsHint)
 
     override fun linkedPubKeys() = tags.mapNotNull(UserTag::parseKey)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/peopleList/PeopleListEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/peopleList/PeopleListEvent.kt
@@ -35,6 +35,7 @@ import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip23LongContent.tags.TitleTag
 import com.vitorpamplona.quartz.nip31Alts.AltTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip51Lists.PrivateTagArrayEvent
 import com.vitorpamplona.quartz.nip51Lists.encryption.PrivateTagsInContent
 import com.vitorpamplona.quartz.nip51Lists.muteList.tags.MuteTag
@@ -57,7 +58,12 @@ class PeopleListEvent(
     content: String,
     sig: HexKey,
 ) : PrivateTagArrayEvent(id, pubKey, createdAt, KIND, tags, content, sig),
-    PubKeyHintProvider {
+    PubKeyHintProvider,
+    SearchableEvent {
+    // Only the public label/description is indexed; members can live in NIP-44
+    // encrypted content and are intentionally never indexed.
+    override fun indexableContent() = listOfNotNull(titleOrName(), description()).joinToString("\n")
+
     override fun pubKeyHints() = tags.mapNotNull(UserTag::parseAsHint)
 
     override fun linkedPubKeys() = tags.mapNotNull(UserTag::parseKey)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/pictureCurationSet/PictureCurationSetEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/pictureCurationSet/PictureCurationSetEvent.kt
@@ -33,6 +33,7 @@ import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip31Alts.AltTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip51Lists.PrivateTagArrayEvent
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.BookmarkIdTag
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.EventBookmark
@@ -54,7 +55,10 @@ class PictureCurationSetEvent(
     content: String,
     sig: HexKey,
 ) : PrivateTagArrayEvent(id, pubKey, createdAt, KIND, tags, content, sig),
-    EventHintProvider {
+    EventHintProvider,
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(title(), description()).joinToString("\n")
+
     override fun eventHints() = tags.mapNotNull(EventBookmark::parseAsHint)
 
     override fun linkedEventIds() = tags.mapNotNull(EventBookmark::parseId)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/relaySets/RelaySetEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/relaySets/RelaySetEvent.kt
@@ -30,6 +30,7 @@ import com.vitorpamplona.quartz.nip01Core.signers.SignerExceptions
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip31Alts.AltTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip51Lists.PrivateTagArrayEvent
 import com.vitorpamplona.quartz.nip51Lists.encryption.PrivateTagsInContent
 import com.vitorpamplona.quartz.nip51Lists.encryption.signNip51List
@@ -49,7 +50,12 @@ class RelaySetEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : PrivateTagArrayEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : PrivateTagArrayEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    // Only the public title/description is indexed; relays can live in NIP-44
+    // encrypted content and are intentionally never indexed.
+    override fun indexableContent() = listOfNotNull(title(), description()).joinToString("\n")
+
     fun relays(): List<NormalizedRelayUrl> = tags.mapNotNull(RelayTag.Companion::parse)
 
     fun title() = tags.firstNotNullOfOrNull(TitleTag::parse)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/releaseArtifactSet/ReleaseArtifactSetEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/releaseArtifactSet/ReleaseArtifactSetEvent.kt
@@ -33,6 +33,7 @@ import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip31Alts.AltTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.AddressBookmark
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.BookmarkIdTag
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.EventBookmark
@@ -53,7 +54,10 @@ class ReleaseArtifactSetEvent(
     sig: HexKey,
 ) : com.vitorpamplona.quartz.nip01Core.core.BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     EventHintProvider,
-    AddressHintProvider {
+    AddressHintProvider,
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(title(), description()).joinToString("\n")
+
     override fun eventHints() = tags.mapNotNull(EventBookmark::parseAsHint)
 
     override fun linkedEventIds() = tags.mapNotNull(EventBookmark::parseId)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/videoCurationSet/VideoCurationSetEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip51Lists/videoCurationSet/VideoCurationSetEvent.kt
@@ -34,6 +34,7 @@ import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip31Alts.AltTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip51Lists.PrivateTagArrayEvent
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.AddressBookmark
 import com.vitorpamplona.quartz.nip51Lists.bookmarkList.tags.BookmarkIdTag
@@ -57,7 +58,10 @@ class VideoCurationSetEvent(
     sig: HexKey,
 ) : PrivateTagArrayEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     EventHintProvider,
-    AddressHintProvider {
+    AddressHintProvider,
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(title(), description()).joinToString("\n")
+
     override fun eventHints() = tags.mapNotNull(EventBookmark::parseAsHint)
 
     override fun linkedEventIds() = tags.mapNotNull(EventBookmark::parseId)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip52Calendar/appt/day/CalendarDateSlotEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip52Calendar/appt/day/CalendarDateSlotEvent.kt
@@ -35,6 +35,7 @@ import com.vitorpamplona.quartz.nip23LongContent.tags.ImageTag
 import com.vitorpamplona.quartz.nip23LongContent.tags.SummaryTag
 import com.vitorpamplona.quartz.nip23LongContent.tags.TitleTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip52Calendar.appt.tags.LocationTag
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlin.uuid.ExperimentalUuidApi
@@ -48,7 +49,10 @@ class CalendarDateSlotEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = "title: " + title().orEmpty() + "\nsummary: " + summary().orEmpty() + "\n" + content
+
     fun title() = tags.firstNotNullOfOrNull(TitleTag.Companion::parse)
 
     fun location() = tags.firstNotNullOfOrNull(LocationTag.Companion::parse)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip52Calendar/appt/day/CalendarDateSlotEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip52Calendar/appt/day/CalendarDateSlotEvent.kt
@@ -51,7 +51,7 @@ class CalendarDateSlotEvent(
     sig: HexKey,
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     SearchableEvent {
-    override fun indexableContent() = "title: " + title().orEmpty() + "\nsummary: " + summary().orEmpty() + "\n" + content
+    override fun indexableContent() = listOfNotNull(title(), summary(), content).joinToString("\n")
 
     fun title() = tags.firstNotNullOfOrNull(TitleTag.Companion::parse)
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip52Calendar/appt/time/CalendarTimeSlotEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip52Calendar/appt/time/CalendarTimeSlotEvent.kt
@@ -52,7 +52,7 @@ class CalendarTimeSlotEvent(
     sig: HexKey,
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     SearchableEvent {
-    override fun indexableContent() = "title: " + title().orEmpty() + "\nsummary: " + summary().orEmpty() + "\n" + content
+    override fun indexableContent() = listOfNotNull(title(), summary(), content).joinToString("\n")
 
     fun title() = tags.firstNotNullOfOrNull(TitleTag.Companion::parse)
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip52Calendar/appt/time/CalendarTimeSlotEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip52Calendar/appt/time/CalendarTimeSlotEvent.kt
@@ -36,6 +36,7 @@ import com.vitorpamplona.quartz.nip23LongContent.tags.ImageTag
 import com.vitorpamplona.quartz.nip23LongContent.tags.SummaryTag
 import com.vitorpamplona.quartz.nip23LongContent.tags.TitleTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip52Calendar.appt.tags.LocationTag
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlin.uuid.ExperimentalUuidApi
@@ -49,7 +50,10 @@ class CalendarTimeSlotEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = "title: " + title().orEmpty() + "\nsummary: " + summary().orEmpty() + "\n" + content
+
     fun title() = tags.firstNotNullOfOrNull(TitleTag.Companion::parse)
 
     fun location() = tags.firstNotNullOfOrNull(LocationTag.Companion::parse)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip52Calendar/calendar/CalendarEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip52Calendar/calendar/CalendarEvent.kt
@@ -44,7 +44,7 @@ class CalendarEvent(
     sig: HexKey,
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     SearchableEvent {
-    override fun indexableContent() = "title: " + title().orEmpty() + "\n" + content
+    override fun indexableContent() = listOfNotNull(title(), content).joinToString("\n")
 
     fun title() = tags.firstNotNullOfOrNull(TitleTag::parse)
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip52Calendar/calendar/CalendarEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip52Calendar/calendar/CalendarEvent.kt
@@ -29,6 +29,7 @@ import com.vitorpamplona.quartz.nip01Core.tags.aTag.taggedAddresses
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip23LongContent.tags.TitleTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -41,7 +42,10 @@ class CalendarEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = "title: " + title().orEmpty() + "\n" + content
+
     fun title() = tags.firstNotNullOfOrNull(TitleTag::parse)
 
     fun calendarEventAddresses() = taggedAddresses()

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip53LiveActivities/clip/LiveActivitiesClipEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip53LiveActivities/clip/LiveActivitiesClipEvent.kt
@@ -37,6 +37,7 @@ import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip01Core.tags.references.ReferenceTag
 import com.vitorpamplona.quartz.nip23LongContent.tags.TitleTag
 import com.vitorpamplona.quartz.nip31Alts.AltTag
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip53LiveActivities.streaming.LiveActivitiesEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
@@ -63,7 +64,10 @@ class LiveActivitiesClipEvent(
     sig: HexKey,
 ) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
     AddressHintProvider,
-    PubKeyHintProvider {
+    PubKeyHintProvider,
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(title(), content).joinToString("\n")
+
     override fun addressHints(): List<AddressHint> = tags.mapNotNull(ATag::parseAsHint)
 
     override fun linkedAddressIds(): List<String> = tags.mapNotNull(ATag::parseAddressId)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip53LiveActivities/meetingSpaces/MeetingRoomEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip53LiveActivities/meetingSpaces/MeetingRoomEvent.kt
@@ -38,6 +38,7 @@ import com.vitorpamplona.quartz.nip23LongContent.tags.SummaryTag
 import com.vitorpamplona.quartz.nip23LongContent.tags.TitleTag
 import com.vitorpamplona.quartz.nip31Alts.AltTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip53LiveActivities.LiveStreamLike
 import com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.tags.MeetingSpaceTag
 import com.vitorpamplona.quartz.nip53LiveActivities.streaming.tags.CurrentParticipantsTag
@@ -66,7 +67,10 @@ class MeetingRoomEvent(
     EventHintProvider,
     AddressHintProvider,
     PubKeyHintProvider,
-    LiveStreamLike {
+    LiveStreamLike,
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(title(), summary()).joinToString("\n")
+
     override fun eventHints(): List<EventIdHint> {
         val pinnedEvents = pinned()
         if (pinnedEvents.isEmpty()) return emptyList()

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip53LiveActivities/meetingSpaces/MeetingSpaceEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip53LiveActivities/meetingSpaces/MeetingSpaceEvent.kt
@@ -33,6 +33,7 @@ import com.vitorpamplona.quartz.nip23LongContent.tags.ImageTag
 import com.vitorpamplona.quartz.nip23LongContent.tags.SummaryTag
 import com.vitorpamplona.quartz.nip31Alts.AltTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.tags.EndpointUrlTag
 import com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.tags.RelayListTag
 import com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.tags.RoomNameTag
@@ -52,7 +53,10 @@ class MeetingSpaceEvent(
     content: String,
     sig: HexKey,
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
-    PubKeyHintProvider {
+    PubKeyHintProvider,
+    SearchableEvent {
+    override fun indexableContent() = "room: " + room().orEmpty() + "\nsummary: " + summary().orEmpty() + "\n" + content
+
     override fun pubKeyHints() = tags.mapNotNull(ParticipantTag::parseAsHint)
 
     override fun linkedPubKeys() = tags.mapNotNull(ParticipantTag::parseKey)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip53LiveActivities/meetingSpaces/MeetingSpaceEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip53LiveActivities/meetingSpaces/MeetingSpaceEvent.kt
@@ -55,7 +55,7 @@ class MeetingSpaceEvent(
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     PubKeyHintProvider,
     SearchableEvent {
-    override fun indexableContent() = "room: " + room().orEmpty() + "\nsummary: " + summary().orEmpty() + "\n" + content
+    override fun indexableContent() = listOfNotNull(room(), summary(), content).joinToString("\n")
 
     override fun pubKeyHints() = tags.mapNotNull(ParticipantTag::parseAsHint)
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip53LiveActivities/streaming/LiveActivitiesEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip53LiveActivities/streaming/LiveActivitiesEvent.kt
@@ -65,7 +65,7 @@ class LiveActivitiesEvent(
     PubKeyHintProvider,
     LiveStreamLike,
     SearchableEvent {
-    override fun indexableContent() = "title: " + title().orEmpty() + "\nsummary: " + summary().orEmpty() + "\n" + content
+    override fun indexableContent() = listOfNotNull(title(), summary(), content).joinToString("\n")
 
     override fun eventHints(): List<EventIdHint> {
         val pinnedEvents = pinned()

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip53LiveActivities/streaming/LiveActivitiesEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip53LiveActivities/streaming/LiveActivitiesEvent.kt
@@ -36,6 +36,7 @@ import com.vitorpamplona.quartz.nip23LongContent.tags.SummaryTag
 import com.vitorpamplona.quartz.nip23LongContent.tags.TitleTag
 import com.vitorpamplona.quartz.nip31Alts.AltTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip53LiveActivities.LiveStreamLike
 import com.vitorpamplona.quartz.nip53LiveActivities.streaming.tags.CurrentParticipantsTag
 import com.vitorpamplona.quartz.nip53LiveActivities.streaming.tags.EndsTag
@@ -62,7 +63,10 @@ class LiveActivitiesEvent(
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     EventHintProvider,
     PubKeyHintProvider,
-    LiveStreamLike {
+    LiveStreamLike,
+    SearchableEvent {
+    override fun indexableContent() = "title: " + title().orEmpty() + "\nsummary: " + summary().orEmpty() + "\n" + content
+
     override fun eventHints(): List<EventIdHint> {
         val pinnedEvents = pinned()
         if (pinnedEvents.isEmpty()) return emptyList()

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip54Wiki/WikiNoteEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip54Wiki/WikiNoteEvent.kt
@@ -78,7 +78,7 @@ class WikiNoteEvent(
     IForkableEvent,
     RootScope,
     SearchableEvent {
-    override fun indexableContent() = "title: " + title() + "\nsummary: " + summary() + "\n" + content
+    override fun indexableContent() = listOfNotNull(title(), summary(), content).joinToString("\n")
 
     override fun eventHints(): List<EventIdHint> {
         val eHints = tags.mapNotNull(MarkedETag::parseAsHint)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip57Zaps/LnZapEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip57Zaps/LnZapEvent.kt
@@ -31,6 +31,7 @@ import com.vitorpamplona.quartz.nip01Core.hints.PubKeyHintProvider
 import com.vitorpamplona.quartz.nip01Core.tags.aTag.ATag
 import com.vitorpamplona.quartz.nip01Core.tags.events.ETag
 import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.Log
 
 @Immutable
@@ -45,7 +46,12 @@ class LnZapEvent(
     LnZapEventInterface,
     EventHintProvider,
     AddressHintProvider,
-    PubKeyHintProvider {
+    PubKeyHintProvider,
+    SearchableEvent {
+    // The zap comment lives in the embedded request, which init{} already parses
+    // into [zapRequest] — so indexing it adds no extra parse cost.
+    override fun indexableContent() = zapRequest?.content.orEmpty()
+
     override fun pubKeyHints() = tags.mapNotNull(PTag::parseAsHint)
 
     override fun linkedPubKeys() = tags.mapNotNull(PTag::parseKey)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip57Zaps/LnZapRequestEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip57Zaps/LnZapRequestEvent.kt
@@ -37,6 +37,7 @@ import com.vitorpamplona.quartz.nip01Core.tags.events.ETag
 import com.vitorpamplona.quartz.nip01Core.tags.kinds.KindTag
 import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip31Alts.AltTag
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 @Immutable
@@ -50,7 +51,12 @@ class LnZapRequestEvent(
 ) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
     EventHintProvider,
     AddressHintProvider,
-    PubKeyHintProvider {
+    PubKeyHintProvider,
+    SearchableEvent {
+    // content is the public zap comment. Private-zap messages live encrypted in
+    // the `anon` tag, not in content, so they are naturally excluded.
+    override fun indexableContent() = content
+
     override fun pubKeyHints() = tags.mapNotNull(PTag::parseAsHint)
 
     override fun linkedPubKeys() = tags.mapNotNull(PTag::parseKey)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip58Badges/definition/BadgeDefinitionEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip58Badges/definition/BadgeDefinitionEvent.kt
@@ -43,7 +43,7 @@ class BadgeDefinitionEvent(
     sig: HexKey,
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     SearchableEvent {
-    override fun indexableContent() = "name: " + name().orEmpty() + "\ndescription: " + description().orEmpty() + "\n" + content
+    override fun indexableContent() = listOfNotNull(name(), description(), content).joinToString("\n")
 
     fun name() = tags.badgeName()
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip58Badges/definition/BadgeDefinitionEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip58Badges/definition/BadgeDefinitionEvent.kt
@@ -27,6 +27,7 @@ import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip58Badges.definition.tags.ImageTag
 import com.vitorpamplona.quartz.nip58Badges.definition.tags.ThumbTag
 import com.vitorpamplona.quartz.nip94FileMetadata.tags.DimensionTag
@@ -40,7 +41,10 @@ class BadgeDefinitionEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = "name: " + name().orEmpty() + "\ndescription: " + description().orEmpty() + "\n" + content
+
     fun name() = tags.badgeName()
 
     fun image() = tags.badgeImageUrl()

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip5aStaticWebsites/NamedSiteEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip5aStaticWebsites/NamedSiteEvent.kt
@@ -27,6 +27,7 @@ import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip5aStaticWebsites.tags.PathTag
 import com.vitorpamplona.quartz.utils.TimeUtils
 
@@ -38,7 +39,10 @@ class NamedSiteEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(title(), description()).joinToString("\n")
+
     fun paths() = tags.sitePaths()
 
     fun servers() = tags.siteServers()

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip5aStaticWebsites/RootSiteEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip5aStaticWebsites/RootSiteEvent.kt
@@ -26,6 +26,7 @@ import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip5aStaticWebsites.tags.PathTag
 import com.vitorpamplona.quartz.utils.TimeUtils
 
@@ -37,7 +38,10 @@ class RootSiteEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : BaseReplaceableEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : BaseReplaceableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(title(), description()).joinToString("\n")
+
     fun paths() = tags.sitePaths()
 
     fun servers() = tags.siteServers()

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip61Nutzaps/nutzap/NutzapEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip61Nutzaps/nutzap/NutzapEvent.kt
@@ -31,6 +31,7 @@ import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.events.ETag
 import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 @Immutable
@@ -43,7 +44,11 @@ class NutzapEvent(
     sig: HexKey,
 ) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
     EventHintProvider,
-    PubKeyHintProvider {
+    PubKeyHintProvider,
+    SearchableEvent {
+    // content is the optional nutzap message.
+    override fun indexableContent() = content
+
     override fun eventHints() = tags.mapNotNull(ETag::parseAsHint)
 
     override fun linkedEventIds() = tags.mapNotNull(ETag::parseId)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip68Picture/PictureEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip68Picture/PictureEvent.kt
@@ -30,6 +30,7 @@ import com.vitorpamplona.quartz.nip01Core.tags.hashtags.hashtags
 import com.vitorpamplona.quartz.nip22Comments.RootScope
 import com.vitorpamplona.quartz.nip23LongContent.tags.TitleTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip68Picture.tags.LocationTag
 import com.vitorpamplona.quartz.nip92IMeta.imetas
 import com.vitorpamplona.quartz.nip94FileMetadata.tags.HashSha256Tag
@@ -45,7 +46,10 @@ class PictureEvent(
     content: String,
     sig: HexKey,
 ) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
-    RootScope {
+    RootScope,
+    SearchableEvent {
+    override fun indexableContent() = "title: " + title().orEmpty() + "\n" + content
+
     @kotlinx.serialization.Transient
     @kotlin.jvm.Transient
     var iMetas: List<PictureMeta>? = null

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip68Picture/PictureEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip68Picture/PictureEvent.kt
@@ -48,7 +48,7 @@ class PictureEvent(
 ) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
     RootScope,
     SearchableEvent {
-    override fun indexableContent() = "title: " + title().orEmpty() + "\n" + content
+    override fun indexableContent() = listOfNotNull(title(), content).joinToString("\n")
 
     @kotlinx.serialization.Transient
     @kotlin.jvm.Transient

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip71Video/AddressableVideoEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip71Video/AddressableVideoEvent.kt
@@ -51,7 +51,7 @@ abstract class AddressableVideoEvent(
     VideoEvent,
     RootScope,
     SearchableEvent {
-    override fun indexableContent() = "title: " + title().orEmpty() + "\n" + content
+    override fun indexableContent() = listOfNotNull(title(), content).joinToString("\n")
 
     @kotlinx.serialization.Transient
     @kotlin.jvm.Transient

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip71Video/AddressableVideoEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip71Video/AddressableVideoEvent.kt
@@ -30,6 +30,7 @@ import com.vitorpamplona.quartz.nip01Core.tags.publishedAt.PublishedAtProvider
 import com.vitorpamplona.quartz.nip22Comments.RootScope
 import com.vitorpamplona.quartz.nip23LongContent.tags.PublishedAtTag
 import com.vitorpamplona.quartz.nip23LongContent.tags.TitleTag
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip71Video.tags.DurationTag
 import com.vitorpamplona.quartz.nip71Video.tags.SegmentTag
 import com.vitorpamplona.quartz.nip92IMeta.imetas
@@ -48,7 +49,10 @@ abstract class AddressableVideoEvent(
 ) : BaseAddressableEvent(id, pubKey, createdAt, kind, tags, content, sig),
     PublishedAtProvider,
     VideoEvent,
-    RootScope {
+    RootScope,
+    SearchableEvent {
+    override fun indexableContent() = "title: " + title().orEmpty() + "\n" + content
+
     @kotlinx.serialization.Transient
     @kotlin.jvm.Transient
     var iMetas: List<VideoMeta>? = null

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip71Video/RegularVideoEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip71Video/RegularVideoEvent.kt
@@ -51,7 +51,7 @@ abstract class RegularVideoEvent(
     VideoEvent,
     RootScope,
     SearchableEvent {
-    override fun indexableContent() = "title: " + title().orEmpty() + "\n" + content
+    override fun indexableContent() = listOfNotNull(title(), content).joinToString("\n")
 
     @kotlinx.serialization.Transient
     @kotlin.jvm.Transient

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip71Video/RegularVideoEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip71Video/RegularVideoEvent.kt
@@ -30,6 +30,7 @@ import com.vitorpamplona.quartz.nip01Core.tags.publishedAt.PublishedAtProvider
 import com.vitorpamplona.quartz.nip22Comments.RootScope
 import com.vitorpamplona.quartz.nip23LongContent.tags.PublishedAtTag
 import com.vitorpamplona.quartz.nip23LongContent.tags.TitleTag
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip71Video.tags.DurationTag
 import com.vitorpamplona.quartz.nip71Video.tags.SegmentTag
 import com.vitorpamplona.quartz.nip92IMeta.imetas
@@ -48,7 +49,10 @@ abstract class RegularVideoEvent(
 ) : Event(id, pubKey, createdAt, kind, tags, content, sig),
     PublishedAtProvider,
     VideoEvent,
-    RootScope {
+    RootScope,
+    SearchableEvent {
+    override fun indexableContent() = "title: " + title().orEmpty() + "\n" + content
+
     @kotlinx.serialization.Transient
     @kotlin.jvm.Transient
     var iMetas: List<VideoMeta>? = null

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip72ModCommunities/definition/CommunityDefinitionEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip72ModCommunities/definition/CommunityDefinitionEvent.kt
@@ -58,7 +58,7 @@ class CommunityDefinitionEvent(
     AddressHintProvider,
     PubKeyHintProvider,
     SearchableEvent {
-    override fun indexableContent() = "name: " + name().orEmpty() + "\ndescription: " + description().orEmpty() + "\nrules: " + rules().orEmpty() + "\n" + content
+    override fun indexableContent() = listOfNotNull(name(), description(), rules(), content).joinToString("\n")
 
     override fun eventHints() = tags.mapNotNull(ETag::parseAsHint) + tags.mapNotNull(QTag::parseEventAsHint)
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip72ModCommunities/definition/CommunityDefinitionEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip72ModCommunities/definition/CommunityDefinitionEvent.kt
@@ -34,6 +34,7 @@ import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip01Core.tags.events.ETag
 import com.vitorpamplona.quartz.nip18Reposts.quotes.QTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip72ModCommunities.definition.tags.DescriptionTag
 import com.vitorpamplona.quartz.nip72ModCommunities.definition.tags.ImageTag
 import com.vitorpamplona.quartz.nip72ModCommunities.definition.tags.ModeratorTag
@@ -55,7 +56,10 @@ class CommunityDefinitionEvent(
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     EventHintProvider,
     AddressHintProvider,
-    PubKeyHintProvider {
+    PubKeyHintProvider,
+    SearchableEvent {
+    override fun indexableContent() = "name: " + name().orEmpty() + "\ndescription: " + description().orEmpty() + "\nrules: " + rules().orEmpty() + "\n" + content
+
     override fun eventHints() = tags.mapNotNull(ETag::parseAsHint) + tags.mapNotNull(QTag::parseEventAsHint)
 
     override fun linkedEventIds() = tags.mapNotNull(ETag::parseId) + tags.mapNotNull(QTag::parseEventId)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip75ZapGoals/GoalEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip75ZapGoals/GoalEvent.kt
@@ -60,7 +60,7 @@ class GoalEvent(
     AddressHintProvider,
     PubKeyHintProvider,
     SearchableEvent {
-    override fun indexableContent() = "summary: " + summary().orEmpty() + "\n" + content
+    override fun indexableContent() = listOfNotNull(summary(), content).joinToString("\n")
 
     override fun pubKeyHints() = tags.mapNotNull(PTag::parseAsHint)
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip75ZapGoals/GoalEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip75ZapGoals/GoalEvent.kt
@@ -41,6 +41,7 @@ import com.vitorpamplona.quartz.nip01Core.tags.references.reference
 import com.vitorpamplona.quartz.nip23LongContent.tags.ImageTag
 import com.vitorpamplona.quartz.nip23LongContent.tags.SummaryTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip75ZapGoals.tags.AmountTag
 import com.vitorpamplona.quartz.nip75ZapGoals.tags.ClosedAtTag
 import com.vitorpamplona.quartz.nip75ZapGoals.tags.RelayListTag
@@ -57,7 +58,10 @@ class GoalEvent(
 ) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
     EventHintProvider,
     AddressHintProvider,
-    PubKeyHintProvider {
+    PubKeyHintProvider,
+    SearchableEvent {
+    override fun indexableContent() = "summary: " + summary().orEmpty() + "\n" + content
+
     override fun pubKeyHints() = tags.mapNotNull(PTag::parseAsHint)
 
     override fun linkedPubKeys() = tags.mapNotNull(PTag::parseKey)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip7DThreads/ThreadEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip7DThreads/ThreadEvent.kt
@@ -41,7 +41,7 @@ class ThreadEvent(
 ) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
     RootScope,
     SearchableEvent {
-    override fun indexableContent() = "title: " + title() + "\n" + content
+    override fun indexableContent() = listOfNotNull(title(), content).joinToString("\n")
 
     fun title() = tags.title()
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip84Highlights/HighlightEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip84Highlights/HighlightEvent.kt
@@ -66,7 +66,7 @@ class HighlightEvent(
     AddressHintProvider,
     PubKeyHintProvider,
     SearchableEvent {
-    override fun indexableContent() = "comment: " + comment() + "\ncontext: " + context() + "\n" + content
+    override fun indexableContent() = listOfNotNull(comment(), context(), content).joinToString("\n")
 
     override fun eventHints(): List<EventIdHint> {
         val eHints = tags.mapNotNull(ETag::parseAsHint)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip85TrustedAssertions/users/ContactCardEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip85TrustedAssertions/users/ContactCardEvent.kt
@@ -29,6 +29,7 @@ import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import com.vitorpamplona.quartz.nip01Core.tags.aTag.ATag
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip51Lists.PrivateTagArrayEvent
 import com.vitorpamplona.quartz.nip51Lists.encryption.PrivateTagsInContent
 import com.vitorpamplona.quartz.nip85TrustedAssertions.users.tags.ActiveHoursEndTag
@@ -60,7 +61,12 @@ class ContactCardEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : PrivateTagArrayEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : PrivateTagArrayEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    // Only the public summary tag is indexed; the rest of the card lives in
+    // NIP-44 encrypted content and is intentionally never indexed.
+    override fun indexableContent() = listOfNotNull(summary()).joinToString("\n")
+
     fun aboutUser() = tags.dTag()
 
     fun rank() = tags.firstNotNullOfOrNull(RankTag::parse)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip88Polls/poll/PollEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip88Polls/poll/PollEvent.kt
@@ -28,6 +28,7 @@ import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip22Comments.RootScope
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip88Polls.poll.tags.OptionTag
 import com.vitorpamplona.quartz.nip88Polls.poll.tags.PollType
 import com.vitorpamplona.quartz.utils.TimeUtils
@@ -41,7 +42,14 @@ class PollEvent(
     content: String,
     sig: HexKey,
 ) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
-    RootScope {
+    RootScope,
+    SearchableEvent {
+    override fun indexableContent() =
+        buildString {
+            append(content)
+            options().forEach { append('\n').append(it.label) }
+        }
+
     fun options() = tags.options()
 
     fun relays() = tags.relays()

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip89AppHandlers/definition/AppDefinitionEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip89AppHandlers/definition/AppDefinitionEvent.kt
@@ -32,6 +32,7 @@ import com.vitorpamplona.quartz.nip01Core.tags.publishedAt.PublishedAtProvider
 import com.vitorpamplona.quartz.nip21UriScheme.toNostrUri
 import com.vitorpamplona.quartz.nip23LongContent.tags.PublishedAtTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip89AppHandlers.PlatformType
 import com.vitorpamplona.quartz.nip89AppHandlers.definition.tags.PlatformLinkTag
 import com.vitorpamplona.quartz.utils.Log
@@ -50,7 +51,27 @@ class AppDefinitionEvent(
     content: String,
     sig: HexKey,
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
-    PublishedAtProvider {
+    PublishedAtProvider,
+    SearchableEvent {
+    // App-handler content is JSON; parse it and index the human-meaningful
+    // fields plus the addresses/URLs people search by.
+    override fun indexableContent() =
+        appMetaData()?.let {
+            listOfNotNull(
+                it.name,
+                it.username,
+                it.displayName,
+                it.about,
+                it.nip05,
+                it.lud06,
+                it.lud16,
+                it.website,
+                it.picture,
+                it.banner,
+                it.image,
+            ).joinToString(" ")
+        } ?: ""
+
     @kotlinx.serialization.Transient
     @kotlin.jvm.Transient
     private var cachedMetadata: AppMetadata? = null

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip94FileMetadata/FileHeaderEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip94FileMetadata/FileHeaderEvent.kt
@@ -27,6 +27,7 @@ import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.core.any
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip94FileMetadata.tags.BlurhashTag
 import com.vitorpamplona.quartz.nip94FileMetadata.tags.DimensionTag
 import com.vitorpamplona.quartz.nip94FileMetadata.tags.FallbackTag
@@ -51,7 +52,10 @@ class FileHeaderEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : Event(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(summary(), content).joinToString("\n")
+
     fun url() = tags.firstNotNullOfOrNull(UrlTag::parse)
 
     fun urls() = tags.mapNotNull(UrlTag::parse)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip99Classifieds/ClassifiedsEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip99Classifieds/ClassifiedsEvent.kt
@@ -55,7 +55,7 @@ class ClassifiedsEvent(
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
     PublishedAtProvider,
     SearchableEvent {
-    override fun indexableContent() = "title: " + title().orEmpty() + "\nsummary: " + summary().orEmpty() + "\n" + content
+    override fun indexableContent() = listOfNotNull(title(), summary(), content).joinToString("\n")
 
     fun title() = tags.firstNotNullOfOrNull(TitleTag::parse)
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip99Classifieds/ClassifiedsEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip99Classifieds/ClassifiedsEvent.kt
@@ -34,6 +34,7 @@ import com.vitorpamplona.quartz.nip23LongContent.tags.PublishedAtTag
 import com.vitorpamplona.quartz.nip23LongContent.tags.SummaryTag
 import com.vitorpamplona.quartz.nip23LongContent.tags.TitleTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip92IMeta.imetas
 import com.vitorpamplona.quartz.nip99Classifieds.tags.ConditionTag
 import com.vitorpamplona.quartz.nip99Classifieds.tags.LocationTag
@@ -52,7 +53,10 @@ class ClassifiedsEvent(
     content: String,
     sig: HexKey,
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
-    PublishedAtProvider {
+    PublishedAtProvider,
+    SearchableEvent {
+    override fun indexableContent() = "title: " + title().orEmpty() + "\nsummary: " + summary().orEmpty() + "\n" + content
+
     fun title() = tags.firstNotNullOfOrNull(TitleTag::parse)
 
     fun image() = tags.firstNotNullOfOrNull(ImageTag::parse)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nipB0WebBookmarks/WebBookmarkEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nipB0WebBookmarks/WebBookmarkEvent.kt
@@ -32,6 +32,7 @@ import com.vitorpamplona.quartz.nip22Comments.RootScope
 import com.vitorpamplona.quartz.nip23LongContent.tags.PublishedAtTag
 import com.vitorpamplona.quartz.nip23LongContent.tags.TitleTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 @Immutable
@@ -43,7 +44,10 @@ class WebBookmarkEvent(
     content: String,
     sig: HexKey,
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
-    RootScope {
+    RootScope,
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(title(), description()).joinToString("\n")
+
     fun url(): String {
         val dTagValue = dTag()
         return if (dTagValue.isNotEmpty()) "https://$dTagValue" else ""

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nipBCOnchainZaps/zap/OnchainZapEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nipBCOnchainZaps/zap/OnchainZapEvent.kt
@@ -36,6 +36,7 @@ import com.vitorpamplona.quartz.nip01Core.tags.events.ETag
 import com.vitorpamplona.quartz.nip01Core.tags.events.toETag
 import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 /**
@@ -58,7 +59,11 @@ class OnchainZapEvent(
 ) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
     EventHintProvider,
     AddressHintProvider,
-    PubKeyHintProvider {
+    PubKeyHintProvider,
+    SearchableEvent {
+    // content is the optional onchain-zap message.
+    override fun indexableContent() = content
+
     override fun pubKeyHints() = tags.mapNotNull(PTag::parseAsHint)
 
     override fun linkedPubKeys() = tags.mapNotNull(PTag::parseKey)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nipC0CodeSnippets/CodeSnippetEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nipC0CodeSnippets/CodeSnippetEvent.kt
@@ -27,6 +27,7 @@ import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip22Comments.RootScope
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 /**
@@ -43,7 +44,10 @@ class CodeSnippetEvent(
     content: String,
     sig: HexKey,
 ) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
-    RootScope {
+    RootScope,
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(snippetName(), snippetDescription(), content).joinToString("\n")
+
     /** Programming language, lowercase (e.g. "python"). */
     fun language() = tags.language()
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nipF4Podcasts/episode/PodcastEpisodeEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nipF4Podcasts/episode/PodcastEpisodeEvent.kt
@@ -26,6 +26,7 @@ import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nipF4Podcasts.episode.tags.AudioTag
 import com.vitorpamplona.quartz.nipF4Podcasts.episode.tags.DescriptionTag
 import com.vitorpamplona.quartz.nipF4Podcasts.episode.tags.ImageTag
@@ -47,7 +48,10 @@ class PodcastEpisodeEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : Event(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(title(), description(), content).joinToString("\n")
+
     fun title() = tags.firstNotNullOfOrNull(TitleTag::parse)
 
     fun image() = tags.firstNotNullOfOrNull(ImageTag::parse)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nipF4Podcasts/metadata/PodcastMetadataEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nipF4Podcasts/metadata/PodcastMetadataEvent.kt
@@ -28,6 +28,7 @@ import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.aTag.ATag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nipF4Podcasts.metadata.tags.AuthorTag
 import com.vitorpamplona.quartz.nipF4Podcasts.metadata.tags.DescriptionTag
 import com.vitorpamplona.quartz.nipF4Podcasts.metadata.tags.ImageTag
@@ -53,7 +54,10 @@ class PodcastMetadataEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : BaseReplaceableEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : BaseReplaceableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(title(), description()).joinToString("\n")
+
     fun title() = tags.firstNotNullOfOrNull(TitleTag::parse)
 
     fun image() = tags.firstNotNullOfOrNull(ImageTag::parse)

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/QueryAssemblerTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/QueryAssemblerTest.kt
@@ -238,9 +238,9 @@ class QueryAssemblerTest : BaseDBTest() {
                     INNER JOIN (
                         SELECT row_id FROM (SELECT event_headers.row_id as row_id FROM event_headers ORDER BY event_headers.created_at DESC LIMIT 10)
                         UNION
-                        SELECT row_id FROM (SELECT event_fts.event_header_row_id as row_id FROM event_fts INNER JOIN event_headers ON event_headers.row_id = event_fts.event_header_row_id WHERE (event_headers.kind IN ("1", "1111")) AND (event_headers.pubkey = "7c5eb72a4584fdaaeaa145b25c92ea9917704224951219dbd43acef9e91fb88d") AND (event_fts MATCH "keywords") ORDER BY event_headers.created_at DESC LIMIT 100)
+                        SELECT row_id FROM (SELECT event_fts.rowid as row_id FROM event_fts INNER JOIN event_headers ON event_headers.row_id = event_fts.rowid WHERE (event_headers.kind IN ("1", "1111")) AND (event_headers.pubkey = "7c5eb72a4584fdaaeaa145b25c92ea9917704224951219dbd43acef9e91fb88d") AND (event_fts MATCH "keywords") ORDER BY event_headers.created_at DESC LIMIT 100)
                         UNION
-                        SELECT row_id FROM (SELECT event_fts.event_header_row_id as row_id FROM event_fts INNER JOIN event_headers ON event_headers.row_id = event_fts.event_header_row_id WHERE (event_headers.kind = "20") AND (event_fts MATCH "cats") ORDER BY event_headers.created_at DESC LIMIT 30)
+                        SELECT row_id FROM (SELECT event_fts.rowid as row_id FROM event_fts INNER JOIN event_headers ON event_headers.row_id = event_fts.rowid WHERE (event_headers.kind = "20") AND (event_fts MATCH "cats") ORDER BY event_headers.created_at DESC LIMIT 30)
                     ) AS filtered
                     ON event_headers.row_id = filtered.row_id
                     ORDER BY $orderBy
@@ -252,13 +252,13 @@ class QueryAssemblerTest : BaseDBTest() {
                     │       │   └── SCAN (subquery-1)
                     │       ├── UNION USING TEMP B-TREE
                     │       │   ├── CO-ROUTINE (subquery-3)
-                    │       │   │   ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M2
+                    │       │   │   ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M1
                     │       │   │   ├── SEARCH event_headers USING INTEGER PRIMARY KEY (rowid=?)
                     │       │   │   └── USE TEMP B-TREE FOR ORDER BY
                     │       │   └── SCAN (subquery-3)
                     │       └── UNION USING TEMP B-TREE
                     │           ├── CO-ROUTINE (subquery-5)
-                    │           │   ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M2
+                    │           │   ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M1
                     │           │   ├── SEARCH event_headers USING INTEGER PRIMARY KEY (rowid=?)
                     │           │   └── USE TEMP B-TREE FOR ORDER BY
                     │           └── SCAN (subquery-5)
@@ -275,9 +275,9 @@ class QueryAssemblerTest : BaseDBTest() {
                     INNER JOIN (
                         SELECT row_id FROM (SELECT event_headers.row_id as row_id FROM event_headers ORDER BY event_headers.created_at DESC LIMIT 10)
                         UNION
-                        SELECT row_id FROM (SELECT event_fts.event_header_row_id as row_id FROM event_fts INNER JOIN event_headers ON event_headers.row_id = event_fts.event_header_row_id WHERE (event_headers.kind IN ("1", "1111")) AND (event_headers.pubkey = "7c5eb72a4584fdaaeaa145b25c92ea9917704224951219dbd43acef9e91fb88d") AND (event_fts MATCH "keywords") ORDER BY event_headers.created_at DESC LIMIT 100)
+                        SELECT row_id FROM (SELECT event_fts.rowid as row_id FROM event_fts INNER JOIN event_headers ON event_headers.row_id = event_fts.rowid WHERE (event_headers.kind IN ("1", "1111")) AND (event_headers.pubkey = "7c5eb72a4584fdaaeaa145b25c92ea9917704224951219dbd43acef9e91fb88d") AND (event_fts MATCH "keywords") ORDER BY event_headers.created_at DESC LIMIT 100)
                         UNION
-                        SELECT row_id FROM (SELECT event_fts.event_header_row_id as row_id FROM event_fts INNER JOIN event_headers ON event_headers.row_id = event_fts.event_header_row_id WHERE (event_headers.kind = "20") AND (event_fts MATCH "cats") ORDER BY event_headers.created_at DESC LIMIT 30)
+                        SELECT row_id FROM (SELECT event_fts.rowid as row_id FROM event_fts INNER JOIN event_headers ON event_headers.row_id = event_fts.rowid WHERE (event_headers.kind = "20") AND (event_fts MATCH "cats") ORDER BY event_headers.created_at DESC LIMIT 30)
                     ) AS filtered
                     ON event_headers.row_id = filtered.row_id
                     ORDER BY $orderBy
@@ -290,13 +290,13 @@ class QueryAssemblerTest : BaseDBTest() {
                     │       │   └── SCAN (subquery-1)
                     │       ├── UNION USING TEMP B-TREE
                     │       │   ├── CO-ROUTINE (subquery-3)
-                    │       │   │   ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M2
+                    │       │   │   ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M1
                     │       │   │   ├── SEARCH event_headers USING INTEGER PRIMARY KEY (rowid=?)
                     │       │   │   └── USE TEMP B-TREE FOR ORDER BY
                     │       │   └── SCAN (subquery-3)
                     │       └── UNION USING TEMP B-TREE
                     │           ├── CO-ROUTINE (subquery-5)
-                    │           │   ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M2
+                    │           │   ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M1
                     │           │   ├── SEARCH event_headers USING INTEGER PRIMARY KEY (rowid=?)
                     │           │   └── USE TEMP B-TREE FOR ORDER BY
                     │           └── SCAN (subquery-5)
@@ -712,10 +712,10 @@ class QueryAssemblerTest : BaseDBTest() {
                 assertEquals(
                     """
                     SELECT event_headers.id, event_headers.pubkey, event_headers.created_at, event_headers.kind, event_headers.tags, event_headers.content, event_headers.sig FROM event_headers
-                    INNER JOIN event_fts ON event_headers.row_id = event_fts.event_header_row_id
+                    INNER JOIN event_fts ON event_headers.row_id = event_fts.rowid
                     WHERE (event_fts MATCH "keywords") AND (event_headers.pubkey IN ("7c5eb72a4584fdaaeaa145b25c92ea9917704224951219dbd43acef9e91fb88d", "f3ac434d61bc0f491a814782ccfdf9c439dae1f0bde9097ad4a245f4c495cd14", "12ae0fd81c85e1e7d9ed096397dc3129849425fe6f8afce7213ebf38ddfc6ca9"))
                     ORDER BY event_headers.created_at DESC, event_headers.id ASC
-                    ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M2
+                    ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M1
                     ├── SEARCH event_headers USING INTEGER PRIMARY KEY (rowid=?)
                     └── USE TEMP B-TREE FOR ORDER BY
                     """.trimIndent(),
@@ -725,10 +725,10 @@ class QueryAssemblerTest : BaseDBTest() {
                 assertEquals(
                     """
                     SELECT event_headers.id, event_headers.pubkey, event_headers.created_at, event_headers.kind, event_headers.tags, event_headers.content, event_headers.sig FROM event_headers
-                    INNER JOIN event_fts ON event_headers.row_id = event_fts.event_header_row_id
+                    INNER JOIN event_fts ON event_headers.row_id = event_fts.rowid
                     WHERE (event_fts MATCH "keywords") AND (event_headers.pubkey IN ("7c5eb72a4584fdaaeaa145b25c92ea9917704224951219dbd43acef9e91fb88d", "f3ac434d61bc0f491a814782ccfdf9c439dae1f0bde9097ad4a245f4c495cd14", "12ae0fd81c85e1e7d9ed096397dc3129849425fe6f8afce7213ebf38ddfc6ca9"))
                     ORDER BY event_headers.created_at DESC
-                    ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M2
+                    ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M1
                     ├── SEARCH event_headers USING INTEGER PRIMARY KEY (rowid=?)
                     └── USE TEMP B-TREE FOR ORDER BY
                     """.trimIndent(),
@@ -745,10 +745,10 @@ class QueryAssemblerTest : BaseDBTest() {
             assertEquals(
                 """
                 SELECT event_headers.id, event_headers.pubkey, event_headers.created_at, event_headers.kind, event_headers.tags, event_headers.content, event_headers.sig FROM event_headers
-                INNER JOIN event_fts ON event_headers.row_id = event_fts.event_header_row_id
+                INNER JOIN event_fts ON event_headers.row_id = event_fts.rowid
                 WHERE (event_fts MATCH "keywords") AND (event_headers.kind IN ("1", "1111", "10000"))
                 ORDER BY $orderBy
-                ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M2
+                ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M1
                 ├── SEARCH event_headers USING INTEGER PRIMARY KEY (rowid=?)
                 └── USE TEMP B-TREE FOR ORDER BY
                 """.trimIndent(),

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/QueryAssemblerTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/QueryAssemblerTest.kt
@@ -238,9 +238,9 @@ class QueryAssemblerTest : BaseDBTest() {
                     INNER JOIN (
                         SELECT row_id FROM (SELECT event_headers.row_id as row_id FROM event_headers ORDER BY event_headers.created_at DESC LIMIT 10)
                         UNION
-                        SELECT row_id FROM (SELECT event_fts.rowid as row_id FROM event_fts INNER JOIN event_headers ON event_headers.row_id = event_fts.rowid WHERE (event_headers.kind IN ("1", "1111")) AND (event_headers.pubkey = "7c5eb72a4584fdaaeaa145b25c92ea9917704224951219dbd43acef9e91fb88d") AND (event_fts MATCH "keywords") ORDER BY event_headers.created_at DESC LIMIT 100)
+                        SELECT row_id FROM (SELECT event_fts.event_header_row_id as row_id FROM event_fts INNER JOIN event_headers ON event_headers.row_id = event_fts.event_header_row_id WHERE (event_headers.kind IN ("1", "1111")) AND (event_headers.pubkey = "7c5eb72a4584fdaaeaa145b25c92ea9917704224951219dbd43acef9e91fb88d") AND (event_fts MATCH "keywords") ORDER BY event_headers.created_at DESC LIMIT 100)
                         UNION
-                        SELECT row_id FROM (SELECT event_fts.rowid as row_id FROM event_fts INNER JOIN event_headers ON event_headers.row_id = event_fts.rowid WHERE (event_headers.kind = "20") AND (event_fts MATCH "cats") ORDER BY event_headers.created_at DESC LIMIT 30)
+                        SELECT row_id FROM (SELECT event_fts.event_header_row_id as row_id FROM event_fts INNER JOIN event_headers ON event_headers.row_id = event_fts.event_header_row_id WHERE (event_headers.kind = "20") AND (event_fts MATCH "cats") ORDER BY event_headers.created_at DESC LIMIT 30)
                     ) AS filtered
                     ON event_headers.row_id = filtered.row_id
                     ORDER BY $orderBy
@@ -252,13 +252,13 @@ class QueryAssemblerTest : BaseDBTest() {
                     │       │   └── SCAN (subquery-1)
                     │       ├── UNION USING TEMP B-TREE
                     │       │   ├── CO-ROUTINE (subquery-3)
-                    │       │   │   ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M1
+                    │       │   │   ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M2
                     │       │   │   ├── SEARCH event_headers USING INTEGER PRIMARY KEY (rowid=?)
                     │       │   │   └── USE TEMP B-TREE FOR ORDER BY
                     │       │   └── SCAN (subquery-3)
                     │       └── UNION USING TEMP B-TREE
                     │           ├── CO-ROUTINE (subquery-5)
-                    │           │   ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M1
+                    │           │   ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M2
                     │           │   ├── SEARCH event_headers USING INTEGER PRIMARY KEY (rowid=?)
                     │           │   └── USE TEMP B-TREE FOR ORDER BY
                     │           └── SCAN (subquery-5)
@@ -275,9 +275,9 @@ class QueryAssemblerTest : BaseDBTest() {
                     INNER JOIN (
                         SELECT row_id FROM (SELECT event_headers.row_id as row_id FROM event_headers ORDER BY event_headers.created_at DESC LIMIT 10)
                         UNION
-                        SELECT row_id FROM (SELECT event_fts.rowid as row_id FROM event_fts INNER JOIN event_headers ON event_headers.row_id = event_fts.rowid WHERE (event_headers.kind IN ("1", "1111")) AND (event_headers.pubkey = "7c5eb72a4584fdaaeaa145b25c92ea9917704224951219dbd43acef9e91fb88d") AND (event_fts MATCH "keywords") ORDER BY event_headers.created_at DESC LIMIT 100)
+                        SELECT row_id FROM (SELECT event_fts.event_header_row_id as row_id FROM event_fts INNER JOIN event_headers ON event_headers.row_id = event_fts.event_header_row_id WHERE (event_headers.kind IN ("1", "1111")) AND (event_headers.pubkey = "7c5eb72a4584fdaaeaa145b25c92ea9917704224951219dbd43acef9e91fb88d") AND (event_fts MATCH "keywords") ORDER BY event_headers.created_at DESC LIMIT 100)
                         UNION
-                        SELECT row_id FROM (SELECT event_fts.rowid as row_id FROM event_fts INNER JOIN event_headers ON event_headers.row_id = event_fts.rowid WHERE (event_headers.kind = "20") AND (event_fts MATCH "cats") ORDER BY event_headers.created_at DESC LIMIT 30)
+                        SELECT row_id FROM (SELECT event_fts.event_header_row_id as row_id FROM event_fts INNER JOIN event_headers ON event_headers.row_id = event_fts.event_header_row_id WHERE (event_headers.kind = "20") AND (event_fts MATCH "cats") ORDER BY event_headers.created_at DESC LIMIT 30)
                     ) AS filtered
                     ON event_headers.row_id = filtered.row_id
                     ORDER BY $orderBy
@@ -290,13 +290,13 @@ class QueryAssemblerTest : BaseDBTest() {
                     │       │   └── SCAN (subquery-1)
                     │       ├── UNION USING TEMP B-TREE
                     │       │   ├── CO-ROUTINE (subquery-3)
-                    │       │   │   ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M1
+                    │       │   │   ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M2
                     │       │   │   ├── SEARCH event_headers USING INTEGER PRIMARY KEY (rowid=?)
                     │       │   │   └── USE TEMP B-TREE FOR ORDER BY
                     │       │   └── SCAN (subquery-3)
                     │       └── UNION USING TEMP B-TREE
                     │           ├── CO-ROUTINE (subquery-5)
-                    │           │   ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M1
+                    │           │   ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M2
                     │           │   ├── SEARCH event_headers USING INTEGER PRIMARY KEY (rowid=?)
                     │           │   └── USE TEMP B-TREE FOR ORDER BY
                     │           └── SCAN (subquery-5)
@@ -712,10 +712,10 @@ class QueryAssemblerTest : BaseDBTest() {
                 assertEquals(
                     """
                     SELECT event_headers.id, event_headers.pubkey, event_headers.created_at, event_headers.kind, event_headers.tags, event_headers.content, event_headers.sig FROM event_headers
-                    INNER JOIN event_fts ON event_headers.row_id = event_fts.rowid
+                    INNER JOIN event_fts ON event_headers.row_id = event_fts.event_header_row_id
                     WHERE (event_fts MATCH "keywords") AND (event_headers.pubkey IN ("7c5eb72a4584fdaaeaa145b25c92ea9917704224951219dbd43acef9e91fb88d", "f3ac434d61bc0f491a814782ccfdf9c439dae1f0bde9097ad4a245f4c495cd14", "12ae0fd81c85e1e7d9ed096397dc3129849425fe6f8afce7213ebf38ddfc6ca9"))
                     ORDER BY event_headers.created_at DESC, event_headers.id ASC
-                    ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M1
+                    ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M2
                     ├── SEARCH event_headers USING INTEGER PRIMARY KEY (rowid=?)
                     └── USE TEMP B-TREE FOR ORDER BY
                     """.trimIndent(),
@@ -725,10 +725,10 @@ class QueryAssemblerTest : BaseDBTest() {
                 assertEquals(
                     """
                     SELECT event_headers.id, event_headers.pubkey, event_headers.created_at, event_headers.kind, event_headers.tags, event_headers.content, event_headers.sig FROM event_headers
-                    INNER JOIN event_fts ON event_headers.row_id = event_fts.rowid
+                    INNER JOIN event_fts ON event_headers.row_id = event_fts.event_header_row_id
                     WHERE (event_fts MATCH "keywords") AND (event_headers.pubkey IN ("7c5eb72a4584fdaaeaa145b25c92ea9917704224951219dbd43acef9e91fb88d", "f3ac434d61bc0f491a814782ccfdf9c439dae1f0bde9097ad4a245f4c495cd14", "12ae0fd81c85e1e7d9ed096397dc3129849425fe6f8afce7213ebf38ddfc6ca9"))
                     ORDER BY event_headers.created_at DESC
-                    ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M1
+                    ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M2
                     ├── SEARCH event_headers USING INTEGER PRIMARY KEY (rowid=?)
                     └── USE TEMP B-TREE FOR ORDER BY
                     """.trimIndent(),
@@ -745,10 +745,10 @@ class QueryAssemblerTest : BaseDBTest() {
             assertEquals(
                 """
                 SELECT event_headers.id, event_headers.pubkey, event_headers.created_at, event_headers.kind, event_headers.tags, event_headers.content, event_headers.sig FROM event_headers
-                INNER JOIN event_fts ON event_headers.row_id = event_fts.rowid
+                INNER JOIN event_fts ON event_headers.row_id = event_fts.event_header_row_id
                 WHERE (event_fts MATCH "keywords") AND (event_headers.kind IN ("1", "1111", "10000"))
                 ORDER BY $orderBy
-                ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M1
+                ├── SCAN event_fts VIRTUAL TABLE INDEX 0:M2
                 ├── SEARCH event_headers USING INTEGER PRIMARY KEY (rowid=?)
                 └── USE TEMP B-TREE FOR ORDER BY
                 """.trimIndent(),

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/SearchTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/SearchTest.kt
@@ -26,6 +26,8 @@ import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerSync
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
 import com.vitorpamplona.quartz.nip22Comments.CommentEvent
 import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
+import com.vitorpamplona.quartz.nip34Git.repository.GitRepositoryEvent
+import com.vitorpamplona.quartz.nip52Calendar.calendar.CalendarEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlin.test.Test
 
@@ -128,5 +130,39 @@ class SearchTest : BaseDBTest() {
             // v1's FTS row must be gone; v2's content takes over.
             db.assertQuery(null, Filter(search = "uniqalpha"))
             db.assertQuery(v2, Filter(search = "uniqbeta"))
+        }
+
+    @Test
+    fun testNewlySearchableKinds() =
+        forEachDB { db ->
+            // CalendarEvent indexes the title tag plus the free-text content.
+            val cal =
+                signer.sign(
+                    CalendarEvent.build(
+                        title = "uniqtitle Meetup",
+                        content = "annual uniqbody gathering",
+                    ),
+                )
+            // GitRepositoryEvent has an empty content field — its searchable
+            // text comes entirely from the name and description tags.
+            val repo =
+                signer.sign(
+                    GitRepositoryEvent.build(
+                        name = "uniqname",
+                        description = "uniqdesc nostr client",
+                    ),
+                )
+
+            db.store.insertEvent(cal)
+            db.store.insertEvent(repo)
+
+            // Title tag and content are both indexed for the calendar event.
+            db.assertQuery(cal, Filter(search = "uniqtitle"))
+            db.assertQuery(cal, Filter(search = "uniqbody"))
+
+            // Name and description tags are indexed even with empty content.
+            db.assertQuery(repo, Filter(search = "uniqname"))
+            db.assertQuery(repo, Filter(search = "uniqdesc"))
+            db.assertQuery(repo, Filter(kinds = listOf(GitRepositoryEvent.KIND), search = "uniqdesc"))
         }
 }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/SearchTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/SearchTest.kt
@@ -165,4 +165,33 @@ class SearchTest : BaseDBTest() {
             db.assertQuery(repo, Filter(search = "uniqdesc"))
             db.assertQuery(repo, Filter(kinds = listOf(GitRepositoryEvent.KIND), search = "uniqdesc"))
         }
+
+    @Test
+    fun testBackgroundReindexBackfillsExistingEvents() =
+        forEachDB { db ->
+            val a = signer.sign(CalendarEvent.build(title = "uniqalpha", content = "uniqbody"))
+            val b = signer.sign(GitRepositoryEvent.build(name = "uniqgamma", description = "uniqdelta"))
+            db.store.insertEvent(a)
+            db.store.insertEvent(b)
+
+            // Live insert path already indexed them.
+            db.assertQuery(a, Filter(search = "uniqalpha"))
+            db.assertQuery(b, Filter(search = "uniqdelta"))
+
+            // Simulate the post-migration state: FTS table emptied + marker armed.
+            db.store.dropFtsAndMarkPendingForTest()
+            db.assertQuery(null, Filter(search = "uniqalpha"))
+            db.assertQuery(null, Filter(search = "uniqdelta"))
+
+            // Background backfill rebuilds the index from event_headers.
+            db.store.reindexFullTextIfPending()
+            db.assertQuery(a, Filter(search = "uniqalpha"))
+            db.assertQuery(a, Filter(search = "uniqbody"))
+            db.assertQuery(b, Filter(search = "uniqgamma"))
+            db.assertQuery(b, Filter(search = "uniqdelta"))
+
+            // Marker is cleared, so a second run is a no-op and search still works.
+            db.store.reindexFullTextIfPending()
+            db.assertQuery(a, Filter(search = "uniqalpha"))
+        }
 }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/SearchTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/SearchTest.kt
@@ -26,6 +26,7 @@ import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerSync
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
 import com.vitorpamplona.quartz.nip22Comments.CommentEvent
 import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
+import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelCreateEvent
 import com.vitorpamplona.quartz.nip34Git.repository.GitRepositoryEvent
 import com.vitorpamplona.quartz.nip52Calendar.calendar.CalendarEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
@@ -164,5 +165,49 @@ class SearchTest : BaseDBTest() {
             db.assertQuery(repo, Filter(search = "uniqname"))
             db.assertQuery(repo, Filter(search = "uniqdesc"))
             db.assertQuery(repo, Filter(kinds = listOf(GitRepositoryEvent.KIND), search = "uniqdesc"))
+        }
+
+    @Test
+    fun testProfileJsonFieldsAreSearchable() =
+        forEachDB { db ->
+            // Kind-0 content is JSON; we parse it and index names, bio, and the
+            // addresses people search by (nip05 email, lightning address, URLs).
+            val p =
+                signer.sign(
+                    MetadataEvent.createNew(
+                        name = "uniqalice",
+                        about = "loves uniqbio and coffee",
+                        nip05 = "alice@uniqmail.example",
+                        lnAddress = "alice@uniqln.example",
+                        website = "https://uniqsite.example",
+                    ),
+                )
+            db.store.insertEvent(p)
+
+            db.assertQuery(p, Filter(search = "uniqalice")) // name
+            db.assertQuery(p, Filter(search = "uniqbio")) // about
+            db.assertQuery(p, Filter(search = "uniqmail")) // nip05 email
+            db.assertQuery(p, Filter(search = "uniqln")) // lightning address
+            db.assertQuery(p, Filter(search = "uniqsite")) // website URL
+            db.assertQuery(p, Filter(kinds = listOf(MetadataEvent.KIND), search = "uniqalice"))
+        }
+
+    @Test
+    fun testChannelJsonFieldsAreSearchable() =
+        forEachDB { db ->
+            val chan =
+                signer.sign(
+                    ChannelCreateEvent.build(
+                        name = "uniqchan",
+                        about = "a uniqtopic discussion",
+                        picture = "https://uniqpic.example/c.jpg",
+                        relays = null,
+                    ),
+                )
+            db.store.insertEvent(chan)
+
+            db.assertQuery(chan, Filter(search = "uniqchan")) // name
+            db.assertQuery(chan, Filter(search = "uniqtopic")) // about
+            db.assertQuery(chan, Filter(search = "uniqpic")) // picture URL
         }
 }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/SearchTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/SearchTest.kt
@@ -165,33 +165,4 @@ class SearchTest : BaseDBTest() {
             db.assertQuery(repo, Filter(search = "uniqdesc"))
             db.assertQuery(repo, Filter(kinds = listOf(GitRepositoryEvent.KIND), search = "uniqdesc"))
         }
-
-    @Test
-    fun testBackgroundReindexBackfillsExistingEvents() =
-        forEachDB { db ->
-            val a = signer.sign(CalendarEvent.build(title = "uniqalpha", content = "uniqbody"))
-            val b = signer.sign(GitRepositoryEvent.build(name = "uniqgamma", description = "uniqdelta"))
-            db.store.insertEvent(a)
-            db.store.insertEvent(b)
-
-            // Live insert path already indexed them.
-            db.assertQuery(a, Filter(search = "uniqalpha"))
-            db.assertQuery(b, Filter(search = "uniqdelta"))
-
-            // Simulate the post-migration state: FTS table emptied + marker armed.
-            db.store.dropFtsAndMarkPendingForTest()
-            db.assertQuery(null, Filter(search = "uniqalpha"))
-            db.assertQuery(null, Filter(search = "uniqdelta"))
-
-            // Background backfill rebuilds the index from event_headers.
-            db.store.reindexFullTextIfPending()
-            db.assertQuery(a, Filter(search = "uniqalpha"))
-            db.assertQuery(a, Filter(search = "uniqbody"))
-            db.assertQuery(b, Filter(search = "uniqgamma"))
-            db.assertQuery(b, Filter(search = "uniqdelta"))
-
-            // Marker is cleared, so a second run is a no-op and search still works.
-            db.store.reindexFullTextIfPending()
-            db.assertQuery(a, Filter(search = "uniqalpha"))
-        }
 }

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsSearchTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsSearchTest.kt
@@ -105,9 +105,9 @@ class FsSearchTest {
 
             val ftsRoot = root.resolve("idx/fts")
             val tokenDirs = ftsRoot.listDirectoryEntries().map { it.fileName.toString() }.toSet()
-            // TextNoteEvent.indexableContent() prepends a "Subject: " prefix so
-            // we get the content tokens plus the subject ones. What matters is
-            // that each unique token yields exactly one entry under its dir.
+            // This note has no subject, so indexableContent() is just the
+            // content. What matters is that each unique token yields exactly
+            // one entry under its dir.
             assertTrue("bitcoin" in tokenDirs)
             assertTrue("nostr" in tokenDirs)
             assertEquals(1, ftsRoot.resolve("bitcoin").listDirectoryEntries().size)

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsSearchTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsSearchTest.kt
@@ -20,7 +20,7 @@
  */
 package com.vitorpamplona.quartz.nip01Core.store.fs
 
-import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
+import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerSync
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
@@ -117,17 +117,18 @@ class FsSearchTest {
     @Test
     fun `non-searchable event does not produce fts entries`() =
         runBlocking {
-            val meta =
-                signer.sign<MetadataEvent>(
+            // An event whose kind has no SearchableEvent mapping must not be indexed.
+            val nonSearchable =
+                signer.sign<Event>(
                     createdAt = 1,
-                    kind = MetadataEvent.KIND,
+                    kind = 9999,
                     tags = emptyArray(),
-                    content = "{\"name\":\"vitor\"}",
+                    content = "this text must not be indexed",
                 )
-            store.insert(meta)
+            store.insert(nonSearchable)
 
             val ftsRoot = root.resolve("idx/fts")
-            assertEquals(0, ftsRoot.listDirectoryEntries().size, "MetadataEvent is not SearchableEvent")
+            assertEquals(0, ftsRoot.listDirectoryEntries().size, "unknown kind is not SearchableEvent")
         }
 
     @Test


### PR DESCRIPTION
## Summary

Extends NIP-50 full-text search support to 30+ additional event kinds by implementing the `SearchableEvent` interface. Adds `indexableContent()` methods that extract human-meaningful fields from JSON-encoded event content (profiles, channels, app definitions) and tag-based metadata (calendar events, git repositories, polls, etc.). Updates search tests to verify the new searchable kinds work correctly.

## Changes

**Core search infrastructure:**
- `MetadataEvent` (kind 0): indexes name, displayName, about, nip05, lud06, lud16, website, picture, banner
- `AppDefinitionEvent` (kind 31990): indexes app metadata fields plus contact info
- `ChannelCreateEvent` (kind 40) and `ChannelMetadataEvent` (kind 41): index channel name, about, picture URL

**Tag-based events:**
- `CalendarEvent` (kind 31922): indexes title tag + content
- `GitRepositoryEvent` (kind 30618): indexes name and description tags (content is empty)
- `InterestSetEvent` (kind 10015): indexes title and description tags
- `PeopleListEvent` (kind 10001), `BookmarkListEvent` (kind 10003), `RelaySetEvent` (kind 10002), and other list events: index title/description tags
- `PollEvent` (kind 1808): indexes content + poll options
- `AudioTrackEvent`, `MusicTrackEvent`, `MusicPlaylistEvent`: index title/artist/album/description
- `FileStorageHeaderEvent`, `ProfileGalleryEntryEvent`, `SoftwareReleaseEvent`: index relevant metadata
- `LnZapEvent`, `LnZapRequestEvent`, `NutzapEvent`, `OnchainZapEvent`: index zap metadata
- `ChatMessageEvent` (kind 17): indexes message content
- `ZapPollEvent`: indexes content + poll options
- `FundraiserEvent`, `AttestorProficiencyEvent`, `AttestorRecommendationEvent`, `AudioHeaderEvent`, `BirdexEvent`, `WorkoutRecordEvent`, `InteractiveStoryBaseEvent`, `SoftwareApplicationEvent`, `FeedDefinitionEvent`, `GroupMetadataEvent`, `EmojiPackEvent`, `GitPatchEvent`, `GitPullRequestEvent`, `GitReplyEvent`, `TorrentEvent`, `TorrentCommentEvent`, `StatusEvent`, `BadgeDefinitionEvent`, `NamedSiteEvent`, `RootSiteEvent`, `PictureEvent`, `AddressableVideoEvent`, `RegularVideoEvent`, `CommunityDefinitionEvent`, `GoalEvent`, `FileHeaderEvent`, `ClassifiedsEvent`, `WebBookmarkEvent`, `CodeSnippetEvent`, `PodcastEpisodeEvent`, `PodcastMetadataEvent`, `LiveActivitiesClipEvent`, `MeetingRoomEvent`, `MeetingSpaceEvent`, `LiveActivitiesEvent`, `CalendarDateSlotEvent`, `CalendarTimeSlotEvent`, `HighlightEvent`, `WikiNoteEvent`, `ThreadEvent`, `NipTextEvent`: all implement `SearchableEvent`

**Test coverage:**
- Added `testNewlySearchableKinds()`: verifies CalendarEvent and GitRepositoryEvent search
- Added `testProfileJsonFieldsAreSearchable()`: verifies MetadataEvent JSON field indexing
- Added `testChannelJsonFieldsAreSearchable()`: verifies ChannelCreateEvent JSON field indexing
- Updated `FsSearchTest` to clarify that non-searchable events (those without `SearchableEvent` mapping) are not indexed

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Ran `./gradlew test` — all search tests pass, including new test cases for CalendarEvent, GitRepositoryEvent, MetadataEvent, and ChannelCreateEvent
- [x] Verified existing search tests still pass (TextNoteEvent, LongTextNoteEvent, etc.)

## Interop suites

- [x] N/A — change

https://claude.ai/code/session_01RFdWREvyvixRXnmNXNzmmN