### PR TITLE
Pre-seed Gradle distribution in web sandbox to unblock ./gradlew

### DIFF
--- a/.claude/hooks/pre-push-spotless.sh
+++ b/.claude/hooks/pre-push-spotless.sh
@@ -64,13 +64,9 @@ before="$(git diff HEAD -- '*.kt' '*.kts' 2>/dev/null | sha1sum)"
 log="$(mktemp /tmp/spotless-gate.XXXXXX.log)"
 if ! ./gradlew spotlessApply >"$log" 2>&1; then
   # Distinguish a formatting failure (block) from Gradle being unable to RUN —
-  # e.g. deps can't resolve, or the wrapper can't even download the Gradle
-  # distribution, in a restricted sandbox. An infra failure must not strand the
-  # agent; warn and let CI's spotlessCheck be the backstop. The distribution
-  # patterns (the `gradle-<ver>-bin.zip` URL, the Java download exception, and a
-  # proxy 40x on that fetch) only appear when `./gradlew` failed *before* running
-  # any task, so they can't mask a real formatting/compile error.
-  if grep -qiE "could not resolve|could not (get|download)|handshake|connect timed out|no address|unable to (find|resolve) host|read timed out|server returned http response code|gradle-[0-9][0-9.]*-(bin|all)\.zip|could not install gradle" "$log"; then
+  # e.g. deps can't resolve in a restricted sandbox. An infra failure must not
+  # strand the agent; warn and let CI's spotlessCheck be the backstop.
+  if grep -qiE "could not resolve|could not (get|download)|handshake|connect timed out|no address|unable to (find|resolve) host|read timed out" "$log"; then
     echo "WARN: could not run spotlessApply (Gradle infra/network failure), skipping the formatting gate." >&2
     echo "      CI's spotlessCheck still enforces formatting on the PR." >&2
     rm -f "$log"

--- a/.claude/hooks/pre-push-spotless.sh
+++ b/.claude/hooks/pre-push-spotless.sh
@@ -63,15 +63,10 @@ before="$(git diff HEAD -- '*.kt' '*.kts' 2>/dev/null | sha1sum)"
 
 log="$(mktemp /tmp/spotless-gate.XXXXXX.log)"
 if ! ./gradlew spotlessApply >"$log" 2>&1; then
-  # Distinguish a formatting failure (block) from Gradle being unable to RUN —
-  # e.g. deps can't resolve in a restricted sandbox. An infra failure must not
-  # strand the agent; warn and let CI's spotlessCheck be the backstop.
-  if grep -qiE "could not resolve|could not (get|download)|handshake|connect timed out|no address|unable to (find|resolve) host|read timed out" "$log"; then
-    echo "WARN: could not run spotlessApply (Gradle infra/network failure), skipping the formatting gate." >&2
-    echo "      CI's spotlessCheck still enforces formatting on the PR." >&2
-    rm -f "$log"
-    exit 0
-  fi
+  # Any failure blocks. The web sandbox pre-seeds the Gradle distribution (see
+  # .claude/hooks/session-start.sh) and Gradle resolves deps through the proxy,
+  # so spotlessApply no longer fails for infra reasons — a failure here is a
+  # real formatting/compile error, not a restricted-sandbox hiccup.
   echo "BLOCKED: spotlessApply failed — fix the build/formatting error before pushing." >&2
   echo "----- gradle output (tail) -----" >&2
   tail -n 40 "$log" >&2

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -211,6 +211,60 @@ install_konan_dep "llvm-19-x86_64-linux-essentials-109" \
 install_konan_dep "libffi-3.2.1-2-linux-x86-64" \
   "$KONAN_DEPS_URL/libffi-3.2.1-2-linux-x86-64.tar.gz"
 
+# --- Gradle distribution: pre-seed the wrapper distribution ---
+# The wrapper's distributionUrl (services.gradle.org) 307-redirects to
+# github.com release assets, which the web sandbox's git-only GitHub proxy
+# blocks (403) even at Full network access — so `./gradlew` can't bootstrap.
+# Download the pinned distribution from a mirror instead, but verify it against
+# Gradle's OFFICIAL sha256 (served from services.gradle.org, reachable here)
+# so a tampered/wrong mirror file is rejected and never executed. Idempotent:
+# skips entirely if the distribution is already installed.
+seed_gradle_distribution() {
+  local props="$CLAUDE_PROJECT_DIR/gradle/wrapper/gradle-wrapper.properties"
+  [ -f "$props" ] || return 0
+  local url zip name hash dir ver official mirror ok=""
+  url=$(sed -n 's/^distributionUrl=//p' "$props" | sed 's/\\//g')
+  [ -n "$url" ] || return 0
+  zip=${url##*/}; name=${zip%.zip}
+  # Gradle stores the dist under base36(md5(distributionUrl)) — derive it so this
+  # keeps working across version bumps instead of hardcoding the hash dir.
+  hash=$(python3 - "$url" <<'PY'
+import hashlib, sys
+n = int.from_bytes(hashlib.md5(sys.argv[1].encode()).digest(), 'big')
+d = "0123456789abcdefghijklmnopqrstuvwxyz"; s = ""
+while n:
+    s = d[n % 36] + s; n //= 36
+print(s or "0")
+PY
+)
+  dir="${GRADLE_USER_HOME:-$HOME/.gradle}/wrapper/dists/$name/$hash"
+  ver=${name%-bin}; ver=${ver%-all}
+  if [ -x "$dir/$ver/bin/gradle" ]; then return 0; fi   # already installed
+  echo "Seeding Gradle distribution $ver (github release blocked; using verified mirror)..." >&2
+  mkdir -p "$dir"
+  official=$(curl -fsSL "https://services.gradle.org/distributions/${zip}.sha256") || {
+    echo "Could not fetch official Gradle checksum; leaving gradlew to fail as before." >&2
+    return 0
+  }
+  for mirror in \
+      "https://mirrors.cloud.tencent.com/gradle" \
+      "https://mirrors.huaweicloud.com/gradle"; do
+    if curl -fsSL -o "$dir/$zip" "$mirror/$zip" \
+       && echo "${official}  $dir/$zip" | sha256sum -c - >/dev/null 2>&1; then
+      ok=1; break
+    fi
+    echo "Mirror $mirror failed download/verify; trying next." >&2
+    rm -f "$dir/$zip"
+  done
+  if [ -z "$ok" ]; then
+    echo "Gradle seed failed against all mirrors; leaving gradlew to fail as before." >&2
+    return 0
+  fi
+  unzip -q "$dir/$zip" -d "$dir" && touch "$dir/$zip.ok"
+  echo "Gradle $ver seeded and verified against official sha256." >&2
+}
+seed_gradle_distribution
+
 cd "$CLAUDE_PROJECT_DIR"
 ./gradlew --version > /dev/null 2>&1
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 #Wed Jan 04 09:23:50 EST 2023
 distributionBase=GRADLE_USER_HOME
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
+distributionSha256Sum=553c78f50dafcd54d65b9a444649057857469edf836431389695608536d6b746
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary

The web sandbox's git-only GitHub proxy blocks downloads from `github.com` release assets (403 error), which prevents `./gradlew` from bootstrapping the Gradle distribution. This PR adds a pre-seeding mechanism that downloads the pinned Gradle distribution from verified mirrors during session startup, then validates it against the official SHA256 checksum before use. The `pre-push-spotless.sh` hook is simplified since infra failures are now prevented upstream.

## Changes

- **`.claude/hooks/session-start.sh`**: Added `seed_gradle_distribution()` function that:
  - Parses the Gradle wrapper properties to extract the distribution URL
  - Derives the cache directory path using the same base36(md5) algorithm Gradle uses
  - Fetches the official SHA256 checksum from `services.gradle.org` (reachable in the sandbox)
  - Downloads from Tencent Cloud or Huawei Cloud mirrors as fallbacks
  - Verifies the downloaded file against the official checksum before extraction
  - Skips entirely if the distribution is already installed (idempotent)
  - Gracefully degrades if mirrors fail, allowing `./gradlew` to attempt its normal flow

- **`.claude/hooks/pre-push-spotless.sh`**: Removed the infra-failure detection logic that was masking Gradle bootstrap errors. Since the distribution is now pre-seeded, any `spotlessApply` failure is a real formatting/compile error, not a sandbox hiccup.

- **`gradle/wrapper/gradle-wrapper.properties`**: Added `distributionSha256Sum` field for verification (Gradle 8.5+ supports this; older versions ignore it).

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Verified `seed_gradle_distribution()` is called during session startup
- [x] Confirmed the function correctly derives the Gradle cache directory path
- [x] Tested that `./gradlew --version` succeeds after seeding
- [x] Verified idempotency: running the function twice doesn't re-download
- [x] Confirmed SHA256 verification rejects tampered files (tested with intentionally corrupted mirror response)

## Interop suites

- [x] N/A — change is build infrastructure only, doesn't affect wire bytes or protocol logic

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01A7bocRTSPyXwz6zVMzDbKR