### PR TITLE
feat: expand the "Let's be reasonable" napplet auto-approve set

### DIFF
--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/AppSignerPolicy.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/AppSignerPolicy.kt
@@ -30,9 +30,11 @@ enum class AppSignerPolicy {
     FULL_TRUST,
 
     /**
-     * Auto-approve the most common operations: kind 1 short notes, kind 6 reposts, kind 7
-     * reactions, and all encrypt/decrypt operations; ask before anything else.
-     * A reasonable default for most apps.
+     * Auto-approve the most common, harmless operations: additive public content events — short
+     * notes, reposts, reactions, picture posts, public chat, highlights, comments, and user status
+     * (see [NostrSignerPermissionLedger.REASONABLE_SIGN_KINDS]) — plus encryption; ask before
+     * anything that could spend money, overwrite account config, delete content, or reveal private
+     * data (including decryption). A reasonable default for most apps.
      */
     REASONABLE,
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/NostrSignerPermissionLedger.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/NostrSignerPermissionLedger.kt
@@ -28,11 +28,21 @@ import com.vitorpamplona.quartz.nip25Reactions.ReactionEvent
 import com.vitorpamplona.quartz.nip28PublicChat.message.ChannelMessageEvent
 import com.vitorpamplona.quartz.nip38UserStatus.StatusEvent
 import com.vitorpamplona.quartz.nip42RelayAuth.RelayAuthEvent
+import com.vitorpamplona.quartz.nip53LiveActivities.chat.LiveActivitiesChatMessageEvent
 import com.vitorpamplona.quartz.nip57Zaps.LnZapRequestEvent
 import com.vitorpamplona.quartz.nip68Picture.PictureEvent
 import com.vitorpamplona.quartz.nip71Video.VideoNormalEvent
 import com.vitorpamplona.quartz.nip71Video.VideoShortEvent
+import com.vitorpamplona.quartz.nip7DThreads.ThreadEvent
 import com.vitorpamplona.quartz.nip84Highlights.HighlightEvent
+import com.vitorpamplona.quartz.nip88Polls.poll.PollEvent
+import com.vitorpamplona.quartz.nip88Polls.response.PollResponseEvent
+import com.vitorpamplona.quartz.nip94FileMetadata.FileHeaderEvent
+import com.vitorpamplona.quartz.nipA0VoiceMessages.VoiceEvent
+import com.vitorpamplona.quartz.nipA0VoiceMessages.VoiceReplyEvent
+import com.vitorpamplona.quartz.nipA4PublicMessages.PublicMessageEvent
+import com.vitorpamplona.quartz.nipC0CodeSnippets.CodeSnippetEvent
+import com.vitorpamplona.quartz.nipC7Chats.ChatEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 /**
@@ -141,8 +151,9 @@ class NostrSignerPermissionLedger(
          *
          * Most of these are *additive, public, non-destructive content* — a new note-like event the
          * user could delete afterwards, in the same risk class as the original kind 1/6/7 set (notes,
-         * reposts, reactions, pictures, videos, public chat, highlights, comments, status). The set
-         * also includes two harmless non-content signatures:
+         * reposts, reactions, pictures, videos, voice, public/live/relay chat, threads, polls,
+         * comments, highlights, code snippets, file metadata, status). The set also includes two
+         * harmless non-content signatures:
          *  - **zap request** (9734) — moves nothing; it only fetches a Lightning invoice. The payment
          *    itself is the separately-gated `value.payInvoice` capability that prompts on *every* use
          *    regardless of policy.
@@ -158,6 +169,10 @@ class NostrSignerPermissionLedger(
          *    destructive/admin calls (NIP-96 blob deletes, NIP-86 relay management); blast radius is too
          *    broad to auto-approve.
          *  - **decryption** ([NostrSignerOp.Decrypt]) and DMs — reveal private content.
+         *  - **reports** (1984) and **torrents** (2003/2004) — publicly attributable social/legal acts
+         *    whose reputational weight makes silent signing surprising, even though they are additive.
+         *  - **addressable/replaceable content** (long-form 30023, wiki 30818, etc.) — a re-sign with
+         *    the same `d` tag overwrites a prior version, so they carry an overwrite risk.
          *
          * Deliberately conservative: when a kind's blast radius is unclear, it is left out so the user
          * is asked rather than surprised.
@@ -167,15 +182,25 @@ class NostrSignerPermissionLedger(
                 TextNoteEvent.KIND, // 1 — short text notes & replies
                 RepostEvent.KIND, // 6 — reposts of text notes
                 ReactionEvent.KIND, // 7 — likes / emoji reactions
+                ChatEvent.KIND, // 9 — NIP-C7 relay chat messages (public)
+                ThreadEvent.KIND, // 11 — NIP-7D thread posts (same risk as kind 1)
                 GenericRepostEvent.KIND, // 16 — reposts of non-text content (same risk as kind 6)
                 PictureEvent.KIND, // 20 — picture posts (same risk as kind 1)
                 VideoNormalEvent.KIND, // 21 — video posts (same risk as a picture)
                 VideoShortEvent.KIND, // 22 — short-form video posts (same risk as a picture)
+                PublicMessageEvent.KIND, // 24 — NIP-A4 public messages (plaintext, public)
                 ChannelMessageEvent.KIND, // 42 — public chat messages
+                PollResponseEvent.KIND, // 1018 — voting in a poll (additive, like a reaction)
+                FileHeaderEvent.KIND, // 1063 — NIP-94 file metadata (shares a file reference)
+                PollEvent.KIND, // 1068 — creating a poll (additive public content)
+                CommentEvent.KIND, // 1111 — NIP-22 threaded comments (same risk as kind 1)
+                VoiceEvent.KIND, // 1222 — voice messages (audio post, like a picture/video)
+                VoiceReplyEvent.KIND, // 1244 — voice replies
+                LiveActivitiesChatMessageEvent.KIND, // 1311 — live-stream chat (sibling of kind 42)
+                CodeSnippetEvent.KIND, // 1337 — NIP-C0 code snippets (additive public content)
                 HighlightEvent.KIND, // 9802 — highlighted snippets shared publicly
                 LnZapRequestEvent.KIND, // 9734 — Lightning zap request; the payment itself still prompts
                 RelayAuthEvent.KIND, // 22242 — NIP-42 relay auth; ephemeral, bound to one relay+challenge
-                CommentEvent.KIND, // 1111 — NIP-22 threaded comments (same risk as kind 1)
                 StatusEvent.KIND, // 30315 — ephemeral user status / presence
             )
     }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/NostrSignerPermissionLedger.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/NostrSignerPermissionLedger.kt
@@ -27,6 +27,7 @@ import com.vitorpamplona.quartz.nip22Comments.CommentEvent
 import com.vitorpamplona.quartz.nip25Reactions.ReactionEvent
 import com.vitorpamplona.quartz.nip28PublicChat.message.ChannelMessageEvent
 import com.vitorpamplona.quartz.nip38UserStatus.StatusEvent
+import com.vitorpamplona.quartz.nip57Zaps.LnZapRequestEvent
 import com.vitorpamplona.quartz.nip68Picture.PictureEvent
 import com.vitorpamplona.quartz.nip84Highlights.HighlightEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
@@ -139,7 +140,10 @@ class NostrSignerPermissionLedger(
          * when doing so **cannot harm the user**. Everything here is *additive, public, and
          * non-destructive* — creating a new note-like event that the user could delete afterwards, in
          * the same risk class as the original kind 1/6/7 set. None of them can silently:
-         *  - spend money (zaps/nutzaps are gated separately and always prompt),
+         *  - spend money — signing a **zap request** (9734) moves nothing; it only fetches a Lightning
+         *    invoice, and the payment itself is the separately-gated `value.payInvoice` capability that
+         *    prompts on *every* use regardless of policy. **Nutzaps (9321) are excluded**: publishing
+         *    one *is* the payment (the event carries the spendable ecash proofs), so it stays ASK.
          *  - overwrite account configuration (profile 0, contacts 3, relay/mute/bookmark lists are
          *    replaceable — a bad write can wipe settings, so they stay ASK),
          *  - delete existing content (kind 5), or
@@ -157,6 +161,7 @@ class NostrSignerPermissionLedger(
                 PictureEvent.KIND, // 20 — picture posts (same risk as kind 1)
                 ChannelMessageEvent.KIND, // 42 — public chat messages
                 HighlightEvent.KIND, // 9802 — highlighted snippets shared publicly
+                LnZapRequestEvent.KIND, // 9734 — Lightning zap request; the payment itself still prompts
                 CommentEvent.KIND, // 1111 — NIP-22 threaded comments (same risk as kind 1)
                 StatusEvent.KIND, // 30315 — ephemeral user status / presence
             )

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/NostrSignerPermissionLedger.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/NostrSignerPermissionLedger.kt
@@ -24,15 +24,22 @@ import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
 import com.vitorpamplona.quartz.nip18Reposts.GenericRepostEvent
 import com.vitorpamplona.quartz.nip18Reposts.RepostEvent
 import com.vitorpamplona.quartz.nip22Comments.CommentEvent
+import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
 import com.vitorpamplona.quartz.nip25Reactions.ReactionEvent
 import com.vitorpamplona.quartz.nip28PublicChat.message.ChannelMessageEvent
+import com.vitorpamplona.quartz.nip35Torrents.TorrentCommentEvent
+import com.vitorpamplona.quartz.nip35Torrents.TorrentEvent
 import com.vitorpamplona.quartz.nip38UserStatus.StatusEvent
 import com.vitorpamplona.quartz.nip42RelayAuth.RelayAuthEvent
 import com.vitorpamplona.quartz.nip53LiveActivities.chat.LiveActivitiesChatMessageEvent
+import com.vitorpamplona.quartz.nip54Wiki.WikiNoteEvent
+import com.vitorpamplona.quartz.nip56Reports.ReportEvent
 import com.vitorpamplona.quartz.nip57Zaps.LnZapRequestEvent
 import com.vitorpamplona.quartz.nip68Picture.PictureEvent
+import com.vitorpamplona.quartz.nip71Video.VideoHorizontalEvent
 import com.vitorpamplona.quartz.nip71Video.VideoNormalEvent
 import com.vitorpamplona.quartz.nip71Video.VideoShortEvent
+import com.vitorpamplona.quartz.nip71Video.VideoVerticalEvent
 import com.vitorpamplona.quartz.nip7DThreads.ThreadEvent
 import com.vitorpamplona.quartz.nip84Highlights.HighlightEvent
 import com.vitorpamplona.quartz.nip88Polls.poll.PollEvent
@@ -149,11 +156,14 @@ class NostrSignerPermissionLedger(
         /**
          * Event kinds auto-approved under [AppSignerPolicy.REASONABLE].
          *
-         * Most of these are *additive, public, non-destructive content* — a new note-like event the
-         * user could delete afterwards, in the same risk class as the original kind 1/6/7 set (notes,
-         * reposts, reactions, pictures, videos, voice, public/live/relay chat, threads, polls,
-         * comments, highlights, code snippets, file metadata, status). The set also includes two
-         * harmless non-content signatures:
+         * Most of these are *public, non-destructive content* — an event the user creates and could
+         * delete afterwards, in the same risk class as the original kind 1/6/7 set (notes, reposts,
+         * reactions, pictures, videos, voice, public/live/relay chat, threads, polls, comments,
+         * highlights, code snippets, file metadata, reports, torrents, long-form articles, wiki, status).
+         * Some are *addressable* (long-form 30023, wiki 30818, legacy video 34235/34236): re-signing
+         * with the same `d` tag replaces the app's own prior version at that address — an accepted
+         * trade-off, since an app that can already post arbitrary notes could do equal reputational harm.
+         * The set also includes two harmless non-content signatures:
          *  - **zap request** (9734) — moves nothing; it only fetches a Lightning invoice. The payment
          *    itself is the separately-gated `value.payInvoice` capability that prompts on *every* use
          *    regardless of policy.
@@ -169,10 +179,8 @@ class NostrSignerPermissionLedger(
          *    destructive/admin calls (NIP-96 blob deletes, NIP-86 relay management); blast radius is too
          *    broad to auto-approve.
          *  - **decryption** ([NostrSignerOp.Decrypt]) and DMs — reveal private content.
-         *  - **reports** (1984) and **torrents** (2003/2004) — publicly attributable social/legal acts
-         *    whose reputational weight makes silent signing surprising, even though they are additive.
-         *  - **addressable/replaceable content** (long-form 30023, wiki 30818, etc.) — a re-sign with
-         *    the same `d` tag overwrites a prior version, so they carry an overwrite risk.
+         *  - **replaceable configuration** (profile 0, contacts 3, and the 10000-range lists above) —
+         *    unlike addressable *content*, these hold account settings a bad write can silently wipe.
          *
          * Deliberately conservative: when a kind's blast radius is unclear, it is left out so the user
          * is asked rather than surprised.
@@ -198,10 +206,17 @@ class NostrSignerPermissionLedger(
                 VoiceReplyEvent.KIND, // 1244 — voice replies
                 LiveActivitiesChatMessageEvent.KIND, // 1311 — live-stream chat (sibling of kind 42)
                 CodeSnippetEvent.KIND, // 1337 — NIP-C0 code snippets (additive public content)
+                ReportEvent.KIND, // 1984 — NIP-56 content/spam reports (moderation flag)
+                TorrentEvent.KIND, // 2003 — NIP-35 torrent announcements (additive public content)
+                TorrentCommentEvent.KIND, // 2004 — NIP-35 torrent comments
                 HighlightEvent.KIND, // 9802 — highlighted snippets shared publicly
                 LnZapRequestEvent.KIND, // 9734 — Lightning zap request; the payment itself still prompts
                 RelayAuthEvent.KIND, // 22242 — NIP-42 relay auth; ephemeral, bound to one relay+challenge
+                LongTextNoteEvent.KIND, // 30023 — NIP-23 long-form articles (addressable content)
                 StatusEvent.KIND, // 30315 — ephemeral user status / presence
+                WikiNoteEvent.KIND, // 30818 — NIP-54 wiki articles (addressable content)
+                VideoHorizontalEvent.KIND, // 34235 — legacy addressable horizontal video (NIP-71)
+                VideoVerticalEvent.KIND, // 34236 — legacy addressable vertical video (NIP-71)
             )
     }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/NostrSignerPermissionLedger.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/NostrSignerPermissionLedger.kt
@@ -27,8 +27,11 @@ import com.vitorpamplona.quartz.nip22Comments.CommentEvent
 import com.vitorpamplona.quartz.nip25Reactions.ReactionEvent
 import com.vitorpamplona.quartz.nip28PublicChat.message.ChannelMessageEvent
 import com.vitorpamplona.quartz.nip38UserStatus.StatusEvent
+import com.vitorpamplona.quartz.nip42RelayAuth.RelayAuthEvent
 import com.vitorpamplona.quartz.nip57Zaps.LnZapRequestEvent
 import com.vitorpamplona.quartz.nip68Picture.PictureEvent
+import com.vitorpamplona.quartz.nip71Video.VideoNormalEvent
+import com.vitorpamplona.quartz.nip71Video.VideoShortEvent
 import com.vitorpamplona.quartz.nip84Highlights.HighlightEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
@@ -136,18 +139,25 @@ class NostrSignerPermissionLedger(
         /**
          * Event kinds auto-approved under [AppSignerPolicy.REASONABLE].
          *
-         * The rule for membership: an app may sign these on the user's behalf without a prompt only
-         * when doing so **cannot harm the user**. Everything here is *additive, public, and
-         * non-destructive* — creating a new note-like event that the user could delete afterwards, in
-         * the same risk class as the original kind 1/6/7 set. None of them can silently:
-         *  - spend money — signing a **zap request** (9734) moves nothing; it only fetches a Lightning
-         *    invoice, and the payment itself is the separately-gated `value.payInvoice` capability that
-         *    prompts on *every* use regardless of policy. **Nutzaps (9321) are excluded**: publishing
-         *    one *is* the payment (the event carries the spendable ecash proofs), so it stays ASK.
-         *  - overwrite account configuration (profile 0, contacts 3, relay/mute/bookmark lists are
-         *    replaceable — a bad write can wipe settings, so they stay ASK),
-         *  - delete existing content (kind 5), or
-         *  - leak private data (DMs and [NostrSignerOp.Decrypt] stay ASK).
+         * Most of these are *additive, public, non-destructive content* — a new note-like event the
+         * user could delete afterwards, in the same risk class as the original kind 1/6/7 set (notes,
+         * reposts, reactions, pictures, videos, public chat, highlights, comments, status). The set
+         * also includes two harmless non-content signatures:
+         *  - **zap request** (9734) — moves nothing; it only fetches a Lightning invoice. The payment
+         *    itself is the separately-gated `value.payInvoice` capability that prompts on *every* use
+         *    regardless of policy.
+         *  - **relay auth** (22242, NIP-42) — an ephemeral proof-of-key bound to a single relay and
+         *    challenge (it cannot be replayed to another relay). Amethyst's own client auto-signs it
+         *    for every logged-in account, so treating it as background noise matches existing behavior.
+         *
+         * None of the members can silently: spend money, overwrite account configuration (profile 0,
+         * contacts 3, relay/mute/bookmark lists are replaceable — a bad write can wipe settings),
+         * delete content (kind 5), or leak private data. Notable exclusions that stay ASK:
+         *  - **nutzap** (9321) — publishing one *is* the payment (it carries spendable ecash proofs).
+         *  - **NIP-98 HTTP auth** (27235) — authorizes an arbitrary HTTP request as the user, including
+         *    destructive/admin calls (NIP-96 blob deletes, NIP-86 relay management); blast radius is too
+         *    broad to auto-approve.
+         *  - **decryption** ([NostrSignerOp.Decrypt]) and DMs — reveal private content.
          *
          * Deliberately conservative: when a kind's blast radius is unclear, it is left out so the user
          * is asked rather than surprised.
@@ -159,9 +169,12 @@ class NostrSignerPermissionLedger(
                 ReactionEvent.KIND, // 7 — likes / emoji reactions
                 GenericRepostEvent.KIND, // 16 — reposts of non-text content (same risk as kind 6)
                 PictureEvent.KIND, // 20 — picture posts (same risk as kind 1)
+                VideoNormalEvent.KIND, // 21 — video posts (same risk as a picture)
+                VideoShortEvent.KIND, // 22 — short-form video posts (same risk as a picture)
                 ChannelMessageEvent.KIND, // 42 — public chat messages
                 HighlightEvent.KIND, // 9802 — highlighted snippets shared publicly
                 LnZapRequestEvent.KIND, // 9734 — Lightning zap request; the payment itself still prompts
+                RelayAuthEvent.KIND, // 22242 — NIP-42 relay auth; ephemeral, bound to one relay+challenge
                 CommentEvent.KIND, // 1111 — NIP-22 threaded comments (same risk as kind 1)
                 StatusEvent.KIND, // 30315 — ephemeral user status / presence
             )

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/NostrSignerPermissionLedger.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/NostrSignerPermissionLedger.kt
@@ -20,6 +20,15 @@
  */
 package com.vitorpamplona.amethyst.commons.napplet.signers
 
+import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
+import com.vitorpamplona.quartz.nip18Reposts.GenericRepostEvent
+import com.vitorpamplona.quartz.nip18Reposts.RepostEvent
+import com.vitorpamplona.quartz.nip22Comments.CommentEvent
+import com.vitorpamplona.quartz.nip25Reactions.ReactionEvent
+import com.vitorpamplona.quartz.nip28PublicChat.message.ChannelMessageEvent
+import com.vitorpamplona.quartz.nip38UserStatus.StatusEvent
+import com.vitorpamplona.quartz.nip68Picture.PictureEvent
+import com.vitorpamplona.quartz.nip84Highlights.HighlightEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
 
 /**
@@ -28,7 +37,7 @@ import com.vitorpamplona.quartz.utils.TimeUtils
  *
  * 1. Per-operation overrides ([NostrSignerPermissionStore.loadOpDecision]) — these always win.
  * 2. The app's [AppSignerPolicy] trust level ([NostrSignerPermissionStore.loadPolicy]).
- * 3. The built-in "reasonable" set (kind 1/6/7 + encrypt are auto-allowed) when policy is [AppSignerPolicy.REASONABLE].
+ * 3. The built-in "reasonable" set ([REASONABLE_SIGN_KINDS] + encrypt are auto-allowed) when policy is [AppSignerPolicy.REASONABLE].
  *
  * When no policy has been set (`null`), [decide] returns [NostrOpDecision.ASK], which triggers the
  * first-connect dialog in the broker.
@@ -117,13 +126,39 @@ class NostrSignerPermissionLedger(
     private fun reasonableDecision(op: NostrSignerOp): NostrOpDecision =
         when (op) {
             is NostrSignerOp.SignKind ->
-                when (op.kind) {
-                    1 -> NostrOpDecision.ALLOW
-                    6 -> NostrOpDecision.ALLOW
-                    7 -> NostrOpDecision.ALLOW
-                    else -> NostrOpDecision.ASK
-                }
+                if (op.kind in REASONABLE_SIGN_KINDS) NostrOpDecision.ALLOW else NostrOpDecision.ASK
             NostrSignerOp.Encrypt -> NostrOpDecision.ALLOW
             NostrSignerOp.Decrypt -> NostrOpDecision.ASK
         }
+
+    companion object {
+        /**
+         * Event kinds auto-approved under [AppSignerPolicy.REASONABLE].
+         *
+         * The rule for membership: an app may sign these on the user's behalf without a prompt only
+         * when doing so **cannot harm the user**. Everything here is *additive, public, and
+         * non-destructive* — creating a new note-like event that the user could delete afterwards, in
+         * the same risk class as the original kind 1/6/7 set. None of them can silently:
+         *  - spend money (zaps/nutzaps are gated separately and always prompt),
+         *  - overwrite account configuration (profile 0, contacts 3, relay/mute/bookmark lists are
+         *    replaceable — a bad write can wipe settings, so they stay ASK),
+         *  - delete existing content (kind 5), or
+         *  - leak private data (DMs and [NostrSignerOp.Decrypt] stay ASK).
+         *
+         * Deliberately conservative: when a kind's blast radius is unclear, it is left out so the user
+         * is asked rather than surprised.
+         */
+        val REASONABLE_SIGN_KINDS: Set<Int> =
+            setOf(
+                TextNoteEvent.KIND, // 1 — short text notes & replies
+                RepostEvent.KIND, // 6 — reposts of text notes
+                ReactionEvent.KIND, // 7 — likes / emoji reactions
+                GenericRepostEvent.KIND, // 16 — reposts of non-text content (same risk as kind 6)
+                PictureEvent.KIND, // 20 — picture posts (same risk as kind 1)
+                ChannelMessageEvent.KIND, // 42 — public chat messages
+                HighlightEvent.KIND, // 9802 — highlighted snippets shared publicly
+                CommentEvent.KIND, // 1111 — NIP-22 threaded comments (same risk as kind 1)
+                StatusEvent.KIND, // 30315 — ephemeral user status / presence
+            )
+    }
 }

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/NostrSignerPermissionLedgerTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/NostrSignerPermissionLedgerTest.kt
@@ -51,13 +51,14 @@ class NostrSignerPermissionLedgerTest {
             ledger.setPolicy(coordinate, AppSignerPolicy.REASONABLE)
 
             // Profile (0), contacts (3), deletion (5), relay list (10002), nutzap (9321), NIP-98 HTTP
-            // auth (27235), and gift-wrapped DM (1059) must never auto-sign — they change config,
-            // delete, spend ecash, authorize arbitrary HTTP calls, or leak. A nutzap in particular *is*
-            // the payment (it carries the ecash proofs), unlike a zap request (9734) which only fetches
-            // an invoice; and NIP-98 authorizes destructive/admin HTTP requests, unlike NIP-42 relay
-            // auth (22242) which is a replay-bound read proof. Decryption reveals private content, so it
-            // also asks.
-            for (kind in listOf(0, 3, 5, 10002, 9321, 27235, 1059)) {
+            // auth (27235), gift-wrapped DM (1059), report (1984), torrent (2003), and long-form
+            // article (30023) must never auto-sign — they change config, delete, spend ecash, authorize
+            // arbitrary HTTP calls, leak, carry reputational/legal weight, or overwrite prior versions.
+            // A nutzap in particular *is* the payment (it carries the ecash proofs), unlike a zap
+            // request (9734) which only fetches an invoice; and NIP-98 authorizes destructive/admin HTTP
+            // requests, unlike NIP-42 relay auth (22242) which is a replay-bound read proof. Decryption
+            // reveals private content, so it also asks.
+            for (kind in listOf(0, 3, 5, 10002, 9321, 27235, 1059, 1984, 2003, 30023)) {
                 assertEquals(
                     NostrOpDecision.ASK,
                     ledger.decide(coordinate, NostrSignerOp.SignKind(kind)),

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/NostrSignerPermissionLedgerTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/NostrSignerPermissionLedgerTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.napplet.signers
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NostrSignerPermissionLedgerTest {
+    private val coordinate = "aa".repeat(32) + ":demo"
+
+    @Test
+    fun reasonableAutoApprovesAdditivePublicContentKinds() =
+        runTest {
+            val ledger = NostrSignerPermissionLedger(InMemoryNostrSignerPermissionStore())
+            ledger.setPolicy(coordinate, AppSignerPolicy.REASONABLE)
+
+            // Every kind in the curated set auto-allows; encryption too.
+            for (kind in NostrSignerPermissionLedger.REASONABLE_SIGN_KINDS) {
+                assertEquals(
+                    NostrOpDecision.ALLOW,
+                    ledger.decide(coordinate, NostrSignerOp.SignKind(kind)),
+                    "kind $kind should be auto-approved under REASONABLE",
+                )
+            }
+            assertEquals(NostrOpDecision.ALLOW, ledger.decide(coordinate, NostrSignerOp.Encrypt))
+        }
+
+    @Test
+    fun reasonableStillAsksForRiskyKindsAndDecryption() =
+        runTest {
+            val ledger = NostrSignerPermissionLedger(InMemoryNostrSignerPermissionStore())
+            ledger.setPolicy(coordinate, AppSignerPolicy.REASONABLE)
+
+            // Profile (0), contacts (3), deletion (5), relay list (10002), zap request (9734),
+            // and gift-wrapped DM (1059) must never auto-sign — they change config, delete, spend,
+            // or leak. Decryption reveals private content, so it also asks.
+            for (kind in listOf(0, 3, 5, 10002, 9734, 1059)) {
+                assertEquals(
+                    NostrOpDecision.ASK,
+                    ledger.decide(coordinate, NostrSignerOp.SignKind(kind)),
+                    "kind $kind must still prompt under REASONABLE",
+                )
+            }
+            assertEquals(NostrOpDecision.ASK, ledger.decide(coordinate, NostrSignerOp.Decrypt))
+        }
+
+    @Test
+    fun fullTrustAllowsEveryKindAndDecryption() =
+        runTest {
+            val ledger = NostrSignerPermissionLedger(InMemoryNostrSignerPermissionStore())
+            ledger.setPolicy(coordinate, AppSignerPolicy.FULL_TRUST)
+
+            assertEquals(NostrOpDecision.ALLOW, ledger.decide(coordinate, NostrSignerOp.SignKind(9999)))
+            assertEquals(NostrOpDecision.ALLOW, ledger.decide(coordinate, NostrSignerOp.Decrypt))
+        }
+
+    @Test
+    fun paranoidAsksForEverything() =
+        runTest {
+            val ledger = NostrSignerPermissionLedger(InMemoryNostrSignerPermissionStore())
+            ledger.setPolicy(coordinate, AppSignerPolicy.PARANOID)
+
+            assertEquals(NostrOpDecision.ASK, ledger.decide(coordinate, NostrSignerOp.SignKind(1)))
+            assertEquals(NostrOpDecision.ASK, ledger.decide(coordinate, NostrSignerOp.Encrypt))
+        }
+
+    @Test
+    fun noPolicyAsks() =
+        runTest {
+            val ledger = NostrSignerPermissionLedger(InMemoryNostrSignerPermissionStore())
+            assertEquals(NostrOpDecision.ASK, ledger.decide(coordinate, NostrSignerOp.SignKind(1)))
+        }
+}

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/NostrSignerPermissionLedgerTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/NostrSignerPermissionLedgerTest.kt
@@ -50,10 +50,12 @@ class NostrSignerPermissionLedgerTest {
             val ledger = NostrSignerPermissionLedger(InMemoryNostrSignerPermissionStore())
             ledger.setPolicy(coordinate, AppSignerPolicy.REASONABLE)
 
-            // Profile (0), contacts (3), deletion (5), relay list (10002), zap request (9734),
-            // and gift-wrapped DM (1059) must never auto-sign — they change config, delete, spend,
-            // or leak. Decryption reveals private content, so it also asks.
-            for (kind in listOf(0, 3, 5, 10002, 9734, 1059)) {
+            // Profile (0), contacts (3), deletion (5), relay list (10002), nutzap (9321), and
+            // gift-wrapped DM (1059) must never auto-sign — they change config, delete, spend ecash,
+            // or leak. A nutzap in particular *is* the payment (it carries the ecash proofs), unlike a
+            // zap request (9734) which only fetches an invoice. Decryption reveals private content, so
+            // it also asks.
+            for (kind in listOf(0, 3, 5, 10002, 9321, 1059)) {
                 assertEquals(
                     NostrOpDecision.ASK,
                     ledger.decide(coordinate, NostrSignerOp.SignKind(kind)),
@@ -61,6 +63,11 @@ class NostrSignerPermissionLedgerTest {
                 )
             }
             assertEquals(NostrOpDecision.ASK, ledger.decide(coordinate, NostrSignerOp.Decrypt))
+
+            // Contrast: a Lightning zap request (9734) auto-signs (the payment prompts separately),
+            // but an ecash nutzap (9321) does not — publishing it spends the tokens.
+            assertEquals(NostrOpDecision.ALLOW, ledger.decide(coordinate, NostrSignerOp.SignKind(9734)))
+            assertEquals(NostrOpDecision.ASK, ledger.decide(coordinate, NostrSignerOp.SignKind(9321)))
         }
 
     @Test

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/NostrSignerPermissionLedgerTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/NostrSignerPermissionLedgerTest.kt
@@ -51,14 +51,14 @@ class NostrSignerPermissionLedgerTest {
             ledger.setPolicy(coordinate, AppSignerPolicy.REASONABLE)
 
             // Profile (0), contacts (3), deletion (5), relay list (10002), nutzap (9321), NIP-98 HTTP
-            // auth (27235), gift-wrapped DM (1059), report (1984), torrent (2003), and long-form
-            // article (30023) must never auto-sign — they change config, delete, spend ecash, authorize
-            // arbitrary HTTP calls, leak, carry reputational/legal weight, or overwrite prior versions.
-            // A nutzap in particular *is* the payment (it carries the ecash proofs), unlike a zap
-            // request (9734) which only fetches an invoice; and NIP-98 authorizes destructive/admin HTTP
-            // requests, unlike NIP-42 relay auth (22242) which is a replay-bound read proof. Decryption
-            // reveals private content, so it also asks.
-            for (kind in listOf(0, 3, 5, 10002, 9321, 27235, 1059, 1984, 2003, 30023)) {
+            // auth (27235), and gift-wrapped DM (1059) must never auto-sign — they change config,
+            // delete, spend ecash, authorize arbitrary HTTP calls, or leak. These are replaceable
+            // *configuration* (0/3/10002), unlike addressable *content* such as long-form (30023) which
+            // is allowed. A nutzap in particular *is* the payment (it carries the ecash proofs), unlike a
+            // zap request (9734) which only fetches an invoice; and NIP-98 authorizes destructive/admin
+            // HTTP requests, unlike NIP-42 relay auth (22242) which is a replay-bound read proof.
+            // Decryption reveals private content, so it also asks.
+            for (kind in listOf(0, 3, 5, 10002, 9321, 27235, 1059)) {
                 assertEquals(
                     NostrOpDecision.ASK,
                     ledger.decide(coordinate, NostrSignerOp.SignKind(kind)),

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/NostrSignerPermissionLedgerTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/NostrSignerPermissionLedgerTest.kt
@@ -50,12 +50,14 @@ class NostrSignerPermissionLedgerTest {
             val ledger = NostrSignerPermissionLedger(InMemoryNostrSignerPermissionStore())
             ledger.setPolicy(coordinate, AppSignerPolicy.REASONABLE)
 
-            // Profile (0), contacts (3), deletion (5), relay list (10002), nutzap (9321), and
-            // gift-wrapped DM (1059) must never auto-sign — they change config, delete, spend ecash,
-            // or leak. A nutzap in particular *is* the payment (it carries the ecash proofs), unlike a
-            // zap request (9734) which only fetches an invoice. Decryption reveals private content, so
-            // it also asks.
-            for (kind in listOf(0, 3, 5, 10002, 9321, 1059)) {
+            // Profile (0), contacts (3), deletion (5), relay list (10002), nutzap (9321), NIP-98 HTTP
+            // auth (27235), and gift-wrapped DM (1059) must never auto-sign — they change config,
+            // delete, spend ecash, authorize arbitrary HTTP calls, or leak. A nutzap in particular *is*
+            // the payment (it carries the ecash proofs), unlike a zap request (9734) which only fetches
+            // an invoice; and NIP-98 authorizes destructive/admin HTTP requests, unlike NIP-42 relay
+            // auth (22242) which is a replay-bound read proof. Decryption reveals private content, so it
+            // also asks.
+            for (kind in listOf(0, 3, 5, 10002, 9321, 27235, 1059)) {
                 assertEquals(
                     NostrOpDecision.ASK,
                     ledger.decide(coordinate, NostrSignerOp.SignKind(kind)),
@@ -68,6 +70,11 @@ class NostrSignerPermissionLedgerTest {
             // but an ecash nutzap (9321) does not — publishing it spends the tokens.
             assertEquals(NostrOpDecision.ALLOW, ledger.decide(coordinate, NostrSignerOp.SignKind(9734)))
             assertEquals(NostrOpDecision.ASK, ledger.decide(coordinate, NostrSignerOp.SignKind(9321)))
+
+            // Contrast: NIP-42 relay auth (22242) auto-signs — it is a replay-bound read proof — but
+            // NIP-98 HTTP auth (27235) does not, since it can authorize destructive/admin HTTP calls.
+            assertEquals(NostrOpDecision.ALLOW, ledger.decide(coordinate, NostrSignerOp.SignKind(22242)))
+            assertEquals(NostrOpDecision.ASK, ledger.decide(coordinate, NostrSignerOp.SignKind(27235)))
         }
 
     @Test


### PR DESCRIPTION
## Summary

The `REASONABLE` app-signer policy ("Let's be reasonable") previously auto-approved only kinds **1, 6, 7** + encrypt, so common napplets prompted on almost every action. This expands the auto-approve set to the full class of **additive, public, non-destructive** content and engagement events plus two harmless non-content signatures, cutting redundant permission prompts without lowering the security bar. The dividing line is documented in `NostrSignerPermissionLedger.REASONABLE_SIGN_KINDS`.

**Now auto-approved** (in addition to 1/6/7 + encrypt): relay chat (9), threads (11), generic reposts (16), pictures (20), video (21/22), public messages (24), public chat (42), poll votes (1018), file metadata (1063), polls (1068), comments (1111), voice (1222/1244), live-stream chat (1311), code snippets (1337), reports (1984), torrents (2003/2004), zap requests (9734), highlights (9802), NIP-42 relay auth (22242), long-form articles (30023), user status (30315), wiki (30818), and the legacy addressable video kinds (34235/34236).

**Still prompts (`ASK`) by design:**
- **Money-movers** — nutzaps (9321) *are* the payment (they carry spendable ecash proofs). Zap requests (9734) only fetch an invoice; the actual payment is the separately-gated `value.payInvoice` capability that prompts on every use regardless of policy.
- **Replaceable configuration** — profile (0), contacts (3), and the 10000-range lists (relays, mutes, bookmarks). A bad write there can silently wipe account settings — distinct from *addressable content*, which only replaces the app's own prior version.
- **Destructive** — deletions (5).
- **NIP-98 HTTP auth (27235)** — authorizes arbitrary HTTP requests as the user, including destructive NIP-96 blob deletes and NIP-86 relay-admin calls; too broad to sign silently, unlike NIP-42's replay-bound relay auth.
- **Private data** — DMs and all decryption.

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Ran `./gradlew :commons:jvmTest` for `NostrSignerPermissionLedgerTest` (new) and `NappletBrokerTest` — both green
- [x] Manually exercised the change via the new unit tests

Notes:

Added `NostrSignerPermissionLedgerTest` which drives the decision path end-to-end: every kind in `REASONABLE_SIGN_KINDS` auto-allows, encryption allows, and the excluded kinds (0/3/5/10002 config, 9321 nutzap, 27235 NIP-98, 1059 DM) plus decryption still `ASK`. It also pins the two contrasts that motivate the split — zap request (9734) allows while nutzap (9321) asks; NIP-42 relay auth (22242) allows while NIP-98 HTTP auth (27235) asks. `FULL_TRUST`, `PARANOID`, and no-policy paths are covered too.

This is backend permission logic in `commons` — no UI surface changed.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## AI assistance

- [x] Drafted with AI assistance, manually reviewed and tested

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WMrHZfwN5tM4ecvdz7xigo

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMrHZfwN5tM4ecvdz7xigo)_