### PR TITLE
fix(ci): serialize :amethyst Kotlin compilations on CI to stop daemon OOMs

### DIFF
--- a/amethyst/build.gradle.kts
+++ b/amethyst/build.gradle.kts
@@ -1,4 +1,7 @@
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     alias(libs.plugins.androidApplication)
@@ -340,6 +343,25 @@ kotlin {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_21)
     }
+}
+
+// Gradle schedules Kotlin compilations of different variants of this module
+// concurrently (e.g. playDebug + playBenchmark when CI runs unit tests, lint,
+// and assembleBenchmark in one invocation), but they all share a single Kotlin
+// daemon whose heap (kotlin.daemon.jvmargs) cannot fit two full :amethyst
+// codegen passes — CI runs died with "GC overhead limit exceeded" inside the
+// daemon. This no-op shared build service with maxParallelUsages = 1 tells the
+// scheduler to run this module's Kotlin compile tasks one at a time; other
+// projects' tasks (JVM tests, lint analysis, packaging) still run in parallel.
+abstract class AmethystKotlinCompileLimiter : BuildService<BuildServiceParameters.None>
+
+val kotlinCompileLimiter =
+    gradle.sharedServices.registerIfAbsent("amethystKotlinCompileLimiter", AmethystKotlinCompileLimiter::class) {
+        maxParallelUsages.set(1)
+    }
+
+tasks.withType<KotlinCompile>().configureEach {
+    usesService(kotlinCompileLimiter)
 }
 
 composeCompiler {

--- a/amethyst/build.gradle.kts
+++ b/amethyst/build.gradle.kts
@@ -353,15 +353,20 @@ kotlin {
 // daemon. This no-op shared build service with maxParallelUsages = 1 tells the
 // scheduler to run this module's Kotlin compile tasks one at a time; other
 // projects' tasks (JVM tests, lint analysis, packaging) still run in parallel.
+//
+// CI-only: the OOM needs a cache-cold compile of several variants at once,
+// which local builds (incremental, usually one variant) don't produce.
 abstract class AmethystKotlinCompileLimiter : BuildService<BuildServiceParameters.None>
 
-val kotlinCompileLimiter =
-    gradle.sharedServices.registerIfAbsent("amethystKotlinCompileLimiter", AmethystKotlinCompileLimiter::class) {
-        maxParallelUsages.set(1)
-    }
+if (System.getenv("CI") != null) {
+    val kotlinCompileLimiter =
+        gradle.sharedServices.registerIfAbsent("amethystKotlinCompileLimiter", AmethystKotlinCompileLimiter::class) {
+            maxParallelUsages.set(1)
+        }
 
-tasks.withType<KotlinCompile>().configureEach {
-    usesService(kotlinCompileLimiter)
+    tasks.withType<KotlinCompile>().configureEach {
+        usesService(kotlinCompileLimiter)
+    }
 }
 
 composeCompiler {


### PR DESCRIPTION
## Summary

CI's `test-and-build-android` job keeps dying with `java.lang.OutOfMemoryError` (`GC overhead limit exceeded` / `Java heap space`) inside the shared Kotlin compile daemon when two `:amethyst` variant compilations run at the same time — `KotlinCompile` submits its work asynchronously via the Worker API, so the project lock is released while compilation is still running in the daemon and Gradle starts the next variant's compile alongside it. Two cache-cold `:amethyst` codegen passes no longer fit the daemon's `-Xmx8g` heap (runs [29260711359](https://github.com/vitorpamplona/amethyst/actions/runs/29260711359), [29248927324](https://github.com/vitorpamplona/amethyst/actions/runs/29248927324); removing Kover in #3539 helped but wasn't sufficient). This PR registers a no-op shared `BuildService` with `maxParallelUsages = 1` and has every `:amethyst` `KotlinCompile` task use it, so this module's compilations run one at a time while all other work (other modules, JVM tests, lint analysis, packaging) keeps its parallelism.

Gated on the `CI` env var (always set on GitHub Actions): the OOM needs a cache-cold multi-variant compile in one invocation, which local incremental single-variant builds don't produce — local builds are untouched.

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Project configures cleanly on Gradle 9.4.1 (`./gradlew :amethyst:help`)
- [x] Manually exercised the change (see notes below)

Notes:

Verified the scheduler behavior end-to-end with probe tasks (init script) registered on `:amethyst` that reproduce `KotlinCompile`'s execution shape — the task action submits a 6-second sleep through `WorkerExecutor.noIsolation()` and returns:

- **Baseline (no constraint):** two same-project probes started the same millisecond — reproduces the concurrent-compile overlap seen in CI.
  ```
  PROBE free0 START 1783958057960
  PROBE free1 START 1783958057959   <- overlap
  ```
- **With `usesService(limiter)` and `CI=true`:** strictly serialized; the second probe starts only after the first's async work completes (14s wall vs 8s).
  ```
  PROBE limited0 START 1783965585220
  PROBE limited0 END   1783965591229
  PROBE limited1 START 1783965591241   <- waits for completion
  ```
- **Without `CI` set:** the service is not registered at all (probe lookup fails with `BuildServiceRegistration ... not found`), confirming local builds don't carry the constraint.

This PR's own CI run is the real end-to-end test: the branch touches `:amethyst` build config, which invalidates the remote cache for exactly the compile tasks that were OOMing, forcing the cold four-variant build that previously failed.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## AI assistance

- [x] Drafted with AI assistance, manually reviewed and tested

## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ifbUGCADckUb3zaox9wBo