### PR TITLE
docs: update v1.13.00 changelog with Buzz, Notifications, and more

### DIFF
--- a/docs/changelog/v1.13.00.md
+++ b/docs/changelog/v1.13.00.md
@@ -24,6 +24,10 @@ Highlights:
   trust relays used by people you follow.
 - Adds **NIP-29 Groups**: relay-hosted group chat with subgroups, custom roles,
   invite links, threads, and pinned messages.
+- Adds **Buzz workspaces**: a self-hosted space where people and AI agents build
+  together on a relay you own — with native channels, forums, direct messages,
+  live typing and presence, and an agent-owner console for personas, costs, and
+  attestations.
 - Redesigns the **Messages inbox**: groups community and group channels with
   last-message previews, unread dots, facepiles, live typing, and per-type load
   toggles.
@@ -143,6 +147,42 @@ Highlights:
 - Adds a map-based location picker when creating a group, and lets pinned group
   tabs act as bottom-nav roots.
 
+### Buzz (Agent Workspaces)
+
+- Adds Buzz: a self-hosted workspace where humans and AI agents build together on
+  a relay you own, built on the NIP-29 relay-group family with plaintext content
+  so the relay can run search, audit, and workflows. Reachable from a "Buzz
+  Workspaces" bottom-nav tab and the drawer Feeds list.
+- Renders workspace channels natively and composes messages; sections a community
+  into Channels, Forums, inline DMs, and an Agent Console; and renders forum posts
+  as Concord-style threads with the full chat composer.
+- Adds an agent-owner console with cost and personas tabs, an agent-fleet cost
+  aggregator, live observer telemetry, persona create/edit, and NIP-OA attestation
+  issuance.
+- Adds live typing indicators, presence dots, collapsible sections with unread and
+  stars, a workspace canvas viewer and edit composer, and a bot "Working…"
+  indicator.
+- Invites people to a channel or community and mints invite links; redeems invite
+  links (intercepted into the in-app browser) and auto-invites mentioned
+  non-members.
+- Wires Buzz direct messages end to end, titles a DM by its participant, and
+  surfaces Buzz DMs in the Notification feed rendered as messages.
+- Discovers workspaces and DMs via the relay's own kinds, imports workspace
+  channels from a relay in "Find groups", and routes Tor workspaces to clearnet
+  when needed.
+
+### Notifications
+
+- Redesigns push notifications into per-kind, observable, richly-rendered
+  notifications that resolve inline @npub mentions to display names, render an
+  inline image link as the big picture, and attribute a reply's parent to its real
+  author.
+- Adds push notifications for Buzz DMs and for bare reactions and reposts to your
+  notes, with repost-mute parity.
+- Rebuilds the in-app Notifications tab with infinite-scroll paging via a
+  look-ahead buffer, time-based history paging with in-feed load markers, and
+  auto-retry of stalled or faulty relays with an actionable relay detail.
+
 ### Remote Signer & Security
 
 - Lets other apps and websites sign through Amethyst for the first time
@@ -219,6 +259,12 @@ Highlights:
 - Renders NIP-30 custom-emoji reactions as an avatar badge, a lone zap/nutzap as
   a large activity card, and NIP-84 highlights from web highlighter clients.
 - Supports NIP-51 mute-list hashtag entries and public-chat reply notifications.
+- Modernizes the Privacy, Profile UI, Home Tabs, and Calendar Reminder settings
+  screens into grouped in-screen options.
+- Adds "Share as QR" for a note, with a choice of `note` or `naddr` payload and an
+  image thumbnail for image-only notes.
+- Resolves NIP-05 identifiers (including Namecoin `.bit`) in the @-mention
+  popover, wiring them to `nostr:` mentions.
 
 ## Performance
 
@@ -237,6 +283,11 @@ Highlights:
   an accent change.
 - Parallelizes Blossom "Sync all", prefetches a joined group's history, and mines
   proof-of-work on half the device's cores.
+- Orders NIP-50 relay search by bm25 relevance and scales search and tag-watcher
+  queries with corpus size, picking the SQLite filesystem driver by cost and
+  materializing indexes at runtime.
+- Removes live-path allocations in `LiveEventStore` and `FilterIndex` (and on the
+  frame/search paths), and snapshots `FilterIndex` with a persistent map.
 
 ## Improvements and Bug fixes
 
@@ -256,6 +307,19 @@ Highlights:
 - Fixes Concord invite handling (revocation, keyless CORD-05, clearer failure
   copy, no hang on bad links, skip re-join) and channel rows stuck on "No
   messages yet".
+- Persists the Concord community list and loads pinned communities from their own
+  relays so cold boot no longer refetches, shows channels on Messages as soon as
+  the control plane folds, warms channel previews so the list fills without opening
+  each channel, and rank-gates the Ban/Remove affordances (CORD-04).
+- Warns about DMs from senders reported by people you follow: flags a reported
+  counterpart on the chat-list row and inside the room, with a per-user
+  report-warning flow.
+- Sizes the video player box so live streams stop rendering black bars, and
+  enforces the decoder budget when acquiring players.
+- Stops stamping our client tag on someone else's event template so external
+  signers sign it unchanged.
+- Keeps calendar RSVP buttons on a single line, drops dead top padding on Home
+  when there are no live bubbles, and modernizes the Zap the Devs donation card.
 - Rejects NIP-29 group state not signed by the relay, opens group posts in the
   group chat, and fixes subgroup edit safety and pinned-message jump.
 - Makes tapping a message timestamp open delivery info instead of toggling the
@@ -288,6 +352,12 @@ Highlights:
   and the Wallet column, and a hashtag-spam filter.
 - Renders rich text through the shared core (removes the desktop-only fork) and
   ships as a Flatpak bundle.
+- Adds moderation & safety: mute/block and NIP-56 report actions in the note menu
+  with feed, thread, and profile enforcement (previously a silent no-op), NIP-36
+  content-warning blur with tap-to-reveal, a sensitive-content toggle, and
+  management screens — with snackbar feedback and zero-relay send warnings.
+- Adds NIP-88 polls (render, vote, create) with a "Polls" search facet, and
+  unifies the note ⋮ overflow and right-click menus.
 - Fixes a desktop-cache race that could wipe the follow list, and makes sidebar
   navigation replace the detail overlay instead of hiding behind it.
 
@@ -304,6 +374,11 @@ Highlights:
   live interop smoke test.
 - Adds `amy git` (NIP-34), `amy podcast` and `amy podcast20` (Podcasting 2.0 with
   V4V splits).
+- Rounds out `amy git` to full NIP-34 parity: `browse`/`cat`/`log` over
+  smart-HTTP, `init` from a local checkout, `label` (NIP-32), `apply` a patch to
+  the working tree, and `grasp list`/`set` (GRASP server list, kind 10317).
+- Adds `amy buzz` for block/buzz workspaces (channels, DMs, invite-link
+  redemption), verified against a live Buzz relay.
 - Adds the `amy cashu` wallet (NIP-60/61): wallet lifecycle, balance, mint,
   receive/send (LN / token / nutzap), and maintenance.
 - Adds `amy admin` (NIP-86 relay moderation) and `amy serve` (run a relay by
@@ -341,6 +416,10 @@ Highlights:
   restore.
 - Adds an OutboxDispatcher to fetch profile/contact events via each author's
   outbox relays, and richer NIP-89 app-handler parsing.
+- Adds the Buzz protocol surface (~78 event kinds spanning NIP-OA owner
+  attestation, NIP-AM agent turn metrics, personas/teams/managed agents, streams,
+  DMs, forums, presence, and moderation), verified against vectors generated by
+  Buzz's own Rust reference.
 
 ## Geode (standalone relay)
 
@@ -358,6 +437,9 @@ Highlights:
   catch-up IDs instead of materializing them.
 - Adds relayBench, a head-to-head benchmark harness (geode vs strfry vs any
   relay) measuring ingest, query, and NIP-77 sync over a shared corpus.
+- Enables a combined tag+kind+pubkey index, a cost-based filesystem-driver pick,
+  and runtime index materialization, with new tag∩author and driver-selection
+  relayBench shapes.
 
 ## Build & Documentation
 
@@ -366,6 +448,11 @@ Highlights:
   mirror in the web sandbox.
 - Adds NIP-29 group-chat test coverage across every assembler, filter shape, and
   relay integration.
+- Targets JVM 17 for Quartz, upgrades AGP, and replaces the abandoned
+  android-test-report action with `mikepenz/action-junit-report`.
+- Adds a coding standard banning raw invisible/bidirectional Unicode in source
+  (Trojan-Source, CVE-2021-42574) and replaces existing occurrences with `\u`
+  escapes.
 
 ## Contributors
 


### PR DESCRIPTION
## Summary

Updates the v1.13.00 changelog to document the major features and improvements shipped in this release, including Buzz workspaces (self-hosted agent collaboration spaces), redesigned push notifications, NIP-05 identifier resolution in mentions, performance optimizations (NIP-50 search, FilterIndex snapshots), and improvements across Android, Desktop, and CLI platforms.

## Test plan

- [ ] N/A — documentation-only change

## Interop suites

- [ ] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [ ] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

https://claude.ai/code/session_018o1pqCDfqqSu2UHRPuqTK1