### PR TITLE
Add delete group/channel functionality (kind-9008)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -299,6 +299,7 @@ import com.vitorpamplona.quartz.nip29RelayGroups.hTag
 import com.vitorpamplona.quartz.nip29RelayGroups.metadata.GroupMetadataEvent
 import com.vitorpamplona.quartz.nip29RelayGroups.moderation.CreateGroupEvent
 import com.vitorpamplona.quartz.nip29RelayGroups.moderation.CreateInviteEvent
+import com.vitorpamplona.quartz.nip29RelayGroups.moderation.DeleteGroupEvent
 import com.vitorpamplona.quartz.nip29RelayGroups.moderation.EditMetadataEvent
 import com.vitorpamplona.quartz.nip29RelayGroups.moderation.PutUserEvent
 import com.vitorpamplona.quartz.nip29RelayGroups.moderation.RemoveUserEvent
@@ -3447,6 +3448,18 @@ class Account(
     /** Send a kind 9022 leave request to the host relay and drop it from our list. */
     suspend fun leaveRelayGroup(channel: RelayGroupChannel) {
         val template = LeaveRequestEvent.build(channel.groupId.id)
+        signAndSendPrivatelyOrBroadcast(template) { channel.relays().toList() }
+        unfollow(channel)
+    }
+
+    /**
+     * Delete the whole group with a kind 9008 delete-group event (owner/admin only — the relay
+     * enforces this). Unlike [leaveRelayGroup], this destroys the channel for everyone rather than
+     * just removing me; the relay drops the group and its messages. Also drops it from our own list
+     * so it disappears from Messages immediately instead of lingering as a now-dead id.
+     */
+    suspend fun deleteRelayGroup(channel: RelayGroupChannel) {
+        val template = DeleteGroupEvent.build(channel.groupId.id)
         signAndSendPrivatelyOrBroadcast(template) { channel.relays().toList() }
         unfollow(channel)
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -1672,6 +1672,9 @@ class AccountViewModel(
 
     fun leaveRelayGroup(channel: RelayGroupChannel) = launchSigner { account.leaveRelayGroup(channel) }
 
+    /** Delete the channel/group for everyone (kind-9008). Owner/admin only; the relay enforces it. */
+    fun deleteRelayGroup(channel: RelayGroupChannel) = launchSigner { account.deleteRelayGroup(channel) }
+
     /**
      * Take a relay group off Messages WITHOUT leaving it: drop it from my kind-10009 list so it stops
      * showing, but send no kind-9022 — I stay in the relay roster and can still read/post, and re-joining

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/relayGroup/RelayGroupTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/relayGroup/RelayGroupTopBar.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FilledTonalButton
@@ -35,6 +36,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
@@ -117,6 +119,8 @@ fun RelayGroupTopBar(
     val canPop = nav.canPop()
     var showInvite by remember { mutableStateOf(false) }
     var showJoinCode by remember { mutableStateOf(false) }
+    var confirmDelete by remember { mutableStateOf(false) }
+    val isBuzzRelay = remember(channel.groupId.relayUrl) { BuzzRelayDialect.isBuzz(channel.groupId.relayUrl) }
 
     TopBarExtensibleWithBackButton(
         title = {
@@ -184,7 +188,6 @@ fun RelayGroupTopBar(
             // outright. So a DM shows the icon only when a canvas already exists — which is also what
             // keeps us from advertising "start a shared doc" in a two-person conversation.
             val hasCanvas by observeBuzzCanvas(channel.groupId.id)
-            val isBuzzRelay = remember(channel.groupId.relayUrl) { BuzzRelayDialect.isBuzz(channel.groupId.relayUrl) }
             if (isBuzzRelay && (!isDm || hasCanvas)) {
                 IconButton(onClick = { nav.nav(Route.BuzzCanvas(channel.groupId.id, channel.groupId.relayUrl.url)) }) {
                     Icon(
@@ -318,6 +321,23 @@ fun RelayGroupTopBar(
                                 if (canPop) nav.popBack()
                             },
                         )
+                        // Deleting the whole channel/group (kind-9008) is destructive for everyone, so it's
+                        // shown ONLY to an admin/owner — the same authorization gate as Edit above — and
+                        // routed through a confirmation dialog rather than firing on tap.
+                        if (displayMembership == RelayGroupMembership.ADMIN) {
+                            DropdownMenuItem(
+                                text = {
+                                    Text(
+                                        text = stringRes(if (isBuzzRelay) R.string.buzz_channel_delete else R.string.relay_group_delete),
+                                        color = MaterialTheme.colorScheme.error,
+                                    )
+                                },
+                                onClick = {
+                                    menuOpen = false
+                                    confirmDelete = true
+                                },
+                            )
+                        }
                     }
                 }
             }
@@ -337,6 +357,36 @@ fun RelayGroupTopBar(
             accountViewModel = accountViewModel,
             onJoined = { requested = true },
             onDismiss = { showJoinCode = false },
+        )
+    }
+
+    if (confirmDelete) {
+        val deleteLabel = stringRes(if (isBuzzRelay) R.string.buzz_channel_delete else R.string.relay_group_delete)
+        AlertDialog(
+            onDismissRequest = { confirmDelete = false },
+            title = { Text(deleteLabel) },
+            text = {
+                Text(
+                    stringRes(
+                        if (isBuzzRelay) R.string.buzz_channel_delete_confirm else R.string.relay_group_delete_confirm,
+                        channel.toBestDisplayName(),
+                    ),
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    confirmDelete = false
+                    accountViewModel.deleteRelayGroup(channel)
+                    if (canPop) nav.popBack()
+                }) {
+                    Text(deleteLabel, color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { confirmDelete = false }) {
+                    Text(stringRes(R.string.cancel))
+                }
+            },
         )
     }
 }

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -2587,6 +2587,10 @@
     <string name="relay_group_edit_confirm">Save</string>
     <string name="relay_group_menu_members">Members</string>
     <string name="relay_group_menu_edit">Edit group</string>
+    <string name="relay_group_delete">Delete group</string>
+    <string name="relay_group_delete_confirm">Delete \"%1$s\"? This removes the group and its history for everyone, and cannot be undone.</string>
+    <string name="buzz_channel_delete">Delete channel</string>
+    <string name="buzz_channel_delete_confirm">Delete \"%1$s\"? This removes the channel and its messages for everyone, and cannot be undone.</string>
     <string name="relay_group_threads_title">Threads</string>
     <string name="relay_group_pin_message">Pin message</string>
     <string name="relay_group_unpin_message">Unpin message</string>


### PR DESCRIPTION
## Summary

Adds the ability for group/channel admins to permanently delete relay groups and Buzz channels via a new kind-9008 delete-group event. The deletion is destructive for everyone (removes the group and its history from the relay), so it's gated to admins only and routed through a confirmation dialog to prevent accidental deletion.

## Changes

- **RelayGroupTopBar.kt**: Added a "Delete group/channel" menu item (admin-only) that opens a confirmation dialog before calling the delete action. Moved `isBuzzRelay` calculation to top-level state so it can be reused in both the canvas button and delete menu.
- **Account.kt**: Implemented `deleteRelayGroup()` suspend function that builds and sends a kind-9008 `DeleteGroupEvent`, then removes the channel from the local follow list so it disappears immediately from Messages.
- **AccountViewModel.kt**: Added `deleteRelayGroup()` wrapper that launches the signer coroutine.
- **strings.xml**: Added four new string resources for delete confirmation UI (separate labels/messages for relay groups vs. Buzz channels).

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Ran `./gradlew test` — existing tests pass
- [x] Manually exercised the change:
  - Verified delete menu item appears only for admins
  - Confirmed confirmation dialog displays correct channel name and warning text
  - Tested that canceling the dialog closes it without action
  - Confirmed delete action sends kind-9008 event and removes channel from Messages
  - Verified both "relay group" and "Buzz channel" label variants display correctly

## Interop suites

- [x] N/A — change affects only UI and local group management; wire format (kind-9008) is defined by NIP-29 and tested at the quartz layer

https://claude.ai/code/session_01Bfd77tUsZ8h6ywcgwY7VVB