### PR TITLE
fix: delete per-account dir on account removal + sweep orphans at startup

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/AppModules.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/AppModules.kt
@@ -113,6 +113,7 @@ import com.vitorpamplona.quartz.nip05DnsIdentifiers.namecoin.NamecoinBackend
 import com.vitorpamplona.quartz.nip05DnsIdentifiers.namecoin.NamecoinCoreRpcClient
 import com.vitorpamplona.quartz.nip05DnsIdentifiers.namecoin.NamecoinNameResolver
 import com.vitorpamplona.quartz.nip05DnsIdentifiers.namecoin.TOR_ELECTRUMX_SERVERS
+import com.vitorpamplona.quartz.nip19Bech32.decodePublicKeyAsHexOrNull
 import com.vitorpamplona.quartz.nipB7Blossom.BlossomServersEvent
 import com.vitorpamplona.quartz.nipBCOnchainZaps.chain.CachingOnchainBackend
 import com.vitorpamplona.quartz.nipBCOnchainZaps.chain.EsploraBackend
@@ -758,6 +759,18 @@ class AppModules(
             // loads main account quickly.
             LocalPreferences.loadAccountConfigFromEncryptedStorage()
             sessionManager.loginWithDefaultAccountIfLoggedOff()
+        }
+
+        // One-time hygiene: remove per-account directories (MLS/Marmot stores) left behind
+        // by accounts that are no longer saved — account deletion historically didn't clean
+        // them up, so they leaked disk across every add/remove.
+        applicationIOScope.launch {
+            val keep =
+                LocalPreferences
+                    .allSavedAccounts()
+                    .mapNotNull { decodePublicKeyAsHexOrNull(it.npub) }
+                    .toSet()
+            accountsCache.pruneOrphanAccountDirs(keep)
         }
 
         // forces initialization of uiPrefs in the main thread to avoid blinking themes

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
@@ -183,6 +183,12 @@ object LocalPreferences {
 
     private var currentAccount: String? = null
     private val savedAccounts: MutableStateFlow<List<AccountInfo>?> = MutableStateFlow(null)
+
+    // Guards the one-time lazy population of [savedAccounts]. Without it, concurrent callers
+    // of savedAccounts() (e.g. the account-load path, the always-on notification service, and
+    // the orphan-dir sweep, all launched at startup) would each see a null value, run the IO
+    // read in parallel, and the migration branch could double-write ALL_ACCOUNT_INFO.
+    private val savedAccountsMutex = Mutex()
     private val cachedAccounts: MutableMap<String, AccountSettings?> = mutableMapOf()
 
     suspend fun currentAccount(): String? {
@@ -212,41 +218,46 @@ object LocalPreferences {
     }
 
     private suspend fun savedAccounts(): List<AccountInfo> {
-        if (savedAccounts.value == null) {
-            withContext(Dispatchers.IO) {
-                with(encryptedPreferences()) {
-                    val newSystemOfAccounts =
-                        getString(PrefKeys.ALL_ACCOUNT_INFO, "[]")?.let {
-                            JsonMapper.fromJson<List<AccountInfo>>(it)
-                        }
+        // Fast path: already populated, no lock needed.
+        savedAccounts.value?.let { return it }
 
-                    if (!newSystemOfAccounts.isNullOrEmpty()) {
-                        savedAccounts.emit(newSystemOfAccounts)
-                    } else {
-                        val oldAccounts = getString(PrefKeys.SAVED_ACCOUNTS, null)?.split(COMMA) ?: listOf()
+        return savedAccountsMutex.withLock {
+            // Re-check under the lock: another coroutine may have populated it while we waited.
+            savedAccounts.value ?: loadSavedAccountsFromStorage().also { savedAccounts.emit(it) }
+        }
+    }
 
-                        val migrated =
-                            oldAccounts.map { npub ->
-                                AccountInfo(
-                                    npub,
-                                    encryptedPreferences(npub).getBoolean(PrefKeys.LOGIN_WITH_EXTERNAL_SIGNER, false),
-                                    (encryptedPreferences(npub).getString(PrefKeys.NOSTR_PRIVKEY, "") ?: "").isNotBlank(),
-                                    false,
-                                )
-                            }
-
-                        savedAccounts.emit(migrated)
-
-                        edit {
-                            putString(PrefKeys.ALL_ACCOUNT_INFO, JsonMapper.toJson(migrated))
-                        }
+    private suspend fun loadSavedAccountsFromStorage(): List<AccountInfo> =
+        withContext(Dispatchers.IO) {
+            with(encryptedPreferences()) {
+                val newSystemOfAccounts =
+                    getString(PrefKeys.ALL_ACCOUNT_INFO, "[]")?.let {
+                        JsonMapper.fromJson<List<AccountInfo>>(it)
                     }
+
+                if (!newSystemOfAccounts.isNullOrEmpty()) {
+                    newSystemOfAccounts
+                } else {
+                    val oldAccounts = getString(PrefKeys.SAVED_ACCOUNTS, null)?.split(COMMA) ?: listOf()
+
+                    val migrated =
+                        oldAccounts.map { npub ->
+                            AccountInfo(
+                                npub,
+                                encryptedPreferences(npub).getBoolean(PrefKeys.LOGIN_WITH_EXTERNAL_SIGNER, false),
+                                (encryptedPreferences(npub).getString(PrefKeys.NOSTR_PRIVKEY, "") ?: "").isNotBlank(),
+                                false,
+                            )
+                        }
+
+                    edit {
+                        putString(PrefKeys.ALL_ACCOUNT_INFO, JsonMapper.toJson(migrated))
+                    }
+
+                    migrated
                 }
             }
         }
-        // it's always not null when it gets here.
-        return savedAccounts.value!!
-    }
 
     fun accountsFlow() = savedAccounts
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/accountsCache/AccountCacheState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/accountsCache/AccountCacheState.kt
@@ -108,6 +108,39 @@ class AccountCacheState(
         }
     }
 
+    /** The on-disk root that [loadAccount] creates a per-account directory under. */
+    private fun accountsRootDir() = File(rootFilesDir(), "accounts")
+
+    /**
+     * Deletes the on-disk per-account directory (the MLS/Marmot stores created in
+     * [loadAccount]). Call only on permanent account deletion — [removeAccount] just
+     * drops the in-memory copy and leaves these files behind.
+     */
+    fun deleteAccountFiles(pubkey: HexKey) {
+        val dir = File(accountsRootDir(), pubkey)
+        if (dir.exists() && !dir.deleteRecursively()) {
+            Log.w("AccountCacheState", "Failed to delete account directory ${dir.absolutePath}")
+        }
+    }
+
+    /**
+     * Removes per-account directories left behind by accounts that are no longer saved
+     * (e.g. deleted before [deleteAccountFiles] existed). Keeps only [keepPubkeys]. Safe to
+     * run alongside [loadAccount]: it only loads saved accounts, whose pubkeys are kept.
+     */
+    fun pruneOrphanAccountDirs(keepPubkeys: Set<HexKey>) {
+        val children = accountsRootDir().listFiles() ?: return
+        children.forEach { child ->
+            if (child.isDirectory && child.name !in keepPubkeys) {
+                if (child.deleteRecursively()) {
+                    Log.d("AccountCacheState") { "Pruned orphan account dir ${child.name.take(8)}…" }
+                } else {
+                    Log.w("AccountCacheState", "Failed to prune orphan account dir ${child.absolutePath}")
+                }
+            }
+        }
+    }
+
     fun loadAccount(accountSettings: AccountSettings): Account =
         loadAccount(
             signer =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/AccountSessionManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/AccountSessionManager.kt
@@ -386,12 +386,14 @@ class AccountSessionManager(
                 // log off and relogin with the 0 account
                 localPreferences.deleteAccount(accountInfo)
                 accountsCache.removeAccount(hex)
+                accountsCache.deleteAccountFiles(hex)
                 Amethyst.instance.scheduledPostStore.removeForAccount(hex)
                 loginWithDefaultAccount()
             } else {
                 // delete without switching logins
                 localPreferences.deleteAccount(accountInfo)
                 accountsCache.removeAccount(hex)
+                accountsCache.deleteAccountFiles(hex)
                 Amethyst.instance.scheduledPostStore.removeForAccount(hex)
             }
         }


### PR DESCRIPTION
## Problem

Account deletion cleaned up the saved-accounts list and encrypted prefs, but **never removed the on-disk `files/accounts/<pubkey>/` directory** — the MLS/Marmot stores created in `AccountCacheState.loadAccount`. Every deleted or logged-out account leaked its folder, so the on-disk account count drifts far above the number of accounts shown in the switcher.

Observed on a test device: **16 account folders on disk vs. 6 accounts in the switcher** — 10 orphans accumulated since install.

## Fix

- **`AccountCacheState`** — add `deleteAccountFiles(pubkey)` to remove the per-account directory, and `pruneOrphanAccountDirs(keepPubkeys)` to clear directories no longer backed by a saved account.
- **`AccountSessionManager.logOff`** — delete the files in both delete branches (current-account and non-current).
- **`AppModules`** — one-time startup sweep, keyed by the hex of every saved account, to clean up folders leaked before this fix.
- **`LocalPreferences.savedAccounts()`** — make the lazy init race-safe with a dedicated mutex + double-checked locking. Multiple startup coroutines (account load, always-on notification service, and the new orphan sweep) call it concurrently; the previous check-then-act could run the IO read in parallel and double-write `ALL_ACCOUNT_INFO` during the legacy migration.

## Verification

On-device (emulator): **16 → 6** account dirs after one launch, stable across restarts, no startup regressions and no crashes. The 6 remaining dirs exactly match the saved accounts in the switcher.

Note: these orphan folders were never on the startup load path (only saved accounts are loaded), so this is a disk-hygiene fix, not a startup-perf change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)