### PR TITLE
docs(changelog): add v1.13.0 release notes

### DIFF
--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -2,6 +2,7 @@
 
 Release notes for Amethyst, one file per version. Files are named with zero-padded version numbers so they sort correctly in any file browser. Use [`TEMPLATE.md`](TEMPLATE.md) as the starting point for the next release.
 
+- [v1.13.0 — Web Apps, Communities & Git](v1.13.00.md)
 - [v1.12.6 — Napplets, Static Sites & Cashu Multi-Mint](v1.12.06.md)
 - [v1.12.5 — macOS Desktop Signing Fix (cont.)](v1.12.05.md)
 - [v1.12.4 — macOS Desktop Signing Fix](v1.12.04.md)

--- a/docs/changelog/v1.13.00.md
+++ b/docs/changelog/v1.13.00.md
@@ -1,0 +1,374 @@
+# v1.13.0: Web Apps, Communities & Git
+
+Highlights:
+
+- Adds an **in-app Browser for Nostr web clients**, with support for **Nostr Web
+  Apps (NIP-5D napplets)** and **static websites (NIP-5A nSites)**. They run in a
+  keyless sandbox that can never touch your private key — every signature,
+  payment, or data read needs your explicit approval. "Log in with Amethyst"
+  lets Nostr web apps sign in as you.
+- Adds **Communities (Concord)**: a new end-to-end-encrypted communities
+  protocol with channels, invites, roles, moderation, and full history —
+  browsable and chattable from Messages.
+- Adds **Git collaboration (NIP-34)**: browse Nostr git repositories with a
+  full code browser (branches, diffs, syntax highlighting, commit history),
+  review patches and pull requests, and open and label issues — all in-app.
+- Adds a **Remote Signer (NIP-46)**: for the first time, other apps and websites
+  can sign through Amethyst — with informed, per-account consent — whether your
+  key lives in Amethyst or on an external signer like Amber. Also adds a
+  **Privacy Lock** that gates your Messages behind a password or biometric.
+- Adds **relay login permissions (NIP-42)**: when a relay asks you to
+  authenticate, choose Once / Always / Never per relay, with one-tap trust for
+  your follows' relays.
+- Adds **NIP-29 Groups**: relay-hosted group chat with subgroups, custom roles,
+  invite links, threads, and pinned messages.
+- Redesigns the **Messages inbox**: groups community and group channels with
+  last-message previews, unread dots, facepiles, live typing, and per-type load
+  toggles.
+- Adds **Blossom file sync**: a media file manager to browse your stored blobs,
+  mirror them across servers, and "Sync all" with progress — including
+  confirm-then-pay for paid servers.
+- Adds **Podcasting 2.0**: shows, episodes, chapters, transcripts, person
+  credits, and per-minute value-for-value Lightning splits.
+- Repaints the app around **your chosen accent color**, with font and size
+  options that flow through buttons, badges, and highlights.
+- Adds **proof-of-work (NIP-13)** publishing and **negentropy (NIP-77)** sync.
+
+## New Features
+
+### Web Apps, Sites & the Browser
+
+- Opens Nostr web apps (NIP-5D napplets) and static websites (NIP-5A nSites)
+  directly inside Amethyst, rendered in an isolated, keyless sandbox process that
+  cannot reach your private key, storage, or data.
+- Adds an in-app Browser — a drawer entry and pinnable bottom-bar tab — with an
+  omnibox address bar, autocomplete, history, favorites, recents, and captured
+  favicons. The trusted app draws the address bar so a page can never spoof its
+  URL.
+- Adds "Log in with Amethyst": nSites open with a NIP-07 `window.nostr`
+  provider, so standard Nostr web apps can sign in and request signatures as your
+  active account — consent-gated, sign-only, and scoped per site.
+- Lets web apps, with your permission, pay through your wallet (NWC), run live
+  relay subscriptions and queries, and read your identity (profile, lists, zaps,
+  badges) — every capability brokered and permission-gated (once / this session /
+  always).
+- Pins favorite web apps to the bottom bar as embedded, swap-in-place tabs that
+  stay warm and show the app's own icon.
+- Discovers web apps: the empty browser suggests a curated list plus nSites and
+  napplets published by people you follow, and profiles gain an "Apps & Sites"
+  tab.
+- Adds a Connected Apps / permissions screen to review and revoke what each app
+  can do.
+- Routes nSite web traffic through Tor by default when Tor is active, with a
+  per-site onion/globe toggle.
+
+### Communities (Concord)
+
+- Adds Concord: an end-to-end-encrypted communities protocol with channels,
+  membership, invites, roles, moderation, and history — reachable from a hub in
+  the drawer and pinnable to the bottom nav.
+- Creates and edits communities with encrypted icon/banner, relay editing, and
+  channel management.
+- Invites and joins via minted invites with QR codes, tappable invite links,
+  paste-to-redeem from Search, deep links, and direct member invites.
+- Chats in channels with a rich composer (@mentions, custom-emoji autocomplete,
+  reply preview), encrypted image messages, reactions, replies, and typing
+  indicators.
+- Adds threaded replies (inline or minichat modes) and delivery ticks for your
+  own messages.
+- Groups channels by community in Messages with last-message, unread counts,
+  facepiles, and live typing.
+- Adds moderation: ban/unban with read-time enforcement, role grants, a "Make
+  admin" toggle, and a full member roster.
+- Backfills channel history across epochs, paging back to the true start of a
+  channel.
+- Surfaces Concord replies and reactions on the Notifications tab with a
+  community pill.
+
+### Git Collaboration (NIP-34)
+
+- Browses Nostr git repositories in-app: a Git Repositories feed and a per-repo
+  screen with README and Code tabs.
+- Reads code with branch/tag switching, file search, image preview, commit
+  history, syntax highlighting, and word-level diff highlighting.
+- Reviews patches and pull requests with computed diffs and status actions; PR
+  updates surface on the repo screen.
+- Manages issues: Issues and Patches & PRs tabs split by open/closed, issue
+  labels with filtering, and a full-screen New Issue composer.
+- Edits a repository announcement from the repo screen, bookmarks repositories,
+  and filters the feed to your own repos.
+- Adds a project-home dashboard with stats, languages, recent activity, and
+  last-commit rows.
+
+### Location Channels
+
+- Adds Location Channels: geohash-based public rooms that interoperate with
+  BitChat, browsable from a dedicated drawer list and pinnable to the bottom nav.
+- Posts under an unlinkable per-area anonymous identity (with an optional
+  nickname that survives restarts), or opt in to post as your real account.
+- Teleports to any place from a map picker or the feed-filter dialog to read and
+  post to distant rooms, and follows a teleported place to keep its feed.
+- Reacts, zaps, and replies on location messages, with a "live near you" bubble
+  on Home surfacing nearby rooms.
+- Adds a "pick on map" location picker to the short-note and all other composers.
+
+### Groups (NIP-29)
+
+- Adds relay groups: group chat, a discovery feed with a top-bar filter and
+  favorites, and join / leave / create / invite actions.
+- Adds subgroups (parent/child hierarchy), custom roles (kind 39003), threads,
+  and message pinning.
+- Shares groups via `naddr` and invite links with one-tap join; inline group
+  links render as self-loading cards.
+- Adds a map-based location picker when creating a group, and lets pinned group
+  tabs act as bottom-nav roots.
+
+### Remote Signer & Security
+
+- Lets other apps and websites sign through Amethyst for the first time
+  (NIP-46): connect by scanning or pasting a `nostrconnect://` code or a
+  `bunker://` link, and keep signing in the background — whether your key is
+  stored directly in Amethyst or delegated to an external signer like Amber
+  (NIP-55).
+- Asks for informed consent before authorizing an app — showing its name and
+  icon, which account will sign, the exact permissions, and an event preview —
+  with per-account sheets and one-tap batched approval.
+- Manages connected apps from a dedicated screen with per-app relay list, live
+  health, time-bound grants, and instant "forget this app".
+- Adds a Privacy Lock for Messages (Android and Desktop): gate your DMs behind a
+  password or biometric, with an inactivity auto-lock and optional preview
+  redaction.
+- Adds interactive relay login prompts (NIP-42): choose Once / Always / Never
+  per relay, with venue-aware prompts for public chats, communities, and live
+  streams, and one-tap trust for your follows' relays.
+
+### Web of Trust (GrapeRank)
+
+- Computes GrapeRank Web-of-Trust scores by crawling the social graph and scoring
+  every user — now even without a personal account (operator-less mode).
+- Crawls followers in reverse (who follows a user) alongside follows-of-follows,
+  and tracks hop distance and follower count on trust cards.
+- Discovers score providers via NIP-85 and fetches follow/profile data through
+  each author's own outbox relays for fuller coverage.
+
+### Publishing & Sync
+
+- Adds proof-of-work (NIP-13) publishing: a fire-and-forget mining queue with
+  per-account difficulty and per-category settings, scheduled-post mining, and
+  per-post overrides, shielded by a foreground service and mined across all
+  cores.
+- Adds NIP-77 negentropy sync as a first-class capability, with deletion
+  (NIP-09/62) propagation so scoped syncs no longer strand deletions.
+- Shows PoW mining progress, and surfaces PoW, OpenTimestamps, and location
+  markers as tap-to-explain pills in the note header.
+
+### Podcasts
+
+- Adds Podcasting 2.0: renders shows in detail and thread views, surfaces
+  episodes in the merged podcast feed, and plays trailers.
+- Shows person credits as real Nostr profiles, soundbites, in-app chapters, a
+  transcript viewer, and a Top Supporters leaderboard.
+- Adds per-episode reactions and NIP-22 comments, a Podcast Bookmarks screen, and
+  value-for-value Lightning splits paid per-minute during real playback.
+
+### Wallet & Payments
+
+- Adds a Cashu wallet setup wizard: find-or-create with cross-relay discovery,
+  mint suggestions, and a CashuMints screen; the wallet auto-publishes on mint
+  add/remove.
+- Adds a setting to hide the on-chain (Bitcoin) wallet, including from zap
+  buttons.
+- Adds a data-usage screen with stat tiles, a trend chart, proportion bars, and a
+  live memory card.
+
+### Look, Media & Navigation
+
+- Adds theme customization: pick an accent color (with a swatch picker), font,
+  and font size. The accent now drives Material 3 containers, buttons, FABs,
+  switches, unread dots, selected-reaction highlights, verified NIP-05 / image
+  marks, and the Following badge.
+- Redesigns UI Preferences into grouped in-screen options with live font
+  previews, and adds a settings search filter in the app bar.
+- Adds a Blossom media file manager: browse and manage stored blobs with per-file
+  controls, mirror and `/media` toggles, an app-level "Sync all" with progress,
+  and BUD-07 confirm-then-pay mirroring for paid servers.
+- Redesigns the Media Servers screen as a single auto-saving canvas with a
+  reorderable priority list and cached health probes.
+- Redesigns the bottom-bar setup with a live preview, drag-to-reorder, and real
+  favicons; the default bar becomes Home, Messages, Wallet, Browser,
+  Notifications.
+- Adds fitness support: renders POWR strength workouts (kind 1301) and exercise
+  templates (kind 33401) as cards.
+- Renders NIP-30 custom-emoji reactions as an avatar badge, a lone zap/nutzap as
+  a large activity card, and NIP-84 highlights from web highlighter clients.
+- Supports NIP-51 mute-list hashtag entries and public-chat reply notifications.
+
+## Performance
+
+- Speeds up napplet/nSite opens by overlapping WebView init, prefetching blobs in
+  parallel, and fast-serving content-addressed blobs from cache.
+- Substantially faster GrapeRank crawls (background IO, mass pre-connect with
+  cached DNS, batched contact reads, parallel outbox fetches, early dead-relay
+  pruning) and faster scoring via Gauss-Seidel sweeps over a compact integer
+  graph.
+- Speeds up NIP-77 reconcile with direct-built wire frames (~2.5x), O(1) range
+  fingerprints, a live negentropy index, and an allocation-free idle watchdog.
+- Prefetches media and pre-parses note text ahead of the viewport, adds a k-way
+  merge for the home feed, and pins indexes for multi-author queries.
+- Isolates WebSocket frame dispatch onto a dedicated pool, adopts a caching event
+  decoder across Android/Desktop/CLI, and keeps light/dark resolution O(1) after
+  an accent change.
+- Parallelizes Blossom "Sync all", prefetches a joined group's history, and mines
+  proof-of-work on half the device's cores.
+
+## Improvements and Bug fixes
+
+- Normalizes accent theming: contrast-picks onPrimary so filled buttons/FABs stop
+  washing out, bases light/dark on background luminance, and fixes accent
+  regressions.
+- Keeps live HLS streams playing and caches only proven on-demand HLS; shows a
+  browser-fallback overlay when a decoder stalls and pauses looping videos after
+  5 plays.
+- Adds an HTTP/2 keepalive ping to stop stale-connection image stalls, and trims
+  the image cache and player warm pool under memory pressure.
+- Hardens the relay client: enforces blocked relays on every REQ/COUNT/publish,
+  stops re-sending REQs relays refuse, evicts failures on the first strike, and
+  fixes reconnect backoff on network/transport changes.
+- Fixes nutzap relay routing to receive/advertise on inbox/DM (kind 10019)
+  relays instead of outbox.
+- Fixes Concord invite handling (revocation, keyless CORD-05, clearer failure
+  copy, no hang on bad links, skip re-join) and channel rows stuck on "No
+  messages yet".
+- Rejects NIP-29 group state not signed by the relay, opens group posts in the
+  group chat, and fixes subgroup edit safety and pinned-message jump.
+- Makes tapping a message timestamp open delivery info instead of toggling the
+  time format, and right-aligns your own messages.
+- Recovers a media file's type from its extension when the imeta MIME is
+  malformed, and moves several disk reads (boot receiver, signer policy) off the
+  main thread.
+- Serializes account construction so concurrent loaders can't build duplicate
+  accounts.
+- Routes Onion-Location through every HTTP client and maps Tor/Arti errors to
+  accurate SOCKS reply codes.
+- Extracts the rich-text renderer and many event cards (calendar/RSVP, podcast
+  atoms/splits, relay discovery, code snippet, ecash mint, activity, Git
+  diff/status, and more) into shared commons so Desktop and Android render
+  identically.
+- Shortens over-long translated strings across 23 locales and fixes duplicate
+  and CDATA translation issues.
+
+## Desktop
+
+- Redesigns notifications with a reworked inbox and native OS toast
+  notifications.
+- Adds NIP-42 relay AUTH with an inline Once / Always / Never approval banner and
+  persisted grants.
+- Makes NIP-17 private DMs reliable: resolves recipient inbox relays, fetches DM
+  relay lists and account/Blossom config from outbox relays, and stops falling
+  back to connected relays.
+- Adds Web-of-Trust score badges, Follow Packs (NIP-51) discovery with one-tap
+  follow, note scheduling, opt-in NIP-37 draft sync, a Privacy Lock for Messages
+  and the Wallet column, and a hashtag-spam filter.
+- Renders rich text through the shared core (removes the desktop-only fork) and
+  ships as a Flatpak bundle.
+- Fixes a desktop-cache race that could wipe the follow list, and makes sidebar
+  navigation replace the detail overlay instead of hiding behind it.
+
+## Cli
+
+- Adds nak-style primitives: `amy decode`/`encode` (NIP-19/21), `verify`, `key`
+  (generate/public/encrypt/decrypt/validate, NIP-49), and `filter`.
+- Adds query verbs: `amy fetch` (one-shot with code-mode outbox resolution),
+  `subscribe` (live NDJSON), `count` (NIP-45), and `outbox USER` (NIP-65).
+- Adds `amy sync` — NIP-77 negentropy reconcile with deletion propagation — and
+  `amy event` / `amy publish` for raw and pre-signed events.
+- Adds `amy encrypt`/`decrypt` (NIP-44/04) and `amy gift wrap`/`unwrap` (NIP-59).
+- Adds `amy blossom` (upload/download/list/delete/check/mirror, NIP-B7) with a
+  live interop smoke test.
+- Adds `amy git` (NIP-34), `amy podcast` and `amy podcast20` (Podcasting 2.0 with
+  V4V splits).
+- Adds the `amy cashu` wallet (NIP-60/61): wallet lifecycle, balance, mint,
+  receive/send (LN / token / nutzap), and maintenance.
+- Adds `amy admin` (NIP-86 relay moderation) and `amy serve` (run a relay by
+  embedding geode).
+- Adds NIP-46 remote signing: `amy bunker` server, `amy login bunker://…`, and
+  `amy login --nostrconnect`, gated with `--perms` and interactive approval.
+- Adds the `amy graperank` suite (crawl/score/publish/followers/rank/…),
+  account-less crawl/score, and NIP-85 card publishing.
+- Adds `amy fof` (follows-of-follows, renamed from `amy wot`), `amy concord`
+  (encrypted communities), `amy relaygroup` (NIP-29), and `amy geochat`
+  (BitChat-interoperable geohash channels).
+- Adds NIP-13 proof of work (`amy pow`, `--pow` on posts), `amy kind`, `amy nip`,
+  `amy namecoin`, `amy status`, and `amy logoff`.
+- Expands `amy nsite`/`napplet` with `publish`, `serve`, and `list`.
+- Switches the default event store to SQLite and hardens the output contract:
+  single-line `--json`, exit codes 0/1/2/124, publish results carry each relay's
+  rejection reason, and read-only verbs run without an account.
+
+## Quartz
+
+- Adds NIP-77 negentropy sync (pipelined worker pool, multi-connection fan-out,
+  bounded-memory streaming, `LiveNegentropyIndex`) and NIP-09/62 deletion
+  propagation.
+- Adds NIP-13 proof-of-work publishing: a cooperative-cancellation miner and a
+  `PoWNostrSigner` decorator that composes with any signer, plus NIP-59
+  gift-wrap mining on the outer wrap only.
+- Adds NIP-66 `RelayReachabilityStore` — a durable, shareable dead-relay cache
+  backed by kind:30166 events.
+- Adds the Concord/CORD protocol foundation (key derivation, envelope layer,
+  authority resolver, roles/moderation, CORD-05/06/07) and the NIP-5D/5A
+  trust-boundary core (capability model, permission ledger, broker, wire
+  protocol).
+- Implements Marmot (MLS-over-Nostr) group icons byte-for-byte with the
+  mdk/whitenoise scheme, and fixes SecretTree ratchet preservation across
+  restore.
+- Adds an OutboxDispatcher to fetch profile/contact events via each author's
+  outbox relays, and richer NIP-89 app-handler parsing.
+
+## Geode (standalone relay)
+
+- Adds relay-to-relay mirroring with strfry-router parity: a two-phase model
+  (NIP-77 negentropy sync catch-up plus a live REQ tail), `down` / `up` / `both`
+  directions, per-upstream mirror filters, and relay-to-relay trust.
+- Keeps mirrors alive across upstream restarts with a retry pump and ping
+  keepalive, and advances the since-watermark correctly on reconnect.
+- Adds `import` / `export` NDJSON verbs and an optional no-full-text-search mode
+  (`--no-search`) for lighter deployments.
+- Adds `[database]` tuning knobs with periodic `PRAGMA optimize`, and validates
+  config knobs and mirror filters at boot.
+- Runs embedded in the CLI via `amy serve`.
+- Serves full-set negentropy NEG-OPENs from a live index and streams mirror
+  catch-up IDs instead of materializing them.
+- Adds relayBench, a head-to-head benchmark harness (geode vs strfry vs any
+  relay) measuring ingest, query, and NIP-77 sync over a shared corpus.
+
+## Build & Documentation
+
+- Rebuilds the Tor/Arti native library for the SOCKS reply-code fix, ships a
+  Homebrew formula for `amy`, and seeds the Gradle distribution from a verified
+  mirror in the web sandbox.
+- Adds NIP-29 group-chat test coverage across every assembler, filter shape, and
+  relay integration.
+
+## Contributors
+
+- @npub1gcxzte5zlkncx26j68ez60fzkvtkm9e0vrwdcvsjakxf9mu9qewqlfnj5z
+- @npub1e2yuky03caw4ke3zy68lg0fz3r4gkt94hx4fjmlelacyljgyk79svn3eef
+- @npub12cfje6nl2nuxplcqfvhg7ljt89fmpj0n0fd24zxsukja5qm9wmtqd7y76c
+- @npub1dn0tej4a5806qk9ts56j572sndvjk27l5qmsxf0z3mquknccve7s4k8tfp
+- @npub1w4uswmv6lu9yel005l3qgheysmr7tk9uvwluddznju3nuxalevvs2d0jr5
+- roguehashrate
+- LubuSeb
+
+## Translations
+
+- Czech, German, Brazilian Portuguese, and Swedish by @npub1e2yuky03caw4ke3zy68lg0fz3r4gkt94hx4fjmlelacyljgyk79svn3eef
+- Spanish (Spain, Mexico, and US) by @npub1luhyzgce7qtcs6r6v00ryjxza8av8u4dzh3avg0zks38tjktnmxspxq903
+- French by @npub106efcyntxc5qwl3w8krrhyt626m59ya2nk9f40px5s968u5xdwhsjsr8fz
+- Hungarian by @npub1dnvslq0vvrs8d603suykc4harv94yglcxwna9sl2xu8grt2afm3qgfh0tp
+- Dutch by @npub1w4la29u3zv09r6crx5u8yxax0ffxgekzdm2egzjkjckef7xc83fs0ftxcd
+- Hindi by @npub1ww6huwu3xye6r05n3qkjeq62wds5pq0jswhl7uc59lchc0n0ns4sdtw5e6
+- Polish by @npub16gjyljum0ksrrm28zzvejydgxwfm7xse98zwc4hlgq8epxeuggushqwyrm
+- Slovenian by @npub1qqqqqqz7nhdqz3uuwmzlflxt46lyu7zkuqhcapddhgz66c4ddynswreecw
+- Chinese Simplified by hypnotichemionus4
+- German by crowdin.pretended462


### PR DESCRIPTION
## Summary

Adds the v1.13.0 "Web Apps, Communities & Git" release notes (`docs/changelog/v1.13.00.md`) and links them at the top of the changelog index. Covers the full `v1.12.6..HEAD` range — 323 merged PRs — grouped by user impact.

Docs-only. The `libs.versions.toml` / README / packaging version bumps are intentionally left out of this PR so the notes can be reviewed on their own; they'll follow separately.

Headline items covered: the in-app Browser and NIP-5D/5A Nostr web clients (keyless sandbox), Concord communities, NIP-34 git collaboration, Location Channels, the NIP-46 Remote Signer and Privacy Lock, NIP-42 relay login permissions, NIP-29 Groups, the redesigned Messages inbox, Blossom file sync, Podcasting 2.0, proof-of-work (NIP-13), negentropy (NIP-77) sync, GrapeRank, and accent theming — plus the Desktop, `amy` CLI, Quartz, and Geode sections.

## Test plan

Docs-only change — no code paths touched.

- [x] Rendered the Markdown and checked the section structure and links
- [x] Verified the index link resolves to the new file
- [ ] N/A — `./gradlew spotlessApply` (no Kotlin changed)
- [ ] N/A — `./gradlew test` (no code changed)

Notes: contributor npubs were resolved from `docs/changelog/github.json`; two Crowdin translators (`hypnotichemionus4`, `crowdin.pretended462`) remain unmapped to npubs and are listed by handle.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## AI assistance

- [x] Drafted with AI assistance, manually reviewed and tested

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrPNt4FchqArpMtAHHfqGi)_