### PR TITLE
Aggregate Kover coverage (for SonarQube import)

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -278,6 +278,25 @@ call does not guarantee lint finishes first):
 The reports persist under each module's `build/reports/`, so re-run lint only
 when you want fresh lint data in the next scan.
 
+### 5. Optional: include test coverage
+
+Coverage comes from [Kover](https://github.com/Kotlin/kotlinx-kover). The root
+`koverXmlReportCoverage` task runs the unit-test suites of the covered modules
+(`quartz`, `commons`, `quic`, `nestsClient`, `geode`, `cli`, `relayBench`,
+`desktopApp`, and `amethyst`'s `fdroidDebug` variant) and merges the result
+into `build/reports/kover/reportCoverage.xml`, which the scanner imports
+automatically when it exists. Same recipe as lint — generate first, scan
+second:
+
+```bash
+./gradlew koverXmlReportCoverage
+./gradlew sonar
+```
+
+For a human-readable version of the same data, run
+`./gradlew koverHtmlReportCoverage` and open
+`build/reports/kover/htmlCoverage/index.html`.
+
 Every `sonar.*` entry in `local.properties` is forwarded to the scanner, so any
 [analysis parameter](https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/analysis-parameters/)
 can be set there. `sonar.projectKey` / `sonar.projectName` default to the root

--- a/amethyst/build.gradle.kts
+++ b/amethyst/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.jetbrainsComposeCompiler)
     alias(libs.plugins.serialization)
     alias(libs.plugins.googleKsp)
+    alias(libs.plugins.kotlinxKover)
 }
 
 fun getCurrentBranch(workingDir: java.io.File): String =

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,50 @@ plugins {
     alias(libs.plugins.androidKotlinMultiplatformLibrary) apply false
     alias(libs.plugins.serialization)
     alias(libs.plugins.googleKsp) apply false
+    alias(libs.plugins.kotlinxKover)
+}
+
+// Aggregated code coverage: `./gradlew koverXmlReportCoverage` runs the unit
+// test suites of the modules below and merges their coverage into
+// build/reports/kover/reportCoverage.xml (JaCoCo-compatible XML, importable by
+// SonarQube — see BUILDING.md). `koverHtmlReportCoverage` renders the same
+// data for humans. A named variant is used instead of Kover's default total
+// report because the total for an Android project unconditionally merges
+// EVERY build variant — compiling all release/benchmark variants of
+// :amethyst just to measure unit tests. The "coverage" variant below picks
+// one representative compilation per project: the `jvm` target for KMP/JVM
+// modules and `playDebug` for :amethyst — play is the primary flavor and the
+// larger code surface (both `add`s are optional so the one block fits every
+// project). :nappletHost stays out — it has no tests.
+dependencies {
+    kover(project(":amethyst"))
+    kover(project(":quartz"))
+    kover(project(":commons"))
+    kover(project(":quic"))
+    kover(project(":nestsClient"))
+    kover(project(":geode"))
+    kover(project(":cli"))
+    kover(project(":relayBench"))
+    kover(project(":desktopApp"))
+}
+
+kover {
+    currentProject {
+        createVariant("coverage") {}
+    }
+}
+
+subprojects {
+    plugins.withId("org.jetbrains.kotlinx.kover") {
+        configure<kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension> {
+            currentProject {
+                createVariant("coverage") {
+                    add("jvm", optional = true)
+                    add("playDebug", optional = true)
+                }
+            }
+        }
+    }
 }
 
 // Shared app version for all subprojects — read from gradle/libs.versions.toml.
@@ -119,6 +163,15 @@ if (sonarEnabled) {
         .stringPropertyNames()
         .filter { it.startsWith("sonar.") }
         .forEach { System.setProperty(it, sonarProperties.getProperty(it)) }
+
+    // Import Kover's aggregated coverage (run `./gradlew koverXmlReportCoverage`
+    // first) unless the operator pointed the scanner somewhere else.
+    if (System.getProperty("sonar.coverage.jacoco.xmlReportPaths") == null) {
+        System.setProperty(
+            "sonar.coverage.jacoco.xmlReportPaths",
+            layout.buildDirectory.file("reports/kover/reportCoverage.xml").get().asFile.absolutePath,
+        )
+    }
 
     // The scanner's sonarResolver task reads AGP's generated-res-values provider
     // but doesn't depend on the task that produces it — wire it up in every

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     alias(libs.plugins.jetbrainsKotlinJvm)
     application
+    alias(libs.plugins.kotlinxKover)
 }
 
 kotlin {

--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -25,6 +25,7 @@ plugins {
     alias(libs.plugins.jetbrainsComposeCompiler)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.serialization)
+    alias(libs.plugins.kotlinxKover)
 }
 
 kotlin {

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.jetbrainsKotlinJvm)
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.jetbrainsComposeCompiler)
+    alias(libs.plugins.kotlinxKover)
 }
 
 // RPM rejects dashes in version strings — replace with tilde (~) which RPM uses

--- a/geode/build.gradle.kts
+++ b/geode/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.serialization)
     application
     `java-test-fixtures`
+    alias(libs.plugins.kotlinxKover)
 }
 
 application {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ kmpTorResource = "409.5.0"
 junit = "4.13.2"
 kchesslib = "1.0.5"
 kotlin = "2.4.0"
+kover = "0.9.8"
 kotlinxCollectionsImmutable = "0.5.0"
 kotlinxCoroutinesCore = "1.11.0"
 kotlinxSerialization = "1.11.0"
@@ -246,6 +247,7 @@ jetbrainsKotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 jetbrainsComposeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 serialization = { id = 'org.jetbrains.kotlin.plugin.serialization', version.ref = 'kotlin' }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+kotlinxKover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 androidKotlinMultiplatformLibrary = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 vanniktech-mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }

--- a/nestsClient/build.gradle.kts
+++ b/nestsClient/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidKotlinMultiplatformLibrary)
     alias(libs.plugins.serialization)
+    alias(libs.plugins.kotlinxKover)
 }
 
 kotlin {

--- a/quartz/build.gradle.kts
+++ b/quartz/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.androidKotlinMultiplatformLibrary)
     alias(libs.plugins.serialization)
     alias(libs.plugins.vanniktech.mavenPublish)
+    alias(libs.plugins.kotlinxKover)
 }
 
 kotlin {

--- a/quic/build.gradle.kts
+++ b/quic/build.gradle.kts
@@ -23,6 +23,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidKotlinMultiplatformLibrary)
+    alias(libs.plugins.kotlinxKover)
 }
 
 kotlin {

--- a/relayBench/build.gradle.kts
+++ b/relayBench/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     alias(libs.plugins.jetbrainsKotlinJvm)
     application
+    alias(libs.plugins.kotlinxKover)
 }
 
 application {


### PR DESCRIPTION
## What

Adds test-coverage reporting via [Kover](https://github.com/Kotlin/kotlinx-kover) 0.9.8, aggregated across the KMP/JVM modules **and the Android app module**, wired into the opt-in local SonarQube analysis (#3504).

- Applies the Kover plugin to `quartz`, `commons`, `quic`, `nestsClient`, `geode`, `cli`, `relayBench`, `desktopApp`, and `amethyst`, with root-level aggregation: `./gradlew koverXmlReportCoverage` runs the unit-test suites and merges the result into `build/reports/kover/reportCoverage.xml` (JaCoCo-compatible XML). `koverHtmlReportCoverage` renders the same data for humans.
- The report uses a named `coverage` variant rather than Kover's default total report, because the Android total unconditionally merges **every** build variant — compiling both flavors × debug/release/benchmark of the 358k-LOC app just to measure unit tests (it OOMed the Kotlin daemon). The named variant picks one representative compilation per project: the `jvm` target for KMP/JVM modules and `playDebug` for `amethyst` (play is the primary flavor and larger code surface).
- The opt-in `sonar` run defaults `sonar.coverage.jacoco.xmlReportPaths` to the merged report when the operator hasn't set the property in `local.properties`, so coverage appears on the dashboard with no extra configuration.
- Documents the recipe in BUILDING.md alongside the lint-import step: generate first, scan second.

## Why Kover

Coverage was previously absent. Kover was chosen over raw JaCoCo because it is Kotlin-aware (filters compiler-generated bytecode like suspend state machines and data-class synthetics, attributes inline functions correctly) and understands KMP targets natively — the nine-module aggregation is one `kover(project(…))` block plus one shared variant definition, instead of hand-wired per-module `JacocoReport` + merge tasks. The XML output stays JaCoCo-compatible, so SonarQube imports it through its standard coverage sensor.

## Notes

- **License:** Kover is Apache-2.0 (verified from the Maven Central POM). Build-time only, never linked into shipped artifacts.
- Test tasks in covered modules now run with the Kover agent attached; overhead is small (single-digit percent).
- `:nappletHost` is excluded — it has no tests, so inclusion would only add build time for a guaranteed 0%.
- Instrumented tests (`androidTest*`) cannot contribute — on-device coverage is a different mechanism regardless of tool.
- A handful of KMP files (7) fail Sonar's per-file import with a line-mapping quirk (`Line N is out of range`) from expect/actual compilation; they simply show no coverage. Known Kover/KMP artifact, does not affect the rest of the report.

## Verified

Full run end to end: `koverXmlReportCoverage` (all suites green) → `sonar` — coverage imported and visible on the dashboard: 1,227 packages, ~17.6% line coverage overall (the app module's large untested Compose UI surface pulls the headline down; the KMP/JVM modules alone sit around 36%).

<img width="500" alt="Screenshot 2026-07-11 at 15 46 46" src="https://github.com/user-attachments/assets/f5c9127b-682e-4882-9a67-2b21c33889e4" />


## License

- [ ] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
