### PR TITLE
fix(build): resolve :nappletHost benchmark variant via matchingFallbacks

### DIFF
--- a/amethyst/build.gradle.kts
+++ b/amethyst/build.gradle.kts
@@ -212,9 +212,6 @@ android {
         }
         create("benchmark") {
             initWith(getByName("release"))
-            // Plain AGP library deps (e.g. :nappletHost) only declare debug/release build types,
-            // so fall back to their `release` variant when resolving the benchmark build type.
-            matchingFallbacks += "release"
             applicationIdSuffix = ".benchmark"
             versionNameSuffix = "-BENCHMARK"
             resValue("string", "app_name", "@string/app_name_benchmark")

--- a/amethyst/build.gradle.kts
+++ b/amethyst/build.gradle.kts
@@ -212,6 +212,9 @@ android {
         }
         create("benchmark") {
             initWith(getByName("release"))
+            // Plain AGP library deps (e.g. :nappletHost) only declare debug/release build types,
+            // so fall back to their `release` variant when resolving the benchmark build type.
+            matchingFallbacks += "release"
             applicationIdSuffix = ".benchmark"
             versionNameSuffix = "-BENCHMARK"
             resValue("string", "app_name", "@string/app_name_benchmark")

--- a/nappletHost/build.gradle.kts
+++ b/nappletHost/build.gradle.kts
@@ -16,6 +16,14 @@ android {
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
     }
+
+    buildTypes {
+        // :amethyst defines a `benchmark` build type (release + profileable) for macrobenchmarks.
+        // Declare a matching variant here so the app can resolve this library for benchmark builds.
+        create("benchmark") {
+            initWith(getByName("release"))
+        }
+    }
 }
 
 kotlin {


### PR DESCRIPTION
The new plain-AGP :nappletHost library only declares debug/release build
types (unlike the KMP :commons/:quartz libs, which match any build type).
The :amethyst app's `benchmark` build type had no fallback, so Gradle could
not resolve a matching :nappletHost variant for fdroidBenchmark/playBenchmark,
breaking Test/Build CI on main.

Add `matchingFallbacks += "release"` to the benchmark build type so it falls
back to a library's release variant when no benchmark variant exists.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014tzXcqVUcAPhyDDFak4SQ8