### PR TITLE
fix(quartz): route kind-39005 by tag shape so Buzz thread summaries stop parsing as NIP-29 pin lists

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/utils/EventFactory.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/utils/EventFactory.kt
@@ -28,6 +28,7 @@ import com.vitorpamplona.quartz.buzz.amTurnMetrics.AgentTurnMetricEvent
 import com.vitorpamplona.quartz.buzz.aoObserver.ObserverFrameEvent
 import com.vitorpamplona.quartz.buzz.apPersonas.PersonaEvent
 import com.vitorpamplona.quartz.buzz.audit.AuditEntryEvent
+import com.vitorpamplona.quartz.buzz.cwChannelWindow.ThreadSummaryEvent
 import com.vitorpamplona.quartz.buzz.cwChannelWindow.WindowBoundsEvent
 import com.vitorpamplona.quartz.buzz.dm.DmAddMemberEvent
 import com.vitorpamplona.quartz.buzz.dm.DmCreatedEvent
@@ -193,6 +194,7 @@ import com.vitorpamplona.quartz.nip29RelayGroups.moderation.RemoveUserEvent
 import com.vitorpamplona.quartz.nip29RelayGroups.moderation.UpdatePinListEvent
 import com.vitorpamplona.quartz.nip29RelayGroups.request.JoinRequestEvent
 import com.vitorpamplona.quartz.nip29RelayGroups.request.LeaveRequestEvent
+import com.vitorpamplona.quartz.nip29RelayGroups.tags.GroupIdTag
 import com.vitorpamplona.quartz.nip30CustomEmoji.pack.EmojiPackEvent
 import com.vitorpamplona.quartz.nip30CustomEmoji.selection.EmojiPackSelectionEvent
 import com.vitorpamplona.quartz.nip32Labeling.LabelEvent
@@ -559,7 +561,25 @@ class EventFactory {
                 GroupMembersEvent.KIND -> GroupMembersEvent(id, pubKey, createdAt, tags, content, sig)
                 SupportedRolesEvent.KIND -> SupportedRolesEvent(id, pubKey, createdAt, tags, content, sig)
                 GroupParticipantsEvent.KIND -> GroupParticipantsEvent(id, pubKey, createdAt, tags, content, sig)
-                GroupPinnedEvent.KIND -> GroupPinnedEvent(id, pubKey, createdAt, tags, content, sig)
+                // kind:39005 is shared by two relay-signed, addressable events that never coexist on
+                // one relay: NIP-29's group pin list (relay29 family) and Buzz's NIP-CW thread
+                // summary. Disambiguate by Buzz's required `h` (channel) tag — a thread summary is
+                // addressed by `d` = the thread ROOT EVENT ID and also carries `e` = that root and
+                // `h` = the channel, while a pin list is addressed by `d` = the GROUP ID with the
+                // pinned ids as `e` tags and no `h` at all.
+                //
+                // Without this, a Buzz thread summary parses as a GroupPinnedEvent — silently, since
+                // nothing throws — and `pinnedEventIds()` would read the summary's `e` tag and report
+                // the thread root as a pinned message. Buzz publishes these live to channel
+                // subscribers (`side_effects.rs`, Redis fan-out to `EventTopic::Channel`), not only on
+                // its HTTP bridge, so any future channel-scoped filter that asks for 39005 receives
+                // them. Buzz's own pinned message is a different kind entirely (40004).
+                GroupPinnedEvent.KIND ->
+                    if (tags.any { it.size > 1 && it[0] == GroupIdTag.TAG_NAME }) {
+                        ThreadSummaryEvent(id, pubKey, createdAt, tags, content, sig)
+                    } else {
+                        GroupPinnedEvent(id, pubKey, createdAt, tags, content, sig)
+                    }
                 UpdatePinListEvent.KIND -> UpdatePinListEvent(id, pubKey, createdAt, tags, content, sig)
                 ChessGameEvent.KIND -> ChessGameEvent(id, pubKey, createdAt, tags, content, sig)
                 CodeSnippetEvent.KIND -> CodeSnippetEvent(id, pubKey, createdAt, tags, content, sig)

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip29RelayGroups/PinEventsTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip29RelayGroups/PinEventsTest.kt
@@ -20,6 +20,8 @@
  */
 package com.vitorpamplona.quartz.nip29RelayGroups
 
+import com.vitorpamplona.quartz.buzz.cwChannelWindow.ThreadSummaryContent
+import com.vitorpamplona.quartz.buzz.cwChannelWindow.ThreadSummaryEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip29RelayGroups.metadata.GroupPinnedEvent
 import com.vitorpamplona.quartz.nip29RelayGroups.moderation.UpdatePinListEvent
@@ -50,6 +52,39 @@ class PinEventsTest {
         event as GroupPinnedEvent
         assertEquals(gid, event.groupId())
         assertEquals(listOf(id1, id2, id3), event.pinnedEventIds())
+    }
+
+    /**
+     * kind:39005 is shared with Buzz's [ThreadSummaryEvent]. A summary carries `h` (the channel);
+     * every NIP-29 relay-generated 39xxx event — this one included — is addressed by `d` alone and
+     * never emits `h`, which is what [EventFactory] discriminates on. Without it a summary parsed as
+     * a pin list and `pinnedEventIds()` reported the thread root as a pinned message.
+     */
+    @Test
+    fun threadSummaryWithChannelTagDoesNotParseAsAPinList() {
+        val tags = arrayOf(arrayOf("d", id1), arrayOf("e", id1), arrayOf("h", gid))
+        val content = ThreadSummaryContent(replyCount = 3, descendantCount = 5, lastReplyAt = 99).encodeToJson()
+        val event: Event = EventFactory.create("00".repeat(32), relaySelf, 100, ThreadSummaryEvent.KIND, tags, content, "22".repeat(64))
+
+        assertEquals(true, event is ThreadSummaryEvent)
+        event as ThreadSummaryEvent
+        assertEquals(id1, event.rootId())
+        assertEquals(id1, event.rootEventTag())
+        assertEquals(gid, event.channelId())
+        assertEquals(3, event.summary().replyCount)
+    }
+
+    /** Both classes' own builders keep that shape, so outbound signing routes back to the right class. */
+    @Test
+    fun bothBuildersRoundTripThroughTheFactory() {
+        val pin = GroupPinnedEvent.build(gid, listOf(id1, id2))
+        val summary = ThreadSummaryEvent.build(id1, gid, ThreadSummaryContent(replyCount = 1, descendantCount = 1))
+
+        val parsedPin: Event = EventFactory.create("00".repeat(32), relaySelf, 100, pin.kind, pin.tags, pin.content, "22".repeat(64))
+        val parsedSummary: Event = EventFactory.create("00".repeat(32), relaySelf, 100, summary.kind, summary.tags, summary.content, "22".repeat(64))
+
+        assertEquals(true, parsedPin is GroupPinnedEvent)
+        assertEquals(true, parsedSummary is ThreadSummaryEvent)
     }
 
     @Test


### PR DESCRIPTION
## The collision

kind:39005 is claimed by two unrelated relay-signed addressable events:

| | `d` | `e` | `h` | content |
|--|--|--|--|--|
| **`GroupPinnedEvent`** (NIP-29) | group id | pinned message ids | — | empty |
| **`ThreadSummaryEvent`** (Buzz NIP-CW) | thread root id | that same root | channel id | `{reply_count, descendant_count, last_reply_at, participants}` |

`EventFactory` mapped 39005 unconditionally to `GroupPinnedEvent`, so `ThreadSummaryEvent` was **unreachable** — nothing ever constructed one from the wire. Nothing throws on the mismatch either, so a summary parsed as a pin list and `pinnedEventIds()` would have read the summary's `e` tag and reported the thread root as a pinned message.

## The fix

Discriminate inside the kind's block on the `h` tag, following the precedent already in this file for kind:20001 (shared by BitChat's `GeohashPresenceEvent` and Buzz's `PresenceUpdateEvent`, split on `g`).

`h` is safe in both directions, verified rather than assumed:

- the entire NIP-29 relay-generated 39xxx family — metadata, admins, members, participants, supported-roles, pinned — is addressed by `d` alone and **never** emits `h`;
- neither `GroupPinnedEvent.build` nor `ThreadSummaryEvent.build` deviates, so both classes round-trip through the factory on **outbound signing** as well as inbound parse (both paths go through `create`).

The two meanings never coexist on one relay in practice — Buzz's own pinned-message kind is 40004 — so this is purely Amethyst's global-factory clash.

## Why it matters beyond correctness

Buzz publishes thread summaries **live** to channel subscribers (`side_effects.rs` fans a 39005 out to `EventTopic::Channel`), not only over its HTTP bridge. Today we never receive them only because no filter asks for 39005 with a channel's `h`. This change is what makes it safe for a channel-scoped filter to ask at all — without it, adding 39005 to one would silently corrupt the channel's pinned list.

## Downstream

`LocalCache` has no `is ThreadSummaryEvent` branch, so a summary now falls to the `else` ("Event Not Supported", returns false) instead of calling `updatePinned()` with a thread root. Strictly better than the status quo; consuming them to drive thread reply counts is a follow-up.

## Testing

Two regression tests in `PinEventsTest.kt` (a summary with `h` parses as `ThreadSummaryEvent` with root/channel/reply-count intact; both builders round-trip through the factory). `RelayGroupChannelTest.pinned()` casts a factory-built 39005 `as GroupPinnedEvent` and still routes correctly — its tags are `d` + `e` only.

`:quartz:jvmTest`, `:commons:jvmTest` and `:amethyst:testPlayDebugUnitTest` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)