### PR TITLE
Fix unstable sort in live activity feeds by snapshotting status order

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip53LiveActivities/DiscoverLiveFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip53LiveActivities/DiscoverLiveFeedFilter.kt
@@ -106,10 +106,17 @@ open class DiscoverLiveFeedFilter(
         val allParticipants =
             items.associate { it to counter.countFollowsThatParticipateOn(it, null) }
 
+        // Snapshots the status order once per item. convertStatusToOrder reads the
+        // OnlineChecker cache and the moving five-minute window, both of which can change
+        // mid-sort (a background online check can update the cache). Reading it lazily inside
+        // the comparator makes the ordering unstable and TimSort throws
+        // "Comparison method violates its general contract!".
+        val statusOrders = items.associateWith { convertStatusToOrder(it.event) }
+
         return items
             .sortedWith(
                 compareBy(
-                    { convertStatusToOrder(it.event) },
+                    { statusOrders[it] },
                     { participantCounts[it] },
                     { allParticipants[it] },
                     {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/livestreams/dal/LiveStreamsFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/livestreams/dal/LiveStreamsFeedFilter.kt
@@ -106,10 +106,17 @@ class LiveStreamsFeedFilter(
         val allParticipants =
             items.associate { it to counter.countFollowsThatParticipateOn(it, null) }
 
+        // Snapshots the status order once per item. convertStatusToOrder reads the
+        // OnlineChecker cache and the moving five-minute window, both of which can change
+        // mid-sort (a background online check can update the cache). Reading it lazily inside
+        // the comparator makes the ordering unstable and TimSort throws
+        // "Comparison method violates its general contract!".
+        val statusOrders = items.associateWith { convertStatusToOrder(it.event) }
+
         return items
             .sortedWith(
                 compareBy(
-                    { convertStatusToOrder(it.event) },
+                    { statusOrders[it] },
                     { participantCounts[it] },
                     { allParticipants[it] },
                     {


### PR DESCRIPTION
## Summary

Fix a `TimSort` contract violation in `DiscoverLiveFeedFilter` and `LiveStreamsFeedFilter` by snapshotting the status order before sorting. The `convertStatusToOrder()` function reads from the `OnlineChecker` cache and a moving five-minute window, both of which can change during the sort operation when background online checks update the cache. This causes the comparator to return inconsistent results, violating TimSort's stability contract.

The fix pre-computes `statusOrders` once per item before sorting, ensuring the comparator always sees the same ordering values throughout the sort.

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes: This is a correctness fix for a race condition in the sort comparator. The change is minimal and defensive — it trades a small amount of upfront computation (one pass over items to snapshot status orders) for guaranteed sort stability. No new test coverage needed; existing feed tests will benefit from the fix.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01HwZzCdNMQoRWbgtZrp4SKH