### PR TITLE
fix: keep "Can't play this video" overlay visible on a paused, frameless player

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/WatchPlaybackErrors.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/composable/WatchPlaybackErrors.kt
@@ -103,10 +103,19 @@ fun WatchPlaybackErrors(controllerState: MediaControllerState) {
                 override fun onPlayerErrorChanged(error: PlaybackException?) {
                     if (error != null) {
                         Log.w(ERROR_LOG_TAG) { "Error raised on ${controller.currentMediaItem?.mediaId}: ${error.describe()}" }
+                        errorState.value = error
                     } else if (errorState.value != null) {
-                        Log.d(ERROR_LOG_TAG) { "Error cleared on ${controller.currentMediaItem?.mediaId}" }
+                        // The player cleared its own error — this fires on every prepare(), which a
+                        // Play-button retry, a warm-pool re-acquire, or ExoPlayer's decoder fallback
+                        // all trigger. The very next decoder-init attempt usually fails again, so
+                        // mirroring this null straight into errorState was what made the overlay
+                        // blink on and then vanish, leaving a paused, frameless player with no
+                        // message. Hold the overlay instead: it is cleared only on a genuine
+                        // recovery (STATE_READY, i.e. a frame was produced — see
+                        // onPlaybackStateChanged), a new media item (onMediaItemTransition), or a
+                        // playhead that starts advancing again (watchForDecodeStall).
+                        Log.d(ERROR_LOG_TAG) { "playerError cleared by controller (re-prepare?) on ${controller.currentMediaItem?.mediaId} — holding overlay until STATE_READY" }
                     }
-                    errorState.value = error
                 }
 
                 override fun onMediaItemTransition(


### PR DESCRIPTION
A decoder-init failure surfaced the codec-error overlay only for a blink
before it vanished, leaving the user staring at a blank/white surface with
no message and no playback. The player is then parked paused in STATE_IDLE
with no rendered frame — exactly when the message is most useful.

Root cause: WatchPlaybackErrors mirrored onPlayerErrorChanged(null) straight
into the overlay state. That null fires on every prepare() — a Play-button
retry, a warm-pool re-acquire, or ExoPlayer's own decoder fallback all
trigger it — and the very next decoder-init attempt usually fails again. So
each retry cleared the overlay for an instant, then re-raised the error,
producing the on/off blink and (once the player settled IDLE) hiding the
message entirely.

Hold the overlay across that transient clear instead. It is now cleared only
on a genuine recovery: STATE_READY (a frame was produced), a new media item
(onMediaItemTransition), or a playhead that starts advancing again
(watchForDecodeStall) — so a paused, frameless player keeps showing the
codec-not-supported message and its "Open in browser" fallback.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TnysuLo51i31jyjhhvtxb5