### PR TITLE
fix: surface reply, not root, for multi-e-tag reactions in Android tray

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
@@ -756,7 +756,12 @@ class EventNotificationConsumer(
         // p-tag match already enforced by consumeFromCache; no redundant
         // isTaggedUser re-check needed.
 
-        val reactedPostId = event.originalPost().firstOrNull() ?: return
+        // NIP-25: when a reaction carries multiple `e` tags (e.g. both the
+        // thread root and the replied-to note), the LAST one is the event
+        // actually being reacted to. Using the first tag would surface the
+        // root in the tray when the like was really on a reply. This matches
+        // the in-app card, which resolves the target via replyTo.lastOrNull().
+        val reactedPostId = event.originalPost().lastOrNull() ?: return
         val reactedNote = LocalCache.checkGetOrCreateNote(reactedPostId)
 
         // Drop reactions on muted threads, hidden authors, etc.


### PR DESCRIPTION
A kind:7 reaction can carry several `e` tags (e.g. the thread root plus
the actually-reacted-to reply). Per NIP-25 the last `e` tag is the event
being reacted to, but the notification consumer resolved the reacted note
via `originalPost().firstOrNull()`, which picked the root. The tray then
showed the like as if it targeted the root note instead of the reply.

Switch to `lastOrNull()` to match NIP-25 and the in-app reaction card,
which already resolves the target with `note.replyTo?.lastOrNull()`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018EEQN8Sy7mQ81BEC3rUu5o