### PR TITLE
Warn users when a DM comes from an account that people they follow have reported

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -1742,6 +1742,11 @@ object LocalCache : ILocalCache, ICacheProvider {
                 event.reportedPost().mapNotNull { checkGetOrCreateNote(it.eventId) } +
                     event.reportedAddresses().map { getOrCreateAddressableNote(it.address) }
 
+            // Every report that names an author lands here, including those that also name an event
+            // and are therefore filed against the note below. Read only by the DM sender warning —
+            // the hide threshold keeps counting `receivedReportsByAuthor` alone.
+            authorsReported.forEach { author -> author.reports().addReportNamingUser(note) }
+
             if (eventsReported.isEmpty()) {
                 authorsReported.forEach { author -> author.reports().addReport(note) }
             } else {
@@ -3268,7 +3273,10 @@ object LocalCache : ILocalCache, ICacheProvider {
 
         if (noteEvent is ReportEvent) {
             noteEvent.reportedAuthor().forEach {
-                getUserIfExists(it.pubkey)?.reportsOrNull()?.removeReport(note)
+                getUserIfExists(it.pubkey)?.reportsOrNull()?.let { reports ->
+                    reports.removeReport(note)
+                    reports.removeReportNamingUser(note)
+                }
             }
 
             noteEvent.reportedPost().forEach {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -1742,15 +1742,26 @@ object LocalCache : ILocalCache, ICacheProvider {
                 event.reportedPost().mapNotNull { checkGetOrCreateNote(it.eventId) } +
                     event.reportedAddresses().map { getOrCreateAddressableNote(it.address) }
 
-            // Every report that names an author lands here, including those that also name an event
-            // and are therefore filed against the note below. Read only by the DM sender warning —
-            // the hide threshold keeps counting `receivedReportsByAuthor` alone.
-            authorsReported.forEach { author -> author.reports().addReportNamingUser(note) }
-
+            // Every report that names an author also lands in the naming index, including those
+            // filed against a note rather than a profile. Read only by the DM sender warning — the
+            // hide threshold keeps counting `receivedReportsByAuthor` alone.
             if (eventsReported.isEmpty()) {
-                authorsReported.forEach { author -> author.reports().addReport(note) }
+                authorsReported.forEach { author ->
+                    val reports = author.reports()
+                    reports.addReport(note)
+                    reports.addReportNamingUser(note)
+                }
             } else {
                 eventsReported.forEach { it.addReport(note) }
+
+                // Index only the authors whose own `p` tag carries a report type: an event-scoped
+                // report can `p`-tag an incidentally-mentioned third party with no type of its own,
+                // and there is no threshold here to absorb that noise the way
+                // `receivedReportsByAuthor`'s hide path does.
+                val explicitlyTyped = event.reportedAuthorsWithOwnType().mapTo(mutableSetOf()) { it.pubkey }
+                authorsReported.forEach { author ->
+                    if (author.pubkeyHex in explicitlyTyped) author.reports().addReportNamingUser(note)
+                }
             }
         }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Report.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Report.kt
@@ -26,17 +26,14 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.model.EmptyTagList
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.components.TranslatableRichTextViewer
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.NoteCompose
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
-import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.replyModifier
 import com.vitorpamplona.quartz.nip56Reports.ReportEvent
-import com.vitorpamplona.quartz.nip56Reports.ReportType
 
 @Composable
 fun RenderReport(
@@ -54,35 +51,11 @@ fun RenderReport(
                 .mapTo(LinkedHashSet()) { it.type }
         }
 
-    val explicitContent = stringRes(R.string.explicit_content)
-    val nudity = stringRes(R.string.nudity)
-    val profanity = stringRes(R.string.profanity_hateful_speech)
-    val spam = stringRes(R.string.spam)
-    val impersonation = stringRes(R.string.impersonation)
-    val illegal = stringRes(R.string.illegal_behavior)
-    val malware = stringRes(R.string.malware)
-    val other = stringRes(R.string.other)
-    val harassment = stringRes(R.string.harassment)
-    val violence = stringRes(R.string.violence)
+    val reportTypeLabels = reportTypes.map { reportTypeLabel(it) }
 
     val content =
-        remember(reportTypes, noteEvent) {
-            val reportTypeText =
-                reportTypes.joinToString(", ") {
-                    when (it) {
-                        ReportType.EXPLICIT -> explicitContent
-                        ReportType.NUDITY -> nudity
-                        ReportType.PROFANITY -> profanity
-                        ReportType.SPAM -> spam
-                        ReportType.IMPERSONATION -> impersonation
-                        ReportType.ILLEGAL -> illegal
-                        ReportType.MALWARE -> malware
-                        ReportType.OTHER -> other
-                        ReportType.HARASSMENT -> harassment
-                        ReportType.VIOLENCE -> violence
-                        null -> other
-                    }
-                }
+        remember(reportTypeLabels, noteEvent) {
+            val reportTypeText = reportTypeLabels.joinToString(", ")
             val extra = noteEvent.content.ifBlank { null }?.let { ": $it" } ?: ""
             reportTypeText + extra
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/ReportTypeLabel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/ReportTypeLabel.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.note.types
+
+import androidx.compose.runtime.Composable
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.quartz.nip56Reports.ReportType
+
+/** The localized name of a NIP-56 report reason. An unrecognized reason reads as "Other". */
+@Composable
+fun reportTypeLabel(type: ReportType?): String =
+    when (type) {
+        ReportType.EXPLICIT -> stringRes(R.string.explicit_content)
+        ReportType.NUDITY -> stringRes(R.string.nudity)
+        ReportType.PROFANITY -> stringRes(R.string.profanity_hateful_speech)
+        ReportType.SPAM -> stringRes(R.string.spam)
+        ReportType.IMPERSONATION -> stringRes(R.string.impersonation)
+        ReportType.ILLEGAL -> stringRes(R.string.illegal_behavior)
+        ReportType.MALWARE -> stringRes(R.string.malware)
+        ReportType.OTHER -> stringRes(R.string.other)
+        ReportType.HARASSMENT -> stringRes(R.string.harassment)
+        ReportType.VIOLENCE -> stringRes(R.string.violence)
+        null -> stringRes(R.string.other)
+    }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/ReportTypeLabel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/ReportTypeLabel.kt
@@ -25,6 +25,13 @@ import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.quartz.nip56Reports.ReportType
 
+/**
+ * [reportTypeLabel] for each reason. Resolved into a list first because `joinToString` is not
+ * inline and so cannot call a composable, while `map` is.
+ */
+@Composable
+fun reportTypeLabels(types: Collection<ReportType?>): List<String> = types.map { reportTypeLabel(it) }
+
 /** The localized name of a NIP-56 report reason. An unrecognized reason reads as "Other". */
 @Composable
 fun reportTypeLabel(type: ReportType?): String =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -803,13 +803,12 @@ class AccountViewModel(
                 account.kind3FollowList.flow,
                 account.settings.syncedSettings.security.warnAboutPostsWithReports,
             ) { _, followList, warnAboutReports ->
-                emit(reportWarningFor(user, followList.authors, warnAboutReports))
-            }.onStart {
                 emit(
-                    reportWarningFor(
-                        user,
-                        account.followingKeySet(),
-                        account.settings.syncedSettings.security.warnAboutPostsWithReports.value,
+                    dmReportWarningFor(
+                        counterpart = user,
+                        loggedInPubKey = account.signer.pubKey,
+                        followingKeySet = followList.authors,
+                        warnAboutReports = warnAboutReports,
                     ),
                 )
             }.flowOn(Dispatchers.IO)
@@ -820,17 +819,6 @@ class AccountViewModel(
                 ).also {
                     userReportWarningFlows.put(user, it)
                 }
-
-    private fun reportWarningFor(
-        user: User,
-        followingKeySet: Set<HexKey>,
-        warnAboutReports: Boolean,
-    ) = dmReportWarningFor(
-        counterpart = user,
-        loggedInPubKey = account.signer.pubKey,
-        followingKeySet = followingKeySet,
-        warnAboutReports = warnAboutReports,
-    )
 
     private val noteMustShowExpandButtonFlows = LruCache<Note, StateFlow<Boolean>>(300)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -49,6 +49,8 @@ import com.vitorpamplona.amethyst.commons.model.geohashChat.GeohashChatChannel
 import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatChannel
 import com.vitorpamplona.amethyst.commons.model.nip29RelayGroups.RelayGroupChannel
 import com.vitorpamplona.amethyst.commons.model.nip53LiveActivities.LiveActivitiesChannel
+import com.vitorpamplona.amethyst.commons.model.nip56Reports.UserReportWarningState
+import com.vitorpamplona.amethyst.commons.model.nip56Reports.dmReportWarningFor
 import com.vitorpamplona.amethyst.commons.model.observables.CreatedAtComparator
 import com.vitorpamplona.amethyst.commons.nipACWebRtcCalls.CallManager
 import com.vitorpamplona.amethyst.commons.relayClient.BlockedRelayFilteringClient
@@ -785,6 +787,50 @@ class AccountViewModel(
                 ).also {
                     noteIsHiddenFlows.put(note, it)
                 }
+
+    private val userReportWarningFlows = LruCache<User, StateFlow<UserReportWarningState>>(300)
+
+    /**
+     * Whether to warn about [user] as the counterpart of a 1:1 DM, and with what.
+     *
+     * Safe to cache: [User.reports] is never nulled once created, so the upstream this subscribes to
+     * survives the idle gaps that `WhileSubscribed` introduces.
+     */
+    fun createUserReportWarningFlow(user: User): StateFlow<UserReportWarningState> =
+        userReportWarningFlows.get(user)
+            ?: combineTransform(
+                user.reports().reportsNamingUser,
+                account.kind3FollowList.flow,
+                account.settings.syncedSettings.security.warnAboutPostsWithReports,
+            ) { _, followList, warnAboutReports ->
+                emit(reportWarningFor(user, followList.authors, warnAboutReports))
+            }.onStart {
+                emit(
+                    reportWarningFor(
+                        user,
+                        account.followingKeySet(),
+                        account.settings.syncedSettings.security.warnAboutPostsWithReports.value,
+                    ),
+                )
+            }.flowOn(Dispatchers.IO)
+                .stateIn(
+                    viewModelScope,
+                    SharingStarted.WhileSubscribed(10000, 10000),
+                    UserReportWarningState.SILENT,
+                ).also {
+                    userReportWarningFlows.put(user, it)
+                }
+
+    private fun reportWarningFor(
+        user: User,
+        followingKeySet: Set<HexKey>,
+        warnAboutReports: Boolean,
+    ) = dmReportWarningFor(
+        counterpart = user,
+        loggedInPubKey = account.signer.pubKey,
+        followingKeySet = followingKeySet,
+        warnAboutReports = warnAboutReports,
+    )
 
     private val noteMustShowExpandButtonFlows = LruCache<Note, StateFlow<Boolean>>(300)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/ChatroomView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/ChatroomView.kt
@@ -60,6 +60,7 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.feed.RefreshingChatro
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.feed.formatHistoryReachDate
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.privateDM.dal.ChatroomFeedViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.privateDM.datasource.ChatroomFilterAssemblerSubscription
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.privateDM.header.DmReportWarningCard
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.privateDM.send.ChatNewMessageViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.privateDM.send.PrivateMessageEditFieldRow
 import com.vitorpamplona.amethyst.ui.theme.DoubleVertSpacer
@@ -257,6 +258,8 @@ fun ChatroomViewUI(
 
     Column(Modifier.fillMaxHeight()) {
         ObserveRelayListForDMsAndDisplayIfNotFound(accountViewModel, nav)
+
+        DmReportWarningCard(room, accountViewModel, nav)
 
         Column(
             modifier =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/header/DmReportWarningCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/header/DmReportWarningCard.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -48,7 +49,7 @@ import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.model.nip56Reports.UserReportWarningState
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.NoteAuthorPicture
-import com.vitorpamplona.amethyst.ui.note.types.reportTypeLabel
+import com.vitorpamplona.amethyst.ui.note.types.reportTypeLabels
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.LoadUser
 import com.vitorpamplona.amethyst.ui.stringRes
@@ -72,13 +73,18 @@ fun DmReportWarningCard(
 
     LoadUser(baseUserHex = counterpartHex, accountViewModel = accountViewModel) { user ->
         if (user != null) {
-            val state by accountViewModel.createUserReportWarningFlow(user).collectAsStateWithLifecycle()
+            val flow = remember(user) { accountViewModel.createUserReportWarningFlow(user) }
+            val state by flow.collectAsStateWithLifecycle()
 
-            if (state.shouldWarn) {
-                var dismissed by remember(counterpartHex) { mutableStateOf(false) }
+            key(counterpartHex) {
+                // Hoisted above the `shouldWarn` check so it survives the transient SILENT state the
+                // flow emits on ~20s of backgrounding (`WhileSubscribed(10000, 10000)` +
+                // lifecycle-driven unsubscribe at ON_STOP) rather than being lost when this
+                // `remember` group briefly leaves composition.
+                var dismissed by remember { mutableStateOf(false) }
 
-                if (!dismissed) {
-                    ReportWarningBody(state, accountViewModel, nav, counterpartHex) { dismissed = true }
+                if (state.shouldWarn && !dismissed) {
+                    ReportWarningBody(state, accountViewModel, nav) { dismissed = true }
                 }
             }
         }
@@ -91,14 +97,11 @@ private fun ReportWarningBody(
     state: UserReportWarningState,
     accountViewModel: AccountViewModel,
     nav: INav,
-    counterpartHex: String,
     onDismiss: () -> Unit,
 ) {
-    var expanded by remember(counterpartHex) { mutableStateOf(false) }
+    var expanded by remember { mutableStateOf(false) }
 
-    // `map` is inline so it may call a composable; `joinToString` is not, so the labels have to be
-    // resolved before they are joined.
-    val typeLabels = state.types.map { reportTypeLabel(it) }
+    val typeLabels = reportTypeLabels(state.types)
 
     Card(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 5.dp),
@@ -123,7 +126,7 @@ private fun ReportWarningBody(
 
             if (expanded) {
                 FlowRow(modifier = Modifier.padding(top = 10.dp)) {
-                    state.reports.distinctBy { it.author }.forEach { report ->
+                    state.reports.forEach { report ->
                         NoteAuthorPicture(
                             baseNote = report,
                             size = Size35dp,
@@ -167,7 +170,7 @@ private fun ReportWarningBody(
 
 /** "Reported by 2 people you follow". The reason, if any, is rendered separately. */
 @Composable
-fun reportWarningHeadline(state: UserReportWarningState): String =
+private fun reportWarningHeadline(state: UserReportWarningState): String =
     pluralStringResource(
         R.plurals.dm_sender_reported,
         state.reporterCount,
@@ -182,7 +185,9 @@ fun reportWarningHeadline(state: UserReportWarningState): String =
 @Composable
 fun reportWarningContentDescription(state: UserReportWarningState): String {
     val headline = reportWarningHeadline(state)
-    val typeLabels = state.types.map { reportTypeLabel(it) }
+    val typeLabels = reportTypeLabels(state.types)
 
-    return if (typeLabels.isEmpty()) headline else headline + ". " + typeLabels.joinToString(", ")
+    return remember(headline, typeLabels) {
+        if (typeLabels.isEmpty()) headline else headline + ". " + typeLabels.joinToString(", ")
+    }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/header/DmReportWarningCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/header/DmReportWarningCard.kt
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.privateDM.header
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.model.nip56Reports.UserReportWarningState
+import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.note.NoteAuthorPicture
+import com.vitorpamplona.amethyst.ui.note.types.reportTypeLabel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.LoadUser
+import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.amethyst.ui.theme.Size35dp
+import com.vitorpamplona.quartz.nip17Dm.base.ChatroomKey
+
+/**
+ * Warns that the person on the other end of a 1:1 DM has been reported by someone the user follows.
+ *
+ * Collapsed it states the count and, when the reports agree on one reason, that reason. The reporters
+ * themselves stay behind a tap so an accusation is visible only when the user asks for it. Group rooms
+ * render nothing — the warning names one person.
+ */
+@Composable
+fun DmReportWarningCard(
+    room: ChatroomKey,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    val counterpartHex = room.users.singleOrNull() ?: return
+
+    LoadUser(baseUserHex = counterpartHex, accountViewModel = accountViewModel) { user ->
+        if (user != null) {
+            val state by accountViewModel.createUserReportWarningFlow(user).collectAsStateWithLifecycle()
+
+            if (state.shouldWarn) {
+                var dismissed by remember(counterpartHex) { mutableStateOf(false) }
+
+                if (!dismissed) {
+                    ReportWarningBody(state, accountViewModel, nav, counterpartHex) { dismissed = true }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun ReportWarningBody(
+    state: UserReportWarningState,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+    counterpartHex: String,
+    onDismiss: () -> Unit,
+) {
+    var expanded by remember(counterpartHex) { mutableStateOf(false) }
+
+    // `map` is inline so it may call a composable; `joinToString` is not, so the labels have to be
+    // resolved before they are joined.
+    val typeLabels = state.types.map { reportTypeLabel(it) }
+
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 5.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer),
+    ) {
+        Column(modifier = Modifier.padding(10.dp)) {
+            Text(
+                text = reportWarningHeadline(state),
+                color = MaterialTheme.colorScheme.onErrorContainer,
+            )
+
+            // The reason gets its own line rather than being spliced into the sentence above, so no
+            // translated noun has to agree with a surrounding grammar. Shown collapsed only when the
+            // reports agree; when they disagree the full list appears on expand.
+            if (typeLabels.size == 1) {
+                Text(
+                    text = typeLabels.first(),
+                    color = MaterialTheme.colorScheme.onErrorContainer,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+
+            if (expanded) {
+                FlowRow(modifier = Modifier.padding(top = 10.dp)) {
+                    state.reports.distinctBy { it.author }.forEach { report ->
+                        NoteAuthorPicture(
+                            baseNote = report,
+                            size = Size35dp,
+                            accountViewModel = accountViewModel,
+                            nav = nav,
+                        )
+                    }
+                }
+
+                if (typeLabels.size > 1) {
+                    Text(
+                        text = typeLabels.joinToString(", "),
+                        color = MaterialTheme.colorScheme.onErrorContainer,
+                        modifier = Modifier.padding(top = 5.dp),
+                        textAlign = TextAlign.Start,
+                    )
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(
+                    onClick = { expanded = !expanded },
+                    colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.onErrorContainer),
+                ) {
+                    Text(text = stringRes(R.string.dm_sender_reported_who))
+                }
+                TextButton(
+                    onClick = onDismiss,
+                    colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.onErrorContainer),
+                ) {
+                    Text(text = stringRes(R.string.dm_sender_reported_dismiss))
+                }
+            }
+        }
+    }
+}
+
+/** "Reported by 2 people you follow". The reason, if any, is rendered separately. */
+@Composable
+fun reportWarningHeadline(state: UserReportWarningState): String =
+    pluralStringResource(
+        R.plurals.dm_sender_reported,
+        state.reporterCount,
+        state.reporterCount,
+    )
+
+/**
+ * The headline followed by the reasons as separate sentences, for the chat-list row's screen reader
+ * label — where there is no second line to put them on. Sentence-separated rather than spliced, for
+ * the same translation reason the headline avoids interpolation.
+ */
+@Composable
+fun reportWarningContentDescription(state: UserReportWarningState): String {
+    val headline = reportWarningHeadline(state)
+    val typeLabels = state.types.map { reportTypeLabel(it) }
+
+    return if (typeLabels.isEmpty()) headline else headline + ". " + typeLabels.joinToString(", ")
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/header/DmReportWarningCard.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/header/DmReportWarningCard.kt
@@ -20,16 +20,26 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.privateDM.header
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -41,11 +51,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.pluralStringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
+import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
 import com.vitorpamplona.amethyst.commons.model.nip56Reports.UserReportWarningState
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.NoteAuthorPicture
@@ -53,8 +65,14 @@ import com.vitorpamplona.amethyst.ui.note.types.reportTypeLabels
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.LoadUser
 import com.vitorpamplona.amethyst.ui.stringRes
-import com.vitorpamplona.amethyst.ui.theme.Size35dp
+import com.vitorpamplona.amethyst.ui.theme.DoubleHorzSpacer
+import com.vitorpamplona.amethyst.ui.theme.Size20dp
+import com.vitorpamplona.amethyst.ui.theme.Size30dp
+import com.vitorpamplona.amethyst.ui.theme.Size36dp
 import com.vitorpamplona.quartz.nip17Dm.base.ChatroomKey
+
+/** Reporter avatars shown before the row collapses into a "+N" overflow chip. */
+private const val MAX_REPORTER_AVATARS = 6
 
 /**
  * Warns that the person on the other end of a 1:1 DM has been reported by someone the user follows.
@@ -91,6 +109,12 @@ fun DmReportWarningCard(
     }
 }
 
+/**
+ * Restrained Material 3 banner: the alert rides on a neutral `surfaceContainer` card and carries its
+ * severity through the `error` color role — a tinted report badge, an error headline, and a
+ * filled-tonal primary action — rather than flooding the whole header in `errorContainer`. Themes for
+ * free: every color resolves from the scheme, so light and dark need no branching here.
+ */
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun ReportWarningBody(
@@ -103,68 +127,172 @@ private fun ReportWarningBody(
 
     val typeLabels = reportTypeLabels(state.types)
 
+    // Reason chips: the single agreed reason stays visible collapsed; the full list appears on expand.
+    val chipLabels = if (expanded || typeLabels.size == 1) typeLabels else emptyList()
+
     Card(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 5.dp),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
     ) {
-        Column(modifier = Modifier.padding(10.dp)) {
-            Text(
-                text = reportWarningHeadline(state),
-                color = MaterialTheme.colorScheme.onErrorContainer,
-            )
-
-            // The reason gets its own line rather than being spliced into the sentence above, so no
-            // translated noun has to agree with a surrounding grammar. Shown collapsed only when the
-            // reports agree; when they disagree the full list appears on expand.
-            if (typeLabels.size == 1) {
-                Text(
-                    text = typeLabels.first(),
-                    color = MaterialTheme.colorScheme.onErrorContainer,
-                    style = MaterialTheme.typography.bodySmall,
-                )
-            }
-
-            if (expanded) {
-                FlowRow(modifier = Modifier.padding(top = 10.dp)) {
-                    state.reports.forEach { report ->
-                        NoteAuthorPicture(
-                            baseNote = report,
-                            size = Size35dp,
-                            accountViewModel = accountViewModel,
-                            nav = nav,
-                        )
-                    }
-                }
-
-                if (typeLabels.size > 1) {
+        Column(modifier = Modifier.padding(14.dp)) {
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                ReportBadge()
+                Column {
                     Text(
-                        text = typeLabels.joinToString(", "),
-                        color = MaterialTheme.colorScheme.onErrorContainer,
-                        modifier = Modifier.padding(top = 5.dp),
-                        textAlign = TextAlign.Start,
+                        text = reportWarningHeadline(state),
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.titleSmall,
+                    )
+                    Text(
+                        text = stringRes(R.string.dm_sender_reported_subtitle),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        style = MaterialTheme.typography.bodySmall,
                     )
                 }
             }
 
+            if (chipLabels.isNotEmpty()) {
+                FlowRow(
+                    modifier = Modifier.padding(top = 10.dp),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    chipLabels.forEach { ReasonChip(it) }
+                }
+            }
+
+            if (expanded) {
+                ReporterCluster(state, accountViewModel, nav)
+            }
+
             Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End,
+                modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.End),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 TextButton(
-                    onClick = { expanded = !expanded },
-                    colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.onErrorContainer),
-                ) {
-                    Text(text = stringRes(R.string.dm_sender_reported_who))
-                }
-                TextButton(
                     onClick = onDismiss,
-                    colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.onErrorContainer),
+                    colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.onSurfaceVariant),
                 ) {
                     Text(text = stringRes(R.string.dm_sender_reported_dismiss))
                 }
+                FilledTonalButton(
+                    onClick = { expanded = !expanded },
+                    colors =
+                        ButtonDefaults.filledTonalButtonColors(
+                            containerColor = MaterialTheme.colorScheme.error.copy(alpha = 0.14f),
+                            contentColor = MaterialTheme.colorScheme.error,
+                        ),
+                ) {
+                    Text(
+                        text =
+                            if (expanded) {
+                                stringRes(R.string.dm_sender_reported_hide)
+                            } else {
+                                stringRes(R.string.dm_sender_reported_who)
+                            },
+                    )
+                }
             }
         }
+    }
+}
+
+/** Error-tinted circular badge carrying the report glyph — the card's single splash of red. */
+@Composable
+private fun ReportBadge() {
+    Box(
+        modifier =
+            Modifier
+                .size(Size36dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.error.copy(alpha = 0.15f)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            symbol = MaterialSymbols.Report,
+            contentDescription = stringRes(R.string.dm_sender_reported_icon),
+            tint = MaterialTheme.colorScheme.error,
+            modifier = Modifier.size(Size20dp),
+        )
+    }
+}
+
+/** Outlined error chip naming one report reason. */
+@Composable
+private fun ReasonChip(label: String) {
+    val error = MaterialTheme.colorScheme.error
+    Text(
+        text = label,
+        style = MaterialTheme.typography.labelMedium,
+        color = error,
+        modifier =
+            Modifier
+                .border(1.dp, error.copy(alpha = 0.5f), RoundedCornerShape(8.dp))
+                .padding(horizontal = 10.dp, vertical = 4.dp),
+    )
+}
+
+/**
+ * Overlapping reporter avatars, capped at [MAX_REPORTER_AVATARS] and spilling the remainder into a
+ * "+N" chip so a busy account doesn't render a wall of faces. Each avatar wears a card-colored ring
+ * so the overlap reads cleanly.
+ */
+@Composable
+private fun ReporterCluster(
+    state: UserReportWarningState,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    val shown = state.reports.take(MAX_REPORTER_AVATARS)
+    val overflow = state.reporterCount - shown.size
+
+    Row(
+        modifier = Modifier.padding(top = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy((-8).dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        shown.forEach { report ->
+            Box(
+                modifier =
+                    Modifier
+                        .background(MaterialTheme.colorScheme.surfaceContainer, CircleShape)
+                        .padding(2.dp),
+            ) {
+                NoteAuthorPicture(
+                    baseNote = report,
+                    size = Size30dp,
+                    accountViewModel = accountViewModel,
+                    nav = nav,
+                )
+            }
+        }
+        if (overflow > 0) {
+            Spacer(DoubleHorzSpacer)
+            OverflowChip(overflow)
+        }
+    }
+}
+
+/** The "+N" pill closing the capped reporter row. */
+@Composable
+private fun OverflowChip(count: Int) {
+    Box(
+        modifier =
+            Modifier
+                .height(Size30dp)
+                .defaultMinSize(minWidth = Size30dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                .border(1.dp, MaterialTheme.colorScheme.outlineVariant, CircleShape)
+                .padding(horizontal = 8.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = stringRes(R.string.dm_sender_reported_more_count, count),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/header/RoomNameOnlyDisplay.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/header/RoomNameOnlyDisplay.kt
@@ -109,6 +109,11 @@ fun RoomNameDisplay(
     room: ChatroomKey,
     modifier: Modifier,
     accountViewModel: AccountViewModel,
+    // The 1:1 counterpart, resolved once per row by the caller. Null for group rooms, which
+    // resolve every member on their own via DisplayUserSetAsSubject. Deliberately has no default:
+    // this function no longer self-resolves, so a caller must decide explicitly rather than
+    // silently rendering a blank 1:1 name.
+    preloadedUser: User?,
 ) {
     val roomSubject by accountViewModel.account.chatroomList
         .getOrCreatePrivateChatroom(room)
@@ -120,7 +125,11 @@ fun RoomNameDisplay(
             if (room.users.size > 1) {
                 DisplayRoomSubject(it)
             } else {
-                DisplayUserAndSubject(room.users.first(), it, accountViewModel)
+                DisplayUserAndSubject(it, accountViewModel, preloadedUser)
+            }
+        } else if (room.users.size == 1) {
+            Row {
+                preloadedUser?.let { UsernameDisplay(it, Modifier.weight(1f), accountViewModel = accountViewModel) }
             }
         } else {
             DisplayUserSetAsSubject(room, accountViewModel)
@@ -144,9 +153,9 @@ fun DisplayRoomSubject(
 
 @Composable
 private fun DisplayUserAndSubject(
-    user: HexKey,
     subject: String,
     accountViewModel: AccountViewModel,
+    preloadedUser: User?,
 ) {
     Row {
         Text(
@@ -160,9 +169,7 @@ private fun DisplayUserAndSubject(
             fontWeight = FontWeight.Bold,
             maxLines = 1,
         )
-        LoadUser(baseUserHex = user, accountViewModel = accountViewModel) {
-            it?.let { UsernameDisplay(it, Modifier.weight(1f), accountViewModel = accountViewModel) }
-        }
+        preloadedUser?.let { UsernameDisplay(it, Modifier.weight(1f), accountViewModel = accountViewModel) }
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChatroomHeaderCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChatroomHeaderCompose.kt
@@ -89,6 +89,7 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup.loadMarmo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup.marmotGroupLastReadRoute
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup.rememberMarmotGroupIconUrl
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.privateDM.header.RoomNameDisplay
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.privateDM.header.reportWarningContentDescription
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.concord.ConcordCommunityPill
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.concord.concordChannelLastReadRoute
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.concord.concordCommunityHasUnreadFlow
@@ -730,6 +731,35 @@ private fun ChannelTitleWithLabelInfo(
     }
 }
 
+/**
+ * A warning glyph on the row of a 1:1 room whose counterpart has been reported by someone the user
+ * follows. This is the surface where the user decides whether to open an unsolicited DM at all, so it
+ * warns before engagement rather than after. Group rooms render nothing.
+ */
+@Composable
+private fun RoomReportWarningIcon(
+    room: ChatroomKey,
+    accountViewModel: AccountViewModel,
+) {
+    val counterpartHex = room.users.singleOrNull() ?: return
+
+    LoadUser(baseUserHex = counterpartHex, accountViewModel = accountViewModel) { user ->
+        if (user != null) {
+            val state by accountViewModel.createUserReportWarningFlow(user).collectAsStateWithLifecycle()
+
+            if (state.shouldWarn) {
+                Icon(
+                    symbol = MaterialSymbols.Warning,
+                    contentDescription = reportWarningContentDescription(state),
+                    modifier = Size15Modifier,
+                    tint = MaterialTheme.colorScheme.error,
+                )
+                Spacer(modifier = StdHorzSpacer)
+            }
+        }
+    }
+}
+
 @Composable
 private fun UserRoomCompose(
     room: ChatroomKey,
@@ -753,6 +783,7 @@ private fun UserRoomCompose(
         },
         firstRow = {
             RoomNameDisplay(room, Modifier.weight(1f), accountViewModel)
+            RoomReportWarningIcon(room, accountViewModel)
             if (room in pinnedRooms.value) {
                 Icon(
                     symbol = MaterialSymbols.PushPin,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChatroomHeaderCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChatroomHeaderCompose.kt
@@ -738,25 +738,21 @@ private fun ChannelTitleWithLabelInfo(
  */
 @Composable
 private fun RoomReportWarningIcon(
-    room: ChatroomKey,
+    preloadedUser: User?,
     accountViewModel: AccountViewModel,
 ) {
-    val counterpartHex = room.users.singleOrNull() ?: return
+    val user = preloadedUser ?: return
+    val flow = remember(user) { accountViewModel.createUserReportWarningFlow(user) }
+    val state by flow.collectAsStateWithLifecycle()
 
-    LoadUser(baseUserHex = counterpartHex, accountViewModel = accountViewModel) { user ->
-        if (user != null) {
-            val state by accountViewModel.createUserReportWarningFlow(user).collectAsStateWithLifecycle()
-
-            if (state.shouldWarn) {
-                Icon(
-                    symbol = MaterialSymbols.Warning,
-                    contentDescription = reportWarningContentDescription(state),
-                    modifier = Size15Modifier,
-                    tint = MaterialTheme.colorScheme.error,
-                )
-                Spacer(modifier = StdHorzSpacer)
-            }
-        }
+    if (state.shouldWarn) {
+        Icon(
+            symbol = MaterialSymbols.Warning,
+            contentDescription = reportWarningContentDescription(state),
+            modifier = Size15Modifier,
+            tint = MaterialTheme.colorScheme.error,
+        )
+        Spacer(modifier = StdHorzSpacer)
     }
 }
 
@@ -782,8 +778,17 @@ private fun UserRoomCompose(
             )
         },
         firstRow = {
-            RoomNameDisplay(room, Modifier.weight(1f), accountViewModel)
-            RoomReportWarningIcon(room, accountViewModel)
+            val counterpartHex = room.users.singleOrNull()
+            if (counterpartHex != null) {
+                // 1:1 room: resolve the counterpart once and share it between the name and the
+                // report-warning icon below, instead of each doing its own LoadUser.
+                LoadUser(baseUserHex = counterpartHex, accountViewModel = accountViewModel) { counterpart ->
+                    RoomNameDisplay(room, Modifier.weight(1f), accountViewModel, preloadedUser = counterpart)
+                    RoomReportWarningIcon(counterpart, accountViewModel)
+                }
+            } else {
+                RoomNameDisplay(room, Modifier.weight(1f), accountViewModel, preloadedUser = null)
+            }
             if (room in pinnedRooms.value) {
                 Icon(
                     symbol = MaterialSymbols.PushPin,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/reports/dal/UserProfileReportFeedViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/reports/dal/UserProfileReportFeedViewModel.kt
@@ -50,7 +50,7 @@ class UserProfileReportFeedViewModel(
     val followersFlow: StateFlow<List<Note>> =
         user
             .reports()
-            .receivedReportsByAuthor
+            .reportsNamingUser
             .map {
                 it.values.flatten().sortedWith(sortingModel)
             }.sample(500)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/theme/Shape.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/theme/Shape.kt
@@ -124,6 +124,7 @@ val Size27dp = 27.dp
 val Size30dp = 30.dp
 val Size34dp = 34.dp
 val Size35dp = 35.dp
+val Size36dp = 36.dp
 val Size40dp = 40.dp
 val Size50dp = 50.dp
 val Size55dp = 55.dp

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -423,6 +423,11 @@
     <string name="chats_reply_searched">Searched every relay · tap to see</string>
     <string name="dm_sender_reported_who">Who reported this?</string>
     <string name="dm_sender_reported_dismiss">Dismiss</string>
+    <string name="dm_sender_reported_hide">Hide</string>
+    <string name="dm_sender_reported_subtitle">Someone you follow flagged this account</string>
+    <string name="dm_sender_reported_icon">Reported</string>
+    <!-- Overflow count on the capped reporter avatar row, e.g. "+21". -->
+    <string name="dm_sender_reported_more_count">+%1$d</string>
     <string name="error_loading_replies">"Error loading replies: "</string>
     <string name="try_again">Try again</string>
     <string name="notification_feed_is_empty">No notifications yet.</string>

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -20,6 +20,10 @@
         <item quantity="one">+%1$d\nreply</item>
         <item quantity="other">+%1$d\nreplies</item>
     </plurals>
+    <plurals name="dm_sender_reported">
+        <item quantity="one">Reported by %1$d person you follow</item>
+        <item quantity="other">Reported by %1$d people you follow</item>
+    </plurals>
     <string name="post_not_found">Event is loading or can\'t be found in your relay list</string>
     <string name="post_not_found_short">👀</string>
     <string name="channel_image">Channel Image</string>
@@ -417,6 +421,8 @@
     <string name="chats_reply_not_found">Couldn\'t find this message</string>
     <!-- Reply subtitle when every relay genuinely bottomed out (no stalls) and it still wasn't there. -->
     <string name="chats_reply_searched">Searched every relay · tap to see</string>
+    <string name="dm_sender_reported_who">Who reported this?</string>
+    <string name="dm_sender_reported_dismiss">Dismiss</string>
     <string name="error_loading_replies">"Error loading replies: "</string>
     <string name="try_again">Try again</string>
     <string name="notification_feed_is_empty">No notifications yet.</string>

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/model/ReportNamingIndexIngestionTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/model/ReportNamingIndexIngestionTest.kt
@@ -84,4 +84,39 @@ class ReportNamingIndexIngestionTest {
         assertEquals(1, reported.reports().reportsNaming(setOf(reporter)).size)
         assertEquals(0, reported.reports().countReportAuthorsBy(setOf(reporter)))
     }
+
+    @Test
+    fun aBareCoMentionedPTagIsNotIndexedWhileTheExplicitlyTypedOffenderIs() {
+        val reporter = "e1".repeat(32)
+        val offender = "e2".repeat(32)
+        val bystander = "e3".repeat(32)
+        val reportedNoteId = "e4".repeat(32)
+
+        val report =
+            ReportEvent(
+                id = "e5".repeat(32),
+                pubKey = reporter,
+                createdAt = 1_700_000_000L,
+                tags =
+                    arrayOf(
+                        arrayOf("e", reportedNoteId, ReportType.IMPERSONATION.code),
+                        // offender: explicitly typed, own report type
+                        arrayOf("p", offender, ReportType.IMPERSONATION.code),
+                        // bystander: bare 2-element p tag, no explicit type of its own
+                        arrayOf("p", bystander),
+                    ),
+                content = "",
+                sig = "sig",
+            )
+
+        LocalCache.consume(report, null, true)
+
+        val reportedOffender = LocalCache.getUserIfExists(offender)
+        assertTrue("the offender must exist in the cache", reportedOffender != null)
+        assertEquals(1, reportedOffender!!.reports().reportsNaming(setOf(reporter)).size)
+
+        val reportedBystander = LocalCache.getUserIfExists(bystander)
+        assertTrue("the bystander must exist in the cache", reportedBystander != null)
+        assertEquals(0, reportedBystander!!.reports().reportsNaming(setOf(reporter)).size)
+    }
 }

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/model/ReportNamingIndexIngestionTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/model/ReportNamingIndexIngestionTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.model
+
+import com.vitorpamplona.quartz.nip56Reports.ReportEvent
+import com.vitorpamplona.quartz.nip56Reports.ReportType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * `LocalCache` is a process-wide object (`LocalCache.kt:353`) and JUnit 4's default method order is
+ * hash-based, not source order. So each test method uses its **own** reporter, target and event ids —
+ * sharing them across methods would let one test's consumed report inflate another's count depending
+ * on which ran first.
+ */
+class ReportNamingIndexIngestionTest {
+    private fun reportNamingBothNoteAndAuthor(
+        id: String,
+        reporter: String,
+        target: String,
+        reportedNoteId: String,
+    ) = ReportEvent(
+        id = id,
+        pubKey = reporter,
+        createdAt = 1_700_000_000L,
+        tags =
+            arrayOf(
+                arrayOf("e", reportedNoteId, ReportType.IMPERSONATION.code),
+                arrayOf("p", target, ReportType.IMPERSONATION.code),
+            ),
+        content = "",
+        sig = "sig",
+    )
+
+    @Test
+    fun aReportFiledFromANoteStillReachesTheUserNamingIndex() {
+        val reporter = "c1".repeat(32)
+        val target = "c2".repeat(32)
+
+        LocalCache.consume(
+            reportNamingBothNoteAndAuthor("c3".repeat(32), reporter, target, "c4".repeat(32)),
+            null,
+            true,
+        )
+
+        val reported = LocalCache.getUserIfExists(target)
+        assertTrue("the reported author must exist in the cache", reported != null)
+
+        assertEquals(1, reported!!.reports().reportsNaming(setOf(reporter)).size)
+    }
+
+    @Test
+    fun theHideThresholdCountIsUnaffectedByNoteFiledReports() {
+        val reporter = "d1".repeat(32)
+        val target = "d2".repeat(32)
+
+        LocalCache.consume(
+            reportNamingBothNoteAndAuthor("d3".repeat(32), reporter, target, "d4".repeat(32)),
+            null,
+            true,
+        )
+
+        val reported = LocalCache.getUserIfExists(target)!!
+
+        assertEquals(1, reported.reports().reportsNaming(setOf(reporter)).size)
+        assertEquals(0, reported.reports().countReportAuthorsBy(setOf(reporter)))
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip56Reports/DmReportWarning.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip56Reports/DmReportWarning.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+@file:Suppress("ktlint:standard:filename")
+
+package com.vitorpamplona.amethyst.commons.model.nip56Reports
+
+import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip56Reports.ReportEvent
+import com.vitorpamplona.quartz.nip56Reports.ReportType
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.collections.immutable.toImmutableSet
+
+/**
+ * What the DM surfaces should say about the person on the other end of a 1:1 chat.
+ *
+ * [reports] are the kind-1984 notes themselves so the UI can render reporter avatars; [reporterCount]
+ * is the number of distinct reporters, which is what the headline counts.
+ */
+@Immutable
+data class UserReportWarningState(
+    val reports: ImmutableList<Note> = persistentListOf(),
+    val types: ImmutableSet<ReportType> = persistentSetOf(),
+    val reporterCount: Int = 0,
+) {
+    val shouldWarn: Boolean get() = reports.isNotEmpty()
+
+    companion object {
+        val SILENT = UserReportWarningState()
+    }
+}
+
+/**
+ * Decides whether to warn about [counterpart] in a 1:1 DM, and with what.
+ *
+ * Warns on a single report from a follow. There is deliberately no threshold here: the hide
+ * threshold governs individual messages, never the chat-list row, so suppressing above it would
+ * leave the most-reported senders with the least signal on the surface where the user decides
+ * whether to open an unsolicited DM at all.
+ *
+ * [followingKeySet] serves both jobs it serves in `Account.isAcceptable(user)`: the exemption for a
+ * counterpart the user follows, and the filter deciding whose reports count.
+ */
+fun dmReportWarningFor(
+    counterpart: User,
+    loggedInPubKey: HexKey,
+    followingKeySet: Set<HexKey>,
+    warnAboutReports: Boolean,
+): UserReportWarningState {
+    if (!warnAboutReports) return UserReportWarningState.SILENT
+    if (counterpart.pubkeyHex == loggedInPubKey) return UserReportWarningState.SILENT
+    if (counterpart.pubkeyHex in followingKeySet) return UserReportWarningState.SILENT
+
+    val reports = counterpart.reportsOrNull()?.reportsNaming(followingKeySet).orEmpty()
+    if (reports.isEmpty()) return UserReportWarningState.SILENT
+
+    val types =
+        reports.flatMapTo(LinkedHashSet<ReportType>()) { report ->
+            (report.event as? ReportEvent)
+                ?.reportedAuthor()
+                ?.filter { it.pubkey == counterpart.pubkeyHex }
+                ?.mapNotNull { it.type }
+                .orEmpty()
+        }
+
+    val reporters = reports.mapNotNullTo(mutableSetOf()) { it.author?.pubkeyHex }
+
+    return UserReportWarningState(
+        reports = reports.toImmutableList(),
+        types = types.toImmutableSet(),
+        reporterCount = reporters.size,
+    )
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip56Reports/UserReportCache.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip56Reports/UserReportCache.kt
@@ -41,85 +41,21 @@ class UserReportCache : UserDependencies {
      * Every report whose `reportedAuthor()` names this user, keyed by the reporting user — including
      * reports that also name a specific event and therefore never reach [receivedReportsByAuthor].
      *
-     * A superset of [receivedReportsByAuthor], read only by the DM sender warning. Keeping it
-     * separate leaves [countReportAuthorsBy] — and with it `Account.isAcceptable(user)` and the hide
-     * threshold — counting exactly the reports they counted before.
+     * A superset of [receivedReportsByAuthor], read by the DM sender warning and the profile Reports
+     * tab. Keeping it separate leaves [countReportAuthorsBy] — and with it `Account.isAcceptable(user)`
+     * and the hide threshold — counting exactly the reports they counted before.
      */
     val reportsNamingUser = MutableStateFlow(mapOf<User, Set<Note>>())
 
-    fun addReportNamingUser(note: Note) {
-        val author = note.author ?: return
+    fun addReportNamingUser(note: Note) = reportsNamingUser.index(note)
 
-        val existing = reportsNamingUser.value[author]
-        if (existing != null && existing.contains(note)) return
+    fun removeReportNamingUser(deleteNote: Note) = reportsNamingUser.deindex(deleteNote)
 
-        reportsNamingUser.update {
-            val current = it[author] ?: emptySet()
-            it + (author to current + note)
-        }
-    }
+    fun reportsNaming(users: Set<HexKey>): List<Note> = reportsNamingUser.value.notesFrom(users)
 
-    fun removeReportNamingUser(deleteNote: Note) {
-        val author = deleteNote.author ?: return
+    fun addReport(note: Note) = receivedReportsByAuthor.index(note)
 
-        val existing = reportsNamingUser.value[author]
-        if (existing == null || !existing.contains(deleteNote)) return
-
-        reportsNamingUser.update {
-            val current = it[author] ?: return@update it
-            it + (author to current - deleteNote)
-        }
-    }
-
-    fun reportsNaming(users: Set<HexKey>): List<Note> =
-        reportsNamingUser.value.flatMap {
-            if (it.key.pubkeyHex in users) {
-                it.value
-            } else {
-                emptyList()
-            }
-        }
-
-    fun addReport(note: Note) {
-        val author = note.author ?: return
-
-        val reportsBy = receivedReportsByAuthor.value[author]
-
-        // if it's already there, quick exit
-        if (reportsBy != null && reportsBy.contains(note)) return
-
-        receivedReportsByAuthor.update {
-            val author = note.author
-            if (author == null) {
-                it
-            } else {
-                val reportsByInner = it[author] ?: emptySet()
-                it + (author to reportsByInner + note)
-            }
-        }
-    }
-
-    fun removeReport(deleteNote: Note) {
-        val author = deleteNote.author ?: return
-        val reportsBy = receivedReportsByAuthor.value[author]
-
-        // if it's not already there, quick exit
-        if (reportsBy == null || !reportsBy.contains(deleteNote)) return
-
-        receivedReportsByAuthor.update {
-            val author = deleteNote.author
-            if (author == null) {
-                it
-            } else {
-                val reportsByInner = it[author]
-                if (reportsByInner == null) {
-                    it
-                } else {
-                    it + (author to reportsByInner - deleteNote)
-                }
-            }
-        }
-    }
+    fun removeReport(deleteNote: Note) = receivedReportsByAuthor.deindex(deleteNote)
 
     fun reportsBy(user: User): Set<Note> = receivedReportsByAuthor.value[user] ?: emptySet()
 
@@ -134,15 +70,7 @@ class UserReportCache : UserDependencies {
 
     fun all() = receivedReportsByAuthor.value.values.flatten()
 
-    fun reportsBy(users: Set<HexKey>): List<Note> =
-        receivedReportsByAuthor.value
-            .flatMap {
-                if (it.key.pubkeyHex in users) {
-                    it.value
-                } else {
-                    emptyList()
-                }
-            }
+    fun reportsBy(users: Set<HexKey>): List<Note> = receivedReportsByAuthor.value.notesFrom(users)
 
     fun hasReport(
         loggedIn: User,
@@ -153,4 +81,39 @@ class UserReportCache : UserDependencies {
         } != null
 
     fun hasReportNewerThan(timeInSeconds: Long): Boolean = receivedReportsByAuthor.value.any { pair -> pair.value.firstOrNull { (it.createdAt() ?: 0L) > timeInSeconds } != null }
+}
+
+/** Files [note] under its author, unless it is already there. */
+private fun MutableStateFlow<Map<User, Set<Note>>>.index(note: Note) {
+    val author = note.author ?: return
+    if (value[author]?.contains(note) == true) return
+
+    update {
+        val existing = it[author] ?: emptySet()
+        it + (author to existing + note)
+    }
+}
+
+/** Drops [note] from its author's set, unless it isn't there. */
+private fun MutableStateFlow<Map<User, Set<Note>>>.deindex(note: Note) {
+    val author = note.author ?: return
+    if (value[author]?.contains(note) != true) return
+
+    update {
+        val existing = it[author] ?: return@update it
+        it + (author to existing - note)
+    }
+}
+
+/** Every note filed under an author in [authors]. Allocates nothing while the index is empty. */
+private fun Map<User, Set<Note>>.notesFrom(authors: Set<HexKey>): List<Note> {
+    if (isEmpty()) return emptyList()
+
+    return flatMap {
+        if (it.key.pubkeyHex in authors) {
+            it.value
+        } else {
+            emptyList()
+        }
+    }
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip56Reports/UserReportCache.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip56Reports/UserReportCache.kt
@@ -37,6 +37,49 @@ class UserReportCache : UserDependencies {
     /** Tracks EOSE (End Of Stored Events) for relay subscriptions */
     val latestEOSEs = EOSERelayList()
 
+    /**
+     * Every report whose `reportedAuthor()` names this user, keyed by the reporting user — including
+     * reports that also name a specific event and therefore never reach [receivedReportsByAuthor].
+     *
+     * A superset of [receivedReportsByAuthor], read only by the DM sender warning. Keeping it
+     * separate leaves [countReportAuthorsBy] — and with it `Account.isAcceptable(user)` and the hide
+     * threshold — counting exactly the reports they counted before.
+     */
+    val reportsNamingUser = MutableStateFlow(mapOf<User, Set<Note>>())
+
+    fun addReportNamingUser(note: Note) {
+        val author = note.author ?: return
+
+        val existing = reportsNamingUser.value[author]
+        if (existing != null && existing.contains(note)) return
+
+        reportsNamingUser.update {
+            val current = it[author] ?: emptySet()
+            it + (author to current + note)
+        }
+    }
+
+    fun removeReportNamingUser(deleteNote: Note) {
+        val author = deleteNote.author ?: return
+
+        val existing = reportsNamingUser.value[author]
+        if (existing == null || !existing.contains(deleteNote)) return
+
+        reportsNamingUser.update {
+            val current = it[author] ?: return@update it
+            it + (author to current - deleteNote)
+        }
+    }
+
+    fun reportsNaming(users: Set<HexKey>): List<Note> =
+        reportsNamingUser.value.flatMap {
+            if (it.key.pubkeyHex in users) {
+                it.value
+            } else {
+                emptyList()
+            }
+        }
+
     fun addReport(note: Note) {
         val author = note.author ?: return
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip56Reports/UserReportWarningState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip56Reports/UserReportWarningState.kt
@@ -18,8 +18,6 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-@file:Suppress("ktlint:standard:filename")
-
 package com.vitorpamplona.amethyst.commons.model.nip56Reports
 
 import androidx.compose.runtime.Immutable
@@ -38,15 +36,16 @@ import kotlinx.collections.immutable.toImmutableSet
 /**
  * What the DM surfaces should say about the person on the other end of a 1:1 chat.
  *
- * [reports] are the kind-1984 notes themselves so the UI can render reporter avatars; [reporterCount]
- * is the number of distinct reporters, which is what the headline counts.
+ * [reports] holds one kind-1984 note per distinct reporter — the avatars the UI renders, and what
+ * the headline counts.
  */
 @Immutable
 data class UserReportWarningState(
     val reports: ImmutableList<Note> = persistentListOf(),
     val types: ImmutableSet<ReportType> = persistentSetOf(),
-    val reporterCount: Int = 0,
 ) {
+    val reporterCount: Int get() = reports.size
+
     val shouldWarn: Boolean get() = reports.isNotEmpty()
 
     companion object {
@@ -78,20 +77,20 @@ fun dmReportWarningFor(
     val reports = counterpart.reportsOrNull()?.reportsNaming(followingKeySet).orEmpty()
     if (reports.isEmpty()) return UserReportWarningState.SILENT
 
-    val types =
-        reports.flatMapTo(LinkedHashSet<ReportType>()) { report ->
-            (report.event as? ReportEvent)
-                ?.reportedAuthor()
-                ?.filter { it.pubkey == counterpart.pubkeyHex }
-                ?.mapNotNull { it.type }
-                .orEmpty()
-        }
+    val types = LinkedHashSet<ReportType>()
+    val oneReportPerReporter = LinkedHashMap<HexKey, Note>()
 
-    val reporters = reports.mapNotNullTo(mutableSetOf()) { it.author?.pubkeyHex }
+    reports.forEach { report ->
+        report.author?.let { oneReportPerReporter.getOrPut(it.pubkeyHex) { report } }
+
+        (report.event as? ReportEvent)?.reportedAuthor()?.forEach {
+            // A single report can name several people; only this counterpart's reason belongs here.
+            if (it.pubkey == counterpart.pubkeyHex) it.type?.let(types::add)
+        }
+    }
 
     return UserReportWarningState(
-        reports = reports.toImmutableList(),
+        reports = oneReportPerReporter.values.toImmutableList(),
         types = types.toImmutableSet(),
-        reporterCount = reporters.size,
     )
 }

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/nip56Reports/DmReportWarningTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/nip56Reports/DmReportWarningTest.kt
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model.nip56Reports
+
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.UserContext
+import com.vitorpamplona.quartz.nip56Reports.ReportEvent
+import com.vitorpamplona.quartz.nip56Reports.ReportType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DmReportWarningTest {
+    private val noCtx = UserContext { Note("addr") }
+
+    private val me = "1".repeat(64)
+    private val counterpartHex = "2".repeat(64)
+
+    private fun user(hex: String) = User(hex, noCtx)
+
+    /** A kind-1984 note by [reporter] naming [targetHex] with [type]. */
+    private fun report(
+        id: String,
+        reporter: User,
+        type: ReportType,
+        targetHex: String = counterpartHex,
+    ): Note {
+        val event =
+            ReportEvent(
+                id = id,
+                pubKey = reporter.pubkeyHex,
+                createdAt = 1_700_000_000L,
+                tags = arrayOf(arrayOf("p", targetHex, type.code)),
+                content = "",
+                sig = "sig",
+            )
+        return Note(id).apply {
+            this.author = reporter
+            this.event = event
+        }
+    }
+
+    /** A counterpart whose naming index already holds [reports]. */
+    private fun counterpartReportedBy(vararg reports: Note): User =
+        user(counterpartHex).also { target ->
+            reports.forEach { target.reports().addReportNamingUser(it) }
+        }
+
+    @Test
+    fun noReportsIsSilent() {
+        val state =
+            dmReportWarningFor(
+                counterpart = user(counterpartHex),
+                loggedInPubKey = me,
+                followingKeySet = setOf("a".repeat(64)),
+                warnAboutReports = true,
+            )
+
+        assertFalse(state.shouldWarn)
+    }
+
+    @Test
+    fun reportsOnlyFromNonFollowsAreSilent() {
+        val stranger = user("9".repeat(64))
+        val counterpart = counterpartReportedBy(report("r1", stranger, ReportType.IMPERSONATION))
+
+        val state =
+            dmReportWarningFor(
+                counterpart = counterpart,
+                loggedInPubKey = me,
+                followingKeySet = setOf("a".repeat(64)),
+                warnAboutReports = true,
+            )
+
+        assertFalse(state.shouldWarn)
+    }
+
+    @Test
+    fun oneReportFromAFollowWarnsAndCarriesItsType() {
+        val alice = user("a".repeat(64))
+        val counterpart = counterpartReportedBy(report("r1", alice, ReportType.IMPERSONATION))
+
+        val state =
+            dmReportWarningFor(
+                counterpart = counterpart,
+                loggedInPubKey = me,
+                followingKeySet = setOf(alice.pubkeyHex),
+                warnAboutReports = true,
+            )
+
+        assertTrue(state.shouldWarn)
+        assertEquals(1, state.reporterCount)
+        assertEquals(setOf(ReportType.IMPERSONATION), state.types.toSet())
+    }
+
+    @Test
+    fun multipleReportersAggregateAndTypesDeduplicate() {
+        val alice = user("a".repeat(64))
+        val bob = user("b".repeat(64))
+        val counterpart =
+            counterpartReportedBy(
+                report("r1", alice, ReportType.IMPERSONATION),
+                report("r2", bob, ReportType.IMPERSONATION),
+                report("r3", bob, ReportType.SPAM),
+            )
+
+        val state =
+            dmReportWarningFor(
+                counterpart = counterpart,
+                loggedInPubKey = me,
+                followingKeySet = setOf(alice.pubkeyHex, bob.pubkeyHex),
+                warnAboutReports = true,
+            )
+
+        assertEquals(3, state.reports.size)
+        assertEquals(2, state.reporterCount)
+        assertEquals(setOf(ReportType.IMPERSONATION, ReportType.SPAM), state.types.toSet())
+    }
+
+    @Test
+    fun aMultiTargetReportOnlyContributesTheCounterpartsOwnReason() {
+        // One kind-1984 event naming two different people with two different reasons. It lands in
+        // the counterpart's index because it names them, but the other person's reason must not
+        // leak into this warning.
+        val alice = user("a".repeat(64))
+        val someoneElse = "8".repeat(64)
+        val multiTarget =
+            Note("r1").apply {
+                author = alice
+                event =
+                    ReportEvent(
+                        id = "r1",
+                        pubKey = alice.pubkeyHex,
+                        createdAt = 1_700_000_000L,
+                        tags =
+                            arrayOf(
+                                arrayOf("p", counterpartHex, ReportType.IMPERSONATION.code),
+                                arrayOf("p", someoneElse, ReportType.NUDITY.code),
+                            ),
+                        content = "",
+                        sig = "sig",
+                    )
+            }
+        val counterpart = counterpartReportedBy(multiTarget)
+
+        val state =
+            dmReportWarningFor(
+                counterpart = counterpart,
+                loggedInPubKey = me,
+                followingKeySet = setOf(alice.pubkeyHex),
+                warnAboutReports = true,
+            )
+
+        assertTrue(state.shouldWarn)
+        assertEquals(setOf(ReportType.IMPERSONATION), state.types.toSet())
+    }
+
+    @Test
+    fun theLoggedInUserIsNeverWarnedAboutThemselves() {
+        val alice = user("a".repeat(64))
+        val self =
+            user(me).also { it.reports().addReportNamingUser(report("r1", alice, ReportType.SPAM, targetHex = me)) }
+
+        val state =
+            dmReportWarningFor(
+                counterpart = self,
+                loggedInPubKey = me,
+                followingKeySet = setOf(alice.pubkeyHex),
+                warnAboutReports = true,
+            )
+
+        assertFalse(state.shouldWarn)
+    }
+
+    @Test
+    fun aFollowedCounterpartIsNeverWarnedAbout() {
+        val alice = user("a".repeat(64))
+        val counterpart = counterpartReportedBy(report("r1", alice, ReportType.IMPERSONATION))
+
+        val state =
+            dmReportWarningFor(
+                counterpart = counterpart,
+                loggedInPubKey = me,
+                // The real caller passes one set that contains both the reporters it filters by and,
+                // when applicable, the counterpart themselves. This is that state.
+                followingKeySet = setOf(alice.pubkeyHex, counterpartHex),
+                warnAboutReports = true,
+            )
+
+        assertFalse(state.shouldWarn)
+    }
+
+    @Test
+    fun theWarnToggleOffSilencesEverything() {
+        val alice = user("a".repeat(64))
+        val counterpart = counterpartReportedBy(report("r1", alice, ReportType.IMPERSONATION))
+
+        val state =
+            dmReportWarningFor(
+                counterpart = counterpart,
+                loggedInPubKey = me,
+                followingKeySet = setOf(alice.pubkeyHex),
+                warnAboutReports = false,
+            )
+
+        assertFalse(state.shouldWarn)
+    }
+
+    @Test
+    fun manyReportsStillWarnRatherThanDeferringToTheHideThreshold() {
+        // Guards the regression the first draft of the spec would have shipped: a counterpart far
+        // above reportWarningThreshold must still produce a warning, because nothing hides a DM
+        // room row.
+        val reporters = listOf('a', 'b', 'c', 'd', 'e', 'f', 'g').map { user(it.toString().repeat(64)) }
+        val counterpart =
+            counterpartReportedBy(
+                *reporters
+                    .mapIndexed { index, reporter -> report("r$index", reporter, ReportType.IMPERSONATION) }
+                    .toTypedArray(),
+            )
+
+        val state =
+            dmReportWarningFor(
+                counterpart = counterpart,
+                loggedInPubKey = me,
+                followingKeySet = reporters.mapTo(mutableSetOf()) { it.pubkeyHex },
+                warnAboutReports = true,
+            )
+
+        assertTrue(state.shouldWarn)
+        assertEquals(7, state.reporterCount)
+    }
+}

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/nip56Reports/DmReportWarningTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/nip56Reports/DmReportWarningTest.kt
@@ -132,7 +132,8 @@ class DmReportWarningTest {
                 warnAboutReports = true,
             )
 
-        assertEquals(3, state.reports.size)
+        // Bob filed two of the three; the state keeps one report per reporter, for one avatar each.
+        assertEquals(2, state.reports.size)
         assertEquals(2, state.reporterCount)
         assertEquals(setOf(ReportType.IMPERSONATION, ReportType.SPAM), state.types.toSet())
     }

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/nip56Reports/UserReportCacheNamingIndexTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/nip56Reports/UserReportCacheNamingIndexTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model.nip56Reports
+
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.UserContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class UserReportCacheNamingIndexTest {
+    private val noCtx = UserContext { Note("addr") }
+
+    private fun user(seed: Char) = User(seed.toString().repeat(64), noCtx)
+
+    private fun reportBy(
+        id: String,
+        reporter: User,
+    ) = Note(id).apply { author = reporter }
+
+    @Test
+    fun addRecordsTheReportUnderItsReporter() {
+        val cache = UserReportCache()
+        val alice = user('a')
+
+        cache.addReportNamingUser(reportBy("report1", alice))
+
+        assertEquals(1, cache.reportsNaming(setOf(alice.pubkeyHex)).size)
+    }
+
+    @Test
+    fun addingTheSameReportTwiceKeepsOneCopy() {
+        val cache = UserReportCache()
+        val alice = user('a')
+        val report = reportBy("report1", alice)
+
+        cache.addReportNamingUser(report)
+        cache.addReportNamingUser(report)
+
+        assertEquals(1, cache.reportsNaming(setOf(alice.pubkeyHex)).size)
+    }
+
+    @Test
+    fun reportsNamingExcludesReportersOutsideTheGivenSet() {
+        val cache = UserReportCache()
+        val alice = user('a')
+        val bob = user('b')
+
+        cache.addReportNamingUser(reportBy("report1", alice))
+        cache.addReportNamingUser(reportBy("report2", bob))
+
+        val onlyAlice = cache.reportsNaming(setOf(alice.pubkeyHex))
+
+        assertEquals(1, onlyAlice.size)
+        assertEquals("report1", onlyAlice.first().idHex)
+    }
+
+    @Test
+    fun removeDropsTheReport() {
+        val cache = UserReportCache()
+        val alice = user('a')
+        val report = reportBy("report1", alice)
+
+        cache.addReportNamingUser(report)
+        cache.removeReportNamingUser(report)
+
+        assertTrue(cache.reportsNaming(setOf(alice.pubkeyHex)).isEmpty())
+    }
+
+    @Test
+    fun theNewIndexDoesNotFeedTheHideThresholdCount() {
+        val cache = UserReportCache()
+        val alice = user('a')
+
+        cache.addReportNamingUser(reportBy("report1", alice))
+
+        assertEquals(0, cache.countReportAuthorsBy(setOf(alice.pubkeyHex)))
+        assertTrue(cache.reportsBy(setOf(alice.pubkeyHex)).isEmpty())
+    }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip56Reports/ReportEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip56Reports/ReportEvent.kt
@@ -71,6 +71,16 @@ class ReportEvent(
 
     fun reportedAuthor() = tags.mapNotNull { ReportedAuthorTag.parse(it, defaultReportType()) }
 
+    /**
+     * Only the authors whose own `p` tag carries a report type, without the event-level fallback
+     * [reportedAuthor] applies. Separates an author this report is actually about from one it
+     * merely `p`-tags as a mention of an otherwise event-scoped report.
+     */
+    fun reportedAuthorsWithOwnType() =
+        tags.mapNotNull { tag ->
+            ReportedAuthorTag.parse(tag)?.takeIf { it.type != null }
+        }
+
     companion object {
         const val KIND = 1984
 


### PR DESCRIPTION
Fix for #644

Warning in feed:
<img width="300" alt="Screenshot_20260723-182230" src="https://github.com/user-attachments/assets/381a4f54-3ae8-4ec5-a17f-03470b0a8feb" />

<img width="300" alt="Screenshot_20260723-182243" src="https://github.com/user-attachments/assets/f31eaf87-ad61-4043-bdfe-0f75f7c581ea" /> <img width="300" alt="Screenshot_20260723-182254" src="https://github.com/user-attachments/assets/42435446-9afc-4554-89dc-12c386928256" />

<img width="300" alt="Screenshot_20260723-182320" src="https://github.com/user-attachments/assets/523a8412-2ea7-45ae-ac2d-660edf29479f" />

## The gap

Amethyst already collects kind-1984 (NIP-56) reports, but a report filed against a *note* is routed to that note and never reaches the reported author's user-level cache. So the DM surfaces showed no signal at all: over the hide threshold a room is silently dropped, and under it there was nothing — a follow reporting a DM sender for impersonation or malware was invisible to you.

Note that two of the issue's threads are already resolved in `main`: the report threshold has been configurable for a while (`reportWarningThreshold` in Security Filters), and reporter avatars already render on hidden notes. This PR is the original ask that remained: surfacing that signal in the DM UI.

## What this adds

Two surfaces, both for 1:1 private DMs (NIP-04 + NIP-17):

- **A dismissible banner** at the top of the conversation — "Reported by N people you follow", with the report reasons and, on tap, the reporters themselves ("who reported this?" hidden behind a tap, per @weex's suggestion in the issue).
- **A warning glyph** on the chat-list row, so you're warned *before* opening an unsolicited DM — the New/requests tab is the primary surface, since that's where impersonation DMs from strangers land.

## How it works

- A new additive index `reportsNamingUser` on `UserReportCache`, populated from every report that names an author — including note-filed reports that previously only reached the note. It is kept **separate** from `receivedReportsByAuthor`, which the hide path counts, so `Account.isAcceptable`, `countReportAuthorsBy` and the hide threshold are completely unchanged — no user's hidden status shifts.
- A new `ReportEvent.reportedAuthorsWithOwnType()` in quartz indexes only authors a report is actually *about* (their `p` tag carries its own report type), not accounts incidentally `p`-tagged as mentions of an event-scoped report.
- A pure classifier (`dmReportWarningFor`) in `commons` decides whether to warn, unit-tested in isolation; `AccountViewModel` wraps it in a cached `StateFlow` mirroring the existing `createIsHiddenFlow`.

## Design decisions

- **Warns at a single report from someone you follow**, with no threshold suppression — the hide threshold governs individual messages, never the chat-list row, so suppressing above it would give the most-reported senders the *least* signal where you decide whether to open the DM.
- **Never warns about someone you follow or yourself**, and respects the existing "Warn about reported posts" toggle — no new setting.
- **Reasons are shown on their own line, not interpolated** into the sentence, because the labels are sentence-cased noun phrases that don't survive being spliced into inflecting languages.
- **All report types trigger the warning, with the reason named.** The issue is titled "impersonators," but the warning's value is "should I trust this DM sender", for which a malware or scam flag is at least as urgent — so impersonation is surfaced by name rather than being the sole gate. This is the one point I'd like a maintainer's call on: happy to narrow it to impersonation (or a deception/danger subset) if you'd prefer — it's a one-line filter in the classifier.

## A tradeoff worth flagging

One report from one follow now produces a visible warning, which is a lower bar than anything else in the app. It's mitigated structurally rather than numerically: the reporter is always named (a smear is attributable), and the result is a warning you can read past, not a hide.

## Testing

- Unit tests for the classifier, the additive index, and the ingestion routing (including that note-filed reports reach the new index while leaving the hide count untouched).
- Verified end-to-end on device against a real, heavily-reported Michael Saylor impersonator: the banner and glyph render, dismissal survives backgrounding, and the `p`-tag narrowing correctly warns about a typed offender while ignoring an incidentally-mentioned bystander in the same report.
- Cross-checked report counts against relays with `nak` — the app's follow-scoped counts reconcile with the network totals.

## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
