### PR TITLE
Support P2PK witness signing for pasted Cashu tokens

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip60Cashu/CashuWalletState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip60Cashu/CashuWalletState.kt
@@ -39,6 +39,7 @@ import com.vitorpamplona.quartz.nip01Core.core.toHexKey
 import com.vitorpamplona.quartz.nip01Core.hints.EventHintBundle
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
 import com.vitorpamplona.quartz.nip09Deletions.DeletionEvent
 import com.vitorpamplona.quartz.nip60Cashu.history.CashuSpendingHistoryEvent
 import com.vitorpamplona.quartz.nip60Cashu.mintApi.DeterministicSecretFactory
@@ -312,6 +313,19 @@ class CashuWalletState(
      * external signers may reject the decrypt). Callers should handle null.
      */
     suspend fun exportP2pkPrivkeyHex(): String? = walletPrivkeyHex()
+
+    /**
+     * Private keys that can sign a NUT-11 P2PK witness when redeeming a pasted
+     * `cashuA`/`cashuB` token — see [CashuWalletOps.redeemToken].
+     *
+     * `first` is the wallet's kind:17375 P2PK key (for tokens locked to our
+     * wallet key, e.g. an inbound nutzap handed over out-of-band). `second` is
+     * the account identity key, present ONLY for a local nsec signer — some
+     * senders (e.g. Bey Wallet's P2PK send) lock ecash directly to the
+     * recipient's npub, and only a local key can produce that raw signature.
+     * A remote (NIP-46) / external (NIP-55) signer yields null there.
+     */
+    suspend fun redeemSigningKeys(): Pair<String?, String?> = walletPrivkeyHex() to (signer as? NostrSignerInternal)?.keyPair?.privKey?.toHexKey()
 
     private suspend fun walletPrivkeyHex(): String? =
         _walletEvent.value?.let { evt ->

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/CashuWalletViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/CashuWalletViewModel.kt
@@ -27,6 +27,7 @@ import com.vitorpamplona.amethyst.commons.cashu.ops.MintQuoteStarted
 import com.vitorpamplona.amethyst.commons.cashu.ops.TokenEntry
 import com.vitorpamplona.amethyst.commons.cashu.ops.describeMintError
 import com.vitorpamplona.amethyst.commons.cashu.ops.describeRedeemError
+import com.vitorpamplona.amethyst.commons.cashu.ops.requireP2pkRedeemable
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.nip60Cashu.CashuWalletState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -919,6 +920,9 @@ class CashuWalletViewModel : ViewModel() {
                     } else {
                         null to null
                     }
+                // All-or-nothing: reject an unsignable P2PK lock before redeeming
+                // any group, so a multi-mint token never ends up half-redeemed.
+                requireP2pkRedeemable(parsedTokens.flatMap { it.proofs }, walletKey, identityKey)
                 val total =
                     parsedTokens.sumOf {
                         ops

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/CashuWalletViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/CashuWalletViewModel.kt
@@ -33,6 +33,7 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.quartz.lightning.LnInvoiceUtil
 import com.vitorpamplona.quartz.nip60Cashu.mintApi.MeltQuoteBolt11ResponseDto
 import com.vitorpamplona.quartz.nip60Cashu.mintApi.MintHttpException
+import com.vitorpamplona.quartz.nip60Cashu.p2pk.anyP2pkLocked
 import com.vitorpamplona.quartz.nip60Cashu.token.CashuTokenB64Parser
 import com.vitorpamplona.quartz.nip87Ecash.recommendation.MintRecommendationEvent
 import com.vitorpamplona.quartz.utils.Log
@@ -909,7 +910,15 @@ class CashuWalletViewModel : ViewModel() {
                 // Keys that can unlock a P2PK-locked token: our wallet key, and
                 // — for a local nsec login only — the identity key (some senders,
                 // e.g. Bey Wallet, P2PK-lock ecash straight to the recipient npub).
-                val (walletKey, identityKey) = state.redeemSigningKeys()
+                // Only gathered when a proof is actually locked: redeemSigningKeys()
+                // decrypts the kind:17375 privkey, which is a signer round-trip on
+                // a bunker/external signer we shouldn't pay for a plain token.
+                val (walletKey, identityKey) =
+                    if (parsedTokens.any { it.proofs.anyP2pkLocked() }) {
+                        state.redeemSigningKeys()
+                    } else {
+                        null to null
+                    }
                 val total =
                     parsedTokens.sumOf {
                         ops

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/CashuWalletViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/CashuWalletViewModel.kt
@@ -26,6 +26,7 @@ import com.vitorpamplona.amethyst.commons.cashu.ops.CashuWalletOps
 import com.vitorpamplona.amethyst.commons.cashu.ops.MintQuoteStarted
 import com.vitorpamplona.amethyst.commons.cashu.ops.TokenEntry
 import com.vitorpamplona.amethyst.commons.cashu.ops.describeMintError
+import com.vitorpamplona.amethyst.commons.cashu.ops.describeRedeemError
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.nip60Cashu.CashuWalletState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -905,10 +906,25 @@ class CashuWalletViewModel : ViewModel() {
         _redeemState.value = CashuRedeemFlowState.Redeeming
         vm.launchSigner {
             try {
-                val total = parsedTokens.sumOf { ops.redeemToken(trimmed, it.proofs, it.mint).amount }
+                // Keys that can unlock a P2PK-locked token: our wallet key, and
+                // — for a local nsec login only — the identity key (some senders,
+                // e.g. Bey Wallet, P2PK-lock ecash straight to the recipient npub).
+                val (walletKey, identityKey) = state.redeemSigningKeys()
+                val total =
+                    parsedTokens.sumOf {
+                        ops
+                            .redeemToken(
+                                cashuToken = trimmed,
+                                proofs = it.proofs,
+                                mintUrl = it.mint,
+                                walletP2pkPrivkeyHex = walletKey,
+                                identityPrivkeyHex = identityKey,
+                            ).amount
+                    }
                 _redeemState.value = CashuRedeemFlowState.Completed(total)
             } catch (e: Exception) {
-                _redeemState.value = CashuRedeemFlowState.Error(describeMintError(e))
+                _redeemState.value =
+                    CashuRedeemFlowState.Error(describeRedeemError(e, account!!.signer.pubKey))
             }
         }
     }

--- a/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/cashu/CashuReceiveCommands.kt
+++ b/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/cashu/CashuReceiveCommands.kt
@@ -26,6 +26,9 @@ import com.vitorpamplona.amethyst.cli.DataDir
 import com.vitorpamplona.amethyst.cli.Output
 import com.vitorpamplona.amethyst.cli.commands.route
 import com.vitorpamplona.quartz.lightning.LnInvoiceUtil
+import com.vitorpamplona.quartz.nip01Core.core.toHexKey
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
+import com.vitorpamplona.quartz.nip60Cashu.p2pk.P2PKUnredeemableException
 import com.vitorpamplona.quartz.nip60Cashu.token.CashuTokenB64Parser
 
 /**
@@ -156,12 +159,25 @@ object CashuReceiveCommands {
         Context.open(dataDir).use { ctx ->
             ctx.prepare()
             return try {
+                // Keys that can unlock a P2PK-locked token: the wallet's kind:17375
+                // key, plus — for a local key account — the identity key (some
+                // senders, e.g. Bey Wallet, P2PK-lock ecash to the recipient npub).
+                val snap = ctx.cashuSnapshot()
+                val walletKey = snap.walletEvent?.let { runCatching { it.privkey(ctx.signer) }.getOrNull() }
+                val identityKey = (ctx.signer as? NostrSignerInternal)?.keyPair?.privKey?.toHexKey()
                 var total = 0L
                 var lastTokenEventId: String? = null
                 var lastHistoryEventId: String? = null
                 var mint = ""
                 for (t in parsed) {
-                    val redeemed = ctx.cashuOps().redeemToken(raw, t.proofs, t.mint)
+                    val redeemed =
+                        ctx.cashuOps().redeemToken(
+                            cashuToken = raw,
+                            proofs = t.proofs,
+                            mintUrl = t.mint,
+                            walletP2pkPrivkeyHex = walletKey,
+                            identityPrivkeyHex = identityKey,
+                        )
                     total += redeemed.amount
                     lastTokenEventId = redeemed.tokenEvent.id
                     lastHistoryEventId = redeemed.historyEvent.id
@@ -176,6 +192,8 @@ object CashuReceiveCommands {
                     ),
                 )
                 0
+            } catch (e: P2PKUnredeemableException) {
+                Output.error("p2pk_locked", "token is P2PK-locked to a key this wallet can't sign for (${e.lockPubKeyHex})")
             } catch (e: Exception) {
                 Output.error("mint_proofs_spent", describe(e))
             }

--- a/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/cashu/CashuReceiveCommands.kt
+++ b/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/cashu/CashuReceiveCommands.kt
@@ -29,6 +29,7 @@ import com.vitorpamplona.quartz.lightning.LnInvoiceUtil
 import com.vitorpamplona.quartz.nip01Core.core.toHexKey
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
 import com.vitorpamplona.quartz.nip60Cashu.p2pk.P2PKUnredeemableException
+import com.vitorpamplona.quartz.nip60Cashu.p2pk.anyP2pkLocked
 import com.vitorpamplona.quartz.nip60Cashu.token.CashuTokenB64Parser
 
 /**
@@ -162,9 +163,12 @@ object CashuReceiveCommands {
                 // Keys that can unlock a P2PK-locked token: the wallet's kind:17375
                 // key, plus — for a local key account — the identity key (some
                 // senders, e.g. Bey Wallet, P2PK-lock ecash to the recipient npub).
-                val snap = ctx.cashuSnapshot()
-                val walletKey = snap.walletEvent?.let { runCatching { it.privkey(ctx.signer) }.getOrNull() }
-                val identityKey = (ctx.signer as? NostrSignerInternal)?.keyPair?.privKey?.toHexKey()
+                // Only decrypt the wallet key when a proof is actually locked (a
+                // signer round-trip on bunker accounts, wasted on a plain token).
+                val locked = parsed.any { it.proofs.anyP2pkLocked() }
+                val walletKey =
+                    if (locked) ctx.cashuSnapshot().walletEvent?.let { runCatching { it.privkey(ctx.signer) }.getOrNull() } else null
+                val identityKey = if (locked) (ctx.signer as? NostrSignerInternal)?.keyPair?.privKey?.toHexKey() else null
                 var total = 0L
                 var lastTokenEventId: String? = null
                 var lastHistoryEventId: String? = null

--- a/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/cashu/CashuReceiveCommands.kt
+++ b/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/cashu/CashuReceiveCommands.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.amethyst.cli.Context
 import com.vitorpamplona.amethyst.cli.DataDir
 import com.vitorpamplona.amethyst.cli.Output
 import com.vitorpamplona.amethyst.cli.commands.route
+import com.vitorpamplona.amethyst.commons.cashu.ops.requireP2pkRedeemable
 import com.vitorpamplona.quartz.lightning.LnInvoiceUtil
 import com.vitorpamplona.quartz.nip01Core.core.toHexKey
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
@@ -169,6 +170,9 @@ object CashuReceiveCommands {
                 val walletKey =
                     if (locked) ctx.cashuSnapshot().walletEvent?.let { runCatching { it.privkey(ctx.signer) }.getOrNull() } else null
                 val identityKey = if (locked) (ctx.signer as? NostrSignerInternal)?.keyPair?.privKey?.toHexKey() else null
+                // All-or-nothing: reject an unsignable P2PK lock before redeeming
+                // any group, so a multi-mint token never ends up half-redeemed.
+                if (locked) requireP2pkRedeemable(parsed.flatMap { it.proofs }, walletKey, identityKey)
                 var total = 0L
                 var lastTokenEventId: String? = null
                 var lastHistoryEventId: String? = null

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/cashu/ops/CashuWalletOps.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/cashu/ops/CashuWalletOps.kt
@@ -46,6 +46,7 @@ import com.vitorpamplona.quartz.nip60Cashu.mintApi.RandomSecretFactory
 import com.vitorpamplona.quartz.nip60Cashu.mintApi.SecretFactory
 import com.vitorpamplona.quartz.nip60Cashu.mintApi.splitAmountIntoDenominations
 import com.vitorpamplona.quartz.nip60Cashu.p2pk.P2PK
+import com.vitorpamplona.quartz.nip60Cashu.p2pk.P2PKUnredeemableException
 import com.vitorpamplona.quartz.nip60Cashu.quote.CashuMintQuoteEvent
 import com.vitorpamplona.quartz.nip60Cashu.token.CashuProof
 import com.vitorpamplona.quartz.nip60Cashu.token.CashuTokenEvent
@@ -630,9 +631,29 @@ class CashuWalletOps(
         proofs: List<CashuProof>,
         mintUrl: String,
         nutzapEventId: String? = null,
+        /**
+         * The wallet's NIP-60 P2PK private key (kind:17375 `privkey`, hex).
+         * Used to sign the NUT-11 witness when the token is locked to our
+         * wallet key. Null when the wallet hasn't decrypted its kind:17375.
+         */
+        walletP2pkPrivkeyHex: String? = null,
+        /**
+         * The account's Nostr identity private key (hex), available ONLY for a
+         * local nsec signer. Some senders (e.g. Bey Wallet's P2PK send) lock
+         * ecash directly to the recipient's npub, so we sign the witness with
+         * the identity key when the lock targets it. Null for remote (NIP-46)
+         * or external (NIP-55) signers — they can't produce a raw witness
+         * signature, so such a token surfaces as [P2PKUnredeemableException].
+         */
+        identityPrivkeyHex: String? = null,
     ): RedeemCompleted {
         if (proofs.isEmpty()) throw IllegalArgumentException("Token has no proofs")
-        val swap = ops(mintUrl).swap(proofs, targetSplit = null)
+        // Index our candidate signing keys by their x-only pubkey so a locked
+        // proof can be matched to the key that unlocks it. Empty when we hold
+        // no keys (e.g. CLI callers) — a locked token then throws a clear
+        // P2PKUnredeemableException instead of an unsigned swap.
+        val signingKeys = p2pkKeyIndex(walletP2pkPrivkeyHex, identityPrivkeyHex)
+        val swap = ops(mintUrl).redeemToken(proofs) { lockXOnly -> signingKeys[lockXOnly] }
         val total = swap.keep.sumOf { it.amount }
 
         // All output goes to "keep" since targetSplit was null.
@@ -1276,12 +1297,55 @@ data class RestoreOutcome(
 /** Drop the leading parity byte if present so two pubkeys can be compared. */
 private fun String.lastHex64(): String = if (length == 66) substring(2) else this
 
+/**
+ * Index the given private keys by their 32-byte x-only pubkey hex, skipping
+ * blanks. Used by [CashuWalletOps.redeemToken] to resolve which of our keys (if
+ * any) unlocks a P2PK proof, comparing against the lock's x-only `data`.
+ */
+private fun p2pkKeyIndex(vararg privKeysHex: String?): Map<String, String> =
+    buildMap {
+        privKeysHex.forEach { hex ->
+            if (!hex.isNullOrBlank()) {
+                val xOnly =
+                    Secp256k1
+                        .pubKeyCompress(Secp256k1.pubkeyCreate(hex.hexToByteArray()))
+                        .toHexKey()
+                        .lastHex64()
+                put(xOnly, hex)
+            }
+        }
+    }
+
 /** Catches mint HTTP / protocol errors and surfaces their detail message. */
 fun describeMintError(e: Throwable): String =
     when (e) {
+        is P2PKUnredeemableException -> "This ecash is locked to a public key this wallet can't sign for."
         is MintHttpException -> "Mint error (HTTP ${e.httpStatus}): ${e.detail ?: e.message}"
         is MintProtocolException -> "Mint refused: ${e.message}"
         else -> e.message ?: e::class.simpleName ?: "Unknown error"
+    }
+
+/**
+ * Error text for the redeem-token flow. Adds context [describeMintError] can't:
+ * when a token is P2PK-locked to the user's own [identityPubKeyHex] but we
+ * couldn't sign for it, it means the current signer is a bunker/external one
+ * that can't produce a raw witness — so point the user at claiming it elsewhere.
+ * Falls back to [describeMintError] for everything else.
+ */
+fun describeRedeemError(
+    e: Throwable,
+    identityPubKeyHex: String?,
+): String =
+    if (e is P2PKUnredeemableException) {
+        val lock = e.lockPubKeyHex.lastHex64()
+        if (identityPubKeyHex != null && lock == identityPubKeyHex.lastHex64()) {
+            "This ecash is locked to your Nostr identity key, which the current login can't sign for " +
+                "(only a local key / nsec login can). Import your nsec into a Cashu wallet to claim it."
+        } else {
+            "This ecash is locked to a public key you don't control (${lock.take(12)}…) and can't be claimed here."
+        }
+    } else {
+        describeMintError(e)
     }
 
 /** A decrypted, unspent token event ready to be spent. */

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/cashu/ops/CashuWalletOps.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/cashu/ops/CashuWalletOps.kt
@@ -47,6 +47,7 @@ import com.vitorpamplona.quartz.nip60Cashu.mintApi.SecretFactory
 import com.vitorpamplona.quartz.nip60Cashu.mintApi.splitAmountIntoDenominations
 import com.vitorpamplona.quartz.nip60Cashu.p2pk.P2PK
 import com.vitorpamplona.quartz.nip60Cashu.p2pk.P2PKUnredeemableException
+import com.vitorpamplona.quartz.nip60Cashu.p2pk.firstUnsignableP2pkLock
 import com.vitorpamplona.quartz.nip60Cashu.quote.CashuMintQuoteEvent
 import com.vitorpamplona.quartz.nip60Cashu.token.CashuProof
 import com.vitorpamplona.quartz.nip60Cashu.token.CashuTokenEvent
@@ -1306,6 +1307,8 @@ private fun p2pkKeyIndex(vararg privKeysHex: String?): Map<String, String> =
     buildMap {
         privKeysHex.forEach { hex ->
             if (!hex.isNullOrBlank()) {
+                // toHexKey() emits lowercase, matching the lowercased x-only the
+                // resolver is queried with (see P2PKRedeem.xOnly).
                 val xOnly =
                     Secp256k1
                         .pubKeyCompress(Secp256k1.pubkeyCreate(hex.hexToByteArray()))
@@ -1315,6 +1318,23 @@ private fun p2pkKeyIndex(vararg privKeysHex: String?): Map<String, String> =
             }
         }
     }
+
+/**
+ * Pre-flight a token's proofs against the keys we hold: throws
+ * [P2PKUnredeemableException] (naming the offending lock) if any P2PK-locked
+ * proof can't be signed. Callers redeem a multi-group token one group at a time,
+ * each swapping + publishing, so checking every group up front avoids redeeming
+ * some and then failing on an unsignable one — mirroring the unknown-mint
+ * pre-check. Plain (unlocked) proofs are ignored.
+ */
+fun requireP2pkRedeemable(
+    proofs: List<CashuProof>,
+    walletP2pkPrivkeyHex: String?,
+    identityPrivkeyHex: String?,
+) {
+    val signingKeys = p2pkKeyIndex(walletP2pkPrivkeyHex, identityPrivkeyHex)
+    firstUnsignableP2pkLock(proofs) { signingKeys[it] }?.let { throw P2PKUnredeemableException(it) }
+}
 
 /** Catches mint HTTP / protocol errors and surfaces their detail message. */
 fun describeMintError(e: Throwable): String =
@@ -1338,7 +1358,7 @@ fun describeRedeemError(
 ): String =
     if (e is P2PKUnredeemableException) {
         val lock = e.lockPubKeyHex.lastHex64()
-        if (identityPubKeyHex != null && lock == identityPubKeyHex.lastHex64()) {
+        if (identityPubKeyHex != null && lock.equals(identityPubKeyHex.lastHex64(), ignoreCase = true)) {
             "This ecash is locked to your Nostr identity key, which the current login can't sign for " +
                 "(only a local key / nsec login can). Import your nsec into a Cashu wallet to claim it."
         } else {

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip60Cashu/p2pk/P2PK.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip60Cashu/p2pk/P2PK.kt
@@ -92,8 +92,13 @@ object P2PK {
      * Parse a Cashu P2PK secret string. Returns null if the string is not a
      * NUT-11 P2PK secret.
      */
-    fun parseSecret(secret: String): ParsedP2pk? =
-        try {
+    fun parseSecret(secret: String): ParsedP2pk? {
+        // Fast reject before the (throwing) JSON parse: NUT-10 well-known
+        // secrets are a JSON array (`["P2PK", …]`), while a plain Cashu secret
+        // is opaque hex/base64. Redeeming a token calls this once per proof, so
+        // skipping the parse+exception for the common plain case matters.
+        if (!secret.looksLikeJsonArray()) return null
+        return try {
             val arr = json.parseToJsonElement(secret) as? JsonArray ?: return null
             if (arr.size < 2) return null
             val kind = (arr[0] as? JsonPrimitive)?.content
@@ -105,6 +110,16 @@ object P2PK {
         } catch (_: Exception) {
             null
         }
+    }
+
+    /** True when the first non-whitespace char is `[` — i.e. it may be a JSON array. */
+    private fun String.looksLikeJsonArray(): Boolean {
+        for (c in this) {
+            if (c.isWhitespace()) continue
+            return c == '['
+        }
+        return false
+    }
 
     /**
      * BIP-340 Schnorr signature over `sha256(secret_bytes)` used as the unlock

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip60Cashu/p2pk/P2PK.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip60Cashu/p2pk/P2PK.kt
@@ -125,6 +125,14 @@ object P2PK {
      * BIP-340 Schnorr signature over `sha256(secret_bytes)` used as the unlock
      * witness. Returns the witness JSON string ready to drop into a Cashu
      * proof's `witness` field.
+     *
+     * SECURITY: [secret] is attacker-controlled (it comes from a pasted token),
+     * and when [privKeyHex] is the account's Nostr identity key this signs
+     * `sha256(secret)` with that key. Cross-protocol reuse against Nostr event
+     * signing is prevented only because a valid P2PK secret must start with
+     * `["P2PK"` while a Nostr event serialization starts with `[0,` — so callers
+     * MUST only reach here for secrets that already passed [parseSecret]; that
+     * prefix check is load-bearing for safety, not just parsing.
      */
     fun signWitness(
         secret: String,

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip60Cashu/p2pk/P2PKRedeem.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip60Cashu/p2pk/P2PKRedeem.kt
@@ -55,13 +55,34 @@ fun signP2pkWitnesses(
 ): List<CashuProof> =
     proofs.map { proof ->
         val parsed = P2PK.parseSecret(proof.secret) ?: return@map proof
-        val xOnly = parsed.pubKeyHex.xOnly()
-        val privKeyHex = signingKeyFor(xOnly) ?: throw P2PKUnredeemableException(parsed.pubKeyHex)
+        val privKeyHex = signingKeyFor(parsed.pubKeyHex.xOnly()) ?: throw P2PKUnredeemableException(parsed.pubKeyHex)
         proof.copy(witness = P2PK.signWitness(proof.secret, privKeyHex))
     }
+
+/**
+ * The first P2PK lock across [proofs] that [signingKeyFor] can't resolve, or
+ * null if every locked proof is signable (plain proofs are ignored). Lets a
+ * caller pre-flight a multi-group token so it never swaps some groups and then
+ * discovers a later group is unredeemable — leaving a half-redeemed state.
+ */
+fun firstUnsignableP2pkLock(
+    proofs: List<CashuProof>,
+    signingKeyFor: (lockPubKeyXOnly: String) -> String?,
+): String? {
+    proofs.forEach { proof ->
+        val parsed = P2PK.parseSecret(proof.secret) ?: return@forEach
+        if (signingKeyFor(parsed.pubKeyHex.xOnly()) == null) return parsed.pubKeyHex
+    }
+    return null
+}
 
 /** True when any proof in the set carries a NUT-11 P2PK-locked secret. */
 fun List<CashuProof>.anyP2pkLocked(): Boolean = any { P2PK.parseSecret(it.secret) != null }
 
-/** Drop a 33-byte compressed pubkey's parity prefix, yielding the 32-byte x-only hex. */
-private fun String.xOnly(): String = if (length == 66) substring(2) else this
+/**
+ * Drop a 33-byte compressed pubkey's parity prefix, yielding the 32-byte x-only
+ * hex, and lowercase it. The `data` field is formatted by the sender and NUT-11
+ * doesn't mandate a case, so normalize before matching against our (lowercase)
+ * key index — otherwise an uppercase lock we *can* sign for is falsely rejected.
+ */
+private fun String.xOnly(): String = (if (length == 66) substring(2) else this).lowercase()

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip60Cashu/p2pk/P2PKRedeem.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip60Cashu/p2pk/P2PKRedeem.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip60Cashu.p2pk
+
+import com.vitorpamplona.quartz.nip60Cashu.token.CashuProof
+
+/**
+ * Thrown when a proof set contains a NUT-11 P2PK-locked proof that this wallet
+ * has no private key to sign for. [lockPubKeyHex] is the pubkey the proof is
+ * locked to, exactly as it appears in the secret (32-byte x-only or 33-byte
+ * compressed) — callers may compare it against the user's own keys to craft a
+ * tailored message (e.g. "locked to your identity key, redeem it elsewhere").
+ */
+class P2PKUnredeemableException(
+    val lockPubKeyHex: String,
+) : RuntimeException("This ecash is locked to a public key this wallet can't sign for ($lockPubKeyHex).")
+
+/**
+ * Attach NUT-11 unlock witnesses to any P2PK-locked proofs in [proofs] so the
+ * set can be spent at `/v1/swap`.
+ *
+ * Each proof's secret is inspected via [P2PK.parseSecret]:
+ *  - a plain (non-P2PK) secret passes through unchanged;
+ *  - a P2PK secret is signed with the private key returned by [signingKeyFor],
+ *    which is invoked with the lock's 32-byte **x-only** pubkey hex (the parity
+ *    prefix of a 33-byte compressed `data` is stripped first, since BIP-340
+ *    verification — what the mint runs — is x-only).
+ *
+ * When [signingKeyFor] returns null for a locked proof, we hold no key for it
+ * and [P2PKUnredeemableException] is thrown (naming the original lock pubkey)
+ * rather than sending an unsigned swap the mint would reject with an opaque
+ * `witness is missing for p2pk signature` 400.
+ */
+fun signP2pkWitnesses(
+    proofs: List<CashuProof>,
+    signingKeyFor: (lockPubKeyXOnly: String) -> String?,
+): List<CashuProof> =
+    proofs.map { proof ->
+        val parsed = P2PK.parseSecret(proof.secret) ?: return@map proof
+        val xOnly = parsed.pubKeyHex.xOnly()
+        val privKeyHex = signingKeyFor(xOnly) ?: throw P2PKUnredeemableException(parsed.pubKeyHex)
+        proof.copy(witness = P2PK.signWitness(proof.secret, privKeyHex))
+    }
+
+/** True when any proof in the set carries a NUT-11 P2PK-locked secret. */
+fun List<CashuProof>.anyP2pkLocked(): Boolean = any { P2PK.parseSecret(it.secret) != null }
+
+/** Drop a 33-byte compressed pubkey's parity prefix, yielding the 32-byte x-only hex. */
+private fun String.xOnly(): String = if (length == 66) substring(2) else this

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip60Cashu/p2pk/P2PKRedeemTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip60Cashu/p2pk/P2PKRedeemTest.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip60Cashu.p2pk
+
+import com.vitorpamplona.quartz.nip01Core.core.hexToByteArray
+import com.vitorpamplona.quartz.nip01Core.core.toHexKey
+import com.vitorpamplona.quartz.nip60Cashu.token.CashuProof
+import com.vitorpamplona.quartz.utils.Secp256k1Instance
+import com.vitorpamplona.quartz.utils.sha256.sha256
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * [signP2pkWitnesses] — the redeem-side counterpart to spending a pasted
+ * cashu token that may (or may not) be NUT-11 P2PK-locked.
+ *
+ * Reproduces the interop scenario reported against Bey Wallet, which
+ * P2PK-locks ecash to the recipient's Nostr identity pubkey: before the fix
+ * the redeem path sent the locked proofs to /v1/swap with no witness and the
+ * mint rejected them with `witness is missing for p2pk signature`. Here we
+ * assert the witness is produced and verifies under the lock pubkey.
+ */
+class P2PKRedeemTest {
+    // Deterministic key (== 1) — same construction as P2PKTest.
+    private val priv = "1".padStart(64, '0')
+    private val xOnlyPub =
+        Secp256k1Instance
+            .compressedPubKeyFor(priv.hexToByteArray())
+            .copyOfRange(1, 33)
+            .toHexKey()
+
+    private fun lockedProof(lockPubKeyHex: String) = CashuProof(id = "keyset1", amount = 4, secret = P2PK.lockedSecret(lockPubKeyHex), c = "c-hex")
+
+    private fun plainProof() = CashuProof(id = "keyset1", amount = 1, secret = "9a1b...plain-secret", c = "c-hex")
+
+    private fun witnessVerifies(
+        proof: CashuProof,
+        xOnlyHex: String,
+    ): Boolean {
+        val witness = proof.witness ?: return false
+        val sigs = (Json.parseToJsonElement(witness) as JsonObject)["signatures"] as JsonArray
+        val sigHex = (sigs[0] as JsonPrimitive).content
+        return Secp256k1Instance.verifySchnorr(
+            signature = sigHex.hexToByteArray(),
+            hash = sha256(proof.secret.encodeToByteArray()),
+            pubKey = xOnlyHex.hexToByteArray(),
+        )
+    }
+
+    @Test
+    fun plainProofPassesThroughUnsigned() {
+        val proof = plainProof()
+        val out = signP2pkWitnesses(listOf(proof)) { error("resolver must not be called for a plain proof") }
+        assertEquals(1, out.size)
+        assertNull(out[0].witness, "a non-P2PK proof must not gain a witness")
+        assertEquals(proof, out[0])
+    }
+
+    @Test
+    fun lockedProofGetsVerifiableWitness() {
+        // Locked to the x-only key (Nostr-identity style, 64 hex).
+        val out =
+            signP2pkWitnesses(listOf(lockedProof(xOnlyPub))) { lockXOnly ->
+                assertEquals(xOnlyPub, lockXOnly, "resolver is queried by the lock's x-only pubkey")
+                priv
+            }
+        assertTrue(witnessVerifies(out[0], xOnlyPub), "witness must verify under the lock pubkey")
+    }
+
+    @Test
+    fun compressedLockResolvesByXOnly() {
+        // Locked to the 33-byte compressed form (02/03 prefix) — the resolver
+        // must still be asked by the 32-byte x-only pubkey, and the witness
+        // must verify (the mint runs x-only BIP-340).
+        val compressed = "02$xOnlyPub"
+        val out =
+            signP2pkWitnesses(listOf(lockedProof(compressed))) { lockXOnly ->
+                assertEquals(xOnlyPub, lockXOnly, "the parity prefix must be stripped before resolving")
+                priv
+            }
+        assertTrue(witnessVerifies(out[0], xOnlyPub))
+    }
+
+    @Test
+    fun unknownLockThrowsNamingThePubkey() {
+        val compressed = "02$xOnlyPub"
+        val e =
+            assertFailsWith<P2PKUnredeemableException> {
+                signP2pkWitnesses(listOf(lockedProof(compressed))) { null }
+            }
+        // The exception carries the lock exactly as it appears in the secret so
+        // callers can compare it against the user's own keys.
+        assertEquals(compressed, e.lockPubKeyHex)
+    }
+
+    @Test
+    fun mixedSetSignsOnlyTheLockedProofs() {
+        val plain = plainProof()
+        val locked = lockedProof(xOnlyPub)
+        val out = signP2pkWitnesses(listOf(plain, locked)) { priv }
+        assertNull(out[0].witness, "plain proof stays unsigned")
+        assertTrue(witnessVerifies(out[1], xOnlyPub), "locked proof is signed")
+    }
+
+    @Test
+    fun anyP2pkLockedDetectsLockedProofs() {
+        assertFalse(listOf(plainProof()).anyP2pkLocked())
+        assertTrue(listOf(plainProof(), lockedProof(xOnlyPub)).anyP2pkLocked())
+    }
+}

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip60Cashu/p2pk/P2PKRedeemTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip60Cashu/p2pk/P2PKRedeemTest.kt
@@ -133,4 +133,33 @@ class P2PKRedeemTest {
         assertFalse(listOf(plainProof()).anyP2pkLocked())
         assertTrue(listOf(plainProof(), lockedProof(xOnlyPub)).anyP2pkLocked())
     }
+
+    @Test
+    fun uppercaseLockMatchesLowercaseKeyIndex() {
+        // NUT-11 doesn't mandate a hex case for `data`. Our key index is keyed
+        // by lowercase x-only (Hex.encode is lowercase), so an uppercase lock we
+        // hold the key for must still resolve — not be reported unredeemable.
+        val upperLock = "02${xOnlyPub.uppercase()}"
+        val index = mapOf(xOnlyPub to priv)
+        val out = signP2pkWitnesses(listOf(lockedProof(upperLock))) { index[it] }
+        assertTrue(witnessVerifies(out[0], xOnlyPub), "an uppercase lock we hold the key for must sign")
+    }
+
+    @Test
+    fun firstUnsignableReturnsNullWhenAllSignable() {
+        assertNull(firstUnsignableP2pkLock(listOf(plainProof(), lockedProof(xOnlyPub))) { priv })
+    }
+
+    @Test
+    fun firstUnsignableNamesTheUnredeemableLock() {
+        val other = "02${"b".repeat(64)}"
+        assertEquals(other, firstUnsignableP2pkLock(listOf(plainProof(), lockedProof(other))) { null })
+    }
+
+    @Test
+    fun firstUnsignableIsCaseInsensitive() {
+        val upperLock = "02${xOnlyPub.uppercase()}"
+        val index = mapOf(xOnlyPub to priv)
+        assertNull(firstUnsignableP2pkLock(listOf(lockedProof(upperLock))) { index[it] })
+    }
 }

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip60Cashu/mintApi/CashuMintOperations.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip60Cashu/mintApi/CashuMintOperations.kt
@@ -24,6 +24,7 @@ import com.vitorpamplona.quartz.nip01Core.core.hexToByteArray
 import com.vitorpamplona.quartz.nip01Core.core.toHexKey
 import com.vitorpamplona.quartz.nip60Cashu.bdhke.Bdhke
 import com.vitorpamplona.quartz.nip60Cashu.p2pk.P2PK
+import com.vitorpamplona.quartz.nip60Cashu.p2pk.signP2pkWitnesses
 import com.vitorpamplona.quartz.nip60Cashu.seed.CashuDeterministic
 import com.vitorpamplona.quartz.nip60Cashu.token.CashuProof
 import com.vitorpamplona.quartz.nip60Cashu.token.TokenContent
@@ -213,6 +214,28 @@ class CashuMintOperations(
                 proof.copy(witness = witness)
             }
         return swap(unlocked, targetSplit = null)
+    }
+
+    /**
+     * Redeem the proofs of an out-of-band token (a pasted `cashuA`/`cashuB`
+     * string) into fresh proofs in our wallet.
+     *
+     * Unlike [redeemNutzap] — which assumes every proof is P2PK-locked to our
+     * single wallet key — a pasted token may be plain, P2PK-locked, or a mix,
+     * and the lock may target any key. [signP2pkWitnesses] inspects each secret
+     * and, for locked proofs, asks [signingKeyFor] for the matching private key
+     * (by the lock's x-only pubkey). Plain proofs pass straight through.
+     *
+     * Throws [P2PKUnredeemableException] if a locked proof's key is unknown —
+     * caught upstream to show "this ecash is locked to a key you don't control"
+     * instead of leaking the mint's raw `witness is missing` 400.
+     */
+    suspend fun redeemToken(
+        proofs: List<CashuProof>,
+        signingKeyFor: (lockPubKeyXOnly: String) -> String?,
+    ): SwapResult {
+        if (proofs.isEmpty()) throw IllegalArgumentException("Nothing to redeem")
+        return swap(signP2pkWitnesses(proofs, signingKeyFor), targetSplit = null)
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds support for redeeming NUT-11 P2PK-locked Cashu tokens that are pasted out-of-band (not nutzaps). When a token's proofs are locked to a public key, the wallet now automatically signs the required BIP-340 witness using either the wallet's P2PK key (kind:17375) or the account's Nostr identity key (for local nsec signers only). Tokens locked to unknown keys surface a clear error message instead of leaking the mint's opaque `witness is missing for p2pk signature` 400.

This fixes the interop scenario where Bey Wallet P2PK-locks ecash to the recipient's npub — previously the redeem path sent unsigned proofs and the mint rejected them.

## Changes

**New modules:**
- `P2PKRedeem.kt` — Core redeem-side logic: `signP2pkWitnesses()` attaches witnesses to locked proofs, `firstUnsignableP2pkLock()` pre-flights unsignable locks, `anyP2pkLocked()` detects locked proofs.
- `P2PKRedeemTest.kt` — Comprehensive test suite covering plain proofs, x-only/compressed locks, case-insensitive key matching, and mixed proof sets.

**Modified modules:**
- `P2PK.kt` — Added fast-path rejection for non-JSON secrets (common case) before expensive parse; documented security invariant for witness signing.
- `CashuMintOperations.kt` — New `redeemToken()` method for out-of-band tokens (unlike `redeemNutzap()` which assumes wallet-key locks).
- `CashuWalletOps.kt` — Updated `redeemToken()` signature to accept wallet and identity private keys; added `p2pkKeyIndex()` to build a key resolver, `requireP2pkRedeemable()` for all-or-nothing pre-flight, and `describeRedeemError()` for user-friendly error messages (e.g. "locked to your identity key, which the current login can't sign for").
- `CashuWalletViewModel.kt` — Gathers signing keys only when a proof is actually locked (avoids unnecessary signer round-trips); pre-flights all groups before redeeming any.
- `CashuReceiveCommands.kt` (CLI) — Same pattern: conditional key gathering and pre-flight check.
- `CashuWalletState.kt` — New `redeemSigningKeys()` method to fetch both wallet and identity keys.

## Test plan

- [x] Ran `./gradlew test` — all tests pass, including new `P2PKRedeemTest` suite
- [x] Manually verified witness generation and verification under lock pubkey
- [x] Verified case-insensitive key matching (uppercase lock vs. lowercase index)
- [x] Verified plain proofs pass through unsigned
- [x] Verified mixed proof sets (plain + locked) are handled correctly

The new test suite (`P2PKRedeemTest`) covers:
- Plain proofs pass through unchanged
- Locked proofs receive verifiable witnesses
- Compressed (33-byte) locks are resolved by x-only (32-byte) pubkey
- Unknown locks throw `P2PKUnredeemableException` with the lock pubkey
- Mixed sets sign only locked proofs
- Case-insensitive key matching
- Pre-flight detection of unsignable locks

## Interop suites

- [x] N/A — change affects Cashu token redeem path (no wire bytes / audio / MLS / DM envelope impact)

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01QKeRaX749TYnJ7oR8UpqA4