### PR TITLE
fix(strictmode): stop CleartextNetworkViolation noise from the Tor SOCKS proxy

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/logging/Logging.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/logging/Logging.kt
@@ -43,7 +43,14 @@ class Logging {
                     .detectLeakedClosableObjects()
                     .detectLeakedRegistrationObjects()
                     .detectFileUriExposure()
-                    .detectCleartextNetwork()
+                    // detectCleartextNetwork() is intentionally NOT enabled. netd enforces it
+                    // per-UID at the packet level (it flags a socket whose first bytes aren't a
+                    // TLS handshake) and there is no per-host exemption. Every relay WebSocket
+                    // tunneled over the embedded Arti Tor SOCKS proxy on 127.0.0.1:17392 opens
+                    // with a cleartext SOCKS5 greeting, so this detector fires constantly on
+                    // legitimate loopback traffic. The Network-Security-Config localhost
+                    // allowlist does NOT silence it — that flag only governs the voluntary
+                    // NetworkSecurityPolicy.isCleartextTrafficPermitted() check, not netd.
                     .detectContentUriWithoutPermission()
                     .apply {
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {

--- a/amethyst/src/main/res/xml/network_security_config.xml
+++ b/amethyst/src/main/res/xml/network_security_config.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
     Cleartext traffic is permitted globally so user-configured ws:// relays keep working.
-    The explicit localhost domain-config silences StrictMode CleartextNetworkViolation
-    for the Tor SOCKS proxy on 127.0.0.1.
+    The explicit localhost domain-config keeps NetworkSecurityPolicy.isCleartextTrafficPermitted()
+    happy for loopback services (the Tor SOCKS proxy on 127.0.0.1:17392, the local Blossom cache
+    on :24242). Note: this does NOT silence StrictMode's detectCleartextNetwork() — that detector
+    runs in netd at the packet level and ignores this allowlist, which is why we don't enable it
+    (see Logging.kt).
 -->
 <network-security-config>
     <base-config cleartextTrafficPermitted="true">


### PR DESCRIPTION
## What

Debug builds spammed StrictMode:

```
CleartextNetworkViolation: Detected cleartext network traffic from UID … to /127.0.0.1
```

The destination is Amethyst's **own** embedded Arti Tor SOCKS proxy on `127.0.0.1:17392` (`TorService.DEFAULT_SOCKS_PORT`). Every relay WebSocket tunneled over Tor opens that loopback socket with a cleartext SOCKS5 greeting before the real TLS is tunneled through it.

## Why the existing config didn't silence it

`network_security_config.xml` already had a `127.0.0.1`/`localhost` `domain-config`, with a comment claiming it silenced the violation. That's wrong: `detectCleartextNetwork()` is enforced by **netd, per-UID, at the packet level** — it flags any socket whose first bytes aren't a TLS handshake, and it ignores the Network-Security-Config host allowlist. That `cleartextTrafficPermitted` flag only governs the voluntary `NetworkSecurityPolicy.isCleartextTrafficPermitted()` check HTTP stacks consult. There is no per-host exemption for the detector.

## Change

- **`Logging.kt`** — drop `.detectCleartextNetwork()` from the debug VmPolicy. The app already sets `cleartextTrafficPermitted="true"` globally (for user-configured `ws://` relays), so the detector produced little signal while firing constantly on legitimate loopback SOCKS traffic. Replaced with a comment explaining why it can't be used alongside a local SOCKS proxy.
- **`network_security_config.xml`** — correct the misleading comment (the localhost entry is kept; it's still needed for the voluntary cleartext check on the Tor proxy and the local Blossom cache on `:24242`).

Debug-only, `penaltyLog` — no behavior change in release. Verified `:amethyst:installPlayDebug` builds and installs; pre-commit static analysis passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)