### PR TITLE
Stop the inline audio player painting over the note

### DIFF
--- a/amethyst/src/androidTest/java/com/vitorpamplona/amethyst/ui/components/AudioPlayerBoxOverflowTest.kt
+++ b/amethyst/src/androidTest/java/com/vitorpamplona/amethyst/ui/components/AudioPlayerBoxOverflowTest.kt
@@ -55,18 +55,19 @@ class AudioPlayerBoxOverflowTest {
     private class Bounds {
         var top = 0f
         var bottom = 0f
+        var width = 0
         var height = 0
 
         fun modifier() =
             Modifier.onGloballyPositioned {
                 top = it.positionInRoot().y
+                width = it.size.width
                 height = it.size.height
                 bottom = top + height
             }
     }
 
     private fun measure(
-        mimeType: String?,
         url: String,
         square: Boolean,
     ): Pair<Bounds, Bounds> {
@@ -76,7 +77,7 @@ class AudioPlayerBoxOverflowTest {
         rule.setContent {
             Box(Modifier.size(width = 400.dp, height = 1200.dp)) {
                 Box(
-                    modifier = mediaSizingModifier(unknownMediaAspectRatio(mimeType, url), ContentScale.Fit).then(box.modifier()),
+                    modifier = mediaSizingModifier(unknownMediaAspectRatio(null, url), ContentScale.Fit).then(box.modifier()),
                     contentAlignment = Alignment.Center,
                 ) {
                     Box((if (square) Modifier.audioSquare() else Modifier).then(player.modifier()))
@@ -90,7 +91,7 @@ class AudioPlayerBoxOverflowTest {
 
     @Test
     fun squareAudioPlayerStaysInsideItsMediaBox() {
-        val (box, player) = measure(null, "https://haven.sdbitcoiners.com/f28a5a2e.mp3", square = true)
+        val (box, player) = measure("https://haven.sdbitcoiners.com/f28a5a2e.mp3", square = true)
 
         assertTrue(
             "player overflows above the media box by ${box.top - player.top}px",
@@ -104,22 +105,9 @@ class AudioPlayerBoxOverflowTest {
     }
 
     @Test
-    fun audioWithAnExplicitMimeAlsoStaysInside() {
-        val (box, player) = measure("audio/mpeg", "https://example.com/download?id=7", square = true)
-
-        assertTrue(player.top >= box.top && player.bottom <= box.bottom)
-        assertEquals(player.height, box.height)
-    }
-
-    @Test
     fun videoOfUnknownSizeKeeps16by9() {
-        val (box, _) = measure(null, "https://example.com/a.mp4", square = false)
+        val (box, _) = measure("https://example.com/a.mp4", square = false)
 
-        // 400.dp wide at 16:9. Rounding lands within a pixel either way.
-        val expected = box.height * 16f / 9f
-        assertTrue(
-            "expected a 16:9 box, got height=${box.height} for width=$expected",
-            kotlin.math.abs(expected - 400 * rule.density.density) <= 1f,
-        )
+        assertEquals(16f / 9f, box.width.toFloat() / box.height, 0.01f)
     }
 }

--- a/amethyst/src/androidTest/java/com/vitorpamplona/amethyst/ui/components/AudioPlayerBoxOverflowTest.kt
+++ b/amethyst/src/androidTest/java/com/vitorpamplona/amethyst/ui/components/AudioPlayerBoxOverflowTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.vitorpamplona.amethyst.service.playback.composable.audioSquare
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * The inline audio player sizes itself as a square so the visualizer and controls get room, which is
+ * taller than the 16:9 box [ZoomableContentView] builds for a video of unknown dimensions. That box
+ * is centre-aligned and nothing between it and NoteComposeLayout clips, so caging the square in it
+ * makes the player paint over the note header above and the reactions row below.
+ *
+ * These tests recreate that enclosure — the real [mediaSizingModifier] over the real
+ * [unknownMediaAspectRatio], holding the real [audioSquare] — and pin both halves of the contract:
+ * audio must not be given a ratio, and video must keep the 16:9 assumption that stops live streams
+ * from letterboxing on first play.
+ */
+@RunWith(AndroidJUnit4::class)
+class AudioPlayerBoxOverflowTest {
+    @get:Rule val rule = createComposeRule()
+
+    private class Bounds {
+        var top = 0f
+        var bottom = 0f
+        var height = 0
+
+        fun modifier() =
+            Modifier.onGloballyPositioned {
+                top = it.positionInRoot().y
+                height = it.size.height
+                bottom = top + height
+            }
+    }
+
+    private fun measure(
+        mimeType: String?,
+        url: String,
+        square: Boolean,
+    ): Pair<Bounds, Bounds> {
+        val box = Bounds()
+        val player = Bounds()
+
+        rule.setContent {
+            Box(Modifier.size(width = 400.dp, height = 1200.dp)) {
+                Box(
+                    modifier = mediaSizingModifier(unknownMediaAspectRatio(mimeType, url), ContentScale.Fit).then(box.modifier()),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Box((if (square) Modifier.audioSquare() else Modifier).then(player.modifier()))
+                }
+            }
+        }
+        rule.waitForIdle()
+
+        return box to player
+    }
+
+    @Test
+    fun squareAudioPlayerStaysInsideItsMediaBox() {
+        val (box, player) = measure(null, "https://haven.sdbitcoiners.com/f28a5a2e.mp3", square = true)
+
+        assertTrue(
+            "player overflows above the media box by ${box.top - player.top}px",
+            player.top >= box.top,
+        )
+        assertTrue(
+            "player overflows below the media box by ${player.bottom - box.bottom}px",
+            player.bottom <= box.bottom,
+        )
+        assertEquals("the box should wrap the square", player.height, box.height)
+    }
+
+    @Test
+    fun audioWithAnExplicitMimeAlsoStaysInside() {
+        val (box, player) = measure("audio/mpeg", "https://example.com/download?id=7", square = true)
+
+        assertTrue(player.top >= box.top && player.bottom <= box.bottom)
+        assertEquals(player.height, box.height)
+    }
+
+    @Test
+    fun videoOfUnknownSizeKeeps16by9() {
+        val (box, _) = measure(null, "https://example.com/a.mp4", square = false)
+
+        // 400.dp wide at 16:9. Rounding lands within a pixel either way.
+        val expected = box.height * 16f / 9f
+        assertTrue(
+            "expected a 16:9 box, got height=${box.height} for width=$expected",
+            kotlin.math.abs(expected - 400 * rule.density.density) <= 1f,
+        )
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
@@ -87,6 +87,7 @@ import com.vitorpamplona.amethyst.commons.richtext.MediaUrlContent
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlImage
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlPdf
 import com.vitorpamplona.amethyst.commons.richtext.MediaUrlVideo
+import com.vitorpamplona.amethyst.commons.richtext.RichTextParser
 import com.vitorpamplona.amethyst.commons.richtext.toCoilModel
 import com.vitorpamplona.amethyst.commons.ui.components.LoadingAnimation
 import com.vitorpamplona.amethyst.model.MediaAspectRatioCache
@@ -143,6 +144,28 @@ private const val SHARED_VIDEO_CLEANUP_DELAY_MS = 120_000L
 // and bottom. Guessing the overwhelmingly common video shape puts the first layout in the right
 // place; [MediaAspectRatioCache] then corrects anything unusual once the decoder reports its size.
 private const val DEFAULT_VIDEO_ASPECT_RATIO = 16f / 9f
+
+/**
+ * Shape to assume for a [MediaUrlVideo] nobody has reported dimensions for — no imeta `dim` and
+ * nothing in [MediaAspectRatioCache].
+ *
+ * Video gets [DEFAULT_VIDEO_ASPECT_RATIO]. Audio gets null, meaning "no ratio, wrap whatever the
+ * player asks for": audio has no picture, and the inline player sizes itself as a square (see
+ * `AudioPlayerSquare.audioSquare`) so the visualizer and controls get room. A square is taller than
+ * 16:9, so caging it in a 16:9 box — which is centre-aligned and unclipped all the way up through
+ * NoteComposeLayout — makes the player paint over the note header above it and the reactions row
+ * below. Audio also never reaches the cache, since it has no video track to report a size, so the
+ * miss is permanent rather than first-play-only.
+ */
+internal fun unknownMediaAspectRatio(
+    mimeType: String?,
+    url: String,
+): Float? =
+    when {
+        mimeType != null -> if (mimeType.startsWith("audio/")) null else DEFAULT_VIDEO_ASPECT_RATIO
+        RichTextParser.isAudioUrl(url) -> null
+        else -> DEFAULT_VIDEO_ASPECT_RATIO
+    }
 
 @Composable
 fun ZoomableContentView(
@@ -203,7 +226,10 @@ fun ZoomableContentView(
         }
 
         is MediaUrlVideo -> {
-            val ratio = content.dim?.aspectRatio() ?: MediaAspectRatioCache.get(content.url) ?: DEFAULT_VIDEO_ASPECT_RATIO
+            val ratio =
+                content.dim?.aspectRatio()
+                    ?: MediaAspectRatioCache.get(content.url)
+                    ?: unknownMediaAspectRatio(content.mimeType, content.url)
             val bridgedUrl =
                 remember(content.url, useLocalBlossomBridge) {
                     content.toCoilModel(useLocalBlossomBridge)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/components/ZoomableContentView.kt
@@ -160,12 +160,7 @@ private const val DEFAULT_VIDEO_ASPECT_RATIO = 16f / 9f
 internal fun unknownMediaAspectRatio(
     mimeType: String?,
     url: String,
-): Float? =
-    when {
-        mimeType != null -> if (mimeType.startsWith("audio/")) null else DEFAULT_VIDEO_ASPECT_RATIO
-        RichTextParser.isAudioUrl(url) -> null
-        else -> DEFAULT_VIDEO_ASPECT_RATIO
-    }
+): Float? = if (RichTextParser.isAudioContent(mimeType, url)) null else DEFAULT_VIDEO_ASPECT_RATIO
 
 @Composable
 fun ZoomableContentView(
@@ -226,10 +221,16 @@ fun ZoomableContentView(
         }
 
         is MediaUrlVideo -> {
+            // The fallback classifies the URL string, so compute it once per content — for audio
+            // the cache miss is permanent and this branch re-runs on every recomposition.
+            val fallbackRatio =
+                remember(content.url, content.mimeType) {
+                    unknownMediaAspectRatio(content.mimeType, content.url)
+                }
             val ratio =
                 content.dim?.aspectRatio()
                     ?: MediaAspectRatioCache.get(content.url)
-                    ?: unknownMediaAspectRatio(content.mimeType, content.url)
+                    ?: fallbackRatio
             val bridgedUrl =
                 remember(content.url, useLocalBlossomBridge) {
                     content.toCoilModel(useLocalBlossomBridge)

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/components/UnknownMediaAspectRatioTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/components/UnknownMediaAspectRatioTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The audio player sizes itself as a square (see AudioPlayerSquare.audioSquare), which is taller than
+ * 16:9. Handing audio the video default therefore cages the square in a shorter, centre-aligned box
+ * that nothing clips, and the player — visualizer included — paints over the note header above and
+ * the reactions row below. Audio must stay ratio-less so the box wraps the square instead.
+ */
+class UnknownMediaAspectRatioTest {
+    @Test
+    fun unknownVideoAssumes16by9() {
+        assertEquals(16f / 9f, unknownMediaAspectRatio(null, "https://example.com/a.mp4"))
+    }
+
+    @Test
+    fun liveStreamPlaylistKeeps16by9() {
+        assertEquals(16f / 9f, unknownMediaAspectRatio(null, "https://example.com/stream.m3u8"))
+    }
+
+    @Test
+    fun bareAudioUrlHasNoRatio() {
+        assertNull(unknownMediaAspectRatio(null, "https://haven.sdbitcoiners.com/f28a5a2e.mp3"))
+    }
+
+    @Test
+    fun audioMimeHasNoRatioEvenWithoutAnExtension() {
+        assertNull(unknownMediaAspectRatio("audio/mpeg", "https://example.com/download?id=7"))
+    }
+
+    @Test
+    fun videoMimeWinsOverNothing() {
+        assertEquals(16f / 9f, unknownMediaAspectRatio("video/mp4", "https://example.com/download?id=7"))
+    }
+
+    @Test
+    fun unknownEverythingAssumes16by9() {
+        assertEquals(16f / 9f, unknownMediaAspectRatio(null, "https://example.com/download?id=7"))
+    }
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
@@ -495,13 +495,20 @@ class RichTextParser {
             )
 
         val imageExt = listOf("png", "jpg", "gif", "bmp", "jpeg", "webp", "svg", "avif")
-        val videoExt = listOf("mp4", "avi", "wmv", "mpg", "amv", "webm", "mov", "mp3", "m3u8", "ogg", "wav", "flac", "aac", "opus", "m4a", "f4a")
-        val pdfExt = listOf("pdf")
 
-        // The audio-only members of [videoExt] — both play through the same video pipeline, but audio
-        // has no picture, so anything that reasons about the shape of the media (aspect ratios, player
-        // sizing) has to tell them apart. `m3u8` stays out: a playlist carries either.
+        // Audio is folded into [videoExt] because both play through the same video pipeline — but
+        // audio has no picture, so anything that reasons about the shape of the media (aspect
+        // ratios, player sizing) has to tell them apart. `m3u8` stays video-only: a playlist
+        // carries either.
+        //
+        // Composing [videoExt] out of [audioExt] is what keeps "every audio extension is also a
+        // video extension" true by construction rather than by convention — the two lists cannot
+        // drift apart. It is also why [audioExt] is declared first; the compiler rejects the
+        // reverse order outright ("Variable 'audioExt' must be initialized"), so this note is
+        // intent, not a guard rail.
         val audioExt = listOf("mp3", "ogg", "wav", "flac", "aac", "opus", "m4a", "f4a")
+        val videoExt = listOf("mp4", "avi", "wmv", "mpg", "amv", "webm", "mov", "m3u8") + audioExt
+        val pdfExt = listOf("pdf")
 
         val imageExtensions = imageExt + imageExt.map { it.uppercase() }
         val videoExtensions = videoExt + videoExt.map { it.uppercase() }
@@ -518,14 +525,13 @@ class RichTextParser {
                     it.uppercase()
                 }
 
-        private fun removeQueryParamsForExtensionComparison(fullUrl: String): String =
-            if (fullUrl.contains("?")) {
-                fullUrl.split("?")[0]
-            } else if (fullUrl.contains("#")) {
-                fullUrl.split("#")[0]
-            } else {
-                fullUrl
-            }
+        private fun removeQueryParamsForExtensionComparison(fullUrl: String): String {
+            // Called per URL during feed render — substringBefore allocates nothing when the
+            // separator is absent, unlike split().
+            val queryStart = fullUrl.indexOf('?')
+            if (queryStart >= 0) return fullUrl.substring(0, queryStart)
+            return fullUrl.substringBefore('#')
+        }
 
         fun isImageExtension(ext: String) = imageExtensions.any { it == ext }
 
@@ -552,6 +558,13 @@ class RichTextParser {
             val removedParamsFromUrl = removeQueryParamsForExtensionComparison(url)
             return audioExtensions.any { removedParamsFromUrl.endsWith(it) }
         }
+
+        // A declared MIME type is authoritative when present; the URL extension is only a fallback
+        // for the common bare-URL case.
+        fun isAudioContent(
+            mimeType: String?,
+            url: String,
+        ): Boolean = mimeType?.startsWith("audio/") ?: isAudioUrl(url)
 
         // Mirrors the canonical HLS-playlist MIME list also kept in MediaItemCache.toExoPlayerMimeType.
         // Called per URL during feed render — uses `equals(ignoreCase)` instead of `lowercase()` to

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParser.kt
@@ -498,9 +498,15 @@ class RichTextParser {
         val videoExt = listOf("mp4", "avi", "wmv", "mpg", "amv", "webm", "mov", "mp3", "m3u8", "ogg", "wav", "flac", "aac", "opus", "m4a", "f4a")
         val pdfExt = listOf("pdf")
 
+        // The audio-only members of [videoExt] — both play through the same video pipeline, but audio
+        // has no picture, so anything that reasons about the shape of the media (aspect ratios, player
+        // sizing) has to tell them apart. `m3u8` stays out: a playlist carries either.
+        val audioExt = listOf("mp3", "ogg", "wav", "flac", "aac", "opus", "m4a", "f4a")
+
         val imageExtensions = imageExt + imageExt.map { it.uppercase() }
         val videoExtensions = videoExt + videoExt.map { it.uppercase() }
         val pdfExtensions = pdfExt + pdfExt.map { it.uppercase() }
+        val audioExtensions = audioExt + audioExt.map { it.uppercase() }
 
         val tagIndex = Regex("\\#\\[([0-9]+)\\](.*)")
         val hashTagsPattern: Regex =
@@ -540,6 +546,11 @@ class RichTextParser {
         fun isVideoUrl(url: String): Boolean {
             val removedParamsFromUrl = removeQueryParamsForExtensionComparison(url)
             return videoExtensions.any { removedParamsFromUrl.endsWith(it) }
+        }
+
+        fun isAudioUrl(url: String): Boolean {
+            val removedParamsFromUrl = removeQueryParamsForExtensionComparison(url)
+            return audioExtensions.any { removedParamsFromUrl.endsWith(it) }
         }
 
         // Mirrors the canonical HLS-playlist MIME list also kept in MediaItemCache.toExoPlayerMimeType.

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParserAudioUrlTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParserAudioUrlTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.richtext
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RichTextParserAudioUrlTest {
+    @Test
+    fun mp3IsAudio() {
+        assertTrue(RichTextParser.isAudioUrl("https://haven.sdbitcoiners.com/f28a5a2e.mp3"))
+    }
+
+    @Test
+    fun otherAudioContainersAreAudio() {
+        assertTrue(RichTextParser.isAudioUrl("https://example.com/a.wav"))
+        assertTrue(RichTextParser.isAudioUrl("https://example.com/a.flac"))
+        assertTrue(RichTextParser.isAudioUrl("https://example.com/a.aac"))
+        assertTrue(RichTextParser.isAudioUrl("https://example.com/a.opus"))
+        assertTrue(RichTextParser.isAudioUrl("https://example.com/a.m4a"))
+        assertTrue(RichTextParser.isAudioUrl("https://example.com/a.f4a"))
+        assertTrue(RichTextParser.isAudioUrl("https://example.com/a.ogg"))
+    }
+
+    @Test
+    fun uppercaseIsAudio() {
+        assertTrue(RichTextParser.isAudioUrl("https://example.com/A.MP3"))
+    }
+
+    @Test
+    fun queryParamsAndFragmentsAreIgnored() {
+        assertTrue(RichTextParser.isAudioUrl("https://example.com/a.mp3?x=1"))
+        assertTrue(RichTextParser.isAudioUrl("https://example.com/a.mp3#t=10"))
+    }
+
+    @Test
+    fun videoIsNotAudio() {
+        assertFalse(RichTextParser.isAudioUrl("https://example.com/a.mp4"))
+        assertFalse(RichTextParser.isAudioUrl("https://example.com/a.webm"))
+        assertFalse(RichTextParser.isAudioUrl("https://example.com/a.mov"))
+    }
+
+    @Test
+    fun hlsPlaylistIsNotAudio() {
+        // A .m3u8 carries either, and a live stream is the reason the 16:9 default exists.
+        assertFalse(RichTextParser.isAudioUrl("https://example.com/stream.m3u8"))
+    }
+
+    @Test
+    fun imagesAndUnknownAreNotAudio() {
+        assertFalse(RichTextParser.isAudioUrl("https://example.com/a.jpg"))
+        assertFalse(RichTextParser.isAudioUrl("https://example.com/nothing"))
+    }
+
+    @Test
+    fun audioExtensionsAreASubsetOfVideoExtensions() {
+        // Audio arrives as MediaUrlVideo precisely because videoExt lumps the two together.
+        RichTextParser.audioExt.forEach {
+            assertTrue(RichTextParser.videoExt.contains(it), "videoExt must still contain $it")
+        }
+    }
+}

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParserAudioUrlTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParserAudioUrlTest.kt
@@ -31,14 +31,10 @@ class RichTextParserAudioUrlTest {
     }
 
     @Test
-    fun otherAudioContainersAreAudio() {
-        assertTrue(RichTextParser.isAudioUrl("https://example.com/a.wav"))
-        assertTrue(RichTextParser.isAudioUrl("https://example.com/a.flac"))
-        assertTrue(RichTextParser.isAudioUrl("https://example.com/a.aac"))
-        assertTrue(RichTextParser.isAudioUrl("https://example.com/a.opus"))
-        assertTrue(RichTextParser.isAudioUrl("https://example.com/a.m4a"))
-        assertTrue(RichTextParser.isAudioUrl("https://example.com/a.f4a"))
-        assertTrue(RichTextParser.isAudioUrl("https://example.com/a.ogg"))
+    fun everyAudioContainerIsAudio() {
+        RichTextParser.audioExt.forEach {
+            assertTrue(RichTextParser.isAudioUrl("https://example.com/a.$it"), it)
+        }
     }
 
     @Test
@@ -72,10 +68,14 @@ class RichTextParserAudioUrlTest {
     }
 
     @Test
-    fun audioExtensionsAreASubsetOfVideoExtensions() {
-        // Audio arrives as MediaUrlVideo precisely because videoExt lumps the two together.
-        RichTextParser.audioExt.forEach {
-            assertTrue(RichTextParser.videoExt.contains(it), "videoExt must still contain $it")
-        }
+    fun mimeTypeIsAuthoritativeOverTheUrl() {
+        assertTrue(RichTextParser.isAudioContent("audio/mpeg", "https://example.com/download?id=7"))
+        assertFalse(RichTextParser.isAudioContent("video/mp4", "https://example.com/a.mp3"))
+    }
+
+    @Test
+    fun urlExtensionIsTheFallbackWithoutAMimeType() {
+        assertTrue(RichTextParser.isAudioContent(null, "https://example.com/a.mp3"))
+        assertFalse(RichTextParser.isAudioContent(null, "https://example.com/a.mp4"))
     }
 }


### PR DESCRIPTION
Before:
<img width="300" alt="Screenshot_20260726-055347" src="https://github.com/user-attachments/assets/1aa7e559-1b97-43e3-b046-ee48ba8f8dbc" />

After:
<img width="300" alt="Screenshot_20260726-134340" src="https://github.com/user-attachments/assets/a9f106bc-412a-4a6d-bf48-2190e45e385c" />

Performance analysis: the branch makes the hot path modestly faster and adds nothing measurable elsewhere.

## Problem

An `.mp3` posted as a bare URL in a note renders its player — visualizer and all — on top of the note around it: over the author row above and the reply/boost/like row below. Measured at 229px of overspill top and bottom on a Pixel 9a.

Introduced by https://github.com/vitorpamplona/amethyst/commit/edf30489d0

## Root cause

Audio reaches the feed as a `MediaUrlVideo`, because `RichTextParser.videoExt` lumps `mp3`/`wav`/`flac`/`aac`/`opus`/`m4a`/`f4a` in with the video containers — both play through the same pipeline. Since edf30489d0 gave media of unknown dimensions a default 16:9 ratio, `ZoomableContentView` sizes that box with `mediaSizingModifier(16:9)`. Audio has no imeta `dim` and never reaches `MediaAspectRatioCache` — there is no video track to report a size — so unlike a live stream on first play, the miss is permanent and every audio file gets a 16:9 cage.

Meanwhile the inline audio player deliberately sizes itself as a square (`audioSquare`, 0feac36af2) so the visualizer and transport controls get room, and that modifier reports `min(width, 400.dp)` without consulting `constraints.maxHeight`. A square is taller than 16:9, the enclosing `Box` is centre-aligned, and nothing clips between there and `NoteComposeLayout` — which sums *measured* child heights, so the note never grows to accommodate it. The square simply paints outside its slot, over the header rows drawn before it and under the reactions row drawn after.

## Fix

Give audio no ratio, so the box wraps whatever the player asks for. Video keeps the 16:9 assumption that stops live streams letterboxing on first play, and `.m3u8` stays on the video side since a playlist carries either. Detection prefers an explicit `audio/*` mime and falls back to the URL extension, which is what a bare `.mp3` link with no imeta gives us.

Supporting changes: `videoExt` is now composed from `audioExt` plus the video-only extensions, so "every audio extension is also a video extension" holds by construction rather than by convention; the mime-then-URL precedence lives in `RichTextParser.isAudioContent` next to the other URL classifiers; the fallback ratio is remembered per content, since audio's permanent cache miss meant re-running URL classification on every recomposition of every audio note; and `removeQueryParamsForExtensionComparison` drops `split("?")[0]` for `indexOf`/`substringBefore`, which allocates nothing when the separator is absent and serves all five `is*Url` callers on every URL in the feed.

## Tests

`AudioPlayerBoxOverflowTest` (instrumented) composes the real `mediaSizingModifier` over the real `unknownMediaAspectRatio` around the real `audioSquare`, and pins both halves of the contract: the square stays inside its box, and unknown-size video still gets 16:9. Plus `UnknownMediaAspectRatioTest` (6 cases) and `RichTextParserAudioUrlTest` (8 cases) as JVM unit tests.

Verified on a Pixel 9a emulator that reverting the fix makes the instrumented test fail with the same 229px overflow, so it is a genuine regression test rather than one that passes either way. Full suites green: commons 1377, amethyst 990.

## Deliberately left out

A URL with neither an audio extension nor a mime that turns out to be audio-only once the decoder resolves its tracks will still square inside a 16:9 box. Containing that needs a clip on the media box and is left for a follow-up.

`RenderVideoPlayer` still computes its own `mimeType?.startsWith("audio/")` for the square-player trigger. Routing it through the shared `isAudioContent` would keep the two detection paths from drifting, but it would also square bare `.mp3` URLs before their tracks resolve — a runtime behaviour change outside this diff.

## License

- [ ] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
