### PR TITLE
Add bidirectional local relay event sync

### DIFF
--- a/amethyst/src/androidTest/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/eventsync/EventSyncTest.kt
+++ b/amethyst/src/androidTest/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/eventsync/EventSyncTest.kt
@@ -67,6 +67,7 @@ class EventSyncTest {
                     outboxTargets = { setOf(vitor) },
                     inboxTargets = { setOf(vitor) },
                     dmTargets = { setOf(vitor) },
+                    localTargets = { emptySet() },
                     clientBuilder = {
                         NostrClient(socketBuilder, appScope)
                     },
@@ -86,6 +87,7 @@ class EventSyncTest {
                     outboxTargets = { setOf(vitor) },
                     inboxTargets = { setOf(vitor) },
                     dmTargets = { setOf(vitor) },
+                    localTargets = { emptySet() },
                     clientBuilder = {
                         val newClient = NostrClient(socketBuilder, appScope)
                         val logger = RelayLogger(newClient, debugSending = true, debugReceiving = false)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -292,6 +292,7 @@ class AccountViewModel(
             outboxTargets = { account.nip65RelayList.outboxFlow.value },
             inboxTargets = { account.nip65RelayList.inboxFlow.value },
             dmTargets = { account.dmRelayList.flow.value },
+            localTargets = { account.localRelayList.flow.value },
             clientBuilder = {
                 // creates a new client to make sure these events don't end up polluting the local cache.
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/eventsync/EventSync.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/eventsync/EventSync.kt
@@ -81,6 +81,7 @@ class EventSync(
     private val outboxTargets: () -> Set<NormalizedRelayUrl>,
     private val inboxTargets: () -> Set<NormalizedRelayUrl>,
     private val dmTargets: () -> Set<NormalizedRelayUrl>,
+    private val localTargets: () -> Set<NormalizedRelayUrl>,
     private val clientBuilder: () -> INostrClient,
     private val scope: CoroutineScope,
 ) {
@@ -147,6 +148,7 @@ class EventSync(
      * @param outboxTargets  Relays receiving events authored by the user.
      * @param inboxTargets  Relays receiving events that mention the user.
      * @param dmTargets  Relays receiving DMs addressed to the user.
+     * @param localTargets  Personal archive relays receiving all three event categories.
      */
     @Stable
     data class LiveSyncActivity(
@@ -155,6 +157,7 @@ class EventSync(
         val outboxTargets: Map<NormalizedRelayUrl, DestinationRelayInfo> = emptyMap(),
         val inboxTargets: Map<NormalizedRelayUrl, DestinationRelayInfo> = emptyMap(),
         val dmTargets: Map<NormalizedRelayUrl, DestinationRelayInfo> = emptyMap(),
+        val localTargets: Map<NormalizedRelayUrl, DestinationRelayInfo> = emptyMap(),
     ) {
         val sortedCompletedRelays =
             completedRelays.values.let {
@@ -178,12 +181,14 @@ class EventSync(
             outboxTargets: List<DestinationRelayInfo>,
             inboxTargets: List<DestinationRelayInfo>,
             dmTargets: List<DestinationRelayInfo>,
+            localTargets: List<DestinationRelayInfo>,
         ) : this(
             runningRelays.associateBy { it.relay },
             completedRelays.associateBy { it.relay },
             outboxTargets.associateBy { it.relay },
             inboxTargets.associateBy { it.relay },
             dmTargets.associateBy { it.relay },
+            localTargets.associateBy { it.relay },
         )
 
         sealed interface ConnectionStatus {
@@ -250,6 +255,7 @@ class EventSync(
         liveOutboxTargets: Set<NormalizedRelayUrl> = emptySet(),
         liveInboxTargets: Set<NormalizedRelayUrl> = emptySet(),
         liveDmTargets: Set<NormalizedRelayUrl> = emptySet(),
+        liveLocalTargets: Set<NormalizedRelayUrl> = emptySet(),
     ) {
         _liveActivity.value =
             LiveSyncActivity(
@@ -289,6 +295,14 @@ class EventSync(
                     },
                 dmTargets =
                     liveDmTargets.associateWith { relay ->
+                        LiveSyncActivity.DestinationRelayInfo(
+                            relay = relay,
+                            eventsSent = MutableStateFlow<Int>(0),
+                            eventsAccepted = MutableStateFlow<Int>(0),
+                        )
+                    },
+                localTargets =
+                    liveLocalTargets.associateWith { relay ->
                         LiveSyncActivity.DestinationRelayInfo(
                             relay = relay,
                             eventsSent = MutableStateFlow<Int>(0),
@@ -336,7 +350,8 @@ class EventSync(
 
         val myPubKey = accountPubKey
 
-        val relaysToProcess = relayDb()
+        val localTargets = localTargets()
+        val relaysToProcess = (relayDb() + localTargets).distinct()
 
         if (relaysToProcess.isEmpty()) {
             _syncState.value =
@@ -352,18 +367,20 @@ class EventSync(
 
         val defaultFilters =
             buildList {
-                if (outboxTargets.isNotEmpty()) add(Filter(authors = listOf(myPubKey), since = filterSince, until = filterUntil))
-                if (inboxTargets.isNotEmpty() || dmTargets.isNotEmpty()) {
+                if (outboxTargets.isNotEmpty() || localTargets.isNotEmpty()) {
+                    add(Filter(authors = listOf(myPubKey), since = filterSince, until = filterUntil))
+                }
+                if (inboxTargets.isNotEmpty() || dmTargets.isNotEmpty() || localTargets.isNotEmpty()) {
                     add(Filter(tags = mapOf("p" to listOf(myPubKey)), since = filterSince, until = filterUntil))
                 }
             }
 
         if (defaultFilters.isEmpty()) {
-            _syncState.value = SyncState.Error("No outbox, inbox, or DM relays configured.", filterSince, filterUntil)
+            _syncState.value = SyncState.Error("No outbox, inbox, DM, or local relays configured.", filterSince, filterUntil)
             return
         }
 
-        val usersRelays = outboxTargets + inboxTargets + dmTargets
+        val usersRelays = outboxTargets + inboxTargets + dmTargets + localTargets
 
         val perRelayFilters =
             relaysToProcess.associateWith {
@@ -385,6 +402,7 @@ class EventSync(
             outboxTargets,
             inboxTargets,
             dmTargets,
+            localTargets,
         )
 
         // Thread-safe dedup sets — prevent the same event from being forwarded twice when
@@ -392,6 +410,7 @@ class EventSync(
         val outboxDedup = ConcurrentHashMap.newKeySet<String>()
         val inboxDedup = ConcurrentHashMap.newKeySet<String>()
         val dmDedup = ConcurrentHashMap.newKeySet<String>()
+        val localDedup = ConcurrentHashMap.newKeySet<String>()
 
         val sourceRelayOfEvent = ConcurrentHashMap<HexKey, NormalizedRelayUrl>()
 
@@ -447,6 +466,12 @@ class EventSync(
                                 ?.update { it + 1 }
                             hasSent = true
                         }
+                        if (localDedup.contains(cmd.event.id)) {
+                            liveActivity.value.localTargets[relay.url]
+                                ?.eventsSent
+                                ?.update { it + 1 }
+                            hasSent = true
+                        }
 
                         if (hasSent) {
                             runningState.eventsSent.update { it + 1 }
@@ -489,6 +514,13 @@ class EventSync(
                         }
                         if (inboxDedup.contains(msg.eventId)) {
                             val relayTarget = liveActivity.value.inboxTargets[relay.url]
+                            if (relayTarget != null) {
+                                relayTarget.eventsAccepted.update { it + 1 }
+                                runningState.eventsAccepted.update { it + 1 }
+                            }
+                        }
+                        if (localDedup.contains(msg.eventId)) {
+                            val relayTarget = liveActivity.value.localTargets[relay.url]
                             if (relayTarget != null) {
                                 relayTarget.eventsAccepted.update { it + 1 }
                                 runningState.eventsAccepted.update { it + 1 }
@@ -539,6 +571,13 @@ class EventSync(
                         if (mentionsMe && !isDmKind && inboxTargets.isNotEmpty()) {
                             if (inboxDedup.add(event.id)) {
                                 client.publish(event, inboxTargets)
+                                newEvent = true
+                            }
+                            matchesAtLeastOneFilter = true
+                        }
+                        if ((isMyEvent || mentionsMe) && localTargets.isNotEmpty()) {
+                            if (localDedup.add(event.id)) {
+                                client.publish(event, localTargets - sourceRelay)
                                 newEvent = true
                             }
                             matchesAtLeastOneFilter = true

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/eventsync/EventSyncScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/eventsync/EventSyncScreen.kt
@@ -139,7 +139,8 @@ fun EventScreenBody(
         // ---- Live relay activity (shown during and after sync) ----
         if (liveActivity.outboxTargets.isNotEmpty() ||
             liveActivity.inboxTargets.isNotEmpty() ||
-            liveActivity.dmTargets.isNotEmpty()
+            liveActivity.dmTargets.isNotEmpty() ||
+            liveActivity.localTargets.isNotEmpty()
         ) {
             item {
                 Spacer(Modifier.height(16.dp))
@@ -267,6 +268,8 @@ private fun ExplanationCard(
             StepRow(number = "2", text = stringRes(R.string.event_sync_step2))
             Spacer(Modifier.height(4.dp))
             StepRow(number = "3", text = stringRes(R.string.event_sync_step3))
+            Spacer(Modifier.height(4.dp))
+            StepRow(number = "4", text = stringRes(R.string.event_sync_step4))
             Spacer(Modifier.height(10.dp))
 
             // ---- WiFi warning ----
@@ -516,6 +519,17 @@ private fun DestinationRelaysCard(activity: EventSync.LiveSyncActivity) {
                     label = stringRes(R.string.event_sync_dm_relays),
                     relays = activity.dmTargets.values,
                     color = MaterialTheme.colorScheme.tertiary,
+                )
+            }
+
+            if (activity.localTargets.isNotEmpty()) {
+                Spacer(Modifier.height(10.dp))
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                Spacer(Modifier.height(10.dp))
+                DestinationSection(
+                    label = stringRes(R.string.event_sync_local_relays),
+                    relays = activity.localTargets.values,
+                    color = MaterialTheme.colorScheme.error,
                 )
             }
         }
@@ -887,6 +901,10 @@ private val previewActivity =
             listOf(
                 EventSync.LiveSyncActivity.DestinationRelayInfo(NormalizedRelayUrl("wss://dm.nostr.com"), 15, 10),
             ),
+        localTargets =
+            listOf(
+                EventSync.LiveSyncActivity.DestinationRelayInfo(NormalizedRelayUrl("ws://localhost:4869"), 2139, 2139),
+            ),
     )
 
 // -------------------------------------------------------------------------
@@ -965,7 +983,7 @@ fun EventScreenBodyPreview() {
     ThemeComparisonRow {
         EventScreenBody(
             EventSync.SyncState.Idle,
-            EventSync.LiveSyncActivity(emptyList(), emptyList(), emptyList(), emptyList(), emptyList()),
+            EventSync.LiveSyncActivity(emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), emptyList()),
         )
     }
 }

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -2883,6 +2883,7 @@
     <string name="event_sync_step1">Download all events you authored and send them to your outbox relays.</string>
     <string name="event_sync_step2">Download all events that mention you and send them to your inbox relays.</string>
     <string name="event_sync_step3">Download all direct messages addressed to you and send them to your DM relays.</string>
+    <string name="event_sync_step4">Copy authored, mentioned, and direct-message events to local archive relays and restore missing events from them.</string>
     <string name="event_sync_wifi_warning">⚠ You appear to be on a metered or mobile connection. This operation can transfer a very large amount of data. Connect to Wi-Fi before starting.</string>
     <string name="event_sync_mobile_data_dialog_title">Use Mobile Data?</string>
     <string name="event_sync_start">Start Sync</string>
@@ -2899,6 +2900,7 @@
     <string name="event_sync_outbox_relays">Outbox</string>
     <string name="event_sync_inbox_relays">Inbox</string>
     <string name="event_sync_dm_relays">DMs</string>
+    <string name="event_sync_local_relays">Local archive</string>
     <string name="event_sync_activity_log">Currently Checking (%1$d relays)</string>
     <string name="event_sync_activity_log_finished">Finished (%1$d relays)</string>
     <string name="event_sync_log_sent">sent %1$s</string>


### PR DESCRIPTION
## Summary

- include configured local relays as both event-sync sources and archive destinations
- copy authored, mentioned, and DM events to local relays while excluding the current source to prevent echo writes
- restore missing local-relay events through the existing outbox, inbox, and DM routing paths
- expose local archive send/accept counters in the sync UI

## Performance and safety

This reuses the existing paginated, 50-relay concurrency-limited sync stream. It does not load or serialize the whole cache, and it uses a dedicated event-id dedup set for local destinations. A local source is excluded from its own destination set, avoiding a write-back loop during large (~20,000 event) syncs.

## Validation

- updated every in-tree `EventSync` constructor call
- updated previews for the extended live-activity model
- source-level consistency checks completed; a full Android build was not available in the contribution environment
- fork CI spotlessCheck, :quartz:verifyKmpPurity, and :commons:verifyKmpPurity passed: https://github.com/silentgeckoaudit3801/amethyst/actions/runs/27917465017/jobs/82605215268

Fixes #2706