### PR TITLE
Remove unused `updated` field from translator mappings

### DIFF
--- a/docs/changelog/translators.json
+++ b/docs/changelog/translators.json
@@ -75,7 +75,6 @@
   "sinceLastTag": {
     "tag": "v1.12.5",
     "since": "2026-06-19T12:55:37-04:00",
-    "updated": "2026-06-19T17:21:54+00:00",
     "translators": [
       {
         "user": "vitorpamplona",

--- a/scripts/translators.sh
+++ b/scripts/translators.sh
@@ -185,8 +185,7 @@ fi
 if [ "$SEED" = "1" ]; then
   before="$(jq '(.mappings // {}) | length' "$MAPPING")"
   merged="$(jq -n --slurpfile cur "$MAPPING" --argjson rep "$report" \
-    --arg tag "$LAST_TAG" --arg since "$DATE_FROM" \
-    --arg updated "$(date -u +%Y-%m-%dT%H:%M:%S+00:00)" '
+    --arg tag "$LAST_TAG" --arg since "$DATE_FROM" '
     ($cur[0]) as $file
     | [ ($rep.data // $rep)[] | {
           user: (.user.username // (.user.id|tostring)),
@@ -198,7 +197,7 @@ if [ "$SEED" = "1" ]; then
           then . else . + { ($u): "" } end) ) as $mappings
     | $file
       + { mappings: $mappings }
-      + { sinceLastTag: { tag: $tag, since: $since, updated: $updated,
+      + { sinceLastTag: { tag: $tag, since: $since,
                           translators: $contribs } }
   ')"
   echo "$merged" > "$MAPPING"


### PR DESCRIPTION
## Summary

Removes the `updated` timestamp field from the `sinceLastTag` object in the translator mappings. This field was being generated dynamically but is no longer needed, simplifying the data structure.

## Test plan

- [ ] N/A — change is a data structure simplification with no functional impact

The change removes an unused field from the translator seed script (`scripts/translators.sh`) and updates the example output in `docs/changelog/translators.json` to reflect the new structure. No new tests are required as this is a straightforward field removal.

## Interop suites

- [ ] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [ ] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01RSoN4DDC5F1ehwGeC33652