### PR TITLE
Load author relay lists for missing addressable notes

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/RelaySubscriptionsCoordinator.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/RelaySubscriptionsCoordinator.kt
@@ -99,7 +99,7 @@ class RelaySubscriptionsCoordinator(
     // loaders of content that is not yet in the device.
     // they are active when looking at events, users, channels.
     val channelFinder = ChannelFinderFilterAssemblyGroup(client)
-    val eventFinder = EventFinderFilterAssembler(client)
+    val eventFinder = EventFinderFilterAssembler(client, cache, failureTracker)
     val userFinder = UserFinderFilterAssembler(client, cache, failureTracker)
 
     // active when searching or tagging users.

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/RelaySubscriptionsCoordinator.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/RelaySubscriptionsCoordinator.kt
@@ -99,8 +99,8 @@ class RelaySubscriptionsCoordinator(
     // loaders of content that is not yet in the device.
     // they are active when looking at events, users, channels.
     val channelFinder = ChannelFinderFilterAssemblyGroup(client)
-    val eventFinder = EventFinderFilterAssembler(client, cache, failureTracker)
     val userFinder = UserFinderFilterAssembler(client, cache, failureTracker)
+    val eventFinder = EventFinderFilterAssembler(client, cache, userFinder)
 
     // active when searching or tagging users.
     val search = SearchFilterAssembler(client, scope, cache)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/EventFinderFilterAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/EventFinderFilterAssembler.kt
@@ -28,8 +28,8 @@ import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.AddressableAuthorRelayLoaderSubAssembler
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.NoteEventLoaderSubAssembler
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.watchers.EventWatcherSubAssembler
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinderFilterAssembler
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
-import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.RelayOfflineTracker
 
 // This allows multiple screen to be listening to tags, even the same tag
 @Stable
@@ -42,13 +42,13 @@ class EventFinderQueryState(
 class EventFinderFilterAssembler(
     client: INostrClient,
     cache: LocalCache,
-    failureTracker: RelayOfflineTracker,
+    userFinder: UserFinderFilterAssembler,
 ) : ComposeSubscriptionManager<EventFinderQueryState>() {
     val group =
         listOf(
             NoteEventLoaderSubAssembler(client, ::allKeys),
             EventWatcherSubAssembler(client, ::allKeys),
-            AddressableAuthorRelayLoaderSubAssembler(client, cache, failureTracker, ::allKeys),
+            AddressableAuthorRelayLoaderSubAssembler(cache, ::allKeys, userFinder),
         )
 
     override fun invalidateFilters() = group.forEach { it.invalidateFilters() }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/EventFinderFilterAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/EventFinderFilterAssembler.kt
@@ -23,10 +23,13 @@ package com.vitorpamplona.amethyst.service.relayClient.reqCommand.event
 import androidx.compose.runtime.Stable
 import com.vitorpamplona.amethyst.commons.relayClient.composeSubscriptionManagers.ComposeSubscriptionManager
 import com.vitorpamplona.amethyst.model.Account
+import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.AddressableAuthorRelayLoaderSubAssembler
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.NoteEventLoaderSubAssembler
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.watchers.EventWatcherSubAssembler
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
+import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.RelayOfflineTracker
 
 // This allows multiple screen to be listening to tags, even the same tag
 @Stable
@@ -38,11 +41,14 @@ class EventFinderQueryState(
 @Stable
 class EventFinderFilterAssembler(
     client: INostrClient,
+    cache: LocalCache,
+    failureTracker: RelayOfflineTracker,
 ) : ComposeSubscriptionManager<EventFinderQueryState>() {
     val group =
         listOf(
             NoteEventLoaderSubAssembler(client, ::allKeys),
             EventWatcherSubAssembler(client, ::allKeys),
+            AddressableAuthorRelayLoaderSubAssembler(client, cache, failureTracker, ::allKeys),
         )
 
     override fun invalidateFilters() = group.forEach { it.invalidateFilters() }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/loaders/AddressableAuthorRelayLoaderSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/loaders/AddressableAuthorRelayLoaderSubAssembler.kt
@@ -12,134 +12,63 @@
  * copies or substantial portions of the Software.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders
 
-import com.vitorpamplona.amethyst.commons.defaults.DefaultIndexerRelayList
-import com.vitorpamplona.amethyst.commons.defaults.DefaultSearchRelayList
-import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.BaseEoseManager
+import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.IEoseManager
 import com.vitorpamplona.amethyst.model.AddressableNote
 import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.model.User
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.follows.pickRelaysToLoadUsers
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.EventFinderQueryState
-import com.vitorpamplona.amethyst.service.relays.EOSEAccountFast
-import com.vitorpamplona.quartz.nip01Core.core.HexKey
-import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
-import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
-import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.RelayOfflineTracker
-import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
-import com.vitorpamplona.quartz.nip01Core.relay.client.pool.groupByRelay
-import com.vitorpamplona.quartz.nip01Core.relay.client.reqs.SubscriptionListener
-import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
-import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
-import com.vitorpamplona.quartz.nip65RelayList.AdvertisedRelayListEvent
-import com.vitorpamplona.quartz.utils.TimeUtils
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinderFilterAssembler
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinderQueryState
 
 /**
- * When an AddressableNote stub (event == null) references an author whose NIP-65 relay list has
- * not been loaded yet, [potentialRelaysToFindAddress] returns an empty set and the event is never
- * found. This assembler detects those cases and fetches kind 0 + kind 10002 for the missing
- * authors from indexer/search relays. Once the relay list arrives, [invalidateFilters] re-triggers
- * [NoteEventLoaderSubAssembler], which can now query the author's actual outbox relays.
+ * Bridges missing-addressable-note authors into [UserFinderFilterAssembler].
+ *
+ * When an [AddressableNote] stub (event == null) references an author whose NIP-65 relay list
+ * has not been loaded yet, [potentialRelaysToFindAddress] returns an empty set and the event
+ * is never fetched. This manager detects those cases and injects a [UserFinderQueryState] for
+ * the author into the existing [UserFinderFilterAssembler], which already knows how to fetch
+ * kind-0 / kind-10002 and resolve outbox relays via [UserOutboxFinderSubAssembler]. Once the
+ * relay list arrives, [EventFinderFilterAssembler] is invalidated and can query the correct relay.
  */
 class AddressableAuthorRelayLoaderSubAssembler(
-    client: INostrClient,
     val cache: LocalCache,
-    val failureTracker: RelayOfflineTracker,
-    allKeys: () -> Set<EventFinderQueryState>,
-) : BaseEoseManager<EventFinderQueryState>(client, allKeys) {
-    val relayListKinds = listOf(MetadataEvent.KIND, AdvertisedRelayListEvent.KIND)
+    val allKeys: () -> Set<EventFinderQueryState>,
+    val userFinder: UserFinderFilterAssembler,
+) : IEoseManager {
+    private val activeSubscriptions = mutableSetOf<UserFinderQueryState>()
 
-    var hasTried: EOSEAccountFast<User> = EOSEAccountFast(200)
+    override fun invalidateFilters(ignoreIfDoing: Boolean) {
+        val needed = mutableSetOf<UserFinderQueryState>()
 
-    val sub =
-        requestNewSubscription(
-            object : SubscriptionListener {
-                override fun onEose(
-                    relay: NormalizedRelayUrl,
-                    forFilters: List<Filter>?,
-                ) {
-                    forFilters?.forEach { filter ->
-                        filter.authors?.forEach { pubKey ->
-                            cache.getUserIfExists(pubKey)?.let { user ->
-                                hasTried.newEose(user, relay, TimeUtils.now())
-                            }
-                        }
-                    }
-                    invalidateFilters()
-                }
-            },
-        )
-
-    override fun updateSubscriptions(keys: Set<EventFinderQueryState>) {
-        val newFilters = updateFilter(keys.toList())?.ifEmpty { null }
-        sub.updateFilters(newFilters?.groupByRelay())
-    }
-
-    fun updateFilter(keys: List<EventFinderQueryState>): List<RelayBasedFilter>? {
-        val unknownAuthors = mutableSetOf<User>()
-        keys.forEach { key ->
+        allKeys().forEach { key ->
             val note = key.note
             if (note is AddressableNote && note.event == null) {
                 val author = cache.getOrCreateUser(note.address.pubKeyHex)
                 if (author.authorRelayList() == null) {
-                    unknownAuthors.add(author)
+                    needed.add(UserFinderQueryState(author, key.account))
                 }
             }
         }
 
-        if (unknownAuthors.isEmpty()) return null
+        val toAdd = needed - activeSubscriptions
+        val toRemove = activeSubscriptions - needed
 
-        val accounts = keys.mapTo(mutableSetOf()) { it.account }
-        val connectedRelays = client.connectedRelaysFlow().value
+        userFinder.subscribe(toAdd.toList())
+        userFinder.unsubscribe(toRemove.toList())
 
-        val perRelayKeys =
-            pickRelaysToLoadUsers(
-                unknownAuthors,
-                accounts,
-                connectedRelays,
-                failureTracker.cannotConnectRelays,
-                hasTried,
-            )
+        activeSubscriptions.clear()
+        activeSubscriptions.addAll(needed)
+    }
 
-        val activeFilters =
-            perRelayKeys.mapNotNull { (relay, pubkeys) ->
-                val sorted = pubkeys.sorted()
-                if (sorted.isNotEmpty()) {
-                    RelayBasedFilter(
-                        relay = relay,
-                        filter = Filter(kinds = relayListKinds, authors = sorted),
-                    )
-                } else {
-                    null
-                }
-            }
-
-        val placedPubkeys = perRelayKeys.values.asSequence().flatten().toSet()
-        val abandonedPubkeys =
-            unknownAuthors.mapNotNullTo(mutableSetOf<HexKey>()) { user ->
-                user.pubkeyHex.takeIf { it !in placedPubkeys }
-            }
-
-        if (abandonedPubkeys.isEmpty()) return activeFilters
-
-        val sortedAbandoned = abandonedPubkeys.sorted()
-        val fallbackRelays = (DefaultIndexerRelayList + DefaultSearchRelayList) - failureTracker.cannotConnectRelays
-        val fallbackFilters =
-            fallbackRelays.map { relay ->
-                RelayBasedFilter(
-                    relay = relay,
-                    filter = Filter(kinds = relayListKinds, authors = sortedAbandoned),
-                )
-            }
-
-        return activeFilters + fallbackFilters
+    override fun destroy() {
+        userFinder.unsubscribe(activeSubscriptions.toList())
+        activeSubscriptions.clear()
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/loaders/AddressableAuthorRelayLoaderSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/loaders/AddressableAuthorRelayLoaderSubAssembler.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders
+
+import com.vitorpamplona.amethyst.commons.defaults.DefaultIndexerRelayList
+import com.vitorpamplona.amethyst.commons.defaults.DefaultSearchRelayList
+import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.BaseEoseManager
+import com.vitorpamplona.amethyst.model.AddressableNote
+import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.model.User
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.follows.pickRelaysToLoadUsers
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.EventFinderQueryState
+import com.vitorpamplona.amethyst.service.relays.EOSEAccountFast
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
+import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
+import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.RelayOfflineTracker
+import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
+import com.vitorpamplona.quartz.nip01Core.relay.client.pool.groupByRelay
+import com.vitorpamplona.quartz.nip01Core.relay.client.reqs.SubscriptionListener
+import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip65RelayList.AdvertisedRelayListEvent
+import com.vitorpamplona.quartz.utils.TimeUtils
+
+/**
+ * When an AddressableNote stub (event == null) references an author whose NIP-65 relay list has
+ * not been loaded yet, [potentialRelaysToFindAddress] returns an empty set and the event is never
+ * found. This assembler detects those cases and fetches kind 0 + kind 10002 for the missing
+ * authors from indexer/search relays. Once the relay list arrives, [invalidateFilters] re-triggers
+ * [NoteEventLoaderSubAssembler], which can now query the author's actual outbox relays.
+ */
+class AddressableAuthorRelayLoaderSubAssembler(
+    client: INostrClient,
+    val cache: LocalCache,
+    val failureTracker: RelayOfflineTracker,
+    allKeys: () -> Set<EventFinderQueryState>,
+) : BaseEoseManager<EventFinderQueryState>(client, allKeys) {
+    val relayListKinds = listOf(MetadataEvent.KIND, AdvertisedRelayListEvent.KIND)
+
+    var hasTried: EOSEAccountFast<User> = EOSEAccountFast(200)
+
+    val sub =
+        requestNewSubscription(
+            object : SubscriptionListener {
+                override fun onEose(
+                    relay: NormalizedRelayUrl,
+                    forFilters: List<Filter>?,
+                ) {
+                    forFilters?.forEach { filter ->
+                        filter.authors?.forEach { pubKey ->
+                            cache.getUserIfExists(pubKey)?.let { user ->
+                                hasTried.newEose(user, relay, TimeUtils.now())
+                            }
+                        }
+                    }
+                    invalidateFilters()
+                }
+            },
+        )
+
+    override fun updateSubscriptions(keys: Set<EventFinderQueryState>) {
+        val newFilters = updateFilter(keys.toList())?.ifEmpty { null }
+        sub.updateFilters(newFilters?.groupByRelay())
+    }
+
+    fun updateFilter(keys: List<EventFinderQueryState>): List<RelayBasedFilter>? {
+        val unknownAuthors = mutableSetOf<User>()
+        keys.forEach { key ->
+            val note = key.note
+            if (note is AddressableNote && note.event == null) {
+                val author = cache.getOrCreateUser(note.address.pubKeyHex)
+                if (author.authorRelayList() == null) {
+                    unknownAuthors.add(author)
+                }
+            }
+        }
+
+        if (unknownAuthors.isEmpty()) return null
+
+        val accounts = keys.mapTo(mutableSetOf()) { it.account }
+        val connectedRelays = client.connectedRelaysFlow().value
+
+        val perRelayKeys =
+            pickRelaysToLoadUsers(
+                unknownAuthors,
+                accounts,
+                connectedRelays,
+                failureTracker.cannotConnectRelays,
+                hasTried,
+            )
+
+        val activeFilters =
+            perRelayKeys.mapNotNull { (relay, pubkeys) ->
+                val sorted = pubkeys.sorted()
+                if (sorted.isNotEmpty()) {
+                    RelayBasedFilter(
+                        relay = relay,
+                        filter = Filter(kinds = relayListKinds, authors = sorted),
+                    )
+                } else {
+                    null
+                }
+            }
+
+        val placedPubkeys = perRelayKeys.values.asSequence().flatten().toSet()
+        val abandonedPubkeys =
+            unknownAuthors.mapNotNullTo(mutableSetOf<HexKey>()) { user ->
+                user.pubkeyHex.takeIf { it !in placedPubkeys }
+            }
+
+        if (abandonedPubkeys.isEmpty()) return activeFilters
+
+        val sortedAbandoned = abandonedPubkeys.sorted()
+        val fallbackRelays = (DefaultIndexerRelayList + DefaultSearchRelayList) - failureTracker.cannotConnectRelays
+        val fallbackFilters =
+            fallbackRelays.map { relay ->
+                RelayBasedFilter(
+                    relay = relay,
+                    filter = Filter(kinds = relayListKinds, authors = sortedAbandoned),
+                )
+            }
+
+        return activeFilters + fallbackFilters
+    }
+}


### PR DESCRIPTION
## Summary

Adds `AddressableAuthorRelayLoaderSubAssembler` to detect when addressable note stubs (events without content) reference authors whose NIP-65 relay lists haven't been loaded yet. When detected, it injects a `UserFinderQueryState` into the existing `UserFinderFilterAssembler` to fetch the author's relay information. Once the relay list arrives, `EventFinderFilterAssembler` is invalidated and can query the correct relays for the missing event.

This fixes a gap where addressable notes with unresolved authors would never be fetched because `potentialRelaysToFindAddress` would return an empty set.

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes: The change is a new sub-assembler integrated into the relay subscription coordinator's event finder pipeline. It follows the existing pattern of `NoteEventLoaderSubAssembler` and `EventWatcherSubAssembler`. The logic is defensive: it only injects user queries when an addressable note stub lacks both event content and the author's relay list, and it properly cleans up subscriptions on invalidation and destruction.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01Q4jYQapmyUjyPkuwx4QiV3