### PR TITLE
refactor(chats): demote Threads and Share to the channel overflow menu

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/BuzzCanvasScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/BuzzCanvasScreen.kt
@@ -22,6 +22,7 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.buzz
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -45,7 +46,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vitorpamplona.amethyst.R
@@ -53,20 +56,25 @@ import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
 import com.vitorpamplona.amethyst.commons.model.EmptyTagList
 import com.vitorpamplona.amethyst.commons.model.buzz.BuzzWorkspaceStates
+import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.ui.components.TranslatableRichTextViewer
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
-import com.vitorpamplona.amethyst.ui.navigation.topbars.TopBarWithBackButton
+import com.vitorpamplona.amethyst.ui.navigation.topbars.TopBarExtensibleWithBackButton
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.quartz.buzz.stream.CanvasEvent
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
+import com.vitorpamplona.quartz.nip29RelayGroups.GroupId
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
- * A Buzz workspace **canvas** (NIP kind 40100): the newest shared markdown document for a channel.
- * The canvas is overlay state held in [BuzzWorkspaceStates] (never a timeline row — a workspace has
+ * A Buzz **canvas** (kind 40100): the newest shared markdown document for ONE channel. The relay
+ * requires an `h` channel tag on every canvas (its own `channel_scoped_content_kinds_require_h_tags`
+ * invariant), so each channel has its own — this is not a workspace-wide document.
+ *
+ * The canvas is overlay state held in [BuzzWorkspaceStates] (never a timeline row — a channel has
  * one live canvas, last-write-wins), so this reads the registry by the channel's `h` id and
  * re-composes off `canvasUpdates` when a newer revision lands.
  *
@@ -87,6 +95,15 @@ fun BuzzCanvasScreen(
     val canvas = remember(version) { state.canvasNote }
     val content = canvas?.event?.content
 
+    // The channel this canvas belongs to, for the subtitle. Null until its kind-39000 lands, which
+    // only costs the subtitle — the canvas itself is keyed by the raw channel id.
+    val channelName =
+        remember(channelId, relayUrl) {
+            RelayUrlNormalizer.normalizeOrNull(relayUrl)?.let { relay ->
+                LocalCache.getRelayGroupChannelIfExists(GroupId(channelId, relay))?.toBestDisplayName()
+            }
+        }
+
     var editing by remember { mutableStateOf(false) }
 
     if (editing) {
@@ -101,7 +118,32 @@ fun BuzzCanvasScreen(
     }
 
     Scaffold(
-        topBar = { TopBarWithBackButton(stringRes(R.string.buzz_canvas_title), nav) },
+        // Name the channel under the title, like the Threads screen: a canvas belongs to one channel,
+        // and arriving here from a chat should not lose track of which.
+        topBar = {
+            TopBarExtensibleWithBackButton(
+                title = {
+                    Column {
+                        Text(
+                            text = stringRes(R.string.buzz_canvas_title),
+                            fontWeight = FontWeight.Bold,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        if (channelName != null) {
+                            Text(
+                                text = channelName,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                    }
+                },
+                popBack = nav::popBack,
+            )
+        },
         floatingActionButton = {
             FloatingActionButton(onClick = { editing = true }) {
                 Icon(symbol = MaterialSymbols.Edit, contentDescription = stringRes(R.string.buzz_canvas_edit))

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/relayGroup/RelayGroupTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/relayGroup/RelayGroupTopBar.kt
@@ -170,20 +170,10 @@ fun RelayGroupTopBar(
             }
         },
         actions = {
-            if (!isDm) {
-                IconButton(onClick = {
-                    nav.nav(Route.RelayGroupThreads(channel.groupId.id, channel.groupId.relayUrl.url))
-                }) {
-                    Icon(
-                        symbol = MaterialSymbols.Forum,
-                        contentDescription = stringRes(R.string.relay_group_threads_title),
-                        modifier = Modifier.size(20.dp),
-                    )
-                }
-            }
-
             // Buzz workspace canvas (kind 40100): shown on any Buzz-dialect relay so a member can
-            // open the shared markdown doc — or create one when the channel has none yet.
+            // open the shared markdown doc — or create one when the channel has none yet. The only
+            // affordance that stays an icon: it is this channel's shared document, i.e. content, while
+            // Threads and Share are navigation the reader needs once in a while.
             if (BuzzRelayDialect.isBuzz(channel.groupId.relayUrl)) {
                 IconButton(onClick = { nav.nav(Route.BuzzCanvas(channel.groupId.id, channel.groupId.relayUrl.url)) }) {
                     Icon(
@@ -197,48 +187,68 @@ fun RelayGroupTopBar(
             // remember the bech32 (naddr) encode — this top bar recomposes on every roster/metadata
             // emission (observeChannel), and the encode is otherwise redone each time.
             val naddr = remember(channel.groupId, isDm) { if (isDm) null else channel.toNAddr() }
-            if (naddr != null) {
-                val context = LocalContext.current
-                IconButton(onClick = { shareRelayGroup(context, naddr) }) {
-                    Icon(
-                        symbol = MaterialSymbols.Share,
-                        contentDescription = stringRes(R.string.quick_action_share),
-                        modifier = Modifier.size(20.dp),
-                    )
+
+            if (displayMembership == RelayGroupMembership.PENDING) {
+                Text(
+                    text = stringRes(R.string.relay_group_pending),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else if (!displayMembership.isMember() && channel.requiresMembershipToPost()) {
+                FilledTonalButton(onClick = {
+                    // Closed groups need an invite code; open groups join directly.
+                    if (channel.isClosed()) {
+                        showJoinCode = true
+                    } else {
+                        requested = true
+                        accountViewModel.joinRelayGroup(channel)
+                    }
+                }) {
+                    Text(stringRes(R.string.join))
                 }
             }
-            when {
-                displayMembership == RelayGroupMembership.PENDING -> {
-                    Text(
-                        text = stringRes(R.string.relay_group_pending),
-                        style = MaterialTheme.typography.labelMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+
+            // The membership actions are only meaningful once the relay lets you in: while a join is
+            // pending, and on a gated group that doesn't list you, the Join affordance above stands in
+            // for them. Threads and Share stay available either way — you can want to hand out a group
+            // you are still only browsing.
+            val showMembershipActions =
+                displayMembership != RelayGroupMembership.PENDING &&
+                    !(!displayMembership.isMember() && channel.requiresMembershipToPost())
+
+            // Everything here used to be a top-bar icon. Threads especially over-advertised itself: on a
+            // Buzz `t=stream` channel it is always empty (forum posts live in `t=forum` channels, which
+            // the relay's channel list already surfaces in their own section), so it read as a broken
+            // feature on every chat. Demoted to the overflow, where the frequency of use actually is.
+            if (!isDm || naddr != null || showMembershipActions) {
+                IconButton(onClick = { menuOpen = true }) {
+                    Icon(
+                        symbol = MaterialSymbols.MoreVert,
+                        contentDescription = stringRes(R.string.more_options),
+                        modifier = Modifier.size(22.dp),
                     )
                 }
-
-                !displayMembership.isMember() && channel.requiresMembershipToPost() -> {
-                    FilledTonalButton(onClick = {
-                        // Closed groups need an invite code; open groups join directly.
-                        if (channel.isClosed()) {
-                            showJoinCode = true
-                        } else {
-                            requested = true
-                            accountViewModel.joinRelayGroup(channel)
-                        }
-                    }) {
-                        Text(stringRes(R.string.join))
-                    }
-                }
-
-                else -> {
-                    IconButton(onClick = { menuOpen = true }) {
-                        Icon(
-                            symbol = MaterialSymbols.MoreVert,
-                            contentDescription = stringRes(R.string.more_options),
-                            modifier = Modifier.size(22.dp),
+                DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                    if (!isDm) {
+                        DropdownMenuItem(
+                            text = { Text(stringRes(R.string.relay_group_threads_title)) },
+                            onClick = {
+                                menuOpen = false
+                                nav.nav(Route.RelayGroupThreads(channel.groupId.id, channel.groupId.relayUrl.url))
+                            },
                         )
                     }
-                    DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                    if (naddr != null) {
+                        val context = LocalContext.current
+                        DropdownMenuItem(
+                            text = { Text(stringRes(R.string.quick_action_share)) },
+                            onClick = {
+                                menuOpen = false
+                                shareRelayGroup(context, naddr)
+                            },
+                        )
+                    }
+                    if (showMembershipActions) {
                         DropdownMenuItem(
                             text = { Text(stringRes(R.string.relay_group_menu_members)) },
                             onClick = {

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -3490,7 +3490,7 @@
     <string name="buzz_forum_upvoted">▲ %1$s upvoted a post</string>
     <string name="buzz_forum_downvoted">▼ %1$s downvoted a post</string>
     <string name="buzz_canvas_title">Canvas</string>
-    <string name="buzz_canvas_empty">No canvas has been shared in this workspace yet.</string>
+    <string name="buzz_canvas_empty">No canvas has been shared in this channel yet.</string>
     <string name="buzz_canvas_edit">Edit canvas</string>
     <string name="buzz_canvas_save">Save canvas</string>
     <string name="buzz_canvas_body_label">Canvas (Markdown)</string>


### PR DESCRIPTION
## Why

The relay-group top bar carried four affordances — **Threads, Canvas, Share, overflow** — which squeezed the title until a channel named `personalized-knowledge-graphs` rendered as `personalized-...` with its relay host truncated too.

**Threads was the worst offender, because it advertises a feature that usually isn't there.** On a Buzz `t=stream` channel the threads list is forum posts (kind 45001), and Buzz only ever creates those in `t=forum` channels — which our relay channel list *already* surfaces in their own **Forums** section, opening straight into this same view. So on every chat channel the button led to:

> **Threads** · personalized-knowledge-graphs
> *No threads yet. Start one with the + button.*

…and that **+** would have published a 45001 into a stream channel, where Buzz's own client never renders it (`ChannelScreen.tsx` mounts `ForumChannelContent` only when `activeChannel.channelType === "forum"`).

It's demoted rather than gated off, because on vanilla NIP-29 relays the same screen is the legitimate NIP-7D kind-11 thread view.

**Canvas keeps its icon** — it's this channel's shared document, i.e. content, while Threads and Share are navigation you reach for occasionally.

## Also fixed: the overflow only existed for members

The menu lived in the `else` branch of the membership `when`, so a pending join or a gated group you don't belong to replaced the *whole menu* with the Join button — Members was unreachable while browsing. Now the overflow is always present, membership actions (Members / Edit / Invite / Leave) gated exactly as before, and Threads/Share always available: you can want to hand out a group you're still only browsing.

## Canvas is per-channel, not per-workspace

The relay requires an `h` channel tag on kind-40100 — its own test `channel_scoped_content_kinds_require_h_tags` asserts it, alongside the three forum kinds. So:

- empty state: "No canvas has been shared in this ~~workspace~~ **channel** yet."
- the KDoc says so explicitly, with the relay invariant cited
- the screen now names its channel under the title, the way Threads does

## Verified on emulator-5554

| | before | after |
|--|--|--|
| Buzz channel | Threads · Canvas · Share · ⋮ (title truncated) | Canvas · ⋮ — full title + relay fit |
| overflow | Members, Leave | Threads, Share, Members, Leave |
| non-Buzz group (basspistol.org) | Threads · Share · ⋮ | ⋮ with the same four items, no Canvas |
| canvas screen | "Canvas", "…in this workspace yet" | "Canvas / personalized-knowledge-graphs", "…in this channel yet" |

`:amethyst:testPlayDebugUnitTest` and `:amethyst:lintPlayDebug` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)