### PR TITLE
Move browser strings to commons for shared localization

### DIFF
--- a/amethyst/src/main/res/values-cs/strings.xml
+++ b/amethyst/src/main/res/values-cs/strings.xml
@@ -4873,15 +4873,11 @@
     
 <string name="browser">Prohlížeč</string>
     
-<string name="browser_address_hint">Hledat nebo zadat adresu</string>
     
 <string name="browser_clear">Vymazat</string>
     
-<string name="browser_console_clear">Vymazat</string>
     
-<string name="browser_console_title">Konzola (%1$d)</string>
     
-<string name="browser_console_title_short">Konzola</string>
     
 <string name="browser_favorites">Oblíbené</string>
     
@@ -5273,7 +5269,6 @@
     
 <string name="napplet_permissions_revoke">Odebrat</string>
     
-<string name="napplet_untitled">Nepojmenovaný nApplet</string>
     
 <string name="napplets">nApplets</string>
     

--- a/amethyst/src/main/res/values-de/strings.xml
+++ b/amethyst/src/main/res/values-de/strings.xml
@@ -4782,15 +4782,11 @@ anz der Bedingungen ist erforderlich</string>
     
 <string name="browser">Browser</string>
     
-<string name="browser_address_hint">Suchen oder Adresse eingeben</string>
     
 <string name="browser_clear">Löschen</string>
     
-<string name="browser_console_clear">Löschen</string>
     
-<string name="browser_console_title">Konsole (%1$d)</string>
     
-<string name="browser_console_title_short">Konsole</string>
     
 <string name="browser_favorites">Favoriten</string>
     
@@ -5182,7 +5178,6 @@ anz der Bedingungen ist erforderlich</string>
     
 <string name="napplet_permissions_revoke">Widerrufen</string>
     
-<string name="napplet_untitled">Unbenanntes nApplet</string>
     
 <string name="napplets">nApplets</string>
     

--- a/amethyst/src/main/res/values-eo/strings.xml
+++ b/amethyst/src/main/res/values-eo/strings.xml
@@ -726,11 +726,7 @@
 <string name="nsites">nSite-oj</string>
 <string name="nsite_none_found">Ankoraŭ neniuj nSite-oj trovitaj.</string>
 <string name="browser">Retumilo</string>
-<string name="browser_address_hint">Serĉi aŭ enigi adreson</string>
 <string name="browser_reload">Reŝargi</string>
-<string name="browser_console_title_short">Konzolo</string>
-<string name="browser_console_title">Konzolo (%1$d)</string>
-<string name="browser_console_clear">Viŝi</string>
 <string name="browser_tor_on">Ŝargante per Tor. Klaku por uzi la malferma reton.</string>
 <string name="browser_tor_off">Ŝargante per la malferma reto. Klaku por uzi Tor.</string>
 <string name="browser_unsupported">La en-aplikaĵa retumilo bezonas Android 11 aŭ pli novan.</string>
@@ -763,7 +759,6 @@
 <string name="napplet_permissions_forget">Forgesi ĉi tiun nApplet-on</string>
 <string name="napplet_permissions_blocked">Blokita</string>
 <string name="napplet_permissions_revoke">Revoki</string>
-<string name="napplet_untitled">Sennoma nApplet</string>
 <string name="napplet_none_found">Ankoraŭ neniuj nApplet-oj trovitaj.</string>
 <string name="napplet_fallback_title">nApplet %1$s…</string>
 <string name="napplet_cap_shell">Ŝelo</string>

--- a/amethyst/src/main/res/values-es/strings.xml
+++ b/amethyst/src/main/res/values-es/strings.xml
@@ -1085,7 +1085,6 @@
     
 <string name="napplet_permissions_revoke">Revocar</string>
     
-<string name="napplet_untitled">NApplet sin título</string>
     
 <string name="napplet_none_found">No se han encontrado nApplets todavía.</string>
     
@@ -3333,15 +3332,11 @@
 
 <string name="browser">Navegador</string>
     
-<string name="browser_address_hint">Buscar o introducir dirección</string>
     
 <string name="browser_reload">Recargar</string>
     
-<string name="browser_console_title_short">Consola</string>
     
-<string name="browser_console_title">Consola (%1$d)</string>
     
-<string name="browser_console_clear">Borrar</string>
     
 <string name="browser_tor_on">Cargando a través de Tor. Toca para usar la web abierta.</string>
     

--- a/amethyst/src/main/res/values-fa/strings.xml
+++ b/amethyst/src/main/res/values-fa/strings.xml
@@ -4725,15 +4725,11 @@
 
     <string name="browser">مرورگر</string>
 
-    <string name="browser_address_hint">جستجو یا وارد کردن آدرس</string>
 
     <string name="browser_reload">بارگذاری مجدد</string>
 
-    <string name="browser_console_title_short">کنسول</string>
 
-    <string name="browser_console_title">کنسول (%1$d)</string>
 
-    <string name="browser_console_clear">پاک کردن</string>
 
     <string name="browser_tor_on">بارگذاری از طریق Tor. برای استفاده از وب باز ضربه بزنید.</string>
 
@@ -4799,7 +4795,6 @@
 
     <string name="napplet_permissions_revoke">لغو</string>
 
-    <string name="napplet_untitled">nApplet بی‌عنوان</string>
 
     <string name="napplet_none_found">هنوز هیچ nApplet ای یافت نشد.</string>
 

--- a/amethyst/src/main/res/values-fr/strings.xml
+++ b/amethyst/src/main/res/values-fr/strings.xml
@@ -2788,15 +2788,11 @@
     
 <string name="browser">Navigateur</string>
     
-<string name="browser_address_hint">Rechercher ou saisir une adresse</string>
     
 <string name="browser_reload">Recharger</string>
     
-<string name="browser_console_title_short">Console</string>
     
-<string name="browser_console_title">Console (%1$d)</string>
     
-<string name="browser_console_clear">Effacer</string>
     
 <string name="browser_tor_on">Chargement via Tor. Appuyer pour utiliser le web ouvert.</string>
     
@@ -2862,7 +2858,6 @@
     
 <string name="napplet_permissions_revoke">Révoquer</string>
     
-<string name="napplet_untitled">nApplet sans titre</string>
     
 <string name="napplet_none_found">Aucun nApplet trouvé pour l\'instant.</string>
     

--- a/amethyst/src/main/res/values-in/strings.xml
+++ b/amethyst/src/main/res/values-in/strings.xml
@@ -5173,15 +5173,11 @@
 
     <string name="browser">Browser</string>
 
-    <string name="browser_address_hint">Cari atau masukkan alamat</string>
 
     <string name="browser_reload">Muat ulang</string>
 
-    <string name="browser_console_title_short">Konsol</string>
 
-    <string name="browser_console_title">Konsol (%1$d)</string>
 
-    <string name="browser_console_clear">Hapus</string>
 
     <string name="browser_tor_on">Memuat melalui Tor. Ketuk untuk menggunakan web terbuka.</string>
 
@@ -5247,7 +5243,6 @@
 
     <string name="napplet_permissions_revoke">Cabut</string>
 
-    <string name="napplet_untitled">nApplet Tanpa Judul</string>
 
     <string name="napplet_none_found">Belum ada nApplet ditemukan.</string>
 

--- a/amethyst/src/main/res/values-ja/strings.xml
+++ b/amethyst/src/main/res/values-ja/strings.xml
@@ -5280,15 +5280,11 @@
     
     <string name="browser">ブラウザ</string>
     
-    <string name="browser_address_hint">検索またはアドレスを入力</string>
     
     <string name="browser_reload">再読み込み</string>
     
-    <string name="browser_console_title_short">コンソール</string>
     
-    <string name="browser_console_title">コンソール（%1$d）</string>
     
-    <string name="browser_console_clear">クリア</string>
     
     <string name="browser_tor_on">Tor経由で読み込み中。タップしてオープンウェブを使用します。</string>
     
@@ -5354,7 +5350,6 @@
     
     <string name="napplet_permissions_revoke">取り消す</string>
     
-    <string name="napplet_untitled">無題の nApplet</string>
     
     <string name="napplet_none_found">nApplet はまだ見つかりません。</string>
     

--- a/amethyst/src/main/res/values-nl-rBE/strings.xml
+++ b/amethyst/src/main/res/values-nl-rBE/strings.xml
@@ -5321,15 +5321,11 @@
 
 <string name="browser">Browser</string>
 
-<string name="browser_address_hint">Zoeken of adres invoeren</string>
 
 <string name="browser_reload">Herladen</string>
 
-<string name="browser_console_title_short">Console</string>
 
-<string name="browser_console_title">Console (%1$d)</string>
 
-<string name="browser_console_clear">Wissen</string>
 
 <string name="browser_tor_on">Laden via Tor. Tik om het open web te gebruiken.</string>
 
@@ -5395,7 +5391,6 @@
 
 <string name="napplet_permissions_revoke">Intrekken</string>
 
-<string name="napplet_untitled">Naamloze nApplet</string>
 
 <string name="napplet_none_found">Nog geen nApplets gevonden.</string>
 

--- a/amethyst/src/main/res/values-nl/strings.xml
+++ b/amethyst/src/main/res/values-nl/strings.xml
@@ -4603,15 +4603,11 @@
 
 <string name="browser">Browser</string>
 
-<string name="browser_address_hint">Zoeken of adres invoeren</string>
 
 <string name="browser_reload">Herladen</string>
 
-<string name="browser_console_title_short">Console</string>
 
-<string name="browser_console_title">Console (%1$d)</string>
 
-<string name="browser_console_clear">Wissen</string>
 
 <string name="browser_tor_on">Laden via Tor. Tik om het open web te gebruiken.</string>
 
@@ -4677,7 +4673,6 @@
 
 <string name="napplet_permissions_revoke">Intrekken</string>
 
-<string name="napplet_untitled">Naamloze nApplet</string>
 
 <string name="napplet_none_found">Nog geen nApplets gevonden.</string>
 

--- a/amethyst/src/main/res/values-ru/strings.xml
+++ b/amethyst/src/main/res/values-ru/strings.xml
@@ -4871,15 +4871,11 @@
     
     <string name="browser">Браузер</string>
     
-    <string name="browser_address_hint">Поиск или введите адрес</string>
     
     <string name="browser_reload">Обновить</string>
     
-    <string name="browser_console_title_short">Консоль</string>
     
-    <string name="browser_console_title">Консоль (%1$d)</string>
     
-    <string name="browser_console_clear">Очистить</string>
     
     <string name="browser_tor_on">Загрузка через Tor. Нажмите, чтобы использовать открытую сеть.</string>
     
@@ -4945,7 +4941,6 @@
     
     <string name="napplet_permissions_revoke">Отозвать</string>
     
-    <string name="napplet_untitled">nApplet без названия</string>
     
     <string name="napplet_none_found">nApplets пока не найдены.</string>
     

--- a/amethyst/src/main/res/values-ta/strings.xml
+++ b/amethyst/src/main/res/values-ta/strings.xml
@@ -677,11 +677,7 @@
 <string name="nsites">nSites</string>
 <string name="nsite_none_found">இன்னும் nSites எதுவும் கிடைக்கவில்லை.</string>
 <string name="browser">உலாவி</string>
-<string name="browser_address_hint">தேடவும் அல்லது முகவரியை உள்ளிடவும்</string>
 <string name="browser_reload">மீண்டும் ஏற்று</string>
-<string name="browser_console_title_short">கன்சோல்</string>
-<string name="browser_console_title">கன்சோல் (%1$d)</string>
-<string name="browser_console_clear">அழிக்கவும்</string>
 <string name="browser_tor_on">Tor மூலம் ஏற்றுகிறது. திறந்த வலையை பயன்படுத்த தட்டவும்.</string>
 <string name="browser_tor_off">திறந்த வலை மூலம் ஏற்றுகிறது. Tor ஐ பயன்படுத்த தட்டவும்.</string>
 <string name="browser_unsupported">உள்-பயன்பாட்டு உலாவிக்கு Android 11 அல்லது புதியது தேவை.</string>
@@ -714,7 +710,6 @@
 <string name="napplet_permissions_forget">இந்த nApplet ஐ மறக்கவும்</string>
 <string name="napplet_permissions_blocked">தடுக்கப்பட்டது</string>
 <string name="napplet_permissions_revoke">திரும்பப் பெறவும்</string>
-<string name="napplet_untitled">தலைப்பற்ற nApplet</string>
 <string name="napplet_none_found">இன்னும் nApplets எதுவும் கிடைக்கவில்லை.</string>
 <string name="napplet_fallback_title">nApplet %1$s…</string>
 <string name="napplet_cap_shell">Shell</string>

--- a/amethyst/src/main/res/values-th/strings.xml
+++ b/amethyst/src/main/res/values-th/strings.xml
@@ -4845,15 +4845,11 @@
 
     <string name="browser">เบราว์เซอร์</string>
 
-    <string name="browser_address_hint">ค้นหาหรือป้อนที่อยู่</string>
 
     <string name="browser_reload">โหลดใหม่</string>
 
-    <string name="browser_console_title_short">คอนโซล</string>
 
-    <string name="browser_console_title">คอนโซล (%1$d)</string>
 
-    <string name="browser_console_clear">ล้าง</string>
 
     <string name="browser_tor_on">กำลังโหลดผ่าน Tor แตะเพื่อใช้เว็บแบบเปิด</string>
 
@@ -4919,7 +4915,6 @@
 
     <string name="napplet_permissions_revoke">เพิกถอน</string>
 
-    <string name="napplet_untitled">nApplet ไม่มีชื่อ</string>
 
     <string name="napplet_none_found">ยังไม่พบ nApplets</string>
 

--- a/amethyst/src/main/res/values-tr/strings.xml
+++ b/amethyst/src/main/res/values-tr/strings.xml
@@ -5600,15 +5600,11 @@
 
     <string name="browser">Tarayıcı</string>
 
-    <string name="browser_address_hint">Ara veya adres gir</string>
 
     <string name="browser_reload">Yenile</string>
 
-    <string name="browser_console_title_short">Konsol</string>
 
-    <string name="browser_console_title">Konsol (%1$d)</string>
 
-    <string name="browser_console_clear">Temizle</string>
 
     <string name="browser_tor_on">Tor üzerinden yükleniyor. Açık web\'i kullanmak için dokun.</string>
 
@@ -5674,7 +5670,6 @@
 
     <string name="napplet_permissions_revoke">İptal et</string>
 
-    <string name="napplet_untitled">Başlıksız nApplet</string>
 
     <string name="napplet_none_found">Henüz hiç nApplet bulunamadı.</string>
 

--- a/amethyst/src/main/res/values-uk/strings.xml
+++ b/amethyst/src/main/res/values-uk/strings.xml
@@ -5291,15 +5291,11 @@
     
     <string name="browser">Браузер</string>
     
-    <string name="browser_address_hint">Пошук або введіть адресу</string>
     
     <string name="browser_reload">Оновити</string>
     
-    <string name="browser_console_title_short">Консоль</string>
     
-    <string name="browser_console_title">Консоль (%1$d)</string>
     
-    <string name="browser_console_clear">Очистити</string>
     
     <string name="browser_tor_on">Завантаження через Tor. Торкніться, щоб використати відкриту мережу.</string>
     
@@ -5365,7 +5361,6 @@
 
     <string name="napplet_permissions_revoke">Відкликати</string>
 
-    <string name="napplet_untitled">NApplet без назви</string>
 
     <string name="napplet_none_found">nApplets ще не знайдено.</string>
 

--- a/amethyst/src/main/res/values-zh/strings.xml
+++ b/amethyst/src/main/res/values-zh/strings.xml
@@ -1048,15 +1048,11 @@
     
 <string name="browser">浏览器</string>
     
-<string name="browser_address_hint">搜索或输入地址</string>
     
 <string name="browser_reload">重新加载</string>
     
-<string name="browser_console_title_short">控制台</string>
     
-<string name="browser_console_title">控制台(%1$d)</string>
     
-<string name="browser_console_clear">清除</string>
     
 <string name="browser_tor_on">正通过 Tor 加载。点击使用 open web。</string>
     
@@ -1122,7 +1118,6 @@
     
 <string name="napplet_permissions_revoke">撤销</string>
     
-<string name="napplet_untitled">未命名nApplet</string>
     
 <string name="napplet_none_found">尚未找到 nApplets 。</string>
     

--- a/commons/src/androidMain/res/values-cs/strings.xml
+++ b/commons/src/androidMain/res/values-cs/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="browser_address_hint">Hledat nebo zadat adresu</string>
+    <string name="browser_console_title_short">Konzola</string>
+    <string name="browser_console_title">Konzola (%1$d)</string>
+    <string name="browser_console_clear">Vymazat</string>
+    <string name="napplet_untitled">Nepojmenovaný nApplet</string>
+</resources>

--- a/commons/src/androidMain/res/values-de/strings.xml
+++ b/commons/src/androidMain/res/values-de/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="browser_address_hint">Suchen oder Adresse eingeben</string>
+    <string name="browser_console_title_short">Konsole</string>
+    <string name="browser_console_title">Konsole (%1$d)</string>
+    <string name="browser_console_clear">Löschen</string>
+    <string name="napplet_untitled">Unbenanntes nApplet</string>
+</resources>

--- a/commons/src/androidMain/res/values-eo/strings.xml
+++ b/commons/src/androidMain/res/values-eo/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="browser_address_hint">Serĉi aŭ enigi adreson</string>
+    <string name="browser_console_title_short">Konzolo</string>
+    <string name="browser_console_title">Konzolo (%1$d)</string>
+    <string name="browser_console_clear">Viŝi</string>
+    <string name="napplet_untitled">Sennoma nApplet</string>
+</resources>

--- a/commons/src/androidMain/res/values-es/strings.xml
+++ b/commons/src/androidMain/res/values-es/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="browser_address_hint">Buscar o introducir dirección</string>
+    <string name="browser_console_title_short">Consola</string>
+    <string name="browser_console_title">Consola (%1$d)</string>
+    <string name="browser_console_clear">Borrar</string>
+    <string name="napplet_untitled">NApplet sin título</string>
+</resources>

--- a/commons/src/androidMain/res/values-fa/strings.xml
+++ b/commons/src/androidMain/res/values-fa/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="browser_address_hint">جستجو یا وارد کردن آدرس</string>
+    <string name="browser_console_title_short">کنسول</string>
+    <string name="browser_console_title">کنسول (%1$d)</string>
+    <string name="browser_console_clear">پاک کردن</string>
+    <string name="napplet_untitled">nApplet بی‌عنوان</string>
+</resources>

--- a/commons/src/androidMain/res/values-fr/strings.xml
+++ b/commons/src/androidMain/res/values-fr/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="browser_address_hint">Rechercher ou saisir une adresse</string>
+    <string name="browser_console_title_short">Console</string>
+    <string name="browser_console_title">Console (%1$d)</string>
+    <string name="browser_console_clear">Effacer</string>
+    <string name="napplet_untitled">nApplet sans titre</string>
+</resources>

--- a/commons/src/androidMain/res/values-in/strings.xml
+++ b/commons/src/androidMain/res/values-in/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="browser_address_hint">Cari atau masukkan alamat</string>
+    <string name="browser_console_title_short">Konsol</string>
+    <string name="browser_console_title">Konsol (%1$d)</string>
+    <string name="browser_console_clear">Hapus</string>
+    <string name="napplet_untitled">nApplet Tanpa Judul</string>
+</resources>

--- a/commons/src/androidMain/res/values-ja/strings.xml
+++ b/commons/src/androidMain/res/values-ja/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="browser_address_hint">検索またはアドレスを入力</string>
+    <string name="browser_console_title_short">コンソール</string>
+    <string name="browser_console_title">コンソール（%1$d）</string>
+    <string name="browser_console_clear">クリア</string>
+    <string name="napplet_untitled">無題の nApplet</string>
+</resources>

--- a/commons/src/androidMain/res/values-nl-rBE/strings.xml
+++ b/commons/src/androidMain/res/values-nl-rBE/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="browser_address_hint">Zoeken of adres invoeren</string>
+    <string name="browser_console_title_short">Console</string>
+    <string name="browser_console_title">Console (%1$d)</string>
+    <string name="browser_console_clear">Wissen</string>
+    <string name="napplet_untitled">Naamloze nApplet</string>
+</resources>

--- a/commons/src/androidMain/res/values-nl/strings.xml
+++ b/commons/src/androidMain/res/values-nl/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="browser_address_hint">Zoeken of adres invoeren</string>
+    <string name="browser_console_title_short">Console</string>
+    <string name="browser_console_title">Console (%1$d)</string>
+    <string name="browser_console_clear">Wissen</string>
+    <string name="napplet_untitled">Naamloze nApplet</string>
+</resources>

--- a/commons/src/androidMain/res/values-ru/strings.xml
+++ b/commons/src/androidMain/res/values-ru/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="browser_address_hint">Поиск или введите адрес</string>
+    <string name="browser_console_title_short">Консоль</string>
+    <string name="browser_console_title">Консоль (%1$d)</string>
+    <string name="browser_console_clear">Очистить</string>
+    <string name="napplet_untitled">nApplet без названия</string>
+</resources>

--- a/commons/src/androidMain/res/values-ta/strings.xml
+++ b/commons/src/androidMain/res/values-ta/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="browser_address_hint">தேடவும் அல்லது முகவரியை உள்ளிடவும்</string>
+    <string name="browser_console_title_short">கன்சோல்</string>
+    <string name="browser_console_title">கன்சோல் (%1$d)</string>
+    <string name="browser_console_clear">அழிக்கவும்</string>
+    <string name="napplet_untitled">தலைப்பற்ற nApplet</string>
+</resources>

--- a/commons/src/androidMain/res/values-th/strings.xml
+++ b/commons/src/androidMain/res/values-th/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="browser_address_hint">ค้นหาหรือป้อนที่อยู่</string>
+    <string name="browser_console_title_short">คอนโซล</string>
+    <string name="browser_console_title">คอนโซล (%1$d)</string>
+    <string name="browser_console_clear">ล้าง</string>
+    <string name="napplet_untitled">nApplet ไม่มีชื่อ</string>
+</resources>

--- a/commons/src/androidMain/res/values-tr/strings.xml
+++ b/commons/src/androidMain/res/values-tr/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="browser_address_hint">Ara veya adres gir</string>
+    <string name="browser_console_title_short">Konsol</string>
+    <string name="browser_console_title">Konsol (%1$d)</string>
+    <string name="browser_console_clear">Temizle</string>
+    <string name="napplet_untitled">Başlıksız nApplet</string>
+</resources>

--- a/commons/src/androidMain/res/values-uk/strings.xml
+++ b/commons/src/androidMain/res/values-uk/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="browser_address_hint">Пошук або введіть адресу</string>
+    <string name="browser_console_title_short">Консоль</string>
+    <string name="browser_console_title">Консоль (%1$d)</string>
+    <string name="browser_console_clear">Очистити</string>
+    <string name="napplet_untitled">NApplet без назви</string>
+</resources>

--- a/commons/src/androidMain/res/values-zh/strings.xml
+++ b/commons/src/androidMain/res/values-zh/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="browser_address_hint">搜索或输入地址</string>
+    <string name="browser_console_title_short">控制台</string>
+    <string name="browser_console_title">控制台(%1$d)</string>
+    <string name="browser_console_clear">清除</string>
+    <string name="napplet_untitled">未命名nApplet</string>
+</resources>


### PR DESCRIPTION
## Summary

Consolidate browser and nApplet UI strings from language-specific files in `amethyst/` into the shared `commons/` module. This enables code reuse across Android and Desktop platforms and simplifies maintenance of localized strings.

The following strings are moved to `commons/src/androidMain/res/values-{lang}/strings.xml`:
- `browser_address_hint`
- `browser_console_title_short`
- `browser_console_title`
- `browser_console_clear`
- `napplet_untitled`

Affected languages: Czech, German, Esperanto, Spanish, Persian, French, Indonesian, Japanese, Dutch (Netherlands & Belgium), Russian, Tamil, Thai, Turkish, Ukrainian, and Chinese.

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes: This is a string resource reorganization with no functional code changes. The strings are moved from `amethyst/src/main/res/values-{lang}/strings.xml` to `commons/src/androidMain/res/values-{lang}/strings.xml` and removed from their original locations. Android's resource resolution will find them in the commons module at runtime. Verify that the browser and nApplet UI displays localized strings correctly on Android.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

https://claude.ai/code/session_01Uza7sGxYPZtY43Ln2yH8FQ