### PR TITLE
Improve NIP-72 approval event parsing robustness

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip72ModCommunities/approval/CommunityPostApprovalEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip72ModCommunities/approval/CommunityPostApprovalEvent.kt
@@ -70,7 +70,9 @@ class CommunityPostApprovalEvent(
 
     fun containedPost(): Event? =
         try {
-            content.ifBlank { null }?.let { fromJson(it) }
+            // Only attempts to parse contents that could be an event json.
+            // Clients in the wild put all sorts of non-event text in here.
+            content.trim().takeIf { it.startsWith("{") }?.let { fromJson(it) }
         } catch (e: Exception) {
             Log.w(
                 "CommunityPostEvent",

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip72ModCommunities/approval/CommunityPostApprovalEventTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip72ModCommunities/approval/CommunityPostApprovalEventTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip72ModCommunities.approval
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class CommunityPostApprovalEventTest {
+    private fun approvalWith(content: String) =
+        CommunityPostApprovalEvent(
+            id = "00".repeat(32),
+            pubKey = "11".repeat(32),
+            createdAt = 1_700_000_000L,
+            tags = arrayOf(arrayOf("a", "34550:${"11".repeat(32)}:community")),
+            content = content,
+            sig = "22".repeat(64),
+        )
+
+    @Test
+    fun containedPostParsesEmbeddedEventJson() {
+        val embedded =
+            """{"id":"${"33".repeat(32)}","pubkey":"${"44".repeat(32)}","created_at":1700000000,"kind":1,"tags":[],"content":"hello","sig":"${"55".repeat(64)}"}"""
+
+        val post = approvalWith(embedded).containedPost()
+
+        assertEquals("33".repeat(32), post?.id)
+        assertEquals(1, post?.kind)
+        assertEquals("hello", post?.content)
+    }
+
+    @Test
+    fun containedPostIgnoresBlankContent() {
+        assertNull(approvalWith("").containedPost())
+        assertNull(approvalWith("   ").containedPost())
+    }
+
+    /**
+     * Clients in the wild fill approval contents with plain text (e.g. braille
+     * ASCII art) instead of the NIP-72 stringified event. These must be skipped
+     * without even attempting a JSON parse.
+     */
+    @Test
+    fun containedPostIgnoresNonJsonContent() {
+        assertNull(approvalWith("⠀⠀⠀⠐⣖⠢⢤⣄⡀⠀").containedPost())
+        assertNull(approvalWith("Approved by moderator").containedPost())
+    }
+
+    /** Valid JSON that isn't a Nostr event (no pubkey field) must return null. */
+    @Test
+    fun containedPostIgnoresNonEventJson() {
+        assertNull(approvalWith("""{"approvedEvent":{"kind":1111},"moderation":{"action":"approve"}}""").containedPost())
+    }
+}


### PR DESCRIPTION
## Summary

Hardens `CommunityPostApprovalEvent.containedPost()` to gracefully handle malformed or non-event content that clients in the wild put into approval event bodies. Instead of attempting JSON parsing on all non-blank content, the parser now only attempts to parse strings that start with `{`, filtering out plain text (e.g., braille ASCII art, moderator notes) without throwing exceptions.

## Changes

- **Modified** `CommunityPostApprovalEvent.containedPost()`: Added a `startsWith("{")` guard before attempting JSON deserialization, with explanatory comments about real-world client behavior
- **Added** `CommunityPostApprovalEventTest`: Comprehensive test suite covering:
  - Valid embedded event JSON parsing
  - Blank/whitespace content rejection
  - Non-JSON plain text rejection (braille art, moderator notes)
  - Valid JSON that isn't a Nostr event rejection

## Test plan

- [x] Added unit tests in `CommunityPostApprovalEventTest` covering all edge cases
- [x] Tests verify the parser gracefully handles malformed content without exceptions
- [x] Existing tests pass (no breaking changes to the public API)

## Interop suites

- [x] N/A — change only affects local event parsing, no wire bytes affected

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01EXiy3Ajmr3vdrV83jZsUx6