### PR TITLE
Prevent re-joining Concord communities via old invite links

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -2075,6 +2075,11 @@ class Account(
      * both explain what went wrong and decide whether a retry could ever help — a
      * bundle we can't open (e.g. minted by a newer client) must not strand the user
      * on a spinner that retries forever.
+     *
+     * If the resolved community is already in the joined list, this returns
+     * [ConcordInviteResult.Joined] without re-following or re-announcing a Guestbook
+     * JOIN, so reopening an old invite for a community you're already in simply takes
+     * you to it.
      */
     suspend fun joinConcordViaInvite(url: String): ConcordInviteResult {
         if (!isWriteable()) return ConcordInviteResult.InvalidLink
@@ -2097,6 +2102,14 @@ class Account(
                 InviteBundleStatus.Unreadable -> return ConcordInviteResult.Incompatible
                 InviteBundleStatus.Absent -> return ConcordInviteResult.NotReachable
             }
+
+        // Already a member? Just take the user to the community. Re-following and re-announcing a
+        // Guestbook JOIN (kind 3306) would spam the community relays with a fresh join every time an
+        // old invite is reopened, so short-circuit to Joined — the screen forwards to the community
+        // either way ("take me there", not "join again").
+        if (concordChannelList.liveCommunities.value.any { it.id == bundle.communityId }) {
+            return ConcordInviteResult.Joined(bundle.communityId)
+        }
 
         val entry =
             ConcordCommunityListEntry(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/concord/ConcordInviteScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/concord/ConcordInviteScreen.kt
@@ -95,7 +95,10 @@ fun ConcordInviteScreen(
 
     LaunchedEffect(state) {
         (state as? RedeemState.Done)?.let { done ->
-            nav.newStack(Route.ConcordServer(done.communityId))
+            // Replace this invite screen with the community, dropping it from the back stack. If it
+            // stayed, Back from the community would land on the auto-redeeming spinner, which would
+            // immediately re-join and forward here again — trapping the user in a Back→forward loop.
+            nav.popUpTo(Route.ConcordServer(done.communityId), Route.ConcordInvite::class)
         }
     }
 


### PR DESCRIPTION
## Summary

When a user reopens an old invite link for a Concord community they're already a member of, the app now short-circuits to the "already joined" state instead of re-following and re-announcing a Guestbook JOIN (kind 3306). This prevents spam to community relays and avoids trapping users in a back-navigation loop.

Two changes work together:

1. **Account.kt**: Added a check in `joinConcordViaInvite()` that returns `ConcordInviteResult.Joined` immediately if the community is already in the joined list, skipping the follow and Guestbook announcement.

2. **ConcordInviteScreen.kt**: Changed navigation from `newStack()` to `popUpTo()` when redeeming an invite. This replaces the invite screen with the community screen and removes the invite from the back stack. Without this, pressing Back from the community would land on the auto-redeeming spinner, which would immediately re-join and forward to the community again — trapping the user in a Back→forward loop.

## Test plan

- [x] Manually exercised the change

**Notes:**
- Opened an old Concord invite link for a community already in the joined list
- Verified the app navigates directly to the community without re-announcing a JOIN
- Verified pressing Back from the community does not return to the invite screen or trigger a re-join

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01MeJJCDLdvi4KQEuozcMMBh