### PR TITLE
fix: decode numeric HTML entities in link preview meta tags

### DIFF
--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/preview/MetaTagsParser.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/preview/MetaTagsParser.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.commons.preview
 
+import com.vitorpamplona.amethyst.commons.util.codePointToChars
 import kotlinx.collections.immutable.toImmutableMap
 
 data class MetaTag(
@@ -179,13 +180,32 @@ object MetaTagsParser {
                 )
 
             fun replaceCharRefs(match: MatchResult): String {
-                val bcr = BASE_CHAR_REFS[match.groupValues[2]]
+                val isNumeric = match.groupValues[1].isNotEmpty()
+                val ref = match.groupValues[2]
+                val terminated = match.groupValues[3].isNotEmpty()
+
+                // Numeric character references (&#34; / &#x22;) must be terminated by ';'
+                if (isNumeric) {
+                    if (!terminated) return match.value
+                    val codePoint =
+                        if (ref.startsWith("x", ignoreCase = true)) {
+                            ref.drop(1).toIntOrNull(16)
+                        } else {
+                            ref.toIntOrNull(10)
+                        } ?: return match.value
+                    if (codePoint !in 0..0x10FFFF || codePoint in 0xD800..0xDFFF) {
+                        return match.value
+                    }
+                    return codePointToChars(codePoint).concatToString()
+                }
+
+                val bcr = BASE_CHAR_REFS[ref]
                 if (bcr != null) {
                     return bcr
                 }
                 // non-base char refs must be terminated by ';'
-                if (match.groupValues[3].isNotEmpty()) {
-                    val cr = CHAR_REFS[match.groupValues[2]]
+                if (terminated) {
+                    val cr = CHAR_REFS[ref]
                     if (cr != null) {
                         return cr
                     }

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/preview/MetaTagsParserCharRefTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/preview/MetaTagsParserCharRefTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.preview
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MetaTagsParserCharRefTest {
+    @Test
+    fun decodesNumericCharacterReferencesInContent() {
+        val input =
+            """
+            |<html><head>
+            |  <meta property="og:description" content="&#34;You can always buy more tokens, not more time.&#34;">
+            |  <meta property="og:title" content="&#x22;hex quotes&#x22;">
+            |</head></html>
+            """.trimMargin()
+
+        val metaTags = MetaTagsParser.parse(input).toList()
+        assertEquals(2, metaTags.size)
+        assertEquals(
+            "\"You can always buy more tokens, not more time.\"",
+            metaTags[0].attr("content"),
+        )
+        assertEquals("\"hex quotes\"", metaTags[1].attr("content"))
+    }
+}


### PR DESCRIPTION
## Summary

Fixes link previews showing raw numeric HTML entities like `&#34;` in `og:description`. `MetaTagsParser.replaceCharRefs` only handled a whitelist of named entities and ignored the `#` flag, so terminated decimal/hex refs were left undecoded. Named refs like `&quot;` already worked.

Fixes #3723

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Added `MetaTagsParserCharRefTest` covering `&#34;` and `&#x22;`
- [ ] Ran `./gradlew :commons:testDebugUnitTest --tests '*MetaTagsParserCharRefTest*'` (blocked locally: Google Maven unreachable from this environment, AGP 9.3.1 could not resolve)
- [x] Independently verified the decode logic against the issue URL content (`&#34;...&#34;` → `"..."`), named refs, unterminated `&#34`, and `&#8217;`
- [ ] Manually exercised the change (see notes below)

Notes / screenshots:

Could not build/install Amethyst here (Google Maven / AGP resolve failure). Please run the commons unit test and/or reopen https://sovereignengineering.io/podcast/31-buzz-mosaico-and-other-stuff-w-pablo in a link preview after merge.

Change is flavour-irrelevant: pure `commons/` meta-tag parsing, no Play/F-Droid divergence.

AI-assisted authoring disclosed (Cursor). Research summary was posted on #3723 before this PR.

## Interop suites

- [x] N/A — does not touch protocol / interop suites
