### PR TITLE
fix(signer): never stamp our client tag on someone else's template

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -325,6 +325,7 @@ import com.vitorpamplona.quartz.nip7DThreads.ThreadEvent
 import com.vitorpamplona.quartz.nip88Polls.poll.PollEvent
 import com.vitorpamplona.quartz.nip88Polls.response.PollResponseEvent
 import com.vitorpamplona.quartz.nip89AppHandlers.clientTag.NostrSignerWithClientTag
+import com.vitorpamplona.quartz.nip89AppHandlers.clientTag.withoutClientTag
 import com.vitorpamplona.quartz.nip90Dvms.contentDiscoveryRequest.NIP90ContentDiscoveryRequestEvent
 import com.vitorpamplona.quartz.nip92IMeta.IMetaTag
 import com.vitorpamplona.quartz.nip92IMeta.imetas
@@ -467,7 +468,10 @@ class Account(
      */
     val nip46Signer =
         Nip46SignerState(
-            signer = signer,
+            // Acting as someone else's bunker: the templates arriving here were composed by the
+            // connected client, so they are signed exactly as received — our client tag would both
+            // misattribute the event and change the id the client expects back.
+            signer = signer.withoutClientTag(),
             client = client,
             ledger = signerPermissionLedger,
             clientStore = nip46ClientStore,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/gateways/AccountNappletGateways.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/gateways/AccountNappletGateways.kt
@@ -60,6 +60,7 @@ import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.NwcErrorResponse
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.PayInvoiceErrorResponse
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.PayInvoiceSuccessResponse
+import com.vitorpamplona.quartz.nip89AppHandlers.clientTag.withoutClientTag
 import com.vitorpamplona.quartz.utils.sha256.sha256
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.withTimeout
@@ -155,7 +156,10 @@ class AccountNappletGateways(
                 )
             }
 
-        return NappletBroker(account.signer, ledger, consent, signerLedger = signerLedger, nostrConnectPrompt = connectPrompt, signerConsentPrompt = signerConsent, relay = relay, storage = storage, wallet = wallet, resource = resource, upload = upload, identityReads = identityReads, theme = theme, notify = notify)
+        // Everything the broker signs belongs to the guest — a napplet, an nSite, or a web app
+        // calling NIP-07 — never to Amethyst, so our client tag has no business on it. It would also
+        // corrupt the template a NIP-07 caller re-checks the returned event against.
+        return NappletBroker(account.signer.withoutClientTag(), ledger, consent, signerLedger = signerLedger, nostrConnectPrompt = connectPrompt, signerConsentPrompt = signerConsent, relay = relay, storage = storage, wallet = wallet, resource = resource, upload = upload, identityReads = identityReads, theme = theme, notify = notify)
     }
 
     /**

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip89AppHandlers/clientTag/NostrSignerWithClientTag.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip89AppHandlers/clientTag/NostrSignerWithClientTag.kt
@@ -117,3 +117,18 @@ class NostrSignerWithClientTag(
         return tags + arrayOf(clientTag)
     }
 }
+
+/**
+ * The same signer with the NIP-89 client-tag decorator peeled off, or the receiver unchanged when it
+ * carries no such decorator.
+ *
+ * The client tag says "this app composed this event", so it belongs only on templates this app
+ * authored. When we sign on someone else's behalf — a napplet, an nSite, a web app over NIP-07, a
+ * client using us as a NIP-46 bunker — the template is theirs, and appending a tag rewrites the very
+ * bytes they are about to have hashed into an id. NIP-07 callers routinely re-check the returned
+ * event against the template they submitted (block/buzz compares `JSON.stringify(tags)` outright)
+ * and reject the result as an invalid signature when it does not match.
+ *
+ * Any decoration under this one (metering, NIP-13 mining) is preserved, as is [NostrSigner.pubKey].
+ */
+fun NostrSigner.withoutClientTag(): NostrSigner = if (this is NostrSignerWithClientTag) inner else this


### PR DESCRIPTION
Joining a Buzz community from the in-app browser failed with **"The NIP-07 extension returned an invalid signed event."** The cause turned out to be broader than NIP-07.

## The rule being broken

The NIP-89 client tag means *"this app composed this event"*, so it belongs only on templates Amethyst authored. `NostrSignerWithClientTag` was applied at the account level, so it also fired on every event we sign **on behalf of an external client**.

That is wrong twice over: it misattributes the event, and because the tag is appended *before* signing it rewrites the exact bytes the caller is about to have hashed into an id. NIP-07 callers routinely re-check the returned event against the template they submitted. block/buzz compares tags outright — [`web/src/shared/lib/nostr-signer.ts`](https://github.com/block/buzz/blob/main/web/src/shared/lib/nostr-signer.ts):

```js
function sameUnsignedEvent(expected, actual) {
  return (
    actual.kind === expected.kind &&
    actual.created_at === expected.created_at &&
    actual.content === expected.content &&
    JSON.stringify(actual.tags) === JSON.stringify(expected.tags)   // ← fails
  );
}
```

## Evidence

Probed live over the WebView devtools protocol against the running app. Every field Buzz checks round-tripped intact **except** tags, which differed by exactly the tag we append:

```
sent: [["u","https://example.com"],["method","GET"]]
got:  [["u","https://example.com"],["method","GET"],["client","Amethyst"]]

pubkeyMatches: true   createdAtMatches: true   kindMatches: true
contentMatches: true  tagsMatch: FALSE
```

Confirming the mechanism: `appendClientTag` skips when a client tag is already present, and a template carrying one round-trips byte-exact. So the injection is the whole difference.

## Fix

Adds `NostrSigner.withoutClientTag()` and applies it at the two boundaries where the template belongs to someone else:

- **the napplet broker** (`AccountNappletGateways`) — napplets, nSites, and web apps over NIP-07
- **`Nip46SignerState`** (`Account.kt`) — where we act as another client's bunker. Same defect, and quieter: that client never learns why its event changed underneath it, it just gets back an id it never asked for.

Checked for a NIP-55 provider surface too — there isn't one, we are only ever the client there.

Amethyst's own events are untouched and still carry the tag (existing `NostrSignerWithClientTagTest` still passes). Unwrapping preserves everything layered below — metering, NIP-13 mining — and leaves `pubKey` alone.

## Verification

After the change, re-probed against Buzz's own four acceptance conditions:

```
pubkeyMatches: true   sameUnsignedEvent: true   buzzWouldAccept: true
```

And the real invite join then succeeded, confirmed by the maintainer.

`./gradlew :amethyst:testPlayDebugUnitTest :commons:jvmTest :quartz:jvmTest` green.

## Note

One loose end, unrelated to this fix: a NIP-11 relay information document showed up during testing where a claim response was expected. The join itself works, and I never established where that document came from — recording it here rather than dropping it silently, in case it resurfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)