### PR TITLE
Downgrade JVM target from 21 to 17 in quartz module

### DIFF
--- a/quartz/build.gradle.kts
+++ b/quartz/build.gradle.kts
@@ -17,7 +17,7 @@ kotlin {
     }
     jvm {
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_21)
+            jvmTarget.set(JvmTarget.JVM_17)
         }
     }
 
@@ -33,7 +33,7 @@ kotlin {
                 .toInt()
 
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_21)
+            jvmTarget.set(JvmTarget.JVM_17)
         }
 
         optimization {


### PR DESCRIPTION
## Summary

Downgrade the Kotlin JVM compilation target from JVM 21 to JVM 17 in the `quartz` module. This change affects both the main JVM target and the Android JVM target configurations in `build.gradle.kts`.

## Test plan

- [ ] Ran `./gradlew :quartz:build` — module builds successfully with JVM 17 target
- [ ] Ran `./gradlew :quartz:test` — all tests pass
- [ ] N/A — change is build configuration only, no functional code changes

## Interop suites

- [ ] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [ ] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01V1Hn61gQJ1joUznESzUHU4