### PR TITLE
Keep NIP-82 release versions live via LocalCache observer

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/SoftwareApp.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/SoftwareApp.kt
@@ -92,6 +92,7 @@ import com.vitorpamplona.quartz.experimental.nip82SoftwareApps.asset.SoftwareAss
 import com.vitorpamplona.quartz.experimental.nip82SoftwareApps.release.SoftwareReleaseEvent
 import com.vitorpamplona.quartz.experimental.nip82SoftwareApps.release.asSoftwareRelease
 import com.vitorpamplona.quartz.experimental.nip82SoftwareApps.release.isNip82SoftwareRelease
+import com.vitorpamplona.quartz.experimental.nip82SoftwareApps.release.tags.AppIdTag
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import kotlinx.collections.immutable.toImmutableList
@@ -198,10 +199,15 @@ fun RenderSoftwareApplication(
  * Releases (kind 30063) are separate events that point back to the app via an
  * `i` tag rather than an `a` tag, so they are never indexed as replies to the
  * app note and never ping its flows. Instead we register an index-driven
- * [LocalCache.observeNotes] observer keyed on kind-30063 / author, so a newer
- * release arriving while the card is visible updates the version chip without
- * a manual refresh. The observer only wakes on matching insertions, so it is
- * far cheaper than re-scanning the cache on every new-event bundle.
+ * [LocalCache.observeNotes] observer, so a newer release arriving while the
+ * card is visible updates the version chip without a manual refresh.
+ *
+ * The filter narrows on the release's `i` tag (the app id), not just the
+ * author, so the observer only ever loads *this* app's releases — an author
+ * with many apps would otherwise pull every release they ever published into
+ * the observer's working set. A blind `limit` is deliberately avoided:
+ * [LocalCache.filter] applies `take(limit)` before sorting by `created_at`,
+ * so it could drop the very release we are looking for.
  */
 @Composable
 fun produceLatestReleaseVersion(app: SoftwareApplicationEvent): State<String?> {
@@ -211,6 +217,7 @@ fun produceLatestReleaseVersion(app: SoftwareApplicationEvent): State<String?> {
                 Filter(
                     kinds = listOf(SoftwareReleaseEvent.KIND),
                     authors = listOf(app.pubKey),
+                    tags = mapOf(AppIdTag.TAG_NAME to listOf(app.appId())),
                 )
             LocalCache
                 .observeNotes(filter)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/SoftwareApp.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/SoftwareApp.kt
@@ -189,9 +189,12 @@ fun RenderSoftwareApplication(
 
 /**
  * Looks up the latest NIP-82 [SoftwareReleaseEvent] for [app] from
- * [LocalCache] and exposes the version string. Recomputes on event identity
- * change; relay-driven recompositions of the surrounding feed will pick up
- * newer releases via re-keying.
+ * [LocalCache] and exposes the version string. Releases (kind 30063) are
+ * separate events that point back to the app via an `i` tag, so they are not
+ * indexed as replies to the app note and never ping its flows. We therefore
+ * re-scan on every [LocalCache.live] new-event bundle so a newer release that
+ * arrives while the card is visible updates the version chip without a manual
+ * refresh.
  */
 @Composable
 fun produceLatestReleaseVersion(app: SoftwareApplicationEvent) =
@@ -200,6 +203,16 @@ fun produceLatestReleaseVersion(app: SoftwareApplicationEvent) =
             withContext(Dispatchers.Default) {
                 findLatestNip82Release(app)?.version()
             }
+
+        LocalCache.live.newEventBundles.collect {
+            val newVersion =
+                withContext(Dispatchers.Default) {
+                    findLatestNip82Release(app)?.version()
+                }
+            if (newVersion != value) {
+                value = newVersion
+            }
+        }
     }
 
 fun findLatestNip82Release(app: SoftwareApplicationEvent): SoftwareReleaseEvent? {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/SoftwareApp.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/SoftwareApp.kt
@@ -43,6 +43,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.produceState
@@ -59,6 +60,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlImage
@@ -90,10 +92,13 @@ import com.vitorpamplona.quartz.experimental.nip82SoftwareApps.asset.SoftwareAss
 import com.vitorpamplona.quartz.experimental.nip82SoftwareApps.release.SoftwareReleaseEvent
 import com.vitorpamplona.quartz.experimental.nip82SoftwareApps.release.asSoftwareRelease
 import com.vitorpamplona.quartz.experimental.nip82SoftwareApps.release.isNip82SoftwareRelease
+import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 
 /**
  * NIP-82 kind 32267 — compact feed card. Renders icon, name, latest version
@@ -188,65 +193,73 @@ fun RenderSoftwareApplication(
 }
 
 /**
- * Looks up the latest NIP-82 [SoftwareReleaseEvent] for [app] from
- * [LocalCache] and exposes the version string. Releases (kind 30063) are
- * separate events that point back to the app via an `i` tag, so they are not
- * indexed as replies to the app note and never ping its flows. We therefore
- * re-scan on every [LocalCache.live] new-event bundle so a newer release that
- * arrives while the card is visible updates the version chip without a manual
- * refresh.
+ * Latest NIP-82 [SoftwareReleaseEvent] version for [app], kept live.
+ *
+ * Releases (kind 30063) are separate events that point back to the app via an
+ * `i` tag rather than an `a` tag, so they are never indexed as replies to the
+ * app note and never ping its flows. Instead we register an index-driven
+ * [LocalCache.observeNotes] observer keyed on kind-30063 / author, so a newer
+ * release arriving while the card is visible updates the version chip without
+ * a manual refresh. The observer only wakes on matching insertions, so it is
+ * far cheaper than re-scanning the cache on every new-event bundle.
  */
 @Composable
-fun produceLatestReleaseVersion(app: SoftwareApplicationEvent) =
-    produceState<String?>(initialValue = null, key1 = app.id) {
-        value =
-            withContext(Dispatchers.Default) {
-                findLatestNip82Release(app)?.version()
-            }
-
-        LocalCache.live.newEventBundles.collect {
-            val newVersion =
-                withContext(Dispatchers.Default) {
-                    findLatestNip82Release(app)?.version()
-                }
-            if (newVersion != value) {
-                value = newVersion
-            }
+fun produceLatestReleaseVersion(app: SoftwareApplicationEvent): State<String?> {
+    val flow =
+        remember(app.pubKey, app.id) {
+            val filter =
+                Filter(
+                    kinds = listOf(SoftwareReleaseEvent.KIND),
+                    authors = listOf(app.pubKey),
+                )
+            LocalCache
+                .observeNotes(filter)
+                .map { notes -> latestNip82Release(notes, app)?.version() }
+                .distinctUntilChanged()
+                .flowOn(Dispatchers.Default)
         }
-    }
-
-fun findLatestNip82Release(app: SoftwareApplicationEvent): SoftwareReleaseEvent? {
-    val prefix = "${app.dTag()}@"
-    val notes =
-        LocalCache.addressables.filterIntoSet(SoftwareReleaseEvent.KIND, app.pubKey) { _, addr ->
-            val ev = addr.event ?: return@filterIntoSet false
-            ev.isNip82SoftwareRelease() && ev.dTag().startsWith(prefix)
-        }
-    return notes
-        .mapNotNull {
-            when (val ev = it.event) {
-                is SoftwareReleaseEvent -> ev
-                null -> null
-                else -> if (ev.isNip82SoftwareRelease()) ev.asSoftwareRelease() else null
-            }
-        }.maxByOrNull { it.createdAt }
+    return flow.collectAsStateWithLifecycle(initialValue = null)
 }
+
+fun findLatestNip82Release(app: SoftwareApplicationEvent): SoftwareReleaseEvent? = latestNip82Release(nip82ReleaseNotesFor(app), app)
+
+/** Picks the newest NIP-82 release for [app] out of an already-narrowed [notes] collection. */
+private fun latestNip82Release(
+    notes: Collection<Note>,
+    app: SoftwareApplicationEvent,
+): SoftwareReleaseEvent? {
+    val prefix = "${app.dTag()}@"
+    return notes
+        .mapNotNull { it.asNip82ReleaseFor(prefix) }
+        .maxByOrNull { it.createdAt }
+}
+
+/** kind-30063 addressables authored by [app] whose `d` tag is `<app-id>@<version>`. */
+private fun nip82ReleaseNotesFor(app: SoftwareApplicationEvent): Set<Note> {
+    val prefix = "${app.dTag()}@"
+    return LocalCache.addressables.filterIntoSet(SoftwareReleaseEvent.KIND, app.pubKey) { _, addr ->
+        val ev = addr.event ?: return@filterIntoSet false
+        ev.isNip82SoftwareRelease() && ev.dTag().startsWith(prefix)
+    }
+}
+
+/**
+ * Re-reads this note as the NIP-82 release for [prefix] (`<app-id>@`). kind 30063
+ * collides with NIP-51 `ReleaseArtifactSetEvent`, which is what `EventFactory`
+ * builds, so we re-parse matching tag arrays as the NIP-82 form.
+ */
+private fun Note.asNip82ReleaseFor(prefix: String): SoftwareReleaseEvent? =
+    when (val ev = event) {
+        null -> null
+        is SoftwareReleaseEvent -> ev.takeIf { it.dTag().startsWith(prefix) }
+        else -> if (ev.isNip82SoftwareRelease() && ev.dTag().startsWith(prefix)) ev.asSoftwareRelease() else null
+    }
 
 fun findAllNip82Releases(app: SoftwareApplicationEvent): List<SoftwareReleaseEvent> {
     val prefix = "${app.dTag()}@"
-    val notes =
-        LocalCache.addressables.filterIntoSet(SoftwareReleaseEvent.KIND, app.pubKey) { _, addr ->
-            val ev = addr.event ?: return@filterIntoSet false
-            ev.isNip82SoftwareRelease() && ev.dTag().startsWith(prefix)
-        }
-    return notes
-        .mapNotNull {
-            when (val ev = it.event) {
-                is SoftwareReleaseEvent -> ev
-                null -> null
-                else -> if (ev.isNip82SoftwareRelease()) ev.asSoftwareRelease() else null
-            }
-        }.sortedByDescending { it.createdAt }
+    return nip82ReleaseNotesFor(app)
+        .mapNotNull { it.asNip82ReleaseFor(prefix) }
+        .sortedByDescending { it.createdAt }
 }
 
 @Composable


### PR DESCRIPTION
## Summary

Refactor `produceLatestReleaseVersion()` to use `LocalCache.observeNotes()` with a filtered flow instead of a one-shot `produceState` lookup. This keeps the version chip updated when new releases arrive while the card is visible, without requiring manual refresh or re-keying.

NIP-82 releases (kind 30063) point back to the app via an `i` tag rather than an `a` tag, so they are never indexed as replies and never ping the app note's flows. The new observer-based approach registers a persistent index-driven listener that fires whenever a matching release is added to the cache.

The filter narrows on the release's `i` tag (app id) and author, so the observer only loads *this* app's releases — avoiding unnecessary churn for authors with many apps. A blind `limit` is deliberately avoided since `LocalCache.filter` applies `take(limit)` before sorting by `created_at`, which could drop the very release we're looking for.

**Refactoring:**
- Extract `latestNip82Release()` helper to pick the newest release from a pre-filtered collection
- Extract `nip82ReleaseNotesFor()` to centralize the addressable lookup logic
- Add `Note.asNip82ReleaseFor()` extension to handle kind-30063 re-parsing (collides with NIP-51)
- Reuse extracted helpers in `findAllNip82Releases()` to eliminate duplication

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Ran `./gradlew test` — existing tests pass
- [x] Manually exercised the change: verified that opening a software app card with available releases displays the latest version, and that new releases arriving in the cache update the version chip without manual refresh

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01EbCTsBoGtBCJ1rTKCcar6w