### PR TITLE
fix(concord): open a community by tapping its name, not just its avatar

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/concord/ConcordHomeScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/concord/ConcordHomeScreen.kt
@@ -310,7 +310,11 @@ private fun CommunityHeader(
             loadRobohash = accountViewModel.settings.isNotPerformanceMode(),
             autoPlayGif = autoPlayGif,
         )
-        Column(Modifier.weight(1f)) {
+        // The identity block — icon *and* name/subtitle — opens the community; the rest of the row and
+        // the chevron expand it. Tapping a title to open the thing it names is the convention users
+        // arrive with, and the name previously fell through to the row's expand, leaving the 40dp
+        // avatar as the only way in with nothing to suggest it was a separate target.
+        Column(Modifier.weight(1f).clickable(onClick = onOpen)) {
             Text(
                 name,
                 style = MaterialTheme.typography.bodyLarge,


### PR DESCRIPTION
Follow-up to #3782, from a snag hit while cleaning up its test artifacts.

On the Concord home list, the row's `clickable` expands/collapses, and the only way to *open* a community is a separate `clickable` on the 40dp avatar. Nothing marks the avatar as its own target, so tapping the name — the thing most people reach for — silently expands the row instead. I lost a few minutes to exactly this before noticing the avatar was live.

The fix gives the name/subtitle column the same `onOpen` the avatar already has: the identity block (icon + title) opens the community, while the rest of the row and the chevron keep expanding it. Tapping a title to open the thing it names is the convention users arrive with, and the disclosure control stays the disclosure control.

One line of behaviour change; no new strings, no layout change (the `clickable` adds no padding, so row height is unchanged — it just picks up its own bounded ripple, which is itself the missing signal that it's a target).

## Testing

On-device, Concord home list:

- Tapped the name **"NosFabrica"** → the community view opens (top bar shows `NosFabrica` + `Members` / `Edit community` / `Invite people` / `More Options`). Before this change that tap expanded the row.
- Tapped the **chevron** on the same row → still expands, revealing its channels (`tapestry`, …). Tapped again → collapses. The expand path is intact.
- Avatar path untouched.

`spotlessCheck` and `:amethyst:testPlayDebugUnitTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)