### PR TITLE
fix(perf): unfreeze the cold-start "Loading account" screen in debug builds

### DIFF
--- a/amethyst/build.gradle.kts
+++ b/amethyst/build.gradle.kts
@@ -348,6 +348,16 @@ composeCompiler {
 dependencies {
     implementation(platform(libs.androidx.compose.bom))
 
+    // Compose composition tracing — DEBUG ONLY, profiling aid (not shipped). Makes each
+    // recomposition show up as a NAMED slice in Perfetto system traces so we can see which
+    // composable recomposes (e.g. during the cold-start feed first-paint). All Apache-2.0.
+    // Usage: runtime-enable, then capture a Perfetto trace with the `track_event` data source:
+    //   adb shell am broadcast -a androidx.tracing.perfetto.action.ENABLE_TRACING \
+    //     -n com.vitorpamplona.amethyst.debug/androidx.tracing.perfetto.TracingReceiver
+    debugImplementation("androidx.compose.runtime:runtime-tracing")
+    debugImplementation("androidx.tracing:tracing-perfetto:1.0.0")
+    debugImplementation("androidx.tracing:tracing-perfetto-binary:1.0.0")
+
     implementation(project(":quartz"))
     implementation(project(":commons"))
     implementation(project(":nestsClient"))

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/MemoryUsageChip.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/MemoryUsageChip.kt
@@ -41,7 +41,9 @@ import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.MemorySnapshot
 import com.vitorpamplona.amethyst.collectMemorySnapshot
 import com.vitorpamplona.amethyst.isDebug
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 
 @Composable
 fun MemoryUsageChip() {
@@ -52,7 +54,12 @@ fun MemoryUsageChip() {
 
     val snapshot by produceState<MemorySnapshot?>(null) {
         while (true) {
-            value = collectMemorySnapshot(context)
+            // collectMemorySnapshot reads coil3.disk.DiskLruCache.size(), which is @Synchronized and
+            // contends with the disk cache's own journal I/O. On cold start that lock is held by a
+            // background worker for seconds (initial journal read + the burst of image writes), so
+            // running this on the produceState default (main) dispatcher froze the UI thread —
+            // the "Loading account" frame couldn't repaint until size() returned. Collect off-main.
+            value = withContext(Dispatchers.IO) { collectMemorySnapshot(context) }
             delay(2_000)
         }
     }


### PR DESCRIPTION
## What

The \"Loading account\" screen froze for ~15–20s on cold start **in debug builds** before switching to the logged-in UI. Root-caused to a main-thread lock stall (not account loading).

## Root cause

The debug-only `MemoryUsageChip` (the `X/YMB` top-bar indicator, gated on `isDebug`) polls `collectMemorySnapshot()` every 2s from a `produceState` block — which runs on the **main thread**. That reads `coil3.disk.DiskLruCache.size()`, a `@Synchronized` call. On cold start the Coil disk cache holds that monitor for several seconds (journal init + the burst of image writes from the initial relay event flood), so the UI thread blocked inside `size()` and the `Loading account` frame couldn't repaint.

Profiling evidence (Perfetto): a single ~8s render frame; the UI thread slice `monitor contention … blocking from coil3.disk.DiskLruCache.size()`, owner a background image-load worker in okio.

## Fix

Collect the snapshot via `withContext(Dispatchers.IO)` so the synchronized read blocks a background thread instead of the UI thread.

**Measured (same emulator/account):** longest main-thread slice 8195ms → 2704ms; `Loading account` on screen ~15–20s → ~5s; home shell visible by ~6s.

## Scope / safety

- **Debug-only behavior change.** `MemoryUsageChip` early-returns when `!isDebug`, so release/production builds never hit this path and were never affected.
- The residual ~2.7s is genuine `NoteCompose` first-composition cost under the cold-start event flood (heavily amplified by debug class-loading; the compose-compiler stability report confirms the note/feed path is fully skippable with all-stable params — no unstable-param recomposition to fix). Out of scope here.

## Second commit (debug tooling)

`chore(debug): add Compose composition tracing deps` — `androidx.compose.runtime:runtime-tracing` + `androidx.tracing:tracing-perfetto[-binary]`, **debugImplementation only** (not shipped, all Apache-2.0). Makes recompositions show up as named slices in Perfetto traces; that's how the residual was attributed to `NoteCompose`. Usage documented inline. Can be dropped from this PR if you'd prefer it separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)