### PR TITLE
test(quartz): clean up compiler warnings across the test suites

### DIFF
--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/buzz/pairing/PairingEventTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/buzz/pairing/PairingEventTest.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class PairingEventTest {
@@ -67,7 +68,7 @@ class PairingEventTest {
     @Test
     fun unknownAbortReasonMapsToUnknown() {
         val decoded = PairingMessage.decodeFromJson("""{"type":"abort","reason":"solar_flare"}""")
-        assertTrue(decoded is PairingMessage.Abort)
-        assertEquals(AbortReason.UNKNOWN, (decoded as PairingMessage.Abort).reasonOrUnknown())
+        assertIs<PairingMessage.Abort>(decoded)
+        assertEquals(AbortReason.UNKNOWN, decoded.reasonOrUnknown())
     }
 }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/cache/projection/EventStoreProjectionTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/cache/projection/EventStoreProjectionTest.kt
@@ -34,7 +34,6 @@ import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
 import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
 import com.vitorpamplona.quartz.nip40Expiration.expiration
 import com.vitorpamplona.quartz.nip62RequestToVanish.RequestToVanishEvent
-import com.vitorpamplona.quartz.utils.Secp256k1Instance
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -64,7 +63,6 @@ class EventStoreProjectionTest {
 
     @BeforeTest
     fun setUp() {
-        Secp256k1Instance
         store = EventStore(dbName = null)
         observable = ObservableEventStore(store)
         scope = CoroutineScope(SupervisorJob())

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/FetchAllIdleTimeoutTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/FetchAllIdleTimeoutTest.kt
@@ -27,6 +27,7 @@ import com.vitorpamplona.quartz.nip01Core.relay.client.reqs.SubscriptionListener
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.currentTime
@@ -41,6 +42,7 @@ import kotlin.test.assertTrue
  * that keeps streaming is never cropped, and a stalled fetch ends one idle
  * window after its last message.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class FetchAllIdleTimeoutTest {
     /** Captures the subscription listener so the test can play a relay. */
     private class ScriptedClient : INostrClient by EmptyNostrClient() {

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/BaseDBTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/BaseDBTest.kt
@@ -20,7 +20,6 @@
  */
 package com.vitorpamplona.quartz.nip01Core.store.sqlite
 
-import com.vitorpamplona.quartz.utils.Secp256k1Instance
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -40,9 +39,6 @@ open class BaseDBTest {
 
     @BeforeTest
     fun setup() {
-        // Load our crypto libs
-        Secp256k1Instance
-
         val booleans = listOf(true, false)
 
         dbs = mutableMapOf<String, EventStore>()

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/MergeQueryCorrectnessTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/MergeQueryCorrectnessTest.kt
@@ -94,10 +94,10 @@ class MergeQueryCorrectnessTest {
     ): List<String> =
         all
             .asSequence()
-            .filter { filter.authors == null || it.pubKey in filter.authors!! }
-            .filter { filter.kinds == null || it.kind in filter.kinds!! }
-            .filter { filter.since == null || it.createdAt >= filter.since!! }
-            .filter { filter.until == null || it.createdAt <= filter.until!! }
+            .filter { filter.authors == null || it.pubKey in filter.authors }
+            .filter { filter.kinds == null || it.kind in filter.kinds }
+            .filter { filter.since == null || it.createdAt >= filter.since }
+            .filter { filter.until == null || it.createdAt <= filter.until }
             .sortedWith(newestFirst)
             .take(limit)
             .map { it.id }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/NoFullTextSearchTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/NoFullTextSearchTest.kt
@@ -25,10 +25,8 @@ import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerSync
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
-import com.vitorpamplona.quartz.utils.Secp256k1Instance
 import com.vitorpamplona.quartz.utils.TimeUtils
 import kotlinx.coroutines.runBlocking
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -46,11 +44,6 @@ import kotlin.test.assertTrue
  */
 class NoFullTextSearchTest {
     private val signer = NostrSignerSync()
-
-    @BeforeTest
-    fun setup() {
-        Secp256k1Instance
-    }
 
     private fun store() =
         SQLiteEventStore(

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip46RemoteSigner/server/NostrConnectSignerServiceTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip46RemoteSigner/server/NostrConnectSignerServiceTest.kt
@@ -42,6 +42,7 @@ import com.vitorpamplona.quartz.nip57Zaps.LnZapPrivateEvent
 import com.vitorpamplona.quartz.nip57Zaps.LnZapRequestEvent
 import com.vitorpamplona.quartz.utils.RandomInstance
 import com.vitorpamplona.quartz.utils.TimeUtils
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -58,6 +59,7 @@ import kotlin.test.assertTrue
  * commonTest), so this exercises the subscribe → decrypt → dispatch → publish
  * plumbing and the JSON round-trip, not the cipher itself.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class NostrConnectSignerServiceTest {
     private val serverKey = "a".repeat(64)
     private val clientKey = "b".repeat(64)

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/podcasts/PodcastCommentScopeTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/podcasts/PodcastCommentScopeTest.kt
@@ -47,11 +47,11 @@ class PodcastCommentScopeTest {
     @Test
     fun `episode events declare themselves as NIP-22 comment roots`() {
         // Consistency with every other commentable content type (articles, videos, …).
-        val pc20 =
+        val pc20: Event =
             signer.sign<Podcasting20EpisodeEvent>(
                 Podcasting20EpisodeEvent.build("ep-1", "E", listOf(PodcastAudio("https://x/a.mp3")), "Thu, 04 Nov 2023 12:00:00 GMT"),
             )
-        val f4 =
+        val f4: Event =
             signer.sign<PodcastEpisodeEvent>(
                 PodcastEpisodeEvent.build("E", "d", listOf(AudioTag("https://x/a.mp3"))),
             )

--- a/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip60Cashu/mintApi/MintExceptionTest.kt
+++ b/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip60Cashu/mintApi/MintExceptionTest.kt
@@ -60,7 +60,9 @@ class MintExceptionTest {
         // describeMintError lives in amethyst-layer, but at the quartz level we
         // can at least confirm both exceptions are runtime — callers don't need
         // to declare them.
-        assertTrue(MintHttpException(200, null, null, "m") is RuntimeException)
-        assertTrue(MintProtocolException("m") is RuntimeException)
+        val http: Exception = MintHttpException(200, null, null, "m")
+        val protocol: Exception = MintProtocolException("m")
+        assertTrue(http is RuntimeException)
+        assertTrue(protocol is RuntimeException)
     }
 }

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/cache/interning/EventInternerTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/cache/interning/EventInternerTest.kt
@@ -24,7 +24,6 @@ import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.OptimizedJsonMapper
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerSync
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
-import com.vitorpamplona.quartz.utils.Secp256k1Instance
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -39,7 +38,6 @@ class EventInternerTest {
 
     @BeforeTest
     fun setUp() {
-        Secp256k1Instance
         interner = EventInterner()
     }
 

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/prodbench/BatchInsertLossTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/prodbench/BatchInsertLossTest.kt
@@ -26,7 +26,6 @@ import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.store.IEventStore
 import com.vitorpamplona.quartz.nip01Core.store.sqlite.DefaultIndexingStrategy
 import com.vitorpamplona.quartz.nip01Core.store.sqlite.EventStore
-import com.vitorpamplona.quartz.utils.Secp256k1Instance
 import kotlinx.coroutines.runBlocking
 import java.io.File
 import kotlin.test.Test
@@ -66,7 +65,6 @@ class BatchInsertLossTest {
     @Test
     fun batchInsertNeverLosesAcceptedRegularEvents() =
         runBlocking {
-            Secp256k1Instance
             val file = File(corpusPath).takeIf { it.exists() } ?: File("../$corpusPath")
             if (!file.exists()) {
                 println("─ BatchInsertLossTest: corpus not found at $corpusPath — skipping ─")

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/prodbench/ConcurrentIngestLossTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/prodbench/ConcurrentIngestLossTest.kt
@@ -27,7 +27,6 @@ import com.vitorpamplona.quartz.nip01Core.relay.server.backend.IngestQueue
 import com.vitorpamplona.quartz.nip01Core.store.IEventStore
 import com.vitorpamplona.quartz.nip01Core.store.sqlite.DefaultIndexingStrategy
 import com.vitorpamplona.quartz.nip01Core.store.sqlite.EventStore
-import com.vitorpamplona.quartz.utils.Secp256k1Instance
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -65,7 +64,6 @@ class ConcurrentIngestLossTest {
     @Test
     fun concurrentIngestNeverLosesAcceptedEvents() =
         runBlocking {
-            Secp256k1Instance
             val file = File(corpusPath).takeIf { it.exists() } ?: File("../$corpusPath")
             if (!file.exists()) {
                 println("─ ConcurrentIngestLossTest: corpus not found — skipping ─")

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/prodbench/GiantReqStreamTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/prodbench/GiantReqStreamTest.kt
@@ -67,14 +67,14 @@ class GiantReqStreamTest {
                     Request.Builder().url(server.url).build(),
                     object : okhttp3.WebSocketListener() {
                         override fun onOpen(
-                            w: okhttp3.WebSocket,
-                            r: Response,
+                            webSocket: okhttp3.WebSocket,
+                            response: Response,
                         ) {
-                            w.send("""["REQ","big",{"kinds":[1]}]""")
+                            webSocket.send("""["REQ","big",{"kinds":[1]}]""")
                         }
 
                         override fun onMessage(
-                            w: okhttp3.WebSocket,
+                            webSocket: okhttp3.WebSocket,
                             text: String,
                         ) {
                             if (text.startsWith("[\"EVENT\"")) {
@@ -85,9 +85,9 @@ class GiantReqStreamTest {
                         }
 
                         override fun onFailure(
-                            w: okhttp3.WebSocket,
+                            webSocket: okhttp3.WebSocket,
                             t: Throwable,
-                            r: Response?,
+                            response: Response?,
                         ) {
                             done.countDown()
                         }

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsAuthorsMissingOutboxTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsAuthorsMissingOutboxTest.kt
@@ -26,7 +26,6 @@ import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
 import com.vitorpamplona.quartz.nip59Giftwrap.wraps.GiftWrapEvent
 import com.vitorpamplona.quartz.nip65RelayList.AdvertisedRelayListEvent
 import com.vitorpamplona.quartz.utils.EventFactory
-import com.vitorpamplona.quartz.utils.Secp256k1Instance
 import kotlinx.coroutines.runBlocking
 import java.nio.file.Files
 import java.nio.file.Path
@@ -50,7 +49,6 @@ class FsAuthorsMissingOutboxTest {
 
     @BeforeTest
     fun setup() {
-        Secp256k1Instance
         root = Files.createTempDirectory("fs-missing-outbox-")
         store = FsEventStore(root)
     }

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsDeletionTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsDeletionTest.kt
@@ -25,7 +25,6 @@ import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerSync
 import com.vitorpamplona.quartz.nip09Deletions.DeletionEvent
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
 import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
-import com.vitorpamplona.quartz.utils.Secp256k1Instance
 import kotlinx.coroutines.runBlocking
 import java.nio.file.Files
 import java.nio.file.Path
@@ -45,7 +44,6 @@ class FsDeletionTest {
 
     @BeforeTest
     fun setup() {
-        Secp256k1Instance
         root = Files.createTempDirectory("fs-del-")
         store = FsEventStore(root)
     }

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsEventStoreTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsEventStoreTest.kt
@@ -23,7 +23,6 @@ package com.vitorpamplona.quartz.nip01Core.store.fs
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerSync
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
-import com.vitorpamplona.quartz.utils.Secp256k1Instance
 import kotlinx.coroutines.runBlocking
 import java.nio.file.Files
 import java.nio.file.Path
@@ -43,7 +42,6 @@ class FsEventStoreTest {
 
     @BeforeTest
     fun setup() {
-        Secp256k1Instance // force crypto lib load
         root = Files.createTempDirectory("fs-store-")
         store = FsEventStore(root)
     }

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsEventToJsonTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsEventToJsonTest.kt
@@ -25,7 +25,6 @@ import com.vitorpamplona.quartz.nip01Core.jackson.JacksonMapper
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerSync
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
-import com.vitorpamplona.quartz.utils.Secp256k1Instance
 import kotlinx.coroutines.runBlocking
 import java.nio.file.Files
 import java.nio.file.Path
@@ -43,7 +42,6 @@ class FsEventToJsonTest {
 
     @BeforeTest
     fun setup() {
-        Secp256k1Instance
         root = Files.createTempDirectory("fs-fmt-")
     }
 

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsExpirationTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsExpirationTest.kt
@@ -23,7 +23,6 @@ package com.vitorpamplona.quartz.nip01Core.store.fs
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerSync
-import com.vitorpamplona.quartz.utils.Secp256k1Instance
 import kotlinx.coroutines.runBlocking
 import java.nio.file.Files
 import java.nio.file.Path
@@ -56,7 +55,6 @@ class FsExpirationTest {
 
     @BeforeTest
     fun setup() {
-        Secp256k1Instance
         root = Files.createTempDirectory("fs-exp-")
         store = ClockedStore(root) { clockNow }
     }

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsMaintenanceTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsMaintenanceTest.kt
@@ -23,7 +23,6 @@ package com.vitorpamplona.quartz.nip01Core.store.fs
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerSync
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
-import com.vitorpamplona.quartz.utils.Secp256k1Instance
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -46,7 +45,6 @@ class FsMaintenanceTest {
 
     @BeforeTest
     fun setup() {
-        Secp256k1Instance
         root = Files.createTempDirectory("fs-maint-")
         store = FsEventStore(root)
     }

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsParityTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsParityTest.kt
@@ -28,7 +28,6 @@ import com.vitorpamplona.quartz.nip01Core.store.sqlite.EventStore
 import com.vitorpamplona.quartz.nip09Deletions.DeletionEvent
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
 import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
-import com.vitorpamplona.quartz.utils.Secp256k1Instance
 import kotlinx.coroutines.runBlocking
 import java.nio.file.Files
 import java.nio.file.Path
@@ -59,7 +58,6 @@ class FsParityTest {
 
     @BeforeTest
     fun setup() {
-        Secp256k1Instance
         fsRoot = Files.createTempDirectory("fs-parity-")
         fs = FsEventStore(fsRoot)
         // Pass dbName=null so SQLite uses an in-memory database.

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsQueryTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsQueryTest.kt
@@ -24,7 +24,6 @@ import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerSync
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
-import com.vitorpamplona.quartz.utils.Secp256k1Instance
 import kotlinx.coroutines.runBlocking
 import java.nio.file.Files
 import java.nio.file.Path
@@ -44,7 +43,6 @@ class FsQueryTest {
 
     @BeforeTest
     fun setup() {
-        Secp256k1Instance
         root = Files.createTempDirectory("fs-query-")
         store = FsEventStore(root)
     }

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsSearchTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsSearchTest.kt
@@ -25,7 +25,6 @@ import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerSync
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
 import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
-import com.vitorpamplona.quartz.utils.Secp256k1Instance
 import kotlinx.coroutines.runBlocking
 import java.nio.file.Files
 import java.nio.file.Path
@@ -45,7 +44,6 @@ class FsSearchTest {
 
     @BeforeTest
     fun setup() {
-        Secp256k1Instance
         root = Files.createTempDirectory("fs-search-")
         store = FsEventStore(root)
     }

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsSlotsTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsSlotsTest.kt
@@ -25,7 +25,6 @@ import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerSync
 import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
-import com.vitorpamplona.quartz.utils.Secp256k1Instance
 import kotlinx.coroutines.runBlocking
 import java.nio.file.Files
 import java.nio.file.Path
@@ -45,7 +44,6 @@ class FsSlotsTest {
 
     @BeforeTest
     fun setup() {
-        Secp256k1Instance
         root = Files.createTempDirectory("fs-slot-")
         store = FsEventStore(root)
     }

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsVanishTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/fs/FsVanishTest.kt
@@ -26,7 +26,6 @@ import com.vitorpamplona.quartz.nip01Core.relay.normalizer.normalizeRelayUrl
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerSync
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
 import com.vitorpamplona.quartz.nip62RequestToVanish.RequestToVanishEvent
-import com.vitorpamplona.quartz.utils.Secp256k1Instance
 import kotlinx.coroutines.runBlocking
 import java.nio.file.Files
 import java.nio.file.Path
@@ -47,7 +46,6 @@ class FsVanishTest {
 
     @BeforeTest
     fun setup() {
-        Secp256k1Instance
         root = Files.createTempDirectory("fs-van-")
         store = FsEventStore(root, relay = storeRelay)
     }

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/ContentlessFtsMigrationTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/ContentlessFtsMigrationTest.kt
@@ -26,7 +26,6 @@ import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerSync
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
-import com.vitorpamplona.quartz.utils.Secp256k1Instance
 import kotlinx.coroutines.runBlocking
 import java.nio.file.Files
 import java.nio.file.Path
@@ -55,7 +54,6 @@ class ContentlessFtsMigrationTest {
 
     @BeforeTest
     fun setup() {
-        Secp256k1Instance
         dbFile = Files.createTempFile("contentless-fts-migration-", ".db")
         Files.deleteIfExists(dbFile)
     }

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/DeferredFtsTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/DeferredFtsTest.kt
@@ -24,7 +24,6 @@ import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerSync
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
-import com.vitorpamplona.quartz.utils.Secp256k1Instance
 import kotlinx.coroutines.runBlocking
 import java.nio.file.Files
 import java.nio.file.Path
@@ -48,7 +47,6 @@ class DeferredFtsTest {
 
     @BeforeTest
     fun setup() {
-        Secp256k1Instance
         dbFile = Files.createTempFile("deferred-fts-", ".db")
         Files.deleteIfExists(dbFile)
         store =

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/ParallelInsertTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/ParallelInsertTest.kt
@@ -23,7 +23,6 @@ package com.vitorpamplona.quartz.nip01Core.store.sqlite
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerSync
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
-import com.vitorpamplona.quartz.utils.Secp256k1Instance
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -60,7 +59,6 @@ class ParallelInsertTest {
 
     @BeforeTest
     fun setup() {
-        Secp256k1Instance
         // Use a real file so the pool can hand out independent reader
         // connections — :memory: would make every connection a separate DB.
         dbFile = Files.createTempFile("parallel-insert-", ".db")

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip66RelayMonitor/reachability/RelayReachabilityStoreTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip66RelayMonitor/reachability/RelayReachabilityStoreTest.kt
@@ -26,7 +26,6 @@ import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
 import com.vitorpamplona.quartz.nip01Core.store.sqlite.DefaultIndexingStrategy
 import com.vitorpamplona.quartz.nip01Core.store.sqlite.EventStore
 import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.tags.NetworkType
-import com.vitorpamplona.quartz.utils.Secp256k1Instance
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -61,7 +60,6 @@ class RelayReachabilityStoreTest {
     @Test
     fun recordsAndReloadsReachability() =
         runBlocking {
-            Secp256k1Instance
             val store = store()
             val cache = cache(store)
             val now = 1_000_000L
@@ -78,7 +76,6 @@ class RelayReachabilityStoreTest {
     @Test
     fun aFreshSuccessfulOpenOverridesAnEarlierDeadMark() =
         runBlocking {
-            Secp256k1Instance
             val store = store()
             val cache = cache(store)
 
@@ -94,7 +91,6 @@ class RelayReachabilityStoreTest {
     @Test
     fun recordsOlderThanTheTtlAreIgnored() =
         runBlocking {
-            Secp256k1Instance
             val store = store()
             val cache = cache(store) // ttl = 3600s
 


### PR DESCRIPTION
Resolve all `:quartz:compileTestKotlin*` warnings without changing any
test's behavior:

- Drop redundant bare `Secp256k1Instance` "force crypto lib load"
  statements (and their now-unused imports). JVM object initialization is
  thread-safe and lazy, and every one of these tests exercises crypto, so
  the lib loads on first use regardless — the eager reference was a no-op
  the K2 compiler flags as an unused expression.
- PairingEventTest: use `assertIs` instead of `assertTrue(x is T)` + cast.
- MergeQueryCorrectnessTest: drop `!!` that smart-cast already made moot.
- PodcastCommentScopeTest / MintExceptionTest: widen the declared type so
  the `is` checks are genuine runtime checks rather than always-true.
- FetchAllIdleTimeoutTest / NostrConnectSignerServiceTest: opt in to
  `ExperimentalCoroutinesApi` at the class level.
- GiantReqStreamTest: name the `WebSocketListener` overrides' parameters
  to match the supertype.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GyXakbYay4zNJ4cwoF4j7N