### PR TITLE
Stop ConcurrentModificationException in AddressableAuthorRelayLoaderSubAssembler

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -8,6 +8,6 @@
   </component>
   <component name="KotlinJpsPluginSettings">
     <option name="externalSystemId" value="Gradle" />
-    <option name="version" value="2.4.0" />
+    <option name="version" value="2.4.10" />
   </component>
 </project>

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/loaders/AddressableAuthorRelayLoaderSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/loaders/AddressableAuthorRelayLoaderSubAssembler.kt
@@ -29,9 +29,6 @@ import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinder
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinderQueryState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
-import kotlin.concurrent.atomics.AtomicBoolean
-import kotlin.concurrent.atomics.AtomicReference
-import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 /**
  * Bridges missing-addressable-note authors into [UserFinderFilterAssembler].
@@ -43,18 +40,18 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
  * kind-0 / kind-10002 and resolve outbox relays via [UserOutboxFinderSubAssembler]. Once the
  * relay list arrives, [EventFinderFilterAssembler] is invalidated and can query the correct relay.
  */
-@OptIn(ExperimentalAtomicApi::class)
 class AddressableAuthorRelayLoaderSubAssembler(
     val cache: LocalCache,
     val allKeys: () -> Set<EventFinderQueryState>,
     val userFinder: UserFinderFilterAssembler,
 ) : IEoseManager {
-    // Immutable snapshots swapped atomically, so a diff can never observe a half-written set.
-    // Mutual exclusion between runs comes from the bundler (one body at a time), not from these
-    // atomics — they exist to hand state over to destroy(), the one caller the bundler cannot
-    // serialize.
-    private val activeSubscriptions = AtomicReference<Set<UserFinderQueryState>>(emptySet())
-    private val destroyed = AtomicBoolean(false)
+    // Private monitor: @Synchronized locks on `this`, which leaves the instance's monitor
+    // reachable to anything holding a reference to this assembler.
+    private val lock = Any()
+
+    // Only ever touched while holding [lock]. See commit() and destroy().
+    private var activeSubscriptions: Set<UserFinderQueryState> = emptySet()
+    private var destroyed = false
 
     // Keeps the scan off the caller's thread. invalidateFilters() is reached synchronously from
     // ComposeSubscriptionManager.subscribe/unsubscribe on every note composable mount/unmount,
@@ -78,26 +75,39 @@ class AddressableAuthorRelayLoaderSubAssembler(
             }
         }
 
-        if (destroyed.load()) return
+        commit(needed)
+    }
 
-        val previous = activeSubscriptions.exchange(needed)
+    /**
+     * Serializes against [destroy] — the one caller the bundler cannot order, because
+     * `bundler.cancel()` cannot stop a body that is already running (it has no suspension points).
+     *
+     * The scan in [forceInvalidate] stays outside [lock], so [destroy] never waits on a
+     * [LocalCache] sweep. It can still wait on the two calls below, which are bounded: a pair of
+     * map updates inside [UserFinderFilterAssembler] plus the coroutine launches its
+     * `invalidateKeys()` fans out to.
+     *
+     * Calling [userFinder] while holding [lock] relies on subscribe/unsubscribe only taking
+     * ComposeSubscriptionManager's own lock and deferring real work to bundled coroutines — they
+     * never call back into this class. Revisit if that changes.
+     */
+    private fun commit(needed: Set<UserFinderQueryState>) {
+        synchronized(lock) {
+            if (destroyed) return
 
-        userFinder.subscribe((needed - previous).toList())
-        userFinder.unsubscribe((previous - needed).toList())
+            userFinder.subscribe((needed - activeSubscriptions).toList())
+            userFinder.unsubscribe((activeSubscriptions - needed).toList())
 
-        // destroy() landed while we were subscribing. bundler.cancel() cannot stop a body that is
-        // already running — it has no suspension points — so the body releases what it just
-        // acquired. destroy() may unsubscribe the same states concurrently; that is a no-op.
-        if (destroyed.load()) {
-            activeSubscriptions.store(emptySet())
-            userFinder.unsubscribe(needed.toList())
+            activeSubscriptions = needed
         }
     }
 
     override fun destroy() {
-        // Flag before cancelling so an in-flight body is guaranteed to see the teardown.
-        destroyed.store(true)
-        bundler.cancel()
-        userFinder.unsubscribe(activeSubscriptions.exchange(emptySet()).toList())
+        synchronized(lock) {
+            destroyed = true
+            bundler.cancel()
+            userFinder.unsubscribe(activeSubscriptions.toList())
+            activeSubscriptions = emptySet()
+        }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/loaders/AddressableAuthorRelayLoaderSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/loaders/AddressableAuthorRelayLoaderSubAssembler.kt
@@ -21,11 +21,17 @@
 package com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders
 
 import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.IEoseManager
+import com.vitorpamplona.amethyst.commons.service.BundledUpdate
 import com.vitorpamplona.amethyst.model.AddressableNote
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.EventFinderQueryState
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinderFilterAssembler
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinderQueryState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 
 /**
  * Bridges missing-addressable-note authors into [UserFinderFilterAssembler].
@@ -37,14 +43,29 @@ import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinder
  * kind-0 / kind-10002 and resolve outbox relays via [UserOutboxFinderSubAssembler]. Once the
  * relay list arrives, [EventFinderFilterAssembler] is invalidated and can query the correct relay.
  */
+@OptIn(ExperimentalAtomicApi::class)
 class AddressableAuthorRelayLoaderSubAssembler(
     val cache: LocalCache,
     val allKeys: () -> Set<EventFinderQueryState>,
     val userFinder: UserFinderFilterAssembler,
 ) : IEoseManager {
-    private val activeSubscriptions = mutableSetOf<UserFinderQueryState>()
+    // Immutable snapshots swapped atomically, so a diff can never observe a half-written set.
+    // Mutual exclusion between runs comes from the bundler (one body at a time), not from these
+    // atomics — they exist to hand state over to destroy(), the one caller the bundler cannot
+    // serialize.
+    private val activeSubscriptions = AtomicReference<Set<UserFinderQueryState>>(emptySet())
+    private val destroyed = AtomicBoolean(false)
+
+    // Keeps the scan off the caller's thread. invalidateFilters() is reached synchronously from
+    // ComposeSubscriptionManager.subscribe/unsubscribe on every note composable mount/unmount,
+    // and those are documented "called by main. Keep it really fast."
+    private val bundler = BundledUpdate(500, Dispatchers.IO)
 
     override fun invalidateFilters(ignoreIfDoing: Boolean) {
+        bundler.invalidate(ignoreIfDoing, ::forceInvalidate)
+    }
+
+    private fun forceInvalidate() {
         val needed = mutableSetOf<UserFinderQueryState>()
 
         allKeys().forEach { key ->
@@ -57,18 +78,26 @@ class AddressableAuthorRelayLoaderSubAssembler(
             }
         }
 
-        val toAdd = needed - activeSubscriptions
-        val toRemove = activeSubscriptions - needed
+        if (destroyed.load()) return
 
-        userFinder.subscribe(toAdd.toList())
-        userFinder.unsubscribe(toRemove.toList())
+        val previous = activeSubscriptions.exchange(needed)
 
-        activeSubscriptions.clear()
-        activeSubscriptions.addAll(needed)
+        userFinder.subscribe((needed - previous).toList())
+        userFinder.unsubscribe((previous - needed).toList())
+
+        // destroy() landed while we were subscribing. bundler.cancel() cannot stop a body that is
+        // already running — it has no suspension points — so the body releases what it just
+        // acquired. destroy() may unsubscribe the same states concurrently; that is a no-op.
+        if (destroyed.load()) {
+            activeSubscriptions.store(emptySet())
+            userFinder.unsubscribe(needed.toList())
+        }
     }
 
     override fun destroy() {
-        userFinder.unsubscribe(activeSubscriptions.toList())
-        activeSubscriptions.clear()
+        // Flag before cancelling so an in-flight body is guaranteed to see the teardown.
+        destroyed.store(true)
+        bundler.cancel()
+        userFinder.unsubscribe(activeSubscriptions.exchange(emptySet()).toList())
     }
 }

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/loaders/AddressableAuthorRelayLoaderSubAssemblerTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/loaders/AddressableAuthorRelayLoaderSubAssemblerTest.kt
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders
+
+import com.vitorpamplona.amethyst.model.Account
+import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.EventFinderQueryState
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinderFilterAssembler
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinderQueryState
+import com.vitorpamplona.quartz.nip01Core.core.Address
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+
+class AddressableAuthorRelayLoaderSubAssemblerTest {
+    /**
+     * Unique per-test-class identities so the shared [LocalCache] singleton isn't polluted with
+     * notes another test class also claims. The prefix keeps the key a valid 64-char hex pubkey.
+     */
+    private fun stubKeys(count: Int): Set<EventFinderQueryState> {
+        val account = mockk<Account>()
+        return (1..count).mapTo(mutableSetOf()) { i ->
+            val address = Address(30023, "ad04%060x".format(i), "d$i")
+            EventFinderQueryState(LocalCache.getOrCreateAddressableNoteInternal(address), account)
+        }
+    }
+
+    /**
+     * Regression test for the `ConcurrentModificationException` in
+     * `SetsKt.minus` reported from `DefaultDispatcher-worker-70`.
+     *
+     * `ComposeSubscriptionManager.subscribe`/`unsubscribe` call `invalidateKeys()` *after*
+     * releasing their own lock, and `LifecycleAwareSubscription`'s 30s grace-period unsubscribe
+     * fires on a `Dispatchers.Default` worker — so this manager is genuinely re-entered from
+     * several threads at once.
+     *
+     * The invariant asserted here is the one that makes the crash impossible: **the body that
+     * reads and swaps the subscription state never runs concurrently with itself.** It's checked
+     * via the injected `allKeys()` lambda (called exactly once per body) rather than by catching
+     * the exception, because once the body is bundled its throwables are swallowed by
+     * `BundledUpdate`'s `CoroutineExceptionHandler` and would never reach the test thread.
+     */
+    @Test
+    fun concurrentInvalidateFiltersNeverOverlap() {
+        val errors = CopyOnWriteArrayList<Throwable>()
+        val userFinder = mockk<UserFinderFilterAssembler>(relaxed = true)
+        val keys = stubKeys(50)
+
+        val inFlight = AtomicInteger(0)
+        val assembler =
+            AddressableAuthorRelayLoaderSubAssembler(
+                LocalCache,
+                {
+                    if (inFlight.incrementAndGet() > 1) {
+                        errors.add(IllegalStateException("forceInvalidate bodies overlapped"))
+                    }
+                    try {
+                        keys
+                    } finally {
+                        inFlight.decrementAndGet()
+                    }
+                },
+                userFinder,
+            )
+
+        val start = CountDownLatch(1)
+        try {
+            val threads =
+                (1..8).map {
+                    thread(start = false) {
+                        start.await()
+                        repeat(500) {
+                            try {
+                                assembler.invalidateFilters()
+                            } catch (t: Throwable) {
+                                errors.add(t)
+                            }
+                        }
+                    }
+                }
+            threads.forEach { it.start() }
+            start.countDown()
+            threads.forEach { it.join() }
+        } finally {
+            assembler.destroy()
+        }
+
+        assertTrue(
+            "invalidateFilters raced under concurrency: " +
+                errors.map { "${it::class.simpleName}: ${it.message}" }.distinct(),
+            errors.isEmpty(),
+        )
+    }
+
+    /** The manager still does its job: unresolved stub authors reach the user finder. */
+    @Test
+    fun bridgesMissingAuthorsIntoUserFinder() {
+        val userFinder = mockk<UserFinderFilterAssembler>(relaxed = true)
+        val keys = stubKeys(3)
+        val assembler = AddressableAuthorRelayLoaderSubAssembler(LocalCache, { keys }, userFinder)
+
+        try {
+            assembler.invalidateFilters()
+
+            verify(timeout = 3000) {
+                userFinder.subscribe(
+                    match<List<UserFinderQueryState>> { it.size == 3 },
+                )
+            }
+        } finally {
+            assembler.destroy()
+        }
+    }
+
+    /**
+     * `bundler.cancel()` cannot stop a body that is already executing — the body has no
+     * suspension points, so it runs to completion after `destroy()` returns. Without the
+     * `destroyed` handshake the body re-subscribes authors that `destroy()` just released,
+     * leaving live kind-0/10002 REQs (and retained `User`/`Account` references) for a dead
+     * account after logout.
+     *
+     * The body is gated inside the injected `allKeys()` lambda so `destroy()` provably runs
+     * underneath an in-flight run rather than racing it by luck.
+     */
+    @Test
+    fun destroyDuringInFlightInvalidateDoesNotLeakSubscriptions() {
+        val userFinder = mockk<UserFinderFilterAssembler>(relaxed = true)
+        val subscribed = CopyOnWriteArrayList<UserFinderQueryState>()
+        val unsubscribed = CopyOnWriteArrayList<UserFinderQueryState>()
+        val subscribeHappened = CountDownLatch(1)
+        every { userFinder.subscribe(any<List<UserFinderQueryState>>()) } answers {
+            subscribed.addAll(firstArg<List<UserFinderQueryState>>())
+            subscribeHappened.countDown()
+        }
+        every { userFinder.unsubscribe(any<List<UserFinderQueryState>>()) } answers {
+            unsubscribed.addAll(firstArg<List<UserFinderQueryState>>())
+        }
+
+        val keys = stubKeys(3)
+        val invalidateEntered = CountDownLatch(1)
+        val destroyFinished = CountDownLatch(1)
+        val assembler =
+            AddressableAuthorRelayLoaderSubAssembler(
+                LocalCache,
+                {
+                    invalidateEntered.countDown()
+                    destroyFinished.await(5, TimeUnit.SECONDS)
+                    keys
+                },
+                userFinder,
+            )
+
+        try {
+            assembler.invalidateFilters()
+            assertTrue("bundled run never started", invalidateEntered.await(5, TimeUnit.SECONDS))
+        } finally {
+            assembler.destroy()
+            destroyFinished.countDown()
+        }
+
+        // Let the in-flight run finish (it either subscribes — the leak — or
+        // observes the teardown and skips; both settle within the timeout).
+        subscribeHappened.await(2, TimeUnit.SECONDS)
+
+        val leaked = subscribed - unsubscribed.toSet()
+        assertTrue(
+            "destroy() left ${leaked.size} subscriptions alive in userFinder",
+            leaked.isEmpty(),
+        )
+    }
+}

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/loaders/AddressableAuthorRelayLoaderSubAssemblerTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/loaders/AddressableAuthorRelayLoaderSubAssemblerTest.kt
@@ -29,9 +29,10 @@ import com.vitorpamplona.quartz.nip01Core.core.Address
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -40,7 +41,7 @@ import kotlin.concurrent.thread
 class AddressableAuthorRelayLoaderSubAssemblerTest {
     /**
      * Unique per-test-class identities so the shared [LocalCache] singleton isn't polluted with
-     * notes another test class also claims. The prefix keeps the key a valid 64-char hex pubkey.
+     * notes another test class also claims.
      */
     private fun stubKeys(count: Int): Set<EventFinderQueryState> {
         val account = mockk<Account>()
@@ -51,34 +52,28 @@ class AddressableAuthorRelayLoaderSubAssemblerTest {
     }
 
     /**
-     * Regression test for the `ConcurrentModificationException` in
-     * `SetsKt.minus` reported from `DefaultDispatcher-worker-70`.
+     * Regression test for the `ConcurrentModificationException` in `SetsKt.minus` reported from
+     * `DefaultDispatcher-worker-70`: this manager is genuinely re-entered from several threads at
+     * once, because `ComposeSubscriptionManager.subscribe`/`unsubscribe` call `invalidateKeys()`
+     * *after* releasing their own lock, and `LifecycleAwareSubscription`'s 30s grace-period
+     * unsubscribe fires on a `Dispatchers.Default` worker.
      *
-     * `ComposeSubscriptionManager.subscribe`/`unsubscribe` call `invalidateKeys()` *after*
-     * releasing their own lock, and `LifecycleAwareSubscription`'s 30s grace-period unsubscribe
-     * fires on a `Dispatchers.Default` worker — so this manager is genuinely re-entered from
-     * several threads at once.
-     *
-     * The invariant asserted here is the one that makes the crash impossible: **the body that
-     * reads and swaps the subscription state never runs concurrently with itself.** It's checked
-     * via the injected `allKeys()` lambda (called exactly once per body) rather than by catching
-     * the exception, because once the body is bundled its throwables are swallowed by
-     * `BundledUpdate`'s `CoroutineExceptionHandler` and would never reach the test thread.
+     * Overlap is detected through the injected `allKeys()` lambda rather than by catching — once
+     * the body is bundled its throwables are swallowed by `BundledUpdate`'s
+     * `CoroutineExceptionHandler` and would never reach the test thread.
      */
     @Test
     fun concurrentInvalidateFiltersNeverOverlap() {
-        val errors = CopyOnWriteArrayList<Throwable>()
         val userFinder = mockk<UserFinderFilterAssembler>(relaxed = true)
         val keys = stubKeys(50)
 
         val inFlight = AtomicInteger(0)
+        val overlaps = AtomicInteger(0)
         val assembler =
             AddressableAuthorRelayLoaderSubAssembler(
                 LocalCache,
                 {
-                    if (inFlight.incrementAndGet() > 1) {
-                        errors.add(IllegalStateException("forceInvalidate bodies overlapped"))
-                    }
+                    if (inFlight.incrementAndGet() > 1) overlaps.incrementAndGet()
                     try {
                         keys
                     } finally {
@@ -94,13 +89,7 @@ class AddressableAuthorRelayLoaderSubAssemblerTest {
                 (1..8).map {
                     thread(start = false) {
                         start.await()
-                        repeat(500) {
-                            try {
-                                assembler.invalidateFilters()
-                            } catch (t: Throwable) {
-                                errors.add(t)
-                            }
-                        }
+                        repeat(500) { assembler.invalidateFilters() }
                     }
                 }
             threads.forEach { it.start() }
@@ -110,11 +99,7 @@ class AddressableAuthorRelayLoaderSubAssemblerTest {
             assembler.destroy()
         }
 
-        assertTrue(
-            "invalidateFilters raced under concurrency: " +
-                errors.map { "${it::class.simpleName}: ${it.message}" }.distinct(),
-            errors.isEmpty(),
-        )
+        assertEquals("forceInvalidate bodies overlapped", 0, overlaps.get())
     }
 
     /** The manager still does its job: unresolved stub authors reach the user finder. */
@@ -138,11 +123,9 @@ class AddressableAuthorRelayLoaderSubAssemblerTest {
     }
 
     /**
-     * `bundler.cancel()` cannot stop a body that is already executing — the body has no
-     * suspension points, so it runs to completion after `destroy()` returns. Without the
-     * `destroyed` handshake the body re-subscribes authors that `destroy()` just released,
-     * leaving live kind-0/10002 REQs (and retained `User`/`Account` references) for a dead
-     * account after logout.
+     * `destroy()` must win against a body that is already past its `allKeys()` scan: otherwise the
+     * body re-subscribes authors `destroy()` just released, leaving live kind-0/10002 REQs (and
+     * retained `User`/`Account` references) for a dead account after logout.
      *
      * The body is gated inside the injected `allKeys()` lambda so `destroy()` provably runs
      * underneath an in-flight run rather than racing it by luck.
@@ -150,15 +133,9 @@ class AddressableAuthorRelayLoaderSubAssemblerTest {
     @Test
     fun destroyDuringInFlightInvalidateDoesNotLeakSubscriptions() {
         val userFinder = mockk<UserFinderFilterAssembler>(relaxed = true)
-        val subscribed = CopyOnWriteArrayList<UserFinderQueryState>()
-        val unsubscribed = CopyOnWriteArrayList<UserFinderQueryState>()
         val subscribeHappened = CountDownLatch(1)
         every { userFinder.subscribe(any<List<UserFinderQueryState>>()) } answers {
-            subscribed.addAll(firstArg<List<UserFinderQueryState>>())
             subscribeHappened.countDown()
-        }
-        every { userFinder.unsubscribe(any<List<UserFinderQueryState>>()) } answers {
-            unsubscribed.addAll(firstArg<List<UserFinderQueryState>>())
         }
 
         val keys = stubKeys(3)
@@ -183,14 +160,11 @@ class AddressableAuthorRelayLoaderSubAssemblerTest {
             destroyFinished.countDown()
         }
 
-        // Let the in-flight run finish (it either subscribes — the leak — or
-        // observes the teardown and skips; both settle within the timeout).
-        subscribeHappened.await(2, TimeUnit.SECONDS)
-
-        val leaked = subscribed - unsubscribed.toSet()
-        assertTrue(
-            "destroy() left ${leaked.size} subscriptions alive in userFinder",
-            leaked.isEmpty(),
+        // The gated body resumes the instant destroyFinished counts down, so a leak shows up
+        // immediately; the wait only has to outlast that hand-off.
+        assertFalse(
+            "in-flight body subscribed after destroy()",
+            subscribeHappened.await(500, TimeUnit.MILLISECONDS),
         )
     }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/eoseManagers/IEoseManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/eoseManagers/IEoseManager.kt
@@ -21,6 +21,12 @@
 package com.vitorpamplona.amethyst.commons.relayClient.eoseManagers
 
 interface IEoseManager {
+    /**
+     * May be called from any thread, concurrently with itself and with [destroy], and is reached
+     * synchronously from main on every composable mount/unmount. Implementations must return fast
+     * and must serialize their own state — see [BaseEoseManager], which does both by routing the
+     * work through a [com.vitorpamplona.amethyst.commons.service.BundledUpdate].
+     */
     fun invalidateFilters(ignoreIfDoing: Boolean = false)
 
     fun destroy()


### PR DESCRIPTION
Fix for #3661 

### Root cause

AddressableAuthorRelayLoaderSubAssembler.activeSubscriptions was a plain LinkedHashSet that was iterated (needed - activeSubscriptions, i.e. SetsKt.minus) and mutated (clear() / addAll()) with no synchronization, while invalidateFilters() ran synchronously on whatever thread called it.

Those callers are genuinely concurrent. ComposeSubscriptionManager.subscribe/unsubscribe invoke invalidateKeys() after releasing their own lock, and LifecycleAwareSubscription's 30-second grace-period unsubscribe fires on a Dispatchers.Default worker while composition subscribes from another thread. One thread iterating the set while another rewrote it produced the reported crash on DefaultDispatcher-worker-70.

This is the only member of EventFinderFilterAssembler.group that implements IEoseManager directly. Its two siblings extend BaseEoseManager, whose invalidateFilters hands off to a BundledUpdate — so their bodies never run on the caller's thread nor concurrently with themselves. This class had fallen off that ladder because BaseEoseManager also owns an INostrClient / SubscriptionController that an assembler bridging into another assembler has no use for.

I checked whether sibling assemblers had the same latent hole: they do not. Every other mutableMapOf/mutableSetOf field in this family is reachable only from inside an already-bundled body. This is a one-class hole, not the first of N.

### The fix

Route invalidateFilters through a BundledUpdate so bodies are serialized and run off the caller's thread, and commit the subscription delta under a private monitor shared with destroy().

### Performance

No lock is taken on the hot path. invalidateFilters() is now just bundler.invalidate(...) — an enqueue. The monitor is acquired only inside commit(), which runs on the bundler's IO thread, and in destroy(). The allKeys() scan and its per-stub LocalCache.getOrCreateUser lookups stay outside the monitor, so destroy() never waits on a cache sweep.

Contention is structurally near-zero: BasicBundledUpdate already guarantees one body at a time, so the only two parties that can ever meet on the monitor are an in-flight body and destroy().

**The hot path got cheaper, not more expensive**. Previously the full scan ran inline on the calling thread on every note composable mount/unmount — and ComposeSubscriptionManager documents subscribe/unsubscribe as "called by main. Keep it really fast." That work is now off-main and coalesced into a 500 ms window (event-driven, not a periodic tick — an idle app does no work).

To be clear about what was and wasn't measured: I did not benchmark the app, so I am claiming no runtime speedup number. The improvement is structural — work moved off the caller thread and repeated invalidations coalesced. The only measured numbers here are test-suite timings, which say nothing about app performance.

An earlier revision of this branch used AtomicReference + AtomicBoolean with a compensating "release what we just acquired" block. Review replaced it with the monitor: the atomics gave visibility but not mutual exclusion, so seven lines existed purely to patch a window that a monitor makes structurally unreachable. That also drops an @OptIn(ExperimentalAtomicApi::class) from a shipping Android class.

### Testing

New test class, 3 tests, all deterministic (latch-gated, no sleeps).

The concurrency test was verified RED against the unfixed code — 8 threads × 500 invalidations reproduced the actual production failure, not a proxy for it: [IllegalStateException: forceInvalidate bodies overlapped, ConcurrentModificationException: null].

Guard-off verification. The destroy()-race test asserts a leak's absence, which is exactly the shape of assertion that passes vacuously if the guard it targets is broken. So it was checked by deleting if (destroyed) return and confirming destroyDuringInFlightInvalidateDoesNotLeakSubscriptions fails, then restoring it. This was done twice — once against the original @Synchronized form, and again after switching to synchronized(lock) { }, because return then sits inside an inline lambda and the earlier check did not carry over.

Overlap is detected through the injected allKeys() lambda rather than by catching exceptions, because once the body is bundled its throwables are swallowed by BundledUpdate's CoroutineExceptionHandler and would never reach the test thread.

The destroy() test previously took 2.015 s because its latch only counted down on the leak path, so the passing case always burned the full timeout — it was slowest when it passed. It now asserts the absence directly: 0.510 s, class total 3.24 s → 1.74 s.

Full :amethyst suite green (941 tests, 0 failures) and :commons:jvmTest green.

### Also included

IEoseManager now documents its threading contract. The interface had no KDoc at all, which is arguably ther had no way to know the method must tolerate concurrent entry.
                                                                                                                                                                                                                                               ### Out of scope
                                                                                                                                                                                                                                               UserFinderQueryState identity equality defeats the subscription delta. It has no equals/hashCode and force instances each run, so needed - previous is always the full set — every run unsubscribes and re-subscribes everything. Pre-existing and unchanged by this PR, which means the diffing preserved here is currently decorative. It is bounded (downstream assemblers distinctBy { it.user }, so no duplicate REQs) and self-limiting (stops once no stub    has an unresolved author). Not fixed here because ComposeSubscriptionManager's identity semantics are delitiple duplications in these subscriptions since we do not control when screens are removed" — so addingstructural equality would collapse two composables watching the same user into one map entry, and the first to unmount would kill the other's live subscription. Any fix needs to reuse prior instances for unchanged logical keys inside this assembler instead. Fixing it would shrink the race window but never close it, so it had to be a separate c

Extracting a client-free BundledEoseManager. BaseEoseManager already contains this exact bundler + invalid, but conflates bundling with owning an INostrClient. Extracting the bundling half would let this classrejoin the base-class ladder. Skipped as out of proportion to a two-file bugfix: it touches a commons base with ~105 subclasses.

## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
