### PR TITLE
Add efficient hex-to-Long conversion utilities for Nostr IDs

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/utils/Hex.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/utils/Hex.kt
@@ -201,6 +201,68 @@ object Hex {
     }
 
     /**
+     * Packs 16 hex chars starting at [offset] into a single [Long] (big-endian:
+     * the first char becomes the most-significant nibble). No allocations, no
+     * branches — just 16 table lookups and shifts.
+     *
+     * Assumes [hex] has at least `offset + 16` valid hex chars; it does not
+     * validate. Guard untrusted input with [isHex64] first, otherwise an invalid
+     * char (table value `-1`) corrupts the result.
+     */
+    fun readLong(
+        hex: String,
+        offset: Int,
+    ): Long =
+        (hexToByte[hex[offset].code].toLong() shl 60) or
+            (hexToByte[hex[offset + 1].code].toLong() shl 56) or
+            (hexToByte[hex[offset + 2].code].toLong() shl 52) or
+            (hexToByte[hex[offset + 3].code].toLong() shl 48) or
+            (hexToByte[hex[offset + 4].code].toLong() shl 44) or
+            (hexToByte[hex[offset + 5].code].toLong() shl 40) or
+            (hexToByte[hex[offset + 6].code].toLong() shl 36) or
+            (hexToByte[hex[offset + 7].code].toLong() shl 32) or
+            (hexToByte[hex[offset + 8].code].toLong() shl 28) or
+            (hexToByte[hex[offset + 9].code].toLong() shl 24) or
+            (hexToByte[hex[offset + 10].code].toLong() shl 20) or
+            (hexToByte[hex[offset + 11].code].toLong() shl 16) or
+            (hexToByte[hex[offset + 12].code].toLong() shl 12) or
+            (hexToByte[hex[offset + 13].code].toLong() shl 8) or
+            (hexToByte[hex[offset + 14].code].toLong() shl 4) or
+            hexToByte[hex[offset + 15].code].toLong()
+
+    /**
+     * Reads the first 64 bits (16 hex chars) of [hex] as a single [Long].
+     * Ideal as a cheap, collision-resistant map/set key or bucket hash for a
+     * 32-byte event id or pubkey. Assumes [hex] is at least 16 valid hex chars —
+     * see [readLong].
+     */
+    fun toLong64(hex: String): Long = readLong(hex, 0)
+
+    /**
+     * Reads the first 128 bits (32 hex chars) of [hex] as two [Long]s, most
+     * significant first. Assumes [hex] is at least 32 valid hex chars — see
+     * [readLong].
+     */
+    fun toLong128(hex: String): LongArray =
+        longArrayOf(
+            readLong(hex, 0),
+            readLong(hex, 16),
+        )
+
+    /**
+     * Reads a full 256-bit (64 hex char) id/pubkey/signature-half as four
+     * [Long]s, most significant first. Assumes [hex] is at least 64 valid hex
+     * chars — see [readLong].
+     */
+    fun toLong256(hex: String): LongArray =
+        longArrayOf(
+            readLong(hex, 0),
+            readLong(hex, 16),
+            readLong(hex, 32),
+            readLong(hex, 48),
+        )
+
+    /**
      * True when the hex string [id] encodes exactly the bytes [ourId], compared
      * without allocating a decode buffer. Handy for matching an incoming hex id
      * against bytes you already hold. Assumes [id] is at least `2 * ourId.size`

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/utils/HexEncodingTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/utils/HexEncodingTest.kt
@@ -77,4 +77,53 @@ class HexEncodingTest {
             )
         }
     }
+
+    @Test
+    fun testToLong64() {
+        assertEquals(0x48a72b485d383386uL.toLong(), Hex.toLong64(testHex))
+        assertEquals(0L, Hex.toLong64("0000000000000000"))
+        assertEquals(-1L, Hex.toLong64("ffffffffffffffff"))
+        // uppercase reads the same
+        assertEquals(0x48a72b485d383386uL.toLong(), Hex.toLong64(testHex.uppercase()))
+    }
+
+    @Test
+    fun testToLong128() {
+        val longs = Hex.toLong128(testHex)
+        assertEquals(2, longs.size)
+        assertEquals(0x48a72b485d383386uL.toLong(), longs[0])
+        assertEquals(0x27ec9d427583551fuL.toLong(), longs[1])
+    }
+
+    @Test
+    fun testToLong256() {
+        val longs = Hex.toLong256(testHex)
+        assertEquals(4, longs.size)
+        assertEquals(0x48a72b485d383386uL.toLong(), longs[0])
+        assertEquals(0x27ec9d427583551fuL.toLong(), longs[1])
+        assertEquals(0x9af4f016c739b8ecuL.toLong(), longs[2])
+        assertEquals(0x0d6313540a8b12cfuL.toLong(), longs[3])
+    }
+
+    @OptIn(ExperimentalStdlibApi::class)
+    @Test
+    fun testToLongMatchesDecodedBytes() {
+        for (i in 0..1000) {
+            val bytes = Random.nextBytes(32)
+            val hex = bytes.toHexString(HexFormat.Default)
+
+            // the four longs must reconstruct exactly the 32 decoded bytes, big-endian
+            val longs = Hex.toLong256(hex)
+            for (word in 0 until 4) {
+                for (b in 0 until 8) {
+                    val expected = bytes[word * 8 + b].toLong() and 0xFF
+                    val actual = (longs[word] ushr ((7 - b) * 8)) and 0xFF
+                    assertEquals(expected, actual, hex)
+                }
+            }
+
+            assertEquals(longs[0], Hex.toLong64(hex))
+            assertEquals(longs.take(2), Hex.toLong128(hex).toList())
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Add three new high-performance functions to `Hex` for converting hex strings directly to `Long` values without allocating intermediate byte arrays. These functions are optimized for Nostr use cases where 64-bit, 128-bit, and 256-bit hex-encoded IDs/pubkeys need to be converted to `LongArray` for efficient hashing, comparison, or storage.

- `readLong(hex, offset)` — core function that packs 16 hex chars into a single `Long` using table lookups and bit shifts
- `toLong64(hex)` — reads first 64 bits (16 hex chars) as a `Long`
- `toLong128(hex)` — reads first 128 bits (32 hex chars) as a `LongArray` of 2 elements
- `toLong256(hex)` — reads full 256 bits (64 hex chars) as a `LongArray` of 4 elements

These are ideal as collision-resistant map/set keys or bucket hashes for event IDs and pubkeys. The implementation uses the existing `hexToByte` lookup table and performs no allocations beyond the returned `LongArray`.

## Test plan

- [x] Ran `./gradlew test` — all tests pass, including new comprehensive test suite
- [x] Added unit tests covering:
  - `testToLong64()` — validates 64-bit conversion with lowercase, uppercase, zero, and max values
  - `testToLong128()` — validates 128-bit conversion returns correct 2-element array
  - `testToLong256()` — validates 256-bit conversion returns correct 4-element array
  - `testToLongMatchesDecodedBytes()` — property-based test (1000 random 32-byte inputs) verifying that the four `Long` values reconstruct exactly the original bytes in big-endian order, and that `toLong64` and `toLong128` are consistent prefixes of `toLong256`

## Interop suites

- [x] N/A — change is a utility function in `quartz/` with no wire format or protocol impact

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_019CU1wR6NvQmdmNNsPe9GuN