### PR TITLE
fix(buzz): drop the grey slab behind the community Channels section

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/BuzzImportRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/BuzzImportRow.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.buzz
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -31,7 +32,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.Card
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.IconButton
@@ -174,10 +174,14 @@ fun BuzzImportRow(
                 accountViewModel = accountViewModel,
             )
         }
+    // A plain row on the screen background, not a filled Card. Each row used to be its own Card, and
+    // because they stack with no gaps their container colour merged into one grey slab behind the
+    // whole Channels section — reading as a box around the channels that the Direct Messages rows
+    // right below (plain rows) didn't have. Matches [BuzzDmInlineRow] and the Concord server list.
     if (onOpen != null) {
-        Card(onClick = onOpen, modifier = Modifier.fillMaxWidth()) { content() }
+        Box(Modifier.fillMaxWidth().clickable(onClick = onOpen)) { content() }
     } else {
-        Card(modifier = Modifier.fillMaxWidth()) { content() }
+        Box(Modifier.fillMaxWidth()) { content() }
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/relayGroup/RelayGroupChannelListScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/relayGroup/RelayGroupChannelListScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Card
@@ -411,7 +410,8 @@ fun RelayGroupChannelListScreen(
                             )
                         }
                         if (!channelsCollapsed) {
-                            items(buzzChatChannels, key = { "chat-${it.id}" }) { groupId ->
+                            itemsIndexed(buzzChatChannels, key = { _, it -> "chat-${it.id}" }) { index, groupId ->
+                                RowHairline(index)
                                 BuzzImportRow(
                                     groupId = groupId,
                                     isAdded = groupId.id in buzzAdded,
@@ -437,7 +437,8 @@ fun RelayGroupChannelListScreen(
                             )
                         }
                         if (!forumsCollapsed) {
-                            items(buzzForumChannels, key = { "forum-${it.id}" }) { groupId ->
+                            itemsIndexed(buzzForumChannels, key = { _, it -> "forum-${it.id}" }) { index, groupId ->
+                                RowHairline(index)
                                 BuzzImportRow(
                                     groupId = groupId,
                                     isAdded = groupId.id in buzzAdded,
@@ -481,7 +482,8 @@ fun RelayGroupChannelListScreen(
                         }
                     } else {
                         val shown = dmRows.take(INLINE_DM_LIMIT)
-                        items(shown, key = { "dm-${it.channelId}" }) { row ->
+                        itemsIndexed(shown, key = { _, it -> "dm-${it.channelId}" }) { index, row ->
+                            RowHairline(index)
                             BuzzDmInlineRow(
                                 row = row,
                                 myPubkey = myPubkey,
@@ -512,7 +514,8 @@ fun RelayGroupChannelListScreen(
                             )
                         }
                         if (showHiddenDms) {
-                            items(hiddenDmRows, key = { "dm-hidden-${it.channelId}" }) { row ->
+                            itemsIndexed(hiddenDmRows, key = { _, it -> "dm-hidden-${it.channelId}" }) { index, row ->
+                                RowHairline(index)
                                 BuzzDmInlineRow(
                                     row = row,
                                     myPubkey = myPubkey,
@@ -530,9 +533,7 @@ fun RelayGroupChannelListScreen(
                 } else {
                     // Vanilla NIP-29 relay: flat channel directory (no forums/DMs/console).
                     itemsIndexed(channels, key = { _, channel -> channel.groupId.id }) { index, channel ->
-                        if (index > 0) {
-                            HorizontalDivider(thickness = 0.25.dp, color = MaterialTheme.colorScheme.outlineVariant)
-                        }
+                        RowHairline(index)
                         RelayGroupChannelRow(channel, myPubkey, accountViewModel) { nav.nav(routeFor(channel)) }
                     }
                 }
@@ -548,6 +549,17 @@ fun RelayGroupChannelListScreen(
             onAdd = { accountViewModel.addCommunityMember(relay, it) },
             onDismiss = { showAddPeople = false },
         )
+    }
+}
+
+/**
+ * The hairline separating two adjacent rows within a section. Drawn *before* row [index], and never
+ * before the first one, so a section's own header keeps providing the separation at its boundaries.
+ */
+@Composable
+private fun RowHairline(index: Int) {
+    if (index > 0) {
+        HorizontalDivider(thickness = 0.25.dp, color = MaterialTheme.colorScheme.outlineVariant)
     }
 }
 


### PR DESCRIPTION
On a Buzz community screen the Channels section sat on a grey block while the Direct Messages section right below it sat on the plain background — the two halves of one screen looked like different surfaces.

The cause is that each channel row is its own filled Material3 `Card`. They stack with no gaps, so the cards' container colour merges into one continuous slab behind the whole section, reading as a box drawn around the channels.

Rendered as a plain `Box` on the screen background instead, keeping the click on the container so the whole row still opens the channel. That matches `BuzzDmInlineRow` directly below it, `RelayGroupChannelRow` on the vanilla NIP-29 branch of the same screen, and the Concord server list — this row was the only one wrapped in a Card.

Affects the **Channels** and **Forums** sections (same composable); no layout, padding or row-height change, and no new strings.

## Testing

On-device, `nosfabrica.communities.buzz.xyz`:

- Channels section now renders on the same background as Direct Messages; the screen reads as one continuous list.
- Tapped a channel row → opens the chat (`amethyst-create-test3`), so moving the click from `Card` to `Box` kept the whole row tappable.
- Tapped a row's overflow → `Pin channel` / `Remove from Messages` still open.

`spotlessCheck` and `:amethyst:testPlayDebugUnitTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)