### PR TITLE
Handle Health Connect binding failures gracefully

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/workouts/health/HealthConnectManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/workouts/health/HealthConnectManager.kt
@@ -96,7 +96,18 @@ class HealthConnectManager(
     suspend fun grantedPermissions(): Set<String> = client.permissionController.getGrantedPermissions()
 
     suspend fun hasAllPermissions(): Boolean {
-        val granted = grantedPermissions()
+        // Some OEM builds report the provider as SDK_AVAILABLE yet fail to bind to the
+        // Health Connect service (e.g. RemoteException "Binding to service failed" on
+        // ITEL/low-end devices). Treat any such failure as "not granted" instead of
+        // letting it crash the app — the carousel then quietly stays in its prompt state.
+        val granted =
+            try {
+                grantedPermissions()
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                Log.w(TAG, "Failed to read Health Connect granted permissions", e)
+                return false
+            }
         val ok = granted.containsAll(PERMISSIONS)
         if (!ok) {
             Log.i(TAG) { "hasAllPermissions=false; missing=${PERMISSIONS - granted}" }


### PR DESCRIPTION
## Summary

Add exception handling to `hasAllPermissions()` in `HealthConnectManager` to gracefully handle cases where Health Connect reports as available but fails to bind to the service. Some OEM builds (particularly on low-end devices like ITEL) report `SDK_AVAILABLE` yet throw `RemoteException` when attempting to read permissions. This change treats such failures as "permissions not granted" rather than crashing the app, allowing the permission prompt carousel to remain in its request state.

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes:
The change is defensive error handling for a known OEM issue. The exception handler:
- Re-throws `CancellationException` to preserve coroutine cancellation semantics
- Logs binding failures at WARN level for diagnostics
- Returns `false` (permissions not granted) to keep the app in a safe state

Existing unit tests for `HealthConnectManager` will continue to pass. The new exception path is exercised only when Health Connect service binding fails, which is not reproducible in standard test environments but has been observed on specific OEM devices.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

https://claude.ai/code/session_01KmuJDzzin15Nfsn1jUYkHh