### PR TITLE
fix: persist the MIP-00 key-package and favorite-algo-feeds lists

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
@@ -40,6 +40,7 @@ import com.vitorpamplona.amethyst.ui.actions.mediaServers.DEFAULT_MEDIA_SERVERS
 import com.vitorpamplona.amethyst.ui.actions.mediaServers.ServerName
 import com.vitorpamplona.quartz.experimental.ephemChat.list.EphemeralChatListEvent
 import com.vitorpamplona.quartz.experimental.nipA3.PaymentTargetsEvent
+import com.vitorpamplona.quartz.marmot.mip00KeyPackages.KeyPackageRelayListEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.JsonMapper
@@ -55,6 +56,7 @@ import com.vitorpamplona.quartz.nip28PublicChat.list.ChannelListEvent
 import com.vitorpamplona.quartz.nip37Drafts.privateOutbox.PrivateOutboxRelayListEvent
 import com.vitorpamplona.quartz.nip47WalletConnect.Nip47WalletConnect
 import com.vitorpamplona.quartz.nip50Search.SearchRelayListEvent
+import com.vitorpamplona.quartz.nip51Lists.favoriteAlgoFeedsList.FavoriteAlgoFeedsListEvent
 import com.vitorpamplona.quartz.nip51Lists.geohashList.GeohashListEvent
 import com.vitorpamplona.quartz.nip51Lists.hashtagList.HashtagListEvent
 import com.vitorpamplona.quartz.nip51Lists.muteList.MuteListEvent
@@ -169,6 +171,8 @@ private object PrefKeys {
     const val LATEST_EPHEMERAL_LIST = "latestEphemeralChatList"
     const val LATEST_RELAY_GROUP_LIST = "latestRelayGroupList"
     const val LATEST_TRUST_PROVIDER_LIST = "latestTrustProviderList"
+    const val LATEST_KEY_PACKAGE_RELAY_LIST = "latestKeyPackageRelayList"
+    const val LATEST_FAVORITE_ALGO_FEEDS_LIST = "latestFavoriteAlgoFeedsList"
     const val CALLS_ENABLED = "calls_enabled"
     const val HIDE_DELETE_REQUEST_DIALOG = "hide_delete_request_dialog"
     const val HIDE_BLOCK_ALERT_DIALOG = "hide_block_alert_dialog"
@@ -578,6 +582,8 @@ object LocalPreferences {
                     putOrRemove(PrefKeys.LATEST_EPHEMERAL_LIST, settings.backupEphemeralChatList)
                     putOrRemove(PrefKeys.LATEST_RELAY_GROUP_LIST, settings.backupRelayGroupList)
                     putOrRemove(PrefKeys.LATEST_TRUST_PROVIDER_LIST, settings.backupTrustProviderList)
+                    putOrRemove(PrefKeys.LATEST_KEY_PACKAGE_RELAY_LIST, settings.backupKeyPackageRelayList)
+                    putOrRemove(PrefKeys.LATEST_FAVORITE_ALGO_FEEDS_LIST, settings.backupFavoriteAlgoFeedsList)
                     putOrRemove(PrefKeys.LATEST_PAYMENT_TARGETS, settings.backupNipA3PaymentTargets)
                     putOrRemove(PrefKeys.LATEST_CASHU_WALLET, settings.backupCashuWallet)
                     putOrRemove(PrefKeys.LATEST_NUTZAP_INFO, settings.backupNutzapInfo)
@@ -764,6 +770,8 @@ object LocalPreferences {
                     val latestEphemeralListStr = getString(PrefKeys.LATEST_EPHEMERAL_LIST, null)
                     val latestRelayGroupListStr = getString(PrefKeys.LATEST_RELAY_GROUP_LIST, null)
                     val latestTrustProviderListStr = getString(PrefKeys.LATEST_TRUST_PROVIDER_LIST, null)
+                    val latestKeyPackageRelayListStr = getString(PrefKeys.LATEST_KEY_PACKAGE_RELAY_LIST, null)
+                    val latestFavoriteAlgoFeedsListStr = getString(PrefKeys.LATEST_FAVORITE_ALGO_FEEDS_LIST, null)
                     val latestPaymentTargetsStr = getString(PrefKeys.LATEST_PAYMENT_TARGETS, null)
                     val latestCashuWalletStr = getString(PrefKeys.LATEST_CASHU_WALLET, null)
                     val latestNutzapInfoStr = getString(PrefKeys.LATEST_NUTZAP_INFO, null)
@@ -824,6 +832,8 @@ object LocalPreferences {
                     val latestEphemeralList = async { parseEventOrNull<EphemeralChatListEvent>(latestEphemeralListStr) }
                     val latestRelayGroupList = async { parseEventOrNull<SimpleGroupListEvent>(latestRelayGroupListStr) }
                     val latestTrustProviderList = async { parseEventOrNull<TrustProviderListEvent>(latestTrustProviderListStr) }
+                    val latestKeyPackageRelayList = async { parseEventOrNull<KeyPackageRelayListEvent>(latestKeyPackageRelayListStr) }
+                    val latestFavoriteAlgoFeedsList = async { parseEventOrNull<FavoriteAlgoFeedsListEvent>(latestFavoriteAlgoFeedsListStr) }
                     val latestPaymentTargets = async { parseEventOrNull<PaymentTargetsEvent>(latestPaymentTargetsStr) }
                     val latestCashuWallet =
                         async {
@@ -876,6 +886,8 @@ object LocalPreferences {
                     val latestEphemeralListResolved = latestEphemeralList.await()
                     val latestRelayGroupListResolved = latestRelayGroupList.await()
                     val latestTrustProviderListResolved = latestTrustProviderList.await()
+                    val latestKeyPackageRelayListResolved = latestKeyPackageRelayList.await()
+                    val latestFavoriteAlgoFeedsListResolved = latestFavoriteAlgoFeedsList.await()
                     val latestPaymentTargetsResolved = latestPaymentTargets.await()
                     val latestCashuWalletResolved = latestCashuWallet.await()
                     val latestNutzapInfoResolved = latestNutzapInfo.await()
@@ -970,6 +982,8 @@ object LocalPreferences {
                         backupEphemeralChatList = latestEphemeralListResolved,
                         backupRelayGroupList = latestRelayGroupListResolved,
                         backupTrustProviderList = latestTrustProviderListResolved,
+                        backupKeyPackageRelayList = latestKeyPackageRelayListResolved,
+                        backupFavoriteAlgoFeedsList = latestFavoriteAlgoFeedsListResolved,
                         lastReadPerRoute = MutableStateFlow(lastReadPerRouteResolved),
                         hasDonatedInVersion = MutableStateFlow(hasDonatedInVersion),
                         dismissedPollNoteIds = MutableStateFlow(dismissedPollNoteIds),


### PR DESCRIPTION
Follow-up to #3658. That PR fixed the Concord community list never being persisted; this audits the rest and fixes the two others with the same gap.

## The audit

`AccountSettings` declares 25 `backup*` fields and saves each on change. Each needs wiring at five sites in `LocalPreferences` — pref key, `putOrRemove`, `getString`, `parseEventOrNull`, and the restore assignment. Checked all 25:

| Field | In `LocalPreferences` |
|---|---|
| `backupKeyPackageRelayList` | **0 occurrences** |
| `backupFavoriteAlgoFeedsList` | **0 occurrences** |
| the other 23 | fully wired |

**NIP-29 is fine** — `backupRelayGroupList` is correctly wired at all five sites. I also checked for alternative persistence of the two event types and found none (the only other hit is `saveRelayList`, which builds and publishes an event rather than storing it).

## Why it matters

Both fields only ever existed for the process lifetime, so their consumers' restore-from-backup paths were dead code after every cold boot:

- `KeyPackageRelayListState.normalizeKeyPackageRelayListWithBackup` falls back to the field
- `FavoriteAlgoFeedsListState`'s `init` seeds the cache from it

For the key-package list this goes beyond latency. It feeds `Account.publishRelaysFor()` — which decides where this account's MIP-00 key packages are published so others can add it to groups — and `Account.updateKeyPackageRelays()` reads it as the *previous* list when computing an update. An empty read there is worth a reviewer's eye.

## Verification

Persist-then-cold-boot pair on the emulator:

| Boot | `Loading saved KeyPackage Relay List` |
|---|---|
| 1 (nothing saved yet) | absent |
| 2 (cold) | **+1.6 s** |

**The favorite-algo-feeds half is not verified end to end.** This account has no kind 10090, so there is nothing to persist and the restore log correctly never fires. Exercising it would mean publishing a favorites list to a real account, which I didn't want to do just for a test. It is wired identically to the verified path and its type arguments are compiler-checked, but reviewers should treat it as unexercised.

There is no existing test covering `LocalPreferences` round-tripping, which is why this class of bug is silent — the in-memory path works perfectly within a session and only a process restart reveals it. A round-trip test over all `backup*` fields would be the durable guard; I have not added one here.

## Merge notes

Branched off `main`, independent of #3658. Both touch `LocalPreferences.kt`; `git merge-tree` reports **no conflicts** in either order.

`:amethyst:testPlayDebugUnitTest`, `:commons:jvmTest` and `:quartz:jvmTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)