### PR TITLE
Implement SearchableEvent interface for NIP-50 search support

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/edits/TextNoteModificationEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/edits/TextNoteModificationEvent.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import com.vitorpamplona.quartz.nip01Core.tags.events.firstTaggedEvent
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 @Immutable
@@ -35,10 +36,13 @@ class TextNoteModificationEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : Event(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
     fun editedNote() = firstTaggedEvent()
 
     fun summary() = tags.firstOrNull { it.size > 1 && it[0] == "summary" }?.get(1)
+
+    override fun indexableContent() = listOfNotNull(content, summary()).joinToString("\n")
 
     companion object {
         const val KIND = 1010

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip15Marketplace/auction/AuctionEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip15Marketplace/auction/AuctionEvent.kt
@@ -29,6 +29,7 @@ import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip01Core.tags.hashtags.hashtags
 import com.vitorpamplona.quartz.nip21UriScheme.toNostrUri
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.CancellationException
@@ -41,7 +42,8 @@ class AuctionEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
     override fun isContentEncoded() = true
 
     fun auctionData(): AuctionData? =
@@ -52,6 +54,8 @@ class AuctionEvent(
             Log.w("AuctionEvent") { "Content Parse Error: ${toNostrUri()} ${e.message}" }
             null
         }
+
+    override fun indexableContent() = auctionData()?.let { listOfNotNull(it.name, it.description).joinToString("\n") } ?: ""
 
     companion object {
         const val KIND = 30020

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip15Marketplace/marketplace/MarketplaceEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip15Marketplace/marketplace/MarketplaceEvent.kt
@@ -28,6 +28,7 @@ import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip21UriScheme.toNostrUri
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.CancellationException
@@ -40,7 +41,8 @@ class MarketplaceEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
     override fun isContentEncoded() = true
 
     fun marketplaceData(): MarketplaceData? =
@@ -51,6 +53,8 @@ class MarketplaceEvent(
             Log.w("MarketplaceEvent") { "Content Parse Error: ${toNostrUri()} ${e.message}" }
             null
         }
+
+    override fun indexableContent() = marketplaceData()?.let { listOfNotNull(it.name, it.about).joinToString("\n") } ?: ""
 
     companion object {
         const val KIND = 30019

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip15Marketplace/product/ProductEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip15Marketplace/product/ProductEvent.kt
@@ -29,6 +29,7 @@ import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip01Core.tags.hashtags.hashtags
 import com.vitorpamplona.quartz.nip21UriScheme.toNostrUri
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.CancellationException
@@ -41,7 +42,8 @@ class ProductEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
     override fun isContentEncoded() = true
 
     fun productData(): ProductData? =
@@ -54,6 +56,8 @@ class ProductEvent(
         }
 
     fun categories() = tags.hashtags()
+
+    override fun indexableContent() = productData()?.let { (listOfNotNull(it.name, it.description) + categories()).joinToString("\n") } ?: ""
 
     companion object {
         const val KIND = 30018

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip15Marketplace/stall/StallEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip15Marketplace/stall/StallEvent.kt
@@ -28,6 +28,7 @@ import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip21UriScheme.toNostrUri
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.CancellationException
@@ -40,7 +41,8 @@ class StallEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
     override fun isContentEncoded() = true
 
     fun stallData(): StallData? =
@@ -51,6 +53,8 @@ class StallEvent(
             Log.w("StallEvent") { "Content Parse Error: ${toNostrUri()} ${e.message}" }
             null
         }
+
+    override fun indexableContent() = stallData()?.let { listOfNotNull(it.name, it.description).joinToString("\n") } ?: ""
 
     companion object {
         const val KIND = 30017

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip29RelayGroups/moderation/EditMetadataEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip29RelayGroups/moderation/EditMetadataEvent.kt
@@ -24,8 +24,10 @@ import androidx.compose.runtime.Immutable
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
+import com.vitorpamplona.quartz.nip01Core.core.firstTagValue
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip29RelayGroups.metadata.GroupMetadataEvent
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 @Immutable
@@ -36,10 +38,17 @@ class EditMetadataEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : Event(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
     fun groupId() = tags.groupId()
 
+    fun name() = tags.firstTagValue("name")
+
+    fun about() = tags.firstTagValue("about")
+
     fun previousEvents() = tags.previousEvents()
+
+    override fun indexableContent() = listOfNotNull(name(), about()).joinToString("\n")
 
     companion object {
         const val KIND = 9002

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip32Labeling/LabelEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip32Labeling/LabelEvent.kt
@@ -41,6 +41,7 @@ import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip01Core.tags.people.pTag
 import com.vitorpamplona.quartz.nip32Labeling.tags.LabelNamespaceTag
 import com.vitorpamplona.quartz.nip32Labeling.tags.LabelTag
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 /**
@@ -61,7 +62,10 @@ class LabelEvent(
 ) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
     EventHintProvider,
     PubKeyHintProvider,
-    AddressHintProvider {
+    AddressHintProvider,
+    SearchableEvent {
+    override fun indexableContent() = (listOf(content) + labels().map { it.label }).filter { it.isNotEmpty() }.joinToString("\n")
+
     override fun pubKeyHints(): List<PubKeyHint> = tags.mapNotNull(PTag::parseAsHint)
 
     override fun linkedPubKeys(): List<HexKey> = tags.mapNotNull(PTag::parseKey)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip34Git/status/GitStatusEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip34Git/status/GitStatusEvent.kt
@@ -28,6 +28,7 @@ import com.vitorpamplona.quartz.nip01Core.hints.PubKeyHintProvider
 import com.vitorpamplona.quartz.nip01Core.tags.aTag.ATag
 import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip10Notes.tags.MarkedETag
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 
 /**
  * Common base for NIP-34 status events (kinds 1630/1631/1632/1633). Each
@@ -46,7 +47,10 @@ abstract class GitStatusEvent(
 ) : Event(id, pubKey, createdAt, kind, tags, content, sig),
     PubKeyHintProvider,
     EventHintProvider,
-    AddressHintProvider {
+    AddressHintProvider,
+    SearchableEvent {
+    override fun indexableContent() = content
+
     override fun pubKeyHints() = tags.mapNotNull(PTag::parseAsHint)
 
     override fun linkedPubKeys() = tags.mapNotNull(PTag::parseKey)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip52Calendar/rsvp/CalendarRSVPEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip52Calendar/rsvp/CalendarRSVPEvent.kt
@@ -33,6 +33,7 @@ import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip01Core.tags.events.ETag
 import com.vitorpamplona.quartz.nip01Core.tags.events.firstTaggedEvent
 import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip52Calendar.appt.tags.RSVPStatusTag
 import com.vitorpamplona.quartz.nip52Calendar.rsvp.tags.FreeBusyTag
 import com.vitorpamplona.quartz.utils.TimeUtils
@@ -48,7 +49,10 @@ class CalendarRSVPEvent(
     content: String,
     sig: HexKey,
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
-    PubKeyHintProvider {
+    PubKeyHintProvider,
+    SearchableEvent {
+    override fun indexableContent() = content
+
     override fun pubKeyHints() = tags.mapNotNull(PTag::parseAsHint)
 
     override fun linkedPubKeys() = tags.mapNotNull(PTag::parseKey)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip53LiveActivities/raid/LiveActivitiesRaidEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip53LiveActivities/raid/LiveActivitiesRaidEvent.kt
@@ -30,6 +30,7 @@ import com.vitorpamplona.quartz.nip01Core.hints.EventHintBundle
 import com.vitorpamplona.quartz.nip01Core.hints.types.AddressHint
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.aTag.ATag
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip53LiveActivities.streaming.LiveActivitiesEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
@@ -53,7 +54,10 @@ class LiveActivitiesRaidEvent(
     content: String,
     sig: HexKey,
 ) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
-    AddressHintProvider {
+    AddressHintProvider,
+    SearchableEvent {
+    override fun indexableContent() = content
+
     override fun addressHints(): List<AddressHint> = tags.mapNotNull(ATag::parseAsHint)
 
     override fun linkedAddressIds(): List<String> = tags.mapNotNull(ATag::parseAddressId)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/P2POrderEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip69P2pOrderEvents/P2POrderEvent.kt
@@ -27,6 +27,7 @@ import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
 import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip40Expiration.expiration
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.FiatAmountTag
 import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.OrderStatus
 import com.vitorpamplona.quartz.nip69P2pOrderEvents.tags.OrderType
@@ -42,7 +43,10 @@ class P2POrderEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = (listOfNotNull(makerName(), currency()) + paymentMethods().orEmpty()).joinToString(" ")
+
     fun orderType() = tags.orderType()
 
     fun currency() = tags.currency()

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip87Ecash/recommendation/MintRecommendationEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip87Ecash/recommendation/MintRecommendationEvent.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip87Ecash.cashu.CashuMintEvent
 import com.vitorpamplona.quartz.nip87Ecash.fedimint.FedimintEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
@@ -37,7 +38,10 @@ class MintRecommendationEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : Event(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = content
+
     fun mintUrls() = tags.mintUrls()
 
     fun mintEventKind() = tags.mintEventKind()

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip90Dvms/imageGeneration/NIP90ImageGenerationRequestEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip90Dvms/imageGeneration/NIP90ImageGenerationRequestEvent.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip90Dvms.tags.InputTag
 import com.vitorpamplona.quartz.nip90Dvms.tags.dvmParam
 import com.vitorpamplona.quartz.nip90Dvms.tags.firstInputByType
@@ -42,7 +43,10 @@ class NIP90ImageGenerationRequestEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : Event(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(prompt(), negativePrompt()).joinToString(" ")
+
     fun inputs(): List<InputTag> = tags.inputs()
 
     fun prompt(): String? = tags.firstInputByType("text")?.value

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip90Dvms/textGeneration/NIP90TextGenerationRequestEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip90Dvms/textGeneration/NIP90TextGenerationRequestEvent.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip90Dvms.tags.InputTag
 import com.vitorpamplona.quartz.nip90Dvms.tags.dvmParam
 import com.vitorpamplona.quartz.nip90Dvms.tags.inputPrompt
@@ -42,7 +43,10 @@ class NIP90TextGenerationRequestEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : Event(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = inputs().filter { it.type == "prompt" || it.type == "text" }.joinToString(" ") { it.value }
+
     fun inputs(): List<InputTag> = tags.inputs()
 
     fun outputMimeType(): String? = tags.outputMimeType()

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip90Dvms/textToSpeech/NIP90TextToSpeechRequestEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip90Dvms/textToSpeech/NIP90TextToSpeechRequestEvent.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nip90Dvms.tags.InputTag
 import com.vitorpamplona.quartz.nip90Dvms.tags.dvmParam
 import com.vitorpamplona.quartz.nip90Dvms.tags.firstInputByType
@@ -41,7 +42,10 @@ class NIP90TextToSpeechRequestEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : Event(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
+    SearchableEvent {
+    override fun indexableContent() = text() ?: ""
+
     fun inputs(): List<InputTag> = tags.inputs()
 
     fun text(): String? = tags.firstInputByType("text")?.value

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nipXXPodcasting20/trailer/Podcasting20TrailerEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nipXXPodcasting20/trailer/Podcasting20TrailerEvent.kt
@@ -29,6 +29,7 @@ import com.vitorpamplona.quartz.nip01Core.tags.dTag.dTag
 import com.vitorpamplona.quartz.nip22Comments.RootScope
 import com.vitorpamplona.quartz.nip31Alts.AltTag
 import com.vitorpamplona.quartz.nip31Alts.alt
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.nipXXPodcasting20.episode.tags.PubDateTag
 import com.vitorpamplona.quartz.nipXXPodcasting20.episode.tags.TitleTag
 import com.vitorpamplona.quartz.nipXXPodcasting20.trailer.tags.LengthTag
@@ -51,7 +52,10 @@ class Podcasting20TrailerEvent(
     content: String,
     sig: HexKey,
 ) : BaseAddressableEvent(id, pubKey, createdAt, KIND, tags, content, sig),
-    RootScope {
+    RootScope,
+    SearchableEvent {
+    override fun indexableContent() = listOfNotNull(title(), content).joinToString("\n")
+
     fun title() = tags.firstNotNullOfOrNull(TitleTag::parse)
 
     fun url() = tags.firstNotNullOfOrNull(UrlTag::parse)


### PR DESCRIPTION
## Summary

Adds `SearchableEvent` interface implementation to 16 event types across multiple NIPs to enable full-text search indexing via NIP-50. Each event class now implements `indexableContent()` to return the searchable text fields relevant to that event type (e.g., name + description for marketplace events, prompt text for DVM requests, content for status events).

## Changes

- **EditMetadataEvent** (NIP-29): indexes name and about fields
- **TextNoteModificationEvent** (NIP-1010): indexes content and summary
- **AuctionEvent, MarketplaceEvent, ProductEvent, StallEvent** (NIP-15): indexes name, description, and categories
- **LabelEvent** (NIP-32): indexes content and label names
- **GitStatusEvent** (NIP-34): indexes content
- **CalendarRSVPEvent** (NIP-52): indexes content
- **LiveActivitiesRaidEvent** (NIP-53): indexes content
- **P2POrderEvent** (NIP-69): indexes maker name, currency, and payment methods
- **MintRecommendationEvent** (NIP-87): indexes content
- **NIP-90 DVM request events**: index prompts/inputs (image generation, text generation, text-to-speech)
- **Podcasting20TrailerEvent** (NIP-XX): indexes title and content

## Test plan

- [ ] N/A — change is a straightforward interface implementation with no behavioral side effects; existing event parsing and serialization remain unchanged

https://claude.ai/code/session_01P5MN4vF4JJG7xFCofJAHg8