### PR TITLE
Fix GC-dependent flaky test in LargeCacheAddressableFilterTest

### DIFF
--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/model/LargeCacheAddressableFilterTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/model/LargeCacheAddressableFilterTest.kt
@@ -28,60 +28,53 @@ import org.junit.Test
 
 class LargeCacheAddressableFilterTest {
     companion object {
-        // LargeSoftCache stores values as WeakReferences, so the cache alone does not
-        // keep the mock notes alive. Without a strong referent they are cleared at the
-        // next GC and every query returns 0 — an order/GC-dependent flake. Hold the notes
-        // strongly here for the lifetime of the test class.
-        private val strongRefs = mutableListOf<AddressableNote>()
-
-        fun LargeSoftCache<Address, AddressableNote>.addMock(
+        fun mock(
             kind: Int,
             pubkey: HexKey,
             dTag: String = "",
-        ) {
-            val address = Address(kind, pubkey, dTag)
-            val note = AddressableNote(address)
-            strongRefs.add(note)
-            put(address, note)
-        }
+        ) = AddressableNote(Address(kind, pubkey, dTag))
+
+        // LargeSoftCache stores values as WeakReferences, so the cache alone does not keep
+        // the mock notes alive. Without a strong referent they are cleared at the next GC
+        // and every query returns 0 — an order/GC-dependent flake. This list is the fixture's
+        // source of truth and holds them strongly for the lifetime of the test class.
+        val notes =
+            listOf(
+                mock(32000, "0b6d941c46411a95edb1c93da7ad6ca26370497d8c7b7d621f5cb59f48841bad"),
+                mock(32000, "6dd3b72e325da7383b275eef1c66131ba4664326e162bc060527509b4e33ae43"),
+                mock(32000, "3064bf97800a4b04b612fc0fd498936eae75fffbdca5bbd09d19a6dc598530ab"),
+                mock(32000, "f8ff11c7a7d3478355d3b4d174e5a473797a906ea4aa61aa9b6bc0652c1ea17a"),
+                mock(32001, "0b6d941c46411a95edb1c93da7ad6ca26370497d8c7b7d621f5cb59f48841bad"),
+                mock(32001, "0b6d941c46411a95edb1c93da7ad6ca26370497d8c7b7d621f5cb59f48841bad", "a"),
+                mock(32001, "0b6d941c46411a95edb1c93da7ad6ca26370497d8c7b7d621f5cb59f48841bad", "z"),
+                mock(32001, "0b6d941c46411a95edb1c93da7ad6ca26370497d8c7b7d621f5cb59f48841bad", "askldfjaljksdflkaj"),
+                mock(32001, "6dd3b72e325da7383b275eef1c66131ba4664326e162bc060527509b4e33ae43"),
+                mock(32001, "3064bf97800a4b04b612fc0fd498936eae75fffbdca5bbd09d19a6dc598530ab"),
+                mock(32001, "f8ff11c7a7d3478355d3b4d174e5a473797a906ea4aa61aa9b6bc0652c1ea17a"),
+                mock(32002, "0b6d941c46411a95edb1c93da7ad6ca26370497d8c7b7d621f5cb59f48841bad"),
+                mock(32002, "6dd3b72e325da7383b275eef1c66131ba4664326e162bc060527509b4e33ae43"),
+                mock(32002, "3064bf97800a4b04b612fc0fd498936eae75fffbdca5bbd09d19a6dc598530ab"),
+                mock(32002, "f8ff11c7a7d3478355d3b4d174e5a473797a906ea4aa61aa9b6bc0652c1ea17a"),
+                mock(32003, "0b6d941c46411a95edb1c93da7ad6ca26370497d8c7b7d621f5cb59f48841bad"),
+                mock(32003, "6dd3b72e325da7383b275eef1c66131ba4664326e162bc060527509b4e33ae43"),
+                mock(32003, "3064bf97800a4b04b612fc0fd498936eae75fffbdca5bbd09d19a6dc598530ab"),
+                mock(32003, "f8ff11c7a7d3478355d3b4d174e5a473797a906ea4aa61aa9b6bc0652c1ea17a"),
+            )
 
         val cache =
             LargeSoftCache<Address, AddressableNote>().apply {
-                addMock(32000, "0b6d941c46411a95edb1c93da7ad6ca26370497d8c7b7d621f5cb59f48841bad")
-                addMock(32000, "6dd3b72e325da7383b275eef1c66131ba4664326e162bc060527509b4e33ae43")
-                addMock(32000, "3064bf97800a4b04b612fc0fd498936eae75fffbdca5bbd09d19a6dc598530ab")
-                addMock(32000, "f8ff11c7a7d3478355d3b4d174e5a473797a906ea4aa61aa9b6bc0652c1ea17a")
-
-                addMock(32001, "0b6d941c46411a95edb1c93da7ad6ca26370497d8c7b7d621f5cb59f48841bad")
-                addMock(32001, "0b6d941c46411a95edb1c93da7ad6ca26370497d8c7b7d621f5cb59f48841bad", "a")
-                addMock(32001, "0b6d941c46411a95edb1c93da7ad6ca26370497d8c7b7d621f5cb59f48841bad", "z")
-                addMock(32001, "0b6d941c46411a95edb1c93da7ad6ca26370497d8c7b7d621f5cb59f48841bad", "askldfjaljksdflkaj")
-                addMock(32001, "6dd3b72e325da7383b275eef1c66131ba4664326e162bc060527509b4e33ae43")
-                addMock(32001, "3064bf97800a4b04b612fc0fd498936eae75fffbdca5bbd09d19a6dc598530ab")
-                addMock(32001, "f8ff11c7a7d3478355d3b4d174e5a473797a906ea4aa61aa9b6bc0652c1ea17a")
-
-                addMock(32002, "0b6d941c46411a95edb1c93da7ad6ca26370497d8c7b7d621f5cb59f48841bad")
-                addMock(32002, "6dd3b72e325da7383b275eef1c66131ba4664326e162bc060527509b4e33ae43")
-                addMock(32002, "3064bf97800a4b04b612fc0fd498936eae75fffbdca5bbd09d19a6dc598530ab")
-                addMock(32002, "f8ff11c7a7d3478355d3b4d174e5a473797a906ea4aa61aa9b6bc0652c1ea17a")
-
-                addMock(32003, "0b6d941c46411a95edb1c93da7ad6ca26370497d8c7b7d621f5cb59f48841bad")
-                addMock(32003, "6dd3b72e325da7383b275eef1c66131ba4664326e162bc060527509b4e33ae43")
-                addMock(32003, "3064bf97800a4b04b612fc0fd498936eae75fffbdca5bbd09d19a6dc598530ab")
-                addMock(32003, "f8ff11c7a7d3478355d3b4d174e5a473797a906ea4aa61aa9b6bc0652c1ea17a")
+                notes.forEach { put(it.address, it) }
             }
     }
 
     @Test
     fun survivesGarbageCollection() {
         // Regression guard for the flaky-fixture root cause: the mock notes must stay
-        // reachable across a GC. Before the strong-reference fix, WeakReference-backed
+        // reachable across a GC. Before `notes` held them strongly, the WeakReference-backed
         // entries were cleared here and every query returned 0.
         System.gc()
-        System.gc()
-        Runtime.getRuntime().freeMemory()
 
-        assertEquals(19, cache.filterIntoSet(listOf(32_000, 32_001, 32_002, 32_003)).size)
+        assertEquals(notes.size, cache.filterIntoSet(listOf(32_000, 32_001, 32_002, 32_003)).size)
     }
 
     @Test

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/model/LargeCacheAddressableFilterTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/model/LargeCacheAddressableFilterTest.kt
@@ -28,13 +28,21 @@ import org.junit.Test
 
 class LargeCacheAddressableFilterTest {
     companion object {
+        // LargeSoftCache stores values as WeakReferences, so the cache alone does not
+        // keep the mock notes alive. Without a strong referent they are cleared at the
+        // next GC and every query returns 0 — an order/GC-dependent flake. Hold the notes
+        // strongly here for the lifetime of the test class.
+        private val strongRefs = mutableListOf<AddressableNote>()
+
         fun LargeSoftCache<Address, AddressableNote>.addMock(
             kind: Int,
             pubkey: HexKey,
             dTag: String = "",
         ) {
             val address = Address(kind, pubkey, dTag)
-            put(address, AddressableNote(address))
+            val note = AddressableNote(address)
+            strongRefs.add(note)
+            put(address, note)
         }
 
         val cache =
@@ -62,6 +70,18 @@ class LargeCacheAddressableFilterTest {
                 addMock(32003, "3064bf97800a4b04b612fc0fd498936eae75fffbdca5bbd09d19a6dc598530ab")
                 addMock(32003, "f8ff11c7a7d3478355d3b4d174e5a473797a906ea4aa61aa9b6bc0652c1ea17a")
             }
+    }
+
+    @Test
+    fun survivesGarbageCollection() {
+        // Regression guard for the flaky-fixture root cause: the mock notes must stay
+        // reachable across a GC. Before the strong-reference fix, WeakReference-backed
+        // entries were cleared here and every query returned 0.
+        System.gc()
+        System.gc()
+        Runtime.getRuntime().freeMemory()
+
+        assertEquals(19, cache.filterIntoSet(listOf(32_000, 32_001, 32_002, 32_003)).size)
     }
 
     @Test


### PR DESCRIPTION
I haven't seen the flakiness on CI but locally it was failing 50%

| Branch | Full-suite runs | Outcome |
|---|---|---|
| main (`94210d202d`) | 4 | 🔴🟢🔴🟢 — intermittent, ~50% here |
| fix (`c5055d28e5`) | 5 | 🟢🟢🟢🟢🟢 — stable |

## Summary

`LargeCacheAddressableFilterTest` is intermittently flaky: it passes in isolation but fails in the full `:amethyst:testPlayDebugUnitTest` run with `expected:<N> but was:<0>` on every assertion. The failure is in the test's own fixture, not the code under test.

`LargeSoftCache` stores values as `WeakReference`, so the cache alone does not keep the mock `AddressableNote`s alive. The fixture builds each note inside `addMock` and holds no strong referent anywhere, so as soon as the `apply { }` initializer returns the notes are only weakly reachable. Any GC between class-load and the test read clears them, and the read methods (which drop entries whose `ref.get() == null`) then return empty sets. Because weak refs are cleared at the next GC regardless of memory pressure, survival depends purely on whether a GC happens to run in that window — hence the order/GC-dependent flakiness.

The fix holds a strong reference to each mock note in a companion-level `strongRefs` list for the lifetime of the test class, so the cache's weak refs can no longer be cleared mid-test. A `survivesGarbageCollection` regression test forces a GC before reading and asserts the entries are still present — it is RED before the fix and GREEN after.

## Test plan

- [x] Reproduced on **pristine, unmodified main**: full `:amethyst:testPlayDebugUnitTest` run with `--rerun` flips between green and 5-failed across repeated runs (~50% locally), matching the exact symptom and line numbers.
- [x] `survivesGarbageCollection` fails deterministically (forced GC) against the old fixture and passes with the fix.
- [x] Full `LargeCacheAddressableFilterTest` class green across 5 consecutive `--rerun` runs on the fix branch.
- [x] Pre-push full test suite passes.

## Interop suites

- [x] N/A — change is test-only, affects no wire bytes or protocol behavior.

## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
