### PR TITLE
MoqLiteSession: send Ended announce on publisher close race

### DIFF
--- a/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/moq/lite/MoqLiteSession.kt
+++ b/nestsClient/src/commonMain/kotlin/com/vitorpamplona/nestsclient/moq/lite/MoqLiteSession.kt
@@ -1398,6 +1398,20 @@ class MoqLiteSession internal constructor(
         ) {
             gate.withLock {
                 if (publisherClosed) {
+                    // publisher.close() raced ahead — write Ended now so
+                    // the relay sees the proper lifecycle close on this bidi.
+                    runCatching {
+                        bidi.write(
+                            MoqLiteCodec.encodeAnnounce(
+                                MoqLiteAnnounce(
+                                    status = MoqLiteAnnounceStatus.Ended,
+                                    suffix = emittedSuffix,
+                                    hops = emptyList(),
+                                ),
+                                version,
+                            ),
+                        )
+                    }
                     runCatching { bidi.finish() }
                     return
                 }


### PR DESCRIPTION
## Summary

When `publisher.close()` races ahead of an incoming announce message, the session now sends an `Ended` announce to the relay before finishing the bidirectional stream. This ensures the relay observes the proper lifecycle close on the bidi stream, preventing potential state inconsistencies.

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew :nestsClient:test` — existing tests pass
- [ ] MoQ-lite hang-tier — `:nestsClient:jvmTest -DnestsHangInterop=true`

## Interop suites

- [ ] MoQ-lite hang-tier — `:nestsClient:jvmTest -DnestsHangInterop=true`
- [ ] MoQ-lite browser-tier — `:nestsClient:jvmTest -DnestsBrowserInterop=true`

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_015t3bsJruGerz53yafZyp9n