### PR TITLE
Fix race condition in NIP-01 compliance test with concurrent relays

### DIFF
--- a/geode/src/test/kotlin/com/vitorpamplona/geode/Nip01ComplianceTest.kt
+++ b/geode/src/test/kotlin/com/vitorpamplona/geode/Nip01ComplianceTest.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -518,8 +519,13 @@ class Nip01ComplianceTest : RelayClientTest() {
             hub.getOrCreate(relayA).preload(fakeEvent(1, kind = 1, content = "from-a"))
             hub.getOrCreate(relayB).preload(fakeEvent(2, kind = 1, content = "from-b"))
 
-            val received = mutableMapOf<NormalizedRelayUrl, String>()
-            val eosed = mutableSetOf<NormalizedRelayUrl>()
+            // Each relay delivers its EVENT/EOSE on its own InProcessWebSocket
+            // scope, so these callbacks fire concurrently from two threads. The
+            // shared collections MUST be thread-safe — a plain HashMap loses a
+            // write when both threads put during a rehash, leaving a relay's
+            // entry null and flaking the assertions below.
+            val received = ConcurrentHashMap<NormalizedRelayUrl, String>()
+            val eosed = ConcurrentHashMap.newKeySet<NormalizedRelayUrl>()
             val ch = Channel<Unit>(UNLIMITED)
             client.subscribe(
                 "multi-1",


### PR DESCRIPTION
## Summary

Replace mutable `HashMap` and `HashSet` with thread-safe `ConcurrentHashMap` and `ConcurrentHashMap.newKeySet()` in the multi-relay test. The test spawns concurrent callbacks from multiple relay threads that write to shared collections; plain `HashMap` can lose writes during rehash, causing flaky assertions.

## Test plan

- [x] Ran `./gradlew test` — `Nip01ComplianceTest` passes consistently
- [x] Ran the specific test multiple times to verify the race condition is fixed

The change is minimal and surgical: only the collection types change, not the test logic. The concurrent access pattern was already present; we're just making the collections thread-safe to match the actual concurrency model.

## Interop suites

- [x] N/A — change is test-only, affects no wire bytes or protocol behavior

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01HeAjLDNBvGPjb5bfViU3ad