### PR TITLE
Reduce PoW badge size for better UI balance

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DisplayPoW.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/DisplayPoW.kt
@@ -64,19 +64,19 @@ fun DisplayPoW(pow: Int) {
             Modifier
                 .clip(RoundedCornerShape(50))
                 .background(MaterialTheme.colorScheme.secondaryContainer)
-                .padding(horizontal = 6.dp, vertical = 1.dp),
+                .padding(horizontal = 5.dp, vertical = 1.dp),
     ) {
         Icon(
             symbol = MaterialSymbols.Manufacturing,
             contentDescription = stringRes(R.string.pow_settings_title),
             tint = MaterialTheme.colorScheme.onSecondaryContainer,
-            modifier = Modifier.size(12.dp),
+            modifier = Modifier.size(10.dp),
         )
         Text(
             text = pow.toString(),
             color = MaterialTheme.colorScheme.onSecondaryContainer,
-            fontSize = 12.sp,
-            lineHeight = 12.sp,
+            fontSize = 10.sp,
+            lineHeight = 10.sp,
             fontWeight = FontWeight.Bold,
             maxLines = 1,
         )


### PR DESCRIPTION
## Summary

Reduced the size of the Proof of Work (PoW) badge in the note display by decreasing padding, icon size, and text size. This makes the badge more compact and better proportioned within the UI layout.

Changes:
- Horizontal padding: 6.dp → 5.dp
- Icon size: 12.dp → 10.dp
- Font size: 12.sp → 10.sp
- Line height: 12.sp → 10.sp

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Manually exercised the change

Notes: Verified the PoW badge displays correctly with reduced dimensions in the note elements. The badge remains visually distinct and readable at the smaller size.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01PbpEL8rRBwLd2mgbAqBPvX