### PR TITLE
fix: Concord groups missing or slow on the Messages tab after a cold boot

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
@@ -38,6 +38,7 @@ import com.vitorpamplona.amethyst.model.UiSettings
 import com.vitorpamplona.amethyst.service.checkNotInMainThread
 import com.vitorpamplona.amethyst.ui.actions.mediaServers.DEFAULT_MEDIA_SERVERS
 import com.vitorpamplona.amethyst.ui.actions.mediaServers.ServerName
+import com.vitorpamplona.quartz.concord.cord02Community.ConcordCommunityListEvent
 import com.vitorpamplona.quartz.experimental.ephemChat.list.EphemeralChatListEvent
 import com.vitorpamplona.quartz.experimental.nipA3.PaymentTargetsEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
@@ -168,6 +169,7 @@ private object PrefKeys {
     const val LATEST_GEOHASH_LIST = "latestGeohashList"
     const val LATEST_EPHEMERAL_LIST = "latestEphemeralChatList"
     const val LATEST_RELAY_GROUP_LIST = "latestRelayGroupList"
+    const val LATEST_CONCORD_LIST = "latestConcordList"
     const val LATEST_TRUST_PROVIDER_LIST = "latestTrustProviderList"
     const val CALLS_ENABLED = "calls_enabled"
     const val HIDE_DELETE_REQUEST_DIALOG = "hide_delete_request_dialog"
@@ -577,6 +579,7 @@ object LocalPreferences {
                     putOrRemove(PrefKeys.LATEST_GEOHASH_LIST, settings.backupGeohashList)
                     putOrRemove(PrefKeys.LATEST_EPHEMERAL_LIST, settings.backupEphemeralChatList)
                     putOrRemove(PrefKeys.LATEST_RELAY_GROUP_LIST, settings.backupRelayGroupList)
+                    putOrRemove(PrefKeys.LATEST_CONCORD_LIST, settings.backupConcordList)
                     putOrRemove(PrefKeys.LATEST_TRUST_PROVIDER_LIST, settings.backupTrustProviderList)
                     putOrRemove(PrefKeys.LATEST_PAYMENT_TARGETS, settings.backupNipA3PaymentTargets)
                     putOrRemove(PrefKeys.LATEST_CASHU_WALLET, settings.backupCashuWallet)
@@ -763,6 +766,7 @@ object LocalPreferences {
                     val latestGeohashListStr = getString(PrefKeys.LATEST_GEOHASH_LIST, null)
                     val latestEphemeralListStr = getString(PrefKeys.LATEST_EPHEMERAL_LIST, null)
                     val latestRelayGroupListStr = getString(PrefKeys.LATEST_RELAY_GROUP_LIST, null)
+                    val latestConcordListStr = getString(PrefKeys.LATEST_CONCORD_LIST, null)
                     val latestTrustProviderListStr = getString(PrefKeys.LATEST_TRUST_PROVIDER_LIST, null)
                     val latestPaymentTargetsStr = getString(PrefKeys.LATEST_PAYMENT_TARGETS, null)
                     val latestCashuWalletStr = getString(PrefKeys.LATEST_CASHU_WALLET, null)
@@ -823,6 +827,7 @@ object LocalPreferences {
                     val latestGeohashList = async { parseEventOrNull<GeohashListEvent>(latestGeohashListStr) }
                     val latestEphemeralList = async { parseEventOrNull<EphemeralChatListEvent>(latestEphemeralListStr) }
                     val latestRelayGroupList = async { parseEventOrNull<SimpleGroupListEvent>(latestRelayGroupListStr) }
+                    val latestConcordList = async { parseEventOrNull<ConcordCommunityListEvent>(latestConcordListStr) }
                     val latestTrustProviderList = async { parseEventOrNull<TrustProviderListEvent>(latestTrustProviderListStr) }
                     val latestPaymentTargets = async { parseEventOrNull<PaymentTargetsEvent>(latestPaymentTargetsStr) }
                     val latestCashuWallet =
@@ -875,6 +880,7 @@ object LocalPreferences {
                     val latestGeohashListResolved = latestGeohashList.await()
                     val latestEphemeralListResolved = latestEphemeralList.await()
                     val latestRelayGroupListResolved = latestRelayGroupList.await()
+                    val latestConcordListResolved = latestConcordList.await()
                     val latestTrustProviderListResolved = latestTrustProviderList.await()
                     val latestPaymentTargetsResolved = latestPaymentTargets.await()
                     val latestCashuWalletResolved = latestCashuWallet.await()
@@ -969,6 +975,7 @@ object LocalPreferences {
                         backupGeohashList = latestGeohashListResolved,
                         backupEphemeralChatList = latestEphemeralListResolved,
                         backupRelayGroupList = latestRelayGroupListResolved,
+                        backupConcordList = latestConcordListResolved,
                         backupTrustProviderList = latestTrustProviderListResolved,
                         lastReadPerRoute = MutableStateFlow(lastReadPerRouteResolved),
                         hasDonatedInVersion = MutableStateFlow(hasDonatedInVersion),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountFeedContentStates.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountFeedContentStates.kt
@@ -77,7 +77,9 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.webBookmarks.dal.WebBookmar
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.workouts.dal.WorkoutFeedFilter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.sample
 import kotlinx.coroutines.launch
 
 class AccountFeedContentStates(
@@ -196,6 +198,26 @@ class AccountFeedContentStates(
         scope.launch(Dispatchers.IO) {
             account.settings.relayGroupViewMode
                 .drop(1)
+                .collect {
+                    dmKnown.invalidateData()
+                }
+        }
+
+        // A Concord control-plane fold is what first reveals a community's channels (and what makes
+        // ConcordCommunitySession.state non-null, without which ChatroomListKnownFeedFilter emits
+        // nothing at all for that community). None of it flows through LocalCache.newEventBundles,
+        // so the additive path can't see it: a folded channel reaches the Messages tab only if a
+        // message for it happens to arrive afterwards. Cold boot therefore shows a *subset* of a
+        // community's channels, or omits a quiet community entirely, until some unrelated
+        // invalidation fires. Rebuild on every structural change instead. `revision` bumps only on
+        // fold/membership/rekey (never a plain message), and sample() coalesces the burst of folds
+        // that lands as each control plane catches up — the same pairing Account.kt uses to drive
+        // refreshConcordChannelIndex off this flow.
+        scope.launch(Dispatchers.IO) {
+            @OptIn(FlowPreview::class)
+            account.concordSessions.revision
+                .drop(1)
+                .sample(500)
                 .collect {
                     dmKnown.invalidateData()
                 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/concord/ConcordCommunitySession.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/concord/ConcordCommunitySession.kt
@@ -62,8 +62,17 @@ enum class ConcordIngestOutcome {
      *  a chat/reaction/reply/delete message landing, or a duplicate wrap. Must NOT bump the revision. */
     NON_STRUCTURAL,
 
-    /** Ours and changed structure: a Control-Plane fold (metadata/channels/membership/authority), a
-     *  guestbook membership change, or a buffered base-rekey. Bumps the revision. */
+    /** Ours and re-folded the Control Plane. The fold republishes [ConcordCommunitySession.state],
+     *  so the session's own state watcher is what bumps the revision — and, because the folded state
+     *  compares by value, only when the fold actually *changed* something. A control wrap that folds
+     *  to an identical state (a prior-epoch wrap that doesn't move the anti-rollback floor, a role
+     *  edition that touches nothing we subscribe on) therefore costs no bump at all. The manager must
+     *  NOT bump on this outcome as well, or every control wrap counts twice. */
+    STRUCTURAL_FOLD,
+
+    /** Ours and changed structure *without* touching [ConcordCommunitySession.state]: a guestbook
+     *  membership change (which republishes `members`) or a buffered base-rekey. No state watcher
+     *  covers these, so the manager bumps the revision directly. */
     STRUCTURAL,
     ;
 
@@ -144,6 +153,22 @@ class ConcordCommunitySession(
 
     // Deduped inbound wraps.
     private val controlWraps = LinkedHashMap<HexKey, Event>()
+
+    /**
+     * Decrypted control editions memoized by wrap id.
+     *
+     * Both [refold] and [controlFloorsLocked] fold their WHOLE buffer on every inbound control
+     * wrap, and turning a wrap into an edition is a NIP-44 open + parse. Re-deriving them each
+     * time made a cold-boot backfill quadratic in decryptions — one measured boot did ~8.6k opens
+     * to ingest 93 control wraps for a single community. Memoizing makes it one open per wrap.
+     *
+     * Wrap ids are unique and a wrap only ever belongs to one plane (it is routed by `pubKey`), so
+     * a single id-keyed map is safe across the current and prior-epoch Control Planes even though
+     * they open under different keys. A wrap that fails to open caches `null` so it is not retried
+     * on every subsequent fold. The wrap buffers are only ever added to, so this tracks their
+     * lifetime exactly and needs no separate eviction.
+     */
+    private val editionByWrapId = HashMap<HexKey, ControlEdition?>()
 
     // Prior-epoch Control Plane address -> (wrapId -> wrap). Kept apart from [controlWraps]: these
     // never join the live fold, they only produce the anti-rollback floor.
@@ -280,7 +305,7 @@ class ConcordCommunitySession(
     fun auxStreamKeys(): List<GroupKey> = listOf(guestbookKey, nextBaseRekeyKey)
 
     /** The community's current Control Plane editions — the input a moderation edition chains onto. */
-    fun controlEditions(): List<ControlEdition> = lock.withLock { ConcordActions.controlEditions(controlWraps.values.toList(), controlPlaneKey) }
+    fun controlEditions(): List<ControlEdition> = lock.withLock { editionsLocked(controlWraps.values.toList(), controlPlaneKey) }
 
     /** The raw Control Plane wraps buffered so far — the input a Refounding compacts (CORD-06 §3). */
     fun controlPlaneWraps(): List<Event> = lock.withLock { controlWraps.values.toList() }
@@ -314,7 +339,7 @@ class ConcordCommunitySession(
                     if (controlWraps.put(wrap.id, wrap) != null) return ConcordIngestOutcome.NON_STRUCTURAL // dup
                 }
                 refold()
-                return ConcordIngestOutcome.STRUCTURAL
+                return ConcordIngestOutcome.STRUCTURAL_FOLD
             }
             guestbookAddress -> {
                 lock.withLock {
@@ -341,7 +366,7 @@ class ConcordCommunitySession(
                         if (buffer.put(wrap.id, wrap) != null) return ConcordIngestOutcome.NON_STRUCTURAL // dup
                     }
                     refold()
-                    return ConcordIngestOutcome.STRUCTURAL
+                    return ConcordIngestOutcome.STRUCTURAL_FOLD
                 }
                 val current = lock.withLock { channelKeysByAddress[wrap.pubKey] }
                 if (current != null) {
@@ -422,7 +447,7 @@ class ConcordCommunitySession(
                 val wraps = controlWraps.values.toList()
                 val folded =
                     ConcordCommunityState.fold(
-                        ConcordActions.controlEditions(wraps, controlPlaneKey),
+                        editionsLocked(wraps, controlPlaneKey),
                         entry.owner,
                         controlFloorsLocked(),
                     )
@@ -456,6 +481,24 @@ class ConcordCommunitySession(
     }
 
     /**
+     * [wraps] opened into editions through [editionByWrapId], so a wrap is only ever decrypted
+     * once no matter how many folds it participates in. Caller must hold [lock].
+     */
+    private fun editionsLocked(
+        wraps: Collection<Event>,
+        planeKey: GroupKey,
+    ): List<ControlEdition> =
+        wraps.mapNotNull { wrap ->
+            if (editionByWrapId.containsKey(wrap.id)) {
+                editionByWrapId[wrap.id]
+            } else {
+                val edition = ConcordStreamEnvelope.openOrNull(wrap, planeKey)?.let { ControlEdition.fromRumor(it.rumor) }
+                editionByWrapId[wrap.id] = edition
+                edition
+            }
+        }
+
+    /**
      * The per-entity anti-rollback floor: the authority-gated heads of every prior epoch's
      * Control Plane we still hold a root for, folded **oldest epoch first** so each epoch is
      * itself anchored at the one before it and the floor only ever rises.
@@ -472,7 +515,7 @@ class ConcordCommunitySession(
         var floors = emptyMap<String, EntityFloor>()
         for ((address, keyAtEpoch) in historicalControlKeys.entries.sortedBy { it.value.second }) {
             val wraps = historicalControlWraps[address]?.values?.toList() ?: continue
-            val editions = ConcordActions.controlEditions(wraps, keyAtEpoch.first)
+            val editions = editionsLocked(wraps, keyAtEpoch.first)
             if (editions.isEmpty()) continue
             floors = ConcordCommunityState.authorizedHeads(editions, entry.owner, floors)
         }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/concord/ConcordSessionManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/concord/ConcordSessionManager.kt
@@ -150,6 +150,9 @@ class ConcordSessionManager(
         seenOnRelays: Set<NormalizedRelayUrl> = emptySet(),
     ): Boolean {
         val outcome = registry.ingest(wrap, seenOnRelays)
+        // Only the planes that change structure *without* republishing `state`. A control-plane
+        // fold returns STRUCTURAL_FOLD and is bumped by the per-session state watcher instead, which
+        // (since the folded state compares by value) fires only when the fold genuinely changed.
         if (outcome == ConcordIngestOutcome.STRUCTURAL) bumpRevision()
         return outcome.claimed
     }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/FeedContentState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/feeds/FeedContentState.kt
@@ -161,7 +161,14 @@ class FeedContentState(
                                 if (noteEvent != null) {
                                     !cacheProvider.hasBeenDeleted(noteEvent)
                                 } else {
-                                    false
+                                    // An event-less row is a placeholder the filter synthesized for a room
+                                    // that has no message yet — a just-joined Concord channel, NIP-29 group,
+                                    // Marmot group or geohash cell. It carries no event, so it cannot have
+                                    // been deleted, and dropping it here deleted every such row from the
+                                    // Messages list the moment ANY kind-5 landed in an unrelated batch. The
+                                    // row then stayed gone until the next full rebuild, which is why a quiet
+                                    // community looked like it had never loaded at all.
+                                    true
                                 }
                             }.toImmutableList()
                     }

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/concord/ConcordCommunitySessionTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/concord/ConcordCommunitySessionTest.kt
@@ -108,7 +108,7 @@ class ConcordCommunitySessionTest {
 
             // Feed the genesis control wraps → state folds, channels + membership resolve. A fold is
             // STRUCTURAL (it moves the subscription set), so it's allowed to bump the revision.
-            community.genesisWraps.forEach { assertEquals(ConcordIngestOutcome.STRUCTURAL, session.ingest(it)) }
+            community.genesisWraps.forEach { assertEquals(ConcordIngestOutcome.STRUCTURAL_FOLD, session.ingest(it)) }
             val state = session.state.value
             assertEquals("Nostrichs", state?.metadata?.name)
             assertTrue(state!!.channels.containsKey(community.generalChannelIdHex))

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/concord/ConcordSessionRegistryTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/concord/ConcordSessionRegistryTest.kt
@@ -70,7 +70,7 @@ class ConcordSessionRegistryTest {
             assertTrue(registry.subscribeAddresses().contains(beta.controlPlane.publicKeyHex))
 
             // A genesis control wrap routes to Alpha's session and folds it (STRUCTURAL).
-            alpha.genesisWraps.forEach { assertEquals(ConcordIngestOutcome.STRUCTURAL, registry.ingest(it)) }
+            alpha.genesisWraps.forEach { assertEquals(ConcordIngestOutcome.STRUCTURAL_FOLD, registry.ingest(it)) }
             val alphaState = registry.sessionFor(alpha.communityIdHex)!!.state.value
             assertEquals("Alpha", alphaState?.metadata?.name)
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/concord/cord02Community/ConcordCommunityState.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/concord/cord02Community/ConcordCommunityState.kt
@@ -33,7 +33,7 @@ import com.vitorpamplona.quartz.concord.cord04Roles.RoleEntity
 import com.vitorpamplona.quartz.concord.cord04Roles.asFloor
 
 /** A channel id paired with its current folded definition. */
-class ConcordChannel(
+data class ConcordChannel(
     val channelIdHex: String,
     val definition: ChannelEntity,
 )
@@ -49,7 +49,7 @@ class ConcordChannel(
  * "Every member keeps the entire Control Plane in sync — it is small and must
  * stay complete." Recompute this whenever the known editions change.
  */
-class ConcordCommunityState(
+data class ConcordCommunityState(
     val ownerPubKey: String,
     val metadata: MetadataEntity?,
     val channels: Map<String, ConcordChannel>,

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/concord/cord04Roles/AuthorityResolver.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/concord/cord04Roles/AuthorityResolver.kt
@@ -44,7 +44,7 @@ import com.vitorpamplona.quartz.nip01Core.core.toHexKey
  * assigned Role and holds [ConcordPermissions.MANAGE_ROLES]. Cycles that never
  * touch the owner can never bootstrap themselves.
  */
-class AuthorityResolver private constructor(
+data class AuthorityResolver private constructor(
     private val ownerLower: String,
     private val roles: Map<String, RoleEntity>,
     private val memberRoles: Map<String, Set<String>>,

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/concord/cord04Roles/ControlEntities.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/concord/cord04Roles/ControlEntities.kt
@@ -64,7 +64,7 @@ object ConcordJson {
  * drops the role, and with it every authority (grant) that depends on it.
  */
 @Serializable
-class RoleScope(
+data class RoleScope(
     val kind: String = "server",
     @SerialName("channel_id") val channelId: String? = null,
 )
@@ -75,7 +75,7 @@ class RoleScope(
  * ranks higher; no role may claim position 0 (reserved for the owner).
  */
 @Serializable
-class RoleEntity(
+data class RoleEntity(
     val name: String = "",
     val position: Long = 0,
     /** u64 permission bitfield as a decimal string. */
@@ -94,7 +94,7 @@ class RoleEntity(
  * terminates at the owner (see [AuthorityResolver]).
  */
 @Serializable
-class GrantEntity(
+data class GrantEntity(
     val member: String = "",
     @SerialName("role_ids") val roleIds: List<String> = emptyList(),
 )
@@ -105,7 +105,7 @@ class GrantEntity(
  * A [deleted] channel is terminal — its id is never reused.
  */
 @Serializable
-class ChannelEntity(
+data class ChannelEntity(
     val name: String = "",
     val private: Boolean = false,
     val voice: Boolean = false,
@@ -122,7 +122,7 @@ class ChannelEntity(
  * community name too.
  */
 @Serializable
-class MetadataEntity(
+data class MetadataEntity(
     val name: String = "",
     val icon: ImagePointer? = null,
     val banner: ImagePointer? = null,


### PR DESCRIPTION
Investigated on-device (emulator + tablet, both logged in, Tor on) why Concord groups sometimes don't appear on the Messages tab after a cold boot, and sometimes take a very long time.

Four independent client bugs, each measured. The relay/Tor theory explained none of them.

## 1. The Concord community list was never persisted

`AccountSettings` has held `backupConcordList` and saved it on change since the feature landed, but it was never wired into `LocalPreferences` — neither written to nor read back from the encrypted prefs. `concordList()` returned null on every cold boot, so the kind-13302 joined-communities list had to be refetched from relays before a single plane could be subscribed. The joined list gates the control-plane REQ, which gates the fold, which gates the channels.

Every sibling list (channel, community, hashtag, geohash, ephemeral chat, relay group, trust provider) is persisted; Concord was the one that was missed.

Boot → first Concord plane wrap: **45 s → 6 s**. Without the backup, `liveCommunities` sat empty for ~56 s waiting on the fetch; with it, the list decodes 1.6 s after boot in 30 ms.

## 2. Missing feed invalidation

The **Concord Channels** hub reads session state directly, bypassing the Messages feed filter. Comparing the two at the same instant:

| Community | Channels folded in memory | Rows in Messages |
|---|---|---|
| Soapbox Community | 11 | 1 |
| 3rd times a charm? | 3 | 2 |
| NosFabrica | 3 | **0 — absent entirely** |

`AccountFeedContentStates` forces a `dmKnown` rebuild for the Marmot, NIP-29, geohash, view-mode and pin flows, but had no collector on `concordSessions.revision`. A control-plane fold is what first makes `ConcordCommunitySession.state` non-null, and none of it flows through `LocalCache.newEventBundles` — so a folded channel only reached Messages if a message for it happened to arrive later.

## 3. Placeholder rooms wiped by unrelated deletions

`FeedContentState.refreshFromOldState` re-filters the list when a batch contains a kind-5, and event-less notes returned `false` — so they were dropped. A placeholder row has no event by construction and cannot have been deleted. One unrelated deletion removed every quiet room, and since this is the additive path they stayed gone until the next full rebuild.

**Not Concord-specific** — the same `placeholderNote()` pattern backs just-joined NIP-29 groups, Marmot groups and geohash cells.

## 4. Revision churn (perf)

Cold boot bumped the session revision ~292 times for 3 communities. Identical refolds still republished (the fold result had no value equality), every control wrap bumped twice (`ingest()` **and** the state watcher), and `refold()`/`controlFloorsLocked()` re-opened the whole wrap buffer each time — a NIP-44 decrypt per wrap, making backfill quadratic (~8.6k opens to ingest 93 wraps).

## Measured

| Metric | Before | After |
|---|---|---|
| Boot → first Concord wrap | 45 s | 6 s |
| Revision bumps | 292 | 87 |
| Messages rebuilds | 22 | 7 |
| First fold → all 17 channels | 43 s | 7.5 s |
| Surviving placeholders in `sort()` | 0 | 14 |
| Communities / channels rendered | 3 of 17, 1 community missing | all 17, all 3 communities |

## Testing

`:commons:jvmTest`, `:quartz:jvmTest` and `:amethyst:testPlayDebugUnitTest` all pass. Two `:commons` assertions updated for the new `STRUCTURAL_FOLD` outcome. Verified across repeated cold boots on the emulator; all debug instrumentation removed.

## Reviewer notes

- Commit 2 makes several quartz Concord types **data classes**, changing `equals`/`hashCode` from identity to value. They're only used as map values and in `StateFlow`, never as identity-keyed map keys — but it's the highest-risk piece here.
- Commit 4 persists an event whose content carries community roots. Prefs are encrypted and `backupCashuWallet` already sets the precedent for a secret-bearing backup.

## Not addressed

- An **AUTH gate** on the plane REQ was built and A/B tested (3 runs per arm) and **rejected**: time-to-first-wrap was identical at 63.0 s mean both ways. On a fresh connection the relay hasn't challenged yet, so the gate is open exactly when it would need to act; it only suppresses re-REQs that `checkAuthResults` → `syncFilters` already handles.
- Folded chat rumors still sometimes render as "Event is loading or can't be found in your relay list" — a known separate issue, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)