### PR TITLE
Surface NIP-29 group replies and likes in notifications

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationFeedFilter.kt
@@ -81,6 +81,7 @@ import com.vitorpamplona.quartz.nipA0VoiceMessages.VoiceEvent
 import com.vitorpamplona.quartz.nipA0VoiceMessages.VoiceReplyEvent
 import com.vitorpamplona.quartz.nipA4PublicMessages.PublicMessageEvent
 import com.vitorpamplona.quartz.nipBCOnchainZaps.zap.OnchainZapEvent
+import com.vitorpamplona.quartz.nipC7Chats.ChatEvent
 import com.vitorpamplona.quartz.nipF4Podcasts.episode.PodcastEpisodeEvent
 import com.vitorpamplona.quartz.nipF4Podcasts.metadata.PodcastMetadataEvent
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -136,6 +137,12 @@ class NotificationFeedFilter(
             setOf(
                 BadgeAwardEvent.KIND,
                 ChannelMessageEvent.KIND,
+                // NIP-29 group chat (kind 9). A reply to my group message is a
+                // kind-9 that p-tags me (see ChannelNewMessageViewModel), fetched
+                // at startup by filterGroupNotificationsToPubkey. Without kind 9
+                // here the acceptableEvent kind gate drops it before the p-tag
+                // check, so those replies never render on the Notifications tab.
+                ChatEvent.KIND,
                 ChatMessageEvent.KIND,
                 ChatMessageEncryptedFileHeaderEvent.KIND,
                 CommentEvent.KIND,

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationKindsContractTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationKindsContractTest.kt
@@ -23,6 +23,7 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications.dal
 import com.vitorpamplona.amethyst.commons.moderation.notifications.NotificationKinds
 import com.vitorpamplona.quartz.nip59Giftwrap.wraps.EphemeralGiftWrapEvent
 import com.vitorpamplona.quartz.nip59Giftwrap.wraps.GiftWrapEvent
+import com.vitorpamplona.quartz.nipC7Chats.ChatEvent
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -71,6 +72,25 @@ class NotificationKindsContractTest {
                 "should render them) or to envelopeKinds in this test (if they only " +
                 "deliver an inner payload).",
             unaccounted.isEmpty(),
+        )
+    }
+
+    /**
+     * A reply to my message inside a NIP-29 relay group is a kind-9 [ChatEvent]
+     * that p-tags me. It is fetched at startup by `filterGroupNotificationsToPubkey`
+     * (scoped `#p`=me + `#h`=my groups on the group's host relay), but the
+     * `acceptableEvent` gate first checks `kind in NOTIFICATION_KINDS`, so without
+     * kind 9 in the set the reply is dropped before the p-tag check and never
+     * surfaces on the Notifications tab. Pin its presence so it can't silently
+     * regress.
+     */
+    @Test
+    fun `nip-29 group chat replies render on the Android notifications tab`() {
+        assertTrue(
+            "ChatEvent.KIND (9) is missing from NOTIFICATION_KINDS. NIP-29 group " +
+                "replies that p-tag the user would be dropped by the acceptableEvent " +
+                "kind gate before the p-tag check and never notify.",
+            ChatEvent.KIND in NotificationFeedFilter.NOTIFICATION_KINDS,
         )
     }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip25Reactions/ReactionAction.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip25Reactions/ReactionAction.kt
@@ -24,12 +24,16 @@ import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.amethyst.commons.model.User
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.hints.EventHintBundle
+import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import com.vitorpamplona.quartz.nip01Core.tags.people.taggedUserIds
 import com.vitorpamplona.quartz.nip17Dm.NIP17Factory
 import com.vitorpamplona.quartz.nip17Dm.base.NIP17Group
 import com.vitorpamplona.quartz.nip25Reactions.ReactionEvent
+import com.vitorpamplona.quartz.nip29RelayGroups.groupId
+import com.vitorpamplona.quartz.nip29RelayGroups.hTag
 import com.vitorpamplona.quartz.nip30CustomEmoji.EmojiUrlTag
 
 /**
@@ -64,21 +68,39 @@ object ReactionAction {
             throw IllegalStateException("Cannot react publicly to a private rumor")
         }
 
-        // Handle custom emoji reactions (format: ":emoji_name:")
-        val template =
-            if (reaction.startsWith(":")) {
-                val emojiUrl = EmojiUrlTag.decode(reaction)
-                if (emojiUrl != null) {
-                    ReactionEvent.build(emojiUrl, eventHint)
-                } else {
-                    // Fallback to text if emoji decode fails
-                    ReactionEvent.build(reaction, eventHint)
-                }
-            } else {
-                ReactionEvent.build(reaction, eventHint)
-            }
+        return signer.sign(buildPublicReaction(eventHint, reaction))
+    }
 
-        return signer.sign(template)
+    /**
+     * Builds a public reaction template for [eventHint], decoding a custom-emoji
+     * reaction when present and falling back to plain text otherwise.
+     *
+     * When the target is a NIP-29 group event (it carries an `h` tag), the
+     * reaction copies that `h` tag so the like stays scoped to the group and
+     * lands on the group's host relay — where the recipient's group-notification
+     * subscription (`#p`=them + `#h`=their groups, kind 7 included) can match it.
+     * Without the `h` tag the like is a plain kind-7 that the host-relay query
+     * never sees, so a reaction to someone's group message would only reach them
+     * on the off chance NIP-65 routing delivered it to one of their inbox relays
+     * — never for a host-relay-only group. This mirrors how kind-9 replies carry
+     * the `h` tag to be notifiable.
+     */
+    private fun buildPublicReaction(
+        eventHint: EventHintBundle<Event>,
+        reaction: String,
+    ): EventTemplate<ReactionEvent> {
+        val groupScope: TagArrayBuilder<ReactionEvent>.() -> Unit = {
+            eventHint.event.groupId()?.let { hTag(it) }
+        }
+
+        if (reaction.startsWith(":")) {
+            val emojiUrl = EmojiUrlTag.decode(reaction)
+            if (emojiUrl != null) {
+                return ReactionEvent.build(emojiUrl, eventHint, initializer = groupScope)
+            }
+            // Fallback to text if emoji decode fails
+        }
+        return ReactionEvent.build(reaction, eventHint, initializer = groupScope)
     }
 
     /**
@@ -159,19 +181,7 @@ object ReactionAction {
             )
         } else {
             // Public reaction
-            val template =
-                if (reaction.startsWith(":")) {
-                    val emojiUrl = EmojiUrlTag.decode(reaction)
-                    if (emojiUrl != null) {
-                        ReactionEvent.build(emojiUrl, eventHint)
-                    } else {
-                        ReactionEvent.build(reaction, eventHint)
-                    }
-                } else {
-                    ReactionEvent.build(reaction, eventHint)
-                }
-
-            onPublic(signer.sign(template))
+            onPublic(signer.sign(buildPublicReaction(eventHint, reaction)))
         }
     }
 

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/nip25Reactions/ReactionActionTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/nip25Reactions/ReactionActionTest.kt
@@ -27,9 +27,12 @@ import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
 import com.vitorpamplona.quartz.nip01Core.tags.people.PTag
 import com.vitorpamplona.quartz.nip01Core.tags.people.pTags
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
+import com.vitorpamplona.quartz.nip29RelayGroups.hTag
+import com.vitorpamplona.quartz.nipC7Chats.ChatEvent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
@@ -57,8 +60,42 @@ class ReactionActionTest {
                     publicCalls++
                     assertTrue(reaction.sig.isNotEmpty(), "public reaction must be signed")
                     assertTrue(reaction.tags.any { it.size >= 2 && it[0] == "e" && it[1] == note.id })
+                    assertFalse(
+                        reaction.tags.any { it.isNotEmpty() && it[0] == "h" },
+                        "a reaction to a non-group note must not carry an `h` tag",
+                    )
                 },
                 onPrivate = { fail("reaction to a public note must not be gift-wrapped") },
+            )
+            assertEquals(1, publicCalls)
+        }
+
+    @Test
+    fun reactionToRelayGroupMessage_carriesTheGroupHTag() =
+        runTest {
+            // A NIP-29 group chat message: a kind-9 ChatEvent scoped by `h`.
+            val groupId = "abcd1234"
+            val groupMessage = aliceSigner.sign(ChatEvent.build("gm") { hTag(groupId) })
+
+            var publicCalls = 0
+            ReactionAction.reactToWithGroupSupport(
+                eventHint = EventHintBundle(groupMessage, null),
+                reaction = "+",
+                signer = bobSigner,
+                onPublic = { reaction ->
+                    publicCalls++
+                    // Standard NIP-25 targeting …
+                    assertTrue(reaction.tags.any { it.size >= 2 && it[0] == "e" && it[1] == groupMessage.id })
+                    assertTrue(reaction.tags.any { it.size >= 2 && it[0] == "p" && it[1] == aliceSigner.pubKey })
+                    // … plus the group `h` tag copied from the target, so the like
+                    // stays in the group and the recipient's `#p`+`#h` host-relay
+                    // notification query can match it.
+                    assertTrue(
+                        reaction.tags.any { it.size >= 2 && it[0] == "h" && it[1] == groupId },
+                        "a reaction to a NIP-29 group message must copy the group's `h` tag",
+                    )
+                },
+                onPrivate = { fail("a public group message reaction must not be gift-wrapped") },
             )
             assertEquals(1, publicCalls)
         }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip25Reactions/ReactionEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip25Reactions/ReactionEvent.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Immutable
 import com.vitorpamplona.quartz.nip01Core.core.AddressableEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.hints.AddressHintProvider
 import com.vitorpamplona.quartz.nip01Core.hints.EventHintBundle
 import com.vitorpamplona.quartz.nip01Core.hints.EventHintProvider
@@ -88,6 +89,7 @@ class ReactionEvent(
             reaction: String,
             reactedTo: EventHintBundle<Event>,
             createdAt: Long = TimeUtils.now(),
+            initializer: TagArrayBuilder<ReactionEvent>.() -> Unit = {},
         ) = eventTemplate<ReactionEvent>(KIND, reaction, createdAt) {
             eTag(reactedTo.toETag())
             if (reactedTo.event is AddressableEvent) {
@@ -95,12 +97,14 @@ class ReactionEvent(
             }
             pTag(reactedTo.event.pubKey, reactedTo.relay)
             kind(reactedTo.event.kind)
+            initializer()
         }
 
         fun build(
             reaction: EmojiUrlTag,
             reactedTo: EventHintBundle<Event>,
             createdAt: Long = TimeUtils.now(),
+            initializer: TagArrayBuilder<ReactionEvent>.() -> Unit = {},
         ) = eventTemplate<ReactionEvent>(KIND, reaction.toContentEncode(), createdAt) {
             eTag(reactedTo.toETag())
             if (reactedTo.event is AddressableEvent) {
@@ -109,6 +113,7 @@ class ReactionEvent(
             pTag(reactedTo.event.pubKey, reactedTo.relay)
             kind(reactedTo.event.kind)
             emoji(reaction)
+            initializer()
         }
     }
 }


### PR DESCRIPTION
## Summary

Two fixes so activity on my messages inside a joined NIP-29 relay group actually reaches the Notifications tab. Both target the group's **host relay** (where group content lives), which the startup query `filterGroupNotificationsToPubkey` already polls scoped `#p`=me + `#h`=my groups.

**1. Render kind-9 group replies (`NotificationFeedFilter`).**
A reply to my group message is a kind-9 `ChatEvent` that p-tags me — already fetched at startup, but `NOTIFICATION_KINDS` (the display gate in `acceptableEvent`) didn't list kind 9, so the kind check dropped it *before* the p-tag check and it never surfaced. Added `ChatEvent.KIND` to `NOTIFICATION_KINDS`. The existing gates handle the rest: my own messages are excluded, the reply p-tags me (`isTaggedUser`), and its `q`-tag to my message makes it pass `tagsAnEventByUser` in Selected mode too.

**2. Keep group "likes" in the group (`ReactionEvent` / `ReactionAction`).**
A like was built as a plain NIP-25 reaction — `e` + `p` + `k`, no `h` tag. The host-relay notification query requires `#h`, so an untagged like was never matched there and only reached me if NIP-65 routing happened to drop it on an inbox relay — never for a host-relay-only group, so likes on group messages effectively never notified. Now a reaction to a group-scoped event copies the target's `h` tag (mirroring how kind-9 replies carry it), so it stays in the group, lands on the host relay, and the existing kind-7 `#p`+`#h` query picks it up (kind 7 was already in `NOTIFICATION_KINDS` and `GroupNotificationKinds`). `ReactionEvent.build` gains the `initializer` param its own KDoc already documented; `ReactionAction` applies the tag on both the tracked and fire-and-forget paths.

Note (fix 2): this is the sender side — a like notifies me only if the liker's client tags it with `h`. Amethyst now does; spec-compliant NIP-29 clients should too.

## Test plan

- [x] `./gradlew test` green (pre-push suite passed)
- [x] `NotificationKindsContractTest`: new tripwire pins `ChatEvent.KIND` in `NOTIFICATION_KINDS`; existing contract tests still pass
- [x] `ReactionActionTest`: new cases assert a reaction to a NIP-29 group message carries the group's `h` tag, and a reaction to a non-group note does not
- [x] `./gradlew spotlessApply` clean

## Interop suites

- [x] N/A — fix 1 is local notification display only. Fix 2 adds one `h` tag to outgoing reactions on group content (spec-aligned: every in-group event carries `h`); no new wire formats or protocol state.

https://claude.ai/code/session_01VxpT7J4xt37EF5yJDw1htK