### PR TITLE
Mark DM rooms as read when wraps are mined in background

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -2828,7 +2828,12 @@ class Account(
             // process death mid-mine cannot lose the file announcement.
             val senderMessage = signer.sign(template)
             val seals = NIP17Factory().createSeals(senderMessage, senderMessage.groupMembers(), signer)
-            if (mineWrapsInBackground(seals.seals, seals.expirationDelta, powDifficulty)) return
+            if (mineWrapsInBackground(seals.seals, seals.expirationDelta, powDifficulty)) {
+                // The wraps publish only after mining, but the user has already
+                // replied — advance the read marker now.
+                markDmRoomAsRead(senderMessage)
+                return
+            }
         }
 
         broadcastPrivately(NIP17Factory().createEncryptedFileNIP17(template, signer))
@@ -2840,7 +2845,12 @@ class Account(
             // See sendNip17EncryptedFile: sign inline, queue only wrap mining.
             val senderMessage = signer.sign(template)
             val seals = NIP17Factory().createSeals(senderMessage, senderMessage.groupMembers(), signer)
-            if (mineWrapsInBackground(seals.seals, seals.expirationDelta, powDifficulty)) return
+            if (mineWrapsInBackground(seals.seals, seals.expirationDelta, powDifficulty)) {
+                // The wraps publish only after mining, but the user has already
+                // replied — advance the read marker now.
+                markDmRoomAsRead(senderMessage)
+                return
+            }
         }
 
         broadcastPrivately(NIP17Factory().createMessageNIP17(template, signer))
@@ -2881,7 +2891,10 @@ class Account(
         }
     }
 
-    suspend fun broadcastPrivately(signedEvents: NIP17Factory.Result) = broadcastPrivately(signedEvents.wraps)
+    suspend fun broadcastPrivately(signedEvents: NIP17Factory.Result) {
+        broadcastPrivately(signedEvents.wraps)
+        markDmRoomAsRead(signedEvents.msg)
+    }
 
     suspend fun broadcastPrivately(wraps: List<GiftWrapEvent>) {
         val mine = wraps.filter { (it.recipientPubKey() == signer.pubKey) }
@@ -2910,8 +2923,6 @@ class Account(
         // batcher re-delivers this note later; the processor's replay path and
         // the chatroom add are both idempotent.
         mineNote?.let { newNotesPreProcessor.consume(it) }
-
-        markDmRoomAsRead(signedEvents.msg)
     }
 
     /**


### PR DESCRIPTION
## Summary

When sending NIP-17 encrypted messages with proof-of-work wraps that are mined in the background, the DM room read marker was not being advanced until after mining completed. This caused a race condition where the UI would show unread messages even though the user had just sent a reply. The fix ensures the read marker is advanced immediately when the user sends a message, regardless of whether wrap mining happens synchronously or in the background.

## Changes

- In `sendNip17EncryptedMessage()` and `sendNip17EncryptedFile()`: Call `markDmRoomAsRead()` before returning when `mineWrapsInBackground()` returns true, so the read marker advances immediately rather than waiting for mining to complete.
- In `broadcastPrivately(NIP17Factory.Result)`: Refactored the one-liner to explicitly call `markDmRoomAsRead()` on the message, ensuring the read marker is always advanced when wraps are broadcast (whether mined in background or not).
- Removed the duplicate `markDmRoomAsRead()` call from the lower-level `broadcastPrivately(List<GiftWrapEvent>)` to avoid calling it twice.

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes: The change affects the timing of when `markDmRoomAsRead()` is called in the message-sending flow. Existing unit tests for the Account class should cover these code paths. Manual testing would involve sending NIP-17 messages with proof-of-work enabled and verifying that the DM room read marker advances immediately after sending, not after mining completes.

## Interop suites

- [ ] NIP-17 DM — `cli/tests/dm/dm-interop-headless.sh` (if testing DM envelope behavior)
- [ ] N/A — change affects read-marker state management, not wire bytes or envelope structure

https://claude.ai/code/session_01V1hu9zpyiuJo6yyoJs1vdw