### PR TITLE
Replace synchronized with Mutex in InMemoryAuthApprovalStore

### DIFF
--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/auth/AuthApprovalPolicy.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/auth/AuthApprovalPolicy.kt
@@ -22,6 +22,8 @@ package com.vitorpamplona.amethyst.commons.relayClient.auth
 
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 /**
  * Persisted scope for an AUTH approval decision.
@@ -113,19 +115,19 @@ interface AuthApprovalStore {
  */
 class InMemoryAuthApprovalStore : AuthApprovalStore {
     private val scopes = mutableMapOf<NormalizedRelayUrl, AuthApprovalScope>()
-    private val lock = Any()
+    private val lock = Mutex()
 
-    override suspend fun getScope(relayUrl: NormalizedRelayUrl): AuthApprovalScope? = synchronized(lock) { scopes[relayUrl] }
+    override suspend fun getScope(relayUrl: NormalizedRelayUrl): AuthApprovalScope? = lock.withLock { scopes[relayUrl] }
 
     override suspend fun setScope(
         relayUrl: NormalizedRelayUrl,
         scope: AuthApprovalScope,
     ) {
-        synchronized(lock) { scopes[relayUrl] = scope }
+        lock.withLock { scopes[relayUrl] = scope }
     }
 
     override suspend fun clear() {
-        synchronized(lock) { scopes.clear() }
+        lock.withLock { scopes.clear() }
     }
 }
 


### PR DESCRIPTION
## Summary

Replace blocking `synchronized` calls with coroutine-safe `Mutex` in `InMemoryAuthApprovalStore`. This aligns the locking mechanism with the suspend function signatures and prevents potential thread-blocking issues in async contexts.

## Changes

- Changed `lock` from `Any()` to `Mutex()`
- Replaced `synchronized(lock)` blocks with `lock.withLock()` in all three methods: `getScope()`, `setScope()`, and `clear()`
- Added imports for `kotlinx.coroutines.sync.Mutex` and `kotlinx.coroutines.sync.withLock`

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] N/A — Manually exercised the change (straightforward refactor from blocking to async-safe locking)

## Interop suites

- [ ] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [ ] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01A918G2Ks9i9LXRuVoNgm7R