### PR TITLE
Fix NoteHeaderFirstRowDensityPreview to use tryEmit for Flow

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/NoteHeaderMarkersPreview.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/NoteHeaderMarkersPreview.kt
@@ -90,7 +90,8 @@ fun NoteHeaderFirstRowDensityPreview() {
     val nav = EmptyNav()
 
     // The jump-to-parent arrow only renders in complete UI mode.
-    accountViewModel.settings.uiSettingsFlow.featureSet.value = FeatureSetType.COMPLETE
+    accountViewModel.settings.uiSettingsFlow.featureSet
+        .tryEmit(FeatureSetType.COMPLETE)
 
     // Let DisplayLocation resolve the geohash synchronously from the cache.
     CachedReversedGeoLocations.locationNames.put(GEOHASH, "Belo Horizonte")


### PR DESCRIPTION
## Summary

Changed `NoteHeaderFirstRowDensityPreview` to use `tryEmit()` instead of direct `.value` assignment when setting the feature set. This properly emits the value through the Flow rather than bypassing the reactive stream.

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes / screenshots:

The preview composable will now correctly emit the `FeatureSetType.COMPLETE` value through the Flow, ensuring the jump-to-parent arrow renders as intended in the preview.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

https://claude.ai/code/session_011ct5ZETDh5AsVtgPgiE6Uj