### PR TITLE
Update Brainstorm web app icon URL

### DIFF
--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/browser/DefaultWebClients.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/browser/DefaultWebClients.kt
@@ -125,7 +125,7 @@ object DefaultWebClients {
             webApp("Nostrocket", "https://nostrocket.org", "Project coordination")
             webApp("Plektos", "https://plektos.app", "Decentralized meetup events", "https://plektos.app/icon-180.png")
             webApp("Zaplytics", "https://zaplytics.app", "Zap analytics for creators")
-            webApp("Brainstorm", "https://brainstorm.world", "Web-of-trust explorer", "https://brainstorm.world/brainstorm.svg")
+            webApp("Brainstorm", "https://brainstorm.world", "Web-of-trust explorer", "https://brainstorm.world/apple-touch-icon.png")
             webApp("MAKIMONO", "https://makimono.lumilumi.app", "Long-form article editor", "https://makimono.lumilumi.app/favicon3.png")
             webApp("Primal Studio", "https://studio.primal.net", "Schedule & publish content")
             webApp("nostr.build", "https://nostr.build", "Media & image uploads", "https://nostr.build/apple-touch-icon.png")


### PR DESCRIPTION
## Summary

Updates the Brainstorm web app icon URL from `brainstorm.world/brainstorm.svg` to `brainstorm.world/apple-touch-icon.png` in the default web clients list. This aligns with the standard Apple touch icon naming convention used by other web apps in the same list.

## Test plan

- [ ] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

This is a configuration-only change to a web app icon URL. No functional code paths are affected.

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01EzQhmuFNULgiP31XqMRpJP