### PR TITLE
Remove unnecessary IO dispatcher from BlossomServerListState

### DIFF
--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nipB7Blossom/BlossomServerListState.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nipB7Blossom/BlossomServerListState.kt
@@ -26,11 +26,8 @@ import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSigner
 import com.vitorpamplona.quartz.nipB7Blossom.BlossomServersEvent
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
@@ -65,7 +62,6 @@ class BlossomServerListState(
         getBlossomServersListFlow()
             .map { normalizeServers(it.note) }
             .onStart { emit(normalizeServers(blossomListNote)) }
-            .flowOn(Dispatchers.IO)
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,


### PR DESCRIPTION
## Summary

Removed the `flowOn(Dispatchers.IO)` call from the Blossom server list state flow. The dispatcher was unnecessary since the flow operations (mapping and normalizing servers) are lightweight and don't perform blocking I/O — the data is already loaded from the cache or event. This simplifies the coroutine context management without affecting functionality.

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes: The change is a straightforward removal of an unnecessary dispatcher override. The state flow will now execute on the caller's context (typically the main dispatcher for UI updates), which is appropriate for this lightweight operation. Existing tests for `BlossomServerListState` will verify the behavior remains unchanged.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [ ] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

https://claude.ai/code/session_01U9APGdQP1Hp3ppMe1Nrnro