### PR TITLE
Keep balanced closing delimiters in URLs

### DIFF
--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/UrlParserTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/UrlParserTest.kt
@@ -322,6 +322,34 @@ class UrlParserTest {
         )
 
     @Test
+    fun testUrlWithBalancedParenthesis() =
+        test(
+            "https://en.wikipedia.org/wiki/Bitcoin_(disambiguation)",
+            Urls(withScheme = setOf("https://en.wikipedia.org/wiki/Bitcoin_(disambiguation)")),
+        )
+
+    @Test
+    fun testUrlWithCommaAndBalancedParenthesis() =
+        test(
+            "https://memory-alpha.fandom.com/wiki/Scorpion,_Part_II_(episode)",
+            Urls(withScheme = setOf("https://memory-alpha.fandom.com/wiki/Scorpion,_Part_II_(episode)")),
+        )
+
+    @Test
+    fun testUrlWithBalancedParenthesisInSentence() =
+        test(
+            "Read https://en.wikipedia.org/wiki/Bitcoin_(disambiguation) for context.",
+            Urls(withScheme = setOf("https://en.wikipedia.org/wiki/Bitcoin_(disambiguation)")),
+        )
+
+    @Test
+    fun testUrlWrappedInParenthesisDropsCloser() =
+        test(
+            "(see https://test.com)",
+            Urls(withScheme = setOf("https://test.com")),
+        )
+
+    @Test
     fun testBlossom() {
         val blossom = "blossom:b1674191a88ec5cdd733e4240a81803105dc412d6c6708d53ab94fc248f4f553.pdf?xs=cdn.satellite.earth"
         test(blossom, Urls(blossomUris = setOf(blossom)))

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/utils/urldetector/detection/UrlDetector.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/utils/urldetector/detection/UrlDetector.kt
@@ -649,8 +649,11 @@ class UrlDetector(
         // if the url is valid and greater then 0
         if (state == ReadEndState.ValidUrl && buffer.isNotEmpty()) {
             var url = buffer.toString()
-            if (url.lastOrNull() in CANNOT_END_URLS_WITH) url = url.dropLast(1)
-            urlList.add(currentUrlMarker.createUrl(url))
+            val last = url.lastOrNull()
+            if (last != null && last in CANNOT_END_URLS_WITH && !url.endsOnBalancedCloser(last)) {
+                url = url.dropLast(1)
+            }
+            if (url.isNotEmpty()) urlList.add(currentUrlMarker.createUrl(url))
         }
 
         // clear out the buffer.
@@ -665,6 +668,37 @@ class UrlDetector(
 
         // return true if valid.
         return state == ReadEndState.ValidUrl
+    }
+
+    /**
+     * Decides whether a trailing closing delimiter ([last]) should be kept as part of the URL.
+     *
+     * Closing parenthesis, braces and brackets are common inside real URLs (e.g. Wikipedia's
+     * `…/Bitcoin_(disambiguation)`), so we keep a trailing closer when the URL also contains its
+     * matching opener — i.e. the delimiters are balanced. When the closer is unbalanced it is
+     * almost always wrapping/sentence punctuation (e.g. `(see example.com)` or `http://test.com)`)
+     * and is stripped. Any opening delimiter or other punctuation is never balanced, so it falls
+     * through to the normal trailing strip.
+     */
+    private fun String.endsOnBalancedCloser(last: Char): Boolean {
+        val opener =
+            when (last) {
+                ')' -> '('
+                '}' -> '{'
+                ']' -> '['
+                else -> return false
+            }
+
+        var depth = 0
+        for (c in this) {
+            if (c == opener) {
+                depth++
+            } else if (c == last) {
+                depth--
+            }
+        }
+        // depth >= 0 means every closer (including the trailing one) has a matching opener.
+        return depth >= 0
     }
 
     companion object {
@@ -694,6 +728,7 @@ class UrlDetector(
                 '!',
                 ')',
                 '}',
+                ']',
                 '(',
                 '{',
                 '\u3002',
@@ -711,6 +746,7 @@ class UrlDetector(
                 ':',
                 ')',
                 '}',
+                ']',
                 '(',
                 '{',
                 '\u3002',

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/utils/urldetector/detection/UriDetectionTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/utils/urldetector/detection/UriDetectionTest.kt
@@ -839,6 +839,49 @@ class UriDetectionTest {
         }
     }
 
+    @Test
+    fun testBalancedClosingDelimitersAreKept() {
+        // Wikipedia-style urls whose path legitimately ends in a balanced ")".
+        runTest(
+            "https://en.wikipedia.org/wiki/Bitcoin_(disambiguation)",
+            "https://en.wikipedia.org/wiki/Bitcoin_(disambiguation)",
+        )
+        // also exercises a comma without surrounding spaces inside the path.
+        runTest(
+            "https://memory-alpha.fandom.com/wiki/Scorpion,_Part_II_(episode)",
+            "https://memory-alpha.fandom.com/wiki/Scorpion,_Part_II_(episode)",
+        )
+
+        // a balanced closer is kept even when followed by sentence punctuation/words.
+        runTest(
+            "See https://en.wikipedia.org/wiki/Bitcoin_(disambiguation).",
+            "https://en.wikipedia.org/wiki/Bitcoin_(disambiguation)",
+        )
+        runTest(
+            "read https://en.wikipedia.org/wiki/Bitcoin_(disambiguation) now",
+            "https://en.wikipedia.org/wiki/Bitcoin_(disambiguation)",
+        )
+
+        // balanced braces/brackets inside the path are kept as well.
+        runTest("https://example.com/a[b]c", "https://example.com/a[b]c")
+        runTest("https://example.com/a{b}c", "https://example.com/a{b}c")
+
+        // commas without surrounding spaces stay part of the url.
+        runTest("https://example.com/a,b,c", "https://example.com/a,b,c")
+    }
+
+    @Test
+    fun testUnbalancedClosingDelimitersAreStripped() {
+        // a closer that wraps the url (no matching opener inside it) is still removed.
+        runTest("(see example.com)", "example.com")
+        runTest("look [example.com]", "example.com")
+        runTest("note {example.com}", "example.com")
+        runTest("https://example.com/path)", "https://example.com/path")
+
+        // a trailing comma is sentence punctuation and is still removed.
+        runTest("visit example.com,", "example.com")
+    }
+
     private fun runTest(
         text: String,
         vararg expected: String?,


### PR DESCRIPTION
## Summary

URLs commonly contain balanced parentheses, brackets, and braces in their paths (e.g. Wikipedia's `Bitcoin_(disambiguation)`). The URL detector was stripping all trailing closing delimiters, breaking these legitimate URLs. This change keeps trailing closers when they are balanced (have a matching opener in the URL), while still removing unbalanced ones that are typically sentence punctuation or wrapping delimiters.

## Changes

- **`UrlDetector.kt`**: Added `endsOnBalancedCloser()` helper that checks if a trailing closing delimiter has a matching opener in the URL. Modified the URL finalization logic to only strip trailing closers when they are unbalanced. Also added `]` to the `CANNOT_END_URLS_WITH` sets for consistency.
- **Test coverage**: Added comprehensive test cases in both `UriDetectionTest.kt` and `UrlParserTest.kt` covering:
  - Wikipedia-style URLs with balanced parentheses
  - URLs with commas and balanced delimiters
  - Balanced delimiters in various contexts (sentence-final, mid-sentence)
  - Balanced brackets and braces
  - Unbalanced delimiters that should still be stripped

## Test plan

- [x] Ran `./gradlew test` — all new tests pass, existing tests continue to pass
- [x] Verified the new test cases exercise the balanced delimiter logic:
  - `testBalancedClosingDelimitersAreKept()` validates that legitimate URLs with balanced delimiters are preserved
  - `testUnbalancedClosingDelimitersAreStripped()` validates that wrapping/sentence punctuation is still removed
  - Corresponding tests in `UrlParserTest.kt` verify end-to-end behavior

The change is backward compatible — unbalanced closers continue to be stripped as before, and the new logic only affects URLs with matching opener/closer pairs.

## Interop suites

- [x] N/A — change only affects URL detection in text parsing, does not affect wire bytes or protocol state

https://claude.ai/code/session_01AzZzVcMcuzjSdhD3xqCE87