### PR TITLE
docs: fix license badge and refresh stale SKILL.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Join the social network you control.
 [![Maven Central](https://img.shields.io/maven-central/v/com.vitorpamplona.quartz/quartz?label=Quartz%20%28Maven%20Central%29&labelColor=27303D&color=0877d2)](https://central.sonatype.com/artifact/com.vitorpamplona.quartz/quartz)
 [![JitPack snapshots](https://img.shields.io/badge/Quartz%20snapshots-JitPack-27303D?labelColor=27303D&color=0877d2)](https://jitpack.io/#vitorpamplona/amethyst)
 [![CI](https://img.shields.io/github/actions/workflow/status/vitorpamplona/amethyst/build.yml?labelColor=27303D)](https://github.com/vitorpamplona/amethyst/actions/workflows/build.yml)
-[![License: Apache-2.0](https://img.shields.io/github/license/vitorpamplona/amethyst?labelColor=27303D&color=0877d2)](/LICENSE)
+[![License: MIT](https://img.shields.io/github/license/vitorpamplona/amethyst?labelColor=27303D&color=0877d2)](/LICENSE)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/vitorpamplona/amethyst)
 
 ## Download and Install

--- a/SKILL.md
+++ b/SKILL.md
@@ -24,7 +24,9 @@ Build customized Amethyst Nostr clients for Android. Fork, rebrand, customize, a
 
 2. **Android SDK**
    - Command-line tools from https://developer.android.com/studio#command-line-tools-only
-   - Required components: build-tools, platform-tools, platforms;android-35
+   - Required components: build-tools, platform-tools, platforms;android-37
+   - The exact SDK level is `android-compileSdk` in `gradle/libs.versions.toml` —
+     check there if this number has drifted.
 
 3. **Git** for cloning the repository
 
@@ -66,48 +68,54 @@ keyPassword=your-password
 
 ### 3. Configure Signing
 
-Add to `amethyst/build.gradle` inside the `android {}` block:
+Add to `amethyst/build.gradle.kts` inside the `android {}` block:
 
-```gradle
-def keystorePropertiesFile = rootProject.file("keystore.properties")
-def keystoreProperties = new Properties()
+```kotlin
+val keystorePropertiesFile = rootProject.file("keystore.properties")
+val keystoreProperties = Properties()
 if (keystorePropertiesFile.exists()) {
-    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+    keystorePropertiesFile.inputStream().use { keystoreProperties.load(it) }
 }
 
 signingConfigs {
-    release {
+    create("release") {
         if (keystorePropertiesFile.exists()) {
-            storeFile rootProject.file(keystoreProperties['storeFile'])
-            storePassword keystoreProperties['storePassword']
-            keyAlias keystoreProperties['keyAlias']
-            keyPassword keystoreProperties['keyPassword']
+            storeFile = rootProject.file(keystoreProperties["storeFile"] as String)
+            storePassword = keystoreProperties["storePassword"] as String
+            keyAlias = keystoreProperties["keyAlias"] as String
+            keyPassword = keystoreProperties["keyPassword"] as String
         }
     }
 }
 ```
 
+This needs `import java.util.Properties` at the top of the file.
+
 Update the release buildType to use the signing config:
-```gradle
+```kotlin
 buildTypes {
-    release {
-        signingConfig signingConfigs.release
+    getByName("release") {
+        signingConfig = signingConfigs.getByName("release")
         // ... existing config
     }
 }
 ```
 
+Verify with `./gradlew :amethyst:signingReport` — the release variants should
+report your keystore rather than `~/.android/debug.keystore`.
+
 ### 4. Disable Google Services (Required for F-Droid)
 
 **⚠️ CRITICAL:** The Google Services plugin fails when you change the package name. For F-Droid builds, disable it.
 
-Edit `amethyst/build.gradle`, comment out the plugin:
-```gradle
+Edit `amethyst/build.gradle.kts`, comment out the plugin:
+```kotlin
 plugins {
     alias(libs.plugins.androidApplication)
-    alias(libs.plugins.jetbrainsKotlinAndroid)
     // alias(libs.plugins.googleServices)  // DISABLED for F-Droid
     alias(libs.plugins.jetbrainsComposeCompiler)
+    alias(libs.plugins.serialization)
+    alias(libs.plugins.googleKsp)
 }
 ```
 
@@ -141,8 +149,8 @@ Edit `amethyst/src/main/res/values/strings.xml`:
 
 ### Change Package ID
 
-Edit `amethyst/build.gradle`:
-```gradle
+Edit `amethyst/build.gradle.kts`:
+```kotlin
 android {
     defaultConfig {
         applicationId = "com.yourcompany.yourapp"
@@ -152,8 +160,8 @@ android {
 
 ### Change Project Name
 
-Edit `settings.gradle`:
-```gradle
+Edit `settings.gradle.kts`:
+```kotlin
 rootProject.name = "YourAppName"
 ```
 
@@ -167,36 +175,28 @@ Replace icon files in:
 
 Make your app identify itself on posts with `["client", "YourAppName"]`.
 
-**1. Create tag builder extension:**
+You do **not** need to add the tag per event type. The client tag is applied
+centrally by `NostrSignerWithClientTag`, a signer decorator that appends the tag
+to everything it signs (and respects the user's "add client tag" privacy
+setting). Changing the name is a one-constant edit:
 
-Create `quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/tags/clientTag/TagArrayBuilderExt.kt`:
+Edit `amethyst/src/main/java/com/vitorpamplona/amethyst/model/accountsCache/AccountCacheState.kt`:
 ```kotlin
-package com.vitorpamplona.quartz.nip01Core.tags.clientTag
-
-import com.vitorpamplona.quartz.nip01Core.core.Event
-import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
-
-fun <T : Event> TagArrayBuilder<T>.client(clientName: String) = 
-    addUnique(arrayOf(ClientTag.TAG_NAME, clientName))
+const val CLIENT_TAG_NAME = "YourAppName"
 ```
 
-**2. Add to TextNoteEvent:**
+That constant is passed to `NostrSignerWithClientTag` when the account's signer
+is built, so every signed event carries your name.
 
-Edit `quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip10Notes/TextNoteEvent.kt`:
-
-Add import:
-```kotlin
-import com.vitorpamplona.quartz.nip01Core.tags.clientTag.client
-```
-
-In both `build()` functions, add after `alt(...)`:
-```kotlin
-client("YourAppName")
-```
+The tag itself lives in
+`quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip89AppHandlers/clientTag/`
+(`ClientTag`, `TagArrayBuilderExt`, `NostrSignerWithClientTag`) — you only need to
+touch it if you want the optional NIP-89 handler address / relay hint variants.
 
 ### Modify Default Relays
 
-Edit relay configuration in `quartz/src/main/java/com/vitorpamplona/quartz/nip01Core/relay/` or the UI settings files.
+Edit `commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/defaults/Constants.kt`
+(see also `AmethystDefaults.kt` and `DefaultDmIndexerRelays.kt` in the same folder).
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Fixes the README license badge (labelled `Apache-2.0`; the project is MIT) and
refreshes `SKILL.md`, the fork-and-rebrand guide, which had drifted from the
codebase since the Kotlin DSL migration.

Docs only — no code, build scripts or resources touched.

### What was stale in SKILL.md

| Claim | Reality |
|---|---|
| `amethyst/build.gradle`, `settings.gradle` + Groovy snippets | Repo is `.gradle.kts` throughout |
| plugins block lists `jetbrainsKotlinAndroid` | Gone; `serialization` + `googleKsp` were missing |
| `platforms;android-35` | `android-compileSdk = "37"` |
| "Create `nip01Core/tags/clientTag/TagArrayBuilderExt.kt`, then edit both `build()` fns in TextNoteEvent" | That file already exists at `nip89AppHandlers/clientTag/`. The tag is applied centrally by the `NostrSignerWithClientTag` decorator — rebranding is a one-constant edit to `CLIENT_TAG_NAME` |
| Default relays in `quartz/src/main/java/…` | Path doesn't exist in the KMP layout; they're in `commons/…/defaults/` |

The client-tag section was the one that actually mattered — following it as
written would have had a forker create a duplicate extension in the wrong
package and patch event builders by hand, while the signer decorator kept
stamping "Amethyst" on their events anyway.

## Test plan

Docs-only, so there is no new code path to fire. What I did verify:

**The signing snippet is executed, not just eyeballed.** The old Groovy snippet
can't work on a `.gradle.kts` build, so the replacement needed to be real. I
temporarily applied the new Kotlin DSL snippet to `amethyst/build.gradle.kts`,
pointed `keystore.properties` at a throwaway keystore, and ran:

```
$ ./gradlew :amethyst:signingReport
Config: release
Store: /tmp/rk.jks
Alias: testkey
...
BUILD SUCCESSFUL in 5s
```

Release variants picked up the keystore instead of `~/.android/debug.keystore`,
confirming both the `signingConfigs { create("release") { … } }` block and the
`getByName("release") { signingConfig = … }` wiring. The temporary patch and the
keystore were then reverted — `git status` clean before committing.

**Every other path/constant in the diff was checked against the tree** rather
than assumed: `android-compileSdk = "37"` in `gradle/libs.versions.toml`, the
current `plugins {}` block, `CLIENT_TAG_NAME` at `AccountCacheState.kt:308` and
its use at `AccountCacheState.kt:210`, the `nip89AppHandlers/clientTag/` package
contents, and `commons/…/defaults/`.

- [x] Ran `./gradlew :amethyst:signingReport` — output above
- [ ] Ran `./gradlew spotlessApply` — N/A, no Kotlin files changed
- [ ] Ran `./gradlew test` — N/A, no code changed

Not done, and worth a maintainer's eye: I did **not** run a full
`assembleFdroidRelease` end-to-end following the guide from a clean fork, so the
guide is verified claim-by-claim rather than as one continuous walkthrough.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

(Per CONTRIBUTING.md: documentation-only changes skip the interop suites.)

## AI assistance

- [x] Drafted with AI assistance, manually reviewed and tested

Written by Claude Opus 4.8 driving the repo directly. Worth noting against
`CONTRIBUTING-WITH-AI.md`'s own gates: the "build both flavors / test the
R8-minified build" gates don't apply to a docs-only diff, and the cross-model
review gate has **not** been satisfied — a second pair of eyes on the client-tag
rewrite in particular would be welcome, since that's the one place I replaced
instructions rather than renaming a path.

## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license.
