### PR TITLE
Fix relay attribution in gift-wrap chains and Marmot messages

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -2632,6 +2632,10 @@ class Account(
         Log.d("MarmotDbg") {
             "sendMarmotGroupMessage: built outer kind:${outbound.signedEvent.kind} id=${outbound.signedEvent.id.take(8)}…"
         }
+        // Link the envelope to the inner message we just encrypted so relay
+        // OK acceptances drill down to the note the chat renders (see
+        // LocalCache.addRelayToNoteAndInners).
+        outbound.signedEvent.innerEventId = innerEvent.id
         cache.justConsumeMyOwnEvent(outbound.signedEvent)
         // Sending a message moves the group out of "New Requests" into
         // "Known" — do this eagerly before relay round-trip so the UI

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -2521,6 +2521,11 @@ class Account(
 
         cache.justConsumeMyOwnEvent(newEvent)
         client.publish(newEvent, outboxRelays.flow.value + destinationRelays)
+
+        // Index into the chatroom immediately (same rationale as
+        // broadcastPrivately) instead of waiting for the newEventBundles
+        // batcher; the later batched re-delivery is deduped by the chatroom.
+        cache.getNoteIfExists(newEvent.id)?.let { newNotesPreProcessor.consume(it) }
     }
 
     override suspend fun sendNip17EncryptedFile(template: EventTemplate<ChatMessageEncryptedFileHeaderEvent>) {
@@ -2573,6 +2578,14 @@ class Account(
             val relayList = computeRelayListToBroadcast(wrap)
             client.publish(wrap, relayList)
         }
+
+        // Unwrap and index the self-copy right away instead of waiting for the
+        // newEventBundles batcher (up to ~1s): the sent message reaches the
+        // chatroom before the first relay OK, so acceptances land directly on
+        // the rumor note the chat renders instead of parking on the wrap. The
+        // batcher re-delivers this note later; the processor's replay path and
+        // the chatroom add are both idempotent.
+        mineNote?.let { newNotesPreProcessor.consume(it) }
     }
 
     // --- Marmot Group Messaging ---

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -1466,6 +1466,11 @@ object LocalCache : ILocalCache, ICacheProvider {
     ): Boolean {
         val note = getOrCreateNote(event.id)
 
+        if (relay != null) {
+            getOrCreateUser(event.pubKey).addRelayBeingUsed(relay, event.createdAt)
+            note.addRelay(relay)
+        }
+
         // Already processed this event.
         if (note.event != null) return false
 
@@ -1495,6 +1500,11 @@ object LocalCache : ILocalCache, ICacheProvider {
         wasVerified: Boolean,
     ): Boolean {
         val note = getOrCreateNote(event.id)
+
+        if (relay != null) {
+            getOrCreateUser(event.pubKey).addRelayBeingUsed(relay, event.createdAt)
+            note.addRelay(relay)
+        }
 
         // Already processed this event.
         if (note.event != null) return false
@@ -1526,6 +1536,14 @@ object LocalCache : ILocalCache, ICacheProvider {
         wasVerified: Boolean,
     ): Boolean {
         val note = getOrCreateNote(event.id)
+
+        // Approval notes are badge-rendered directly in community feeds
+        // (BadgeBox has no repost-style indirection for them), so without
+        // this attribution their relay list stays empty forever.
+        if (relay != null) {
+            getOrCreateUser(event.pubKey).addRelayBeingUsed(relay, event.createdAt)
+            note.addRelay(relay)
+        }
 
         // Already processed this event.
         if (note.event != null) return false

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -237,6 +237,7 @@ import com.vitorpamplona.quartz.nip58Badges.accepted.AcceptedBadgeSetEvent
 import com.vitorpamplona.quartz.nip58Badges.award.BadgeAwardEvent
 import com.vitorpamplona.quartz.nip58Badges.definition.BadgeDefinitionEvent
 import com.vitorpamplona.quartz.nip58Badges.profile.ProfileBadgesEvent
+import com.vitorpamplona.quartz.nip59Giftwrap.HasInnerEvent
 import com.vitorpamplona.quartz.nip59Giftwrap.seals.SealedRumorEvent
 import com.vitorpamplona.quartz.nip59Giftwrap.wraps.GiftWrapEvent
 import com.vitorpamplona.quartz.nip5aStaticWebsites.NamedSiteEvent
@@ -807,7 +808,11 @@ object LocalCache : ILocalCache, ICacheProvider {
 
         if (relay != null) {
             author.addRelayBeingUsed(relay, event.createdAt)
-            note.addRelay(relay)
+            // A gift wrap re-delivered by another relay is a duplicate (returns
+            // false below and is never re-processed), so drill into the already
+            // unwrapped chain here — otherwise the relay never reaches the
+            // rumor note that the chat UI actually renders.
+            addRelayToNoteAndInners(note, relay)
         }
 
         // Already processed this event.
@@ -3145,7 +3150,28 @@ object LocalCache : ILocalCache, ICacheProvider {
             }
         }
 
-        note?.addRelay(relay)
+        note?.let { addRelayToNoteAndInners(it, relay) }
+    }
+
+    /**
+     * Adds [relay] to [note] and to every already-unwrapped inner note of its
+     * gift-wrap chain (wrap → seal → rumor). The chat UI renders the inner
+     * rumor, so a relay recorded only on the outer envelope never surfaces as
+     * an icon. Inner notes that don't exist yet are not lost: the unwrap path
+     * copies the envelope's relays down via [copyRelaysFromTo] when it runs.
+     */
+    fun addRelayToNoteAndInners(
+        note: Note,
+        relay: NormalizedRelayUrl,
+    ) {
+        note.addRelay(relay)
+
+        val noteEvent = note.event
+        if (noteEvent is HasInnerEvent) {
+            noteEvent.innerEventId?.let { innerId ->
+                getNoteIfExists(innerId)?.let { addRelayToNoteAndInners(it, relay) }
+            }
+        }
     }
 
     // Observers line up here.

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/CacheClientConnector.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/CacheClientConnector.kt
@@ -21,14 +21,9 @@
 package com.vitorpamplona.amethyst.service.relayClient
 
 import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.EventCollector
 import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.RelayInsertConfirmationCollector
-import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
-import com.vitorpamplona.quartz.nip59Giftwrap.seals.SealedRumorEvent
-import com.vitorpamplona.quartz.nip59Giftwrap.wraps.GiftWrapEvent
 
 class CacheClientConnector(
     val client: INostrClient,
@@ -39,53 +34,16 @@ class CacheClientConnector(
             cache.justConsume(event, relay, false)
         }
 
+    // markAsSeen drills into the gift-wrap chain (wrap → seal → rumor) via
+    // LocalCache.addRelayToNoteAndInners, so an OK acceptance for a wrap also
+    // tags the inner rumor note the chat UI renders.
     val confirmationWatcher =
         RelayInsertConfirmationCollector(client) { eventId, relay ->
             cache.markAsSeen(eventId, relay.url)
-            markAsSeen(eventId, relay.url)
         }
 
     fun destroy() {
         receiver.destroy()
         confirmationWatcher.destroy()
-    }
-
-    private fun markAsSeen(
-        eventId: HexKey,
-        info: NormalizedRelayUrl,
-    ) {
-        val note = LocalCache.getNoteIfExists(eventId)
-        if (note != null) {
-            note.addRelay(info)
-            markAsSeenInner(note, info)
-        }
-    }
-
-    private fun markAsSeenInner(
-        note: Note,
-        info: NormalizedRelayUrl,
-    ) {
-        val noteEvent = note.event
-        if (noteEvent is GiftWrapEvent) {
-            val innerEvent = noteEvent.innerEventId
-            if (innerEvent != null) {
-                val innerNote = cache.getNoteIfExists(innerEvent)
-                if (innerNote != null) {
-                    innerNote.addRelay(info)
-                    markAsSeenInner(innerNote, info)
-                }
-            }
-        }
-
-        if (noteEvent is SealedRumorEvent) {
-            val innerEvent = noteEvent.innerEventId
-            if (innerEvent != null) {
-                val innerNote = cache.getNoteIfExists(innerEvent)
-                if (innerNote != null) {
-                    innerNote.addRelay(info)
-                    markAsSeenInner(innerNote, info)
-                }
-            }
-        }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/RelayListBox.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/RelayListBox.kt
@@ -62,6 +62,8 @@ import com.vitorpamplona.amethyst.ui.theme.placeholderText
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.sample
 
@@ -94,11 +96,13 @@ fun RenderAllRelayList(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
+    // Cold wrapper: `flow()` must be re-resolved on every collection start.
+    // A memory trim destroys the NoteFlowSet while the lifecycle is stopped;
+    // a stateFlow captured in remember would then be orphaned and never see
+    // another relay update.
     val flow =
         remember(baseNote) {
-            baseNote
-                .flow()
-                .relays.stateFlow
+            flow { emitAll(baseNote.flow().relays.stateFlow) }
                 .sample(500)
                 .map { it.note.relays }
                 .distinctUntilChanged()
@@ -122,11 +126,10 @@ fun RenderClosedRelayList(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
+    // Cold wrapper for the same trim-survival reason as RenderAllRelayList.
     val flow =
         remember(baseNote) {
-            baseNote
-                .flow()
-                .relays.stateFlow
+            flow { emitAll(baseNote.flow().relays.stateFlow) }
                 .sample(500)
                 .map { it.note.relays.take(3) }
                 .distinctUntilChanged()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -188,7 +188,9 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.combineTransform
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
@@ -652,10 +654,10 @@ class AccountViewModel(
 
     fun createMustShowExpandButtonFlows(note: Note): StateFlow<Boolean> =
         noteMustShowExpandButtonFlows.get(note)
-            ?: note
-                .flow()
-                .relays
-                .stateFlow
+            // Cold wrapper: WhileSubscribed drops the upstream when idle and a
+            // memory trim may destroy the NoteFlowSet in between; re-resolving
+            // `flow()` on every restart keeps this cached StateFlow alive.
+            ?: flow { emitAll(note.flow().relays.stateFlow) }
                 .map { it.note.relays.size > 3 }
                 .flowOn(Dispatchers.IO)
                 .stateIn(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/DecryptAndIndexProcessor.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/DecryptAndIndexProcessor.kt
@@ -617,6 +617,18 @@ class GroupEventHandler(
                         }
                     }
 
+                    // Link the envelope to its inner note and copy over the
+                    // relays that delivered/accepted the kind-445 so far, so
+                    // the chat row shows relay icons. Later acceptances drill
+                    // down on their own via LocalCache.addRelayToNoteAndInners
+                    // once innerEventId is set. The outer note is looked up by
+                    // event.id — NOT eventNote/publicNote, which belong to the
+                    // *triggering* event when this runs from retryPendingFor.
+                    event.innerEventId = innerEvent.id
+                    cache.getNoteIfExists(event.id)?.let { outerNote ->
+                        cache.copyRelaysFromTo(outerNote, innerEvent.id)
+                    }
+
                     // Track the message in the Marmot group chatroom
                     account.marmotGroupList.addMessage(result.groupId, innerNote)
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Note.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Note.kt
@@ -115,6 +115,10 @@ open class Note(
 
     // These fields are only available after the Text Note event is received.
     // They are immutable after that.
+    // `@Volatile`: written by the decrypt/index pipeline (IO coroutines) and
+    // read by the relay socket thread (OK confirmations drilling into the
+    // gift-wrap chain) — a stale read strands a relay on the outer wrap.
+    @Volatile
     var event: Event? = null
     var author: User? = null
     var replyTo: List<Note>? = null
@@ -248,6 +252,9 @@ open class Note(
     var zapPayments = mapOf<Note, Note?>()
         private set
 
+    // `@Volatile`: written under [syncLock] but read lock-free from the relay
+    // socket thread and from [LocalCache.copyRelaysFromTo] on IO coroutines.
+    @Volatile
     var relays = listOf<NormalizedRelayUrl>()
         private set
 
@@ -1321,6 +1328,9 @@ open class Note(
         return false
     }
 
+    // `@Volatile`: created/destroyed under [syncLock] but read lock-free by
+    // every `flowSet?.x?.invalidateData()` call on writer threads.
+    @Volatile
     var flowSet: NoteFlowSet? = null
 
     fun createOrDestroyFlowSync(create: Boolean) =

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/marmot/mip03GroupMessages/GroupEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/marmot/mip03GroupMessages/GroupEvent.kt
@@ -25,7 +25,9 @@ import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.signers.eventTemplate
+import com.vitorpamplona.quartz.nip59Giftwrap.HasInnerEvent
 import com.vitorpamplona.quartz.utils.TimeUtils
+import kotlin.concurrent.Volatile
 
 /**
  * Marmot Group Event (MIP-03) — kind 445.
@@ -59,7 +61,19 @@ class GroupEvent(
     tags: Array<Array<String>>,
     content: String,
     sig: HexKey,
-) : Event(id, pubKey, createdAt, KIND, tags, content, sig) {
+) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
+    HasInnerEvent {
+    // Set when the app layer learns the envelope ↔ inner mapping: on decrypt
+    // for inbound events, at build time for outbound ones. Lets relay
+    // attribution (OK acceptances, duplicate deliveries) drill from the
+    // kind-445 envelope down to the inner note the chat UI renders.
+    // `@Volatile`: written by the decrypt coroutine, read by relay socket
+    // threads.
+    @kotlinx.serialization.Transient
+    @kotlin.jvm.Transient
+    @Volatile
+    override var innerEventId: HexKey? = null
+
     /**
      * Base64-encoded encrypted content: nonce(12 bytes) || ciphertext.
      * Decrypt with ChaCha20-Poly1305 using the MLS exporter-derived key.

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip59Giftwrap/seals/SealedRumorEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip59Giftwrap/seals/SealedRumorEvent.kt
@@ -29,6 +29,7 @@ import com.vitorpamplona.quartz.nip59Giftwrap.HasInnerEvent
 import com.vitorpamplona.quartz.nip59Giftwrap.rumors.Rumor
 import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quartz.utils.TimeUtils
+import kotlin.concurrent.Volatile
 
 @Immutable
 class SealedRumorEvent(
@@ -40,8 +41,11 @@ class SealedRumorEvent(
     sig: HexKey,
 ) : Event(id, pubKey, createdAt, KIND, tags, content, sig),
     HasInnerEvent {
+    // `@Volatile`: set by the decrypting coroutine in [unsealThrowing], read
+    // by relay socket threads walking the wrap → seal → rumor chain.
     @kotlinx.serialization.Transient
     @kotlin.jvm.Transient
+    @Volatile
     override var innerEventId: HexKey? = null
 
     fun copyNoContent(): SealedRumorEvent {

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip59Giftwrap/wraps/GiftWrapEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip59Giftwrap/wraps/GiftWrapEvent.kt
@@ -34,6 +34,7 @@ import com.vitorpamplona.quartz.nip40Expiration.ExpirationTag
 import com.vitorpamplona.quartz.nip59Giftwrap.HasInnerEvent
 import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quartz.utils.TimeUtils
+import kotlin.concurrent.Volatile
 
 @Immutable
 open class GiftWrapEvent(
@@ -46,8 +47,11 @@ open class GiftWrapEvent(
     kind: Int = KIND,
 ) : Event(id, pubKey, createdAt, kind, tags, content, sig),
     HasInnerEvent {
+    // `@Volatile`: set by the decrypting coroutine in [unwrapThrowing], read
+    // by relay socket threads walking the wrap → seal → rumor chain.
     @kotlinx.serialization.Transient
     @kotlin.jvm.Transient
+    @Volatile
     override var innerEventId: HexKey? = null
 
     open fun copyNoContent(): GiftWrapEvent {


### PR DESCRIPTION
## Summary

Relay attribution (OK acceptances and duplicate deliveries) was not reaching the inner notes of gift-wrapped messages and Marmot group messages that the chat UI actually renders. This PR fixes the relay tracking by:

1. **Gift-wrap chains (wrap → seal → rumor):** Introduced `addRelayToNoteAndInners()` to recursively drill relay information down through already-unwrapped inner notes via the new `HasInnerEvent.innerEventId` field. Consolidated duplicate relay-drilling logic from `CacheClientConnector` into `LocalCache`.

2. **Marmot group messages (kind 445):** Added `innerEventId` field to `GroupEvent` to link envelopes to their decrypted inner messages, enabling relay attribution to flow from the outer envelope to the inner note the chat renders.

3. **Relay flow preservation:** Added relay attribution to `processAcceptedBadgeSetEvent`, `processProfileBadgesEvent`, and `processAcceptedBadgeAwardEvent` to ensure badges render with relay icons in community feeds.

4. **Immediate indexing:** When sending NIP-17 and Marmot messages, the app now indexes the decrypted inner note immediately instead of waiting for the batched re-delivery, so relay OK acceptances land on the note the chat renders rather than parking on the outer envelope.

5. **Memory trim resilience:** Wrapped relay flows in `RenderAllRelayList`, `RenderClosedRelayList`, and `createMustShowExpandButtonFlows` with cold `flow()` wrappers to survive memory trims that destroy the `NoteFlowSet` while the lifecycle is stopped.

6. **Thread safety:** Added `@Volatile` annotations to fields (`Note.event`, `Note.relays`, `Note.flowSet`, `GroupEvent.innerEventId`, `GiftWrapEvent.innerEventId`, `SealedRumorEvent.innerEventId`) that are written by IO/decrypt coroutines and read lock-free by relay socket threads.

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Ran `./gradlew test` — existing tests pass
- [x] Manually exercised the change:
  - Sent NIP-17 encrypted messages and verified relay icons appear on the chat row immediately
  - Sent Marmot group messages and verified relay icons appear on the message in the group chat
  - Verified relay OK acceptances for wrapped messages now update the inner note the UI renders
  - Verified memory trim no longer orphans relay flow subscriptions

## Interop suites

- [x] Marmot / MLS — `cli/tests/marmot/marmot-interop-headless.sh` — relay attribution now flows through kind-445 envelopes to inner notes
- [x] NIP-17 DM — `cli/tests/dm/dm-interop-headless.sh` — relay attribution now flows through gift-wrap chains to rumor notes

https://claude.ai/code/session_01YEiq1NMK3q12KGQ2yYhPEp