### PR TITLE
Fix null pointer in AntiSpamFilter when LRU cache evicts duplicates

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AntiSpamFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AntiSpamFilter.kt
@@ -82,10 +82,12 @@ class AntiSpamFilter {
                 (recentAddressables[hash] != null && recentAddressables[hash] != address) ||
                 (spamMessages[hash] != null && !spamMessages[hash].duplicatedEventAddresses.contains(address))
             ) {
+                // may be null if the first duplicate was evicted from the LRU cache
+                // while the spammer record still matches this hash.
                 val existingAddress = recentAddressables[hash]
 
-                val link1 = njumpLink(NAddress.create(existingAddress.kind, existingAddress.pubKeyHex, existingAddress.dTag, relay))
                 val link2 = njumpLink(NAddress.create(event.kind, event.pubKey, event.dTag(), relay))
+                val link1 = existingAddress?.let { njumpLink(NAddress.create(it.kind, it.pubKeyHex, it.dTag, relay)) } ?: link2
 
                 Log.w("Duplicated/SPAM") { "${relay?.url} $link1 $link2" }
 
@@ -111,8 +113,10 @@ class AntiSpamFilter {
                 (existingEvent != null && existingEvent != event.id) ||
                 (spamMessages[hash] != null && !spamMessages[hash].duplicatedEventIds.contains(event.id))
             ) {
-                val link1 = njumpLink(NEvent.create(existingEvent, null, null, relay))
                 val link2 = njumpLink(NEvent.create(event.id, null, null, relay))
+                // existingEvent may be null if the first duplicate was evicted from the
+                // LRU cache while the spammer record still matches this hash.
+                val link1 = existingEvent?.let { njumpLink(NEvent.create(it, null, null, relay)) } ?: link2
 
                 Log.w("Duplicated/SPAM") { "${relay?.url} $link1 $link2" }
 
@@ -149,12 +153,12 @@ class AntiSpamFilter {
                     Spammer(
                         pubkeyHex = event.pubKey,
                         duplicatedEventIds = setOf(),
-                        duplicatedEventAddresses = setOf(recentAddressables[hashCode], event.address()),
+                        duplicatedEventAddresses = setOfNotNull(recentAddressables[hashCode], event.address()),
                     )
                 } else {
                     Spammer(
                         pubkeyHex = event.pubKey,
-                        duplicatedEventIds = setOf(recentEventIds[hashCode], event.id),
+                        duplicatedEventIds = setOfNotNull(recentEventIds[hashCode], event.id),
                         duplicatedEventAddresses = setOf(),
                     )
                 }


### PR DESCRIPTION
## Summary

Fix potential null pointer exceptions in `AntiSpamFilter` when the first duplicate event is evicted from the LRU cache while the spammer record still references that hash. The code now safely handles null values from `recentAddressables` and `recentEventIds` lookups using safe navigation and `setOfNotNull`.

## Changes

- Reordered link creation to compute `link2` first (always available from current event)
- Added safe navigation (`?.let`) for `existingAddress` and `existingEvent` which may be null if evicted from LRU cache
- Fallback to `link2` when `link1` cannot be created due to null cached value
- Replaced `setOf()` with `setOfNotNull()` when constructing `Spammer` objects to handle null cache values gracefully
- Added clarifying comments explaining the null-safety rationale

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)

Notes: This is a defensive null-safety fix for an edge case in spam detection. The changes ensure the filter continues to log spam events even when LRU cache eviction occurs, rather than crashing. Existing spam detection logic and thresholds are unchanged.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01UGiCujAHWMbmGT89X77S4K