### PR TITLE
Add NIP-29 relay groups button to relay information screen

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/RelayInformationScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/RelayInformationScreen.kt
@@ -830,7 +830,7 @@ private fun RelayHeader(
         )
 
         FlowRow(
-            modifier = Modifier.padding(horizontal = 30.dp),
+            modifier = Modifier.padding(horizontal = 20.dp),
             horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.CenterHorizontally),
         ) {
             OutlinedButton(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/RelayInformationScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/RelayInformationScreen.kt
@@ -829,9 +829,9 @@ private fun RelayHeader(
             textAlign = TextAlign.Center,
         )
 
-        Row(
+        FlowRow(
             modifier = Modifier.padding(horizontal = 30.dp),
-            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.CenterHorizontally),
         ) {
             OutlinedButton(
                 shape = ButtonBorder,
@@ -843,7 +843,22 @@ private fun RelayHeader(
                     modifier = Modifier.size(18.dp),
                 )
                 Spacer(modifier = Modifier.width(4.dp))
-                Text(text = stringRes(R.string.see_relay_feed))
+                Text(text = stringRes(R.string.see_relay_feed), maxLines = 1)
+            }
+
+            if (supportsNip29(relayInfo.supported_nips)) {
+                OutlinedButton(
+                    onClick = { nav.nav(Route.RelayGroupServer(relay.url)) },
+                    shape = ButtonBorder,
+                ) {
+                    Icon(
+                        MaterialSymbols.Groups,
+                        contentDescription = stringRes(R.string.relay_groups_button),
+                        modifier = Modifier.size(18.dp),
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(text = stringRes(R.string.relay_groups_button), maxLines = 1)
+                }
             }
 
             if (supportsNip43(relayInfo.supported_nips)) {
@@ -857,7 +872,7 @@ private fun RelayHeader(
                         modifier = Modifier.size(18.dp),
                     )
                     Spacer(modifier = Modifier.width(4.dp))
-                    Text(text = stringRes(R.string.relay_members))
+                    Text(text = stringRes(R.string.relay_members), maxLines = 1)
                 }
             }
 
@@ -876,6 +891,8 @@ private fun RelayHeader(
         }
     }
 }
+
+fun supportsNip29(supportedNips: List<String>?): Boolean = supportedNips?.any { it == "29" } == true
 
 fun supportsNip43(supportedNips: List<String>?): Boolean = supportedNips?.any { it == "43" } == true
 

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -1972,6 +1972,7 @@
     <string name="relay_group_view_grouped_desc">Collapse each relay\'s groups into a single row, placed at its newest message.</string>
     <string name="relay_group_view_mode_title">NIP-29 group display</string>
     <string name="relay_group_server_label">Relay groups</string>
+    <string name="relay_groups_button">Groups</string>
     <string name="messages_settings">Messages</string>
     <string name="messages_settings_search_keywords" translatable="false">messages, chats, groups, nip-29, relay, inline, dm</string>
     <string name="relay_group_create_title">Create a group</string>


### PR DESCRIPTION
## Summary

Adds support for displaying a "Groups" button on the relay information screen for relays that support NIP-29 (relay-based groups). The button navigates to the relay groups view. Also refactors the button layout from `Row` to `FlowRow` to better handle multiple buttons and adds `maxLines = 1` to button text to prevent wrapping.

## Changes

- Replace `Row` with `FlowRow` in `RelayHeader` to allow buttons to wrap gracefully when space is constrained
- Add `supportsNip29()` helper function to check if a relay supports NIP-29
- Add conditional "Groups" button that appears for NIP-29 supporting relays, navigating to `Route.RelayGroupServer`
- Add `maxLines = 1` to text in all relay action buttons to prevent text wrapping
- Add string resource `relay_groups_button` for the new button label

## Test plan

- [ ] Manually tested on a device with a NIP-29 supporting relay to verify the Groups button appears and navigates correctly
- [ ] Verified button layout with `FlowRow` handles multiple buttons without overlap
- [ ] Verified text truncation with `maxLines = 1` works as expected

## Interop suites

- [ ] N/A — UI-only change, no wire bytes or protocol changes affected

https://claude.ai/code/session_012w9KridAbRpesbX2ytdjn4