### PR TITLE
fix(concord): recover communities that won't load + warm channel previews

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -26,6 +26,7 @@ import com.vitorpamplona.amethyst.BuildConfig
 import com.vitorpamplona.amethyst.LocalPreferences
 import com.vitorpamplona.amethyst.commons.actions.ConcordActions
 import com.vitorpamplona.amethyst.commons.actions.ConcordModeration
+import com.vitorpamplona.amethyst.commons.actions.ConcordSubscriptionPlanner
 import com.vitorpamplona.amethyst.commons.audio.VisualizerStyle
 import com.vitorpamplona.amethyst.commons.connectedApps.nip46.InMemoryNip46ClientStore
 import com.vitorpamplona.amethyst.commons.connectedApps.nip46.Nip46ClientStore
@@ -154,6 +155,7 @@ import com.vitorpamplona.amethyst.service.relayClient.notifyCommand.model.Notify
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.nwc.NWCPaymentFilterAssembler
 import com.vitorpamplona.amethyst.service.uploads.FileHeader
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.EventProcessor
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.concord.concordChannelLastReadRoute
 import com.vitorpamplona.quartz.buzz.dm.DmAddMemberEvent
 import com.vitorpamplona.quartz.buzz.dm.DmHideEvent
 import com.vitorpamplona.quartz.buzz.dm.DmOpenEvent
@@ -2923,6 +2925,33 @@ class Account(
                 "newest=${newest?.id?.take(8)}@${newest?.createdAt}, decoded $entryCount entr${if (entryCount == 1) "y" else "ies"}",
         )
         newest?.let { cache.justConsumeMyOwnEvent(it) }
+    }
+
+    /**
+     * One-shot warm of every channel of [entries] so a community's channel list and the Messages inbox
+     * fill in without the user opening each channel one by one. Per channel, a channel read before is
+     * caught up from its last-read time (accurate unread badge + the missed messages ready when it
+     * opens) while a channel never read pulls only its single newest wrap for a preview — see
+     * [ConcordSubscriptionPlanner.channelPreviewFilters].
+     *
+     * This is deliberately **not** a live subscription: every wrap the drain pulls flows through the
+     * global cache connector (`CacheClientConnector` → `LocalCache.justConsume` → `concordSessions.ingest`),
+     * so it lands in the channel's message store the previews/unread counts read — and the always-on
+     * plane subscription ([RelaySubscriptionsCoordinator.concordChannels]) keeps them fresh afterward.
+     * So this only needs to run when a community's channels first fold (the account preload) or its
+     * screen is opened. One drain per call: all [entries]' per-channel filters are grouped by relay.
+     */
+    suspend fun warmConcordChannelPreviews(entries: List<ConcordCommunityListEntry>) {
+        val filters =
+            entries.flatMap { entry ->
+                val state = concordSessions.sessionFor(entry.id)?.state?.value ?: return@flatMap emptyList()
+                ConcordSubscriptionPlanner.channelPreviewFilters(entry, state, lastReadFor = { channelIdHex ->
+                    loadLastRead(concordChannelLastReadRoute(entry.id, channelIdHex))
+                })
+            }
+        if (filters.isEmpty()) return
+        val byRelay = filters.groupBy { it.relay }.mapValues { (_, group) -> group.map { it.filter } }
+        client.fetchAll(filters = byRelay, timeoutMs = 20_000L)
     }
 
     // ── NIP-29 relay-group actions ───────────────────────────────────────────

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/concord/ConcordChannelListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/concord/ConcordChannelListScreen.kt
@@ -75,6 +75,7 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.note.timeAgo
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.concord.datasource.ConcordChannelPreviewLoader
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.concord.datasource.ConcordChannelSubscription
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.qrcode.QrCodeDrawer
 import com.vitorpamplona.amethyst.ui.stringRes
@@ -99,6 +100,8 @@ fun ConcordChannelListScreen(
     nav: INav,
 ) {
     ConcordChannelSubscription(accountViewModel.dataSources().concordChannels, accountViewModel)
+    // Warm every channel's last-message preview so the list fills in without opening each channel.
+    ConcordChannelPreviewLoader(communityId, accountViewModel)
 
     val account = accountViewModel.account
     // Re-resolve on each revision so a deep link that lands before the session exists picks it up.

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/concord/datasource/ConcordChannelPreviewLoader.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/concord/datasource/ConcordChannelPreviewLoader.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.concord.datasource
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import kotlinx.coroutines.delay
+
+/**
+ * One-shot warm of the last-message preview of **every channel in one community** when its screen is
+ * open, so the channel list fills in without the user tapping into each channel.
+ *
+ * Not a live subscription: it drains one `limit:1` REQ per channel once (the wraps ingest through the
+ * normal cache path and the always-on plane subscription keeps them fresh afterward — see
+ * [com.vitorpamplona.amethyst.model.Account.warmConcordChannelPreviews]). It re-runs when a fold
+ * changes the channel set, debounced so the cold-boot burst of fold revisions coalesces into one warm.
+ */
+@Composable
+fun ConcordChannelPreviewLoader(
+    communityId: String,
+    accountViewModel: AccountViewModel,
+) {
+    val account = accountViewModel.account
+    val revision by account.concordSessions.revision.collectAsStateWithLifecycle()
+
+    LaunchedEffect(communityId, revision) {
+        // Let a burst of folds settle before draining, and coalesce repeated revisions into one warm.
+        delay(800)
+        val entry =
+            account.concordChannelList.liveCommunities.value
+                .firstOrNull { it.id == communityId } ?: return@LaunchedEffect
+        account.warmConcordChannelPreviews(listOf(entry))
+    }
+}
+
+/**
+ * Always-on account-level warm of channel previews for **every subscribed community**, mounted once
+ * high in the logged-in tree from `ConcordChannelPreload`. This is why the Messages inbox shows a last
+ * message for channels the user never opened — one drain covers all joined communities at once.
+ *
+ * A single [com.vitorpamplona.amethyst.model.Account.warmConcordChannelPreviews] call groups every
+ * community's per-channel `limit:1` filters by relay, so there is one REQ per relay (not one live
+ * subscription per community). Debounced on the fold revision so the cold-boot burst warms once.
+ */
+@Composable
+fun ConcordChannelPreviewAccountPreload(accountViewModel: AccountViewModel) {
+    val account = accountViewModel.account
+    val communities by account.concordChannelList.liveCommunities.collectAsStateWithLifecycle()
+    val revision by account.concordSessions.revision.collectAsStateWithLifecycle()
+
+    LaunchedEffect(communities, revision) {
+        // Debounce the cold-boot burst of fold revisions (and any join/leave churn) into one drain.
+        delay(1500)
+        account.warmConcordChannelPreviews(communities)
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/concord/datasource/ConcordChannelSubscription.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/concord/datasource/ConcordChannelSubscription.kt
@@ -100,6 +100,10 @@ fun ConcordChannelPreload(accountViewModel: AccountViewModel) {
 
     bootstrapPinnedCommunities(accountViewModel)
 
+    // Warm the last-message preview of every channel of every joined community (one drain per relay),
+    // so the Messages inbox shows a preview for channels the user has never opened.
+    ConcordChannelPreviewAccountPreload(accountViewModel)
+
     KeyDataSourceSubscription(state, dataSource)
 }
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/actions/ConcordSubscriptionPlanner.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/actions/ConcordSubscriptionPlanner.kt
@@ -135,6 +135,66 @@ object ConcordSubscriptionPlanner {
     }
 
     /**
+     * Per-channel **preview / catch-up** filters for every channel of a folded community, so its
+     * channel list and the Messages inbox fill in without the user opening each channel one by one.
+     * One filter per channel (never collapsed like the live [channelPlaneSubs], where the relay caps
+     * every channel's planes as one result and starves the quiet channels); each channel's authors
+     * span every held epoch so it reaches across a CORD-06 Refounding, and only stored wraps
+     * ([ConcordStreamEnvelope.KIND_WRAP]) count — the ephemeral 21059 is a typing heartbeat.
+     *
+     * How much to pull is per-channel, from [lastReadFor] (0 = never read):
+     *  - **Read before** → everything since the last-read time (capped at [catchUpLimit]), so the
+     *    unread badge is accurate and the missed messages are already in cache when the channel opens.
+     *    The last-read value *is a message's `created_at`* (the read marker is stamped with the seen
+     *    message's timestamp, not wall-clock), so the window is `since = lastRead - 1`: that
+     *    re-includes the last-read message itself, guaranteeing a preview even for a fully caught-up
+     *    channel — and since the unread count is a strict `created_at > lastRead`, that boundary
+     *    message is not miscounted as unread.
+     *  - **Never read** → the [previewLimit] newest wraps — enough for a preview and a rough sense of
+     *    how busy the channel is (the unread badge counts what we pulled), without dragging a whole
+     *    channel's backlog into a community the user has only glanced at. The full history still pages
+     *    in on open (the backward history pager).
+     *
+     * The returned filters `groupByRelay` into one REQ per relay, one filter per channel.
+     */
+    fun channelPreviewFilters(
+        entry: ConcordCommunityListEntry,
+        state: ConcordCommunityState,
+        lastReadFor: (channelIdHex: String) -> Long,
+        catchUpLimit: Int = 50,
+        previewLimit: Int = 10,
+    ): List<RelayBasedFilter> {
+        val authorsByChannel = LinkedHashMap<ConcordChannelId, MutableSet<String>>()
+        val relaysByChannel = HashMap<ConcordChannelId, Set<NormalizedRelayUrl>>()
+        for (sub in channelPlaneSubs(entry, state)) {
+            val channelId = sub.channelId ?: continue
+            authorsByChannel.getOrPut(channelId) { LinkedHashSet() }.add(sub.pubKeyHex)
+            relaysByChannel[channelId] = sub.relays
+        }
+        return authorsByChannel.flatMap { (channelId, authors) ->
+            val lastRead = lastReadFor(channelId.channelId)
+            val filter =
+                if (lastRead > 0L) {
+                    Filter(
+                        kinds = listOf(ConcordStreamEnvelope.KIND_WRAP),
+                        authors = authors.toList(),
+                        // -1 so the last-read message (created_at == lastRead) is itself returned:
+                        // a caught-up channel still gets a preview, and strict-> unread stays correct.
+                        since = lastRead - 1,
+                        limit = catchUpLimit,
+                    )
+                } else {
+                    Filter(
+                        kinds = listOf(ConcordStreamEnvelope.KIND_WRAP),
+                        authors = authors.toList(),
+                        limit = previewLimit,
+                    )
+                }
+            (relaysByChannel[channelId] ?: emptySet()).map { relay -> RelayBasedFilter(relay = relay, filter = filter) }
+        }
+    }
+
+    /**
      * Collapses [subs] into a `relay -> [filter]` map ready for a drain/subscribe.
      * All plane wraps are kind-1059 authored by the plane address, so each relay
      * gets one `{kinds:[1059], authors:[…all plane pks on it…]}` filter.

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/actions/ConcordSubscriptionPlannerTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/actions/ConcordSubscriptionPlannerTest.kt
@@ -108,6 +108,64 @@ class ConcordSubscriptionPlannerTest {
         }
 
     @Test
+    fun channelPreviewFiltersAreOnePerChannelWithLimitOne() =
+        runTest {
+            val community = ConcordCommunityFactory.create(owner, "Nostrichs", createdAt = 1L, relays = listOf("wss://r.example"))
+            val entry =
+                com.vitorpamplona.quartz.concord.cord02Community.ConcordCommunityListEntry(
+                    id = community.communityIdHex,
+                    owner = community.ownerPubKey,
+                    ownerSalt = community.ownerSalt.toHexKey(),
+                    root = community.communityRoot.toHexKey(),
+                    rootEpoch = community.rootEpoch,
+                    relays = listOf("wss://r.example"),
+                    name = "Nostrichs",
+                )
+            val state = ConcordActions.foldCommunity(community.genesisWraps, community.controlPlane, community.ownerPubKey)
+
+            // Never read (lastRead == 0) ⇒ the newest few wraps (previewLimit), no `since`.
+            val previews = ConcordSubscriptionPlanner.channelPreviewFilters(entry, state, lastReadFor = { 0L }, previewLimit = 10)
+
+            // One filter per channel (a fresh community has just #general) on the one community relay.
+            assertEquals(1, previews.size)
+            val preview = previews.first()
+            assertEquals(10, preview.filter.limit) // a handful of recent messages, not the whole backlog
+            assertNull(preview.filter.since) // never read ⇒ no catch-up window
+            assertEquals(listOf(1059), preview.filter.kinds) // stored wraps only — not ephemeral 21059 typing
+            val general = ConcordActions.publicChannel(community.communityRoot, community.generalChannelId, community.rootEpoch).publicKeyHex
+            assertTrue(preview.filter.authors?.contains(general) == true, "no limit:1 preview for #general")
+        }
+
+    @Test
+    fun channelPreviewFiltersCatchUpSinceLastReadWhenRead() =
+        runTest {
+            val community = ConcordCommunityFactory.create(owner, "Nostrichs", createdAt = 1L, relays = listOf("wss://r.example"))
+            val entry =
+                com.vitorpamplona.quartz.concord.cord02Community.ConcordCommunityListEntry(
+                    id = community.communityIdHex,
+                    owner = community.ownerPubKey,
+                    ownerSalt = community.ownerSalt.toHexKey(),
+                    root = community.communityRoot.toHexKey(),
+                    rootEpoch = community.rootEpoch,
+                    relays = listOf("wss://r.example"),
+                    name = "Nostrichs",
+                )
+            val state = ConcordActions.foldCommunity(community.genesisWraps, community.controlPlane, community.ownerPubKey)
+
+            // Read before (lastRead > 0) ⇒ everything since, capped, so the unread badge is accurate.
+            val lastRead = 1_700_000_000L
+            val previews =
+                ConcordSubscriptionPlanner.channelPreviewFilters(entry, state, lastReadFor = { lastRead }, catchUpLimit = 25)
+
+            assertEquals(1, previews.size)
+            val preview = previews.first()
+            // `since = lastRead - 1` re-includes the last-read message (its created_at == lastRead),
+            // so even a caught-up channel still yields a preview.
+            assertEquals(lastRead - 1, preview.filter.since)
+            assertEquals(25, preview.filter.limit) // bounded by catchUpLimit, not 1
+        }
+
+    @Test
     fun relayBasedFiltersCollapsePerRelayAndApplySince() =
         runTest {
             val community = ConcordCommunityFactory.create(owner, "Nostrichs", createdAt = 1L, relays = listOf("wss://r.example"))

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/concord/cord02Community/ConcordCommunityList.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/concord/cord02Community/ConcordCommunityList.kt
@@ -29,6 +29,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import kotlinx.serialization.descriptors.elementNames
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -98,10 +99,16 @@ class ConcordEntryResidue(
  * - [tombstones] — the document's tombstones, verbatim. We derive liveness from them but
  *   never author one, so dropping them on write would both lose another client's unknown
  *   keys and resurrect communities that client deliberately removed.
+ * - [unparsedEntries] — entries we could not decode into the typed model, kept verbatim. A
+ *   single entry carrying a wire field this version still requires but a peer omitted would
+ *   otherwise throw and empty the *entire* list; instead we skip just that entry on read and
+ *   re-emit it untouched on write, so a read-modify-write never deletes a membership this
+ *   version merely failed to understand — the same guarantee [tombstones]/[extras] give.
  */
 class ConcordListResidue(
     val extras: JsonObject = NoExtras,
     val tombstones: List<JsonObject> = emptyList(),
+    val unparsedEntries: List<JsonObject> = emptyList(),
 ) {
     companion object {
         val EMPTY = ConcordListResidue()
@@ -229,7 +236,11 @@ object ConcordCommunityList {
     @Serializable
     private class WireChannel(
         val id: String,
-        val key: String,
+        // A public channel carries no delivered key, so a writer lists it with only {id, epoch,
+        // name}. `key` MUST default rather than be required: a single keyless channel would
+        // otherwise throw MissingFieldException and make the whole document decode to empty,
+        // silently dropping *every* joined community from the list.
+        val key: String = "",
         val epoch: Long,
         val name: String = "",
         @SerialName(EXTRAS) val extras: JsonObject = NoExtras,
@@ -373,7 +384,15 @@ object ConcordCommunityList {
                 tombstones = residue.tombstones,
                 extras = residue.extras,
             )
-        return ConcordJson.instance.encodeToString(CommunityListDocSerializer, doc)
+        if (residue.unparsedEntries.isEmpty()) {
+            return ConcordJson.instance.encodeToString(CommunityListDocSerializer, doc)
+        }
+        // Re-attach the entries we couldn't parse, verbatim, so a read-modify-write never deletes
+        // a membership this version failed to understand. They ride alongside the typed entries.
+        val encoded = ConcordJson.instance.encodeToJsonElement(CommunityListDocSerializer, doc).jsonObject
+        val allEntries = ((encoded["entries"] as? JsonArray)?.toList() ?: emptyList()) + residue.unparsedEntries
+        val merged = JsonObject(encoded + ("entries" to JsonArray(allEntries)))
+        return ConcordJson.instance.encodeToString(JsonObject.serializer(), merged)
     }
 
     /**
@@ -385,38 +404,70 @@ object ConcordCommunityList {
 
     /**
      * Parses the decrypted plaintext JSON document into its live entries plus the
-     * document-level residue (unknown keys and tombstones) that [encode] must hand back.
-     * Returns an empty document on failure.
+     * document-level residue (unknown keys, tombstones, and any entries we couldn't decode)
+     * that [encode] must hand back.
+     *
+     * Entries are decoded **one at a time**: an entry this version can't parse (a wire field we
+     * still require that a peer omitted) is skipped and kept verbatim in
+     * [ConcordListResidue.unparsedEntries], never allowed to fail the whole document and empty
+     * the user's entire community list. Returns an empty document only when the outer structure
+     * itself is unreadable.
      */
     fun decodeDocument(json: String): ConcordCommunityListDocument =
         try {
-            val doc = ConcordJson.instance.decodeFromString(CommunityListDocSerializer, json)
+            val root = ConcordJson.instance.parseToJsonElement(json).jsonObject
+            val tombstones = (root["tombstones"] as? JsonArray)?.mapNotNull { it as? JsonObject } ?: emptyList()
+
             val latestRemoval = HashMap<String, Long>()
-            for (t in doc.tombstones) {
+            for (t in tombstones) {
                 val id = (t["community_id"] as? JsonPrimitive)?.contentOrNull ?: continue
                 val removedAt = (t["removed_at"] as? JsonPrimitive)?.longOrNull ?: 0L
                 val prev = latestRemoval[id]
                 if (prev == null || removedAt > prev) latestRemoval[id] = removedAt
             }
-            val entries =
-                doc.entries.mapNotNull { e ->
-                    val removedAt = latestRemoval[e.communityId]
-                    if (removedAt != null && e.addedAt <= removedAt) return@mapNotNull null
-                    val current = e.current
-                    val seed = e.seed?.let { ConcordJson.instance.decodeFromJsonElement(JoinMaterialWireSerializer, it) }
-                    // Hydrating from `seed` mints a fresh `current`; its unknown keys stay safe in
-                    // the verbatim seed, so they are not copied into the new snapshot.
-                    val residue =
-                        ConcordEntryResidue(
-                            entryExtras = e.extras,
-                            seed = e.seed,
-                            currentExtras = if (current != null) current.extras else NoExtras,
-                        )
-                    (current ?: seed)?.toEntry(e.addedAt, e.inviteRef, e.excludedAtEpoch, residue)
-                }
+
+            val entries = ArrayList<ConcordCommunityListEntry>()
+            val unparsed = ArrayList<JsonObject>()
+            for (element in (root["entries"] as? JsonArray ?: emptyList())) {
+                val wireObj = element as? JsonObject ?: continue
+                val e =
+                    try {
+                        ConcordJson.instance.decodeFromJsonElement(CommunityListEntryWireSerializer, wireObj)
+                    } catch (_: Exception) {
+                        // Skip just this entry, but keep it verbatim so a later write re-emits it
+                        // instead of deleting a membership this version failed to understand.
+                        unparsed.add(wireObj)
+                        continue
+                    }
+                val removedAt = latestRemoval[e.communityId]
+                if (removedAt != null && e.addedAt <= removedAt) continue
+                val current = e.current
+                // Hydrating from `seed` mints a fresh `current`; its unknown keys stay safe in the
+                // verbatim seed, so they are not copied into the new snapshot. `seed` decode is
+                // guarded too: it only hydrates when `current` is absent, and survives in residue.
+                val seed =
+                    e.seed?.let {
+                        try {
+                            ConcordJson.instance.decodeFromJsonElement(JoinMaterialWireSerializer, it)
+                        } catch (_: Exception) {
+                            null
+                        }
+                    }
+                val residue =
+                    ConcordEntryResidue(
+                        entryExtras = e.extras,
+                        seed = e.seed,
+                        currentExtras = if (current != null) current.extras else NoExtras,
+                    )
+                (current ?: seed)?.toEntry(e.addedAt, e.inviteRef, e.excludedAtEpoch, residue)?.let { entries.add(it) }
+            }
+
+            // Doc-level unknown keys: everything at the root that is not a field we model.
+            val docExtras = JsonObject(root.filterKeys { it != "entries" && it != "tombstones" })
+
             ConcordCommunityListDocument(
                 entries = entries,
-                residue = ConcordListResidue(extras = doc.extras, tombstones = doc.tombstones),
+                residue = ConcordListResidue(extras = docExtras, tombstones = tombstones, unparsedEntries = unparsed),
             )
         } catch (_: Exception) {
             ConcordCommunityListDocument(emptyList())

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/concord/cord02Community/ConcordCommunityListTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/concord/cord02Community/ConcordCommunityListTest.kt
@@ -134,6 +134,108 @@ class ConcordCommunityListTest {
     }
 
     @Test
+    fun aKeylessChannelDoesNotNukeTheWholeList() {
+        // A public channel carries no delivered key, so a writer lists it under `channels`
+        // with only {id, epoch, name} and no `key`. The whole document must still decode —
+        // a single keyless channel entry must not throw MissingFieldException and take every
+        // joined community down with it (the "Concord communities won't load" regression).
+        val json =
+            """
+            {
+              "entries": [
+                {
+                  "community_id": "${"11".repeat(32)}",
+                  "current": {
+                    "community_id": "${"11".repeat(32)}",
+                    "owner": "${"0f".repeat(32)}",
+                    "owner_salt": "${"aa".repeat(32)}",
+                    "community_root": "${"cc".repeat(32)}",
+                    "root_epoch": 0,
+                    "channels": [
+                      { "id": "${"ee".repeat(32)}", "epoch": 0, "name": "general" }
+                    ],
+                    "relays": ["wss://relay.example"],
+                    "name": "Has A Public Channel"
+                  },
+                  "added_at": 1700000000000
+                }
+              ],
+              "tombstones": []
+            }
+            """.trimIndent()
+
+        val entries = ConcordCommunityList.decode(json)
+        assertEquals(1, entries.size, "a keyless (public) channel must not drop the entry")
+        assertEquals("Has A Public Channel", entries[0].name)
+        assertEquals(1, entries[0].privateChannels.size)
+        assertEquals("", entries[0].privateChannels[0].key) // absent key ⇒ empty, not a throw
+    }
+
+    // A good entry, and one whose `current` is missing the required `owner` field so it cannot be
+    // decoded into the typed model at all.
+    private fun docWithOneUnparseableEntry() =
+        """
+        {
+          "entries": [
+            {
+              "community_id": "${"11".repeat(32)}",
+              "current": {
+                "community_id": "${"11".repeat(32)}",
+                "owner": "${"0f".repeat(32)}",
+                "owner_salt": "${"aa".repeat(32)}",
+                "community_root": "${"cc".repeat(32)}",
+                "root_epoch": 0,
+                "relays": ["wss://relay.example"],
+                "name": "Healthy"
+              },
+              "added_at": 1700000000000
+            },
+            {
+              "community_id": "${"22".repeat(32)}",
+              "current": {
+                "community_id": "${"22".repeat(32)}",
+                "owner_salt": "${"bb".repeat(32)}",
+                "community_root": "${"dd".repeat(32)}",
+                "root_epoch": 0,
+                "name": "Missing Owner"
+              },
+              "added_at": 1700000000001
+            }
+          ],
+          "tombstones": []
+        }
+        """.trimIndent()
+
+    @Test
+    fun oneUnparseableEntryDoesNotDropItsGoodNeighbors() {
+        val doc = ConcordCommunityList.decodeDocument(docWithOneUnparseableEntry())
+        // The healthy entry survives; the broken one is set aside, not fatal to the whole list.
+        assertEquals(1, doc.entries.size)
+        assertEquals("Healthy", doc.entries[0].name)
+        assertEquals("11".repeat(32), doc.entries[0].id)
+        assertEquals(1, doc.residue.unparsedEntries.size)
+        assertEquals(
+            "22".repeat(32),
+            doc.residue.unparsedEntries[0]["community_id"]!!
+                .jsonPrimitive.content,
+        )
+    }
+
+    @Test
+    fun anUnparseableEntrySurvivesAWriteRoundTrip() {
+        // A write (follow/unfollow) must re-emit the entry we couldn't parse, verbatim — dropping
+        // it would delete another client's membership just because this version can't model it.
+        val doc = ConcordCommunityList.decodeDocument(docWithOneUnparseableEntry())
+        val out = ConcordCommunityList.encode(doc.entries, doc.residue).asJson()
+        val ids =
+            out["entries"]!!.jsonArray.map { it.jsonObject["community_id"]!!.jsonPrimitive.content }.toSet()
+        assertTrue(ids.contains("11".repeat(32)), "the healthy entry is written back")
+        assertTrue(ids.contains("22".repeat(32)), "the unparseable entry is preserved verbatim")
+        // And a second decode still surfaces exactly the one healthy entry (idempotent).
+        assertEquals(1, ConcordCommunityList.decode(out.toString()).size)
+    }
+
+    @Test
     fun tombstoneAfterAddDropsEntry() {
         val jm = """{"community_id":"${"11".repeat(32)}","owner":"${"0f".repeat(32)}","owner_salt":"${"aa".repeat(32)}","community_root":"${"bb".repeat(32)}","root_epoch":0,"channels":[],"relays":[],"name":"Gone"}"""
         val json =


### PR DESCRIPTION
Two related Concord community fixes.

## 1. `fix`: a keyless (public) channel silently drops the whole community list

A public channel carries no delivered key, so a writer lists it under a
kind-13302 entry's `channels` with only `{id, epoch, name}`. `WireChannel.key`
was a **required** field, so kotlinx.serialization threw `MissingFieldException`
— and `decodeDocument`'s catch-all turned that one bad channel into an **empty
list**, silently dropping **every** joined community. Symptom: pinned communities
open blank ("No channels yet") and the whole list disappears; it reproduced on a
real account whose list was rewritten with two public-channel entries.

- `WireChannel.key` now defaults to `""` — a keyless public channel no longer throws.
- Entries decode **one at a time**; any we still can't parse are kept verbatim in
  `ConcordListResidue.unparsedEntries` and re-emitted on write, so one malformed
  entry can never wipe the list and a read-modify-write never deletes a membership
  this version can't model.

Verified end-to-end: `amy concord import` went from **0 → 5** communities on the real list.

## 2. `feat`: warm channel previews so the list fills without opening each channel

Concord fetched a channel's messages only when its screen was open, so un-opened
channels showed "No messages yet" in the community list and never reached the
Messages inbox — unlike NIP-28 / NIP-29, which preload a last message per room.
Added a one-shot warm drain (`Account.warmConcordChannelPreviews`), triggered on
community-screen open and app-wide per subscribed community from the account
preload (both debounced so the cold-boot fold burst warms once).

Per channel (`ConcordSubscriptionPlanner.channelPreviewFilters`):
- **never read** → newest 10 wraps: a preview plus a rough sense of how busy it is.
- **read** → everything `since lastRead - 1` (capped): accurate unread badge, missed
  messages cached for on-open, and the last-read message re-included so a caught-up
  channel still shows a preview (unread stays exact — the count is strict `>`).

Filters group into one REQ per relay; wraps ingest through the normal cache path,
and the always-on plane subscription keeps them fresh. Full history still pages in
on open via the backward history pager.

## Testing
- Unit tests: `ConcordCommunityListTest` (keyless channel doesn't nuke the list; an
  unparseable entry survives a write round-trip) and `ConcordSubscriptionPlannerTest`
  (never-read `limit:10`/no `since`; read `since:lastRead-1`).
- Compiles + all tests pass; verified on-device (emulator): communities fold, channel
  previews populate, and read channels show accurate unread counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)