### PR TITLE
Adaptive large-screen layout: nav rail, permanent drawer, notification panel, reading-column cap

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/feeds/RememberForeverStates.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/feeds/RememberForeverStates.kt
@@ -39,6 +39,7 @@ private data class ScrollState(
 object ScrollStateKeys {
     const val NOTIFICATION_SCREEN = "NotificationsFeed"
     const val NOTIFICATION_SIDE_PANEL = "NotificationsSidePanel"
+    const val NOTIFICATION_SIDE_PANEL_FOLLOWING = "NotificationsSidePanelFollowing"
     const val NOTIFICATION_FOLLOWING = "NotificationsFollowingFeed"
     const val NOTIFICATION_EVERYONE = "NotificationsEveryoneFeed"
     const val VIDEO_SCREEN = "VideoFeed"

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/feeds/RememberForeverStates.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/feeds/RememberForeverStates.kt
@@ -38,6 +38,7 @@ private data class ScrollState(
 
 object ScrollStateKeys {
     const val NOTIFICATION_SCREEN = "NotificationsFeed"
+    const val NOTIFICATION_SIDE_PANEL = "NotificationsSidePanel"
     const val NOTIFICATION_FOLLOWING = "NotificationsFollowingFeed"
     const val NOTIFICATION_EVERYONE = "NotificationsEveryoneFeed"
     const val VIDEO_SCREEN = "VideoFeed"

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/DisappearingScaffold.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/DisappearingScaffold.kt
@@ -24,10 +24,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -129,7 +132,8 @@ fun DisappearingScaffold(
         }
     val rootModifier =
         baseModifier
-            .let { if (topBar == null) it.statusBarsPadding() else it }
+            // systemBars (not just statusBars) so a desktop window's caption bar is respected too.
+            .let { if (topBar == null) it.windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top)) else it }
             .let { if (bottomBar == null) it.navigationBarsPadding() else it }
 
     Surface(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/DisappearingScaffold.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/DisappearingScaffold.kt
@@ -109,6 +109,14 @@ fun DisappearingScaffold(
         ImmersiveStatusBarEffect(state)
     }
 
+    // If the bars were scrolled away when hiding got disabled (e.g. the window grew to a
+    // large tier mid-scroll), nothing above can bring them back — the nested-scroll
+    // connection and the resume reset are gone. Snap them visible here instead of
+    // leaving the chrome stranded off-screen.
+    LaunchedEffect(canHideBars, state) {
+        if (!canHideBars) state.resetToVisible()
+    }
+
     // When bars are pinned, skip attaching the nested-scroll connection entirely.
     // The outer Surface provides the Material container color + onBackground as
     // LocalContentColor, matching M3 Scaffold's behaviour (without it, default text

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/DisappearingScaffold.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/DisappearingScaffold.kt
@@ -80,10 +80,14 @@ fun DisappearingScaffold(
 ) {
     val state = rememberDisappearingBarState()
 
+    // Large screens (rail / permanent drawer) pin the chrome: bars never slide away on
+    // scroll, and the immersive status-bar hiding stays off.
+    val canHideBars = allowBarHide && !LocalScreenLayout.current.isLargeScreen
+
     // Hold the latest values in state so the NSC's captured lambda stays fresh across
     // recompositions without rebuilding the NSC itself.
     val latestIsActive by rememberUpdatedState(isActive)
-    val latestAllowBarHide by rememberUpdatedState(allowBarHide)
+    val latestAllowBarHide by rememberUpdatedState(canHideBars)
     val latestAccountViewModel by rememberUpdatedState(accountViewModel)
 
     val connection =
@@ -100,7 +104,7 @@ fun DisappearingScaffold(
         }
 
     // Only wire the lifecycle observer + system-bar control when the scaffold actually moves its bars.
-    if (allowBarHide) {
+    if (canHideBars) {
         ResetBarsOnResume(state)
         ImmersiveStatusBarEffect(state)
     }
@@ -110,7 +114,7 @@ fun DisappearingScaffold(
     // LocalContentColor, matching M3 Scaffold's behaviour (without it, default text
     // color falls back to Color.Black and is invisible on the dark theme).
     val baseModifier =
-        if (allowBarHide) {
+        if (canHideBars) {
             Modifier.imePadding().nestedScroll(connection)
         } else {
             Modifier.imePadding()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/ScreenLayout.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/ScreenLayout.kt
@@ -20,6 +20,11 @@
  */
 package com.vitorpamplona.amethyst.ui.layouts
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
@@ -27,6 +32,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.ui.components.getActivity
@@ -80,11 +87,37 @@ val PermanentDrawerWidth = 300.dp
 val NotificationPanelWidth = 360.dp
 
 /**
- * Maximum width of a feed's content column inside a wide center pane. Wider than this,
- * feeds center themselves via [com.vitorpamplona.amethyst.commons.ui.layouts.LocalFeedSidePadding];
- * the scroll surface itself stays full-pane so pull-to-refresh and scrolling work edge to edge.
+ * Maximum width of a screen's content column inside a wide center pane. Every NavHost
+ * destination is wrapped in [CappedScreenContent] (via the builders in NavigationEffects),
+ * so the whole screen — top bar, tabs, feed, settings rows — shares one centered reading
+ * column instead of stretching across the pane. Screens that genuinely need the full pane
+ * (Messages' two-pane split, the embedded browser surfaces) opt out at registration.
  */
 val FeedContentMaxWidth = 600.dp
+
+/**
+ * Centers a destination's content at [FeedContentMaxWidth]. The outer box paints the theme
+ * background so the gutters match the screens' own surfaces; on Compact windows the cap is
+ * wider than the pane and this is a visual no-op.
+ */
+@Composable
+fun CappedScreenContent(content: @Composable () -> Unit) {
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background),
+        contentAlignment = Alignment.TopCenter,
+    ) {
+        Box(
+            Modifier
+                .widthIn(max = FeedContentMaxWidth)
+                .fillMaxSize(),
+        ) {
+            content()
+        }
+    }
+}
 
 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @Composable

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/ScreenLayout.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/layouts/ScreenLayout.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.layouts
+
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.dp
+import com.vitorpamplona.amethyst.ui.components.getActivity
+
+/** How the app shell presents its top-level navigation for the current window size. */
+enum class NavigationStyle {
+    /** Compact windows (phones): bottom navigation bar + modal drawer. */
+    BOTTOM_BAR,
+
+    /**
+     * Medium windows (portrait tablets, unfolded foldables): a left navigation rail
+     * replaces the bottom bar; the drawer stays modal behind the rail's avatar button.
+     */
+    NAV_RAIL,
+
+    /** Expanded windows (landscape tablets, desktop windows): the drawer docks permanently on the left. */
+    PERMANENT_DRAWER,
+}
+
+/**
+ * The shell layout decisions for the current window, published once per window size change
+ * through [LocalScreenLayout] so every screen, bar and panel agrees on the same tier.
+ */
+@Immutable
+data class ScreenLayoutSpec(
+    val navigationStyle: NavigationStyle,
+    val showsNotificationPanel: Boolean,
+) {
+    /**
+     * True on the rail and permanent-drawer tiers. Large screens hide the bottom bar and pin
+     * the top/bottom chrome (no disappearing bars on scroll).
+     */
+    val isLargeScreen: Boolean get() = navigationStyle != NavigationStyle.BOTTOM_BAR
+
+    companion object {
+        val Phone = ScreenLayoutSpec(NavigationStyle.BOTTOM_BAR, showsNotificationPanel = false)
+    }
+}
+
+val LocalScreenLayout = compositionLocalOf { ScreenLayoutSpec.Phone }
+
+/**
+ * Minimum window width for the docked notification panel: the permanent drawer
+ * ([PermanentDrawerWidth]) + a readable center pane + the panel ([NotificationPanelWidth])
+ * only coexist comfortably from a landscape-tablet-sized window up.
+ */
+private const val NOTIFICATION_PANEL_MIN_WINDOW_DP = 1200
+
+val PermanentDrawerWidth = 300.dp
+
+val NotificationPanelWidth = 360.dp
+
+/**
+ * Maximum width of a feed's content column inside a wide center pane. Wider than this,
+ * feeds center themselves via [com.vitorpamplona.amethyst.commons.ui.layouts.LocalFeedSidePadding];
+ * the scroll surface itself stays full-pane so pull-to-refresh and scrolling work edge to edge.
+ */
+val FeedContentMaxWidth = 600.dp
+
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
+@Composable
+fun rememberScreenLayoutSpec(): ScreenLayoutSpec {
+    val widthSizeClass = calculateWindowSizeClass(getActivity()).widthSizeClass
+    val windowWidthDp = LocalConfiguration.current.screenWidthDp
+    return remember(widthSizeClass, windowWidthDp) {
+        val style =
+            when (widthSizeClass) {
+                WindowWidthSizeClass.Expanded -> NavigationStyle.PERMANENT_DRAWER
+                WindowWidthSizeClass.Medium -> NavigationStyle.NAV_RAIL
+                else -> NavigationStyle.BOTTOM_BAR
+            }
+        ScreenLayoutSpec(
+            navigationStyle = style,
+            showsNotificationPanel =
+                style == NavigationStyle.PERMANENT_DRAWER &&
+                    windowWidthDp >= NOTIFICATION_PANEL_MIN_WINDOW_DP,
+        )
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -293,6 +294,10 @@ fun AppNavigation(
     // function body so anything added to AppNavigation later is inside it by construction.
     val screenLayout = rememberScreenLayoutSpec()
     val tabReselectCoordinator = remember { TabReselectCoordinator() }
+
+    // Mirror the tier for the nav-transition specs, which run outside composition and so
+    // can't read LocalScreenLayout (see NavTransitionTier).
+    SideEffect { NavTransitionTier.isLargeScreen = screenLayout.isLargeScreen }
 
     CompositionLocalProvider(
         LocalScreenLayout provides screenLayout,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -380,9 +380,9 @@ fun BuildNavigation(
         enterTransition = { fadeIn(animationSpec = tween(200)) },
         exitTransition = { fadeOut(animationSpec = tween(200)) },
     ) {
-        composable<Route.Home> { HomeScreen(accountViewModel, nav) }
+        composableCapped<Route.Home> { HomeScreen(accountViewModel, nav) }
         composable<Route.Message> { MessagesScreen(accountViewModel, nav) }
-        composable<Route.Video> { VideoScreen(accountViewModel, nav) }
+        composableCapped<Route.Video> { VideoScreen(accountViewModel, nav) }
         composableArgs<Route.Discover> { DiscoverScreen(it.initialTab, accountViewModel, nav) }
         composableArgs<Route.Notification> { NotificationScreen(it.scrollToEventId, accountViewModel, nav) }
         composableFromEnd<Route.Polls> { PollsScreen(accountViewModel, nav) }
@@ -399,10 +399,10 @@ fun BuildNavigation(
         composableFromEnd<Route.SoftwareApps> { SoftwareAppsScreen(accountViewModel, nav) }
         composableFromEnd<Route.Napplets> { NappletsScreen(accountViewModel, nav) }
         composableFromEnd<Route.Nsites> { NsitesScreen(accountViewModel, nav) }
-        composableFromEnd<Route.Browser> { BrowserScreen(accountViewModel, nav) }
+        composableFromEnd<Route.Browser>(capWidth = false) { BrowserScreen(accountViewModel, nav) }
         composableFromEnd<Route.FavoriteApps> { FavoriteAppsScreen(accountViewModel, nav) }
-        composableFromEndArgs<Route.WebApp> { WebAppScreen(it.url, accountViewModel, nav) }
-        composableFromEndArgs<Route.NostrApp> { NostrAppScreen(it.coordinate, accountViewModel, nav) }
+        composableFromEndArgs<Route.WebApp>(capWidth = false) { WebAppScreen(it.url, accountViewModel, nav) }
+        composableFromEndArgs<Route.NostrApp>(capWidth = false) { NostrAppScreen(it.coordinate, accountViewModel, nav) }
         composableFromEnd<Route.ConnectedApps> { ConnectedAppsScreen(accountViewModel, nav) }
         composableFromEndArgs<Route.ConnectedAppDetail> { ConnectedAppDetailScreen(it.coordinate, accountViewModel, nav) }
         composableFromEnd<Route.RelayAuthSettings> { RelayAuthSettingsScreen(accountViewModel, nav) }
@@ -441,7 +441,7 @@ fun BuildNavigation(
         composableFromEndArgs<Route.NewMusicPlaylist> { NewMusicPlaylistScreen(editDTag = it.dTag, accountViewModel = accountViewModel, nav = nav) }
         composableFromEndArgs<Route.AddToMusicPlaylist> { AddToMusicPlaylistSheet(trackAddress = it.trackAddress, accountViewModel = accountViewModel, nav = nav) }
         composableFromEnd<Route.NewHlsVideo> { NewHlsVideoScreen(accountViewModel, nav) }
-        composable<Route.Chess> { ChessLobbyScreen(accountViewModel, nav) }
+        composableCapped<Route.Chess> { ChessLobbyScreen(accountViewModel, nav) }
 
         composableFromEnd<Route.Wallet> { WalletScreen(accountViewModel, nav) }
         composableFromEndArgs<Route.WalletSend> { WalletSendScreen(it.walletId, accountViewModel, nav) }
@@ -494,7 +494,7 @@ fun BuildNavigation(
         composableFromBottomArgs<Route.TopUpMint> { TopUpMintScreen(it.mintUrl, accountViewModel, nav) }
 
         composableFromBottomArgs<Route.EditProfile> { NewUserMetadataScreen(nav, accountViewModel) }
-        composable<Route.Search> { SearchScreen(accountViewModel, nav) }
+        composableCapped<Route.Search> { SearchScreen(accountViewModel, nav) }
 
         composableFromEnd<Route.AllSettings> { AllSettingsScreen(accountViewModel, nav) }
         composableFromEnd<Route.AccountBackup> { AccountBackupScreen(accountViewModel, nav) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -62,6 +62,8 @@ import com.vitorpamplona.amethyst.ui.components.getActivity
 import com.vitorpamplona.amethyst.ui.components.toasts.DisplayErrorMessages
 import com.vitorpamplona.amethyst.ui.layouts.LocalScreenLayout
 import com.vitorpamplona.amethyst.ui.layouts.rememberScreenLayoutSpec
+import com.vitorpamplona.amethyst.ui.navigation.bottombars.LocalTabReselectCoordinator
+import com.vitorpamplona.amethyst.ui.navigation.bottombars.TabReselectCoordinator
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.favoriteIds
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.navigation.navs.rememberNav
@@ -287,54 +289,50 @@ fun AppNavigation(
 
     // One layout decision per window size for the whole shell: bottom bar vs rail vs
     // permanent drawer, plus the docked notification panel. Every screen, bar and panel
-    // below reads the same spec through LocalScreenLayout.
+    // below reads the same spec through LocalScreenLayout. The provider wraps this whole
+    // function body so anything added to AppNavigation later is inside it by construction.
     val screenLayout = rememberScreenLayoutSpec()
+    val tabReselectCoordinator = remember { TabReselectCoordinator() }
 
-    CompositionLocalProvider(LocalScreenLayout provides screenLayout) {
-        AppNavigationLayers(accountViewModel, accountSessionManager, nav)
-    }
-}
-
-@Composable
-private fun AppNavigationLayers(
-    accountViewModel: AccountViewModel,
-    accountSessionManager: AccountSessionManager,
-    nav: Nav,
-) {
-    AccountSwitcherAndLeftDrawerLayout(accountViewModel, accountSessionManager, nav) {
-        Box(Modifier.fillMaxSize()) {
-            BuildNavigation(accountViewModel, nav)
-            // Pull each pinned nsite/napplet's manifest into LocalCache (and keep a device-local copy)
-            // so its favorite resolves as reliably as a pinned web app's URL — the data the embedded
-            // preloader below and the full-screen launcher both need. Not API-gated: every device's
-            // launcher benefits, and it's the only preload step that runs below API 30.
-            FavoriteAppManifestPreloader(accountViewModel)
-            // Persistent layer that keeps pinned embedded tabs (browser / nsite / napplet) warm by
-            // holding their surfaces attached. Below the drawer (drawn by the layout above) and below
-            // dialogs (separate windows). API 30+ only, matching the embedded-surface feature.
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                val bottomBarItems by accountViewModel.settings.uiSettingsFlow.bottomBarItems
-                    .collectAsStateWithLifecycle()
-                EmbeddedTabLayer(bottomBarItems.favoriteIds())
-                // Warm every pinned tab at startup so the first tap is instant (content already local).
-                EmbeddedTabPreloader(accountViewModel)
-                // Rebuild the warm surfaces in the new theme when the app's DARK/LIGHT preference flips
-                // (an embed WebView's theme is fixed at construction, so it can't follow a live switch).
-                EmbeddedTabThemeWatcher()
+    CompositionLocalProvider(
+        LocalScreenLayout provides screenLayout,
+        LocalTabReselectCoordinator provides tabReselectCoordinator,
+    ) {
+        AccountSwitcherAndLeftDrawerLayout(accountViewModel, accountSessionManager, nav) {
+            Box(Modifier.fillMaxSize()) {
+                BuildNavigation(accountViewModel, nav)
+                // Pull each pinned nsite/napplet's manifest into LocalCache (and keep a device-local copy)
+                // so its favorite resolves as reliably as a pinned web app's URL — the data the embedded
+                // preloader below and the full-screen launcher both need. Not API-gated: every device's
+                // launcher benefits, and it's the only preload step that runs below API 30.
+                FavoriteAppManifestPreloader(accountViewModel)
+                // Persistent layer that keeps pinned embedded tabs (browser / nsite / napplet) warm by
+                // holding their surfaces attached. Below the drawer (drawn by the layout above) and below
+                // dialogs (separate windows). API 30+ only, matching the embedded-surface feature.
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    val bottomBarItems by accountViewModel.settings.uiSettingsFlow.bottomBarItems
+                        .collectAsStateWithLifecycle()
+                    EmbeddedTabLayer(bottomBarItems.favoriteIds())
+                    // Warm every pinned tab at startup so the first tap is instant (content already local).
+                    EmbeddedTabPreloader(accountViewModel)
+                    // Rebuild the warm surfaces in the new theme when the app's DARK/LIGHT preference flips
+                    // (an embed WebView's theme is fixed at construction, so it can't follow a live switch).
+                    EmbeddedTabThemeWatcher()
+                }
             }
         }
+
+        TrackScreenTime(nav)
+        NavigateIfIntentRequested(nav, accountViewModel, accountSessionManager)
+
+        DisplayErrorMessages(accountViewModel.toastManager, accountViewModel, nav)
+        DisplayNotifyMessages(accountViewModel, nav)
+        DisplayCrashMessages(accountViewModel, nav)
+        DisplayResourceUsageAlert(accountViewModel, nav)
+        DisplayBroadcastProgress(accountViewModel)
+
+        ObserveIncomingCalls(accountViewModel)
     }
-
-    TrackScreenTime(nav)
-    NavigateIfIntentRequested(nav, accountViewModel, accountSessionManager)
-
-    DisplayErrorMessages(accountViewModel.toastManager, accountViewModel, nav)
-    DisplayNotifyMessages(accountViewModel, nav)
-    DisplayCrashMessages(accountViewModel, nav)
-    DisplayResourceUsageAlert(accountViewModel, nav)
-    DisplayBroadcastProgress(accountViewModel)
-
-    ObserveIncomingCalls(accountViewModel)
 }
 
 @Composable

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -29,6 +29,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -59,6 +60,8 @@ import com.vitorpamplona.amethyst.ui.broadcast.DisplayBroadcastProgress
 import com.vitorpamplona.amethyst.ui.call.CallActivity
 import com.vitorpamplona.amethyst.ui.components.getActivity
 import com.vitorpamplona.amethyst.ui.components.toasts.DisplayErrorMessages
+import com.vitorpamplona.amethyst.ui.layouts.LocalScreenLayout
+import com.vitorpamplona.amethyst.ui.layouts.rememberScreenLayoutSpec
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.favoriteIds
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.navigation.navs.rememberNav
@@ -282,6 +285,22 @@ fun AppNavigation(
 ) {
     val nav = rememberNav()
 
+    // One layout decision per window size for the whole shell: bottom bar vs rail vs
+    // permanent drawer, plus the docked notification panel. Every screen, bar and panel
+    // below reads the same spec through LocalScreenLayout.
+    val screenLayout = rememberScreenLayoutSpec()
+
+    CompositionLocalProvider(LocalScreenLayout provides screenLayout) {
+        AppNavigationLayers(accountViewModel, accountSessionManager, nav)
+    }
+}
+
+@Composable
+private fun AppNavigationLayers(
+    accountViewModel: AccountViewModel,
+    accountSessionManager: AccountSessionManager,
+    nav: Nav,
+) {
     AccountSwitcherAndLeftDrawerLayout(accountViewModel, accountSessionManager, nav) {
         Box(Modifier.fillMaxSize()) {
             BuildNavigation(accountViewModel, nav)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/NavigationEffects.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/NavigationEffects.kt
@@ -22,6 +22,8 @@ package com.vitorpamplona.amethyst.ui.navigation
 
 import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.animation.slideInHorizontally
@@ -44,6 +46,21 @@ import com.vitorpamplona.amethyst.ui.layouts.CappedScreenContent
 const val BOTTOM_NAV_ROOT_KEY = "bottomNavRoot"
 
 fun NavBackStackEntry.isBottomNavRoot(): Boolean = savedStateHandle.get<Boolean>(BOTTOM_NAV_ROOT_KEY) == true
+
+/**
+ * The shell's current layout tier, mirrored for the transition specs below. Transition
+ * lambdas run when a navigation starts — outside composition — so they can't read
+ * LocalScreenLayout; AppNavigation mirrors the spec here instead.
+ *
+ * One navigation grammar, tier-scaled motion: phones keep full-width slides (a pushed
+ * screen physically stacks on top), while large screens use short shared-axis moves —
+ * content there swaps inside a persistent shell, and a full-pane slide from the right
+ * reads as disconnected when the click came from the docked drawer on the left.
+ */
+object NavTransitionTier {
+    @Volatile
+    var isLargeScreen: Boolean = false
+}
 
 /**
  * Applies the wide-pane reading-column cap ([CappedScreenContent]) to a destination unless
@@ -74,10 +91,10 @@ inline fun <reified T : Any> NavGraphBuilder.composableFromEnd(
     noinline content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
 ) {
     composable<T>(
-        enterTransition = { if (targetState.isBottomNavRoot()) null else slideInHorizontallyFromEnd },
-        exitTransition = { if (targetState.isBottomNavRoot()) null else scaleOut },
-        popEnterTransition = { if (initialState.isBottomNavRoot()) null else scaleIn },
-        popExitTransition = { if (initialState.isBottomNavRoot()) null else slideOutHorizontallyToEnd },
+        enterTransition = { if (targetState.isBottomNavRoot()) null else enterFromEnd() },
+        exitTransition = { if (targetState.isBottomNavRoot()) null else exitBehind() },
+        popEnterTransition = { if (initialState.isBottomNavRoot()) null else popEnterFromBehind() },
+        popExitTransition = { if (initialState.isBottomNavRoot()) null else popExitToEnd() },
         content = { entry ->
             MaybeCappedScreen(capWidth) { content(entry) }
         },
@@ -98,10 +115,10 @@ inline fun <reified T : Any> NavGraphBuilder.composableFromBottom(
     noinline content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
 ) {
     composable<T>(
-        enterTransition = { slideInVerticallyFromBottom },
-        exitTransition = { scaleOut },
-        popEnterTransition = { scaleIn },
-        popExitTransition = { slideOutVerticallyToBottom },
+        enterTransition = { enterFromBottom() },
+        exitTransition = { exitBehind() },
+        popEnterTransition = { popEnterFromBehind() },
+        popExitTransition = { popExitToBottom() },
         content = { entry ->
             MaybeCappedScreen(capWidth) { content(entry) }
         },
@@ -134,3 +151,29 @@ val slideOutHorizontallyToEnd = slideOutHorizontally(animationSpec = tween(), ta
 
 val scaleIn = scaleIn(animationSpec = tween(), initialScale = 0.9f)
 val scaleOut = scaleOut(animationSpec = tween(), targetScale = 0.9f)
+
+/** Fraction of the pane a shared-axis move travels on large screens — a nudge, not a fly-in. */
+private const val SHARED_AXIS_FRACTION = 10
+
+val sharedAxisEnterFromEnd = slideInHorizontally(animationSpec = tween()) { it / SHARED_AXIS_FRACTION } + fadeIn(animationSpec = tween())
+val sharedAxisExitToEnd = slideOutHorizontally(animationSpec = tween()) { it / SHARED_AXIS_FRACTION } + fadeOut(animationSpec = tween())
+val sharedAxisEnterFromBottom = slideInVertically(animationSpec = tween()) { it / SHARED_AXIS_FRACTION } + fadeIn(animationSpec = tween())
+val sharedAxisExitToBottom = slideOutVertically(animationSpec = tween()) { it / SHARED_AXIS_FRACTION } + fadeOut(animationSpec = tween())
+
+// The outgoing/incoming screen *behind* a push: on phones the pushed screen covers it, so a
+// slight scale is enough; on large screens the incoming screen fades, so the one behind must
+// fade too or both stay visible mid-transition.
+val fadeScaleOut = scaleOut + fadeOut(animationSpec = tween())
+val fadeScaleIn = scaleIn + fadeIn(animationSpec = tween())
+
+fun enterFromEnd() = if (NavTransitionTier.isLargeScreen) sharedAxisEnterFromEnd else slideInHorizontallyFromEnd
+
+fun popExitToEnd() = if (NavTransitionTier.isLargeScreen) sharedAxisExitToEnd else slideOutHorizontallyToEnd
+
+fun enterFromBottom() = if (NavTransitionTier.isLargeScreen) sharedAxisEnterFromBottom else slideInVerticallyFromBottom
+
+fun popExitToBottom() = if (NavTransitionTier.isLargeScreen) sharedAxisExitToBottom else slideOutVerticallyToBottom
+
+fun exitBehind() = if (NavTransitionTier.isLargeScreen) fadeScaleOut else scaleOut
+
+fun popEnterFromBehind() = if (NavTransitionTier.isLargeScreen) fadeScaleIn else scaleIn

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/NavigationEffects.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/NavigationEffects.kt
@@ -33,6 +33,7 @@ import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
+import com.vitorpamplona.amethyst.ui.layouts.CappedScreenContent
 
 // Per-entry hint stamped by Nav.navBottomBar marking that the entry was
 // reached via a bottom-nav tab. Used in two places:
@@ -44,41 +45,84 @@ const val BOTTOM_NAV_ROOT_KEY = "bottomNavRoot"
 
 fun NavBackStackEntry.isBottomNavRoot(): Boolean = savedStateHandle.get<Boolean>(BOTTOM_NAV_ROOT_KEY) == true
 
-inline fun <reified T : Any> NavGraphBuilder.composableFromEnd(noinline content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit) {
+/**
+ * Applies the wide-pane reading-column cap ([CappedScreenContent]) to a destination unless
+ * it opted out with `capWidth = false`. Every builder below routes through this, so all
+ * destinations — top bars included — share the centered column on large screens by default.
+ */
+@Composable
+fun MaybeCappedScreen(
+    capWidth: Boolean,
+    content: @Composable () -> Unit,
+) {
+    if (capWidth) {
+        CappedScreenContent(content)
+    } else {
+        content()
+    }
+}
+
+/** Stock fade-transition destination, capped to the reading-column width on wide panes. */
+inline fun <reified T : Any> NavGraphBuilder.composableCapped(noinline content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit) {
+    composable<T> { entry ->
+        CappedScreenContent { content(entry) }
+    }
+}
+
+inline fun <reified T : Any> NavGraphBuilder.composableFromEnd(
+    capWidth: Boolean = true,
+    noinline content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
+) {
     composable<T>(
         enterTransition = { if (targetState.isBottomNavRoot()) null else slideInHorizontallyFromEnd },
         exitTransition = { if (targetState.isBottomNavRoot()) null else scaleOut },
         popEnterTransition = { if (initialState.isBottomNavRoot()) null else scaleIn },
         popExitTransition = { if (initialState.isBottomNavRoot()) null else slideOutHorizontallyToEnd },
-        content = content,
+        content = { entry ->
+            MaybeCappedScreen(capWidth) { content(entry) }
+        },
     )
 }
 
-inline fun <reified T : Any> NavGraphBuilder.composableFromEndArgs(noinline content: @Composable AnimatedContentScope.(T) -> Unit) {
-    composableFromEnd<T> {
+inline fun <reified T : Any> NavGraphBuilder.composableFromEndArgs(
+    capWidth: Boolean = true,
+    noinline content: @Composable AnimatedContentScope.(T) -> Unit,
+) {
+    composableFromEnd<T>(capWidth) {
         content(it.toRoute<T>())
     }
 }
 
-inline fun <reified T : Any> NavGraphBuilder.composableFromBottom(noinline content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit) {
+inline fun <reified T : Any> NavGraphBuilder.composableFromBottom(
+    capWidth: Boolean = true,
+    noinline content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
+) {
     composable<T>(
         enterTransition = { slideInVerticallyFromBottom },
         exitTransition = { scaleOut },
         popEnterTransition = { scaleIn },
         popExitTransition = { slideOutVerticallyToBottom },
-        content = content,
+        content = { entry ->
+            MaybeCappedScreen(capWidth) { content(entry) }
+        },
     )
 }
 
-inline fun <reified T : Any> NavGraphBuilder.composableFromBottomArgs(noinline content: @Composable AnimatedContentScope.(T) -> Unit) {
-    composableFromBottom<T> {
+inline fun <reified T : Any> NavGraphBuilder.composableFromBottomArgs(
+    capWidth: Boolean = true,
+    noinline content: @Composable AnimatedContentScope.(T) -> Unit,
+) {
+    composableFromBottom<T>(capWidth) {
         content(it.toRoute())
     }
 }
 
-inline fun <reified T : Any> NavGraphBuilder.composableArgs(noinline content: @Composable AnimatedContentScope.(T) -> Unit) {
-    composable<T> {
-        content(it.toRoute())
+inline fun <reified T : Any> NavGraphBuilder.composableArgs(
+    capWidth: Boolean = true,
+    noinline content: @Composable AnimatedContentScope.(T) -> Unit,
+) {
+    composable<T> { entry ->
+        MaybeCappedScreen(capWidth) { content(entry.toRoute()) }
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/AppBottomBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/AppBottomBar.kt
@@ -49,6 +49,7 @@ import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
 import com.vitorpamplona.amethyst.favorites.BrowserIconRegistry
 import com.vitorpamplona.amethyst.favorites.FavoriteAppsRegistry
 import com.vitorpamplona.amethyst.favorites.rememberNappletIconModel
+import com.vitorpamplona.amethyst.ui.layouts.LocalScreenLayout
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -73,6 +74,10 @@ fun AppBottomBar(
     accountViewModel: AccountViewModel,
     onClick: (Route) -> Unit,
 ) {
+    // Large screens replace the bottom bar with the navigation rail (Medium) or the
+    // permanently docked drawer (Expanded).
+    if (LocalScreenLayout.current.isLargeScreen) return
+
     // Hide the bar on entries that aren't a tab root (drawer or in-app
     // pushes). Mirrors the back-arrow rule in canPop().
     if (nav.canPop()) return

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/AppBottomBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/AppBottomBar.kt
@@ -36,8 +36,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -74,6 +76,18 @@ fun AppBottomBar(
     accountViewModel: AccountViewModel,
     onClick: (Route) -> Unit,
 ) {
+    // Publish this screen's re-tap behavior even when the bar renders nothing: on large
+    // screens the navigation rail routes reselect taps back through the coordinator so the
+    // same per-screen scroll-to-top/refresh logic runs.
+    val coordinator = LocalTabReselectCoordinator.current
+    val latestRoute by rememberUpdatedState(selectedRoute)
+    val latestOnClick by rememberUpdatedState(onClick)
+    DisposableEffect(coordinator) {
+        val handler: (Route) -> Unit = { latestOnClick(it) }
+        coordinator.register({ latestRoute }, handler)
+        onDispose { coordinator.unregister(handler) }
+    }
+
     // Large screens replace the bottom bar with the navigation rail (Medium) or the
     // permanently docked drawer (Expanded).
     if (LocalScreenLayout.current.isLargeScreen) return
@@ -106,6 +120,43 @@ fun AppBottomBar(
     }
 }
 
+/**
+ * Resolves the icon model for a pinned favorite: a web favorite's captured favicon (else the
+ * generic globe), an nsite/napplet's verified manifest icon bundled in its own content (the
+ * iframe sandbox rules out live capture; else the grid glyph). Shared by the bottom bar and
+ * the navigation rail.
+ */
+@Composable
+internal fun rememberFavoriteIconModel(fav: FavoriteApp): Any? =
+    when (fav) {
+        is FavoriteApp.WebApp -> {
+            // Captured favicons, keyed so the icon appears once the site's capture lands.
+            val iconKeys by BrowserIconRegistry.keys.collectAsStateWithLifecycle()
+            remember(fav, iconKeys) {
+                OmniboxInput.hostOf(fav.url)?.let(BrowserIconRegistry::iconModelFor)
+            }
+        }
+
+        is FavoriteApp.NostrApp -> rememberNappletIconModel(fav.coordinate)
+    }
+
+/** The icon block for a pinned favorite entry, shared by the bottom bar and the rail. */
+@Composable
+internal fun FavoriteEntryIcon(
+    fav: FavoriteApp,
+    selected: Boolean,
+    iconModel: Any?,
+) {
+    Box(Size27Modifier, contentAlignment = Alignment.Center) {
+        FavoriteAppIcon(
+            app = fav,
+            tint = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface65,
+            modifier = Size25Modifier,
+            iconModel = iconModel,
+        )
+    }
+}
+
 @Composable
 private fun RenderBottomMenu(
     items: List<BottomBarEntry>,
@@ -116,9 +167,6 @@ private fun RenderBottomMenu(
 ) {
     // Index favorites by id so resolving each Favorite entry is a map lookup, not a per-entry scan.
     val favoritesById = remember(favorites) { favorites.associateBy { it.id } }
-
-    // Captured favicons, so a pinned web favorite shows the site's icon instead of the generic globe.
-    val iconKeys by BrowserIconRegistry.keys.collectAsStateWithLifecycle()
 
     Column(
         modifier =
@@ -152,17 +200,7 @@ private fun RenderBottomMenu(
                                 is FavoriteApp.WebApp -> Route.WebApp(fav.url)
                                 is FavoriteApp.NostrApp -> Route.NostrApp(fav.coordinate)
                             }
-                        // A web favorite uses its captured favicon; an nsite/napplet uses the verified
-                        // icon blob bundled in its own content (the iframe sandbox rules out live capture).
-                        val iconModel =
-                            when (fav) {
-                                is FavoriteApp.WebApp ->
-                                    remember(fav, iconKeys) {
-                                        OmniboxInput.hostOf(fav.url)?.let(BrowserIconRegistry::iconModelFor)
-                                    }
-                                is FavoriteApp.NostrApp -> rememberNappletIconModel(fav.coordinate)
-                            }
-                        FavoriteNavItem(destination == selectedRoute, fav, iconModel, destination, nav)
+                        FavoriteNavItem(destination == selectedRoute, fav, rememberFavoriteIconModel(fav), destination, nav)
                     }
                 }
             }
@@ -180,18 +218,7 @@ private fun RowScope.FavoriteNavItem(
 ) {
     NavigationBarItem(
         alwaysShowLabel = false,
-        icon = {
-            Box(Size27Modifier, contentAlignment = Alignment.Center) {
-                // A web favorite's captured favicon (else the globe); an nsite/napplet's manifest icon (else
-                // the grid glyph).
-                FavoriteAppIcon(
-                    app = fav,
-                    tint = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface65,
-                    modifier = Size25Modifier,
-                    iconModel = iconModel,
-                )
-            }
-        },
+        icon = { FavoriteEntryIcon(fav, selected, iconModel) },
         // No label — favorite tabs match the built-in items, which show icon only.
         selected = selected,
         onClick = { nav(destination) },
@@ -221,8 +248,9 @@ private fun RowScope.HasNewItemsIcon(
     )
 }
 
+/** The icon block for a built-in entry (catalog icon + new-items dot), shared by the bottom bar and the rail. */
 @Composable
-private fun NotifiableIcon(
+internal fun NotifiableIcon(
     selected: Boolean,
     def: NavBarItemDef,
     destination: Route,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/AppNavigationRail.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/AppNavigationRail.kt
@@ -20,7 +20,6 @@
  */
 package com.vitorpamplona.amethyst.ui.navigation.bottombars
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -35,28 +34,20 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.compose.currentBackStackEntryAsState
-import com.vitorpamplona.amethyst.commons.browser.OmniboxInput
 import com.vitorpamplona.amethyst.commons.favorites.FavoriteApp
-import com.vitorpamplona.amethyst.commons.favorites.FavoriteAppIcon
-import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
-import com.vitorpamplona.amethyst.favorites.BrowserIconRegistry
 import com.vitorpamplona.amethyst.favorites.FavoriteAppsRegistry
-import com.vitorpamplona.amethyst.favorites.rememberNappletIconModel
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.navigation.routes.getRouteWithArguments
 import com.vitorpamplona.amethyst.ui.navigation.topbars.LoggedInUserPictureDrawer
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
-import com.vitorpamplona.amethyst.ui.stringRes
-import com.vitorpamplona.amethyst.ui.theme.Size25Modifier
-import com.vitorpamplona.amethyst.ui.theme.Size27Modifier
-import com.vitorpamplona.amethyst.ui.theme.onSurface65
 
 /**
  * Medium-width windows: a left rail that carries the same user-configured destinations as the
  * phone bottom bar ([BottomBarEntry] list, built-ins and pinned favorites interleaved), so the
  * user's customization and new-item dots carry over. The header avatar opens the modal drawer,
- * mirroring the avatar button in the phone top bars.
+ * mirroring the avatar button in the phone top bars. Re-tapping the selected item routes
+ * through [TabReselectCoordinator] to the screen's own scroll-to-top/refresh handler.
  */
 @Composable
 fun AppNavigationRail(
@@ -68,8 +59,7 @@ fun AppNavigationRail(
     val favorites by FavoriteAppsRegistry.favorites.collectAsStateWithLifecycle()
     val favoritesById = remember(favorites) { favorites.associateBy { it.id } }
 
-    // Captured favicons, so a pinned web favorite shows the site's icon instead of the generic globe.
-    val iconKeys by BrowserIconRegistry.keys.collectAsStateWithLifecycle()
+    val reselectCoordinator = LocalTabReselectCoordinator.current
 
     val navBackStackEntry by nav.controller.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
@@ -93,18 +83,14 @@ fun AppNavigationRail(
                         val selected = currentDestination?.hasRoute(destination::class) == true
                         NavigationRailItem(
                             selected = selected,
-                            onClick = { if (!selected) nav.navBottomBar(destination) },
-                            icon = {
-                                Box(Size27Modifier, contentAlignment = Alignment.Center) {
-                                    Icon(
-                                        symbol = def.icon,
-                                        contentDescription = stringRes(def.labelRes),
-                                        modifier = Size25Modifier,
-                                        tint = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface65,
-                                    )
-                                    AddNotifIconIfNeeded(destination, accountViewModel, Modifier.align(Alignment.TopEnd))
+                            onClick = {
+                                if (selected) {
+                                    reselectCoordinator.reselect(destination)
+                                } else {
+                                    nav.navBottomBar(destination)
                                 }
                             },
+                            icon = { NotifiableIcon(selected, def, destination, accountViewModel) },
                         )
                     }
 
@@ -125,27 +111,16 @@ fun AppNavigationRail(
                                     else -> false
                                 }
                             }
-                        val iconModel =
-                            when (fav) {
-                                is FavoriteApp.WebApp ->
-                                    remember(fav, iconKeys) {
-                                        OmniboxInput.hostOf(fav.url)?.let(BrowserIconRegistry::iconModelFor)
-                                    }
-                                is FavoriteApp.NostrApp -> rememberNappletIconModel(fav.coordinate)
-                            }
                         NavigationRailItem(
                             selected = selected,
-                            onClick = { if (!selected) nav.navBottomBar(destination) },
-                            icon = {
-                                Box(Size27Modifier, contentAlignment = Alignment.Center) {
-                                    FavoriteAppIcon(
-                                        app = fav,
-                                        tint = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface65,
-                                        modifier = Size25Modifier,
-                                        iconModel = iconModel,
-                                    )
+                            onClick = {
+                                if (selected) {
+                                    reselectCoordinator.reselect(destination)
+                                } else {
+                                    nav.navBottomBar(destination)
                                 }
                             },
+                            icon = { FavoriteEntryIcon(fav, selected, rememberFavoriteIconModel(fav)) },
                         )
                     }
                 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/AppNavigationRail.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/AppNavigationRail.kt
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.navigation.bottombars
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationRail
+import androidx.compose.material3.NavigationRailItem
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.compose.currentBackStackEntryAsState
+import com.vitorpamplona.amethyst.commons.browser.OmniboxInput
+import com.vitorpamplona.amethyst.commons.favorites.FavoriteApp
+import com.vitorpamplona.amethyst.commons.favorites.FavoriteAppIcon
+import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
+import com.vitorpamplona.amethyst.favorites.BrowserIconRegistry
+import com.vitorpamplona.amethyst.favorites.FavoriteAppsRegistry
+import com.vitorpamplona.amethyst.favorites.rememberNappletIconModel
+import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
+import com.vitorpamplona.amethyst.ui.navigation.routes.Route
+import com.vitorpamplona.amethyst.ui.navigation.routes.getRouteWithArguments
+import com.vitorpamplona.amethyst.ui.navigation.topbars.LoggedInUserPictureDrawer
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.amethyst.ui.theme.Size25Modifier
+import com.vitorpamplona.amethyst.ui.theme.Size27Modifier
+import com.vitorpamplona.amethyst.ui.theme.onSurface65
+
+/**
+ * Medium-width windows: a left rail that carries the same user-configured destinations as the
+ * phone bottom bar ([BottomBarEntry] list, built-ins and pinned favorites interleaved), so the
+ * user's customization and new-item dots carry over. The header avatar opens the modal drawer,
+ * mirroring the avatar button in the phone top bars.
+ */
+@Composable
+fun AppNavigationRail(
+    nav: Nav,
+    accountViewModel: AccountViewModel,
+) {
+    val items by accountViewModel.settings.uiSettingsFlow.bottomBarItems
+        .collectAsStateWithLifecycle()
+    val favorites by FavoriteAppsRegistry.favorites.collectAsStateWithLifecycle()
+    val favoritesById = remember(favorites) { favorites.associateBy { it.id } }
+
+    // Captured favicons, so a pinned web favorite shows the site's icon instead of the generic globe.
+    val iconKeys by BrowserIconRegistry.keys.collectAsStateWithLifecycle()
+
+    val navBackStackEntry by nav.controller.currentBackStackEntryAsState()
+    val currentDestination = navBackStackEntry?.destination
+
+    NavigationRail(
+        containerColor = MaterialTheme.colorScheme.background,
+        header = {
+            // Same affordance as the phone top bars: the account avatar opens the drawer.
+            LoggedInUserPictureDrawer(accountViewModel, nav::openDrawer)
+        },
+    ) {
+        Column(
+            modifier = Modifier.weight(1f).verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            items.forEach { entry ->
+                when (entry) {
+                    is BottomBarEntry.BuiltIn -> {
+                        val def = NavBarCatalog[entry.item] ?: return@forEach
+                        val destination = remember(def, accountViewModel) { def.resolveRoute(accountViewModel) }
+                        val selected = currentDestination?.hasRoute(destination::class) == true
+                        NavigationRailItem(
+                            selected = selected,
+                            onClick = { if (!selected) nav.navBottomBar(destination) },
+                            icon = {
+                                Box(Size27Modifier, contentAlignment = Alignment.Center) {
+                                    Icon(
+                                        symbol = def.icon,
+                                        contentDescription = stringRes(def.labelRes),
+                                        modifier = Size25Modifier,
+                                        tint = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface65,
+                                    )
+                                    AddNotifIconIfNeeded(destination, accountViewModel, Modifier.align(Alignment.TopEnd))
+                                }
+                            },
+                        )
+                    }
+
+                    is BottomBarEntry.Favorite -> {
+                        val fav = favoritesById[entry.favoriteId] ?: return@forEach
+                        val destination =
+                            when (fav) {
+                                is FavoriteApp.WebApp -> Route.WebApp(fav.url)
+                                is FavoriteApp.NostrApp -> Route.NostrApp(fav.coordinate)
+                            }
+                        // Favorites carry arguments (url / coordinate), so class matching alone
+                        // would light up every pinned app of the same kind; compare the full route.
+                        val selected =
+                            remember(navBackStackEntry, destination) {
+                                when (destination) {
+                                    is Route.WebApp -> getRouteWithArguments(Route.WebApp::class, nav.controller) == destination
+                                    is Route.NostrApp -> getRouteWithArguments(Route.NostrApp::class, nav.controller) == destination
+                                    else -> false
+                                }
+                            }
+                        val iconModel =
+                            when (fav) {
+                                is FavoriteApp.WebApp ->
+                                    remember(fav, iconKeys) {
+                                        OmniboxInput.hostOf(fav.url)?.let(BrowserIconRegistry::iconModelFor)
+                                    }
+                                is FavoriteApp.NostrApp -> rememberNappletIconModel(fav.coordinate)
+                            }
+                        NavigationRailItem(
+                            selected = selected,
+                            onClick = { if (!selected) nav.navBottomBar(destination) },
+                            icon = {
+                                Box(Size27Modifier, contentAlignment = Alignment.Center) {
+                                    FavoriteAppIcon(
+                                        app = fav,
+                                        tint = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface65,
+                                        modifier = Size25Modifier,
+                                        iconModel = iconModel,
+                                    )
+                                }
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/FabBottomBarPadding.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/FabBottomBarPadding.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.vitorpamplona.amethyst.ui.layouts.LocalScreenLayout
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 
 /**
@@ -39,7 +40,13 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 val FABPaddingFromBottom = 30.dp
 
 @Composable
-fun Modifier.fabBottomBarPadding(nav: INav): Modifier = if (nav.canPop()) padding(bottom = FABPaddingFromBottom) else this
+fun Modifier.fabBottomBarPadding(nav: INav): Modifier =
+    if (nav.canPop() || LocalScreenLayout.current.isLargeScreen) {
+        // canPop entries hide the bar on phones; large screens never render it at all.
+        padding(bottom = FABPaddingFromBottom)
+    } else {
+        this
+    }
 
 /**
  * Convenience wrapper that places [content] in a [Box] with [fabBottomBarPadding] applied.

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/TabReselectCoordinator.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/TabReselectCoordinator.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.navigation.bottombars
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.staticCompositionLocalOf
+import com.vitorpamplona.amethyst.ui.navigation.routes.Route
+
+/**
+ * Bridges the shell-level [AppNavigationRail] to the per-screen re-tap behaviors that live in
+ * each screen's [AppBottomBar] onClick lambda (scroll-to-top, feed refresh, ...).
+ *
+ * On phones the bottom bar invokes the screen's lambda directly. On large screens the bar
+ * renders nothing, but it still registers the screen's lambda here; when the user taps the
+ * rail item that is already selected, the rail routes the tap back through [reselect] so the
+ * exact same per-screen logic runs.
+ */
+@Stable
+class TabReselectCoordinator {
+    private var currentRoute: (() -> Route?)? = null
+    private var currentHandler: ((Route) -> Unit)? = null
+
+    fun register(
+        route: () -> Route?,
+        handler: (Route) -> Unit,
+    ) {
+        currentRoute = route
+        currentHandler = handler
+    }
+
+    /** Unregisters only if [handler] is still the active one, so a newly composed screen's
+     * registration is not torn down by the outgoing screen's dispose during a transition. */
+    fun unregister(handler: (Route) -> Unit) {
+        if (currentHandler === handler) {
+            currentHandler = null
+            currentRoute = null
+        }
+    }
+
+    /** Invokes the active tab root's handler if it owns [route]. Returns true if handled. */
+    fun reselect(route: Route): Boolean {
+        val handler = currentHandler ?: return false
+        if (currentRoute?.invoke() != route) return false
+        handler(route)
+        return true
+    }
+}
+
+val LocalTabReselectCoordinator = staticCompositionLocalOf { TabReselectCoordinator() }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerContent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerContent.kt
@@ -104,8 +104,6 @@ import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUse
 import com.vitorpamplona.amethyst.service.scheduledposts.ScheduledPostStatus
 import com.vitorpamplona.amethyst.ui.components.CreateTextWithEmoji
 import com.vitorpamplona.amethyst.ui.components.RobohashFallbackAsyncImage
-import com.vitorpamplona.amethyst.ui.layouts.LocalScreenLayout
-import com.vitorpamplona.amethyst.ui.layouts.NavigationStyle
 import com.vitorpamplona.amethyst.ui.layouts.PermanentDrawerWidth
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.DrawerFeedsItems
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.DrawerNavigateItems
@@ -431,11 +429,10 @@ fun StatusEditBar(
 
     val currentStatus = remember { mutableStateOf(savedStatus ?: "") }
 
-    // In the permanent drawer the DrawerState never opens (it stays Closed while the drawer
+    // In the docked drawer the DrawerState never opens (it stays Closed while the drawer
     // is always on screen), so the modal close-cancels-editing behavior must not apply there.
-    val isPermanentDrawer = LocalScreenLayout.current.navigationStyle == NavigationStyle.PERMANENT_DRAWER
     LaunchedEffect(nav.drawerState.isClosed) {
-        if (!isPermanentDrawer && nav.drawerState.isClosed) {
+        if (!nav.isDrawerDocked && nav.drawerState.isClosed) {
             focusManager.clearFocus(true)
             onDone()
         } else {
@@ -469,6 +466,10 @@ fun StatusEditBar(
                     }
 
                     focusManager.clearFocus(true)
+                    // Collapse back to the read-only bar: in the docked drawer no
+                    // drawer-close will ever do it, and in the modal drawer this beats
+                    // staying in edit mode until the drawer closes.
+                    onDone()
                 },
             ),
         singleLine = true,
@@ -484,12 +485,14 @@ fun StatusEditBar(
                         accountViewModel.updateStatus(address, currentStatus.value)
                     }
                     focusManager.clearFocus(true)
+                    onDone()
                 }
             } else {
                 if (address != null) {
                     UserStatusDeleteButton {
                         accountViewModel.deleteStatus(address)
                         focusManager.clearFocus(true)
+                        onDone()
                     }
                 }
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerContent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerContent.kt
@@ -43,6 +43,7 @@ import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -56,6 +57,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -102,6 +104,9 @@ import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUse
 import com.vitorpamplona.amethyst.service.scheduledposts.ScheduledPostStatus
 import com.vitorpamplona.amethyst.ui.components.CreateTextWithEmoji
 import com.vitorpamplona.amethyst.ui.components.RobohashFallbackAsyncImage
+import com.vitorpamplona.amethyst.ui.layouts.LocalScreenLayout
+import com.vitorpamplona.amethyst.ui.layouts.NavigationStyle
+import com.vitorpamplona.amethyst.ui.layouts.PermanentDrawerWidth
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.DrawerFeedsItems
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.DrawerNavigateItems
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.DrawerYouItems
@@ -147,56 +152,90 @@ fun DrawerContent(
     openSheet: () -> Unit,
     accountViewModel: AccountViewModel,
 ) {
-    val onClickUser = {
-        nav.nav(routeFor(accountViewModel.userProfile()))
-        nav.closeDrawer()
-    }
-
     ModalDrawerSheet(
         windowInsets = WindowInsets.systemBars.only(WindowInsetsSides.Bottom + WindowInsetsSides.Start),
         drawerContainerColor = MaterialTheme.colorScheme.background,
         drawerTonalElevation = 0.dp,
     ) {
+        DrawerContentBody(nav, openSheet, accountViewModel)
+    }
+}
+
+/**
+ * Expanded windows: the same drawer content, permanently docked on the left of the shell
+ * instead of sliding in as a modal sheet.
+ */
+@Composable
+fun PermanentDrawerContent(
+    nav: INav,
+    openSheet: () -> Unit,
+    accountViewModel: AccountViewModel,
+) {
+    Surface(
+        modifier = Modifier.width(PermanentDrawerWidth).fillMaxHeight(),
+        color = MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,
+    ) {
         Column(
-            Modifier
-                .fillMaxHeight()
-                .verticalScroll(rememberScrollState()),
+            Modifier.windowInsetsPadding(
+                WindowInsets.systemBars.only(WindowInsetsSides.Bottom + WindowInsetsSides.Start),
+            ),
         ) {
-            ProfileContent(
-                baseAccountUser = accountViewModel.account.userProfile(),
-                modifier = profileContentHeaderModifier,
-                accountViewModel,
-                onClickUser,
-            )
-
-            Column(drawerSpacing) {
-                EditStatusBoxes(accountViewModel.account.userProfile(), accountViewModel, nav)
-            }
-
-            FollowingAndFollowerCounts(accountViewModel.account, accountViewModel, onClickUser)
-
-            HorizontalDivider(
-                thickness = DividerThickness,
-                modifier = Modifier.padding(top = 20.dp),
-            )
-
-            Spacer(modifier = StdHorzSpacer)
-
-            ListContent(
-                modifier = Modifier.fillMaxWidth(),
-                openSheet,
-                accountViewModel,
-                nav,
-            )
-
-            Spacer(modifier = Modifier.weight(1f))
-
-            BottomContent(
-                accountViewModel.account.userProfile(),
-                accountViewModel,
-                nav,
-            )
+            DrawerContentBody(nav, openSheet, accountViewModel)
         }
+    }
+}
+
+@Composable
+private fun DrawerContentBody(
+    nav: INav,
+    openSheet: () -> Unit,
+    accountViewModel: AccountViewModel,
+) {
+    val onClickUser = {
+        nav.nav(routeFor(accountViewModel.userProfile()))
+        nav.closeDrawer()
+    }
+
+    Column(
+        Modifier
+            .fillMaxHeight()
+            .verticalScroll(rememberScrollState()),
+    ) {
+        ProfileContent(
+            baseAccountUser = accountViewModel.account.userProfile(),
+            modifier = profileContentHeaderModifier,
+            accountViewModel,
+            onClickUser,
+        )
+
+        Column(drawerSpacing) {
+            EditStatusBoxes(accountViewModel.account.userProfile(), accountViewModel, nav)
+        }
+
+        FollowingAndFollowerCounts(accountViewModel.account, accountViewModel, onClickUser)
+
+        HorizontalDivider(
+            thickness = DividerThickness,
+            modifier = Modifier.padding(top = 20.dp),
+        )
+
+        Spacer(modifier = StdHorzSpacer)
+
+        ListContent(
+            modifier = Modifier.fillMaxWidth(),
+            openSheet,
+            accountViewModel,
+            nav,
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        BottomContent(
+            accountViewModel.account.userProfile(),
+            accountViewModel,
+            nav,
+        )
     }
 }
 
@@ -392,8 +431,11 @@ fun StatusEditBar(
 
     val currentStatus = remember { mutableStateOf(savedStatus ?: "") }
 
+    // In the permanent drawer the DrawerState never opens (it stays Closed while the drawer
+    // is always on screen), so the modal close-cancels-editing behavior must not apply there.
+    val isPermanentDrawer = LocalScreenLayout.current.navigationStyle == NavigationStyle.PERMANENT_DRAWER
     LaunchedEffect(nav.drawerState.isClosed) {
-        if (nav.drawerState.isClosed) {
+        if (!isPermanentDrawer && nav.drawerState.isClosed) {
             focusManager.clearFocus(true)
             onDone()
         } else {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/navs/DrawerSwipe.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/navs/DrawerSwipe.kt
@@ -20,45 +20,25 @@
  */
 package com.vitorpamplona.amethyst.ui.navigation.navs
 
-import androidx.compose.material3.DrawerState
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Stable
-import com.vitorpamplona.amethyst.ui.navigation.routes.Route
-import kotlinx.coroutines.CoroutineScope
-import kotlin.reflect.KClass
+import androidx.compose.ui.Modifier
+import com.vitorpamplona.amethyst.commons.ui.components.zonedDrawerSwipe
 
-@Stable
-interface INav {
-    val navigationScope: CoroutineScope
-    val drawerState: DrawerState
-
-    /**
-     * True while the shell renders the drawer permanently docked (Expanded windows). In that
-     * mode [drawerState] never transitions — it stays [androidx.compose.material3.DrawerValue.Closed]
-     * while the drawer is visibly on screen — so drawer consumers (edge swipes, open buttons,
-     * close-driven effects) should consult this instead of inferring from [drawerState].
-     */
-    val isDrawerDocked: Boolean get() = false
-
-    fun closeDrawer()
-
-    fun openDrawer()
-
-    fun nav(route: Route)
-
-    fun nav(computeRoute: suspend () -> Route?)
-
-    fun newStack(route: Route)
-
-    fun navBottomBar(route: Route)
-
-    @Composable
-    fun canPop(): Boolean
-
-    fun popBack()
-
-    fun <T : Route> popUpTo(
-        route: Route,
-        klass: KClass<T>,
-    )
-}
+/**
+ * [zonedDrawerSwipe] gated on the drawer actually being modal. With the drawer permanently
+ * docked ([INav.isDrawerDocked]) there is nothing to open, so the left-edge swipe zone is
+ * not attached at all and the pager keeps its own gestures. Use this instead of calling
+ * [zonedDrawerSwipe] directly from screens — the guard then can't be forgotten at new
+ * call sites.
+ */
+@Composable
+fun Modifier.zonedDrawerSwipeIfModal(
+    pagerState: PagerState,
+    nav: INav,
+): Modifier =
+    if (nav.isDrawerDocked) {
+        this
+    } else {
+        zonedDrawerSwipe(pagerState, nav::openDrawer)
+    }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/navs/Nav.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/navs/Nav.kt
@@ -26,6 +26,8 @@ import androidx.compose.material3.DrawerValue
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -44,11 +46,17 @@ class Nav(
 ) : INav {
     override val drawerState = DrawerState(DrawerValue.Closed)
 
+    /** Set by the shell when the layout tier docks the drawer permanently. */
+    override var isDrawerDocked: Boolean by mutableStateOf(false)
+
     override fun closeDrawer() {
         navigationScope.launch { drawerState.close() }
     }
 
     override fun openDrawer() {
+        // Nothing renders the modal drawer while it is docked; opening the state would
+        // only strand an Open value for the next modal tier to trip over.
+        if (isDrawerDocked) return
         navigationScope.launch { drawerState.open() }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/UserDrawerSearchTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/UserDrawerSearchTopBar.kt
@@ -35,6 +35,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserPicture
 import com.vitorpamplona.amethyst.ui.components.RobohashFallbackAsyncImage
+import com.vitorpamplona.amethyst.ui.layouts.LocalScreenLayout
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.note.ArrowBackIcon
@@ -65,12 +66,14 @@ fun UserDrawerSearchTopBar(
         navigationIcon = {
             // When this screen sits on top of a back stack (entered via the drawer
             // or any deep link), show a back arrow. When it's the root (entered via
-            // the bottom nav, which clears the stack), show the drawer opener.
+            // the bottom nav, which clears the stack), show the drawer opener —
+            // unless a large-screen shell already shows the drawer (rail avatar or
+            // permanently docked pane).
             if (nav.canPop()) {
                 IconButton(onClick = nav::popBack) {
                     ArrowBackIcon()
                 }
-            } else {
+            } else if (!LocalScreenLayout.current.isLargeScreen) {
                 LoggedInUserPictureDrawer(accountViewModel, nav::openDrawer)
             }
         },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/UserDrawerSearchTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/UserDrawerSearchTopBar.kt
@@ -63,26 +63,33 @@ fun UserDrawerSearchTopBar(
                 content()
             }
         },
-        navigationIcon = {
-            // When this screen sits on top of a back stack (entered via the drawer
-            // or any deep link), show a back arrow. When it's the root (entered via
-            // the bottom nav, which clears the stack), show the drawer opener —
-            // unless a large-screen shell already shows the drawer (rail avatar or
-            // permanently docked pane).
-            if (nav.canPop()) {
-                IconButton(onClick = nav::popBack) {
-                    ArrowBackIcon()
-                }
-            } else if (!LocalScreenLayout.current.isLargeScreen) {
-                LoggedInUserPictureDrawer(accountViewModel, nav::openDrawer)
-            }
-        },
+        navigationIcon = { TopBarNavigationIcon(accountViewModel, nav) },
         actions = {
             IconButton(onClick = { nav.nav(Route.Search) }) {
                 SearchIcon(modifier = Size22Modifier, MaterialTheme.colorScheme.placeholderText)
             }
         },
     )
+}
+
+/**
+ * The standard leading slot for root-capable top bars: a back arrow when the screen sits on
+ * top of a back stack; otherwise the avatar drawer-opener — unless a large-screen shell
+ * already presents the drawer (rail avatar or permanently docked pane), in which case
+ * nothing is shown. Use this instead of hand-writing the branches per top bar.
+ */
+@Composable
+fun TopBarNavigationIcon(
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    if (nav.canPop()) {
+        IconButton(onClick = nav::popBack) {
+            ArrowBackIcon()
+        }
+    } else if (!LocalScreenLayout.current.isLargeScreen) {
+        LoggedInUserPictureDrawer(accountViewModel, nav::openDrawer)
+    }
 }
 
 @Composable

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountSwitcherAndLeftDrawerLayout.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountSwitcherAndLeftDrawerLayout.kt
@@ -22,13 +22,19 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn
 
 import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.SheetValue
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -36,15 +42,25 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.compose.currentBackStackEntryAsState
+import com.vitorpamplona.amethyst.commons.ui.layouts.LocalFeedSidePadding
+import com.vitorpamplona.amethyst.ui.layouts.FeedContentMaxWidth
+import com.vitorpamplona.amethyst.ui.layouts.LocalScreenLayout
+import com.vitorpamplona.amethyst.ui.layouts.NavigationStyle
+import com.vitorpamplona.amethyst.ui.navigation.bottombars.AppNavigationRail
 import com.vitorpamplona.amethyst.ui.navigation.drawer.AccountSwitchBottomSheet
 import com.vitorpamplona.amethyst.ui.navigation.drawer.DrawerContent
+import com.vitorpamplona.amethyst.ui.navigation.drawer.PermanentDrawerContent
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.screen.AccountSessionManager
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.embed.EmbeddedSelectionDrag
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications.NotificationSidePanel
+import com.vitorpamplona.amethyst.ui.theme.DividerThickness
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -75,6 +91,51 @@ fun AccountSwitcherAndLeftDrawerLayout(
             }
         }
 
+    when (LocalScreenLayout.current.navigationStyle) {
+        NavigationStyle.PERMANENT_DRAWER ->
+            PermanentDrawerShell(accountViewModel, nav, openSheetFunction, content)
+
+        NavigationStyle.NAV_RAIL ->
+            ModalDrawerShell(accountViewModel, nav, openSheetFunction, showRail = true, content)
+
+        NavigationStyle.BOTTOM_BAR ->
+            ModalDrawerShell(accountViewModel, nav, openSheetFunction, showRail = false, content)
+    }
+
+    // Sheet content
+    if (openAccountSwitcherBottomSheet) {
+        ModalBottomSheet(
+            onDismissRequest = {
+                scope
+                    .launch { sheetState.hide() }
+                    .invokeOnCompletion {
+                        if (!sheetState.isVisible) {
+                            openAccountSwitcherBottomSheet = false
+                        }
+                    }
+            },
+            sheetState = sheetState,
+        ) {
+            AccountSwitchBottomSheet(
+                accountViewModel = accountViewModel,
+                accountSessionManager = accountSessionManager,
+            )
+        }
+    }
+}
+
+/**
+ * Compact and Medium windows: the drawer slides in as a modal sheet. On Medium a
+ * [AppNavigationRail] sits at the left edge in place of the phone bottom bar.
+ */
+@Composable
+private fun ModalDrawerShell(
+    accountViewModel: AccountViewModel,
+    nav: Nav,
+    openSheet: () -> Unit,
+    showRail: Boolean,
+    content: @Composable () -> Unit,
+) {
     val orientation = LocalConfiguration.current.orientation
     val currentDrawerState = nav.drawerState.currentValue
     LaunchedEffect(key1 = orientation) {
@@ -104,30 +165,69 @@ fun AccountSwitcherAndLeftDrawerLayout(
         drawerState = nav.drawerState,
         gesturesEnabled = drawerGesturesEnabled,
         drawerContent = {
-            DrawerContent(nav, openSheetFunction, accountViewModel)
+            DrawerContent(nav, openSheet, accountViewModel)
             BackHandler(enabled = nav.drawerState.isOpen, nav::closeDrawer)
         },
-        content = content,
+        content = {
+            if (showRail) {
+                Row(Modifier.fillMaxSize()) {
+                    AppNavigationRail(nav, accountViewModel)
+                    VerticalDivider(thickness = DividerThickness)
+                    CenterPane(Modifier.weight(1f), content)
+                }
+            } else {
+                content()
+            }
+        },
     )
+}
 
-    // Sheet content
-    if (openAccountSwitcherBottomSheet) {
-        ModalBottomSheet(
-            onDismissRequest = {
-                scope
-                    .launch { sheetState.hide() }
-                    .invokeOnCompletion {
-                        if (!sheetState.isVisible) {
-                            openAccountSwitcherBottomSheet = false
-                        }
-                    }
-            },
-            sheetState = sheetState,
-        ) {
-            AccountSwitchBottomSheet(
-                accountViewModel = accountViewModel,
-                accountSessionManager = accountSessionManager,
-            )
+/**
+ * Expanded windows: the drawer is permanently docked on the left, the bottom bar disappears,
+ * and — when the window is wide enough — the notification feed docks on the right.
+ */
+@Composable
+private fun PermanentDrawerShell(
+    accountViewModel: AccountViewModel,
+    nav: Nav,
+    openSheet: () -> Unit,
+    content: @Composable () -> Unit,
+) {
+    val navBackStackEntry by nav.controller.currentBackStackEntryAsState()
+    // The panel duplicates the Notifications screen, so it steps aside while the user is there.
+    val showPanel =
+        LocalScreenLayout.current.showsNotificationPanel &&
+            navBackStackEntry?.destination?.hasRoute<Route.Notification>() != true
+
+    Row(Modifier.fillMaxSize()) {
+        PermanentDrawerContent(nav, openSheet, accountViewModel)
+
+        VerticalDivider(thickness = DividerThickness)
+
+        CenterPane(Modifier.weight(1f), content)
+
+        if (showPanel) {
+            VerticalDivider(thickness = DividerThickness)
+            NotificationSidePanel(accountViewModel, nav)
+        }
+    }
+}
+
+/**
+ * Hosts the navigation content and publishes the side padding feeds need to cap their content
+ * at [FeedContentMaxWidth] within this pane, via [LocalFeedSidePadding].
+ */
+@Composable
+private fun CenterPane(
+    modifier: Modifier,
+    content: @Composable () -> Unit,
+) {
+    BoxWithConstraints(modifier) {
+        val sidePadding = ((maxWidth - FeedContentMaxWidth) / 2).coerceAtLeast(0.dp)
+        CompositionLocalProvider(LocalFeedSidePadding provides sidePadding) {
+            Box(Modifier.fillMaxSize()) {
+                content()
+            }
         }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountSwitcherAndLeftDrawerLayout.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountSwitcherAndLeftDrawerLayout.kt
@@ -22,7 +22,7 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn
 
 import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -34,7 +34,6 @@ import androidx.compose.material3.SheetValue
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.movableContentOf
@@ -46,12 +45,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.compose.currentBackStackEntryAsState
-import com.vitorpamplona.amethyst.commons.ui.layouts.LocalFeedSidePadding
-import com.vitorpamplona.amethyst.ui.layouts.FeedContentMaxWidth
 import com.vitorpamplona.amethyst.ui.layouts.LocalScreenLayout
 import com.vitorpamplona.amethyst.ui.layouts.NavigationStyle
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.AppNavigationRail
@@ -231,24 +226,17 @@ private fun PermanentDrawerShell(
     }
 }
 
-/** Step size for the feed side padding, so continuous window resizes republish the value
- * (and invalidate every feed reading it) at most once per step instead of once per pixel. */
-private val SidePaddingQuantum = 8.dp
-
 /**
- * Hosts the navigation content and publishes the side padding feeds need to cap their content
- * at [FeedContentMaxWidth] within this pane, via [LocalFeedSidePadding].
+ * Hosts the navigation content. Screen width capping happens per NavHost destination
+ * ([com.vitorpamplona.amethyst.ui.layouts.CappedScreenContent] via the NavigationEffects
+ * builders), so this pane just claims the leftover row width.
  */
 @Composable
 private fun CenterPane(
     modifier: Modifier,
     content: @Composable () -> Unit,
 ) {
-    BoxWithConstraints(modifier.fillMaxHeight()) {
-        val rawPadding = ((maxWidth - FeedContentMaxWidth) / 2).coerceAtLeast(0.dp)
-        val sidePadding = Dp((rawPadding.value / SidePaddingQuantum.value).toInt() * SidePaddingQuantum.value)
-        CompositionLocalProvider(LocalFeedSidePadding provides sidePadding) {
-            content()
-        }
+    Box(modifier.fillMaxHeight()) {
+        content()
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountSwitcherAndLeftDrawerLayout.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountSwitcherAndLeftDrawerLayout.kt
@@ -22,9 +22,9 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn
 
 import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -37,13 +37,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.movableContentOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -91,15 +94,30 @@ fun AccountSwitcherAndLeftDrawerLayout(
             }
         }
 
-    when (LocalScreenLayout.current.navigationStyle) {
-        NavigationStyle.PERMANENT_DRAWER ->
-            PermanentDrawerShell(accountViewModel, nav, openSheetFunction, content)
+    // The layout tier can change while the app runs (fold/unfold, rotation, window resize)
+    // and the shells below place `content` at different composition positions. Movable
+    // content lets the whole NavHost subtree MOVE between those positions instead of being
+    // disposed and rebuilt, preserving every screen's remember/rememberSaveable state.
+    val currentContent by rememberUpdatedState(content)
+    val movableContent = remember { movableContentOf { currentContent() } }
 
-        NavigationStyle.NAV_RAIL ->
-            ModalDrawerShell(accountViewModel, nav, openSheetFunction, showRail = true, content)
+    val docked = LocalScreenLayout.current.navigationStyle == NavigationStyle.PERMANENT_DRAWER
 
-        NavigationStyle.BOTTOM_BAR ->
-            ModalDrawerShell(accountViewModel, nav, openSheetFunction, showRail = false, content)
+    // Publish docked-ness on the Nav so drawer consumers (openDrawer, edge swipes, the
+    // status editor) can behave correctly without each re-deriving the layout tier.
+    LaunchedEffect(docked) {
+        nav.isDrawerDocked = docked
+        // Entering the permanent tier with the modal drawer still Open would otherwise
+        // carry the stale Open value back to the modal tier and pop the drawer uninvited.
+        if (docked && !nav.drawerState.isClosed) {
+            nav.drawerState.snapTo(DrawerValue.Closed)
+        }
+    }
+
+    if (docked) {
+        PermanentDrawerShell(accountViewModel, nav, openSheetFunction, movableContent)
+    } else {
+        ModalDrawerShell(accountViewModel, nav, openSheetFunction, movableContent)
     }
 
     // Sheet content
@@ -125,7 +143,7 @@ fun AccountSwitcherAndLeftDrawerLayout(
 }
 
 /**
- * Compact and Medium windows: the drawer slides in as a modal sheet. On Medium a
+ * Compact and Medium windows: the drawer slides in as a modal sheet. On Medium an
  * [AppNavigationRail] sits at the left edge in place of the phone bottom bar.
  */
 @Composable
@@ -133,15 +151,13 @@ private fun ModalDrawerShell(
     accountViewModel: AccountViewModel,
     nav: Nav,
     openSheet: () -> Unit,
-    showRail: Boolean,
     content: @Composable () -> Unit,
 ) {
     val orientation = LocalConfiguration.current.orientation
-    val currentDrawerState = nav.drawerState.currentValue
     LaunchedEffect(key1 = orientation) {
-        if (
-            orientation == Configuration.ORIENTATION_LANDSCAPE && currentDrawerState == DrawerValue.Closed
-        ) {
+        // Dismiss an open drawer when the device rotates to landscape; the layout
+        // underneath changes too much for the sheet to stay meaningful.
+        if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
             nav.drawerState.close()
         }
     }
@@ -160,6 +176,8 @@ private fun ModalDrawerShell(
             // Suspend the left-edge swipe while a selection/caret handle is dragged over an embedded surface,
             // so a handle drag near the left edge (or the auto-scroll edge drag) doesn't open the drawer.
             !EmbeddedSelectionDrag.dragging
+
+    val showRail = LocalScreenLayout.current.navigationStyle == NavigationStyle.NAV_RAIL
 
     ModalNavigationDrawer(
         drawerState = nav.drawerState,
@@ -213,6 +231,10 @@ private fun PermanentDrawerShell(
     }
 }
 
+/** Step size for the feed side padding, so continuous window resizes republish the value
+ * (and invalidate every feed reading it) at most once per step instead of once per pixel. */
+private val SidePaddingQuantum = 8.dp
+
 /**
  * Hosts the navigation content and publishes the side padding feeds need to cap their content
  * at [FeedContentMaxWidth] within this pane, via [LocalFeedSidePadding].
@@ -222,12 +244,11 @@ private fun CenterPane(
     modifier: Modifier,
     content: @Composable () -> Unit,
 ) {
-    BoxWithConstraints(modifier) {
-        val sidePadding = ((maxWidth - FeedContentMaxWidth) / 2).coerceAtLeast(0.dp)
+    BoxWithConstraints(modifier.fillMaxHeight()) {
+        val rawPadding = ((maxWidth - FeedContentMaxWidth) / 2).coerceAtLeast(0.dp)
+        val sidePadding = Dp((rawPadding.value / SidePaddingQuantum.value).toInt() * SidePaddingQuantum.value)
         CompositionLocalProvider(LocalFeedSidePadding provides sidePadding) {
-            Box(Modifier.fillMaxSize()) {
-                content()
-            }
+            content()
         }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/browser/BrowserScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/browser/BrowserScreen.kt
@@ -28,12 +28,16 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridScope
@@ -313,8 +317,9 @@ private fun OmniBar(
             Modifier
                 .fillMaxWidth()
                 // The omnibox is a plain Row in the topBar slot (not a Material3 TopAppBar), so it must
-                // apply the status-bar inset itself — otherwise it draws under the status bar.
-                .statusBarsPadding()
+                // apply the top system insets itself — systemBars rather than just statusBars, so the
+                // caption bar of a desktop window (Waydroid/DeX freeform) is respected too.
+                .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top))
                 .padding(horizontal = 4.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/MessagesScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/MessagesScreen.kt
@@ -20,57 +20,48 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms
 
-import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
-import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.ui.platform.LocalContext
-import com.vitorpamplona.amethyst.ui.components.getActivity
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.singlepane.MessagesSinglePane
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.twopane.MessagesTwoPane
 
-@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @Composable
 fun MessagesScreen(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    val act = LocalContext.current.getActivity()
-    val windowSizeClass = calculateWindowSizeClass(act)
+    // Decide single- vs two-pane from the pane this screen actually occupies, not the
+    // window: on large screens the shell already spends width on the rail / permanent
+    // drawer / notification panel, so window-level size classes would overestimate.
+    BoxWithConstraints(Modifier.fillMaxSize()) {
+        val paneWidth = maxWidth
 
-    val twoPane by remember(windowSizeClass.widthSizeClass) {
-        derivedStateOf {
-            when (windowSizeClass.widthSizeClass) {
-                WindowWidthSizeClass.Compact -> false
-
-                WindowWidthSizeClass.Expanded,
-                WindowWidthSizeClass.Medium,
-                -> true
-
-                else -> false
-            }
+        if (paneWidth >= 600.dp) {
+            MessagesTwoPane(
+                knownFeedContentState = accountViewModel.feedStates.dmKnown,
+                newFeedContentState = accountViewModel.feedStates.dmNew,
+                widthSizeClass =
+                    if (paneWidth >= 840.dp) {
+                        WindowWidthSizeClass.Expanded
+                    } else {
+                        WindowWidthSizeClass.Medium
+                    },
+                accountViewModel = accountViewModel,
+                nav = nav,
+            )
+        } else {
+            MessagesSinglePane(
+                knownFeedContentState = accountViewModel.feedStates.dmKnown,
+                newFeedContentState = accountViewModel.feedStates.dmNew,
+                accountViewModel = accountViewModel,
+                nav = nav,
+            )
         }
-    }
-
-    if (twoPane) {
-        MessagesTwoPane(
-            knownFeedContentState = accountViewModel.feedStates.dmKnown,
-            newFeedContentState = accountViewModel.feedStates.dmNew,
-            widthSizeClass = windowSizeClass.widthSizeClass,
-            accountViewModel = accountViewModel,
-            nav = nav,
-        )
-    } else {
-        MessagesSinglePane(
-            knownFeedContentState = accountViewModel.feedStates.dmKnown,
-            newFeedContentState = accountViewModel.feedStates.dmNew,
-            accountViewModel = accountViewModel,
-            nav = nav,
-        )
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/MessagesScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/MessagesScreen.kt
@@ -22,15 +22,18 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms
 
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.DpSize
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.singlepane.MessagesSinglePane
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.twopane.MessagesTwoPane
 
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @Composable
 fun MessagesScreen(
     accountViewModel: AccountViewModel,
@@ -39,26 +42,26 @@ fun MessagesScreen(
     // Decide single- vs two-pane from the pane this screen actually occupies, not the
     // window: on large screens the shell already spends width on the rail / permanent
     // drawer / notification panel, so window-level size classes would overestimate.
+    // calculateFromSize keeps the Compact/Medium/Expanded breakpoints in one place
+    // (Material's) instead of restating 600/840 here.
     BoxWithConstraints(Modifier.fillMaxSize()) {
-        val paneWidth = maxWidth
+        val paneWidthClass =
+            WindowSizeClass
+                .calculateFromSize(DpSize(maxWidth, maxHeight))
+                .widthSizeClass
 
-        if (paneWidth >= 600.dp) {
-            MessagesTwoPane(
+        if (paneWidthClass == WindowWidthSizeClass.Compact) {
+            MessagesSinglePane(
                 knownFeedContentState = accountViewModel.feedStates.dmKnown,
                 newFeedContentState = accountViewModel.feedStates.dmNew,
-                widthSizeClass =
-                    if (paneWidth >= 840.dp) {
-                        WindowWidthSizeClass.Expanded
-                    } else {
-                        WindowWidthSizeClass.Medium
-                    },
                 accountViewModel = accountViewModel,
                 nav = nav,
             )
         } else {
-            MessagesSinglePane(
+            MessagesTwoPane(
                 knownFeedContentState = accountViewModel.feedStates.dmKnown,
                 newFeedContentState = accountViewModel.feedStates.dmNew,
+                widthSizeClass = paneWidthClass,
                 accountViewModel = accountViewModel,
                 nav = nav,
             )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/feed/ChatroomListTabs.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/feed/ChatroomListTabs.kt
@@ -42,14 +42,12 @@ import androidx.compose.ui.Modifier
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
-import com.vitorpamplona.amethyst.commons.ui.components.zonedDrawerSwipe
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedContentState
 import com.vitorpamplona.amethyst.ui.components.M3ActionDialog
 import com.vitorpamplona.amethyst.ui.components.M3ActionRow
 import com.vitorpamplona.amethyst.ui.components.M3ActionSection
-import com.vitorpamplona.amethyst.ui.layouts.LocalScreenLayout
-import com.vitorpamplona.amethyst.ui.layouts.NavigationStyle
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.navs.zonedDrawerSwipeIfModal
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.Size40dp
@@ -123,22 +121,10 @@ fun MessagesPager(
     nav: INav,
     modifier: Modifier = Modifier,
 ) {
-    // The left-edge swipe opens the modal drawer; with the drawer permanently docked
-    // there is nothing to open, so leave the pager's own gestures alone.
-    val modalDrawerExists =
-        LocalScreenLayout.current.navigationStyle != NavigationStyle.PERMANENT_DRAWER
     HorizontalPager(
         state = pagerState,
         userScrollEnabled = true,
-        modifier =
-            if (modalDrawerExists) {
-                modifier.zonedDrawerSwipe(
-                    pagerState = pagerState,
-                    openDrawer = nav::openDrawer,
-                )
-            } else {
-                modifier
-            },
+        modifier = modifier.zonedDrawerSwipeIfModal(pagerState, nav),
     ) { page ->
         ChatroomListFeedView(
             feedContentState = tabs[page].feedContentState,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/feed/ChatroomListTabs.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/feed/ChatroomListTabs.kt
@@ -47,6 +47,8 @@ import com.vitorpamplona.amethyst.commons.ui.feeds.FeedContentState
 import com.vitorpamplona.amethyst.ui.components.M3ActionDialog
 import com.vitorpamplona.amethyst.ui.components.M3ActionRow
 import com.vitorpamplona.amethyst.ui.components.M3ActionSection
+import com.vitorpamplona.amethyst.ui.layouts.LocalScreenLayout
+import com.vitorpamplona.amethyst.ui.layouts.NavigationStyle
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
@@ -121,14 +123,22 @@ fun MessagesPager(
     nav: INav,
     modifier: Modifier = Modifier,
 ) {
+    // The left-edge swipe opens the modal drawer; with the drawer permanently docked
+    // there is nothing to open, so leave the pager's own gestures alone.
+    val modalDrawerExists =
+        LocalScreenLayout.current.navigationStyle != NavigationStyle.PERMANENT_DRAWER
     HorizontalPager(
         state = pagerState,
         userScrollEnabled = true,
         modifier =
-            modifier.zonedDrawerSwipe(
-                pagerState = pagerState,
-                openDrawer = nav::openDrawer,
-            ),
+            if (modalDrawerExists) {
+                modifier.zonedDrawerSwipe(
+                    pagerState = pagerState,
+                    openDrawer = nav::openDrawer,
+                )
+            } else {
+                modifier
+            },
     ) { page ->
         ChatroomListFeedView(
             feedContentState = tabs[page].feedContentState,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/twopane/MessagesTwoPane.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/twopane/MessagesTwoPane.kt
@@ -21,22 +21,27 @@
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.twopane
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import com.google.accompanist.adaptive.FoldAwareConfiguration
 import com.google.accompanist.adaptive.HorizontalTwoPaneStrategy
 import com.google.accompanist.adaptive.TwoPane
+import com.google.accompanist.adaptive.TwoPaneStrategy
 import com.google.accompanist.adaptive.calculateDisplayFeatures
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedContentState
+import com.vitorpamplona.amethyst.commons.ui.layouts.LocalFeedSidePadding
 import com.vitorpamplona.amethyst.ui.components.getActivity
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.AppBottomBar
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -72,9 +77,6 @@ fun MessagesTwoPane(
             }
         }
 
-    val act = LocalContext.current.getActivity()
-    val displayFeatures = calculateDisplayFeatures(act)
-
     Scaffold(
         modifier = Modifier.imePadding(),
         topBar = {
@@ -91,58 +93,78 @@ fun MessagesTwoPane(
             }
         },
     ) { padding ->
-        TwoPane(
-            first = {
-                Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.BottomEnd) {
-                    RelayGroupMyJoinedGroupsSubscription(accountViewModel.dataSources().relayGroupMyJoinedGroups, accountViewModel)
-
-                    // Pre-warm NIP-11 for joined groups' host relays so the relay-signed check is a
-                    // cache hit when those groups surface in discovery or any gated surface.
-                    WarmJoinedRelayGroupNip11(accountViewModel)
-
-                    // The inline-vs-grouped NIP-29 preference lives in Settings › Messages; joined
-                    // groups (or per-relay rows in grouped mode) are woven into the list itself.
-                    ChatroomList(
-                        knownFeedContentState,
-                        newFeedContentState,
-                        accountViewModel,
-                        twoPaneNav,
-                    )
-
-                    Box(Modifier.padding(Size20dp), contentAlignment = Alignment.Center) {
-                        ChannelFabColumn(nav)
-                    }
-                }
-            },
-            second = {
-                Box(Modifier.fillMaxSize().padding(padding)) {
-                    twoPaneNav.innerNav.value?.let {
-                        if (it is Route.Room) {
-                            ChatroomView(
-                                room = it.toKey(),
-                                accountViewModel = accountViewModel,
-                                draftMessage = it.message,
-                                replyToNote = it.replyId,
-                                editFromDraft = it.draftId,
-                                expiresDays = it.expiresDays,
-                                nav = nav,
-                            )
-                        }
-
-                        if (it is Route.PublicChatChannel) {
-                            PublicChatChannelView(
-                                channelId = it.id,
-                                accountViewModel = accountViewModel,
-                                nav = nav,
-                            )
-                        }
-                    }
-                }
-            },
-            strategy = strategy,
-            displayFeatures = displayFeatures,
-            foldAwareConfiguration = FoldAwareConfiguration.VerticalFoldsOnly,
-            modifier = Modifier.fillMaxSize(),
-        )
+        // Each pane manages its own width; the shell's center-pane reading cap must not
+        // re-pad the lists inside them.
+        CompositionLocalProvider(LocalFeedSidePadding provides 0.dp) {
+            TwoPaneContent(padding, knownFeedContentState, newFeedContentState, twoPaneNav, strategy, accountViewModel, nav)
+        }
     }
+}
+
+@Composable
+private fun TwoPaneContent(
+    padding: PaddingValues,
+    knownFeedContentState: FeedContentState,
+    newFeedContentState: FeedContentState,
+    twoPaneNav: TwoPaneNav,
+    strategy: TwoPaneStrategy,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    val act = LocalContext.current.getActivity()
+    val displayFeatures = calculateDisplayFeatures(act)
+
+    TwoPane(
+        first = {
+            Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.BottomEnd) {
+                RelayGroupMyJoinedGroupsSubscription(accountViewModel.dataSources().relayGroupMyJoinedGroups, accountViewModel)
+
+                // Pre-warm NIP-11 for joined groups' host relays so the relay-signed check is a
+                // cache hit when those groups surface in discovery or any gated surface.
+                WarmJoinedRelayGroupNip11(accountViewModel)
+
+                // The inline-vs-grouped NIP-29 preference lives in Settings › Messages; joined
+                // groups (or per-relay rows in grouped mode) are woven into the list itself.
+                ChatroomList(
+                    knownFeedContentState,
+                    newFeedContentState,
+                    accountViewModel,
+                    twoPaneNav,
+                )
+
+                Box(Modifier.padding(Size20dp), contentAlignment = Alignment.Center) {
+                    ChannelFabColumn(nav)
+                }
+            }
+        },
+        second = {
+            Box(Modifier.fillMaxSize().padding(padding)) {
+                twoPaneNav.innerNav.value?.let {
+                    if (it is Route.Room) {
+                        ChatroomView(
+                            room = it.toKey(),
+                            accountViewModel = accountViewModel,
+                            draftMessage = it.message,
+                            replyToNote = it.replyId,
+                            editFromDraft = it.draftId,
+                            expiresDays = it.expiresDays,
+                            nav = nav,
+                        )
+                    }
+
+                    if (it is Route.PublicChatChannel) {
+                        PublicChatChannelView(
+                            channelId = it.id,
+                            accountViewModel = accountViewModel,
+                            nav = nav,
+                        )
+                    }
+                }
+            }
+        },
+        strategy = strategy,
+        displayFeatures = displayFeatures,
+        foldAwareConfiguration = FoldAwareConfiguration.VerticalFoldsOnly,
+        modifier = Modifier.fillMaxSize(),
+    )
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/twopane/MessagesTwoPane.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/twopane/MessagesTwoPane.kt
@@ -27,19 +27,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.dp
 import com.google.accompanist.adaptive.FoldAwareConfiguration
 import com.google.accompanist.adaptive.HorizontalTwoPaneStrategy
 import com.google.accompanist.adaptive.TwoPane
 import com.google.accompanist.adaptive.calculateDisplayFeatures
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedContentState
-import com.vitorpamplona.amethyst.commons.ui.layouts.LocalFeedSidePadding
 import com.vitorpamplona.amethyst.ui.components.getActivity
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.AppBottomBar
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -97,62 +94,58 @@ fun MessagesTwoPane(
             }
         },
     ) { padding ->
-        // Each pane manages its own width; the shell's center-pane reading cap must not
-        // re-pad the lists inside them.
-        CompositionLocalProvider(LocalFeedSidePadding provides 0.dp) {
-            TwoPane(
-                first = {
-                    Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.BottomEnd) {
-                        RelayGroupMyJoinedGroupsSubscription(accountViewModel.dataSources().relayGroupMyJoinedGroups, accountViewModel)
+        TwoPane(
+            first = {
+                Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.BottomEnd) {
+                    RelayGroupMyJoinedGroupsSubscription(accountViewModel.dataSources().relayGroupMyJoinedGroups, accountViewModel)
 
-                        // Pre-warm NIP-11 for joined groups' host relays so the relay-signed check is a
-                        // cache hit when those groups surface in discovery or any gated surface.
-                        WarmJoinedRelayGroupNip11(accountViewModel)
+                    // Pre-warm NIP-11 for joined groups' host relays so the relay-signed check is a
+                    // cache hit when those groups surface in discovery or any gated surface.
+                    WarmJoinedRelayGroupNip11(accountViewModel)
 
-                        // The inline-vs-grouped NIP-29 preference lives in Settings › Messages; joined
-                        // groups (or per-relay rows in grouped mode) are woven into the list itself.
-                        ChatroomList(
-                            knownFeedContentState,
-                            newFeedContentState,
-                            accountViewModel,
-                            twoPaneNav,
-                        )
+                    // The inline-vs-grouped NIP-29 preference lives in Settings › Messages; joined
+                    // groups (or per-relay rows in grouped mode) are woven into the list itself.
+                    ChatroomList(
+                        knownFeedContentState,
+                        newFeedContentState,
+                        accountViewModel,
+                        twoPaneNav,
+                    )
 
-                        Box(Modifier.padding(Size20dp), contentAlignment = Alignment.Center) {
-                            ChannelFabColumn(nav)
+                    Box(Modifier.padding(Size20dp), contentAlignment = Alignment.Center) {
+                        ChannelFabColumn(nav)
+                    }
+                }
+            },
+            second = {
+                Box(Modifier.fillMaxSize().padding(padding)) {
+                    twoPaneNav.innerNav.value?.let {
+                        if (it is Route.Room) {
+                            ChatroomView(
+                                room = it.toKey(),
+                                accountViewModel = accountViewModel,
+                                draftMessage = it.message,
+                                replyToNote = it.replyId,
+                                editFromDraft = it.draftId,
+                                expiresDays = it.expiresDays,
+                                nav = nav,
+                            )
+                        }
+
+                        if (it is Route.PublicChatChannel) {
+                            PublicChatChannelView(
+                                channelId = it.id,
+                                accountViewModel = accountViewModel,
+                                nav = nav,
+                            )
                         }
                     }
-                },
-                second = {
-                    Box(Modifier.fillMaxSize().padding(padding)) {
-                        twoPaneNav.innerNav.value?.let {
-                            if (it is Route.Room) {
-                                ChatroomView(
-                                    room = it.toKey(),
-                                    accountViewModel = accountViewModel,
-                                    draftMessage = it.message,
-                                    replyToNote = it.replyId,
-                                    editFromDraft = it.draftId,
-                                    expiresDays = it.expiresDays,
-                                    nav = nav,
-                                )
-                            }
-
-                            if (it is Route.PublicChatChannel) {
-                                PublicChatChannelView(
-                                    channelId = it.id,
-                                    accountViewModel = accountViewModel,
-                                    nav = nav,
-                                )
-                            }
-                        }
-                    }
-                },
-                strategy = strategy,
-                displayFeatures = displayFeatures,
-                foldAwareConfiguration = FoldAwareConfiguration.VerticalFoldsOnly,
-                modifier = Modifier.fillMaxSize(),
-            )
-        }
+                }
+            },
+            strategy = strategy,
+            displayFeatures = displayFeatures,
+            foldAwareConfiguration = FoldAwareConfiguration.VerticalFoldsOnly,
+            modifier = Modifier.fillMaxSize(),
+        )
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/twopane/MessagesTwoPane.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/twopane/MessagesTwoPane.kt
@@ -21,7 +21,6 @@
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.twopane
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
@@ -38,7 +37,6 @@ import androidx.compose.ui.unit.dp
 import com.google.accompanist.adaptive.FoldAwareConfiguration
 import com.google.accompanist.adaptive.HorizontalTwoPaneStrategy
 import com.google.accompanist.adaptive.TwoPane
-import com.google.accompanist.adaptive.TwoPaneStrategy
 import com.google.accompanist.adaptive.calculateDisplayFeatures
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedContentState
 import com.vitorpamplona.amethyst.commons.ui.layouts.LocalFeedSidePadding
@@ -68,14 +66,20 @@ fun MessagesTwoPane(
     val scope = rememberCoroutineScope()
     val twoPaneNav = remember { TwoPaneNav(nav, scope) }
 
+    // Keyed on the size class: the pane can cross the Medium/Expanded boundary while this
+    // screen stays composed (window resize, the notification panel docking/undocking), and
+    // an unkeyed remember would keep serving the stale split fraction.
     val strategy =
-        remember {
+        remember(widthSizeClass) {
             if (widthSizeClass == WindowWidthSizeClass.Expanded) {
                 HorizontalTwoPaneStrategy(splitFraction = 1f / 3f)
             } else {
                 HorizontalTwoPaneStrategy(splitFraction = 1f / 2.5f)
             }
         }
+
+    val act = LocalContext.current.getActivity()
+    val displayFeatures = calculateDisplayFeatures(act)
 
     Scaffold(
         modifier = Modifier.imePadding(),
@@ -96,75 +100,59 @@ fun MessagesTwoPane(
         // Each pane manages its own width; the shell's center-pane reading cap must not
         // re-pad the lists inside them.
         CompositionLocalProvider(LocalFeedSidePadding provides 0.dp) {
-            TwoPaneContent(padding, knownFeedContentState, newFeedContentState, twoPaneNav, strategy, accountViewModel, nav)
+            TwoPane(
+                first = {
+                    Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.BottomEnd) {
+                        RelayGroupMyJoinedGroupsSubscription(accountViewModel.dataSources().relayGroupMyJoinedGroups, accountViewModel)
+
+                        // Pre-warm NIP-11 for joined groups' host relays so the relay-signed check is a
+                        // cache hit when those groups surface in discovery or any gated surface.
+                        WarmJoinedRelayGroupNip11(accountViewModel)
+
+                        // The inline-vs-grouped NIP-29 preference lives in Settings › Messages; joined
+                        // groups (or per-relay rows in grouped mode) are woven into the list itself.
+                        ChatroomList(
+                            knownFeedContentState,
+                            newFeedContentState,
+                            accountViewModel,
+                            twoPaneNav,
+                        )
+
+                        Box(Modifier.padding(Size20dp), contentAlignment = Alignment.Center) {
+                            ChannelFabColumn(nav)
+                        }
+                    }
+                },
+                second = {
+                    Box(Modifier.fillMaxSize().padding(padding)) {
+                        twoPaneNav.innerNav.value?.let {
+                            if (it is Route.Room) {
+                                ChatroomView(
+                                    room = it.toKey(),
+                                    accountViewModel = accountViewModel,
+                                    draftMessage = it.message,
+                                    replyToNote = it.replyId,
+                                    editFromDraft = it.draftId,
+                                    expiresDays = it.expiresDays,
+                                    nav = nav,
+                                )
+                            }
+
+                            if (it is Route.PublicChatChannel) {
+                                PublicChatChannelView(
+                                    channelId = it.id,
+                                    accountViewModel = accountViewModel,
+                                    nav = nav,
+                                )
+                            }
+                        }
+                    }
+                },
+                strategy = strategy,
+                displayFeatures = displayFeatures,
+                foldAwareConfiguration = FoldAwareConfiguration.VerticalFoldsOnly,
+                modifier = Modifier.fillMaxSize(),
+            )
         }
     }
-}
-
-@Composable
-private fun TwoPaneContent(
-    padding: PaddingValues,
-    knownFeedContentState: FeedContentState,
-    newFeedContentState: FeedContentState,
-    twoPaneNav: TwoPaneNav,
-    strategy: TwoPaneStrategy,
-    accountViewModel: AccountViewModel,
-    nav: INav,
-) {
-    val act = LocalContext.current.getActivity()
-    val displayFeatures = calculateDisplayFeatures(act)
-
-    TwoPane(
-        first = {
-            Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.BottomEnd) {
-                RelayGroupMyJoinedGroupsSubscription(accountViewModel.dataSources().relayGroupMyJoinedGroups, accountViewModel)
-
-                // Pre-warm NIP-11 for joined groups' host relays so the relay-signed check is a
-                // cache hit when those groups surface in discovery or any gated surface.
-                WarmJoinedRelayGroupNip11(accountViewModel)
-
-                // The inline-vs-grouped NIP-29 preference lives in Settings › Messages; joined
-                // groups (or per-relay rows in grouped mode) are woven into the list itself.
-                ChatroomList(
-                    knownFeedContentState,
-                    newFeedContentState,
-                    accountViewModel,
-                    twoPaneNav,
-                )
-
-                Box(Modifier.padding(Size20dp), contentAlignment = Alignment.Center) {
-                    ChannelFabColumn(nav)
-                }
-            }
-        },
-        second = {
-            Box(Modifier.fillMaxSize().padding(padding)) {
-                twoPaneNav.innerNav.value?.let {
-                    if (it is Route.Room) {
-                        ChatroomView(
-                            room = it.toKey(),
-                            accountViewModel = accountViewModel,
-                            draftMessage = it.message,
-                            replyToNote = it.replyId,
-                            editFromDraft = it.draftId,
-                            expiresDays = it.expiresDays,
-                            nav = nav,
-                        )
-                    }
-
-                    if (it is Route.PublicChatChannel) {
-                        PublicChatChannelView(
-                            channelId = it.id,
-                            accountViewModel = accountViewModel,
-                            nav = nav,
-                        )
-                    }
-                }
-            }
-        },
-        strategy = strategy,
-        displayFeatures = displayFeatures,
-        foldAwareConfiguration = FoldAwareConfiguration.VerticalFoldsOnly,
-        modifier = Modifier.fillMaxSize(),
-    )
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/HomeScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/HomeScreen.kt
@@ -76,6 +76,8 @@ import com.vitorpamplona.amethyst.ui.feeds.ScrollStateKeys
 import com.vitorpamplona.amethyst.ui.feeds.WatchLifecycleAndUpdateModel
 import com.vitorpamplona.amethyst.ui.feeds.rememberForeverPagerState
 import com.vitorpamplona.amethyst.ui.layouts.DisappearingScaffold
+import com.vitorpamplona.amethyst.ui.layouts.LocalScreenLayout
+import com.vitorpamplona.amethyst.ui.layouts.NavigationStyle
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.AppBottomBar
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.FabBottomBarPadded
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -273,14 +275,22 @@ private fun HomePages(
         // scaffold padding from LocalDisappearingScaffoldPadding via
         // rememberFeedContentPadding, so feed items still scroll behind the bars.
         Box(modifier = Modifier.fillMaxSize()) {
+            // The left-edge swipe opens the modal drawer; with the drawer permanently
+            // docked there is nothing to open, so leave the pager's own gestures alone.
+            val modalDrawerExists =
+                LocalScreenLayout.current.navigationStyle != NavigationStyle.PERMANENT_DRAWER
             HorizontalPager(
                 state = pagerState,
                 userScrollEnabled = true,
                 modifier =
-                    Modifier.zonedDrawerSwipe(
-                        pagerState = pagerState,
-                        openDrawer = nav::openDrawer,
-                    ),
+                    if (modalDrawerExists) {
+                        Modifier.zonedDrawerSwipe(
+                            pagerState = pagerState,
+                            openDrawer = nav::openDrawer,
+                        )
+                    } else {
+                        Modifier
+                    },
             ) { page ->
                 HomeFeeds(
                     feedState = tabs[page].feedState,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/HomeScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/HomeScreen.kt
@@ -58,7 +58,6 @@ import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
 import com.vitorpamplona.amethyst.commons.model.nip53LiveActivities.LiveActivitiesChannel
-import com.vitorpamplona.amethyst.commons.ui.components.zonedDrawerSwipe
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedContentState
 import com.vitorpamplona.amethyst.commons.ui.feeds.FeedState
 import com.vitorpamplona.amethyst.commons.ui.layouts.rememberFeedContentPadding
@@ -76,11 +75,10 @@ import com.vitorpamplona.amethyst.ui.feeds.ScrollStateKeys
 import com.vitorpamplona.amethyst.ui.feeds.WatchLifecycleAndUpdateModel
 import com.vitorpamplona.amethyst.ui.feeds.rememberForeverPagerState
 import com.vitorpamplona.amethyst.ui.layouts.DisappearingScaffold
-import com.vitorpamplona.amethyst.ui.layouts.LocalScreenLayout
-import com.vitorpamplona.amethyst.ui.layouts.NavigationStyle
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.AppBottomBar
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.FabBottomBarPadded
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.navs.zonedDrawerSwipeIfModal
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.note.NoteCompose
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -275,22 +273,10 @@ private fun HomePages(
         // scaffold padding from LocalDisappearingScaffoldPadding via
         // rememberFeedContentPadding, so feed items still scroll behind the bars.
         Box(modifier = Modifier.fillMaxSize()) {
-            // The left-edge swipe opens the modal drawer; with the drawer permanently
-            // docked there is nothing to open, so leave the pager's own gestures alone.
-            val modalDrawerExists =
-                LocalScreenLayout.current.navigationStyle != NavigationStyle.PERMANENT_DRAWER
             HorizontalPager(
                 state = pagerState,
                 userScrollEnabled = true,
-                modifier =
-                    if (modalDrawerExists) {
-                        Modifier.zonedDrawerSwipe(
-                            pagerState = pagerState,
-                            openDrawer = nav::openDrawer,
-                        )
-                    } else {
-                        Modifier
-                    },
+                modifier = Modifier.zonedDrawerSwipeIfModal(pagerState, nav),
             ) { page ->
                 HomeFeeds(
                     feedState = tabs[page].feedState,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/napplets/NappletsTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/napplets/NappletsTopBar.kt
@@ -36,6 +36,7 @@ import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
 import com.vitorpamplona.amethyst.model.TopFilter
+import com.vitorpamplona.amethyst.ui.layouts.LocalScreenLayout
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.navigation.topbars.FeedFilterSpinner
@@ -73,7 +74,7 @@ fun NappletsTopBar(
         navigationIcon = {
             if (nav.canPop()) {
                 IconButton(onClick = nav::popBack) { ArrowBackIcon() }
-            } else {
+            } else if (!LocalScreenLayout.current.isLargeScreen) {
                 LoggedInUserPictureDrawer(accountViewModel, nav::openDrawer)
             }
         },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/napplets/NappletsTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/napplets/NappletsTopBar.kt
@@ -36,13 +36,11 @@ import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
 import com.vitorpamplona.amethyst.model.TopFilter
-import com.vitorpamplona.amethyst.ui.layouts.LocalScreenLayout
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.navigation.topbars.FeedFilterSpinner
-import com.vitorpamplona.amethyst.ui.navigation.topbars.LoggedInUserPictureDrawer
 import com.vitorpamplona.amethyst.ui.navigation.topbars.ShorterTopAppBar
-import com.vitorpamplona.amethyst.ui.note.ArrowBackIcon
+import com.vitorpamplona.amethyst.ui.navigation.topbars.TopBarNavigationIcon
 import com.vitorpamplona.amethyst.ui.note.SearchIcon
 import com.vitorpamplona.amethyst.ui.screen.FeedDefinition
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -71,13 +69,7 @@ fun NappletsTopBar(
                 NappletsTopNavFilterBar(accountViewModel)
             }
         },
-        navigationIcon = {
-            if (nav.canPop()) {
-                IconButton(onClick = nav::popBack) { ArrowBackIcon() }
-            } else if (!LocalScreenLayout.current.isLargeScreen) {
-                LoggedInUserPictureDrawer(accountViewModel, nav::openDrawer)
-            }
-        },
+        navigationIcon = { TopBarNavigationIcon(accountViewModel, nav) },
         actions = {
             IconButton(onClick = { nav.nav(Route.ConnectedApps) }) {
                 Icon(MaterialSymbols.Tune, contentDescription = stringResource(R.string.napplet_manage_permissions))

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationScreen.kt
@@ -214,16 +214,23 @@ private fun SplitNotificationsScaffold(
     }
 }
 
+/**
+ * The refreshable notifications card feed (list + scroll-to-top watcher + inbox-relay
+ * warning header). Shared between the Notifications screen and the docked
+ * [NotificationSidePanel], parameterized by the persisted scroll-state key so each
+ * surface keeps its own position.
+ */
 @Composable
-private fun SingleNotificationsBody(
+internal fun SingleNotificationsBody(
     notifFeedContentState: CardFeedContentState,
     notifPolls: OpenPollsState,
     scrollToEventId: String?,
     accountViewModel: AccountViewModel,
     nav: INav,
+    scrollStateKey: String = ScrollStateKeys.NOTIFICATION_SCREEN,
 ) {
     RefresheableBox(notifFeedContentState, true) {
-        val listState = rememberForeverLazyListState(ScrollStateKeys.NOTIFICATION_SCREEN)
+        val listState = rememberForeverLazyListState(scrollStateKey)
 
         WatchScrollToTop(notifFeedContentState, listState)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationSidePanel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationSidePanel.kt
@@ -39,30 +39,35 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
 import com.vitorpamplona.amethyst.commons.ui.layouts.LocalFeedSidePadding
-import com.vitorpamplona.amethyst.ui.feeds.RefresheableBox
 import com.vitorpamplona.amethyst.ui.feeds.ScrollStateKeys
-import com.vitorpamplona.amethyst.ui.feeds.rememberForeverLazyListState
 import com.vitorpamplona.amethyst.ui.layouts.NotificationPanelWidth
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.DividerThickness
+import com.vitorpamplona.amethyst.ui.theme.Size12dp
+import com.vitorpamplona.amethyst.ui.theme.Size16dp
 import com.vitorpamplona.amethyst.ui.theme.Size22Modifier
 import com.vitorpamplona.amethyst.ui.theme.StdHorzSpacer
 
 /**
  * The docked notification feed shown on very wide windows, to the right of the center pane.
- * It renders the same card feed as the Notifications screen (same last-read marking, so
- * reading here clears the new-item dot too); tapping its header opens the full screen,
- * which keeps the summary chart and the Following/Everyone split.
+ * It renders the same card feed body as the Notifications screen (same last-read marking —
+ * cards mark themselves read as they become visible here, exactly as they would on the
+ * screen, so the new-item dot only lights for items the panel hasn't displayed). When the
+ * user has split notifications enabled, the panel shows the Following feed to match the
+ * screen's default tab. Tapping the header opens the full screen, which adds the summary
+ * chart and the Following/Everyone tabs.
  */
 @Composable
 fun NotificationSidePanel(
@@ -70,7 +75,22 @@ fun NotificationSidePanel(
     nav: INav,
     modifier: Modifier = Modifier,
 ) {
-    val notifFeedContentState = accountViewModel.feedStates.notifications
+    val split by accountViewModel.account.settings.splitNotificationsEnabled
+        .collectAsStateWithLifecycle()
+
+    val notifFeedContentState =
+        if (split) {
+            accountViewModel.feedStates.notificationsFollowing
+        } else {
+            accountViewModel.feedStates.notifications
+        }
+    val scrollStateKey =
+        if (split) {
+            ScrollStateKeys.NOTIFICATION_SIDE_PANEL_FOLLOWING
+        } else {
+            ScrollStateKeys.NOTIFICATION_SIDE_PANEL
+        }
+
     WatchAccountForNotifications(notifFeedContentState, accountViewModel)
 
     Column(
@@ -88,7 +108,7 @@ fun NotificationSidePanel(
                 Modifier
                     .fillMaxWidth()
                     .clickable { nav.nav(Route.Notification()) }
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                    .padding(horizontal = Size16dp, vertical = Size12dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Icon(
@@ -108,19 +128,15 @@ fun NotificationSidePanel(
 
         // The panel is its own narrow pane; never apply the center pane's reading-width cap here.
         CompositionLocalProvider(LocalFeedSidePadding provides 0.dp) {
-            Box(Modifier.fillMaxWidth()) {
-                RefresheableBox(notifFeedContentState, true) {
-                    val listState = rememberForeverLazyListState(ScrollStateKeys.NOTIFICATION_SIDE_PANEL)
-
-                    RenderCardFeed(
-                        feedContent = notifFeedContentState,
-                        pollContent = accountViewModel.feedStates.notificationsOpenPolls,
-                        accountViewModel = accountViewModel,
-                        listState = listState,
-                        nav = nav,
-                        routeForLastRead = NOTIFICATION_LAST_READ_KEY,
-                    )
-                }
+            Box(Modifier.weight(1f).fillMaxWidth()) {
+                SingleNotificationsBody(
+                    notifFeedContentState = notifFeedContentState,
+                    notifPolls = accountViewModel.feedStates.notificationsOpenPolls,
+                    scrollToEventId = null,
+                    accountViewModel = accountViewModel,
+                    nav = nav,
+                    scrollStateKey = scrollStateKey,
+                )
             }
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationSidePanel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationSidePanel.kt
@@ -38,16 +38,13 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
-import com.vitorpamplona.amethyst.commons.ui.layouts.LocalFeedSidePadding
 import com.vitorpamplona.amethyst.ui.feeds.ScrollStateKeys
 import com.vitorpamplona.amethyst.ui.layouts.NotificationPanelWidth
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -126,18 +123,15 @@ fun NotificationSidePanel(
 
         HorizontalDivider(thickness = DividerThickness)
 
-        // The panel is its own narrow pane; never apply the center pane's reading-width cap here.
-        CompositionLocalProvider(LocalFeedSidePadding provides 0.dp) {
-            Box(Modifier.weight(1f).fillMaxWidth()) {
-                SingleNotificationsBody(
-                    notifFeedContentState = notifFeedContentState,
-                    notifPolls = accountViewModel.feedStates.notificationsOpenPolls,
-                    scrollToEventId = null,
-                    accountViewModel = accountViewModel,
-                    nav = nav,
-                    scrollStateKey = scrollStateKey,
-                )
-            }
+        Box(Modifier.weight(1f).fillMaxWidth()) {
+            SingleNotificationsBody(
+                notifFeedContentState = notifFeedContentState,
+                notifPolls = accountViewModel.feedStates.notificationsOpenPolls,
+                scrollToEventId = null,
+                accountViewModel = accountViewModel,
+                nav = nav,
+                scrollStateKey = scrollStateKey,
+            )
         }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationSidePanel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationSidePanel.kt
@@ -36,6 +36,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -90,48 +91,54 @@ fun NotificationSidePanel(
 
     WatchAccountForNotifications(notifFeedContentState, accountViewModel)
 
-    Column(
-        modifier
-            .width(NotificationPanelWidth)
-            .fillMaxHeight()
-            .windowInsetsPadding(
+    // The Surface provides the Material container color + onBackground as LocalContentColor;
+    // in a bare Row the default text color falls back to Color.Black and is invisible on the
+    // dark theme (same reason DisappearingScaffold roots itself in a Surface).
+    Surface(
+        modifier = modifier.width(NotificationPanelWidth).fillMaxHeight(),
+        color = MaterialTheme.colorScheme.background,
+        contentColor = MaterialTheme.colorScheme.onBackground,
+    ) {
+        Column(
+            Modifier.windowInsetsPadding(
                 WindowInsets.systemBars.only(
                     WindowInsetsSides.Top + WindowInsetsSides.Bottom + WindowInsetsSides.End,
                 ),
             ),
-    ) {
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .clickable { nav.nav(Route.Notification()) }
-                    .padding(horizontal = Size16dp, vertical = Size12dp),
-            verticalAlignment = Alignment.CenterVertically,
         ) {
-            Icon(
-                symbol = MaterialSymbols.Notifications,
-                contentDescription = null,
-                modifier = Size22Modifier,
-                tint = MaterialTheme.colorScheme.onBackground,
-            )
-            Spacer(modifier = StdHorzSpacer)
-            Text(
-                text = stringRes(R.string.route_notifications),
-                style = MaterialTheme.typography.titleMedium,
-            )
-        }
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .clickable { nav.nav(Route.Notification()) }
+                        .padding(horizontal = Size16dp, vertical = Size12dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    symbol = MaterialSymbols.Notifications,
+                    contentDescription = null,
+                    modifier = Size22Modifier,
+                    tint = MaterialTheme.colorScheme.onBackground,
+                )
+                Spacer(modifier = StdHorzSpacer)
+                Text(
+                    text = stringRes(R.string.route_notifications),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+            }
 
-        HorizontalDivider(thickness = DividerThickness)
+            HorizontalDivider(thickness = DividerThickness)
 
-        Box(Modifier.weight(1f).fillMaxWidth()) {
-            SingleNotificationsBody(
-                notifFeedContentState = notifFeedContentState,
-                notifPolls = accountViewModel.feedStates.notificationsOpenPolls,
-                scrollToEventId = null,
-                accountViewModel = accountViewModel,
-                nav = nav,
-                scrollStateKey = scrollStateKey,
-            )
+            Box(Modifier.weight(1f).fillMaxWidth()) {
+                SingleNotificationsBody(
+                    notifFeedContentState = notifFeedContentState,
+                    notifPolls = accountViewModel.feedStates.notificationsOpenPolls,
+                    scrollToEventId = null,
+                    accountViewModel = accountViewModel,
+                    nav = nav,
+                    scrollStateKey = scrollStateKey,
+                )
+            }
         }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationSidePanel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationSidePanel.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
+import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
+import com.vitorpamplona.amethyst.commons.ui.layouts.LocalFeedSidePadding
+import com.vitorpamplona.amethyst.ui.feeds.RefresheableBox
+import com.vitorpamplona.amethyst.ui.feeds.ScrollStateKeys
+import com.vitorpamplona.amethyst.ui.feeds.rememberForeverLazyListState
+import com.vitorpamplona.amethyst.ui.layouts.NotificationPanelWidth
+import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.routes.Route
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.amethyst.ui.theme.DividerThickness
+import com.vitorpamplona.amethyst.ui.theme.Size22Modifier
+import com.vitorpamplona.amethyst.ui.theme.StdHorzSpacer
+
+/**
+ * The docked notification feed shown on very wide windows, to the right of the center pane.
+ * It renders the same card feed as the Notifications screen (same last-read marking, so
+ * reading here clears the new-item dot too); tapping its header opens the full screen,
+ * which keeps the summary chart and the Following/Everyone split.
+ */
+@Composable
+fun NotificationSidePanel(
+    accountViewModel: AccountViewModel,
+    nav: INav,
+    modifier: Modifier = Modifier,
+) {
+    val notifFeedContentState = accountViewModel.feedStates.notifications
+    WatchAccountForNotifications(notifFeedContentState, accountViewModel)
+
+    Column(
+        modifier
+            .width(NotificationPanelWidth)
+            .fillMaxHeight()
+            .windowInsetsPadding(
+                WindowInsets.systemBars.only(
+                    WindowInsetsSides.Top + WindowInsetsSides.Bottom + WindowInsetsSides.End,
+                ),
+            ),
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clickable { nav.nav(Route.Notification()) }
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                symbol = MaterialSymbols.Notifications,
+                contentDescription = null,
+                modifier = Size22Modifier,
+                tint = MaterialTheme.colorScheme.onBackground,
+            )
+            Spacer(modifier = StdHorzSpacer)
+            Text(
+                text = stringRes(R.string.route_notifications),
+                style = MaterialTheme.typography.titleMedium,
+            )
+        }
+
+        HorizontalDivider(thickness = DividerThickness)
+
+        // The panel is its own narrow pane; never apply the center pane's reading-width cap here.
+        CompositionLocalProvider(LocalFeedSidePadding provides 0.dp) {
+            Box(Modifier.fillMaxWidth()) {
+                RefresheableBox(notifFeedContentState, true) {
+                    val listState = rememberForeverLazyListState(ScrollStateKeys.NOTIFICATION_SIDE_PANEL)
+
+                    RenderCardFeed(
+                        feedContent = notifFeedContentState,
+                        pollContent = accountViewModel.feedStates.notificationsOpenPolls,
+                        accountViewModel = accountViewModel,
+                        listState = listState,
+                        nav = nav,
+                        routeForLastRead = NOTIFICATION_LAST_READ_KEY,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/ProfileScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/ProfileScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.pager.HorizontalPager
@@ -335,7 +336,10 @@ fun ProfileScreen(
         topBar = {
             ProfileTopBar(baseUser, accountViewModel, nav)
         },
-        contentWindowInsets = WindowInsets(0),
+        // Status-bar handling is done inside RenderSurface, but the bottom inset must stay:
+        // when AppBottomBar renders nothing (pushed entries on phones, all large-screen
+        // tiers) this inset is the only thing keeping content clear of the system nav bar.
+        contentWindowInsets = WindowInsets.navigationBars,
         bottomBar = {
             AppBottomBar(
                 Route.Profile(accountViewModel.userProfile().pubkeyHex),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/search/SearchScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/search/SearchScreen.kt
@@ -26,13 +26,17 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.selection.selectable
@@ -197,7 +201,10 @@ private fun SearchBar(
         modifier =
             Modifier
                 .background(MaterialTheme.colorScheme.surface)
-                .statusBarsPadding(),
+                // A custom bar (not a Material3 TopAppBar) must apply the top system insets
+                // itself. systemBars — not just statusBars — so the caption bar of a desktop
+                // window (Waydroid/DeX freeform) is respected too.
+                .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top)),
     ) {
         SearchTextField(searchBarViewModel, Modifier)
         // Inline Namecoin lookup feedback for the global search field.

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/layouts/PaddingMerge.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/layouts/PaddingMerge.kt
@@ -49,6 +49,18 @@ val LocalDisappearingScaffoldPadding = compositionLocalOf { PaddingValues(0.dp) 
 val LocalDisappearingBarState = compositionLocalOf<DisappearingBarState?> { null }
 
 /**
+ * Extra start/end padding wide layouts ask feeds to apply so their content column stays at a
+ * readable width. The shell computes it as `(paneWidth - feedMaxWidth) / 2` and provides it
+ * around the center pane; feeds pick it up through [rememberFeedContentPadding], so the
+ * scroll surface stays full-pane-width (scrolling and pull-to-refresh keep working edge to
+ * edge) while items center themselves. Defaults to 0 (phones, and any host that doesn't cap).
+ *
+ * Full-bleed surfaces (video/shorts pagers) and secondary panes with their own width (side
+ * panels, two-pane splits) must override this back to 0 for their subtree.
+ */
+val LocalFeedSidePadding = compositionLocalOf { 0.dp }
+
+/**
  * Merges two [PaddingValues] component-wise, resolving start/end against the current
  * [LocalLayoutDirection].
  */
@@ -70,7 +82,13 @@ fun rememberMergedPadding(
 
 /**
  * Convenience for inner LazyColumns/LazyVerticalGrids inside a [DisappearingScaffold]:
- * merges the scaffold's reserved space with the list's own baseline padding.
+ * merges the scaffold's reserved space with the list's own baseline padding, plus the
+ * [LocalFeedSidePadding] width cap requested by wide layouts.
  */
 @Composable
-fun rememberFeedContentPadding(inner: PaddingValues): PaddingValues = rememberMergedPadding(LocalDisappearingScaffoldPadding.current, inner)
+fun rememberFeedContentPadding(inner: PaddingValues): PaddingValues {
+    val merged = rememberMergedPadding(LocalDisappearingScaffoldPadding.current, inner)
+    val sidePadding = LocalFeedSidePadding.current
+    if (sidePadding <= 0.dp) return merged
+    return rememberMergedPadding(merged, PaddingValues(start = sidePadding, end = sidePadding))
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/layouts/PaddingMerge.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/layouts/PaddingMerge.kt
@@ -49,15 +49,15 @@ val LocalDisappearingScaffoldPadding = compositionLocalOf { PaddingValues(0.dp) 
 val LocalDisappearingBarState = compositionLocalOf<DisappearingBarState?> { null }
 
 /**
- * Extra start/end padding wide layouts ask feeds to apply so their content column stays at a
- * readable width. The shell computes it as `(paneWidth - feedMaxWidth) / 2` and provides it
- * around the center pane; feeds pick it up through [rememberFeedContentPadding], so the
- * scroll surface stays full-pane-width (scrolling and pull-to-refresh keep working edge to
- * edge) while items center themselves. Defaults to 0 (phones, and any host that doesn't cap).
+ * Extra start/end padding a host can ask feeds to apply so their content column stays at a
+ * readable width while the scroll surface stays full-pane (scrolling and pull-to-refresh
+ * keep working edge to edge). Feeds pick it up through [rememberFeedContentPadding].
+ * Defaults to 0 everywhere.
  *
- * Panes that manage their own width — side panels, the panes of a two-pane split — must
- * override this back to 0 for their subtree: the shell's value was computed against the full
- * center pane and would over-pad a narrower list.
+ * The Android shell does NOT provide this — it caps each NavHost destination's width
+ * instead (CappedScreenContent), which also constrains top bars and non-feed screens.
+ * The local remains for hosts that prefer padding-based capping (e.g. a desktop-style
+ * reading column where gutters should still scroll).
  */
 val LocalFeedSidePadding = compositionLocalOf { 0.dp }
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/layouts/PaddingMerge.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/layouts/PaddingMerge.kt
@@ -55,8 +55,9 @@ val LocalDisappearingBarState = compositionLocalOf<DisappearingBarState?> { null
  * scroll surface stays full-pane-width (scrolling and pull-to-refresh keep working edge to
  * edge) while items center themselves. Defaults to 0 (phones, and any host that doesn't cap).
  *
- * Full-bleed surfaces (video/shorts pagers) and secondary panes with their own width (side
- * panels, two-pane splits) must override this back to 0 for their subtree.
+ * Panes that manage their own width — side panels, the panes of a two-pane split — must
+ * override this back to 0 for their subtree: the shell's value was computed against the full
+ * center pane and would over-pad a narrower list.
  */
 val LocalFeedSidePadding = compositionLocalOf { 0.dp }
 
@@ -83,12 +84,20 @@ fun rememberMergedPadding(
 /**
  * Convenience for inner LazyColumns/LazyVerticalGrids inside a [DisappearingScaffold]:
  * merges the scaffold's reserved space with the list's own baseline padding, plus the
- * [LocalFeedSidePadding] width cap requested by wide layouts.
+ * [LocalFeedSidePadding] width cap requested by wide layouts — all folded into a single
+ * remember slot, since this runs in every feed on every recomposition.
  */
 @Composable
 fun rememberFeedContentPadding(inner: PaddingValues): PaddingValues {
-    val merged = rememberMergedPadding(LocalDisappearingScaffoldPadding.current, inner)
+    val outer = LocalDisappearingScaffoldPadding.current
     val sidePadding = LocalFeedSidePadding.current
-    if (sidePadding <= 0.dp) return merged
-    return rememberMergedPadding(merged, PaddingValues(start = sidePadding, end = sidePadding))
+    val layoutDirection = LocalLayoutDirection.current
+    return remember(outer, inner, sidePadding, layoutDirection) {
+        PaddingValues(
+            start = outer.calculateStartPadding(layoutDirection) + inner.calculateStartPadding(layoutDirection) + sidePadding,
+            top = outer.calculateTopPadding() + inner.calculateTopPadding(),
+            end = outer.calculateEndPadding(layoutDirection) + inner.calculateEndPadding(layoutDirection) + sidePadding,
+            bottom = outer.calculateBottomPadding() + inner.calculateBottomPadding(),
+        )
+    }
 }


### PR DESCRIPTION
## Summary

[
<img width="1920" height="1080" alt="Screenshot_20260714_103828" src="https://github.com/user-attachments/assets/fdbbb0f8-ac1a-413a-a4a3-54430c9bb624" />
](url)

Adapts the app shell to large screens with three width tiers: phones are unchanged (bottom bar + modal drawer); Medium windows (portrait tablets, unfolded foldables) replace the bottom bar with a left navigation rail built from the same user-configured tab list; Expanded windows dock the drawer permanently on the left and, from ~1200dp, dock a live notification feed panel on the right. Every screen (top bar included) is capped to a centered 600dp reading column on wide panes, chrome no longer hides on scroll on large screens, and navigation transitions scale down to short shared-axis moves instead of full-width slides.

The six commits, in order:

1. **`aa91501b` — the shell.** `ScreenLayoutSpec`/`LocalScreenLayout` computed once per window size; `AppNavigationRail` (reuses the `BottomBarEntry` list, pinned favorites, and new-item dots); `PermanentDrawerShell` with the full drawer content docked; `NotificationSidePanel`; pinned bars via `DisappearingScaffold`; `AppBottomBar` gated centrally so zero per-screen edits were needed.
2. **`f4d2cfbf` — audit hardening.** An adversarial multi-agent review of commit 1 found 9 verified bugs, all fixed here — the two serious ones were runtime window-size changes (fold/unfold, resize) disposing the whole NavHost subtree (fixed with `movableContentOf`) and stranding scrolled-away chrome off-screen (fixed with a reset when hiding is disabled). Also: `TabReselectCoordinator` restores tap-selected-tab-scrolls-to-top on the rail via each screen's existing handler; `INav.isDrawerDocked` models docked-ness explicitly; stale drawer state, keyed two-pane strategy, ProfileScreen insets, status-editor exit, and more.
3. **`86325568` — reading-column cap for all screens.** `CappedScreenContent` applied through the shared route builders, so all ~200 destinations (lists, bookmarks, settings, editors — and their top bars) share one centered 600dp column. Opt-outs: Messages (keeps the full pane for its two-pane split) and Browser/WebApp/NostrApp (embedded surface alignment).
4. **`4ad8f214`** — notification panel rooted in a `Surface` (header text was black-on-black in dark theme).
5. **`71692db0`** — Search/Browser custom top bars and the no-top-bar scaffold fallback pad by `systemBars` instead of `statusBars`, so they clear the caption/title bar in Waydroid/DeX freeform windows.
6. **`91ccbe7d`** — tier-scaled navigation transitions: phones keep full-width slides; large screens get a 1/10-pane shared-axis nudge + fade (a full-pane fly-in from the right reads as disconnected when the click came from the docked drawer on the left).

Known trade-offs, deliberate: the panel marks notifications read as cards become visible (same semantics as the screen); scroll/pull-refresh works inside the capped column, not the gutters; desktop's `ReadingColumn` (720dp) remains a parallel mechanism — unifying it into commons is left as a follow-up.

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted (enforced by the pre-commit hook on every commit)
- [x] Ran tests — the pre-push hook ran `:quartz:jvmTest :commons:jvmTest :nestsClient:jvmTest :quic:jvmTest :amethyst:testPlayDebugUnitTest :cli:test` on every push; all green. `:amethyst:compileFdroidDebugKotlin` + `:commons:compileKotlinJvm` verified per commit.
- [x] Manually exercised the change (see notes below)

Notes: iterated live on **Waydroid on Linux** at desktop resolution during development — that testing surfaced and drove commits 4 (dark-theme panel text), 5 (caption-bar insets), and 6 (transition rework). Still worth a pass on a physical tablet/foldable before merge: fold/unfold mid-scroll and portrait↔landscape tier switches (the `movableContentOf` path), plus light/dark screenshots for the three tiers.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes (UI shell only; no quartz/protocol code touched)

## AI assistance

- [x] Drafted with AI assistance, manually reviewed and tested

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHSoAVvYioihaJeSumX8J7