### PR TITLE
Fix first-connect dialog suppression to allow retry after cooldown

### DIFF
--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/napplet/NappletBroker.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/napplet/NappletBroker.kt
@@ -79,6 +79,8 @@ class NappletBroker(
     private val signerLedger: NostrSignerPermissionLedger? = null,
     private val nostrConnectPrompt: NostrConnectPrompt? = null,
     private val signerConsentPrompt: NostrSignerConsentPrompt? = null,
+    // Wall-clock source (ms) for the post-cancel re-prompt cooldown; injectable for tests.
+    private val nowMillis: () -> Long = { TimeUtils.nowMillis() },
 ) {
     // Serializes the consent-prompt path so concurrent requests queue into one dialog at a time
     // (see [authorizeWithConsent]). Only the prompt is held here; non-prompting paths and execute()
@@ -93,11 +95,16 @@ class NappletBroker(
     // Only accessed under signerConsentLock.
     private val sessionAllows = mutableSetOf<String>()
 
-    // Apps whose first-connect dialog the user dismissed with Cancel this session.
-    // Cancelling means "not now" — we suppress re-prompting within the same session so a
-    // napplet that fires many requests doesn't show the dialog on every one.
+    // Apps whose first-connect dialog the user just dismissed with Cancel, mapped to the wall-clock
+    // instant (ms) their re-prompt suppression expires. Cancelling means "not now": for a brief
+    // cooldown we drop re-prompts so the burst of requests a page/napplet fires on load (relays +
+    // storage + identity, all racing) doesn't relaunch the dialog once per request. Once the cooldown
+    // lapses the entry is stale, so a fresh request — e.g. the user deliberately re-triggering login —
+    // prompts again. (A plain "suppress forever" set used to lock the user out: a single Cancel killed
+    // every future prompt for the broker's whole lifetime, and because Cancel persists nothing there
+    // was no Connected-Apps entry to clear to recover.)
     // Only accessed under signerConsentLock.
-    private val sessionCancelled = mutableSetOf<String>()
+    private val cancelledUntil = mutableMapOf<String, Long>()
 
     /**
      * Authorizes and runs [request] on behalf of [identity]. [declared] is the capability set the
@@ -357,12 +364,19 @@ class NappletBroker(
             // Re-check after acquiring lock: a sibling request may have set the policy while we waited.
             if (sl.hasPolicy(identity.coordinate)) return@withLock true
 
-            // Suppress re-prompting if the user already cancelled this session.
-            if (identity.coordinate in sessionCancelled) return@withLock false
+            // Within the post-cancel cooldown, suppress re-prompting so a load-time burst doesn't
+            // relaunch the dialog per request. Once it lapses, drop the stale entry and fall through to
+            // prompt again — this is what lets the user retry after dismissing the dialog. The cooldown
+            // self-clears, so there is nothing to hunt down and clear in Connected Apps.
+            cancelledUntil[identity.coordinate]?.let { until ->
+                if (nowMillis() < until) return@withLock false
+                cancelledUntil.remove(identity.coordinate)
+            }
 
             val prompt = nostrConnectPrompt ?: return@withLock true
             when (val result = prompt.request(identity)) {
                 is AppConnectResult.Connected -> {
+                    cancelledUntil.remove(identity.coordinate)
                     sl.setPolicy(identity.coordinate, result.policy)
                     // Bulk-grant non-payment capabilities only for non-paranoid policies.
                     // PARANOID users chose "ask me for everything" — leave the capability ledger
@@ -384,7 +398,7 @@ class NappletBroker(
                     false
                 }
                 AppConnectResult.Cancelled -> {
-                    sessionCancelled.add(identity.coordinate)
+                    cancelledUntil[identity.coordinate] = nowMillis() + CANCEL_REPROMPT_COOLDOWN_MS
                     false
                 }
             }
@@ -444,4 +458,13 @@ class NappletBroker(
                 }
             }
         }
+
+    companion object {
+        /**
+         * How long (ms) a Cancel on the first-connect dialog suppresses re-prompting for the same app.
+         * Long enough to absorb the burst of requests a page/napplet fires on load without relaunching
+         * the dialog per request; short enough that a deliberate user retry seconds later prompts again.
+         */
+        private const val CANCEL_REPROMPT_COOLDOWN_MS = 3_000L
+    }
 }

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/napplet/NappletBrokerTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/napplet/NappletBrokerTest.kt
@@ -26,6 +26,11 @@ import com.vitorpamplona.amethyst.commons.napplet.permissions.NappletPermissionL
 import com.vitorpamplona.amethyst.commons.napplet.permissions.PermissionDecision
 import com.vitorpamplona.amethyst.commons.napplet.protocol.NappletRequest
 import com.vitorpamplona.amethyst.commons.napplet.protocol.NappletResponse
+import com.vitorpamplona.amethyst.commons.napplet.signers.AppConnectResult
+import com.vitorpamplona.amethyst.commons.napplet.signers.AppSignerPolicy
+import com.vitorpamplona.amethyst.commons.napplet.signers.InMemoryNostrSignerPermissionStore
+import com.vitorpamplona.amethyst.commons.napplet.signers.NostrConnectPrompt
+import com.vitorpamplona.amethyst.commons.napplet.signers.NostrSignerPermissionLedger
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.hexToByteArray
@@ -279,6 +284,56 @@ class NappletBrokerTest {
 
             assertEquals(1, prompt.calls) // siblings honored the recorded ALLOW_ALWAYS instead of re-prompting
             responses.forEach { assertEquals(NappletResponse.PublicKey(signer.pubKey), it) }
+        }
+
+    /** A first-connect prompt that returns a scripted sequence of answers and counts its calls. */
+    private class ScriptedConnectPrompt(
+        private vararg val answers: AppConnectResult,
+    ) : NostrConnectPrompt {
+        var calls = 0
+            private set
+
+        override suspend fun request(identity: NappletIdentity): AppConnectResult {
+            val answer = answers[minOf(calls, answers.size - 1)]
+            calls++
+            return answer
+        }
+    }
+
+    @Test
+    fun cancellingFirstConnectThenRetryingRePromptsOnceCooldownLapses() =
+        runTest {
+            // Repro for the reported bug: dismissing the "Connect to Nostr" dialog (Back) used to
+            // suppress every future prompt for the broker's whole lifetime, with nothing in Connected
+            // Apps to clear. The user could never re-trigger login. After the fix the suppression is a
+            // short self-clearing cooldown: a deliberate retry past it prompts again.
+            var clock = 1_000L
+            val connect = ScriptedConnectPrompt(AppConnectResult.Cancelled, AppConnectResult.Connected(AppSignerPolicy.REASONABLE))
+            val signerLedger = NostrSignerPermissionLedger(InMemoryNostrSignerPermissionStore())
+            val broker =
+                NappletBroker(
+                    signer = signer,
+                    ledger = NappletPermissionLedger(InMemoryNappletPermissionStore()),
+                    consentPrompt = ScriptedPrompt(GrantState.DENY),
+                    signerLedger = signerLedger,
+                    nostrConnectPrompt = connect,
+                    nowMillis = { clock },
+                )
+
+            // 1. User dismisses the dialog → Denied, and no policy is persisted (nothing to clear).
+            assertIs<NappletResponse.Denied>(broker.handle(applet, NappletRequest.GetPublicKey, allDeclared))
+            assertNull(signerLedger.store.loadPolicy(applet.coordinate))
+
+            // 2. A request inside the cooldown is suppressed silently (no second dialog) — this drains
+            //    the load-time burst without re-prompting per request.
+            assertIs<NappletResponse.Denied>(broker.handle(applet, NappletRequest.GetPublicKey, allDeclared))
+            assertEquals(1, connect.calls)
+
+            // 3. The user retries after the cooldown lapses → the dialog shows again and they connect.
+            clock += 10_000L
+            assertEquals(NappletResponse.PublicKey(signer.pubKey), broker.handle(applet, NappletRequest.GetPublicKey, allDeclared))
+            assertEquals(2, connect.calls)
+            assertEquals(AppSignerPolicy.REASONABLE, signerLedger.store.loadPolicy(applet.coordinate))
         }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes a bug where dismissing the "Connect to Nostr" first-connect dialog (via Cancel/Back) would permanently suppress re-prompting for that app for the broker's entire lifetime, locking the user out of login recovery. The suppression is now a brief self-clearing cooldown (3 seconds) that absorbs the burst of requests a page fires on load without relaunching the dialog per request, but allows deliberate user retries to prompt again.

The root cause was storing cancelled apps in a plain `Set` with no expiration. After the fix, cancellations are tracked in a `Map<String, Long>` with wall-clock expiry times. Once the cooldown lapses, the stale entry is dropped and a fresh request prompts again — no manual cleanup needed in Connected Apps.

## Changes

- **`NappletBroker.kt`**: 
  - Replaced `sessionCancelled: Set<String>` with `cancelledUntil: Map<String, Long>` to track expiry times
  - Added `nowMillis: () -> Long` injectable parameter for testable time source
  - Updated first-connect logic to check cooldown expiry and re-prompt after it lapses
  - Added `CANCEL_REPROMPT_COOLDOWN_MS = 3_000L` constant
  - Remove stale entries when cooldown expires or user successfully connects

- **`NappletBrokerTest.kt`**:
  - Added `ScriptedConnectPrompt` test helper to return a scripted sequence of connect results
  - Added `cancellingFirstConnectThenRetryingRePromptsOnceCooldownLapses()` test that verifies:
    1. Cancelling the dialog returns `Denied` and persists no policy
    2. Requests within the cooldown are silently suppressed (no re-prompt)
    3. After cooldown expires, a retry prompts again and succeeds

## Test plan

- [x] Ran `./gradlew test` — new test `cancellingFirstConnectThenRetryingRePromptsOnceCooldownLapses()` passes and covers the bug fix
- [x] Existing tests pass (no regressions)

The new test directly exercises the fixed code path: Cancel → suppression → cooldown expiry → re-prompt → success.

## Interop suites

- [x] N/A — change is internal to napplet broker permission logic, does not affect wire bytes or protocol

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01HDcts4HzwSff4fy6oSVA6D