### PR TITLE
Repair equals/hashCode contracts in OpenTimestamps ops and VerifyResult

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/VerifyResult.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/VerifyResult.kt
@@ -40,5 +40,10 @@ data class VerifyResult(
         return "block $height attests data existed as of unix timestamp of $timestamp"
     }
 
+    /**
+     * Orders by [height] only, intentionally ignoring [timestamp] — NOT
+     * consistent with [equals], which compares both fields. Fine for picking
+     * the earliest attestation; do not rely on it for sorted-set dedup.
+     */
     override fun compareTo(other: VerifyResult): Int = this.height - other.height
 }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/VerifyResult.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/VerifyResult.kt
@@ -23,7 +23,7 @@ package com.vitorpamplona.quartz.nip03Timestamp.ots
 /**
  * Class that lets us compare, sort, store and print timestamps.
  */
-class VerifyResult(
+data class VerifyResult(
     val timestamp: Long?,
     val height: Int,
 ) : Comparable<VerifyResult> {
@@ -41,11 +41,4 @@ class VerifyResult(
     }
 
     override fun compareTo(other: VerifyResult): Int = this.height - other.height
-
-    override fun equals(other: Any?): Boolean {
-        val vr = other as VerifyResult
-        return this.timestamp == vr.timestamp && this.height == vr.height
-    }
-
-    override fun hashCode(): Int = (((this.timestamp) as Long).toInt()) xor this.height
 }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/op/OpAppend.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/op/OpAppend.kt
@@ -37,16 +37,6 @@ class OpAppend(
 
     public override fun call(msg: ByteArray): ByteArray = msg + this.arg
 
-    override fun equals(other: Any?): Boolean {
-        if (other !is OpAppend) {
-            return false
-        }
-
-        return this.arg.contentEquals(other.arg)
-    }
-
-    override fun hashCode(): Int = TAG.toInt() xor this.arg.contentHashCode()
-
     companion object {
         val TAG: Byte = 0xf0.toByte()
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/op/OpBinary.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/op/OpBinary.kt
@@ -53,7 +53,9 @@ abstract class OpBinary(
         return this.tag() - other.tag()
     }
 
-    override fun hashCode(): Int = TAG.toInt() xor this.arg.contentHashCode()
+    override fun equals(other: Any?): Boolean = other is OpBinary && this.tag() == other.tag() && this.arg.contentEquals(other.arg)
+
+    override fun hashCode(): Int = this.tag().toInt() xor this.arg.contentHashCode()
 
     companion object {
         @Throws(DeserializationException::class)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/op/OpBinary.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/op/OpBinary.kt
@@ -53,7 +53,11 @@ abstract class OpBinary(
         return this.tag() - other.tag()
     }
 
-    override fun equals(other: Any?): Boolean = other is OpBinary && this.tag() == other.tag() && this.arg.contentEquals(other.arg)
+    // Class-scoped equality: never conflates two ops as Timestamp.ops map keys
+    // even if a subclass reused a tag by mistake. hashCode stays tag-based
+    // (collisions are legal). Tag uniqueness itself is a protocol invariant
+    // (serialization dispatches on it), pinned by OtsEqualsContractTest.
+    override fun equals(other: Any?): Boolean = other is OpBinary && this::class == other::class && this.arg.contentEquals(other.arg)
 
     override fun hashCode(): Int = this.tag().toInt() xor this.arg.contentHashCode()
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/op/OpCrypto.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/op/OpCrypto.kt
@@ -64,6 +64,14 @@ abstract class OpCrypto internal constructor() : OpUnary() {
         return hashFd(ctx)
     }
 
+    // Crypto ops carry no identity state — class-scoped equality with a
+    // tag-based hashCode (never conflates ops even if a subclass reused a
+    // tag by mistake). Tag uniqueness itself is a protocol invariant
+    // (serialization dispatches on it), pinned by OtsEqualsContractTest.
+    override fun equals(other: Any?): Boolean = other is OpCrypto && this::class == other::class
+
+    override fun hashCode(): Int = this.tag().toInt()
+
     companion object {
         fun deserializeFromTag(
             ctx: StreamDeserializationContext,

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/op/OpKECCAK256.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/op/OpKECCAK256.kt
@@ -49,10 +49,6 @@ class OpKECCAK256 : OpCrypto() {
         return hash
     }
 
-    override fun equals(other: Any?): Boolean = (other is OpKECCAK256)
-
-    override fun hashCode(): Int = TAG.toInt()
-
     companion object {
         val TAG: Byte = 103.toByte()
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/op/OpKECCAK256.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/op/OpKECCAK256.kt
@@ -51,6 +51,8 @@ class OpKECCAK256 : OpCrypto() {
 
     override fun equals(other: Any?): Boolean = (other is OpKECCAK256)
 
+    override fun hashCode(): Int = TAG.toInt()
+
     companion object {
         val TAG: Byte = 103.toByte()
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/op/OpPrepend.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/op/OpPrepend.kt
@@ -37,16 +37,6 @@ class OpPrepend(
 
     public override fun call(msg: ByteArray): ByteArray = this.arg + msg
 
-    override fun equals(other: Any?): Boolean {
-        if (other !is OpPrepend) {
-            return false
-        }
-
-        return this.arg.contentEquals(other.arg)
-    }
-
-    public override fun hashCode(): Int = TAG.toInt() xor this.arg.contentHashCode()
-
     companion object {
         val TAG: Byte = 0xf1.toByte()
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/op/OpRIPEMD160.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/op/OpRIPEMD160.kt
@@ -48,10 +48,6 @@ class OpRIPEMD160 : OpCrypto() {
         return hash
     }
 
-    override fun equals(other: Any?): Boolean = (other is OpRIPEMD160)
-
-    override fun hashCode(): Int = TAG.toInt()
-
     companion object {
         val TAG: Byte = 0x03
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/op/OpSHA1.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/op/OpSHA1.kt
@@ -46,10 +46,6 @@ class OpSHA1 : OpCrypto() {
 
     override fun call(msg: ByteArray): ByteArray = super.call(msg)
 
-    override fun equals(other: Any?): Boolean = (other is OpSHA1)
-
-    override fun hashCode(): Int = TAG.toInt()
-
     companion object {
         val TAG: Byte = 0x02
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/op/OpSHA256.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/op/OpSHA256.kt
@@ -40,10 +40,6 @@ class OpSHA256 : OpCrypto() {
 
     override fun call(msg: ByteArray): ByteArray = super.call(msg)
 
-    override fun equals(other: Any?): Boolean = (other is OpSHA256)
-
-    override fun hashCode(): Int = TAG.toInt()
-
     companion object {
         val TAG: Byte = 0x08
 

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/OtsEqualsContractTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/OtsEqualsContractTest.kt
@@ -24,11 +24,13 @@ import com.vitorpamplona.quartz.nip03Timestamp.ots.op.Op
 import com.vitorpamplona.quartz.nip03Timestamp.ots.op.OpAppend
 import com.vitorpamplona.quartz.nip03Timestamp.ots.op.OpKECCAK256
 import com.vitorpamplona.quartz.nip03Timestamp.ots.op.OpPrepend
+import com.vitorpamplona.quartz.nip03Timestamp.ots.op.OpRIPEMD160
+import com.vitorpamplona.quartz.nip03Timestamp.ots.op.OpSHA1
+import com.vitorpamplona.quartz.nip03Timestamp.ots.op.OpSHA256
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
 
 /**
  * Equals/hashCode contract tests for the types keying [Timestamp.ops]
@@ -36,6 +38,23 @@ import kotlin.test.assertTrue
  * lookups produce duplicate branches and failed upgrades.
  */
 class OtsEqualsContractTest {
+    @Test
+    fun allOpTagsAreUnique() {
+        // The protocol invariant everything leans on: serialization dispatches
+        // on the tag byte and hashCode is tag-based. A new op MUST use a fresh tag.
+        val tags =
+            listOf(
+                OpAppend.TAG,
+                OpPrepend.TAG,
+                OpSHA1.TAG,
+                OpSHA256.TAG,
+                OpRIPEMD160.TAG,
+                OpKECCAK256.TAG,
+            )
+
+        assertEquals(tags.size, tags.toSet().size)
+    }
+
     // --- OpKECCAK256: equals existed without hashCode; equal instances hashed by identity ---
 
     @Test
@@ -52,6 +71,12 @@ class OtsEqualsContractTest {
         val map = mutableMapOf<Op, String>(OpKECCAK256() to "branch")
 
         assertEquals("branch", map[OpKECCAK256()])
+    }
+
+    @Test
+    fun cryptoOpsWithDifferentTagsAreNotEqual() {
+        // The shared OpCrypto equals is tag-keyed — distinct ops must not conflate.
+        assertNotEquals<Op>(OpSHA256(), OpKECCAK256())
     }
 
     // --- OpBinary: equals is defined once on the superclass, keyed on tag() + arg content ---
@@ -105,6 +130,6 @@ class OtsEqualsContractTest {
         val result = VerifyResult(null, 100)
 
         result.hashCode()
-        assertTrue(result == VerifyResult(null, 100))
+        assertEquals(VerifyResult(null, 100), result)
     }
 }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/OtsEqualsContractTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip03Timestamp/ots/OtsEqualsContractTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip03Timestamp.ots
+
+import com.vitorpamplona.quartz.nip03Timestamp.ots.op.Op
+import com.vitorpamplona.quartz.nip03Timestamp.ots.op.OpAppend
+import com.vitorpamplona.quartz.nip03Timestamp.ots.op.OpKECCAK256
+import com.vitorpamplona.quartz.nip03Timestamp.ots.op.OpPrepend
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Equals/hashCode contract tests for the types keying [Timestamp.ops]
+ * (a MutableMap<Op, Timestamp>): equal ops MUST hash equally or map
+ * lookups produce duplicate branches and failed upgrades.
+ */
+class OtsEqualsContractTest {
+    // --- OpKECCAK256: equals existed without hashCode; equal instances hashed by identity ---
+
+    @Test
+    fun keccakInstancesAreEqualAndHashEqually() {
+        val a = OpKECCAK256()
+        val b = OpKECCAK256()
+
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+
+    @Test
+    fun keccakWorksAsMapKey() {
+        val map = mutableMapOf<Op, String>(OpKECCAK256() to "branch")
+
+        assertEquals("branch", map[OpKECCAK256()])
+    }
+
+    // --- OpBinary: equals is defined once on the superclass, keyed on tag() + arg content ---
+
+    @Test
+    fun binaryOpsWithSameArgAndClassAreEqual() {
+        val arg = byteArrayOf(1, 2, 3)
+
+        assertEquals(OpAppend(arg), OpAppend(byteArrayOf(1, 2, 3)))
+        assertEquals(OpAppend(arg).hashCode(), OpAppend(byteArrayOf(1, 2, 3)).hashCode())
+    }
+
+    @Test
+    fun binaryOpsWithDifferentArgAreNotEqual() {
+        assertNotEquals(OpAppend(byteArrayOf(1, 2, 3)), OpAppend(byteArrayOf(9)))
+    }
+
+    @Test
+    fun appendAndPrependWithSameArgAreNotEqual() {
+        // Same arg content, different tag — the superclass equals must not conflate them.
+        val arg = byteArrayOf(1, 2, 3)
+
+        assertNotEquals<Op>(OpAppend(arg), OpPrepend(arg))
+    }
+
+    @Test
+    fun binaryOpsWorkAsMapKeys() {
+        val map = mutableMapOf<Op, String>()
+        map[OpAppend(byteArrayOf(1, 2, 3))] = "append"
+        map[OpPrepend(byteArrayOf(1, 2, 3))] = "prepend"
+
+        assertEquals(2, map.size)
+        assertEquals("append", map[OpAppend(byteArrayOf(1, 2, 3))])
+        assertEquals("prepend", map[OpPrepend(byteArrayOf(1, 2, 3))])
+    }
+
+    // --- VerifyResult: equals used to throw on null/foreign types; hashCode NPEd on null timestamp ---
+
+    @Test
+    fun verifyResultEqualsNullIsFalse() {
+        assertFalse(VerifyResult(1234L, 100).equals(null))
+    }
+
+    @Test
+    fun verifyResultEqualsForeignTypeIsFalse() {
+        assertFalse(VerifyResult(1234L, 100).equals("not a VerifyResult"))
+    }
+
+    @Test
+    fun verifyResultWithNullTimestampHashesWithoutThrowing() {
+        val result = VerifyResult(null, 100)
+
+        result.hashCode()
+        assertTrue(result == VerifyResult(null, 100))
+    }
+}


### PR DESCRIPTION
Problem

Op instances key Timestamp.ops (a MutableMap<Op, Timestamp>), the tree structure every OTS stamp, merge, upgrade, and verification walks — so equals/hashCode contract violations there translate directly into corrupted timestamp trees. The NIP-03 code had four latent issues:

- OpKECCAK256 defined equals without hashCode, so two equal instances hashed by identity. Logically-equal map keys could land in different buckets, producing duplicate branches or failed lookups when merging or upgrading a timestamp tree with a keccak256 branch (rare in Bitcoin-anchored proofs, which is why it hadn't bitten).
- VerifyResult.equals cast its argument without a type test, throwing ClassCastException instead of returning false for null or foreign types, and VerifyResult.hashCode force-cast the nullable timestamp, crashing with an NPE for any pending result (VerifyResult(null, height)).
- OpBinary.hashCode silently resolved TAG to the base Op.TAG (0x00), a no-op XOR — masked only because both subclasses happened to override it.
- The equals/hashCode pair was copy-pasted across six concrete op classes with slight variations, which is exactly the pattern that produced the missing-hashCode bug and invited the next one.

Fix

- VerifyResult is now a data class: generated equals/hashCode are null-safe and type-tested; the custom toString and compareTo are kept, with compareTo documented as intentionally ordering by height only.
- Each Op subtree defines the pair once: OpBinary (runtime class + arg content) and OpCrypto (runtime class), with tag-based hashCodes; the six per-subclass copies are deleted.
- Equality is class-scoped rather than tag-scoped, so even a future subclass that mistakenly reused a tag byte could never conflate two distinct ops as map keys; the tag-uniqueness protocol invariant itself (serialization dispatches on it) is pinned by a dedicated test.

Testing

- New OtsEqualsContractTest in commonTest (11 tests, runs on plain :quartz:jvmTest, so CI covers it): map-key round-trips for crypto and binary ops, equal-instances-hash-equally, append-vs-prepend and cross-crypto-op non-conflation, the three previously-crashing VerifyResult paths, and pairwise tag uniqueness across all six concrete ops.
- Instrumented OtsTest suite: 4/4 passing on a Pixel 9a (Android 17), exercising real OTS proof verification end-to-end through the changed map keying.
- Manual on-device check: opened live notes carrying kind-1040 attestations in the app built from this branch and confirmed the Timestamp Proof dialog renders the expected "block N attests data existed as of …" result for a recently confirmed attestation.

## License

- [ ] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
