### PR TITLE
Show boosted notes as compact preview in activity cards

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteCompose.kt
@@ -765,6 +765,7 @@ fun InnerNoteWithReactions(
                 unPackReply = unPackReply,
                 accountViewModel = accountViewModel,
                 nav = nav,
+                isBoostedNote = isBoostedNote,
             )
 
             if (!makeItShort) {
@@ -913,6 +914,7 @@ private fun RenderNoteRow(
     editState: State<GenericLoadable<EditState>>,
     accountViewModel: AccountViewModel,
     nav: INav,
+    isBoostedNote: Boolean = false,
 ) {
     when (val noteEvent = baseNote.event) {
         is AppDefinitionEvent -> {
@@ -1367,6 +1369,7 @@ private fun RenderNoteRow(
                 backgroundColor,
                 accountViewModel,
                 nav,
+                isBoostedNote = isBoostedNote,
             )
         }
 
@@ -1379,6 +1382,7 @@ private fun RenderNoteRow(
                 backgroundColor,
                 accountViewModel,
                 nav,
+                isBoostedNote = isBoostedNote,
             )
         }
 
@@ -1391,6 +1395,7 @@ private fun RenderNoteRow(
                 backgroundColor,
                 accountViewModel,
                 nav,
+                isBoostedNote = isBoostedNote,
             )
         }
 
@@ -1526,6 +1531,7 @@ private fun RenderNoteRow(
                 backgroundColor,
                 accountViewModel,
                 nav,
+                isBoostedNote = isBoostedNote,
             )
         }
 
@@ -1540,6 +1546,7 @@ private fun RenderNoteRow(
                 editState,
                 accountViewModel,
                 nav,
+                isBoostedNote = isBoostedNote,
             )
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Chat.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Chat.kt
@@ -49,11 +49,15 @@ fun RenderChat(
     backgroundColor: MutableState<Color>,
     accountViewModel: AccountViewModel,
     nav: INav,
+    isBoostedNote: Boolean = false,
 ) {
     val noteEvent = note.event ?: return
     val eventContent = remember(noteEvent) { noteEvent.content }
 
-    if (makeItShort && accountViewModel.isLoggedUser(note.author)) {
+    // A boosted note inside a zap/nutzap/onchain activity card is always shown as a
+    // compact 2-line preview, even when the logged-in user is only a zap-split
+    // beneficiary (and thus not the author) of the post being zapped.
+    if (makeItShort && (isBoostedNote || accountViewModel.isLoggedUser(note.author))) {
         Text(
             text = eventContent,
             color = MaterialTheme.colorScheme.placeholderText,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Poll.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Poll.kt
@@ -116,10 +116,14 @@ fun RenderPoll(
     backgroundColor: MutableState<Color>,
     accountViewModel: AccountViewModel,
     nav: INav,
+    isBoostedNote: Boolean = false,
 ) {
     val noteEvent = note.event as? PollEvent ?: return
 
-    if (makeItShort && accountViewModel.isLoggedUser(note.author)) {
+    // A boosted note inside a zap/nutzap/onchain activity card is always shown as a
+    // compact 2-line preview, even when the logged-in user is only a zap-split
+    // beneficiary (and thus not the author) of the post being zapped.
+    if (makeItShort && (isBoostedNote || accountViewModel.isLoggedUser(note.author))) {
         Text(
             text = noteEvent.content,
             color = MaterialTheme.colorScheme.placeholderText,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/PublicMessage.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/PublicMessage.kt
@@ -55,11 +55,15 @@ fun RenderPublicMessage(
     backgroundColor: MutableState<Color>,
     accountViewModel: AccountViewModel,
     nav: INav,
+    isBoostedNote: Boolean = false,
 ) {
     val noteEvent = note.event as? PublicMessageEvent ?: return
     val content = remember(noteEvent) { noteEvent.peopleAndContent() }
 
-    if (makeItShort && accountViewModel.isLoggedUser(note.author)) {
+    // A boosted note inside a zap/nutzap/onchain activity card is always shown as a
+    // compact 2-line preview, even when the logged-in user is only a zap-split
+    // beneficiary (and thus not the author) of the post being zapped.
+    if (makeItShort && (isBoostedNote || accountViewModel.isLoggedUser(note.author))) {
         Text(
             text = content,
             color = MaterialTheme.colorScheme.placeholderText,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Text.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Text.kt
@@ -79,6 +79,7 @@ fun RenderTextEvent(
     editState: State<GenericLoadable<EditState>>,
     accountViewModel: AccountViewModel,
     nav: INav,
+    isBoostedNote: Boolean = false,
 ) {
     val noteEvent = note.event ?: return
 
@@ -183,7 +184,10 @@ fun RenderTextEvent(
                 }
             }
 
-        if (makeItShort && accountViewModel.isLoggedUser(note.author)) {
+        // A boosted note inside a zap/nutzap/onchain activity card is always shown as a
+        // compact 2-line preview, even when the logged-in user is only a zap-split
+        // beneficiary (and thus not the author) of the post being zapped.
+        if (makeItShort && (isBoostedNote || accountViewModel.isLoggedUser(note.author))) {
             Text(
                 text = eventContent,
                 color = MaterialTheme.colorScheme.placeholderText,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/ZapPoll.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/ZapPoll.kt
@@ -60,6 +60,7 @@ fun RenderZapPoll(
     backgroundColor: MutableState<Color>,
     accountViewModel: AccountViewModel,
     nav: INav,
+    isBoostedNote: Boolean = false,
 ) {
     val noteEvent = note.event as? ZapPollEvent ?: return
     val eventContent = noteEvent.content
@@ -92,7 +93,10 @@ fun RenderZapPoll(
         }
     }
 
-    if (makeItShort && accountViewModel.isLoggedUser(note.author)) {
+    // A boosted note inside a zap/nutzap/onchain activity card is always shown as a
+    // compact 2-line preview, even when the logged-in user is only a zap-split
+    // beneficiary (and thus not the author) of the post being zapped.
+    if (makeItShort && (isBoostedNote || accountViewModel.isLoggedUser(note.author))) {
         Text(
             text = eventContent,
             color = MaterialTheme.colorScheme.placeholderText,

--- a/amethyst/src/main/res/values-fr-rCA/strings.xml
+++ b/amethyst/src/main/res/values-fr-rCA/strings.xml
@@ -44,7 +44,7 @@
     <string name="timestamp_pending_short">OTS : En attente</string>
     <string name="request_deletion">Demande de suppression</string>
     <string name="block_report">Bloquer / Signaler</string>
-    <string name="block_hide_user"><![CDATA[Bloquer et cacher l'utilisateur]]></string>
+    <string name="block_hide_user"><![CDATA[Bloquer et cacher l\'utilisateur]]></string>
     <string name="report_spam_scam">Signaler Spam / Arnaque</string>
     <string name="report_impersonation">Signaler une falsification d\'identité</string>
     <string name="report_illegal_behaviour">Signaler un comportement illégal</string>
@@ -401,7 +401,7 @@
     <string name="report_dialog_nudity">Nudité ou contenu graphique</string>
     <string name="report_dialog_illegal">Comportement illégal</string>
     <string name="report_dialog_blocking_a_user">Bloquer un utilisateur cachera son contenu dans votre application. Vos notes sont toujours visibles publiquement, y compris pour les personnes que vous bloquez. Les utilisateurs bloqués sont listés sur l\'écran Filtres de Sécurité.</string>
-    <string name="report_dialog_block_hide_user_btn"><![CDATA[Bloquer et Masquer l'Utilisateur]]></string>
+    <string name="report_dialog_block_hide_user_btn"><![CDATA[Bloquer et Masquer l\'Utilisateur]]></string>
     <string name="report_dialog_report_btn">Signaler un Abus</string>
     <string name="report_dialog_reminder_public">Tous les rapports publiés seront visibles publiquement.</string>
     <string name="report_dialog_additional_reason_placeholder">Fournir un contexte optionnel supplémentaire sur votre signalement…</string>


### PR DESCRIPTION
## Summary

Add `isBoostedNote` parameter throughout the note rendering pipeline to ensure that notes displayed within zap/nutzap/onchain activity cards are always shown as compact 2-line previews, regardless of whether the logged-in user is the note author or only a zap-split beneficiary.

Previously, the compact preview was only shown when `makeItShort` was true AND the logged-in user was the note author. This caused boosted notes (where the user may be a beneficiary but not the author) to render in full, breaking the compact layout of activity cards.

## Changes

- Add `isBoostedNote: Boolean = false` parameter to `RenderNoteRow()` and all note type renderers (`RenderTextEvent`, `RenderChat`, `RenderPublicMessage`, `RenderPoll`, `RenderZapPoll`)
- Thread the parameter through the call chain from `InnerNoteWithReactions()` down to individual note type handlers
- Update the compact preview condition from `makeItShort && accountViewModel.isLoggedUser(note.author)` to `makeItShort && (isBoostedNote || accountViewModel.isLoggedUser(note.author))` in all affected renderers
- Add clarifying comments explaining the boosted note behavior
- Fix French localization escaping in `strings-fr-rCA.xml` (unrelated minor fix)

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes: The change is a straightforward parameter threading with conditional logic. Existing tests should cover the note rendering paths. Manual verification would involve viewing a zap activity card containing a note from a non-author beneficiary and confirming it displays as a compact 2-line preview rather than full content.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

https://claude.ai/code/session_01Q4rrFiWApq8EFpk4fSuTFH