### PR TITLE
fix: render markdown when a heading/list follows a blank line

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/CachedRichTextParser.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/CachedRichTextParser.kt
@@ -207,7 +207,14 @@ object CachedRichTextParser {
             // checks that need to know "how much non-space text has
             // appeared on the current line".
             if (isNewLine) {
-                if (c != ' ' && c != '\t') {
+                // A blank line is still "at line start": skipping '\n'/'\r'
+                // here keeps isNewLine true so a heading/blockquote/list
+                // marker on the next line (the standard `\n\n#` spacing) is
+                // still recognized as line-leading. Without the newline
+                // exclusion, the second '\n' of a blank line flipped
+                // isNewLine to false and ATX headings after a blank line
+                // went undetected.
+                if (c != ' ' && c != '\t' && c != '\n' && c != '\r') {
                     isNewLine = false
                     nonSpaceCharCountOnLine = 1
                     lastNonSpaceChar = c

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/CachedRichTextParserMarkdownTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/CachedRichTextParserMarkdownTest.kt
@@ -68,6 +68,46 @@ class CachedRichTextParserMarkdownTest {
 
     @Test fun atxAfterNewlineIsMarkdown() = assertTrue(CachedRichTextParser.isMarkdown("intro\n# Heading"))
 
+    // ---- Line-leading markers after a BLANK line ------------------------
+    // Regression: the standard `\n\n#` spacing (a blank line before a
+    // heading) was undetected because the blank line's second '\n' flipped
+    // the line-start tracker off. NIP-23 long-form articles that are pure
+    // prose plus `## Section` headings rendered as raw text as a result.
+
+    @Test fun atxAfterBlankLineIsMarkdown() = assertTrue(CachedRichTextParser.isMarkdown("intro\n\n# Heading"))
+
+    @Test fun atxH3AfterBlankLineIsMarkdown() = assertTrue(CachedRichTextParser.isMarkdown("intro\n\n### Heading"))
+
+    @Test fun atxAfterMultipleBlankLinesIsMarkdown() = assertTrue(CachedRichTextParser.isMarkdown("intro\n\n\n\n## Heading"))
+
+    @Test fun atxAfterCrlfBlankLineIsMarkdown() = assertTrue(CachedRichTextParser.isMarkdown("intro\r\n\r\n## Heading"))
+
+    @Test fun blockquoteAfterBlankLineIsMarkdown() = assertTrue(CachedRichTextParser.isMarkdown("intro\n\n> quoted"))
+
+    @Test fun bulletAfterBlankLineIsMarkdown() = assertTrue(CachedRichTextParser.isMarkdown("intro\n\n- item"))
+
+    @Test fun orderedListAfterBlankLineIsMarkdown() = assertTrue(CachedRichTextParser.isMarkdown("intro\n\n1. first"))
+
+    @Test
+    fun proseArticleWithHeadingAfterBlankLineIsMarkdown() =
+        assertTrue(
+            CachedRichTextParser.isMarkdown(
+                "The cryptographic part of commerce has been solved.\n\n" +
+                    "What follows is a history.\n\n" +
+                    "### The merchant posts of the Hansa\n\n" +
+                    "Long before any king claimed a monopoly on letters.",
+            ),
+        )
+
+    // Blank lines alone must NOT promote ordinary prose to markdown.
+    @Test
+    fun plainProseWithBlankLinesIsNotMarkdown() =
+        assertFalse(
+            CachedRichTextParser.isMarkdown(
+                "Just a normal sentence.\n\nAnother paragraph with no markdown at all.",
+            ),
+        )
+
     // ---- Blockquote -----------------------------------------------------
 
     @Test fun blockquoteIsMarkdown() = assertTrue(CachedRichTextParser.isMarkdown("> a quote"))


### PR DESCRIPTION
nostr:naddr1qqghg6r9943k7atjd9jhyuedddhx2acpzamhxue69uhhyetvv9ujuurjd9kkzmpwdejhgtczyzm7669svt0xkjsju50a22zurc0qa589z2xd4yatzx6p2z64a5e0cqcyqqq823csdmpnr

Before 
<img width="300" alt="Screenshot_20260623-183342" src="https://github.com/user-attachments/assets/c903cf91-38ab-43af-97a3-2a9c64dd95cf" />

After
<img width="300" alt="Screenshot_20260623-183301" src="https://github.com/user-attachments/assets/0299de74-7fd1-46c5-8b7a-6c7a7718a6e3" />


Long-form (NIP-23) articles made of prose plus `## Section` headings were rendering as raw text — the `### …` showed literal hashes instead of headings.

Root cause is in `CachedRichTextParser.isMarkdown`, the heuristic that gates whether content goes to the CommonMark renderer. Its line-start tracker only skipped spaces and tabs, so the second `\n` of a blank line was treated as a non-space character and flipped `isNewLine` off. Any heading, blockquote, or list marker after the standard `\n\n` spacing was then not recognized as line-leading, and with no other inline markdown the article fell through to plain-text rendering.

Fix: also exclude `\n`/`\r` from the line-start guard so a blank line stays "at line start". This also repairs CRLF line endings, which had the same problem.

Adds regression tests for ATX headings (incl. H3, multiple blank lines, CRLF), blockquotes, and bullet/ordered lists after a blank line, plus a negative test that blank-line prose with no markers stays non-markdown.

Desktop is unaffected — it uses a separate, substring-based `isMarkdown` that doesn't track line position.