### PR TITLE
Improve error message for failed media downloads

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/actions/MediaSaverToDisk.kt
@@ -109,7 +109,9 @@ object MediaSaverToDisk {
 
             client.newCall(request).executeAsync().use { response ->
                 withContext(Dispatchers.IO) {
-                    check(response.isSuccessful)
+                    check(response.isSuccessful) {
+                        "Failed to download $url: HTTP ${response.code} ${response.message}"
+                    }
 
                     val trimmedUrl = trimInlineMetaData(url)
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {


### PR DESCRIPTION
## Summary

Enhanced the error message when media downloads fail by including the HTTP status code and response message. This makes debugging download failures easier by providing more context about what went wrong.

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Ran `./gradlew test` — existing tests pass
- [x] N/A — change only improves error reporting in an existing code path; no new functionality or behavior change

The modification adds a descriptive error message to the existing `check()` call, which will now display the URL, HTTP status code, and server response message when a download fails. This is a pure error reporting improvement with no impact on success paths.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01Cwv4DpPLTyiJP2Thv3H3jR