### PR TITLE
Clean up empty when branches and remove unnecessary null checks

### DIFF
--- a/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/KeyCommands.kt
+++ b/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/KeyCommands.kt
@@ -77,7 +77,7 @@ object KeyCommands {
             Output.emit(mapOf("valid" to false))
             return 0
         }
-        val npub = hex!!.hexToByteArray().toNpub()
+        val npub = hex.hexToByteArray().toNpub()
         Output.emit(mapOf("valid" to true, "pubkey" to hex, "npub" to npub))
         return 0
     }

--- a/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/NostrConnect.kt
+++ b/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/NostrConnect.kt
@@ -81,7 +81,7 @@ object NostrConnect {
             }
         }
         if (secret == null) return null
-        return Offer(clientPubkey, relays, secret!!, name)
+        return Offer(clientPubkey, relays, secret, name)
     }
 
     private fun buildOffer(

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/NostrSignerPermissionLedger.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/napplet/signers/NostrSignerPermissionLedger.kt
@@ -185,6 +185,7 @@ class NostrSignerPermissionLedger(
          * Deliberately conservative: when a kind's blast radius is unclear, it is left out so the user
          * is asked rather than surprised.
          */
+        @Suppress("DEPRECATION") // TorrentCommentEvent is deprecated (NIP-22) but still a reasonable sign kind
         val REASONABLE_SIGN_KINDS: Set<Int> =
             setOf(
                 TextNoteEvent.KIND, // 1 — short text notes & replies

--- a/commons/src/jvmMain/kotlin/com/vitorpamplona/amethyst/commons/keystorage/SecureKeyStorage.kt
+++ b/commons/src/jvmMain/kotlin/com/vitorpamplona/amethyst/commons/keystorage/SecureKeyStorage.kt
@@ -324,7 +324,7 @@ actual class SecureKeyStorage private actual constructor() {
                 } else {
                     // Fallback for non-interactive environments (testing, etc.)
                     print("Enter master password: ")
-                    readLine() ?: throw SecureStorageException("Password required for fallback storage")
+                    readlnOrNull() ?: throw SecureStorageException("Password required for fallback storage")
                 }
         }
         return fallbackPassword!!

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/kinds/KindNames.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/kinds/KindNames.kt
@@ -326,6 +326,7 @@ data class KindName(
  * platform concern layered on top, never a fork of this data.
  */
 object KindNames {
+    @Suppress("DEPRECATION") // registry intentionally names deprecated kinds (GitReply, TorrentComment) for display
     val names: Map<Int, KindName> =
         mapOf(
             AcceptedBadgeSetEvent.KIND to KindName("Accepted Badge Set", "58"),

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/relay/commands/toRelay/CommandSerializer.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip01Core/relay/commands/toRelay/CommandSerializer.kt
@@ -83,9 +83,7 @@ class CommandSerializer : StdSerializer<Command>(Command::class.java) {
                 gen.writeString(cmd.subId)
             }
 
-            else -> {
-                null
-            }
+            else -> {}
         }
 
         gen.writeEndArray()

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnection.kt
@@ -2523,9 +2523,7 @@ class QuicConnection(
             PathValidator.RecordResult.Stored,
             PathValidator.RecordResult.Duplicate,
             PathValidator.RecordResult.AlreadyRetired,
-            -> {
-                Unit
-            }
+            -> {}
 
             PathValidator.RecordResult.PoolFull -> {
                 // Peer over-issued past its own advertised
@@ -2573,11 +2571,9 @@ class QuicConnection(
         // same path before the next outbound packet (which would
         // otherwise stamp a now-retired CID).
         when (val rotation = pathValidator.forceRotateToHigherSequence()) {
-            null -> {
-                Unit
-            }
-
             // active CID is still valid; nothing to do.
+            null -> {}
+
             PathValidator.ForcedRotationResult.NoSpareCid -> {
                 // Watermark forced retirement of the active CID but
                 // the pool is empty — we have nothing valid to use.
@@ -2613,9 +2609,7 @@ class QuicConnection(
         when (val outcome = pathValidator.applyPathResponse(payload)) {
             PathValidator.ValidationOutcome.NotValidating,
             PathValidator.ValidationOutcome.PayloadMismatch,
-            -> {
-                Unit
-            }
+            -> {}
 
             is PathValidator.ValidationOutcome.Validated -> {
                 // Bug-7 fix: a valid PATH_RESPONSE proves the peer

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionParser.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/connection/QuicConnectionParser.kt
@@ -852,9 +852,7 @@ private fun dispatchFrames(
                 // peer knows it just violated the spec instead of
                 // having its bytes silently dropped.
                 when (stream.receive.insert(frame.offset, frame.data, frame.fin)) {
-                    com.vitorpamplona.quic.stream.ReceiveBuffer.InsertResult.OK -> {
-                        Unit
-                    }
+                    com.vitorpamplona.quic.stream.ReceiveBuffer.InsertResult.OK -> {}
 
                     com.vitorpamplona.quic.stream.ReceiveBuffer.InsertResult.OFFSET_PAST_FIN -> {
                         conn.markClosedExternally(

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/http3/Http3FrameReader.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/http3/Http3FrameReader.kt
@@ -165,9 +165,7 @@ class Http3FrameReader(
             )
         }
         when (context) {
-            StreamContext.UNCHECKED -> {
-                Unit
-            }
+            StreamContext.UNCHECKED -> {}
 
             StreamContext.CONTROL -> {
                 // §7.2.4: SETTINGS MUST be the first frame on the

--- a/quic/src/commonMain/kotlin/com/vitorpamplona/quic/webtransport/WtPeerStreamDemux.kt
+++ b/quic/src/commonMain/kotlin/com/vitorpamplona/quic/webtransport/WtPeerStreamDemux.kt
@@ -491,9 +491,7 @@ class WtPeerStreamDemux(
                 }
 
                 // no new requests; we don't enforce yet
-                else -> {
-                    Unit
-                }
+                else -> {}
             }
         }
     }


### PR DESCRIPTION
## Summary

This PR performs a series of code cleanup improvements across the codebase:

1. **Simplify empty `when` branches**: Replace verbose `-> { Unit }` patterns with concise `-> {}` syntax in multiple files (QuicConnection, CommandSerializer, QuicConnectionParser, Http3FrameReader, WtPeerStreamDemux).

2. **Remove unnecessary null-coalescing operators**: Eliminate redundant `!!` and `!` operators where variables are already known to be non-null after null checks (KeyCommands, NostrConnect).

3. **Update deprecated API calls**: Replace `readLine()` with `readlnOrNull()` in SecureKeyStorage to use the modern Kotlin stdlib API.

4. **Add deprecation suppressions**: Add `@Suppress("DEPRECATION")` annotations with explanatory comments for intentional uses of deprecated kinds (TorrentCommentEvent, GitReply) in NostrSignerPermissionLedger and KindNames where the deprecation is acceptable for the use case.

These changes improve code clarity, reduce unnecessary null-safety boilerplate, and modernize API usage without altering functionality.

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Ran `./gradlew test` — all tests pass
- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

These are purely stylistic and API modernization changes with no behavioral impact. The null-check removals are safe because they occur after explicit null checks in the same scope.

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_018nqdy4VTLKidUWzGTJPja9