### PR TITLE
Fix StrictMode DiskReadViolation in BootCompletedReceiver

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/BootCompletedReceiver.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/BootCompletedReceiver.kt
@@ -50,11 +50,23 @@ class BootCompletedReceiver : BroadcastReceiver() {
             "android.intent.action.QUICKBOOT_POWERON",
             Intent.ACTION_MY_PACKAGE_REPLACED,
             -> {
-                Log.d(TAG) { "Received ${intent.action}, checking if notification service should start" }
-                if (NotificationRelayService.isEnabled(context)) {
-                    Log.d(TAG, "Starting notification relay service")
-                    NotificationRelayService.start(context)
-                }
+                // isEnabled() reads plain SharedPreferences (a synchronous disk read, by
+                // design — see LocalPreferences.globalSettingsPrefs) and scans the accounts
+                // cache. onReceive runs on the main thread, so hop off it via goAsync() to
+                // avoid a StrictMode DiskReadViolation while keeping the receiver alive until
+                // the work finishes.
+                val pending = goAsync()
+                Thread {
+                    try {
+                        Log.d(TAG) { "Received ${intent.action}, checking if notification service should start" }
+                        if (NotificationRelayService.isEnabled(context)) {
+                            Log.d(TAG, "Starting notification relay service")
+                            NotificationRelayService.start(context)
+                        }
+                    } finally {
+                        pending.finish()
+                    }
+                }.start()
             }
         }
     }


### PR DESCRIPTION
## Summary

Move the synchronous disk read in `BootCompletedReceiver.onReceive()` off the main thread to avoid a StrictMode `DiskReadViolation`. The `NotificationRelayService.isEnabled()` call reads plain SharedPreferences and scans the accounts cache — both synchronous operations that should not block the main thread. Use `goAsync()` to keep the receiver alive while the work completes on a background thread.

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes:
- Verified that `goAsync()` + `pending.finish()` pattern correctly keeps the receiver alive until the background thread completes
- Confirmed that `NotificationRelayService.isEnabled()` and `.start()` are safe to call from a background thread
- No new tests required; this is a threading fix to an existing code path

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

https://claude.ai/code/session_01P4tx1QSE27uoDpnxZZ7msT