### PR TITLE
fix(nip29): deliver Buzz/NIP-29 channel updates live, and ask before showing channels you were added to

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
@@ -206,6 +206,7 @@ private object PrefKeys {
     const val SIGNER_PACKAGE_NAME = "signer_package_name"
     const val HAS_DONATED_IN_VERSION = "has_donated_in_version"
     const val DISMISSED_POLL_NOTE_IDS = "dismissed_poll_note_ids"
+    const val DISMISSED_CHANNEL_INVITES = "dismissed_channel_invites"
     const val VIEWED_POLL_RESULT_NOTE_IDS = "viewed_poll_result_note_ids"
     const val PENDING_ATTESTATIONS = "pending_attestations"
 
@@ -630,6 +631,7 @@ object LocalPreferences {
                     )
                     putStringSet(PrefKeys.HAS_DONATED_IN_VERSION, settings.hasDonatedInVersion.value)
                     putStringSet(PrefKeys.DISMISSED_POLL_NOTE_IDS, settings.dismissedPollNoteIds.value)
+                    putStringSet(PrefKeys.DISMISSED_CHANNEL_INVITES, settings.dismissedChannelInvites.value)
                     putString(
                         PrefKeys.VIEWED_POLL_RESULT_NOTE_IDS,
                         JsonMapper.toJson(settings.viewedPollResultNoteIds.value),
@@ -744,6 +746,7 @@ object LocalPreferences {
                     val showMessagesInNotifications = getBoolean(PrefKeys.SHOW_MESSAGES_IN_NOTIFICATIONS, true)
                     val hasDonatedInVersion = getStringSet(PrefKeys.HAS_DONATED_IN_VERSION, null) ?: setOf()
                     val dismissedPollNoteIds = getStringSet(PrefKeys.DISMISSED_POLL_NOTE_IDS, null) ?: setOf()
+                    val dismissedChannelInvites = getStringSet(PrefKeys.DISMISSED_CHANNEL_INVITES, null) ?: setOf()
                     val viewedPollResultNoteIdsStr = getString(PrefKeys.VIEWED_POLL_RESULT_NOTE_IDS, null)
                     val localRelayServers = getStringSet(PrefKeys.LOCAL_RELAY_SERVERS, null) ?: setOf()
 
@@ -1000,6 +1003,7 @@ object LocalPreferences {
                         lastReadPerRoute = MutableStateFlow(lastReadPerRouteResolved),
                         hasDonatedInVersion = MutableStateFlow(hasDonatedInVersion),
                         dismissedPollNoteIds = MutableStateFlow(dismissedPollNoteIds),
+                        dismissedChannelInvites = MutableStateFlow(dismissedChannelInvites),
                         viewedPollResultNoteIds = MutableStateFlow(viewedPollResultNoteIdsResolved),
                         pendingAttestations = MutableStateFlow(pendingAttestationsResolved),
                         backupNipA3PaymentTargets = latestPaymentTargetsResolved,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -320,6 +320,12 @@ class AccountSettings(
     val lastReadPerRoute: MutableStateFlow<Map<String, MutableStateFlow<Long>>> = MutableStateFlow(mapOf()),
     val hasDonatedInVersion: MutableStateFlow<Set<String>> = MutableStateFlow(setOf()),
     val dismissedPollNoteIds: MutableStateFlow<Set<String>> = MutableStateFlow(setOf()),
+    /**
+     * Channel ids the viewer chose NOT to show on Messages after somebody added them to the channel
+     * (kind-44100). Local-only: it records a display preference, not membership — the relay roster
+     * still lists you, and Leave (kind 9022) is the separate action that actually removes you.
+     */
+    val dismissedChannelInvites: MutableStateFlow<Set<String>> = MutableStateFlow(setOf()),
     val viewedPollResultNoteIds: MutableStateFlow<Map<String, Long>> = MutableStateFlow(mapOf()),
     val pendingAttestations: MutableStateFlow<Map<HexKey, String>> = MutableStateFlow(mapOf()),
     var backupNipA3PaymentTargets: PaymentTargetsEvent? = null,
@@ -1517,6 +1523,27 @@ class AccountSettings(
             dismissedPollNoteIds.update {
                 it + noteId
             }
+            saveAccountSettings()
+        }
+    }
+
+    // ---
+    // dismissed channel invites (somebody added me to a channel; I don't want it on Messages)
+    // ---
+
+    fun isDismissedChannelInvite(channelId: String) = dismissedChannelInvites.value.contains(channelId)
+
+    fun dismissChannelInvite(channelId: String) {
+        if (!dismissedChannelInvites.value.contains(channelId)) {
+            dismissedChannelInvites.update { it + channelId }
+            saveAccountSettings()
+        }
+    }
+
+    /** Undo a dismissal — used when the viewer accepts the channel after all, so it can re-prompt later. */
+    fun undismissChannelInvite(channelId: String) {
+        if (dismissedChannelInvites.value.contains(channelId)) {
+            dismissedChannelInvites.update { it - channelId }
             saveAccountSettings()
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -27,6 +27,7 @@ import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.commons.cashu.MintDirectoryIndex
 import com.vitorpamplona.amethyst.commons.model.Channel
 import com.vitorpamplona.amethyst.commons.model.OnchainZapStatus
+import com.vitorpamplona.amethyst.commons.model.buzz.BuzzChannelInvites
 import com.vitorpamplona.amethyst.commons.model.buzz.BuzzCommunityMembership
 import com.vitorpamplona.amethyst.commons.model.buzz.BuzzDmRegistry
 import com.vitorpamplona.amethyst.commons.model.buzz.BuzzPresenceState
@@ -2290,6 +2291,22 @@ object LocalCache : ILocalCache, ICacheProvider {
             if (note.event != null) {
                 BuzzWorkspaceStates.getOrCreate(channelId).updateCanvas(note)
             }
+        }
+
+    /**
+     * A kind-44101 "you were removed from a channel". Consumed like any other Buzz event, then used to
+     * withdraw any pending add-prompt for that channel: once the relay has taken the membership away
+     * there is nothing left to accept, so leaving the card up would offer an action that cannot succeed.
+     */
+    private fun consume(
+        event: MemberRemovedNotificationEvent,
+        relay: NormalizedRelayUrl?,
+        wasVerified: Boolean,
+    ): Boolean =
+        consumeBuzzRegularEvent(event, relay, wasVerified).also {
+            val target = event.target() ?: return@also
+            val channelId = event.channel() ?: return@also
+            BuzzChannelInvites.remove(target, channelId)
         }
 
     /**
@@ -4821,7 +4838,7 @@ object LocalCache : ILocalCache, ICacheProvider {
                 is DmAddMemberEvent -> consumeBuzzRegularEvent(event, relay, wasVerified)
                 is DmHideEvent -> consumeBuzzRegularEvent(event, relay, wasVerified)
                 is MemberAddedNotificationEvent -> consumeBuzzRegularEvent(event, relay, wasVerified)
-                is MemberRemovedNotificationEvent -> consumeBuzzRegularEvent(event, relay, wasVerified)
+                is MemberRemovedNotificationEvent -> consume(event, relay, wasVerified)
                 is RelayMembershipListEvent -> consume(event, relay, wasVerified)
                 is RelayAddMemberEvent -> consume(event, relay, wasVerified)
                 is RelayRemoveMemberEvent -> consume(event, relay, wasVerified)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/account/nip01Notifications/AccountNotificationsEoseFromInboxRelaysManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/account/nip01Notifications/AccountNotificationsEoseFromInboxRelaysManager.kt
@@ -20,8 +20,6 @@
  */
 package com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.nip01Notifications
 
-import com.vitorpamplona.amethyst.commons.model.buzz.BuzzDmChannels
-import com.vitorpamplona.amethyst.commons.model.buzz.BuzzDmRegistry
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUserEoseManager
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.AccountQueryState
@@ -29,7 +27,6 @@ import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 import com.vitorpamplona.quartz.nip01Core.relay.client.subscriptions.Subscription
-import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
@@ -84,45 +81,17 @@ class AccountNotificationsEoseFromInboxRelaysManager(
                     )
             }
 
-        // NIP-29 group activity (reactions/replies to my messages) lives on the group's host relay,
-        // not my inbox relays — poll each host relay for those, scoped by `#h` to my joined groups.
-        val groups =
-            key.account.relayGroupList.liveRelayGroupList.value
-                .groupBy({ it.relayUrl }, { it.groupId })
-                .flatMap { (relayUrl, groupIds) ->
-                    val relay = RelayUrlNormalizer.normalizeOrNull(relayUrl) ?: return@flatMap emptyList()
-                    filterGroupNotificationsToPubkey(
-                        relay = relay,
-                        pubkey = user(key).pubkeyHex,
-                        groupIds = groupIds.distinct(),
-                        // Same reasoning as the inbox filters above: `#p` + `#h` + `limit = 200`
-                        // already bound this, so a week floor only hides older group activity.
-                        since = since?.get(relay)?.time ?: pagingBoundary,
-                    )
-                }
-
-        // Buzz DM channels are NOT in the published group list (membership is server-side, tracked in
-        // BuzzDmChannels), so the joined-group query above skips them. Poll each DM host relay the same
-        // way — `#p` = me + `#h` = my DM channels — so a reaction/zap/repost on my DM message surfaces
-        // in notifications, not only as a chip inside the open conversation. Hidden DMs are excluded.
-        val myPubkey = user(key).pubkeyHex
-        val hiddenDms = BuzzDmRegistry.hiddenFor(myPubkey)
-        val dmGroups =
-            BuzzDmChannels
-                .channelsFor(myPubkey)
-                .filterKeys { it !in hiddenDms }
-                .entries
-                .groupBy({ it.value }, { it.key })
-                .flatMap { (relay, channelIds) ->
-                    filterGroupNotificationsToPubkey(
-                        relay = relay,
-                        pubkey = myPubkey,
-                        groupIds = channelIds.distinct(),
-                        since = since?.get(relay)?.time ?: pagingBoundary,
-                    )
-                }
-
-        return inbox + groups + dmGroups
+        // NIP-29 group activity (reactions/replies to my messages) is deliberately NOT requested here.
+        // It lives on the group's host relay and used to be one `#h` filter per relay carrying every
+        // joined group id — but this subscription also carries the inbox filters above, which have no
+        // `#h` at all, and `block/buzz` downgrades any subscription with a channel-less (or multi-
+        // channel) filter to "global", a class that by design never receives channel-scoped events. So
+        // those filters answered the stored query at EOSE and then went deaf until the next launch.
+        //
+        // Group and Buzz-DM activity now rides the per-channel subscriptions that are already scoped to
+        // exactly one channel — RelayGroupJoinedChatTailSubAssembler and BuzzDmJoinedChatTailSubAssembler,
+        // both mounted app-wide from LoggedInPage, so coverage is unchanged and delivery is live.
+        return inbox
     }
 
     val userJobMap = mutableMapOf<User, List<Job>>()
@@ -138,21 +107,8 @@ class AccountNotificationsEoseFromInboxRelaysManager(
                         invalidateFilters()
                     }
                 },
-                // Re-subscribe when I join/leave a group so its host relay is added to (or dropped
-                // from) the notification query.
-                key.account.scope.launch(Dispatchers.IO) {
-                    key.account.relayGroupList.liveRelayGroupList.sample(1000).collectLatest {
-                        invalidateFilters()
-                    }
-                },
-                // Re-subscribe when a Buzz DM is discovered/hidden so its host relay is polled for
-                // reactions/zaps on my DM messages.
-                key.account.scope.launch(Dispatchers.IO) {
-                    BuzzDmChannels.flow.sample(1000).collectLatest { invalidateFilters() }
-                },
-                key.account.scope.launch(Dispatchers.IO) {
-                    BuzzDmRegistry.hidden.sample(1000).collectLatest { invalidateFilters() }
-                },
+                // No group/Buzz-DM watchers here any more: those filters moved to the per-channel
+                // subscriptions, which mount and unmount with the channel itself.
                 key.account.scope.launch(Dispatchers.IO) {
                     key.feedContentStates.notifications.lastNoteCreatedAtWhenFullyLoaded.sample(5000).collectLatest {
                         invalidateFilters()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountFeedContentStates.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountFeedContentStates.kt
@@ -59,6 +59,7 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.music.dal.MusicPlaylistsFee
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.music.dal.MusicTracksFeedFilter
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.nests.dal.NestsFeedFilter
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications.CardFeedContentState
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications.ChannelInvitesState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications.NotificationSummaryState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications.OpenPollsState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications.dal.NotificationFeedFilter
@@ -138,6 +139,9 @@ class AccountFeedContentStates(
     val notificationsEveryone = CardFeedContentState(NotificationFeedFilter(account, TopFilter.Global), scope)
 
     val notificationsOpenPolls = OpenPollsState(account, scope)
+
+    /** Channels somebody added the viewer to, awaiting a show-on-Messages decision. */
+    val channelInvites = ChannelInvitesState(account, scope)
     val notificationSummary = NotificationSummaryState(account)
 
     val feedListOptions = TopNavFilterState(account, scope)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -43,6 +43,7 @@ import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.audio.VisualizerStyle
 import com.vitorpamplona.amethyst.commons.cashu.ops.describeMintError
 import com.vitorpamplona.amethyst.commons.model.LiveHiddenUsers
+import com.vitorpamplona.amethyst.commons.model.buzz.BuzzChannelInvites
 import com.vitorpamplona.amethyst.commons.model.concord.ConcordChannel
 import com.vitorpamplona.amethyst.commons.model.emphChat.EphemeralChatChannel
 import com.vitorpamplona.amethyst.commons.model.geohashChat.GeohashChatChannel
@@ -1682,6 +1683,34 @@ class AccountViewModel(
     ) = launchSigner { account.joinRelayGroup(channel, code) }
 
     fun leaveRelayGroup(channel: RelayGroupChannel) = launchSigner { account.leaveRelayGroup(channel) }
+
+    /**
+     * Accept a channel somebody added me to: write it into my kind-10009 so it shows on Messages and
+     * follows me to other devices. No kind-9021 join — the relay already put me in the roster, which is
+     * why the channel opens and accepts posts today; this only records *my* decision to surface it.
+     */
+    fun acceptChannelInvite(channel: RelayGroupChannel) =
+        launchSigner {
+            account.settings.undismissChannelInvite(channel.groupId.id)
+            account.follow(channel)
+            BuzzChannelInvites.remove(account.userProfile().pubkeyHex, channel.groupId.id)
+        }
+
+    /**
+     * Keep the channel off Messages without touching membership. Local and reversible — I stay in the
+     * roster and can still open and post; [leaveChannelInvite] is the one that actually removes me.
+     */
+    fun dismissChannelInvite(channelId: String) {
+        account.settings.dismissChannelInvite(channelId)
+        BuzzChannelInvites.remove(account.userProfile().pubkeyHex, channelId)
+    }
+
+    /** Actually leave: kind-9022 to the host relay, and drop it from my list and the pending set. */
+    fun leaveChannelInvite(channel: RelayGroupChannel) =
+        launchSigner {
+            account.leaveRelayGroup(channel)
+            BuzzChannelInvites.remove(account.userProfile().pubkeyHex, channel.groupId.id)
+        }
 
     /**
      * Drop a Concord community from this account's private kind-13302 list. Fire-and-forget on the

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/BuzzDmDiscovery.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/BuzzDmDiscovery.kt
@@ -24,10 +24,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.commons.model.buzz.BuzzChannelInvite
+import com.vitorpamplona.amethyst.commons.model.buzz.BuzzChannelInvites
 import com.vitorpamplona.amethyst.commons.model.buzz.BuzzDmChannels
 import com.vitorpamplona.amethyst.commons.model.buzz.BuzzWorkspaces
 import com.vitorpamplona.amethyst.commons.relayauth.RelayAuthDecision
 import com.vitorpamplona.amethyst.model.Account
+import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.relayGroup.datasource.RELAY_GROUP_METADATA_KINDS
 import com.vitorpamplona.quartz.buzz.dvDmVisibility.DmVisibilityEvent
@@ -37,6 +40,7 @@ import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.fetchAllWithH
 import com.vitorpamplona.quartz.nip01Core.relay.client.reqs.subscribeAsFlow
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip29RelayGroups.GroupId
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 
@@ -96,10 +100,11 @@ private suspend fun runBuzzDmDiscovery(
         timeoutMs = 8_000,
         pendingOnAuthRequired = true,
     ) { relay, event ->
-        (event as? MemberAddedNotificationEvent)?.channel()?.let { BuzzDmChannels.record(me, it, relay) }
+        (event as? MemberAddedNotificationEvent)?.let { recordDiscovery(me, it, relay) }
         false
     }
     fetchDmMetadata(account, me)
+    classifyDiscoveredChannels(account, me)
 
     relays.forEach { relay ->
         launch {
@@ -107,9 +112,12 @@ private suspend fun runBuzzDmDiscovery(
             account.client.subscribeAsFlow(relay, filter).collect { events ->
                 var changed = false
                 events.filterIsInstance<MemberAddedNotificationEvent>().forEach { e ->
-                    e.channel()?.let { if (BuzzDmChannels.record(me, it, relay)) changed = true }
+                    if (recordDiscovery(me, e, relay)) changed = true
                 }
-                if (changed) fetchDmMetadata(account, me)
+                if (changed) {
+                    fetchDmMetadata(account, me)
+                    classifyDiscoveredChannels(account, me)
+                }
             }
         }
     }
@@ -128,4 +136,60 @@ private suspend fun fetchDmMetadata(
             .mapValues { (_, ids) -> listOf(Filter(kinds = RELAY_GROUP_METADATA_KINDS, tags = mapOf("d" to ids))) }
     if (byRelay.isEmpty()) return
     account.client.fetchAllWithHooks(filters = byRelay, timeoutMs = 8_000, pendingOnAuthRequired = true) { _, _ -> false }
+}
+
+/**
+ * Records a kind-44100 "you were added" into [BuzzDmChannels] so its directory can be fetched, and — when
+ * somebody *else* did the adding — into [BuzzChannelInvites] as well.
+ *
+ * The relay emits this same kind for a self-join with `actor == me`, so the actor is what separates "I
+ * joined this" from "a stranger put me in this". Everything is provisionally treated as a DM here because
+ * the channel's type only becomes knowable once its kind-39000 lands; [classifyDiscoveredChannels] sorts
+ * them out immediately afterwards.
+ */
+private fun recordDiscovery(
+    me: HexKey,
+    event: MemberAddedNotificationEvent,
+    relay: NormalizedRelayUrl,
+): Boolean {
+    val channelId = event.channel() ?: return false
+    val changed = BuzzDmChannels.record(me, channelId, relay)
+    val actor = event.actor()
+    if (actor == null || !actor.equals(me, ignoreCase = true)) {
+        BuzzChannelInvites.record(me, BuzzChannelInvite(channelId, relay, actor, event.createdAt))
+    }
+    return changed
+}
+
+/**
+ * Splits what discovery found into DMs and named channels, now that each channel's kind-39000 has loaded.
+ *
+ * A `t = dm` channel is a real DM: it stays in [BuzzDmChannels], whose always-on tail keeps it warm so it
+ * can reach Notifications without being opened, and it is never an "invite". Anything else is a named
+ * channel somebody added the viewer to; it must NOT be silently subscribed, so it is dropped from
+ * [BuzzDmChannels] and left in [BuzzChannelInvites] for the viewer to accept or dismiss.
+ *
+ * Channels already in the viewer's kind-10009 (accepted earlier, or joined from this device) are not
+ * invites — the ordinary joined-group path owns them.
+ */
+private fun classifyDiscoveredChannels(
+    account: Account,
+    me: HexKey,
+) {
+    val joined =
+        account.relayGroupList.liveRelayGroupList.value
+            .mapNotNullTo(mutableSetOf()) { it.groupId }
+
+    BuzzDmChannels.channelsFor(me).forEach { (channelId, relay) ->
+        val metadata = LocalCache.getRelayGroupChannelIfExists(GroupId(channelId, relay))?.event
+        when {
+            // Type not known yet — leave both entries alone and re-run when the directory lands.
+            metadata == null -> Unit
+            metadata.isBuzzDmChannel() -> BuzzChannelInvites.remove(me, channelId)
+            else -> {
+                BuzzDmChannels.remove(me, channelId)
+                if (channelId in joined) BuzzChannelInvites.remove(me, channelId)
+            }
+        }
+    }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/relayGroup/datasource/BuzzDmJoinedChatTailFilterAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/relayGroup/datasource/BuzzDmJoinedChatTailFilterAssembler.kt
@@ -28,18 +28,20 @@ import com.vitorpamplona.amethyst.commons.relayClient.paging.WindowLoadTracker
 import com.vitorpamplona.amethyst.commons.relayClient.paging.trackingListener
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUniqueIdEoseManager
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.nip01Notifications.filterGroupNotificationsToPubkey
 import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 import com.vitorpamplona.quartz.nip01Core.relay.client.subscriptions.Subscription
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
-import com.vitorpamplona.quartz.nip51Lists.simpleGroupList.GroupTag
+import com.vitorpamplona.quartz.nip29RelayGroups.GroupId
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.flow.StateFlow
 
-/** One screen's request to keep the viewer's Buzz DM channels' recent chat live. */
+/** One Buzz DM channel whose recent chat is kept live. */
 class BuzzDmJoinedChatTailQueryState(
     val account: Account,
+    val groupId: GroupId,
 )
 
 /**
@@ -71,7 +73,7 @@ class BuzzDmJoinedChatTailFilterAssembler(
 class BuzzDmJoinedChatTailSubAssembler(
     client: INostrClient,
     allKeys: () -> Set<BuzzDmJoinedChatTailQueryState>,
-) : PerUniqueIdEoseManager<BuzzDmJoinedChatTailQueryState, Account>(client, allKeys) {
+) : PerUniqueIdEoseManager<BuzzDmJoinedChatTailQueryState, GroupId>(client, allKeys) {
     private val windowLoad = WindowLoadTracker("buzzDm.preview.live")
     val loadingMore: StateFlow<Boolean> = windowLoad.loading
 
@@ -79,23 +81,35 @@ class BuzzDmJoinedChatTailSubAssembler(
         key: BuzzDmJoinedChatTailQueryState,
         since: SincePerRelayMap?,
     ): List<RelayBasedFilter>? {
+        // The preload only mounts visible channels; re-checked here so hiding a conversation
+        // empties its subscription even if the key outlives the recomposition.
         val me = key.account.userProfile().pubkeyHex
-        val hidden = BuzzDmRegistry.hiddenFor(me)
-        val channels = BuzzDmChannels.channelsFor(me).filterKeys { it !in hidden }
-        if (channels.isEmpty()) {
-            windowLoad.setExpectedRelays(emptySet())
-            return null
-        }
+        if (key.groupId.id in BuzzDmRegistry.hiddenFor(me)) return null
 
-        // Reuse the joined-group tail builder: one #h filter per host relay carrying every DM channel id
-        // on it, bounded by the shared recent floor (no per-channel limit, reconnect-safe).
-        val asTags = channels.map { (channelId, relay) -> GroupTag(channelId, relay.url) }
-        val filters = buildRelayGroupJoinedChatTailFilters(asTags, DmHistoryTuning.recentBoundary())
-        windowLoad.setExpectedRelays(filters.mapTo(mutableSetOf()) { it.relay })
-        return filters
+        // Same one-subscription-per-channel shape as the joined-group tail: a Buzz DM is a
+        // relay-authoritative NIP-29 group, so batching ids into one `#h` would register the
+        // subscription as global on buzz and never deliver live messages. See
+        // [buildRelayGroupJoinedChatTailFilter]. The second filter carries the DM's activity
+        // addressed to me (reactions/zaps/reports) — same channel, so the subscription stays scoped.
+        val relay = key.groupId.relayUrl
+        windowLoad.setExpectedRelays(setOf(relay))
+        return listOf(
+            buildRelayGroupJoinedChatTailFilter(key.groupId, DmHistoryTuning.recentBoundary()),
+            // Newest message at any age — a DM conversation dormant for over a week must still show its
+            // last message on Messages, not a placeholder. See [buildRelayGroupPreviewFilter].
+            buildRelayGroupPreviewFilter(key.groupId, since?.get(relay)?.time),
+            // A DM channel takes reactions/deletions the same way a group channel does.
+            buildRelayGroupAuxFilter(key.groupId, DmHistoryTuning.recentBoundary()),
+        ) +
+            filterGroupNotificationsToPubkey(
+                relay = relay,
+                pubkey = me,
+                groupIds = listOf(key.groupId.id),
+                since = since?.get(relay)?.time,
+            )
     }
 
-    override fun id(key: BuzzDmJoinedChatTailQueryState) = key.account
+    override fun id(key: BuzzDmJoinedChatTailQueryState) = key.groupId
 
     override fun newSub(key: BuzzDmJoinedChatTailQueryState): Subscription {
         windowLoad.startLoading(key.account.scope)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/relayGroup/datasource/RelayGroupChatSubscriptions.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/relayGroup/datasource/RelayGroupChatSubscriptions.kt
@@ -23,13 +23,16 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.relay
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.commons.model.buzz.BuzzDmChannels
 import com.vitorpamplona.amethyst.commons.model.buzz.BuzzDmRegistry
+import com.vitorpamplona.amethyst.commons.model.chats.ChatFeedType
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.KeyDataSourceSubscription
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.LifecycleAwareKeyDataSourceSubscription
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
 import com.vitorpamplona.quartz.nip29RelayGroups.GroupId
 
 /**
@@ -52,18 +55,35 @@ fun RelayGroupJoinedStatePreload(accountViewModel: AccountViewModel) {
 
 /**
  * Always-on preview **live tail** for joined groups' recent chat, mounted alongside [RelayGroupJoinedStatePreload]
- * — keeps the Messages-list previews reflecting the true newest message app-wide. Re-derives on join/leave.
+ * — keeps the Messages-list previews reflecting the true newest message app-wide.
+ *
+ * Mounts **one subscription per joined group** (not one per host relay): a subscription whose `#h` carries
+ * more than one group id is registered as a *global* subscription by `block/buzz` and then never receives
+ * channel-scoped events, so a batched tail backfills once and goes deaf. See
+ * [buildRelayGroupJoinedChatTailFilter]. Joining/leaving adds or removes a key, so nothing needs an
+ * explicit invalidate; a group whose relay url won't normalize is skipped, exactly as the Messages feed
+ * filter skips it.
  */
 @Composable
 fun RelayGroupJoinedChatTailPreload(accountViewModel: AccountViewModel) {
     val account = accountViewModel.account
     val dataSource = accountViewModel.dataSources().relayGroupJoinedChatTail
-    val state = remember(account) { RelayGroupJoinedChatTailQueryState(account) }
 
     val joined by account.relayGroupList.liveRelayGroupList.collectAsStateWithLifecycle()
-    LaunchedEffect(joined) { dataSource.invalidateFilters() }
+    val enabledFeeds by account.settings.enabledChatFeeds.collectAsStateWithLifecycle()
 
-    KeyDataSourceSubscription(state, dataSource)
+    if (ChatFeedType.NIP29 in enabledFeeds) {
+        joined.forEach { tag ->
+            val relay = RelayUrlNormalizer.normalizeOrNull(tag.relayUrl)
+            if (relay != null) {
+                val groupId = GroupId(tag.groupId, relay)
+                key(groupId) {
+                    val state = remember(account, groupId) { RelayGroupJoinedChatTailQueryState(account, groupId) }
+                    KeyDataSourceSubscription(state, dataSource)
+                }
+            }
+        }
+    }
 }
 
 /**
@@ -77,13 +97,27 @@ fun RelayGroupJoinedChatTailPreload(accountViewModel: AccountViewModel) {
 fun BuzzDmJoinedChatTailPreload(accountViewModel: AccountViewModel) {
     val account = accountViewModel.account
     val dataSource = accountViewModel.dataSources().buzzDmJoinedChatTail
-    val state = remember(account) { BuzzDmJoinedChatTailQueryState(account) }
+    val me = account.userProfile().pubkeyHex
 
+    // Both values must be read (not just collected) so the snapshot system recomposes this
+    // preload — and re-derives the mounted set — whenever a DM is discovered or hidden.
     val channels by BuzzDmChannels.flow.collectAsStateWithLifecycle()
     val hidden by BuzzDmRegistry.hidden.collectAsStateWithLifecycle()
-    LaunchedEffect(channels, hidden) { dataSource.invalidateFilters() }
 
-    KeyDataSourceSubscription(state, dataSource)
+    val visible =
+        remember(channels, hidden, me) {
+            BuzzDmChannels.channelsFor(me).filterKeys { it !in BuzzDmRegistry.hiddenFor(me) }
+        }
+
+    // One subscription per DM channel — batching their ids into a single `#h` makes buzz treat the
+    // subscription as global and stop delivering live messages. See [buildRelayGroupJoinedChatTailFilter].
+    visible.forEach { (channelId, relay) ->
+        val groupId = GroupId(channelId, relay)
+        key(groupId) {
+            val state = remember(account, groupId) { BuzzDmJoinedChatTailQueryState(account, groupId) }
+            KeyDataSourceSubscription(state, dataSource)
+        }
+    }
 }
 
 /**

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/relayGroup/datasource/RelayGroupFilterBuilders.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/relayGroup/datasource/RelayGroupFilterBuilders.kt
@@ -43,13 +43,16 @@ import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
+import com.vitorpamplona.quartz.nip09Deletions.DeletionEvent
 import com.vitorpamplona.quartz.nip22Comments.CommentEvent
+import com.vitorpamplona.quartz.nip25Reactions.ReactionEvent
 import com.vitorpamplona.quartz.nip29RelayGroups.GroupId
 import com.vitorpamplona.quartz.nip29RelayGroups.metadata.GroupAdminsEvent
 import com.vitorpamplona.quartz.nip29RelayGroups.metadata.GroupMembersEvent
 import com.vitorpamplona.quartz.nip29RelayGroups.metadata.GroupMetadataEvent
 import com.vitorpamplona.quartz.nip29RelayGroups.metadata.GroupPinnedEvent
 import com.vitorpamplona.quartz.nip29RelayGroups.metadata.SupportedRolesEvent
+import com.vitorpamplona.quartz.nip29RelayGroups.moderation.DeleteEventEvent
 import com.vitorpamplona.quartz.nip29RelayGroups.tags.GroupIdTag
 import com.vitorpamplona.quartz.nip51Lists.simpleGroupList.GroupTag
 import com.vitorpamplona.quartz.nip7DThreads.ThreadEvent
@@ -148,6 +151,33 @@ val BUZZ_RELAY_GROUP_TIMELINE_EXTRA_KINDS =
 val RELAY_GROUP_ALL_TIMELINE_KINDS = RELAY_GROUP_TIMELINE_KINDS + BUZZ_RELAY_GROUP_TIMELINE_EXTRA_KINDS
 
 /**
+ * Channel **aux** kinds — overlays that modify an existing row rather than being a row: reactions (7),
+ * NIP-09 deletions (5) and the Buzz-native NIP-29 delete (9005).
+ *
+ * Requested `#h`-scoped on the channel subscription, which is how the Buzz reference client does it
+ * (`channelEventKinds` in its Flutter client bundles deletion + reaction + the message kinds into the
+ * one `#h` channel REQ). Amethyst otherwise only learns about reactions through the shared `#e`
+ * EventFinder query keyed on the ids of notes currently on screen — and that query carries no `#h`, so
+ * on a relay that scopes live delivery per channel it is registered as a *global* subscription and can
+ * never receive them live (a reaction inherits its target's channel, so it IS channel-scoped). The
+ * result was reaction chips that only ever appeared on a re-query, never as they happened.
+ *
+ * Kept OUT of [RELAY_GROUP_ALL_TIMELINE_KINDS] on purpose: that set feeds the backward history pager,
+ * whose `until` cursor walks `created_at`. Letting reactions consume a page's `limit` would advance the
+ * cursor past chat messages that were never delivered — the same class of cursor-skip bug that the
+ * unconditional-Buzz-kinds note above records.
+ */
+val RELAY_GROUP_AUX_KINDS =
+    listOf(
+        DeletionEvent.KIND,
+        ReactionEvent.KIND,
+        DeleteEventEvent.KIND,
+    )
+
+/** How many aux events a channel replays on subscribe. Bounds the backfill; live delivery is unbounded. */
+const val RELAY_GROUP_AUX_LIMIT = 500
+
+/**
  * Kinds requested on the **open channel's live tail only** — the timeline set plus the
  * ephemeral kind-20002 typing indicator. Typing is scoped to the one channel on screen
  * (not the whole joined fleet) because it's a live "someone is typing" signal, never
@@ -208,25 +238,100 @@ fun buildRelayGroupStateFilters(
     }
 
 /**
- * Recent chat of every joined group, **one `#h` filter per host relay** carrying that relay's group ids,
- * bounded by a shared time floor ([sinceEpoch]) and **no per-group `limit`** — this is what lets the whole
- * relay's groups batch into a single REQ and makes it reconnect-safe.
+ * Recent chat of **one** joined group: a single-valued `#h` filter on its host relay, bounded by a shared
+ * time floor ([sinceEpoch]) and **no `limit`** — a time floor bounds it, so it stays reconnect-safe (a
+ * reconnect re-issues one `since=window` REQ, never a page replay).
+ *
+ * ### Why one group per filter — and per *subscription*
+ *
+ * This used to batch every joined group on a relay into ONE filter carrying every group id in `#h`. That
+ * shape is valid NIP-01 (a multi-value tag filter is an OR), and relays serve it correctly for **stored**
+ * queries — which is exactly what made the bug so confusing: the boot backfill populated every group, so
+ * the Messages list looked right until it needed to update.
+ *
+ * But `block/buzz` (the relay behind `*.communities.buzz.xyz`) indexes each live subscription under a
+ * *single* channel uuid, resolved from the filters' `#h`. When two or more distinct ids appear anywhere
+ * across a subscription's filters, `extract_channel_id_from_filters` returns `None` and the subscription
+ * is registered as **global** — and global subscriptions deliberately never receive channel-scoped events
+ * (`fan_out_scoped`: "Global subscriptions do NOT receive channel-scoped events", guarding against leaking
+ * private channel content to a subscriber whose membership wasn't checked per channel). Net effect: a
+ * batched tail gets full history at EOSE and then goes permanently deaf, so the Messages row froze while
+ * the open chat — which always used a single-valued `#h` — stayed live.
+ *
+ * The resolution scans **all filters of a subscription**, so splitting into one filter per group is not
+ * enough: each group needs its **own subscription** (see [RelayGroupJoinedChatTailFilterAssembler], which
+ * keys its EOSE manager on [GroupId]). Relays advertise room for this — buzz allows `max_subscriptions:
+ * 1024` against `max_filters: 10` — and it sidesteps the filter cap for anyone in more than ten groups.
  */
-fun buildRelayGroupJoinedChatTailFilters(
-    joined: Collection<GroupTag>,
+fun buildRelayGroupJoinedChatTailFilter(
+    groupId: GroupId,
     sinceEpoch: Long,
-): List<RelayBasedFilter> =
-    byHostRelay(joined).map { (relay, ids) ->
-        RelayBasedFilter(
-            relay = relay,
-            filter =
-                Filter(
-                    kinds = RELAY_GROUP_ALL_TIMELINE_KINDS,
-                    tags = mapOf(GroupIdTag.TAG_NAME to ids.distinct()),
-                    since = sinceEpoch,
-                ),
-        )
-    }
+): RelayBasedFilter =
+    RelayBasedFilter(
+        relay = groupId.relayUrl,
+        filter =
+            Filter(
+                kinds = RELAY_GROUP_ALL_TIMELINE_KINDS,
+                tags = mapOf(GroupIdTag.TAG_NAME to listOf(groupId.id)),
+                since = sinceEpoch,
+            ),
+    )
+
+/**
+ * The **newest message** of one joined channel, at any age: single-valued `#h`, `limit = 1`, and a
+ * `since` that is null until this relay EOSEs.
+ *
+ * This is what fills the channel's Messages-list row, and it is deliberately count-bounded rather than
+ * time-bounded. [buildRelayGroupJoinedChatTailFilter] floors at `now - 7 days` to keep recent chat warm
+ * in cache; on its own that means a channel nobody has posted in for eight days returns *zero* events,
+ * so `newestChatNote()` stays null and the row is stuck on its "No messages yet" placeholder forever —
+ * sorted to the bottom of Messages by `createdAt = 0`, indistinguishable from a channel you just joined.
+ *
+ * Every other roster-driven protocol on that screen already bounds by count for exactly this reason:
+ * NIP-28 asks `limit = 1` per followed channel
+ * ([com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.datasource.filterLastMessageFollowingPublicChats]),
+ * Concord asks `limit = 10` per channel with no floor (`ConcordSubscriptionPlanner.channelPreviewFilters`).
+ * They can, because their row set comes from a list event — unlike NIP-17/NIP-04, whose *rooms* are
+ * discovered from the messages themselves and therefore need the backward pagers on the Messages list.
+ * A NIP-29 channel is roster-driven (kind 10009), so it needs one newest message per row, not a window.
+ *
+ * `since` comes from the per-relay EOSE map: null on a cold start (newest message whatever its age),
+ * then advancing, so a reconnect re-asks for one event rather than replaying a window.
+ */
+fun buildRelayGroupPreviewFilter(
+    groupId: GroupId,
+    sinceEpoch: Long?,
+): RelayBasedFilter =
+    RelayBasedFilter(
+        relay = groupId.relayUrl,
+        filter =
+            Filter(
+                kinds = RELAY_GROUP_ALL_TIMELINE_KINDS,
+                tags = mapOf(GroupIdTag.TAG_NAME to listOf(groupId.id)),
+                since = sinceEpoch,
+                limit = 1,
+            ),
+    )
+
+/**
+ * Reactions/deletions for **every** message in one channel, `#h`-scoped on its host relay — see
+ * [RELAY_GROUP_AUX_KINDS]. Single-valued `#h`, so it can share a channel-scoped subscription with the
+ * chat tail without downgrading it.
+ */
+fun buildRelayGroupAuxFilter(
+    groupId: GroupId,
+    sinceEpoch: Long,
+): RelayBasedFilter =
+    RelayBasedFilter(
+        relay = groupId.relayUrl,
+        filter =
+            Filter(
+                kinds = RELAY_GROUP_AUX_KINDS,
+                tags = mapOf(GroupIdTag.TAG_NAME to listOf(groupId.id)),
+                since = sinceEpoch,
+                limit = RELAY_GROUP_AUX_LIMIT,
+            ),
+    )
 
 /** The recent-chat live tail for a single open group, `#h`-scoped on its host relay. */
 fun buildRelayGroupOpenChatTailFilter(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/relayGroup/datasource/RelayGroupJoinedChatTailFilterAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/relayGroup/datasource/RelayGroupJoinedChatTailFilterAssembler.kt
@@ -27,19 +27,21 @@ import com.vitorpamplona.amethyst.commons.relayClient.paging.WindowLoadTracker
 import com.vitorpamplona.amethyst.commons.relayClient.paging.trackingListener
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.PerUniqueIdEoseManager
-import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.launchChatFeedToggleObserver
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.nip01Notifications.filterGroupNotificationsToPubkey
 import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 import com.vitorpamplona.quartz.nip01Core.relay.client.subscriptions.Subscription
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
+import com.vitorpamplona.quartz.nip29RelayGroups.GroupId
 import com.vitorpamplona.quartz.utils.TimeUtils
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.StateFlow
 
-/** One screen's request to keep the user's joined groups' recent chat live. */
+/** One joined group whose recent chat is kept live for the Messages-list preview. */
 class RelayGroupJoinedChatTailQueryState(
     val account: Account,
+    val groupId: GroupId,
 )
 
 /**
@@ -47,15 +49,17 @@ class RelayGroupJoinedChatTailQueryState(
  * analog of the NIP-04 rooms-list live tail
  * ([com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.datasource.ChatroomListNip04SubAssembler]).
  *
- * One `#h`-scoped filter **per host relay** carries every joined group id on that relay at once,
- * `since = recentBoundary()` and **no per-group limit** — a time floor bounds it, so unlike the fixed
- * `limit=50` window it can batch all of a relay's groups into a single REQ. This keeps the Messages-list
- * previews reflecting the true newest message and joined groups' recent chat warm in cache without
+ * **One subscription per joined group**, each a single-valued `#h` filter with `since = recentBoundary()`
+ * and no `limit` — a time floor bounds it, so it stays reconnect-safe. This keeps the Messages-list
+ * previews reflecting the true newest message, and joined groups' recent chat warm in cache, without
  * opening each one. Older history is the [RelayGroupOpenChatHistorySubAssembler]'s job (below the floor).
  *
- * Batching by a shared time floor (rather than a per-group `limit` + shared per-relay EOSE `since`) is
- * what makes this both correct — every joined group is covered the moment it joins — and reconnect-safe:
- * a reconnect re-issues one `since=window` REQ per relay, never a per-group page replay.
+ * These used to be batched into one subscription per host relay carrying every group id in a single `#h`.
+ * That is valid NIP-01 and relays answer it correctly for stored queries, but it silently breaks *live*
+ * delivery on `block/buzz`, which can only index a subscription under one channel and downgrades a
+ * multi-id one to "global" — a class that by design receives no channel-scoped events. The batched tail
+ * therefore backfilled at EOSE and then went permanently deaf, freezing the Messages row while the open
+ * chat (always single-valued) stayed live. See [buildRelayGroupJoinedChatTailFilter] for the full trace.
  */
 class RelayGroupJoinedChatTailFilterAssembler(
     client: INostrClient,
@@ -74,7 +78,7 @@ class RelayGroupJoinedChatTailFilterAssembler(
 class RelayGroupJoinedChatTailSubAssembler(
     client: INostrClient,
     allKeys: () -> Set<RelayGroupJoinedChatTailQueryState>,
-) : PerUniqueIdEoseManager<RelayGroupJoinedChatTailQueryState, Account>(client, allKeys) {
+) : PerUniqueIdEoseManager<RelayGroupJoinedChatTailQueryState, GroupId>(client, allKeys) {
     private val windowLoad = WindowLoadTracker("relayGroup.preview.live")
     val loadingMore: StateFlow<Boolean> = windowLoad.loading
 
@@ -82,42 +86,51 @@ class RelayGroupJoinedChatTailSubAssembler(
         key: RelayGroupJoinedChatTailQueryState,
         since: SincePerRelayMap?,
     ): List<RelayBasedFilter>? {
-        if (!key.account.settings.isChatFeedEnabled(ChatFeedType.NIP29)) {
-            windowLoad.setExpectedRelays(emptySet())
-            return null
-        }
-        val joined = key.account.relayGroupList.liveRelayGroupList.value
-        if (joined.isEmpty()) {
-            windowLoad.setExpectedRelays(emptySet())
-            return null
-        }
+        // The preload only mounts keys while the toggle is on; re-checked here so a flip to off
+        // empties any subscription that outlives the recomposition.
+        if (!key.account.settings.isChatFeedEnabled(ChatFeedType.NIP29)) return null
 
-        // One #h filter per host relay carrying every joined group id on it; bounded by the shared
-        // recent-tail floor, so no per-group limit and no per-group re-subscribe on join.
-        val filters = buildRelayGroupJoinedChatTailFilters(joined, DmHistoryTuning.recentBoundary())
-        windowLoad.setExpectedRelays(filters.mapTo(mutableSetOf()) { it.relay })
-        return filters
+        val relay = key.groupId.relayUrl
+        // The tracker is shared by every key of this assembler, so it must describe the whole joined
+        // fleet rather than whichever channel happened to rebuild last — otherwise each key would
+        // overwrite the expected set with its own single relay. [loadingMore] is what the Messages rows
+        // read to tell "still fetching this channel's newest message" apart from "channel is empty".
+        windowLoad.setExpectedRelays(
+            key.account.relayGroupList.liveRelayGroupList.value
+                .mapNotNullTo(mutableSetOf()) { RelayUrlNormalizer.normalizeOrNull(it.relayUrl) },
+        )
+
+        // Two filters, both `#h`-scoped to THIS group, so the subscription still resolves to a single
+        // channel on buzz (its resolver only bails when two *distinct* ids appear, or when some filter
+        // carries no channel tag at all). Each is queried independently, so they keep their own window:
+        //  - the chat tail: every timeline kind, time-floored, no limit
+        //  - group activity addressed to me: reactions/zaps/reports/replies (kinds the tail doesn't ask
+        //    for), `#p` = me + `limit`, `since` from EOSE so a cold start is all-time and a reconnect is
+        //    cheap. This used to ride the account-wide notifications subscription, which also carries
+        //    inbox filters with no `#h` — that alone forces the whole subscription global on buzz, so
+        //    live group reactions never arrived until the next launch.
+        return listOf(
+            buildRelayGroupJoinedChatTailFilter(key.groupId, DmHistoryTuning.recentBoundary()),
+            // The row's newest message at ANY age. The tail above floors at 7 days to keep recent chat
+            // warm, which on its own strands a channel quiet for longer than that on a placeholder row.
+            buildRelayGroupPreviewFilter(key.groupId, since?.get(relay)?.time),
+            // Reactions/deletions for every message in this channel — the shape Buzz's own client uses.
+            buildRelayGroupAuxFilter(key.groupId, DmHistoryTuning.recentBoundary()),
+        ) +
+            filterGroupNotificationsToPubkey(
+                relay = relay,
+                pubkey = key.account.userProfile().pubkeyHex,
+                groupIds = listOf(key.groupId.id),
+                since = since?.get(relay)?.time,
+            )
     }
 
-    override fun id(key: RelayGroupJoinedChatTailQueryState) = key.account
-
-    private val toggleJobs = mutableMapOf<Account, Job>()
+    override fun id(key: RelayGroupJoinedChatTailQueryState) = key.groupId
 
     override fun newSub(key: RelayGroupJoinedChatTailQueryState): Subscription {
         windowLoad.startLoading(key.account.scope)
-        toggleJobs.remove(key.account)?.cancel()
-        toggleJobs[key.account] =
-            key.account.scope.launchChatFeedToggleObserver(key.account, ChatFeedType.NIP29) { invalidateFilters() }
         return requestNewSubscription(
             windowLoad.trackingListener { relay: NormalizedRelayUrl, filters -> newEose(key, relay, TimeUtils.now(), filters) },
         )
-    }
-
-    override fun endSub(
-        key: Account,
-        subId: String,
-    ) {
-        super.endSub(key, subId)
-        toggleJobs.remove(key)?.cancel()
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/relayGroup/datasource/RelayGroupOpenChatTailFilterAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/relayGroup/datasource/RelayGroupOpenChatTailFilterAssembler.kt
@@ -76,7 +76,12 @@ class RelayGroupOpenChatTailSubAssembler(
         since: SincePerRelayMap?,
     ): List<RelayBasedFilter> {
         windowLoad.setExpectedRelays(setOf(key.groupId.relayUrl))
-        return listOf(buildRelayGroupOpenChatTailFilter(key.groupId, DmHistoryTuning.recentBoundary()))
+        return listOf(
+            buildRelayGroupOpenChatTailFilter(key.groupId, DmHistoryTuning.recentBoundary()),
+            // Reactions/deletions for every message on screen, `#h`-scoped rather than `#e`-scoped —
+            // see [RELAY_GROUP_AUX_KINDS]. Covers a non-joined group opened by link too.
+            buildRelayGroupAuxFilter(key.groupId, DmHistoryTuning.recentBoundary()),
+        )
     }
 
     override fun id(key: RelayGroupOpenChatTailQueryState) = key.groupId

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChatroomHeaderCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChatroomHeaderCompose.kt
@@ -458,9 +458,19 @@ private fun RelayGroupRoomCompose(
             // rather than "author: {json}". Plain chat messages fall through to the usual framing.
             buzzTimelinePreviewSummary(noteEvent) ?: "$authorName: ${noteEvent.content.take(200)}"
         } else {
-            // Event-less placeholder row for a just-joined group with no messages yet — say so
-            // explicitly (like Marmot groups) instead of an empty second line.
-            stringRes(R.string.relay_group_no_messages_yet)
+            // Event-less placeholder row. Until the channel's `limit = 1` preview REQ settles we cannot
+            // tell an empty channel from one whose newest message simply hasn't arrived, and claiming
+            // "No messages yet" for a busy channel reads as a bug — so say "Loading" while the joined
+            // fleet is still fetching, and commit to the empty wording only once it has.
+            val stillFetching by accountViewModel
+                .dataSources()
+                .relayGroupJoinedChatTail.tail.loadingMore
+                .collectAsStateWithLifecycle()
+            if (stillFetching) {
+                stringRes(R.string.loading_feed)
+            } else {
+                stringRes(R.string.relay_group_no_messages_yet)
+            }
         }
 
     val groupPicture = channel.profilePicture()?.ifBlank { null }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/feed/ChatroomListFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/feed/ChatroomListFeedView.kt
@@ -21,8 +21,10 @@
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.feed
 
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -85,6 +87,13 @@ fun ChatroomListFeedView(
     scrollStateKey: String,
     accountViewModel: AccountViewModel,
     nav: INav,
+    /**
+     * Pinned above the rows. Rendered INSIDE the feed rather than beside it so it inherits
+     * [rememberFeedContentPadding] — the collapsing top bar draws over this area, and a header placed
+     * outside the list lands underneath it. Shown in every state, so a standing prompt is still
+     * reachable when the list itself is empty.
+     */
+    headerContent: (@Composable () -> Unit)? = null,
 ) {
     DisposableEffect(Unit) {
         Log.d("DMPagination") { "rooms.list: OPEN" }
@@ -92,7 +101,7 @@ fun ChatroomListFeedView(
     }
     RefresheableBox(feedContentState, true) {
         SaveableFeedContentState(feedContentState, scrollStateKey) { listState ->
-            CrossFadeState(feedContentState, listState, accountViewModel, nav)
+            CrossFadeState(feedContentState, listState, accountViewModel, nav, headerContent)
         }
     }
 }
@@ -103,6 +112,7 @@ private fun CrossFadeState(
     listState: LazyListState,
     accountViewModel: AccountViewModel,
     nav: INav,
+    headerContent: (@Composable () -> Unit)? = null,
 ) {
     val feedState by feedContentState.feedContent.collectAsStateWithLifecycle()
 
@@ -131,10 +141,13 @@ private fun CrossFadeState(
     ) { state ->
         when (state) {
             is FeedState.Empty -> {
-                if (historyExhausted) {
-                    FeedEmpty { feedContentState.invalidateData() }
-                } else {
-                    LoadingFeed()
+                Column(Modifier.padding(rememberFeedContentPadding(FeedPadding))) {
+                    headerContent?.invoke()
+                    if (historyExhausted) {
+                        FeedEmpty { feedContentState.invalidateData() }
+                    } else {
+                        LoadingFeed()
+                    }
                 }
             }
 
@@ -143,7 +156,7 @@ private fun CrossFadeState(
             }
 
             is FeedState.Loaded -> {
-                FeedLoaded(state, listState, accountViewModel, nav)
+                FeedLoaded(state, listState, accountViewModel, nav, headerContent)
             }
 
             FeedState.Loading -> {
@@ -159,6 +172,7 @@ private fun FeedLoaded(
     listState: LazyListState,
     accountViewModel: AccountViewModel,
     nav: INav,
+    headerContent: (@Composable () -> Unit)? = null,
 ) {
     val items by loaded.feed.collectAsStateWithLifecycle()
 
@@ -214,6 +228,8 @@ private fun FeedLoaded(
         contentPadding = rememberFeedContentPadding(FeedPadding),
         state = listState,
     ) {
+        headerContent?.let { item("chatroom-list-header") { it() } }
+
         itemsIndexed(
             items.list,
             key = { _, item -> chatroomLazyKey(item, myPubKey) },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/feed/ChatroomListTabs.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/feed/ChatroomListTabs.kt
@@ -49,6 +49,7 @@ import com.vitorpamplona.amethyst.ui.components.M3ActionSection
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.navs.zonedDrawerSwipeIfModal
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications.ChannelInvitesSection
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.Size40dp
 import com.vitorpamplona.amethyst.ui.theme.TabRowHeight
@@ -131,6 +132,17 @@ fun MessagesPager(
             scrollStateKey = tabs[page].scrollStateKey,
             accountViewModel = accountViewModel,
             nav = nav,
+            // Channels somebody added you to are pending decisions, exactly like an unaccepted DM — so
+            // they belong on New Requests, pinned above the rows. Passed as the feed's header rather
+            // than stacked beside it: the collapsing top bar draws over this area, so a header outside
+            // the list renders underneath it. The Notifications tab shows the same prompts from the
+            // same state holder, so the two surfaces cannot disagree.
+            headerContent =
+                if (tabs[page].resource == R.string.new_requests) {
+                    { ChannelInvitesSection(accountViewModel) }
+                } else {
+                    null
+                },
         )
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/ChannelInvitesSection.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/ChannelInvitesSection.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.model.buzz.BuzzChannelInvite
+import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserName
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.displayUrl
+import com.vitorpamplona.quartz.nip29RelayGroups.GroupId
+
+/**
+ * "Somebody added you to a channel" prompts, rendered above the Notifications feed (the same header slot
+ * the missing-inbox-relay prompt uses) and inside Messages › New Requests.
+ *
+ * These are deliberately NOT auto-accepted. On a Buzz relay another member can add you to a channel
+ * server-side: the relay writes you into the kind-39002 roster and you can immediately read and post,
+ * without you ever agreeing to see it. Amethyst used to silently subscribe to those channels' messages
+ * while showing no row for them anywhere, so a channel could be joined, streaming, and invisible at once.
+ * Now the relay's decision is surfaced as a question instead of being acted on.
+ */
+@Composable
+fun ChannelInvitesSection(
+    accountViewModel: AccountViewModel,
+    modifier: Modifier = Modifier,
+) {
+    val invites by accountViewModel.feedStates.channelInvites.flow
+        .collectAsStateWithLifecycle()
+
+    if (invites.isEmpty()) return
+
+    Column(modifier) {
+        invites.forEach { invite ->
+            ChannelInviteCard(invite, accountViewModel)
+        }
+    }
+}
+
+@Composable
+fun ChannelInviteCard(
+    invite: BuzzChannelInvite,
+    accountViewModel: AccountViewModel,
+) {
+    val channel = remember(invite.channelId, invite.relay) { LocalCache.getOrCreateRelayGroupChannel(GroupId(invite.channelId, invite.relay)) }
+
+    val actorUser = remember(invite.actor) { invite.actor?.let { LocalCache.getOrCreateUser(it) } }
+    val actorName = actorUser?.let { observeUserName(it, accountViewModel).value }
+
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 5.dp),
+    ) {
+        Column(Modifier.padding(12.dp)) {
+            Text(
+                text = stringRes(R.string.channel_invite_title, channel.toBestDisplayName()),
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                // Who did it matters: the relay reports a self-join with the same event, so naming the
+                // actor is what tells "I joined this" apart from "a stranger put me here".
+                text =
+                    stringRes(
+                        R.string.channel_invite_body,
+                        actorName ?: stringRes(R.string.channel_invite_unknown_actor),
+                        invite.relay.displayUrl(),
+                    ),
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+
+            Row(
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth().padding(top = 6.dp),
+            ) {
+                // Leave is separate from Ignore on purpose: Ignore is a local display choice that leaves
+                // you in the roster, Leave is the kind-9022 that actually removes you from the channel.
+                TextButton(onClick = { accountViewModel.leaveChannelInvite(channel) }) {
+                    Text(stringRes(R.string.channel_invite_leave), color = MaterialTheme.colorScheme.error)
+                }
+                TextButton(onClick = { accountViewModel.dismissChannelInvite(invite.channelId) }) {
+                    Text(stringRes(R.string.channel_invite_ignore))
+                }
+                TextButton(onClick = { accountViewModel.acceptChannelInvite(channel) }) {
+                    Text(stringRes(R.string.channel_invite_accept), fontWeight = FontWeight.Bold)
+                }
+            }
+        }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/ChannelInvitesState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/ChannelInvitesState.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications
+
+import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.model.buzz.BuzzChannelInvite
+import com.vitorpamplona.amethyst.commons.model.buzz.BuzzChannelInvites
+import com.vitorpamplona.amethyst.model.Account
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * The channels somebody else added the viewer to that are still awaiting a decision.
+ *
+ * An entry drops out the moment it stops being a question: accepting writes the group into kind-10009
+ * (so `joined` covers it and the ordinary Messages row takes over), dismissing records the channel in
+ * `dismissedChannelInvites`, and leaving makes the relay withdraw the membership. Nothing here asserts
+ * membership — the relay already granted that — it only tracks whose call it is to surface the channel.
+ *
+ * Modelled on [OpenPollsState]: a small always-on projection the Notifications screen and the Messages
+ * "New Requests" tab both render, so the two surfaces can never disagree about what is pending.
+ */
+@Stable
+class ChannelInvitesState(
+    private val account: Account,
+    scope: CoroutineScope,
+) {
+    val flow: StateFlow<List<BuzzChannelInvite>> =
+        combine(
+            BuzzChannelInvites.flow.map { it[account.userProfile().pubkeyHex] ?: emptyMap() },
+            account.settings.dismissedChannelInvites,
+            account.relayGroupList.liveRelayGroupList,
+        ) { invites, dismissed, joined ->
+            val joinedIds = joined.mapTo(HashSet()) { it.groupId }
+            invites.values
+                .filter { it.channelId !in dismissed && it.channelId !in joinedIds }
+                .sortedByDescending { it.createdAt }
+        }.flowOn(Dispatchers.IO)
+            .stateIn(scope, SharingStarted.Eagerly, emptyList())
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/NotificationScreen.kt
@@ -242,7 +242,12 @@ internal fun SingleNotificationsBody(
             nav = nav,
             routeForLastRead = NOTIFICATION_LAST_READ_KEY,
             scrollToEventId = scrollToEventId,
-            headerContent = { ObserveInboxRelayListAndDisplayIfNotFound(accountViewModel, nav) },
+            headerContent = {
+                ObserveInboxRelayListAndDisplayIfNotFound(accountViewModel, nav)
+                // "X added you to #channel" prompts sit above the feed rather than inside it: they are a
+                // standing decision, not a dated event, so they must not scroll away into history.
+                ChannelInvitesSection(accountViewModel)
+            },
         )
     }
 }

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -2653,6 +2653,12 @@
     <string name="relay_group_browse_your_relays">Relays you\'re on</string>
     <string name="relay_group_browse_popular">Popular relays</string>
     <string name="relay_group_no_messages_yet">No messages yet</string>
+    <string name="channel_invite_title">Added to %1$s</string>
+    <string name="channel_invite_body">%1$s added you to this channel on %2$s. Show it in Messages?</string>
+    <string name="channel_invite_unknown_actor">Someone</string>
+    <string name="channel_invite_accept">Show</string>
+    <string name="channel_invite_ignore">Ignore</string>
+    <string name="channel_invite_leave">Leave</string>
     <string name="relay_group_join_to_post">Join this group to send messages.</string>
     <string name="relay_group_invite_only_to_post">This group is invite-only — you need an invite to post.</string>
     <plurals name="relay_group_member_count">

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/relayGroup/datasource/BuzzTimelineKindsTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/relayGroup/datasource/BuzzTimelineKindsTest.kt
@@ -23,7 +23,6 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.relay
 import com.vitorpamplona.quartz.buzz.stream.StreamMessageV2Event
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
 import com.vitorpamplona.quartz.nip29RelayGroups.GroupId
-import com.vitorpamplona.quartz.nip51Lists.simpleGroupList.GroupTag
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -50,10 +49,9 @@ class BuzzTimelineKindsTest {
         assertTrue(openTail.filter.kinds!!.contains(StreamMessageV2Event.KIND))
 
         val fleet =
-            buildRelayGroupJoinedChatTailFilters(
-                listOf(GroupTag("g1", buzzRelay.url), GroupTag("g2", vanillaRelay.url)),
-                sinceEpoch = 0L,
-            )
+            listOf(GroupId("g1", buzzRelay), GroupId("g2", vanillaRelay)).map {
+                buildRelayGroupJoinedChatTailFilter(it, sinceEpoch = 0L)
+            }
         fleet.forEach { assertTrue(it.filter.kinds!!.contains(StreamMessageV2Event.KIND)) }
     }
 }

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/relayGroup/datasource/RelayGroupFilterBuildersTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/relayGroup/datasource/RelayGroupFilterBuildersTest.kt
@@ -24,13 +24,16 @@ import com.vitorpamplona.quartz.buzz.forum.ForumCommentEvent
 import com.vitorpamplona.quartz.buzz.forum.ForumPostEvent
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.FiltersChanged
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
+import com.vitorpamplona.quartz.nip09Deletions.DeletionEvent
 import com.vitorpamplona.quartz.nip22Comments.CommentEvent
+import com.vitorpamplona.quartz.nip25Reactions.ReactionEvent
 import com.vitorpamplona.quartz.nip29RelayGroups.GroupId
 import com.vitorpamplona.quartz.nip29RelayGroups.metadata.GroupAdminsEvent
 import com.vitorpamplona.quartz.nip29RelayGroups.metadata.GroupMembersEvent
 import com.vitorpamplona.quartz.nip29RelayGroups.metadata.GroupMetadataEvent
 import com.vitorpamplona.quartz.nip29RelayGroups.metadata.GroupPinnedEvent
 import com.vitorpamplona.quartz.nip29RelayGroups.metadata.SupportedRolesEvent
+import com.vitorpamplona.quartz.nip29RelayGroups.moderation.DeleteEventEvent
 import com.vitorpamplona.quartz.nip51Lists.simpleGroupList.GroupTag
 import com.vitorpamplona.quartz.nip7DThreads.ThreadEvent
 import com.vitorpamplona.quartz.nip88Polls.poll.PollEvent
@@ -110,21 +113,96 @@ class RelayGroupFilterBuildersTest {
         filters.filter { it.relay == relayB }.forEach { assertNull(it.filter.since) }
     }
 
-    // --- Joined chat tail (always-on): batched #h per relay, time floor, NO per-group limit ---
+    // --- Joined chat tail (always-on): ONE single-valued #h per group, time floor, NO limit ---
 
     @Test
-    fun `joined chat tail batches one h-filter per relay with no count limit`() {
-        val filters = buildRelayGroupJoinedChatTailFilters(joined, 999L)
-        assertEquals(2, filters.size)
+    fun `joined chat tail carries exactly one h value per group with no count limit`() {
+        val filter = buildRelayGroupJoinedChatTailFilter(GroupId("g1", relayA), 999L)
 
-        val a = filters.single { it.relay == relayA }
-        // The joined tail now always carries the Buzz timeline kinds too (see
+        assertEquals(relayA, filter.relay)
+        // The joined tail always carries the Buzz timeline kinds too (see
         // RELAY_GROUP_ALL_TIMELINE_KINDS / BuzzTimelineKindsTest).
-        assertEquals(timelineKinds + BUZZ_RELAY_GROUP_TIMELINE_EXTRA_KINDS, a.filter.kinds)
-        assertEquals(setOf("g1", "g2"), a.filter.tags!!["h"]!!.toSet())
-        assertEquals(999L, a.filter.since)
-        assertNull("a time-floored tail must NOT cap by count (that is what lets it batch)", a.filter.limit)
-        assertNull(a.filter.until)
+        assertEquals(timelineKinds + BUZZ_RELAY_GROUP_TIMELINE_EXTRA_KINDS, filter.filter.kinds)
+        assertEquals(listOf("g1"), filter.filter.tags!!["h"])
+        assertEquals(999L, filter.filter.since)
+        assertNull("a time-floored tail must NOT cap by count", filter.filter.limit)
+        assertNull(filter.filter.until)
+    }
+
+    /**
+     * Regression guard for the Messages-list freeze: `block/buzz` indexes a live subscription under a
+     * single channel uuid resolved from `#h`, and downgrades any subscription whose filters mention two
+     * or more distinct ids to a *global* one — which by design receives no channel-scoped events. The
+     * stored query still answers correctly, so the symptom was "backfills on launch, then never updates".
+     * Each joined group must therefore get its own single-valued filter (and its own subscription).
+     */
+    @Test
+    fun `joined chat tail never batches multiple groups into one h filter`() {
+        joined.forEach { tag ->
+            val relay = RelayUrlNormalizer.normalizeOrNull(tag.relayUrl)!!
+            val values = buildRelayGroupJoinedChatTailFilter(GroupId(tag.groupId, relay), 1L).filter.tags!!["h"]!!
+            assertEquals("a multi-value #h makes buzz register the sub as global and stop live delivery", 1, values.size)
+            assertEquals(tag.groupId, values.single())
+        }
+    }
+
+    /**
+     * The Messages-row preview is bounded by COUNT, never by time. The chat tail floors at `now - 7 days`
+     * to keep recent chat warm; on its own that leaves a channel quiet for longer stuck on its
+     * "No messages yet" placeholder forever, sorted to the bottom by `createdAt = 0`. Roster-driven
+     * protocols fill their rows this way — NIP-28 with `limit = 1`, Concord with `limit = 10` — because
+     * their row set comes from a list event and only needs one newest message per row.
+     */
+    @Test
+    fun `preview filter asks for one newest message with no time floor on a cold start`() {
+        val filter = buildRelayGroupPreviewFilter(g1OnA, null)
+
+        assertEquals(relayA, filter.relay)
+        assertEquals(listOf("g1"), filter.filter.tags!!["h"])
+        assertEquals(1, filter.filter.limit)
+        assertNull("a cold start must reach back past any window to fill the row", filter.filter.since)
+        assertNull(filter.filter.until)
+    }
+
+    @Test
+    fun `preview filter rides the per-relay EOSE since once caught up`() {
+        assertEquals(555L, buildRelayGroupPreviewFilter(g1OnA, 555L).filter.since)
+    }
+
+    /** Single-valued `#h`, so it can share the channel-scoped subscription without downgrading it. */
+    @Test
+    fun `preview filter names exactly one channel`() {
+        assertEquals(1, buildRelayGroupPreviewFilter(g1OnA, null).filter.tags!!["h"]!!.size)
+    }
+
+    /**
+     * Reactions/deletions ride the channel's own `#h` subscription, the way the Buzz reference client
+     * does it (its `channelEventKinds` bundles deletion + reaction into the one `#h` channel REQ).
+     * Amethyst's other source of reactions is the shared `#e` EventFinder query, which carries no `#h`
+     * and is therefore registered as a *global* subscription — a class that never receives
+     * channel-scoped events live, and a reaction inherits its target message's channel.
+     */
+    @Test
+    fun `aux filter carries reactions and deletions scoped to one group`() {
+        val filter = buildRelayGroupAuxFilter(GroupId("g1", relayA), 42L)
+
+        assertEquals(relayA, filter.relay)
+        assertEquals(listOf(DeletionEvent.KIND, ReactionEvent.KIND, DeleteEventEvent.KIND), filter.filter.kinds)
+        assertEquals(listOf("g1"), filter.filter.tags!!["h"])
+        assertEquals(42L, filter.filter.since)
+        assertEquals(RELAY_GROUP_AUX_LIMIT, filter.filter.limit)
+    }
+
+    /**
+     * The aux kinds must stay OUT of the timeline set: that set feeds the backward history pager, whose
+     * `until` cursor walks `created_at`. Reactions eating a page's `limit` would advance the cursor past
+     * chat messages that were never delivered.
+     */
+    @Test
+    fun `aux kinds are not in the timeline set the history pager pages over`() {
+        RELAY_GROUP_AUX_KINDS.forEach {
+            assertFalse("aux kind $it must not consume history-page limit", it in RELAY_GROUP_ALL_TIMELINE_KINDS)
+        }
     }
 
     // --- Open chat tail: a single group's recent #h on the host relay ---
@@ -239,7 +317,6 @@ class RelayGroupFilterBuildersTest {
     @Test
     fun `empty joined set produces no filters`() {
         assertTrue(buildRelayGroupStateFilters(emptySet()) { null }.isEmpty())
-        assertTrue(buildRelayGroupJoinedChatTailFilters(emptySet(), 1L).isEmpty())
     }
 
     // --- Reconnect stability: a `since`-only bump must NOT trigger a fresh REQ (no full replay) ---
@@ -265,8 +342,9 @@ class RelayGroupFilterBuildersTest {
 
     @Test
     fun `joined chat tail advancing its time floor is not a resend`() {
-        val earlier = buildRelayGroupJoinedChatTailFilters(joined, 1_000L).map { it.filter }
-        val later = buildRelayGroupJoinedChatTailFilters(joined, 2_000L).map { it.filter } // recentBoundary() crept forward
+        val groups = joined.map { GroupId(it.groupId, RelayUrlNormalizer.normalizeOrNull(it.relayUrl)!!) }
+        val earlier = groups.map { buildRelayGroupJoinedChatTailFilter(it, 1_000L).filter }
+        val later = groups.map { buildRelayGroupJoinedChatTailFilter(it, 2_000L).filter } // recentBoundary() crept forward
         earlier.zip(later).forEach { (old, new) ->
             assertFalse(
                 "a forward recent-tail floor bump is since-only → reconnect re-REQs the tail, not a full page",

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/buzz/BuzzChannelInvites.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/buzz/BuzzChannelInvites.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model.buzz
+
+import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.commons.util.KmpLock
+import com.vitorpamplona.amethyst.commons.util.withLock
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/** Somebody added [viewer] to a channel: who did it, where, and when. */
+@Immutable
+class BuzzChannelInvite(
+    val channelId: String,
+    val relay: NormalizedRelayUrl,
+    val actor: HexKey?,
+    val createdAt: Long,
+)
+
+/**
+ * App-wide, per-viewer set of channels somebody **else** added the viewer to, awaiting the viewer's
+ * decision about whether they appear on Messages.
+ *
+ * On a Buzz relay, membership is server-side: another member issues the add, the relay writes you into
+ * the channel's kind-39002 roster, and you can immediately read and post. The relay then addresses you a
+ * kind-44100 with `{"actor": …}` naming who did it — and it emits the *same* kind for a self-join, with
+ * `actor == you`, which is the only thing separating the two cases.
+ *
+ * Amethyst used to funnel every 44100 into [BuzzDmChannels], which silently subscribed the viewer to the
+ * channel's messages while the Messages list — which reads the self-published kind-10009 — showed no row
+ * for it. So a channel could be simultaneously joined (relay roster, no Join button, composer enabled),
+ * streaming messages, and invisible. Only `t = dm` channels belong in [BuzzDmChannels]; everything else
+ * lands here until the viewer accepts.
+ *
+ * Accepting adds the group to kind-10009 (`Account.follow`), after which the normal joined-group path
+ * owns it and the entry is dropped. Dismissing is a *display* choice recorded in
+ * `AccountSettings.dismissedChannelInvites`; genuinely leaving is a kind-9022 `LeaveRequestEvent`, which
+ * is a different action because the viewer really is a member until the relay says otherwise.
+ */
+object BuzzChannelInvites {
+    private val lock = KmpLock()
+    private val byViewer = HashMap<HexKey, MutableMap<String, BuzzChannelInvite>>()
+    private val mutableFlow = MutableStateFlow<Map<HexKey, Map<String, BuzzChannelInvite>>>(emptyMap())
+
+    /** Per-viewer pending invites (`channelId` -> who/where/when). */
+    val flow: StateFlow<Map<HexKey, Map<String, BuzzChannelInvite>>> = mutableFlow
+
+    /**
+     * Records that somebody added [viewer] to [channelId]. Returns true when this is newly seen, so
+     * callers can invalidate a feed; a repeat of the same (viewer, channel) returns false rather than
+     * churning the flow — the relay re-sends the notification on every reconnect.
+     */
+    fun record(
+        viewer: HexKey,
+        invite: BuzzChannelInvite,
+    ): Boolean =
+        lock.withLock {
+            val invites = byViewer.getOrPut(viewer) { mutableMapOf() }
+            if (invites.containsKey(invite.channelId)) return@withLock false
+            invites[invite.channelId] = invite
+            mutableFlow.value = snapshot()
+            true
+        }
+
+    /**
+     * Drops an invite once it is no longer pending — the viewer accepted it (now in kind-10009), left the
+     * channel, or the relay reported a kind-44101 removal.
+     */
+    fun remove(
+        viewer: HexKey,
+        channelId: String,
+    ): Boolean =
+        lock.withLock {
+            val invites = byViewer[viewer] ?: return@withLock false
+            if (invites.remove(channelId) == null) return@withLock false
+            mutableFlow.value = snapshot()
+            true
+        }
+
+    /** Invites pending for [viewer], possibly empty. */
+    fun invitesFor(viewer: HexKey): Map<String, BuzzChannelInvite> = mutableFlow.value[viewer] ?: emptyMap()
+
+    private fun snapshot(): Map<HexKey, Map<String, BuzzChannelInvite>> = byViewer.mapValues { it.value.toMap() }
+
+    /** Test-only: clears all state so unit tests don't leak into each other. */
+    fun clearForTesting() =
+        lock.withLock {
+            byViewer.clear()
+            mutableFlow.value = emptyMap()
+        }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/buzz/BuzzDmChannels.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/buzz/BuzzDmChannels.kt
@@ -68,6 +68,23 @@ object BuzzDmChannels {
             true
         }
 
+    /**
+     * Drops a channel that turned out not to be a DM. Discovery provisionally records every kind-44100
+     * here so the channel's kind-39000 can be fetched by id; once that reveals a `t` other than `dm` the
+     * entry is withdrawn, because the always-on DM tail must not silently subscribe the viewer to a named
+     * channel somebody added them to (see [BuzzChannelInvites]).
+     */
+    fun remove(
+        viewer: HexKey,
+        channelId: String,
+    ): Boolean =
+        lock.withLock {
+            val channels = byViewer[viewer] ?: return@withLock false
+            if (channels.remove(channelId) == null) return@withLock false
+            mutableFlow.value = snapshot()
+            true
+        }
+
     /** The DM channels [viewer] is in (`channelId` -> relay), possibly empty. */
     fun channelsFor(viewer: HexKey): Map<String, NormalizedRelayUrl> = mutableFlow.value[viewer] ?: emptyMap()
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/buzz/notifications/MemberAddedNotificationEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/buzz/notifications/MemberAddedNotificationEvent.kt
@@ -49,6 +49,16 @@ class MemberAddedNotificationEvent(
     /** The channel UUID the member was added to - the `h` tag. */
     fun channel() = tags.notificationChannel()
 
+    /**
+     * The relay-reported body: who performed the change ([MembershipNotificationContent.actor]) and the
+     * channel it applies to. The relay emits this kind for a self-join too, so the actor is what
+     * separates "I joined" from "somebody added me" — see [MembershipNotificationContent].
+     */
+    fun notification() = MembershipNotificationContent.parse(content)
+
+    /** The pubkey that performed the add/remove, or null when the body is missing or malformed. */
+    fun actor() = notification()?.actor
+
     companion object {
         const val KIND = 44100
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/buzz/notifications/MemberRemovedNotificationEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/buzz/notifications/MemberRemovedNotificationEvent.kt
@@ -49,6 +49,16 @@ class MemberRemovedNotificationEvent(
     /** The channel UUID the member was removed from - the `h` tag. */
     fun channel() = tags.notificationChannel()
 
+    /**
+     * The relay-reported body: who performed the change ([MembershipNotificationContent.actor]) and the
+     * channel it applies to. The relay emits this kind for a self-join too, so the actor is what
+     * separates "I joined" from "somebody added me" — see [MembershipNotificationContent].
+     */
+    fun notification() = MembershipNotificationContent.parse(content)
+
+    /** The pubkey that performed the add/remove, or null when the body is missing or malformed. */
+    fun actor() = notification()?.actor
+
     companion object {
         const val KIND = 44101
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/buzz/notifications/MembershipNotificationContent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/buzz/notifications/MembershipNotificationContent.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.buzz.notifications
+
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.utils.Log
+
+/**
+ * The JSON body a Buzz relay puts on a kind-44100/44101 membership notification:
+ *
+ * ```json
+ * {"type":"member_added","channel_id":"<uuid>","actor":"<pubkey hex>"}
+ * ```
+ *
+ * Ground truth: `emit_membership_notification` in Buzz's `buzz-relay/src/handlers/side_effects.rs`.
+ *
+ * [actor] is the decisive field. The relay emits the *same* kind whether somebody added you or you
+ * joined yourself — a self-join (kind 9021) is reported with `actor == target`. Without reading it,
+ * "I joined this" and "a stranger put me in this" are indistinguishable, which is what let channels
+ * appear silently.
+ */
+class MembershipNotificationContent(
+    val type: String?,
+    val channelId: String?,
+    val actor: HexKey?,
+) {
+    /** True when this records somebody *else* adding [viewer] — i.e. it needs the viewer's consent. */
+    fun addedBySomeoneElse(viewer: HexKey): Boolean = actor != null && !actor.equals(viewer, ignoreCase = true)
+
+    companion object {
+        const val TYPE_MEMBER_ADDED = "member_added"
+        const val TYPE_MEMBER_REMOVED = "member_removed"
+
+        private val TYPE = Regex("\"type\"\\s*:\\s*\"([^\"]*)\"")
+        private val CHANNEL_ID = Regex("\"channel_id\"\\s*:\\s*\"([^\"]*)\"")
+        private val ACTOR = Regex("\"actor\"\\s*:\\s*\"([0-9a-fA-F]{64})\"")
+
+        /**
+         * Parses the notification body, or null when [content] is blank/unparseable. Regex rather than a
+         * JSON parse because this runs on the consume path for every membership notification and the
+         * body is a fixed three-field object written by the relay; a malformed one must degrade to
+         * "unknown actor" (treated as needing consent) rather than throw.
+         */
+        fun parse(content: String): MembershipNotificationContent? {
+            if (content.isBlank()) return null
+            return try {
+                MembershipNotificationContent(
+                    type = TYPE.find(content)?.groupValues?.get(1),
+                    channelId = CHANNEL_ID.find(content)?.groupValues?.get(1),
+                    actor =
+                        ACTOR
+                            .find(content)
+                            ?.groupValues
+                            ?.get(1)
+                            ?.lowercase(),
+                )
+            } catch (e: Exception) {
+                Log.w("MembershipNotification") { "Could not parse membership notification: ${e.message}" }
+                null
+            }
+        }
+    }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip29RelayGroups/metadata/GroupMetadataEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip29RelayGroups/metadata/GroupMetadataEvent.kt
@@ -70,6 +70,25 @@ class GroupMetadataEvent(
      */
     fun geohashes() = tags.geohashes()
 
+    /**
+     * The Buzz channel type, carried as a `t` tag alongside the NIP-29 metadata:
+     * `stream` (linear chat, the default), `forum`, `dm`, or `workflow`. Ground truth:
+     * `ChannelType` in Buzz's `buzz-core/src/channel.rs`, emitted by the relay in
+     * `side_effects.rs` as `["t", channel_type]`.
+     *
+     * Read through this rather than [hashtags], which returns every `t` tag: on a Buzz relay the
+     * type shares the tag name with real hashtags, so only a value in the known set is a type.
+     * Returns null on a vanilla NIP-29 relay, which has no such concept.
+     */
+    fun buzzChannelType(): String? = tags.firstNotNullOfOrNull { if (it.size > 1 && it[0] == "t" && it[1] in BUZZ_CHANNEL_TYPES) it[1] else null }
+
+    /**
+     * True when this channel is a Buzz direct-message conversation rather than a named channel. The
+     * distinction decides whether a kind-44100 "you were added" belongs in the DM list or needs the
+     * viewer's consent before it shows up on Messages.
+     */
+    fun isBuzzDmChannel() = buzzChannelType() == BUZZ_CHANNEL_TYPE_DM
+
     /** Only members can read. Presence of the `private` flag; absent = public read. */
     fun isPrivate() = tags.hasTagName("private")
 
@@ -134,6 +153,11 @@ class GroupMetadataEvent(
     }
 
     companion object {
+        const val BUZZ_CHANNEL_TYPE_DM = "dm"
+
+        /** Every value Buzz's `ChannelType` can serialize to. */
+        val BUZZ_CHANNEL_TYPES = setOf("stream", "forum", BUZZ_CHANNEL_TYPE_DM, "workflow")
+
         const val KIND = 39000
 
         fun build(


### PR DESCRIPTION
## The bug

Joined NIP-29 groups showed a stale last message on **Messages** while the open chat screen stayed live. It looked like we were not subscribing at all.

We were. The joined-group tail batched every group on a host relay into **one** filter carrying all their ids in `#h`. That is valid NIP-01, and relays answer it correctly for *stored* queries — which is what made it confusing: the boot backfill populated every group, so the list looked right until it needed to change.

`block/buzz` indexes each live subscription under a **single** channel uuid resolved from `#h`. When two or more distinct ids appear anywhere across a subscription's filters, `extract_channel_id_from_filters` returns `None` and the subscription is registered as **global** — and global subscriptions deliberately never receive channel-scoped events, guarding against leaking private channel content to a subscriber whose membership was not checked per channel. So the batched tail backfilled at EOSE and then went permanently deaf.

Measured on device, single variable — same relay, same connection, same subscription id, only the `#h` count changed:

| `#h` values | live push |
|---|---|
| 1 | ✅ |
| 2 | ❌ |

The resolver scans **every** filter of a subscription, so splitting into one filter per group is not enough — each channel needs its own subscription.

## Commits

**`fix(nip29): scope group subscriptions per channel`** — EOSE managers keyed on `GroupId`, one subscription per joined channel. Buzz allows `max_subscriptions: 1024` against `max_filters: 10`, so this also sidesteps the filter cap for anyone in more than ten groups. Three related gaps folded into those same per-channel subscriptions:

- **Group activity addressed to me** moved off the account-wide notifications subscription, which also carries inbox filters with **no `#h` at all** — buzz forces a subscription global on the first channel-less filter, so no reshaping there could ever have worked.
- **Reactions/deletions (5/7/9005)** now ride the channel's own `#h`, the shape Buzz's own client uses (`channelEventKinds`). We otherwise learned about them only via the shared `#e` EventFinder query, which carries no `#h` and is therefore global — reaction chips appeared on a re-query, never as they happened. Kept out of the timeline kind set so they cannot consume a history page's `limit` and walk the `until` cursor past undelivered messages.
- **`limit = 1` preview with no time floor.** The tail floors at `now − 7d` to keep recent chat warm; alone that stranded any channel quiet for longer on a "No messages yet" placeholder sorted to the bottom by `createdAt = 0`. Every other roster-driven protocol on that screen already bounds by count for this reason (NIP-28 `limit = 1`, Concord `limit = 10`) — their row set comes from a list event, unlike NIP-17/NIP-04 whose *rooms* are discovered from the messages and so need the backward pagers.

Rows now say "Loading" rather than "No messages yet" until the fleet settles.

**`feat(buzz): ask before showing channels somebody added you to`** — on a Buzz relay another member can add you server-side: the relay writes you into the kind-39002 roster and you can read and post immediately. We funnelled every kind-44100 into `BuzzDmChannels`, silently subscribing to that channel's messages while Messages (which reads the self-published kind-10009) showed no row. A channel could be joined, streaming, and invisible at once.

Now classified by the `t` tag on the 39000 (`stream`/`forum`/`dm`/`workflow`): only `dm` enters the DM list, everything else becomes a pending invite that subscribes to nothing. 44100 carries `{"type","channel_id","actor"}`, and the relay emits the **same kind** for a self-join with `actor == you` — the actor is the only thing separating "I joined" from "somebody put me here".

Prompt on **both** surfaces from one state holder so they cannot disagree: Notifications, and Messages › New Requests. Actions:

- **Show** → writes the group into kind-10009 (`Account.follow`); no 9021, the relay already has you in the roster
- **Ignore** → local, reversible display choice; you stay in the roster and can still open and post
- **Leave** → kind-9022, the one that actually removes you

kind-44101 withdraws a pending prompt, so a removal cannot leave a card offering an action that would fail.

## Verification

- **4,660 tests, 0 failures** (`:amethyst` 990, `:quartz` 3,670)
- On device: live kind-9 on a per-channel tail 2m20s after its EOSE with no chat screen open; live reactions post-EOSE; a channel 16-17 days quiet finally fetched (`07-09`/`07-10` against a `07-19` floor); "straycat added you to personalized-knowledge-graphs" on both surfaces, and **Show** republished kind-10009 with the channel appended.

## Notes for review

- Relay behaviour claims were verified against `block/buzz` source (`edaec99`), not inferred: `extract_channel_id_from_filters` / `fan_out_scoped` / `derive_reaction_channel` / `emit_membership_notification`.
- **Ignore ≠ Leave** is deliberate and worth a second opinion — an ignored channel is still one you are a member of.
- Group notifications now mount with the channel subscriptions, so they sit behind the NIP-29 Messages toggle. Consistent with that toggle's documented meaning, but it is a behaviour change.
- Branch is 2 commits behind `main`; merges cleanly.

Still open, deliberately not in this PR: the `#e` EventFinder redundancy and its read-privacy leak (viewed message ids go to every visible author's inbox relays), `buildRelayGroupStateFilters` batching `#d`, and buzz-side multi-channel subscription indexing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
