### PR TITLE
Stop the decoder-budget counter from leaking and disabling the warm player cache

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/ExoPlayerPool.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/ExoPlayerPool.kt
@@ -146,8 +146,7 @@ class ExoPlayerPool(
         // Count only once the player exists — incrementing first leaves a phantom decoder on the
         // books if builder.build() throws.
         val player = coldPool.poll() ?: builder.build(context)
-        liveDecoders.incrementAndGet()
-        Log.d(PLAYBACK_DIAG_TAG) { "DECODERS acquire -> ${liveDecoders.get()} / budget $poolSize" }
+        acquireDecoder()
         return player
     }
 
@@ -171,13 +170,20 @@ class ExoPlayerPool(
         }
     }
 
+    // acquireDecoder/releaseDecoder are the only two places the shared counter moves, so the
+    // DECODERS trace always logs the value the mutation itself produced (a re-read could show a
+    // sibling pool's concurrent move instead).
+    private fun acquireDecoder() {
+        val now = liveDecoders.incrementAndGet()
+        Log.d(PLAYBACK_DIAG_TAG) { "DECODERS acquire -> $now / budget $poolSize" }
+    }
+
     // Floored at zero. An under-count is the harmful direction: it lets ensureDecoderHeadroom
     // hand out more concurrent decoders than the device grants, which surfaces as MediaCodec
     // NO_MEMORY and "can't play this video". An over-count only costs the warm cache.
-    private fun releaseDecoder(): Int {
+    private fun releaseDecoder() {
         val now = liveDecoders.updateAndGet { (it - 1).coerceAtLeast(0) }
         Log.d(PLAYBACK_DIAG_TAG) { "DECODERS release -> $now / budget $poolSize" }
-        return now
     }
 
     private fun evictOldestWarm(): Boolean {
@@ -208,6 +214,12 @@ class ExoPlayerPool(
             null
         }
 
+    /**
+     * Queues the return on this pool's single main-thread scope. Contract: returns queued before
+     * [destroy] is called run before destroy's teardown — both serialize on the same scope and
+     * [mutex] — so a caller may tear its sessions down synchronously and then destroy the pool
+     * (see MediaSessionPool.destroy).
+     */
     fun releasePlayerAsync(player: ExoPlayer) {
         scope.launch {
             releasePlayer(player)
@@ -342,22 +354,7 @@ class ExoPlayerPool(
                     }
                     coldPool.clear()
 
-                    // Remove from the shared registry only after this pool has decremented its own
-                    // players, so livePools.isEmpty() becomes true only once EVERY pool has finished
-                    // tearing down. Removing synchronously at the top of destroy() (the previous
-                    // approach) let the first pool's body see an empty list while a sibling's
-                    // decoders were still counted, firing a false drift warning on every ordinary
-                    // two-pool shutdown.
-                    livePools.remove(this@ExoPlayerPool)
-
-                    if (livePools.isEmpty()) {
-                        // Last pool out. A non-zero value here is now a genuine accounting leak —
-                        // a player acquired and never returned — worth seeing.
-                        val stranded = liveDecoders.getAndSet(0)
-                        if (stranded != 0) {
-                            Log.w(PLAYBACK_DIAG_TAG) { "decoder accounting drift at teardown: $stranded" }
-                        }
-                    }
+                    poolFinishedTeardown(this@ExoPlayerPool)
                 }
             }.invokeOnCompletion {
                 scope.cancel()
@@ -378,5 +375,20 @@ class ExoPlayerPool(
         // Every pool that hasn't been destroy()'d, so a pool starved of headroom can reclaim a
         // warm player from a sibling instead of overshooting the shared ceiling.
         private val livePools = ConcurrentLinkedQueue<ExoPlayerPool>()
+
+        // A pool calls this only after decrementing its own players, so livePools.isEmpty()
+        // means EVERY pool has finished tearing down — deregistering earlier would let the first
+        // pool out see a sibling's still-counted decoders as drift. The last pool out resets the
+        // shared counter; a non-zero value at that point is a genuine accounting leak (a player
+        // acquired and never returned), worth seeing.
+        private fun poolFinishedTeardown(pool: ExoPlayerPool) {
+            livePools.remove(pool)
+            if (livePools.isEmpty()) {
+                val stranded = liveDecoders.getAndSet(0)
+                if (stranded != 0) {
+                    Log.w(PLAYBACK_DIAG_TAG) { "decoder accounting drift at teardown: $stranded" }
+                }
+            }
+        }
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/ExoPlayerPool.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/ExoPlayerPool.kt
@@ -25,6 +25,7 @@ import androidx.annotation.OptIn
 import androidx.media3.common.C
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
+import com.vitorpamplona.amethyst.service.playback.PLAYBACK_DIAG_TAG
 import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
@@ -132,17 +133,22 @@ class ExoPlayerPool(
                     Log.d("PlaybackService") { "ExoPlayerPool discarding errored warm player: $preferredMediaId (${error.errorCodeName})" }
                     PcmTapRegistry.unregisterPlayer(warm)
                     warm.release()
-                    liveDecoders.decrementAndGet()
+                    releaseDecoder()
                 } else {
                     Log.d("PlaybackService") { "ExoPlayerPool warm hit: $preferredMediaId" }
                     // Already counted against the decoder budget for as long as it sat warm.
+                    Log.d(PLAYBACK_DIAG_TAG) { "DECODERS warm-hit -> ${liveDecoders.get()} / budget $poolSize (unchanged)" }
                     return warm
                 }
             }
         }
         ensureDecoderHeadroom()
+        // Count only once the player exists — incrementing first leaves a phantom decoder on the
+        // books if builder.build() throws.
+        val player = coldPool.poll() ?: builder.build(context)
         liveDecoders.incrementAndGet()
-        return coldPool.poll() ?: builder.build(context)
+        Log.d(PLAYBACK_DIAG_TAG) { "DECODERS acquire -> ${liveDecoders.get()} / budget $poolSize" }
+        return player
     }
 
     /**
@@ -163,6 +169,15 @@ class ExoPlayerPool(
         while (liveDecoders.get() >= poolSize) {
             if (!evictOldestWarm() && !evictOldestWarmElsewhere()) return
         }
+    }
+
+    // Floored at zero. An under-count is the harmful direction: it lets ensureDecoderHeadroom
+    // hand out more concurrent decoders than the device grants, which surfaces as MediaCodec
+    // NO_MEMORY and "can't play this video". An over-count only costs the warm cache.
+    private fun releaseDecoder(): Int {
+        val now = liveDecoders.updateAndGet { (it - 1).coerceAtLeast(0) }
+        Log.d(PLAYBACK_DIAG_TAG) { "DECODERS release -> $now / budget $poolSize" }
+        return now
     }
 
     private fun evictOldestWarm(): Boolean {
@@ -213,7 +228,7 @@ class ExoPlayerPool(
                 Log.d("PlaybackService") { "ExoPlayerPool dropping errored player: ${player.currentMediaItem?.mediaId} (${error.errorCodeName})" }
                 PcmTapRegistry.unregisterPlayer(player)
                 player.release()
-                liveDecoders.decrementAndGet()
+                releaseDecoder()
                 return@withLock
             }
 
@@ -261,7 +276,7 @@ class ExoPlayerPool(
         // stop() tears the renderers down, which is what actually hands the MediaCodec instance
         // back to the system — so this is the point where the player stops costing budget.
         player.stop()
-        liveDecoders.decrementAndGet()
+        releaseDecoder()
         player.clearVideoSurface()
         player.clearMediaItems()
 
@@ -307,7 +322,6 @@ class ExoPlayerPool(
     }
 
     fun destroy() {
-        livePools.remove(this)
         scope
             .launch {
                 mutex.withLock {
@@ -320,13 +334,30 @@ class ExoPlayerPool(
                     warmSnapshot.forEach {
                         PcmTapRegistry.unregisterPlayer(it.player)
                         it.player.release()
-                        liveDecoders.decrementAndGet()
+                        releaseDecoder()
                     }
                     coldPool.forEach {
                         PcmTapRegistry.unregisterPlayer(it)
                         it.release()
                     }
                     coldPool.clear()
+
+                    // Remove from the shared registry only after this pool has decremented its own
+                    // players, so livePools.isEmpty() becomes true only once EVERY pool has finished
+                    // tearing down. Removing synchronously at the top of destroy() (the previous
+                    // approach) let the first pool's body see an empty list while a sibling's
+                    // decoders were still counted, firing a false drift warning on every ordinary
+                    // two-pool shutdown.
+                    livePools.remove(this@ExoPlayerPool)
+
+                    if (livePools.isEmpty()) {
+                        // Last pool out. A non-zero value here is now a genuine accounting leak —
+                        // a player acquired and never returned — worth seeing.
+                        val stranded = liveDecoders.getAndSet(0)
+                        if (stranded != 0) {
+                            Log.w(PLAYBACK_DIAG_TAG) { "decoder accounting drift at teardown: $stranded" }
+                        }
+                    }
                 }
             }.invokeOnCompletion {
                 scope.cancel()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/MediaSessionPool.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/MediaSessionPool.kt
@@ -52,8 +52,8 @@ class SessionListener(
     val session: MediaSession,
     val playerListener: Player.Listener,
 ) {
-    // Set once, by the retire funnel. Guards the re-entrant path session.release() ->
-    // onDisconnected -> releaseSession -> registry.drop() landing on this same entry.
+    // Set once, by the retire funnel, making retireSession idempotent no matter how many
+    // paths reach the same entry.
     val retired = AtomicBoolean(false)
 
     fun removeListeners() {
@@ -133,18 +133,21 @@ class MediaSessionPool(
         }
 
     /**
-     * The one place a session's player goes back to the pool.
+     * The one place a session's player goes back to the pool — the registry's onDropped and
+     * newSession's failure unwind both land here.
      *
-     * The CAS is not redundant even though [SessionRegistry] signals each drop exactly once:
-     * session.release() below can reach onDisconnected -> releaseSession -> registry.drop() on
-     * the same entry, and that re-entrant path is what the guard stops. Do not remove it.
+     * [SessionRegistry] removes an entry from both of its maps before signaling, so its paths
+     * already deliver each entry at most once; the [SessionListener.retired] CAS keeps the funnel
+     * idempotent regardless, because a double retire would double-return the player — an
+     * under-count, the harmful direction (toward MediaCodec NO_MEMORY).
      *
      * Both orderings below are load-bearing, not tidiness:
      * - removeListeners() before release(), because releasing a session can fire
      *   onIsPlayingChanged, which would re-enter setPlaying while we are still inside
      *   the registry's entryRemoved callback.
      * - releasePlayerAsync() before release(), so a throw from session teardown cannot
-     *   strand the player.
+     *   strand the player. releasePlayerAsync only queues the return, so the listener and
+     *   session are detached before the queued release ever runs.
      */
     private fun retireSession(entry: SessionListener) {
         if (!entry.retired.compareAndSet(false, true)) return
@@ -172,15 +175,13 @@ class MediaSessionPool(
     ): MediaSession {
         val player = exoPlayerPool.acquirePlayer(context, preferredMediaId)
 
-        // newSession owns the player until registry.register() hands ownership over. Anything that
-        // throws in between — MediaSession.Builder.build(), reset(), or the PendingIntent in
-        // bindSessionActivity() — would otherwise strand a counted player with no owner.
-        //
-        // The throw sites named above are all *after* the session exists, so returning the player
-        // alone is not enough: a live MediaSession bound to it, and a listener attached to it,
-        // must come off first, or the pool re-issues a player that something else still holds.
-        var session: MediaSession? = null
-        var connector: MediaSessionExoPlayerConnector? = null
+        // newSession owns the player until registry.register() hands ownership over. Anything
+        // that throws in between — reset(), or the PendingIntent in bindSessionActivity() —
+        // would otherwise strand a counted player with no owner. The unwind routes through
+        // retireSession so there is exactly one teardown sequence; removing a never-added
+        // listener there is a no-op.
+        var entry: SessionListener? = null
+        var handedOff = false
 
         try {
             val mediaSession =
@@ -191,10 +192,9 @@ class MediaSessionPool(
                         setId(id)
                         setCallback(globalCallback)
                     }.build()
-            session = mediaSession
 
             val listener = MediaSessionExoPlayerConnector(mediaSession, this)
-            connector = listener
+            entry = SessionListener(mediaSession, listener)
 
             mediaSession.player.addListener(listener)
 
@@ -207,16 +207,19 @@ class MediaSessionPool(
             // notification opens the originating nostr URI.
             bindSessionActivity(mediaSession, mediaSession.player.currentMediaItem)
 
-            registry.register(mediaSession.id, SessionListener(mediaSession, listener))
+            // Past this point the registry owns the session. register() inserts the entry before
+            // it can fire an eviction's onDropped, so even if register() itself throws (a
+            // displaced entry's retire failing), the new entry is already registered and a later
+            // sweep retires it — the catch must not also return this player, which would
+            // double-return it.
+            handedOff = true
+            registry.register(mediaSession.id, entry)
 
             return mediaSession
         } catch (e: Throwable) {
-            // Unwind in reverse. releasePlayerAsync only *queues* the return, so the session and
-            // listener are detached synchronously before the queued release ever runs — same
-            // rationale as the ordering inside retireSession.
-            exoPlayerPool.releasePlayerAsync(player)
-            connector?.let { player.removeListener(it) }
-            session?.release()
+            if (!handedOff) {
+                entry?.let { retireSession(it) } ?: exoPlayerPool.releasePlayerAsync(player)
+            }
             throw e
         }
     }
@@ -237,14 +240,13 @@ class MediaSessionPool(
     }
 
     fun releaseSession(session: MediaSession) {
-        // The registry removes the entry and then signals; retireSession does the teardown.
-        // Nothing here depends on a cache removal firing a callback — that dependency is what
-        // stranded players whose entry had already been evicted while playing.
+        // The registry removes the entry and then signals; retireSession does the teardown —
+        // explicitly, whether the session is idle or playing, never by relying on a cache
+        // removal firing a callback (a no-op once the entry was evicted while playing).
         //
-        // Unlike the old code this does NOT release the session when the id is unknown. Not in the
-        // registry means already retired (retireSession released it) or never owned, so releasing
-        // again would be exactly the double-release being removed here. newSession's failure path
-        // produces such a session.
+        // An unknown id drops nothing: not in the registry means already retired (retireSession
+        // released it) or never owned (newSession's failure path), and releasing such a session
+        // again would be a double-release.
         registry.drop(session.id)
         cleanupUnused()
     }
@@ -265,14 +267,17 @@ class MediaSessionPool(
     }
 
     fun destroy() {
-        // Synchronous: retireSession uses the non-suspending releasePlayerAsync, so no coroutine
-        // is needed here. Ordering still holds — releasePlayerAsync and ExoPlayerPool.destroy()
-        // both launch on ExoPlayerPool's single main-thread scope and serialize on its one Mutex,
-        // so queued returns run first. The old version launched its teardown and then cancelled
-        // the scope on the same frame, so the teardown never ran at all.
-        registry.dropAll()
-        exoPlayerPool.destroy()
-        scope.cancel()
+        // Synchronous on purpose: retireSession uses the non-suspending releasePlayerAsync, and
+        // releasePlayerAsync's contract guarantees returns queued here run before the pool's own
+        // teardown — so every player is back before exoPlayerPool.destroy() sweeps.
+        try {
+            registry.dropAll()
+        } finally {
+            // The player pool must tear down even if a retire throws mid-sweep; skipping it
+            // would leak every pooled player, not just the session that failed.
+            exoPlayerPool.destroy()
+            scope.cancel()
+        }
     }
 
     fun getSession(
@@ -288,9 +293,7 @@ class MediaSessionPool(
 
     fun playingContent() = registry.playingEntries()
 
-    // Widened from cache-only to cache-or-playing. Inert at its only caller
-    // (PlaybackService.onUpdateNotification), which is inside a `playing.isEmpty()` branch
-    // covering both pools, so no session is playing when it runs.
+    // Resolves the session whether it is idle or playing.
     fun getSession(id: String) = registry.get(id)?.session
 
     class MediaSessionCallback(
@@ -322,10 +325,9 @@ class MediaSessionPool(
         val pool: MediaSessionPool,
     ) : Player.Listener {
         override fun onIsPlayingChanged(isPlaying: Boolean) {
-            // Moves the existing entry. Allocating a fresh SessionListener here (the old
-            // behaviour) meant one session could have two or three live wrappers at once, so a
-            // drop of one could hand its player back while another still pointed at that live
-            // session.
+            // Moves the one existing entry between tiers. A session must never have more than
+            // one live wrapper: dropping one wrapper would hand the player back while another
+            // still pointed at the live session.
             pool.setPlaying(mediaSession.id, isPlaying)
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/MediaSessionPool.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/MediaSessionPool.kt
@@ -25,7 +25,6 @@ package com.vitorpamplona.amethyst.service.playback.playerPool
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.util.LruCache
 import androidx.annotation.OptIn
 import androidx.core.net.toUri
 import androidx.media3.common.MediaItem
@@ -46,12 +45,17 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 
 class SessionListener(
     val session: MediaSession,
     val playerListener: Player.Listener,
 ) {
+    // Set once, by the retire funnel. Guards the re-entrant path session.release() ->
+    // onDisconnected -> releaseSession -> registry.drop() landing on this same entry.
+    val retired = AtomicBoolean(false)
+
     fun removeListeners() {
         session.player.removeListener(playerListener)
     }
@@ -123,28 +127,38 @@ class MediaSessionPool(
         return if (resolved > 0) resolved else (DEFAULT_METADATA_BITMAP_DP * resources.displayMetrics.density).toInt()
     }
 
-    // protects from LruCache killing playing sessions
-    private val playingMap = mutableMapOf<String, SessionListener>()
-
-    private val cache =
-        object : LruCache<String, SessionListener>(maxSessions.coerceIn(1, MAX_CACHED_SESSIONS)) {
-            override fun entryRemoved(
-                evicted: Boolean,
-                key: String?,
-                oldValue: SessionListener?,
-                newValue: SessionListener?,
-            ) {
-                super.entryRemoved(evicted, key, oldValue, newValue)
-
-                if (!playingMap.contains(key)) {
-                    oldValue?.let { pair ->
-                        pair.removeListeners()
-                        exoPlayerPool.releasePlayerAsync(pair.session.player as ExoPlayer)
-                        pair.session.release()
-                    }
-                }
-            }
+    private val registry =
+        SessionRegistry<SessionListener>(maxSessions.coerceIn(1, MAX_CACHED_SESSIONS)) { entry ->
+            retireSession(entry)
         }
+
+    /**
+     * The one place a session's player goes back to the pool.
+     *
+     * The CAS is not redundant even though [SessionRegistry] signals each drop exactly once:
+     * session.release() below can reach onDisconnected -> releaseSession -> registry.drop() on
+     * the same entry, and that re-entrant path is what the guard stops. Do not remove it.
+     *
+     * Both orderings below are load-bearing, not tidiness:
+     * - removeListeners() before release(), because releasing a session can fire
+     *   onIsPlayingChanged, which would re-enter setPlaying while we are still inside
+     *   the registry's entryRemoved callback.
+     * - releasePlayerAsync() before release(), so a throw from session teardown cannot
+     *   strand the player.
+     */
+    private fun retireSession(entry: SessionListener) {
+        if (!entry.retired.compareAndSet(false, true)) return
+        entry.removeListeners()
+        exoPlayerPool.releasePlayerAsync(entry.session.player as ExoPlayer)
+        entry.session.release()
+    }
+
+    internal fun setPlaying(
+        id: String,
+        isPlaying: Boolean,
+    ) {
+        registry.setPlaying(id, isPlaying)
+    }
 
     @OptIn(UnstableApi::class)
     fun newSession(
@@ -156,31 +170,55 @@ class MediaSessionPool(
         // is reused so the populated buffer survives. Null falls back to a cold acquire.
         preferredMediaId: String?,
     ): MediaSession {
-        val mediaSession =
-            MediaSession
-                .Builder(context, exoPlayerPool.acquirePlayer(context, preferredMediaId))
-                .apply {
-                    setBitmapLoader(sharedBitmapLoader)
-                    setId(id)
-                    setCallback(globalCallback)
-                }.build()
+        val player = exoPlayerPool.acquirePlayer(context, preferredMediaId)
 
-        val listener = MediaSessionExoPlayerConnector(mediaSession, this)
+        // newSession owns the player until registry.register() hands ownership over. Anything that
+        // throws in between — MediaSession.Builder.build(), reset(), or the PendingIntent in
+        // bindSessionActivity() — would otherwise strand a counted player with no owner.
+        //
+        // The throw sites named above are all *after* the session exists, so returning the player
+        // alone is not enough: a live MediaSession bound to it, and a listener attached to it,
+        // must come off first, or the pool re-issues a player that something else still holds.
+        var session: MediaSession? = null
+        var connector: MediaSessionExoPlayerConnector? = null
 
-        mediaSession.player.addListener(listener)
+        try {
+            val mediaSession =
+                MediaSession
+                    .Builder(context, player)
+                    .apply {
+                        setBitmapLoader(sharedBitmapLoader)
+                        setId(id)
+                        setCallback(globalCallback)
+                    }.build()
+            session = mediaSession
 
-        reset(mediaSession, keepPlaying)
+            val listener = MediaSessionExoPlayerConnector(mediaSession, this)
+            connector = listener
 
-        // Warm-pool fast path acquires a player that still holds its MediaItem, so the
-        // client side skips setMediaItem (see GetVideoController) and onAddMediaItems
-        // never fires for this fresh session — leaving the notification's tap target
-        // unset. Re-bind it from the player's current item so tapping the playback
-        // notification opens the originating nostr URI.
-        bindSessionActivity(mediaSession, mediaSession.player.currentMediaItem)
+            mediaSession.player.addListener(listener)
 
-        cache.put(mediaSession.id, SessionListener(mediaSession, listener))
+            reset(mediaSession, keepPlaying)
 
-        return mediaSession
+            // Warm-pool fast path acquires a player that still holds its MediaItem, so the
+            // client side skips setMediaItem (see GetVideoController) and onAddMediaItems
+            // never fires for this fresh session — leaving the notification's tap target
+            // unset. Re-bind it from the player's current item so tapping the playback
+            // notification opens the originating nostr URI.
+            bindSessionActivity(mediaSession, mediaSession.player.currentMediaItem)
+
+            registry.register(mediaSession.id, SessionListener(mediaSession, listener))
+
+            return mediaSession
+        } catch (e: Throwable) {
+            // Unwind in reverse. releasePlayerAsync only *queues* the return, so the session and
+            // listener are detached synchronously before the queued release ever runs — same
+            // rationale as the ordering inside retireSession.
+            exoPlayerPool.releasePlayerAsync(player)
+            connector?.let { player.removeListener(it) }
+            session?.release()
+            throw e
+        }
     }
 
     fun bindSessionActivity(
@@ -199,14 +237,15 @@ class MediaSessionPool(
     }
 
     fun releaseSession(session: MediaSession) {
-        val listener = playingMap.get(session.id) ?: cache.get(session.id)
-        if (listener != null) {
-            session.player.removeListener(listener.playerListener)
-        }
-
-        playingMap.remove(session.id)
-        cache.remove(session.id)
-        session.release()
+        // The registry removes the entry and then signals; retireSession does the teardown.
+        // Nothing here depends on a cache removal firing a callback — that dependency is what
+        // stranded players whose entry had already been evicted while playing.
+        //
+        // Unlike the old code this does NOT release the session when the id is unknown. Not in the
+        // registry means already retired (retireSession released it) or never owned, so releasing
+        // again would be exactly the double-release being removed here. newSession's failure path
+        // produces such a session.
+        registry.drop(session.id)
         cleanupUnused()
     }
 
@@ -217,8 +256,7 @@ class MediaSessionPool(
         // CAS so only one caller actually launches the sweep when many releases fire at once.
         if (!lastCleanupNs.compareAndSet(previous, now)) return
         scope.launch {
-            val snap = cache.snapshot()
-            snap.values.forEach {
+            registry.idleSnapshot().forEach {
                 if (it.session.connectedControllers.isEmpty()) {
                     releaseSession(it.session)
                 }
@@ -227,16 +265,12 @@ class MediaSessionPool(
     }
 
     fun destroy() {
-        scope.launch {
-            cache.evictAll()
-            playingMap.forEach {
-                it.value.removeListeners()
-                exoPlayerPool.releasePlayer(it.value.session.player as ExoPlayer)
-                it.value.session.release()
-            }
-            playingMap.clear()
-        }
-
+        // Synchronous: retireSession uses the non-suspending releasePlayerAsync, so no coroutine
+        // is needed here. Ordering still holds — releasePlayerAsync and ExoPlayerPool.destroy()
+        // both launch on ExoPlayerPool's single main-thread scope and serialize on its one Mutex,
+        // so queued returns run first. The old version launched its teardown and then cancelled
+        // the scope on the same frame, so the teardown never ran at all.
+        registry.dropAll()
         exoPlayerPool.destroy()
         scope.cancel()
     }
@@ -247,17 +281,17 @@ class MediaSessionPool(
         context: Context,
         preferredMediaId: String? = null,
     ): MediaSession {
-        val existingSession = playingMap.get(id) ?: cache.get(id)
-        if (existingSession != null) {
-            return existingSession.session
-        }
+        registry.get(id)?.let { return it.session }
 
         return newSession(id, keepPlaying, context, preferredMediaId)
     }
 
-    fun playingContent() = playingMap.values
+    fun playingContent() = registry.playingEntries()
 
-    fun getSession(id: String) = cache.get(id)?.session
+    // Widened from cache-only to cache-or-playing. Inert at its only caller
+    // (PlaybackService.onUpdateNotification), which is inside a `playing.isEmpty()` branch
+    // covering both pools, so no session is playing when it runs.
+    fun getSession(id: String) = registry.get(id)?.session
 
     class MediaSessionCallback(
         val pool: MediaSessionPool,
@@ -288,12 +322,11 @@ class MediaSessionPool(
         val pool: MediaSessionPool,
     ) : Player.Listener {
         override fun onIsPlayingChanged(isPlaying: Boolean) {
-            if (isPlaying) {
-                pool.playingMap.put(mediaSession.id, SessionListener(mediaSession, this))
-            } else {
-                pool.cache.put(mediaSession.id, SessionListener(mediaSession, this))
-                pool.playingMap.remove(mediaSession.id)
-            }
+            // Moves the existing entry. Allocating a fresh SessionListener here (the old
+            // behaviour) meant one session could have two or three live wrappers at once, so a
+            // drop of one could hand its player back while another still pointed at that live
+            // session.
+            pool.setPlaying(mediaSession.id, isPlaying)
         }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/SessionRegistry.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/SessionRegistry.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.playback.playerPool
+
+import androidx.collection.LruCache
+
+/**
+ * Owns which sessions are reachable, and is the only place that decides one has been dropped.
+ *
+ * Two tiers: an LRU of idle entries and a map of ids that are currently playing. A playing entry
+ * stays in [idle] as well — [playing] only makes an eviction non-dropping. That is deliberate: it
+ * matches today's behaviour exactly (a playing session keeps consuming a cache slot until it ages
+ * out), and it is what keeps the replacement guard in [entryRemoved] load-bearing rather than dead
+ * code.
+ *
+ * Generic over the entry type so the bookkeeping — the part that has actually been wrong — is unit
+ * testable on the JVM with no Android or media3 objects involved.
+ *
+ * Uses `androidx.collection.LruCache` rather than `android.util.LruCache`: the latter is stubbed
+ * out under `unitTests.isReturnDefaultValues = true`, which would make every test here vacuous.
+ * The contract is otherwise identical, including `entryRemoved` firing outside the lock.
+ *
+ * Not thread safe. Every caller runs on the main thread (see MediaSessionPool).
+ */
+internal class SessionRegistry<T : Any>(
+    maxIdle: Int,
+    private val onDropped: (T) -> Unit,
+) {
+    private val playing = mutableMapOf<String, T>()
+
+    // Set while an explicit drop is tearing an entry out of [idle], so the resulting entryRemoved
+    // callback doesn't signal a second time for the same drop.
+    //
+    // Resetting to false in `finally` (rather than restoring a saved value) is sound because the
+    // guarded region cannot nest: onDropped is never invoked while the flag is set, so nothing
+    // inside it can re-enter drop()/dropAll(). That non-nesting property is the invariant — not
+    // single-threadedness — and a future edit that called onDropped inside the guarded region
+    // would break it.
+    private var suppressDropSignal = false
+
+    private val idle =
+        object : LruCache<String, T>(maxIdle) {
+            override fun entryRemoved(
+                evicted: Boolean,
+                key: String,
+                oldValue: T,
+                newValue: T?,
+            ) {
+                // A replacement is not a drop: re-putting the same entry (pause -> idle) fires this
+                // with newValue === oldValue, and retiring then would kill the session we are
+                // keeping. `newValue == null` needs no separate test — V is non-null by type, so a
+                // null newValue can never be identical to oldValue.
+                if (suppressDropSignal) return
+                if (newValue !== oldValue && !playing.containsKey(key)) onDropped(oldValue)
+            }
+        }
+
+    fun register(
+        id: String,
+        entry: T,
+    ) {
+        idle.put(id, entry)
+    }
+
+    fun setPlaying(
+        id: String,
+        isPlaying: Boolean,
+    ) {
+        val entry = get(id) ?: return
+        if (isPlaying) {
+            playing[id] = entry
+        } else {
+            // Re-inserts if it was evicted from idle while playing. Must happen before the playing
+            // entry is cleared, so the eviction this put may trigger still sees the pin.
+            idle.put(id, entry)
+            playing.remove(id)
+        }
+    }
+
+    fun get(id: String): T? = playing[id] ?: idle.get(id)
+
+    fun idleSnapshot(): List<T> = idle.snapshot().values.toList()
+
+    // Copies, like idleSnapshot(). Handing out playing.values would be a live view, and a caller
+    // that iterated it while a drop fired would get a ConcurrentModificationException. A type whose
+    // job is owning reachability should not ship that footgun.
+    fun playingEntries(): List<T> = playing.values.toList()
+
+    /**
+     * Explicit release. Drops whether or not the session is playing, and does not rely on
+     * [idle]'s removal firing the callback — that reliance is the leak, because it silently does
+     * nothing when the entry was already evicted while playing.
+     */
+    fun drop(id: String): T? {
+        val entry = playing.remove(id) ?: idle.get(id) ?: return null
+        suppressDropSignal = true
+        try {
+            idle.remove(id)
+        } finally {
+            suppressDropSignal = false
+        }
+        onDropped(entry)
+        return entry
+    }
+
+    /** Teardown sweep: every reachable entry is dropped exactly once, playing or idle. */
+    fun dropAll() {
+        val all = ArrayList<T>()
+        playing.values.forEach { entry -> if (all.none { it === entry }) all.add(entry) }
+        idle.snapshot().values.forEach { entry -> if (all.none { it === entry }) all.add(entry) }
+
+        playing.clear()
+        suppressDropSignal = true
+        try {
+            idle.evictAll()
+        } finally {
+            suppressDropSignal = false
+        }
+
+        all.forEach(onDropped)
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/SessionRegistry.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/playback/playerPool/SessionRegistry.kt
@@ -97,9 +97,10 @@ internal class SessionRegistry<T : Any>(
 
     fun get(id: String): T? = playing[id] ?: idle.get(id)
 
-    fun idleSnapshot(): List<T> = idle.snapshot().values.toList()
+    // snapshot() already materializes a detached map, so its values need no second copy.
+    fun idleSnapshot(): Collection<T> = idle.snapshot().values
 
-    // Copies, like idleSnapshot(). Handing out playing.values would be a live view, and a caller
+    // Detached, like idleSnapshot(). Handing out playing.values would be a live view, and a caller
     // that iterated it while a drop fired would get a ConcurrentModificationException. A type whose
     // job is owning reachability should not ship that footgun.
     fun playingEntries(): List<T> = playing.values.toList()
@@ -110,13 +111,15 @@ internal class SessionRegistry<T : Any>(
      * nothing when the entry was already evicted while playing.
      */
     fun drop(id: String): T? {
-        val entry = playing.remove(id) ?: idle.get(id) ?: return null
+        val playingEntry = playing.remove(id)
         suppressDropSignal = true
-        try {
-            idle.remove(id)
-        } finally {
-            suppressDropSignal = false
-        }
+        val idleEntry =
+            try {
+                idle.remove(id)
+            } finally {
+                suppressDropSignal = false
+            }
+        val entry = playingEntry ?: idleEntry ?: return null
         onDropped(entry)
         return entry
     }

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/service/playback/playerPool/SessionRegistryTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/service/playback/playerPool/SessionRegistryTest.kt
@@ -140,7 +140,7 @@ class SessionRegistryTest {
         registry.register("b", "B")
         registry.setPlaying("a", true)
         assertEquals(setOf("A", "B"), registry.idleSnapshot().toSet())
-        assertEquals(listOf("A"), registry.playingEntries().toList())
+        assertEquals(listOf("A"), registry.playingEntries())
     }
 
     // The replacement guard uses !== (identity, not equality). This test pins that distinction:

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/service/playback/playerPool/SessionRegistryTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/service/playback/playerPool/SessionRegistryTest.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.playback.playerPool
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class SessionRegistryTest {
+    private val dropped = mutableListOf<String>()
+
+    private fun registry(maxIdle: Int) = SessionRegistry<String>(maxIdle) { dropped.add(it) }
+
+    @Test
+    fun evictionDropsTheOldestExactlyOnce() {
+        val registry = registry(maxIdle = 1)
+        registry.register("a", "A")
+        registry.register("b", "B")
+        assertEquals(listOf("A"), dropped)
+    }
+
+    @Test
+    fun playingSessionSurvivesEviction() {
+        val registry = registry(maxIdle = 1)
+        registry.register("a", "A")
+        registry.setPlaying("a", true)
+        registry.register("b", "B")
+        assertEquals(emptyList<String>(), dropped)
+    }
+
+    // The replacement guard. setPlaying(false) re-puts the SAME entry, which fires
+    // entryRemoved(newValue === oldValue). Treating that as a drop would retire the
+    // session we are trying to keep.
+    @Test
+    fun pauseDoesNotDropTheSessionItIsKeeping() {
+        val registry = registry(maxIdle = 2)
+        registry.register("a", "A")
+        registry.setPlaying("a", true)
+        registry.setPlaying("a", false)
+        assertEquals(emptyList<String>(), dropped)
+    }
+
+    @Test
+    fun pausedSessionBecomesEvictableAgain() {
+        val registry = registry(maxIdle = 1)
+        registry.register("a", "A")
+        registry.setPlaying("a", true)
+        registry.register("b", "B") // A survives, but leaves idle
+        registry.setPlaying("a", false) // A re-enters idle and displaces B
+        assertEquals(listOf("B"), dropped)
+    }
+
+    // Leak path 2: an explicit release must drop even while playing.
+    @Test
+    fun explicitDropOfPlayingSessionDropsExactlyOnce() {
+        val registry = registry(maxIdle = 2)
+        registry.register("a", "A")
+        registry.setPlaying("a", true)
+        registry.drop("a")
+        assertEquals(listOf("A"), dropped)
+    }
+
+    // Leak path 2, the exact case the old cache.remove(id) missed: already evicted
+    // from idle while playing, so there is no cache entry left to trigger the callback.
+    @Test
+    fun explicitDropAfterEvictionWhilePlayingStillDrops() {
+        val registry = registry(maxIdle = 1)
+        registry.register("a", "A")
+        registry.setPlaying("a", true)
+        registry.register("b", "B")
+        registry.drop("a")
+        assertEquals(listOf("A"), dropped)
+    }
+
+    @Test
+    fun dropAllDropsEveryEntryExactlyOnce() {
+        val registry = registry(maxIdle = 3)
+        registry.register("a", "A")
+        registry.register("b", "B")
+        registry.register("c", "C")
+        registry.setPlaying("b", true)
+        registry.dropAll()
+        assertEquals(3, dropped.size)
+        assertEquals(setOf("A", "B", "C"), dropped.toSet())
+    }
+
+    @Test
+    fun dropAllIncludesSessionEvictedWhilePlaying() {
+        val registry = registry(maxIdle = 1)
+        registry.register("a", "A")
+        registry.setPlaying("a", true)
+        registry.register("b", "B")
+        registry.dropAll()
+        assertEquals(2, dropped.size)
+        assertEquals(setOf("A", "B"), dropped.toSet())
+    }
+
+    @Test
+    fun getFindsPlayingAndIdleEntries() {
+        val registry = registry(maxIdle = 2)
+        registry.register("a", "A")
+        registry.register("b", "B")
+        registry.setPlaying("a", true)
+        assertSame("A", registry.get("a"))
+        assertSame("B", registry.get("b"))
+        assertNull(registry.get("missing"))
+    }
+
+    @Test
+    fun droppingUnknownIdIsANoOp() {
+        val registry = registry(maxIdle = 2)
+        assertNull(registry.drop("missing"))
+        assertEquals(emptyList<String>(), dropped)
+    }
+
+    @Test
+    fun enumerationSeesIdleAndPlayingSeparately() {
+        val registry = registry(maxIdle = 2)
+        registry.register("a", "A")
+        registry.register("b", "B")
+        registry.setPlaying("a", true)
+        assertEquals(setOf("A", "B"), registry.idleSnapshot().toSet())
+        assertEquals(listOf("A"), registry.playingEntries().toList())
+    }
+
+    // The replacement guard uses !== (identity, not equality). This test pins that distinction:
+    // replacing an entry with an equal-but-not-identical instance must drop the old one.
+    // Changing !== to != would break this test, even though all existing tests would pass.
+    @Test
+    fun replacementWithEqualButDifferentInstanceDropsOldEntry() {
+        val registry = registry(maxIdle = 2)
+        val original = "A"
+        registry.register("a", original)
+
+        // Create a new String instance that is equal to but not identical to the original.
+        // String literals are interned, so we must construct it explicitly.
+        val replacement = buildString { append("A") }
+        assertEquals("Equal values", original, replacement)
+        assertNotSame("Not the same instance", original, replacement)
+
+        // Registering the replacement should drop the original.
+        registry.register("a", replacement)
+        assertEquals(listOf(original), dropped)
+    }
+}


### PR DESCRIPTION
You may want to review this. This was flagged during a different code review. It was reproduced using diagnostics logs and verified using diagnostics logs. I didn't see any issue directly on device (not easy since it's about internal media pool).

## Problem

`ExoPlayerPool.liveDecoders` (a process-wide `AtomicInteger` added in #3667) bounds concurrent `MediaCodec` instances: `ensureDecoderHeadroom` demotes warm players until the count is under `poolSize`. The counter is only correct if every acquired player is returned — and it wasn't. Players were handed out and never returned on several paths, so the count drifted upward and never came back down. Once it reached `poolSize`, `ensureDecoderHeadroom` evicted *every* warm player on *every* acquire, silently disabling the scroll-back warm cache that #2584 exists to provide, for the rest of the process lifetime.

Three leak paths, all closed here: `MediaSessionPool.destroy()` launched its teardown coroutine and then cancelled the scope on the same main-thread frame, so the teardown never ran; `releaseSession()` relied on `cache.remove(id)` firing `entryRemoved` to return the player, a no-op when the LRU had already evicted that entry while it was playing; and the acquire→register window in `newSession` was unowned, so a throw between `acquirePlayer` and registration stranded a counted player.

## Fix

Make `MediaSessionPool` the single owner of record, so every acquired player is provably returned; the counter then balances as a consequence rather than being an independent tally that drifts.

- **`SessionRegistry`** (new) owns which sessions are reachable and is the one place that decides a session was dropped. It's generic over the entry type with no Android/media3 dependency, so the bookkeeping — the part that was actually wrong — is unit-testable on the JVM (12 tests, including the identity-vs-equality drop guard and both explicit-drop leak paths).
- **`MediaSessionPool`** routes every drop through one idempotent `retireSession` funnel wired as the registry's `onDropped`; `destroy()` is now synchronous; and `onIsPlayingChanged` stops allocating a fresh `SessionListener` per play/pause toggle, which previously let one session hold several live wrappers and made dropping one a use-after-release for the others.
- **`ExoPlayerPool`** counts a decoder only after the player is built (a throw from `builder.build()` no longer leaves a phantom count), floors every decrement (an under-count is the harmful direction — it lets `ensureDecoderHeadroom` exceed the device ceiling and produces `MediaCodec` `NO_MEMORY`), and turns the teardown reset into a drift *detector* that warns rather than silently correcting.

## Testing

`SessionRegistry` has 12 JVM unit tests covering eviction, the playing-survives-eviction rule, the pause replacement guard, both explicit-drop leak paths, `dropAll`, and a mutation test pinning the referential-identity guard. Full `./gradlew test` green (run serially — the parallel build OOMs the Kotlin daemon on this repo regardless of branch).

On-device (Pixel 9a, this device advertises a 16-decoder budget): the counter balances over a real 23-acquire session — oscillates 1↔8 and returns downward every time rather than ratcheting up — with 9 warm hits including late in the session, zero drift warnings, and zero crashes across all playback (including the known-bad `nogoodradio` zap.stream feed, which surfaces its usual playback-failed overlay and fails identically in the release client, per #3607 — not a client bug).

Not reproducible on this device, stated honestly: `destroy()`'s sweep returning the counter to 0 with sessions checked out. The 16-decoder budget means the eviction boundary isn't reachable by hand, and the started+bound `MediaSessionService` only dies with the process, which resets the process-static counter for free. That path's correctness rests on review of the synchronous teardown rather than device observation.

## License

- [ ] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
