### PR TITLE
Align Cashu icon with reaction gallery icons in Nutzap

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/MultiSetCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/MultiSetCompose.kt
@@ -451,7 +451,10 @@ fun RenderNutzapGallery(
 
     Row(Modifier.fillMaxWidth()) {
         Box(
-            modifier = WidthAuthorPictureModifier,
+            // Reuse the reaction galleries' icon column (55dp wide with a 5dp end
+            // inset) so the cashu glyph lines up with the like/boost icons above
+            // it, instead of sitting flush-right like the lightning ZappedIcon.
+            modifier = NotificationIconModifier,
         ) {
             Icon(
                 imageVector = CustomHashTagIcons.Cashu,


### PR DESCRIPTION
## Summary

Adjust the Cashu icon column in `RenderNutzapGallery` to use `NotificationIconModifier` instead of `WidthAuthorPictureModifier`. This aligns the Cashu glyph with the like/boost icons above it in the reaction galleries, rather than sitting flush-right like the lightning ZappedIcon.

## Test plan

- [ ] Manually exercised the change (see notes below)

Notes / screenshots:

Verified that the Cashu icon in the Nutzap gallery now visually aligns with the reaction gallery icons (like/boost) above it, using the same 55dp column width with 5dp end inset.

## Interop suites

- [ ] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [ ] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_011qQdaD3DHRQNDKe2BUnEiM