### PR TITLE
Strip trailing whitespace from rich text parser output

### DIFF
--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
@@ -264,7 +264,13 @@ class RichTextParser {
         emojis: Map<String, String>,
         tags: ImmutableListOfLists<String>,
     ): ImmutableList<ParagraphState> {
-        val lines = content.split('\n')
+        // Trailing spaces and newlines would otherwise produce empty trailing
+        // paragraphs, each rendered as a blank line between the last visible
+        // word and the end of the component.
+        val trimmedContent = content.trimEnd()
+        if (trimmedContent.isEmpty()) return persistentListOf()
+
+        val lines = trimmedContent.split('\n')
         val paragraphSegments = ArrayList<ParagraphState>(lines.size)
 
         lines.forEach { paragraph ->

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParserTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParserTest.kt
@@ -4087,9 +4087,53 @@ class RichTextParserTest {
         assertTrue(state.mediaList.isEmpty())
         assertTrue(state.customEmoji.isEmpty())
         assertEquals(
-            "\nHi,\nhow\n\n\n are you doing?\n",
+            "\nHi,\nhow\n\n\n are you doing?",
             state.paragraphs.joinToString("\n") { it.words.joinToString(" ") { it.segmentText } },
         )
+    }
+
+    @Test
+    fun testTrailingWhitespaceIsRemoved() {
+        val state =
+            RichTextParser().parseText("Hi, how are you doing? \n\n  \n", EmptyTagList, null)
+
+        assertEquals(1, state.paragraphs.size)
+        assertEquals(
+            "Hi, how are you doing?",
+            state.paragraphs
+                .firstOrNull()
+                ?.words
+                ?.firstOrNull()
+                ?.segmentText,
+        )
+    }
+
+    @Test
+    fun testTrailingNewLinesAfterImageAreRemoved() {
+        val state =
+            RichTextParser().parseText(
+                "Check this out\nhttps://cdn.nostr.build/image.jpg\n\n\n",
+                EmptyTagList,
+                null,
+            )
+
+        assertEquals(2, state.paragraphs.size)
+        val lastWord =
+            state.paragraphs
+                .last()
+                .words
+                .single()
+        assertEquals(
+            "Image(https://cdn.nostr.build/image.jpg)",
+            "${lastWord::class.simpleName!!.replace("Segment", "")}(${lastWord.segmentText})",
+        )
+    }
+
+    @Test
+    fun testWhitespaceOnlyContentProducesNoParagraphs() {
+        val state = RichTextParser().parseText(" \n \n ", EmptyTagList, null)
+
+        assertTrue(state.paragraphs.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
## Summary

The rich text parser now trims trailing whitespace and newlines from parsed content. This prevents empty trailing paragraphs from being rendered as blank lines at the end of text components. Content that is entirely whitespace now produces no paragraphs instead of empty ones.

## Changes

- Modified `RichTextParser.parseText()` to call `trimEnd()` on input content before splitting into lines
- Returns an empty paragraph list if the trimmed content is empty
- This eliminates trailing blank lines that would otherwise appear between the last visible word and the end of the component

## Test plan

- [x] Added three new unit tests covering the change:
  - `testTrailingWhitespaceIsRemoved()` — verifies trailing spaces and newlines are stripped
  - `testTrailingNewLinesAfterImageAreRemoved()` — verifies trailing newlines after media are removed
  - `testWhitespaceOnlyContentProducesNoParagraphs()` — verifies whitespace-only input produces no paragraphs
- [x] Updated existing test expectation in `testMultiLine()` to match new behavior (trailing newline removed from expected output)
- [x] Ran `./gradlew test` — all tests pass

## Interop suites

- [x] N/A — change affects only text rendering, not wire bytes or protocol state

https://claude.ai/code/session_01UZET7ig8MvR5vSCSxvcURi