### PR TITLE
Remove unused buzz_dm_hide string resource

### DIFF
--- a/amethyst/src/main/res/values-cs/strings.xml
+++ b/amethyst/src/main/res/values-cs/strings.xml
@@ -3348,7 +3348,6 @@
     <string name="buzz_dm_empty_title">Zatím žádné přímé zprávy</string>
     <string name="buzz_dm_empty_body">Začněte soukromou konverzaci s kýmkoli v pracovním prostoru Buzz.</string>
     <string name="buzz_dm_more">Více</string>
-    <string name="buzz_dm_hide">Skrýt konverzaci</string>
     <string name="buzz_dm_add_member">Přidat člena</string>
     <string name="buzz_dm_add_member_title">Přidat někoho do této konverzace</string>
     <string name="buzz_dm_add_member_invalid">Neplatný npub nebo hex klíč</string>

--- a/amethyst/src/main/res/values-de-rDE/strings.xml
+++ b/amethyst/src/main/res/values-de-rDE/strings.xml
@@ -3232,7 +3232,6 @@
     <string name="buzz_dm_empty_title">Noch keine Direktnachrichten</string>
     <string name="buzz_dm_empty_body">Beginne eine private Unterhaltung mit jemandem in einem Buzz-Workspace.</string>
     <string name="buzz_dm_more">Mehr</string>
-    <string name="buzz_dm_hide">Unterhaltung ausblenden</string>
     <string name="buzz_dm_add_member">Mitglied hinzufügen</string>
     <string name="buzz_dm_add_member_title">Jemanden zu dieser DM hinzufügen</string>
     <string name="buzz_dm_add_member_invalid">Kein gültiger npub- oder Hex-Schlüssel</string>

--- a/amethyst/src/main/res/values-hi-rIN/strings.xml
+++ b/amethyst/src/main/res/values-hi-rIN/strings.xml
@@ -3232,7 +3232,6 @@
     <string name="buzz_dm_empty_title">कोई सीधेसन्देश नहीं अब तक</string>
     <string name="buzz_dm_empty_body">आरम्भ करें निजी वार्तालप किसी से भी एक बज्स्स कार्यशाला में।</string>
     <string name="buzz_dm_more">और अधिक</string>
-    <string name="buzz_dm_hide">संवाद छिपाएँ</string>
     <string name="buzz_dm_add_member">सदस्य जोडें</string>
     <string name="buzz_dm_add_member_title">किसी को जोडें इस सीधेसन्देश में</string>
     <string name="buzz_dm_add_member_invalid">मान्य एनपुब॰ अथवा षोडषांक कुंचिका नहीं</string>

--- a/amethyst/src/main/res/values-pl-rPL/strings.xml
+++ b/amethyst/src/main/res/values-pl-rPL/strings.xml
@@ -3297,7 +3297,6 @@ Zaplanowane posty z innych kont nie zostaną opublikowane, dopóki to konto jest
     <string name="buzz_dm_empty_title">Brak bezpośrednich wiadomości</string>
     <string name="buzz_dm_empty_body">Rozpocznij prywatną rozmowę z kimkolwiek w przestrzeni roboczej Buzz.</string>
     <string name="buzz_dm_more">Więcej</string>
-    <string name="buzz_dm_hide">Ukryj konwersację</string>
     <string name="buzz_dm_add_member">Dodaj członka</string>
     <string name="buzz_dm_add_member_title">Dodaj kogoś do tej wiadomości DM</string>
     <string name="buzz_dm_add_member_invalid">Nieprawidłowy klucz npub lub hex</string>

--- a/amethyst/src/main/res/values-pt-rBR/strings.xml
+++ b/amethyst/src/main/res/values-pt-rBR/strings.xml
@@ -3230,7 +3230,6 @@
     <string name="buzz_dm_empty_title">Nenhuma mensagem direta ainda</string>
     <string name="buzz_dm_empty_body">Inicie uma conversa privada com qualquer pessoa em um espaço de trabalho Buzz.</string>
     <string name="buzz_dm_more">Mais</string>
-    <string name="buzz_dm_hide">Ocultar conversa</string>
     <string name="buzz_dm_add_member">Adicionar membro</string>
     <string name="buzz_dm_add_member_title">Adicionar alguém a esta DM</string>
     <string name="buzz_dm_add_member_invalid">Não é uma chave npub ou hex válida</string>

--- a/amethyst/src/main/res/values-sl-rSI/strings.xml
+++ b/amethyst/src/main/res/values-sl-rSI/strings.xml
@@ -3362,7 +3362,6 @@ Za ohranitev zasebnosti to denarnico polni in prazni prek ne-zasebnih računov, 
     <string name="buzz_dm_empty_title">Ni še zasebnih sporočil</string>
     <string name="buzz_dm_empty_body">Začnite zasebni pogovor s komerkoli v delovnem prostoru Buzz.</string>
     <string name="buzz_dm_more">Več</string>
-    <string name="buzz_dm_hide">Skrij pogovore</string>
     <string name="buzz_dm_add_member">Dodaj člana</string>
     <string name="buzz_dm_add_member_title">Dodaj nekoga v to ZS</string>
     <string name="buzz_dm_add_member_invalid">Neveljaven npub ali hex ključ </string>

--- a/amethyst/src/main/res/values-sv-rSE/strings.xml
+++ b/amethyst/src/main/res/values-sv-rSE/strings.xml
@@ -3230,7 +3230,6 @@
     <string name="buzz_dm_empty_title">Inga direktmeddelanden än</string>
     <string name="buzz_dm_empty_body">Starta en privat konversation med vem som helst i en Buzz-arbetsyta.</string>
     <string name="buzz_dm_more">Mer</string>
-    <string name="buzz_dm_hide">Dölj konversation</string>
     <string name="buzz_dm_add_member">Lägg till medlem</string>
     <string name="buzz_dm_add_member_title">Lägg till någon i det här DM:et</string>
     <string name="buzz_dm_add_member_invalid">Inte en giltig npub- eller hexnyckel</string>


### PR DESCRIPTION
## Summary

Remove the `buzz_dm_hide` string resource from all localized strings files (Czech, German, Hindi, Polish, Portuguese, Slovenian, and Swedish). This string is no longer used in the codebase and can be safely removed.

## Test plan

- [ ] N/A — change is strings-only, no functional code affected

## Interop suites

- [ ] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [ ] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_014ksnCb8x45HnL7nFPzxh4B