### PR TITLE
Remove unreachable duplicate StreamMessageV2Event branch in computeReplyTo

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -117,7 +117,6 @@ import com.vitorpamplona.quartz.buzz.stream.sidecars.ChannelSummaryEvent
 import com.vitorpamplona.quartz.buzz.stream.sidecars.PresenceSnapshotEvent
 import com.vitorpamplona.quartz.buzz.teams.TeamEvent
 import com.vitorpamplona.quartz.buzz.threading.buzzThreadReply
-import com.vitorpamplona.quartz.buzz.threading.buzzThreadRoot
 import com.vitorpamplona.quartz.buzz.workflow.ApprovalDenyEvent
 import com.vitorpamplona.quartz.buzz.workflow.ApprovalGrantEvent
 import com.vitorpamplona.quartz.buzz.workflow.WorkflowApprovalDeniedEvent
@@ -1359,16 +1358,6 @@ object LocalCache : ILocalCache, ICacheProvider {
                         .map { it[1] }
                 val qTagTargets = event.quotedEvents().map { it.eventId }
                 (eTagTargets + qTagTargets).mapNotNull { checkGetOrCreateNote(it) }
-            }
-
-            is StreamMessageV2Event -> {
-                // Buzz threads 40002s with marked root/reply e-tags (thread_tags in
-                // buzz-sdk). Link both so inbound replies render their quote bubble —
-                // we emit these markers on send, so we must also read them.
-                listOfNotNull(
-                    event.tags.buzzThreadRoot(),
-                    event.tags.buzzThreadReply(),
-                ).distinct().mapNotNull { checkGetOrCreateNote(it) }
             }
 
             else -> {


### PR DESCRIPTION
LocalCache.computeReplyTo had two `is StreamMessageV2Event ->` branches in the same `when`. The `when` matches the first, so the second (the older buzzThreadRoot+buzzThreadReply variant) was dead code — the condition Sonar flags as duplicating the earlier one. The surviving first branch is the newer, deliberate Concord-style threading behavior that links a 40002 thread reply into its parent's replies via buzzThreadReply. Also drops the now-unused buzzThreadRoot import.

## License

- [ ] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
