### PR TITLE
Missing notifications on fresh install.

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/DebugUtils.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/DebugUtils.kt
@@ -24,6 +24,7 @@ import android.app.ActivityManager
 import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.os.Debug
+import android.os.Trace
 import androidx.core.content.getSystemService
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.quartz.nip01Core.core.Event
@@ -171,6 +172,27 @@ fun debugState(context: Context) {
     qttAddressables.toList().sortedByDescending { bytesNotes[it.first] }.forEach { (kind, qtt) ->
         Log.d(STATE_DUMP_TAG) { "Kind ${kind.toString().padStart(5,' ')}:\t${qtt.toString().padStart(6,' ')} elements\t${bytesAddressables[kind]?.div((1024 * 1024))}MB " }
     }
+}
+
+/**
+ * Wraps [block] in an `android.os.Trace` section so it shows up as a named slice in
+ * Perfetto / `atrace` captures. The platform `Trace` calls are near-free when tracing
+ * is not active, so this is safe to leave always-on, including in release-like builds.
+ *
+ * NOTE: deliberately no `try/finally` — the Compose compiler forbids wrapping a
+ * `@Composable` invocation in `try/catch`, and this helper is used around composables
+ * (e.g. per-card rendering in the feeds). On a thrown exception the section is left
+ * open, which only matters during a crash. Section names must stay under 127 chars
+ * or `beginSection` throws.
+ */
+inline fun <T> traced(
+    sectionName: String,
+    block: () -> T,
+): T {
+    Trace.beginSection(sectionName)
+    val result = block()
+    Trace.endSection()
+    return result
 }
 
 inline fun <T> logTime(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -425,6 +425,8 @@ class Account(
             scope = scope,
             assembler = cashuWalletFilterAssembler(),
             outboxRelaysFlow = outboxRelays.flow,
+            inboxRelaysFlow = notificationRelays.flow,
+            dmRelaysFlow = dmRelays.flow,
             settings = settings,
             okHttpClient = okHttpClientForMoney,
         )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip60Cashu/CashuWalletOps.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip60Cashu/CashuWalletOps.kt
@@ -153,9 +153,11 @@ class CashuWalletOps(
         val walletEvent = signer.sign(walletTemplate)
         publish(walletEvent)
 
-        // Populate `relay` tags so senders know where to publish nutzaps —
-        // without these, they fall back to NIP-65 outbox and may miss our
-        // subscription scope on relays we don't read from.
+        // Populate `relay` tags so senders know where to publish nutzaps.
+        // Per NIP-61 these are the relays where the recipient reads incoming
+        // token events, so callers pass our inbox-side relays here (NIP-65
+        // outbox model). Without them, senders fall back to NIP-65 and may
+        // publish where we don't subscribe for inbound nutzaps.
         val nutzapInfoTemplate =
             NutzapInfoEvent.build(
                 mints = mints.map { NutzapMintTag(it, listOf("sat")) },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip60Cashu/CashuWalletState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip60Cashu/CashuWalletState.kt
@@ -895,10 +895,11 @@ class CashuWalletState(
         ops.publishWalletEvents(
             mints = currentMints,
             p2pkPrivkeyHex = manualPrivkeyHex?.takeIf { it.isNotBlank() },
-            // Advertise our inbox + DM relays as the nutzap relays (NIP-65
+            // Advertise our NIP-65 inbox relays as the nutzap relays (NIP-65
             // outbox model): senders publish kind:9321 where we read inbound
-            // events, matching the wallet's inbound-nutzap subscription set.
-            nutzapRelays = (inboxRelaysFlow.value + dmRelaysFlow.value).toList(),
+            // events. We listen on a wider set (inbox + DM + these tags), but
+            // the kind:10019 default copies the inbox relay list, not outbox.
+            nutzapRelays = inboxRelaysFlow.value.toList(),
         )
         // The NUT-13 seed (derived from the P2PK key) is invalidated by
         // applyEvents when the new kind:17375 round-trips in, so it re-derives

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip60Cashu/CashuWalletState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip60Cashu/CashuWalletState.kt
@@ -97,6 +97,8 @@ class CashuWalletState(
     private val scope: CoroutineScope,
     private val assembler: CashuWalletFilterAssembler,
     private val outboxRelaysFlow: StateFlow<Set<NormalizedRelayUrl>>,
+    private val inboxRelaysFlow: StateFlow<Set<NormalizedRelayUrl>>,
+    private val dmRelaysFlow: StateFlow<Set<NormalizedRelayUrl>>,
     private val settings: AccountSettings,
     okHttpClient: (String) -> OkHttpClient,
 ) {
@@ -436,12 +438,31 @@ class CashuWalletState(
             triggerAutoRedeem()
         }
 
-        // Keep the relay subscription in sync with the outbox set.
+        // Keep the wallet subscription in sync with the relay sets it reads
+        // from. Following the NIP-65 outbox model, the two halves of the
+        // subscription read from different places:
+        //  - our own NIP-60 events (wallet/token/history) are read back from
+        //    our OUTBOX relays, where we published them;
+        //  - inbound kind:9321 nutzaps are read from our INBOX set, since
+        //    that is where other people deliver them. Per NIP-61 the source
+        //    of truth for "where to send me nutzaps" is the `relay` tags in
+        //    our own kind:10019 — and another client may have published that
+        //    with relays unrelated to our NIP-65 lists — so we listen on the
+        //    union of those plus our NIP-65 inbox + DM relays.
         jobs +=
             scope.launch(Dispatchers.IO) {
-                outboxRelaysFlow.collect { relays ->
-                    syncSubscription(relays)
-                }
+                combine(
+                    outboxRelaysFlow,
+                    inboxRelaysFlow,
+                    dmRelaysFlow,
+                    _nutzapInfoEvent,
+                ) { outbox, inbox, dm, info ->
+                    CashuWalletQueryState(
+                        pubkey = pubKey,
+                        ownEventRelays = outbox,
+                        inboxRelays = inbox + dm + (info?.relays() ?: emptyList()),
+                    )
+                }.collect { syncSubscription(it) }
             }
 
         // Reactive incremental update: any new event arrival that matches our
@@ -504,17 +525,16 @@ class CashuWalletState(
     // ============================================================
     // Subscription management
     // ============================================================
-    private fun syncSubscription(relays: Set<NormalizedRelayUrl>) {
+    private fun syncSubscription(next: CashuWalletQueryState) {
         val previous = currentSubscription
-        if (relays.isEmpty()) {
+        if (next.ownEventRelays.isEmpty() && next.inboxRelays.isEmpty()) {
             previous?.let { runCatching { assembler.unsubscribe(it) } }
             currentSubscription = null
             return
         }
-        if (previous != null && previous.relays == relays) return // unchanged
+        if (previous == next) return // unchanged
 
         previous?.let { runCatching { assembler.unsubscribe(it) } }
-        val next = CashuWalletQueryState(pubKey, relays)
         currentSubscription = next
         assembler.subscribe(next)
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip60Cashu/CashuWalletState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip60Cashu/CashuWalletState.kt
@@ -895,7 +895,10 @@ class CashuWalletState(
         ops.publishWalletEvents(
             mints = currentMints,
             p2pkPrivkeyHex = manualPrivkeyHex?.takeIf { it.isNotBlank() },
-            nutzapRelays = outboxRelaysFlow.value.toList(),
+            // Advertise our inbox + DM relays as the nutzap relays (NIP-65
+            // outbox model): senders publish kind:9321 where we read inbound
+            // events, matching the wallet's inbound-nutzap subscription set.
+            nutzapRelays = (inboxRelaysFlow.value + dmRelaysFlow.value).toList(),
         )
         // The NUT-13 seed (derived from the P2PK key) is invalidated by
         // applyEvents when the new kind:17375 round-trips in, so it re-derives

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/account/nip01Notifications/AccountNotificationsEoseFromInboxRelaysManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/account/nip01Notifications/AccountNotificationsEoseFromInboxRelaysManager.kt
@@ -27,7 +27,6 @@ import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 import com.vitorpamplona.quartz.nip01Core.relay.client.subscriptions.Subscription
-import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
@@ -51,15 +50,22 @@ class AccountNotificationsEoseFromInboxRelaysManager(
         since: SincePerRelayMap?,
     ): List<RelayBasedFilter> =
         key.account.notificationRelays.flow.value.flatMap {
+            // On a cold start the EOSE watermark map is empty. Falling back to a
+            // fixed `oneWeekAgo()` here hard-capped the initial backfill to the
+            // last 7 days, so a fresh install showed far fewer notifications than
+            // clients that query the same relays with only a `limit`. Leaving
+            // `since` null lets the per-filter `limit` govern instead, so the
+            // relay returns the newest N notifications regardless of age. Once an
+            // EOSE arrives the per-relay watermark takes over for the live tail.
             filterSummaryNotificationsToPubkey(
                 relay = it,
                 pubkey = user(key).pubkeyHex,
-                since = since?.get(it)?.time ?: TimeUtils.oneWeekAgo(),
+                since = since?.get(it)?.time,
             ) +
                 filterNotificationsToPubkey(
                     relay = it,
                     pubkey = user(key).pubkeyHex,
-                    since = since?.get(it)?.time ?: key.feedContentStates.notifications.lastNoteCreatedAtIfFilled() ?: TimeUtils.oneWeekAgo(),
+                    since = since?.get(it)?.time ?: key.feedContentStates.notifications.lastNoteCreatedAtIfFilled(),
                 )
         }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/account/nip01Notifications/AccountNotificationsEoseFromRandomRelaysManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/account/nip01Notifications/AccountNotificationsEoseFromRandomRelaysManager.kt
@@ -27,7 +27,6 @@ import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 import com.vitorpamplona.quartz.nip01Core.relay.client.subscriptions.Subscription
-import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
@@ -51,8 +50,12 @@ class AccountNotificationsEoseFromRandomRelaysManager(
         key: AccountQueryState,
         since: SincePerRelayMap?,
     ): List<RelayBasedFilter> {
-        // only loads this after the feed is built
-        val defaultSince = key.feedContentStates.notifications.lastNoteCreatedAtIfFilled() ?: TimeUtils.oneWeekAgo()
+        // Null `since` on a cold start: these filters carry tiny limits (20/20/10/2),
+        // so leaving `since` open returns the newest few notifications per relay
+        // regardless of age — a true "just the latest", as the filter name says.
+        // A fixed `oneWeekAgo()` floor used to intersect that with the last 7 days,
+        // hiding older interactions on a fresh install even when well under the limit.
+        val defaultSince = key.feedContentStates.notifications.lastNoteCreatedAtIfFilled()
         return (key.account.followsPerRelay.value.keys - key.account.notificationRelays.flow.value).flatMap {
             val since = since?.get(it)?.time ?: defaultSince
             filterJustTheLatestNotificationsToPubkeyFromRandomRelays(it, user(key).pubkeyHex, since)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/user/UserObservers.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/user/UserObservers.kt
@@ -150,9 +150,15 @@ fun observeUserBanner(
 fun observeUserPicture(
     user: User,
     accountViewModel: AccountViewModel,
+    subscribe: Boolean = true,
 ): State<String?> {
     // Subscribe in the relay for changes in the metadata of this user.
-    UserFinderFilterAssemblerSubscription(user, accountViewModel)
+    // Callers that already hold a single shared subscription for the same user
+    // (e.g. an author avatar that also observes the contact-card score) can pass
+    // subscribe = false to avoid setting up a redundant relay subscription.
+    if (subscribe) {
+        UserFinderFilterAssemblerSubscription(user, accountViewModel)
+    }
 
     // Subscribe in the LocalCache for changes that arrive in the device
     val flow =
@@ -476,9 +482,14 @@ fun observeUserIsFollowingChannel(
 fun observeUserContactCardsScore(
     user: User,
     accountViewModel: AccountViewModel,
+    subscribe: Boolean = true,
 ): State<Int?> {
     // Subscribe in the relay for changes in the metadata of this user.
-    UserFinderFilterAssemblerSubscription(user, accountViewModel)
+    // See observeUserPicture: pass subscribe = false when a shared subscription
+    // for the same user already exists.
+    if (subscribe) {
+        UserFinderFilterAssemblerSubscription(user, accountViewModel)
+    }
 
     // Subscribe in the LocalCache for changes that arrive in the device
     val flow = remember(user) { user.cards().rankFlow(accountViewModel.account.trustProviderList) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/AuthorGalleryRenderContext.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/AuthorGalleryRenderContext.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.note
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+
+/**
+ * The notification galleries (reactions, zaps, nutzaps, boosts) render up to 30
+ * author avatars each. A couple of the inputs to every avatar are *account-global*
+ * — the auto-play-gif setting and the logged-in user's follow set — yet the avatar
+ * code used to collect each of them **once per author**. With dozens of authors per
+ * card that produced dozens of redundant Flow collectors / coroutine launches every
+ * time a card scrolled into view, a measurable chunk of the per-card composition cost.
+ *
+ * Hoisting those reads to a single collection per gallery and handing the snapshot
+ * down through [LocalAuthorGalleryRenderContext] lets each avatar read plain values
+ * and stay skippable. When the local is absent the avatar falls back to its old
+ * per-author behaviour, so callers that don't provide a context keep working.
+ */
+@Immutable
+class AuthorGalleryRenderContext(
+    val autoPlayGif: Boolean,
+    val follows: Set<String>,
+)
+
+val LocalAuthorGalleryRenderContext = compositionLocalOf<AuthorGalleryRenderContext?> { null }
+
+/**
+ * Collects the account-global render inputs a single time. Provide the result via
+ * [LocalAuthorGalleryRenderContext] around a gallery's author list.
+ */
+@Composable
+fun rememberAuthorGalleryRenderContext(accountViewModel: AccountViewModel): AuthorGalleryRenderContext {
+    val autoPlayGif by accountViewModel.settings.autoPlayVideosFlow.collectAsStateWithLifecycle()
+    val follows by accountViewModel.account.allFollows.flow
+        .collectAsStateWithLifecycle()
+
+    val followAuthors = follows.authors
+    return remember(autoPlayGif, followAuthors) {
+        AuthorGalleryRenderContext(autoPlayGif, followAuthors)
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/MultiSetCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/MultiSetCompose.kt
@@ -40,6 +40,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
@@ -72,6 +73,7 @@ import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.NoteState
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.CachedRichTextParser
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinderFilterAssemblerSubscription
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserContactCardsScore
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserPicture
 import com.vitorpamplona.amethyst.ui.components.AnimatedBorderTextCornerRadius
@@ -463,8 +465,12 @@ fun AuthorGalleryZaps(
     nav: INav,
     accountViewModel: AccountViewModel,
 ) {
-    Column(modifier = StdStartPadding) {
-        FlowRow { authorNotes.forEach { RenderState(it, backgroundColor, accountViewModel, nav) } }
+    CompositionLocalProvider(
+        LocalAuthorGalleryRenderContext provides rememberAuthorGalleryRenderContext(accountViewModel),
+    ) {
+        Column(modifier = StdStartPadding) {
+            FlowRow { authorNotes.forEach { RenderState(it, backgroundColor, accountViewModel, nav) } }
+        }
     }
 }
 
@@ -631,8 +637,12 @@ fun AuthorGallery(
     accountViewModel: AccountViewModel,
     clickRoute: (Note) -> Route? = ::authorRouteFor,
 ) {
-    Column(modifier = StdStartPadding) {
-        FlowRow { authorNotes.forEach { note -> BoxedAuthor(note, nav, accountViewModel, clickRoute) } }
+    CompositionLocalProvider(
+        LocalAuthorGalleryRenderContext provides rememberAuthorGalleryRenderContext(accountViewModel),
+    ) {
+        Column(modifier = StdStartPadding) {
+            FlowRow { authorNotes.forEach { note -> BoxedAuthor(note, nav, accountViewModel, clickRoute) } }
+        }
     }
 }
 
@@ -643,9 +653,13 @@ fun AuthorGallery(
     nav: INav,
     accountViewModel: AccountViewModel,
 ) {
-    Column(modifier = StdStartPadding) {
-        FlowRow {
-            noteToGetBoostEvents.note.boosts.forEach { note -> BoxedAuthor(note, nav, accountViewModel) }
+    CompositionLocalProvider(
+        LocalAuthorGalleryRenderContext provides rememberAuthorGalleryRenderContext(accountViewModel),
+    ) {
+        Column(modifier = StdStartPadding) {
+            FlowRow {
+                noteToGetBoostEvents.note.boosts.forEach { note -> BoxedAuthor(note, nav, accountViewModel) }
+            }
         }
     }
 }
@@ -684,7 +698,27 @@ fun WatchUserMetadataAndFollowsAndRenderUserProfilePicture(
     author: User,
     accountViewModel: AccountViewModel,
 ) {
-    WatchUserMetadata(author, accountViewModel) { baseUserPicture ->
+    // When rendered inside a gallery, the account-global auto-play and follow-set
+    // reads are hoisted to a single collection for the whole gallery (see
+    // [rememberAuthorGalleryRenderContext]). Falls back to per-author collection
+    // for callers that don't provide a context.
+    val galleryContext = LocalAuthorGalleryRenderContext.current
+
+    // One shared relay subscription per author. The profile picture and the
+    // contact-card score below both fetch the same kind-0 metadata, so we
+    // subscribe once here and let them skip their own (formerly duplicate) one.
+    UserFinderFilterAssemblerSubscription(author, accountViewModel)
+
+    WatchUserMetadata(author, accountViewModel, subscribe = false) { baseUserPicture ->
+        val autoPlayGif =
+            if (galleryContext != null) {
+                galleryContext.autoPlayGif
+            } else {
+                accountViewModel.settings.autoPlayVideosFlow
+                    .collectAsStateWithLifecycle()
+                    .value
+            }
+
         RobohashFallbackAsyncImage(
             robot = author.pubkeyHex,
             model = baseUserPicture,
@@ -693,30 +727,39 @@ fun WatchUserMetadataAndFollowsAndRenderUserProfilePicture(
             contentScale = ContentScale.Crop,
             loadProfilePicture = accountViewModel.settings.showProfilePictures(),
             loadRobohash = accountViewModel.settings.isNotPerformanceMode(),
-            autoPlayGif =
-                accountViewModel.settings.autoPlayVideosFlow
-                    .collectAsStateWithLifecycle()
-                    .value,
+            autoPlayGif = autoPlayGif,
         )
     }
 
-    WatchUserFollows(author.pubkeyHex, accountViewModel) { isFollowing ->
+    if (galleryContext != null) {
+        val isFollowing =
+            accountViewModel.isLoggedUser(author.pubkeyHex) ||
+                author.pubkeyHex in galleryContext.follows
         if (isFollowing) {
             Box(modifier = Size35Modifier, contentAlignment = Alignment.TopEnd) {
                 FollowingIcon(Size10Modifier)
             }
         }
+    } else {
+        WatchUserFollows(author.pubkeyHex, accountViewModel) { isFollowing ->
+            if (isFollowing) {
+                Box(modifier = Size35Modifier, contentAlignment = Alignment.TopEnd) {
+                    FollowingIcon(Size10Modifier)
+                }
+            }
+        }
     }
 
-    ObserveAndRenderBoxedUserCards(author, accountViewModel)
+    ObserveAndRenderBoxedUserCards(author, accountViewModel, subscribe = false)
 }
 
 @Composable
 fun ObserveAndRenderBoxedUserCards(
     user: User,
     accountViewModel: AccountViewModel,
+    subscribe: Boolean = true,
 ) {
-    val score by observeUserContactCardsScore(user, accountViewModel)
+    val score by observeUserContactCardsScore(user, accountViewModel, subscribe)
 
     score?.let {
         Box(modifier = Size35Modifier, contentAlignment = Alignment.BottomCenter) {
@@ -729,9 +772,10 @@ fun ObserveAndRenderBoxedUserCards(
 private fun WatchUserMetadata(
     author: User,
     accountViewModel: AccountViewModel,
+    subscribe: Boolean = true,
     onNewMetadata: @Composable (String?) -> Unit,
 ) {
-    val userProfile by observeUserPicture(author, accountViewModel)
+    val userProfile by observeUserPicture(author, accountViewModel, subscribe)
 
     onNewMetadata(userProfile)
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/CardFeedContentState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/CardFeedContentState.kt
@@ -279,7 +279,7 @@ class CardFeedContentState(
         // reaction/zap/repost — a meaningful GC saving on full feed conversions.
         val zone = ZoneId.systemDefault()
 
-        fun epochDay(createdAt: Long?): Long = LocalDate.ofInstant(Instant.ofEpochSecond(createdAt ?: 0L), zone).toEpochDay()
+        fun epochDay(createdAt: Long?): Long = Instant.ofEpochSecond(createdAt ?: 0L).atZone(zone).toLocalDate().toEpochDay()
 
         val allBaseNotes = zapsPerEvent.keys + boostsPerEvent.keys + reactionsPerEvent.keys + nutzapsPerEvent.keys
         val multiCards =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/CardFeedContentState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/CardFeedContentState.kt
@@ -38,6 +38,7 @@ import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.BundledInsert
 import com.vitorpamplona.amethyst.service.BundledUpdate
 import com.vitorpamplona.amethyst.service.checkNotInMainThread
+import com.vitorpamplona.amethyst.traced
 import com.vitorpamplona.amethyst.ui.dal.AdditiveFeedFilter
 import com.vitorpamplona.amethyst.ui.dal.DefaultFeedOrderCard
 import com.vitorpamplona.amethyst.ui.dal.FeedFilter
@@ -62,8 +63,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneId
-import java.time.format.DateTimeFormatter
 
 @Stable
 class CardFeedContentState(
@@ -161,7 +162,12 @@ class CardFeedContentState(
         }
     }
 
-    private fun convertToCard(notes: Collection<Note>): List<Card> {
+    private fun convertToCard(notes: Collection<Note>): List<Card> =
+        traced("Notif.convertToCard.${notes.size}") {
+            convertToCardInternal(notes)
+        }
+
+    private fun convertToCardInternal(notes: Collection<Note>): List<Card> {
         checkNotInMainThread()
 
         val reactionsPerEvent = mutableMapOf<Note, MutableList<Note>>()
@@ -266,7 +272,14 @@ class CardFeedContentState(
                 }
             }
 
-        val sdf = DateTimeFormatter.ofPattern("yyyy-MM-dd") // SimpleDateFormat()
+        // Notifications are bucketed per calendar day. Computing the day key as a
+        // raw epoch-day Long (instead of formatting a "yyyy-MM-dd" String per event)
+        // gives identical buckets and chronological ordering while avoiding a
+        // DateTimeFormatter + ZonedDateTime + String allocation for every single
+        // reaction/zap/repost — a meaningful GC saving on full feed conversions.
+        val zone = ZoneId.systemDefault()
+
+        fun epochDay(createdAt: Long?): Long = LocalDate.ofInstant(Instant.ofEpochSecond(createdAt ?: 0L), zone).toEpochDay()
 
         val allBaseNotes = zapsPerEvent.keys + boostsPerEvent.keys + reactionsPerEvent.keys + nutzapsPerEvent.keys
         val multiCards =
@@ -278,21 +291,16 @@ class CardFeedContentState(
 
                 val singleList =
                     (boostsInCard + zapsInCard.map { it.response } + reactionsInCard + nutzapsInCard).groupBy {
-                        sdf.format(
-                            Instant
-                                .ofEpochSecond(it.createdAt() ?: 0L)
-                                .atZone(ZoneId.systemDefault())
-                                .toLocalDateTime(),
-                        )
+                        epochDay(it.createdAt())
                     }
 
                 val days = singleList.keys.sortedBy { it }
 
                 days
-                    .mapNotNull { string ->
+                    .mapNotNull { day ->
                         val sortedList =
                             singleList
-                                .get(string)
+                                .get(day)
                                 ?.sortedWith(compareByDescending<Note> { it.createdAt() }.thenBy { it.idHex })
 
                         sortedList?.chunked(30)?.map { chunk ->
@@ -312,12 +320,7 @@ class CardFeedContentState(
                 .map { user ->
                     val byDay =
                         user.value.groupBy {
-                            sdf.format(
-                                Instant
-                                    .ofEpochSecond(it.createdAt() ?: 0L)
-                                    .atZone(ZoneId.systemDefault())
-                                    .toLocalDateTime(),
-                            )
+                            epochDay(it.createdAt())
                         }
 
                     byDay.values.map { zaps ->
@@ -338,12 +341,7 @@ class CardFeedContentState(
                 .map { user ->
                     val byDay =
                         user.value.groupBy {
-                            sdf.format(
-                                Instant
-                                    .ofEpochSecond(it.createdAt() ?: 0L)
-                                    .atZone(ZoneId.systemDefault())
-                                    .toLocalDateTime(),
-                            )
+                            epochDay(it.createdAt())
                         }
 
                     byDay.values.map { nutzaps ->

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/CardFeedContentState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/CardFeedContentState.kt
@@ -63,7 +63,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import java.time.Instant
-import java.time.LocalDate
 import java.time.ZoneId
 
 @Stable
@@ -279,7 +278,12 @@ class CardFeedContentState(
         // reaction/zap/repost — a meaningful GC saving on full feed conversions.
         val zone = ZoneId.systemDefault()
 
-        fun epochDay(createdAt: Long?): Long = Instant.ofEpochSecond(createdAt ?: 0L).atZone(zone).toLocalDate().toEpochDay()
+        fun epochDay(createdAt: Long?): Long =
+            Instant
+                .ofEpochSecond(createdAt ?: 0L)
+                .atZone(zone)
+                .toLocalDate()
+                .toEpochDay()
 
         val allBaseNotes = zapsPerEvent.keys + boostsPerEvent.keys + reactionsPerEvent.keys + nutzapsPerEvent.keys
         val multiCards =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/CardFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/CardFeedView.kt
@@ -49,13 +49,17 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.ui.notifications.Card
 import com.vitorpamplona.amethyst.commons.ui.notifications.CardFeedState
-import com.vitorpamplona.amethyst.logTime
+import com.vitorpamplona.amethyst.traced
 import com.vitorpamplona.amethyst.ui.feeds.FeedError
 import com.vitorpamplona.amethyst.ui.feeds.LoadingFeed
 import com.vitorpamplona.amethyst.ui.feeds.StickToTopOnPrepend
@@ -138,7 +142,15 @@ fun NotificationFeedEmpty(onRefresh: () -> Unit) {
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
+/**
+ * UiAutomator/Macrobenchmark handle for the notifications list. Exposed as a
+ * resource-id (see the `testTagsAsResourceId` on the LazyColumn below) so the
+ * scroll benchmark targets the feed deterministically — never an embedded,
+ * separately-scrollable widget inside a card (e.g. a Road event's map).
+ */
+const val NOTIFICATION_FEED_TEST_TAG = "notificationFeedList"
+
+@OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
 @Composable
 private fun FeedLoaded(
     loaded: CardFeedState.Loaded,
@@ -174,7 +186,11 @@ private fun FeedLoaded(
     }
 
     LazyColumn(
-        modifier = Modifier.fillMaxSize(),
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .semantics { testTagsAsResourceId = true }
+                .testTag(NOTIFICATION_FEED_TEST_TAG),
         contentPadding = rememberFeedContentPadding(FeedPadding),
         state = listState,
     ) {
@@ -242,9 +258,7 @@ private fun FeedLoaded(
             )
 
             Row(Modifier.fillMaxWidth().background(highlightColor).animateItem()) {
-                logTime(
-                    debugMessage = { "CardFeedView $item" },
-                ) {
+                traced("Notif.Card.${item.javaClass.simpleName}") {
                     RenderCardItem(
                         item,
                         routeForLastRead,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationFeedFilter.kt
@@ -279,17 +279,38 @@ class NotificationFeedFilter(
             }
 
             if (event is ReactionEvent) {
-                return note.replyTo
-                    ?.lastOrNull()
-                    ?.author
-                    ?.pubkeyHex == authorHex
+                // A reaction carries the reacted-to event's author in its own
+                // NIP-25 `p` tag, so a reaction to my note is detectable from the
+                // wrapper alone — before the reacted note loads into the cache. On
+                // a cold start that note is often missing, leaving `replyTo` an
+                // authorless shell; relying solely on the resolved parent author
+                // then drops the reaction until the parent happens to arrive,
+                // which is what makes the missing set differ every launch. The
+                // resolved-parent check is kept as the fallback once it is present.
+                return event.originalAuthor().contains(authorHex) ||
+                    note.replyTo
+                        ?.lastOrNull()
+                        ?.author
+                        ?.pubkeyHex == authorHex
             }
 
-            if (event is RepostEvent || event is GenericRepostEvent) {
-                return note.replyTo
-                    ?.lastOrNull()
-                    ?.author
-                    ?.pubkeyHex == authorHex
+            if (event is RepostEvent) {
+                // Same reasoning as reactions: NIP-18 reposts name the reposted
+                // author in their `p` tag, so a repost of my note is relevant even
+                // before the reposted note loads.
+                return event.originalAuthorKeys().contains(authorHex) ||
+                    note.replyTo
+                        ?.lastOrNull()
+                        ?.author
+                        ?.pubkeyHex == authorHex
+            }
+
+            if (event is GenericRepostEvent) {
+                return event.originalAuthorKeys().contains(authorHex) ||
+                    note.replyTo
+                        ?.lastOrNull()
+                        ?.author
+                        ?.pubkeyHex == authorHex
             }
 
             return true

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/CashuWalletViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/CashuWalletViewModel.kt
@@ -500,12 +500,13 @@ class CashuWalletViewModel : ViewModel() {
                 ops.publishWalletEvents(
                     mints = mints,
                     p2pkPrivkeyHex = privkey,
-                    // Advertise our inbox + DM relays as the nutzap relays, so
-                    // senders publish kind:9321 where we read incoming events
-                    // (NIP-65 outbox model). Mirrors the relay set the wallet
-                    // subscribes to for inbound nutzaps.
+                    // Advertise our NIP-65 inbox relays as the nutzap relays,
+                    // so senders publish kind:9321 where we read incoming
+                    // events (NIP-65 outbox model). The kind:10019 default
+                    // copies the inbox relay list, not outbox; the wallet
+                    // still subscribes to a wider inbox + DM + tags set.
                     nutzapRelays =
-                        (acc.notificationRelays.flow.value + acc.dmRelays.flow.value)
+                        acc.notificationRelays.flow.value
                             .toList(),
                 )
                 _createState.value = CashuWalletCreateState.Success

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/CashuWalletViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/CashuWalletViewModel.kt
@@ -500,8 +500,12 @@ class CashuWalletViewModel : ViewModel() {
                 ops.publishWalletEvents(
                     mints = mints,
                     p2pkPrivkeyHex = privkey,
+                    // Advertise our inbox + DM relays as the nutzap relays, so
+                    // senders publish kind:9321 where we read incoming events
+                    // (NIP-65 outbox model). Mirrors the relay set the wallet
+                    // subscribes to for inbound nutzaps.
                     nutzapRelays =
-                        acc.outboxRelays.flow.value
+                        (acc.notificationRelays.flow.value + acc.dmRelays.flow.value)
                             .toList(),
                 )
                 _createState.value = CashuWalletCreateState.Success

--- a/amethyst/src/main/res/values-zh-rCN/strings.xml
+++ b/amethyst/src/main/res/values-zh-rCN/strings.xml
@@ -566,6 +566,9 @@
     <string name="profile_app_recommendations_title">推荐的应用</string>
     <string name="profile_app_recommendations_description">选择您公开推荐的Nostr应用。建议显示在您的个人资料上，并帮助他人发现此客户端无法打开的内容。</string>
     <string name="profile_app_recommendations_empty">尚未找到应用。应用在您的中继上被发现时会出现在这里。</string>
+    <string name="profile_app_recommendations_search">按名称搜索应用</string>
+    <string name="profile_app_recommendations_search_empty">没有匹配您搜索的应用。</string>
+    <string name="profile_app_recommendations_filter_empty">没有推荐应用匹配此过滤器。</string>
     <string name="app_definition_untitled">未命名应用</string>
     <string name="app_definition_no_supported_kinds">不宣布它处理的内容</string>
     <string name="app_definition_recommend">推荐</string>
@@ -594,6 +597,8 @@
     <string name="workout_sets">集</string>
     <string name="workout_reps">重复</string>
     <string name="workout_weight">体重</string>
+    <string name="workout_exercises">练习</string>
+    <string name="workout_volume">量</string>
     <string name="workout_notes">备注</string>
     <string name="workout_hours">小时</string>
     <string name="workout_minutes">分钟</string>
@@ -614,6 +619,9 @@
     <string name="exercise_meditation">冥想</string>
     <string name="exercise_diet">饮食</string>
     <string name="exercise_fasting">节食</string>
+    <string name="exercise_circuit">循环训练</string>
+    <string name="exercise_emom">EMOM</string>
+    <string name="exercise_amrap">AMRAP</string>
     <string name="software_apps">应用</string>
     <string name="nip82_repository_label">来源： %1$s</string>
     <string name="nip82_version_label">v%1$s</string>

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationTagsAnEventByUserTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationTagsAnEventByUserTest.kt
@@ -20,8 +20,13 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications.dal
 
+import com.vitorpamplona.amethyst.commons.model.AddressableNote
 import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.UserContext
+import com.vitorpamplona.quartz.nip18Reposts.RepostEvent
 import com.vitorpamplona.quartz.nip22Comments.CommentEvent
+import com.vitorpamplona.quartz.nip25Reactions.ReactionEvent
 import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -95,6 +100,121 @@ class NotificationTagsAnEventByUserTest {
             Note(replyId).apply {
                 event = reply
                 replyTo = listOf(Note(zapId))
+            }
+
+        assertTrue(NotificationFeedFilter.tagsAnEventByUser(note, me))
+    }
+
+    // Empty user context — the relevance heuristics only read pubkeyHex.
+    private val noContext = UserContext { addr -> AddressableNote(addr) }
+
+    /**
+     * A plain NIP-25 reaction (kind 7) to my note carries my pubkey in its own
+     * `p` tag (the author of the reacted-to event). On a cold start the reacted
+     * note frequently has not loaded yet, so [Note.replyTo] resolves to an empty
+     * shell with no author. The reaction must still be recognized as mine from
+     * its own `p` tag — otherwise whether it shows depends on the race between
+     * the reaction and its parent arriving, which is exactly the "missing set
+     * differs every launch" symptom.
+     */
+    @Test
+    fun `reaction to my note is relevant from its own p tag without the parent in cache`() {
+        val reaction =
+            ReactionEvent(
+                reactionId,
+                replier,
+                1000,
+                arrayOf(
+                    arrayOf("e", "d".repeat(64)),
+                    arrayOf("p", me),
+                    arrayOf("k", "1"),
+                ),
+                "+",
+                sig,
+            )
+        // Reacted note not in cache yet: replyTo is an empty shell, no author.
+        val note =
+            Note(reactionId).apply {
+                event = reaction
+                replyTo = listOf(Note("d".repeat(64)))
+            }
+
+        assertTrue(NotificationFeedFilter.tagsAnEventByUser(note, me))
+    }
+
+    @Test
+    fun `reaction to my note stays relevant once the parent loads`() {
+        val reaction =
+            ReactionEvent(
+                reactionId,
+                replier,
+                1000,
+                arrayOf(
+                    arrayOf("e", "d".repeat(64)),
+                    arrayOf("p", me),
+                    arrayOf("k", "1"),
+                ),
+                "+",
+                sig,
+            )
+        val parent = Note("d".repeat(64)).apply { author = User(me, noContext) }
+        val note =
+            Note(reactionId).apply {
+                event = reaction
+                replyTo = listOf(parent)
+            }
+
+        assertTrue(NotificationFeedFilter.tagsAnEventByUser(note, me))
+    }
+
+    @Test
+    fun `reaction to someone else's note that does not tag me stays irrelevant`() {
+        val reaction =
+            ReactionEvent(
+                reactionId,
+                replier,
+                1000,
+                arrayOf(
+                    arrayOf("e", "d".repeat(64)),
+                    arrayOf("p", wallet),
+                    arrayOf("k", "1"),
+                ),
+                "+",
+                sig,
+            )
+        val note =
+            Note(reactionId).apply {
+                event = reaction
+                replyTo = listOf(Note("d".repeat(64)))
+            }
+
+        assertFalse(NotificationFeedFilter.tagsAnEventByUser(note, me))
+    }
+
+    /**
+     * NIP-18 reposts (kind 6) likewise carry the reposted author in their `p`
+     * tag, so a repost of my note is relevant even before the reposted note
+     * loads into the cache.
+     */
+    @Test
+    fun `repost of my note is relevant from its own p tag without the parent in cache`() {
+        val repost =
+            RepostEvent(
+                reactionId,
+                replier,
+                1000,
+                arrayOf(
+                    arrayOf("e", "d".repeat(64)),
+                    arrayOf("p", me),
+                    arrayOf("k", "1"),
+                ),
+                "",
+                sig,
+            )
+        val note =
+            Note(reactionId).apply {
+                event = repost
+                replyTo = listOf(Note("d".repeat(64)))
             }
 
         assertTrue(NotificationFeedFilter.tagsAnEventByUser(note, me))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import com.diffplug.gradle.spotless.SpotlessExtensionPredeclare
 plugins {
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.androidLibrary) apply false
+    alias(libs.plugins.androidTest) apply false
     alias(libs.plugins.jetbrainsKotlinJvm) apply false
     alias(libs.plugins.androidBenchmark) apply false
     alias(libs.plugins.diffplugSpotless)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/assemblers/CashuWalletFilterAssembler.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/assemblers/CashuWalletFilterAssembler.kt
@@ -42,13 +42,23 @@ import com.vitorpamplona.quartz.nip87Ecash.recommendation.MintRecommendationEven
  * Query state for the NIP-60 / NIP-61 wallet subscription.
  *
  * `pubkey` is the wallet owner — used both as `authors=` for their own
- * NIP-60 events and as the `#p` tag value for inbound nutzaps. `relays` is
- * the union of relays to subscribe on (NIP-65 outbox + DM relays at minimum).
+ * NIP-60 events and as the `#p` tag value for inbound nutzaps.
+ *
+ * The two filters read from different relay sets, following the NIP-65
+ * outbox model:
+ *  - [ownEventRelays] — the user's own write/outbox relays, where they
+ *    published their NIP-60 wallet/token/history events. Restoring those
+ *    means reading from where they were written.
+ *  - [inboxRelays] — where *other* people deliver kind:9321 nutzaps to this
+ *    user. Per NIP-61 the source of truth is the `relay` tags in the user's
+ *    own kind:10019; in practice we listen on the union of those plus the
+ *    user's NIP-65 inbox + DM relays so a nutzap can't slip past us.
  */
 @Immutable
 data class CashuWalletQueryState(
     val pubkey: HexKey,
-    val relays: Set<NormalizedRelayUrl>,
+    val ownEventRelays: Set<NormalizedRelayUrl>,
+    val inboxRelays: Set<NormalizedRelayUrl>,
 )
 
 /**
@@ -91,11 +101,9 @@ private class CashuWalletSubAssembler(
         if (keys.isEmpty()) return null
 
         val pubkey = keys.first().pubkey
-        val relays =
-            keys
-                .flatMap { it.relays }
-                .toSet()
-                .ifEmpty { return null }
+        val ownEventRelays = keys.flatMap { it.ownEventRelays }.toSet()
+        val inboxRelays = keys.flatMap { it.inboxRelays }.toSet()
+        if (ownEventRelays.isEmpty() && inboxRelays.isEmpty()) return null
 
         val ownedFilter =
             Filter(
@@ -121,18 +129,26 @@ private class CashuWalletSubAssembler(
                 tags = mapOf("p" to listOf(pubkey)),
             )
 
-        return relays.flatMap { relay ->
-            val sinceTime = since?.get(relay)?.time
-            listOf(
+        // Own NIP-60 events are read from the user's outbox; inbound nutzaps
+        // from the user's inbox set. A relay that appears in both gets both
+        // filters.
+        val ownedSubs =
+            ownEventRelays.map { relay ->
+                val sinceTime = since?.get(relay)?.time
                 RelayBasedFilter(
                     relay,
                     if (sinceTime != null) ownedFilter.copy(since = sinceTime) else ownedFilter,
-                ),
+                )
+            }
+        val inboundSubs =
+            inboxRelays.map { relay ->
+                val sinceTime = since?.get(relay)?.time
                 RelayBasedFilter(
                     relay,
                     if (sinceTime != null) inboundNutzapsFilter.copy(since = sinceTime) else inboundNutzapsFilter,
-                ),
-            )
-        }
+                )
+            }
+
+        return ownedSubs + inboundSubs
     }
 }

--- a/docs/changelog/translators.json
+++ b/docs/changelog/translators.json
@@ -95,15 +95,15 @@
         ]
       },
       {
-        "user": "summoner001",
-        "languages": [
-          "Hungarian"
-        ]
-      },
-      {
         "user": "hypnotichemionus4",
         "languages": [
           "Chinese Simplified"
+        ]
+      },
+      {
+        "user": "summoner001",
+        "languages": [
+          "Hungarian"
         ]
       },
       {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ android-compileSdk = "37"
 android-minSdk = "26"
 android-targetSdk = "37"
 androidxJunit = "1.3.0"
+uiautomator = "2.3.0"
 appcompat = "1.7.1"
 audiowaveform = "1.1.2"
 benchmark = "1.5.0-alpha06"
@@ -104,6 +105,8 @@ androidx-appfunctions = { group = "androidx.appfunctions", name = "appfunctions"
 androidx-appfunctions-service = { group = "androidx.appfunctions", name = "appfunctions-service", version.ref = "appfunctions" }
 androidx-appfunctions-compiler = { group = "androidx.appfunctions", name = "appfunctions-compiler", version.ref = "appfunctions" }
 androidx-benchmark-junit4 = { group = "androidx.benchmark", name = "benchmark-junit4", version.ref = "benchmark" }
+androidx-benchmark-macro-junit4 = { group = "androidx.benchmark", name = "benchmark-macro-junit4", version.ref = "benchmark" }
+androidx-test-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiautomator" }
 androidx-biometric-ktx = { group = "androidx.biometric", name = "biometric-ktx", version.ref = "biometricKtx" }
 androidx-camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "androidxCamera" }
 androidx-camera-core = { module = "androidx.camera:camera-core", version.ref = "androidxCamera" }
@@ -225,6 +228,7 @@ androidx-health-connect-client = { group = "androidx.health.connect", name = "co
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidBenchmark = { id = "androidx.benchmark", version.ref = "benchmark" }
+androidTest = { id = "com.android.test", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 diffplugSpotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 googleServices = { id = "com.google.gms.google-services", version.ref = "gms" }

--- a/macrobenchmark/build.gradle.kts
+++ b/macrobenchmark/build.gradle.kts
@@ -1,0 +1,69 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.androidTest)
+}
+
+android {
+    namespace = "com.vitorpamplona.amethyst.macrobenchmark"
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+    }
+
+    defaultConfig {
+        // Macrobenchmark needs a profileable/debuggable target and reliable frame
+        // metrics, which require API 28+. The :amethyst benchmark variant is built
+        // with isProfileable = true to satisfy this.
+        minSdk = 28
+        targetSdk = libs.versions.android.targetSdk.get().toInt()
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        // Allow running on an emulator / low-battery device. Frame numbers from an
+        // emulator are NOT authoritative (its GPU is the whole reason we want a real
+        // device) — this is only so the journey can be smoke-tested and run in CI.
+        testInstrumentationRunnerArguments["androidx.benchmark.suppressErrors"] = "EMULATOR,LOW-BATTERY"
+
+        // :amethyst declares a "channel" flavor dimension (play/fdroid). The
+        // benchmark is flavor-agnostic, so bind it to the play target.
+        missingDimensionStrategy("channel", "play")
+    }
+
+    buildTypes {
+        // Mirrors the app's "benchmark" build type (release-like, debug-signed) so
+        // this test module installs and measures against :amethyst's playBenchmark
+        // variant rather than a plain debug build.
+        create("benchmark") {
+            isDebuggable = true
+            signingConfig = signingConfigs.getByName("debug")
+            matchingFallbacks += listOf("release")
+        }
+    }
+
+    targetProjectPath = ":amethyst"
+    // Run the instrumentation inside the same process partition as required by
+    // Macrobenchmark's self-instrumenting model.
+    experimentalProperties["android.experimental.self-instrumenting"] = true
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_21)
+    }
+}
+
+dependencies {
+    implementation(libs.androidx.junit)
+    implementation(libs.junit)
+    implementation(libs.androidx.test.uiautomator)
+    implementation(libs.androidx.benchmark.macro.junit4)
+}
+
+androidComponents {
+    beforeVariants(selector().all()) {
+        // Only the benchmark variant is meaningful for this module.
+        it.enable = it.buildType == "benchmark"
+    }
+}

--- a/macrobenchmark/src/main/AndroidManifest.xml
+++ b/macrobenchmark/src/main/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2025 Vitor Pamplona
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy of
+  ~ this software and associated documentation files (the "Software"), to deal in
+  ~ the Software without restriction, including without limitation the rights to use,
+  ~ copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+  ~ Software, and to permit persons to whom the Software is furnished to do so,
+  ~ subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all
+  ~ copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+  ~ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+  ~ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+  ~ AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+  ~ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/macrobenchmark/src/main/java/com/vitorpamplona/amethyst/macrobenchmark/NotificationScrollBenchmark.kt
+++ b/macrobenchmark/src/main/java/com/vitorpamplona/amethyst/macrobenchmark/NotificationScrollBenchmark.kt
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.macrobenchmark
+
+import android.os.SystemClock
+import androidx.benchmark.macro.FrameTimingMetric
+import androidx.benchmark.macro.MacrobenchmarkScope
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.Until
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Macrobenchmark for the Notifications feed scroll.
+ *
+ * Measures real on-device frame timing ([FrameTimingMetric]) while scrolling the
+ * notifications list, so we get true `frameDurationCpuMs` / `frameOverrunMs`
+ * percentiles instead of the GPU-bound emulator numbers that `gfxinfo`/`atrace`
+ * report.
+ *
+ * KNOWN ISSUE: on some environments [FrameTimingMetric] fails with "Observed no
+ * renderthread slices in trace" on a random iteration. This was reproduced on both
+ * an emulator and a Samsung SM-T220 (MediaTek), via both `am instrument` and
+ * `connectedBenchmarkAndroidTest`, and is independent of the gesture/startup mode —
+ * so it is NOT this test. Suspected to be the alpha `androidx.benchmark`
+ * (1.5.0-alpha06) trace processing or hardware that doesn't emit the RenderThread
+ * slices the library's trace query expects. Try a stable benchmark version and/or a
+ * Pixel-class device.
+ *
+ * Prerequisites:
+ *  - A device/emulator with a **logged-in account that has notifications**
+ *    (the benchmark scrolls whatever the live Notifications tab shows; an empty
+ *    account produces a trivial, meaningless trace).
+ *  - The app is installed as the `playBenchmark` variant (handled automatically
+ *    when you run this module's `connectedBenchmarkAndroidTest`).
+ *
+ * Run:
+ *   ./gradlew :macrobenchmark:connectedBenchmarkAndroidTest
+ *
+ * Results (per-iteration frame metrics + percentiles) are printed to the test
+ * output and written to a JSON under the module's build/outputs.
+ */
+@RunWith(AndroidJUnit4::class)
+class NotificationScrollBenchmark {
+    @get:Rule val rule = MacrobenchmarkRule()
+
+    @Test
+    fun scrollNotificationsFeed() =
+        rule.measureRepeated(
+            packageName = TARGET_PACKAGE,
+            metrics = listOf(FrameTimingMetric()),
+            iterations = ITERATIONS,
+            // No startupMode: do NOT kill/restart the app between iterations. This is a
+            // steady-state scroll benchmark, not a startup one — keeping the process
+            // alive means its RenderThread stays up and registered across every
+            // iteration's trace. (With WARM restart, each fresh process races the
+            // RenderThread coming up and the first trace can land with no RenderThread
+            // slices, failing the whole run.)
+            setupBlock = {
+                startActivityAndWait()
+                // The bottom-bar Notifications icon exposes the localized label as
+                // its content description (AppBottomBar.NotifiableIcon), so we can
+                // target it directly via UiAutomator.
+                val notifTab = device.wait(Until.findObject(By.desc(NOTIFICATIONS_LABEL)), UI_TIMEOUT_MS)
+                notifTab?.click()
+                // Wait for the notifications list itself — targeted by its testTag
+                // (exposed as a resource-id), NOT By.scrollable(true): a card can
+                // embed its own scrollable widget (e.g. a Road event's map) that
+                // would otherwise be grabbed and panned instead of the feed.
+                device.wait(Until.hasObject(By.res(TARGET_PACKAGE, FEED_TAG)), UI_TIMEOUT_MS)
+                device.waitForIdle()
+                // WARM mode kills the app each iteration, so the feed re-aggregates
+                // from cache/relays on every pass — async, and slow on older devices.
+                // Wait until the list actually has cards before measuring; scrolling a
+                // still-empty feed draws nothing and Macrobenchmark then fails with
+                // "Observed no renderthread slices". A fixed sleep is not enough on a
+                // slow tablet, so poll the live child count instead.
+                val deadline = SystemClock.uptimeMillis() + FEED_LOAD_TIMEOUT_MS
+                while (SystemClock.uptimeMillis() < deadline) {
+                    val feed = device.findObject(By.res(TARGET_PACKAGE, FEED_TAG))
+                    if (feed != null && feed.childCount >= MIN_FEED_CHILDREN) break
+                    Thread.sleep(250)
+                }
+                device.waitForIdle()
+                // Get OFF the top once (un-measured) with a single down-fling. Critical:
+                // never drag the finger downward while the list is at the top — Android
+                // reads that as pull-to-refresh, not a scroll, which reloads the feed and
+                // starves the measured trace of real scroll frames. Landing one fling deep
+                // means the measured oscillation below never touches the top again.
+                swipeFeed(1, down = true)
+            },
+        ) {
+            // Confirm we're on the loaded notifications feed before gesturing.
+            device.findObject(By.res(TARGET_PACKAGE, FEED_TAG)) ?: return@measureRepeated
+            // Oscillate inside the feed body: scroll down N, then back up N. Net drift is
+            // ~zero, so across iterations (the app is kept alive) we never reach the
+            // bottom (down-swipes that can't move = no frames) nor the top (up-swipes
+            // that hit pull-to-refresh). Both directions are real scrolls that draw.
+            swipeFeed(SCROLLS_PER_ITERATION, down = true)
+            swipeFeed(SCROLLS_PER_ITERATION, down = false)
+        }
+
+    /**
+     * Drags the notifications feed [times] times, all within the **left gutter** — the
+     * ~50dp reaction-icon column every card reserves before its body. That strip has no
+     * interactive children, so the vertical drag always reaches the parent LazyColumn
+     * and never an embedded scrollable widget inside a card (e.g. a Road event's map).
+     * A controlled coordinate swipe (not a velocity fling) also registers reliably as a
+     * scroll across devices. [down] = true reveals older items; false scrolls back up.
+     */
+    private fun MacrobenchmarkScope.swipeFeed(
+        times: Int,
+        down: Boolean,
+    ) {
+        val density =
+            InstrumentationRegistry
+                .getInstrumentation()
+                .context.resources.displayMetrics.density
+        val gutterX = (GUTTER_DP * density).toInt()
+        val hi = (device.displayHeight * 0.15).toInt()
+        val lo = (device.displayHeight * 0.85).toInt()
+
+        repeat(times) {
+            if (down) {
+                device.swipe(gutterX, lo, gutterX, hi, SWIPE_STEPS)
+            } else {
+                device.swipe(gutterX, hi, gutterX, lo, SWIPE_STEPS)
+            }
+            device.waitForIdle()
+        }
+    }
+
+    companion object {
+        private const val TARGET_PACKAGE = "com.vitorpamplona.amethyst.benchmark"
+        private const val NOTIFICATIONS_LABEL = "Notifications"
+
+        // Must match NotificationFeedTestTag in :amethyst CardFeedView.kt.
+        private const val FEED_TAG = "notificationFeedList"
+        private const val ITERATIONS = 8
+        private const val SCROLLS_PER_ITERATION = 4
+        private const val UI_TIMEOUT_MS = 5_000L
+
+        // Wait (up to this long) for the feed to re-aggregate after each WARM restart,
+        // until it shows at least MIN_FEED_CHILDREN laid-out rows (header + donation
+        // card + a few notification cards) so we never measure a scroll of an empty list.
+        private const val FEED_LOAD_TIMEOUT_MS = 12_000L
+        private const val MIN_FEED_CHILDREN = 5
+
+        // Left gutter (reaction-icon column) X offset — far enough in to clear the
+        // system back-gesture edge zone, before any card body / interactive child.
+        private const val GUTTER_DP = 50
+
+        // Drag step count controls gesture duration (~5ms/step). Too FAST (≈8 steps /
+        // 40ms) and a real device's touch sampler under-registers the gesture — it barely
+        // scrolls. Too SLOW (≈40 steps) and it's a controlled drag with no fling momentum
+        // — also short travel. ~24 steps (≈120ms) matches a brisk human flick that both
+        // registers cleanly and imparts fling momentum, so the list travels ~a full
+        // screen and plays a long deceleration animation (a rich stream of frames).
+        private const val SWIPE_STEPS = 24
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,6 +32,7 @@ dependencyResolutionManagement {
 rootProject.name = "Amethyst"
 include(":amethyst")
 include(":benchmark")
+include(":macrobenchmark")
 include(":quartz")
 include(":geode")
 include(":commons")


### PR DESCRIPTION
I opened a claude session to debug why I can not find notifications on fresh install, so claude code came up with these two fixes:

> **1. Don't cap notifications to the last 7 days.** Every cold start, the fetchers fall back to `since = oneWeekAgo()`. With the EOSE watermark not persisted, no event DB, and no backward pagination, that 7-day window is the *only* history ever requested — so Amethyst shows far fewer notifications than clients querying the same relays with just a `limit`. Reproduces in Global mode. Fix: drop the `oneWeekAgo()` fallback in `AccountNotificationsEoseFrom{Inbox,Random}RelaysManager` so a null `since` lets `limit` govern; the watermark still drives the live tail after EOSE.

>**2. Show reactions/reposts before their parent loads.** In Curated mode, `tagsAnEventByUser` only accepts a reaction/repost when the target note is already cached (`replyTo.last().author == me`). On cold start the parent often isn't loaded, so the interaction is dropped — and which ones drop differs every launch. Fix: accept on the reaction's NIP-25 `p` tag / repost's NIP-18 `p` tag (which name the target author), keeping the cached-parent check as fallback. Adds unit tests.