### PR TITLE
chore: include commons Compose resources in Crowdin sync

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -61,6 +61,7 @@ jobs:
           branch: l10n_crowdin_translations
           add-paths: |
             amethyst/src/main/res/**/strings.xml
+            commons/src/commonMain/composeResources/**/strings.xml
             docs/changelog/translators.json
           commit-message: 'chore: sync Crowdin translations and seed translator npub placeholders'
           title: 'New Crowdin Translations'


### PR DESCRIPTION
## Summary

Updated the Crowdin workflow to include `commons/src/commonMain/composeResources/**/strings.xml` in the translation sync paths. This ensures that translatable strings in the shared Compose Multiplatform module are picked up and synchronized with Crowdin alongside the existing Android resources.

## Test plan

- [ ] N/A — change is a workflow configuration update with no code logic changes

The Crowdin workflow is automatically triggered on schedule and pull requests. The addition of the commons Compose resources path will be validated when the workflow next runs and creates a translation sync PR.

## Interop suites

- [ ] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [ ] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

https://claude.ai/code/session_0182nHMw2yn84sc7naQg5sYq