### PR TITLE
Remove network routing confirmation dialog from napplet host

### DIFF
--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletHostActivity.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletHostActivity.kt
@@ -736,30 +736,12 @@ class NappletHostActivity : ComponentActivity() {
             title = barTitle(),
             isSandbox = true,
             onReload = { if (this::webView.isInitialized) webView.reload() },
-            // Website-mode nSites can re-route over Tor; switching rebuilds the session via a confirm
-            // dialog, so the row taps through rather than toggling inline.
+            // Website-mode nSites can re-route over Tor; switching rebuilds the session, so the row taps
+            // through to a full relaunch rather than toggling inline.
             torInitiallyOn = if (profile.exposesNetwork && proxyPort > 0) useTor else null,
-            onNetworkTap = if (profile.exposesNetwork && proxyPort > 0) ({ showNetworkDialog() }) else null,
+            onNetworkTap = if (profile.exposesNetwork && proxyPort > 0) ({ setNetworkMode(!useTor) }) else null,
             onInfo = { showAccessDialog() },
         )
-
-    /**
-     * Explains the site's current network routing and offers to switch it. Switching persists the
-     * per-site choice (via the broker, which owns the preference) and relaunches this screen so the new
-     * routing applies cleanly from [onCreate] — the proxy and content server are rebuilt for the new mode.
-     */
-    private fun showNetworkDialog() {
-        val titleRes = if (useTor) R.string.napplet_net_tor_title else R.string.napplet_net_open_title
-        val messageRes = if (useTor) R.string.napplet_net_tor_message else R.string.napplet_net_open_message
-        val switchRes = if (useTor) R.string.napplet_net_switch_open else R.string.napplet_net_switch_tor
-        AlertDialog
-            .Builder(this)
-            .setTitle(getString(titleRes, barTitle()))
-            .setMessage(getString(messageRes))
-            .setPositiveButton(getString(switchRes)) { _, _ -> setNetworkMode(!useTor) }
-            .setNegativeButton(android.R.string.cancel, null)
-            .show()
-    }
 
     /** Persists the new routing choice in the main process, then relaunches this screen to apply it. */
     private fun setNetworkMode(newUseTor: Boolean) {

--- a/nappletHost/src/main/res/values/strings.xml
+++ b/nappletHost/src/main/res/values/strings.xml
@@ -19,12 +19,6 @@
     <!-- nSite network routing (Tor vs open web) -->
     <string name="napplet_net_tor_desc">This site loads over Tor. Tap to change.</string>
     <string name="napplet_net_open_desc">This site loads over the open web. Tap to change.</string>
-    <string name="napplet_net_tor_title">“%1$s” loads over Tor</string>
-    <string name="napplet_net_tor_message">This site\'s traffic is routed through Tor, so it can\'t see your IP address. Some sites are slow or broken over Tor — you can switch this site to the open web. Your choice is remembered for this site.</string>
-    <string name="napplet_net_open_title">“%1$s” loads over the open web</string>
-    <string name="napplet_net_open_message">This site loads directly, so it (and the servers it contacts) can see your IP address. Switch it back to Tor to keep your IP private. Your choice is remembered for this site.</string>
-    <string name="napplet_net_switch_open">Use open web</string>
-    <string name="napplet_net_switch_tor">Use Tor</string>
     <!-- Short labels for the pull-down sheet's network row -->
     <string name="napplet_net_tor_label">Loads over Tor</string>
     <string name="napplet_net_open_label">Loads over the open web</string>


### PR DESCRIPTION
## Summary

Simplifies the network routing UI for napplets by removing the confirmation dialog that appeared when switching between Tor and open-web modes. Instead of showing a dialog, tapping the network row now directly switches the mode and relaunches the screen. This streamlines the UX by eliminating an intermediate confirmation step while maintaining the same end result (mode switch + relaunch).

Removes the `showNetworkDialog()` method and its associated string resources (`napplet_net_tor_title`, `napplet_net_tor_message`, `napplet_net_open_title`, `napplet_net_open_message`, `napplet_net_switch_open`, `napplet_net_switch_tor`), replacing the dialog callback with a direct call to `setNetworkMode()`.

## Test plan

- [ ] N/A — UI-only change to napplet host; no wire bytes or state machine affected
- [ ] Manually exercised the change: opened a napplet with network exposure, tapped the network routing row, verified the mode switches and screen relaunches without showing a dialog

Notes: The change preserves the existing behavior of persisting the choice and relaunching via `setNetworkMode()` — only the confirmation dialog is removed. The comment was updated to reflect the new direct-relaunch behavior.

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_0177rhf2L93YRcq6NrWkkM4Q