### PR TITLE
Fix race condition in fetchFirst when relay sends buffered events at EOSE

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchFirstExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchFirstExt.kt
@@ -120,7 +120,17 @@ suspend fun INostrClient.fetchFirst(
                         remaining.clear()
                     }
                     doneChannel.onReceive { relay ->
-                        remaining.remove(relay)
+                        // A relay sends its matching events before its EOSE, so an event may
+                        // already be buffered when this completion fires. select() picks a ready
+                        // clause at random, so without this drain we could treat the relay as done
+                        // and exit while its event still sits unread in the channel.
+                        val buffered = eventChannel.tryReceive().getOrNull()
+                        if (buffered != null) {
+                            result = buffered
+                            remaining.clear()
+                        } else {
+                            remaining.remove(relay)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Fix a race condition in `NostrClientFetchFirstExt.kt` where a relay's buffered events could be lost if the EOSE completion fires before `select()` reads from the event channel. When a relay sends matching events followed by EOSE, the event may already be buffered in the channel when the completion handler runs. Without draining the channel first, we could incorrectly mark the relay as done and exit while unread events sit in the buffer.

The fix checks for buffered events in the EOSE handler before removing the relay from the remaining set. If an event is found, we use it immediately and clear the remaining relays; otherwise, we proceed with the original removal logic.

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes: This is a defensive fix for a timing-dependent race condition in the relay client's event fetching logic. The change is localized to the EOSE handler in `fetchFirst()` and adds a non-blocking channel drain before marking a relay complete. Existing tests should continue to pass; the fix prevents a rare but real data loss scenario.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

This is an internal client-side timing fix in the Nostr relay communication layer, not a protocol or wire-format change.

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

https://claude.ai/code/session_0132crcc6g7iBhu59KMnhchF