### PR TITLE
fix(ci): reclaim working-tree ownership after Crowdin Docker action

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -41,6 +41,15 @@ jobs:
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
+      # crowdin/github-action runs in a Docker container as root, so any file or
+      # directory it downloads (especially a brand-new locale folder like
+      # values-en-rGB/) ends up owned by root. The unprivileged runner user in
+      # the create-pull-request step below then can't unlink those files, which
+      # aborts its branch checkout with "unable to unlink ... Permission denied".
+      # Reclaim ownership of the whole working tree before touching git.
+      - name: Fix ownership after Crowdin Docker action
+        run: sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE"
+
       # Keep docs/changelog/translators.json seeded with everyone who has translated
       # recently, so the per-release `## Translations` credits (scripts/translators.sh)
       # can resolve them to npubs. Only adds rows when a genuinely new contributor


### PR DESCRIPTION
The crowdin/github-action runs inside a Docker container as root, so files
and directories it downloads are root-owned. When Crowdin creates a brand-new
locale folder (e.g. values-en-rGB/ under commons), the unprivileged runner
user in the peter-evans/create-pull-request step can't unlink files inside it,
so the branch checkout aborts with 'unable to unlink ... Permission denied'.

Add a chown step that reclaims ownership of the whole working tree after the
Crowdin action and before any git manipulation.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0179E3AfsnB1NP87YmtAMZNX