### PR TITLE
style: import the symbols the two merged nostr proposals referenced inline

### DIFF
--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/Main.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/Main.kt
@@ -78,6 +78,8 @@ import com.vitorpamplona.amethyst.commons.icons.symbols.ProvideMaterialSymbols
 import com.vitorpamplona.amethyst.commons.moderation.LocalHashtagSpamSettings
 import com.vitorpamplona.amethyst.commons.moderation.LocalSpamExemptKeys
 import com.vitorpamplona.amethyst.commons.moderation.PreferencesHashtagSpamSettings
+import com.vitorpamplona.amethyst.commons.moderation.notifications.PreferencesNotificationReadState
+import com.vitorpamplona.amethyst.commons.moderation.notifications.PreferencesNotificationSettings
 import com.vitorpamplona.amethyst.commons.relayClient.auth.AuthApprovalBanner
 import com.vitorpamplona.amethyst.commons.relayClient.nip17Dm.DmInboxRelayResolver
 import com.vitorpamplona.amethyst.commons.relayClient.nip17Dm.unwrapAndUnsealOrNull
@@ -131,6 +133,9 @@ import com.vitorpamplona.amethyst.desktop.ui.deck.param
 import com.vitorpamplona.amethyst.desktop.ui.media.LocalAwtWindow
 import com.vitorpamplona.amethyst.desktop.ui.media.LocalIsImmersiveFullscreen
 import com.vitorpamplona.amethyst.desktop.ui.media.LocalWindowState
+import com.vitorpamplona.amethyst.desktop.ui.notifications.LocalNotificationDispatcher
+import com.vitorpamplona.amethyst.desktop.ui.notifications.LocalNotificationReadState
+import com.vitorpamplona.amethyst.desktop.ui.notifications.LocalNotificationSettings
 import com.vitorpamplona.amethyst.desktop.ui.profile.ProfileInfoCard
 import com.vitorpamplona.amethyst.desktop.ui.relay.LocalRelayCategories
 import com.vitorpamplona.amethyst.desktop.ui.relay.RelayStatusCard
@@ -1272,10 +1277,7 @@ private fun AppInner(
                 // switch or granting permission never actually notified the auto-
                 // dispatcher until the app restarted.
                 val notifSettings =
-                    remember {
-                        com.vitorpamplona.amethyst.commons.moderation.notifications
-                            .PreferencesNotificationSettings()
-                    }
+                    remember { PreferencesNotificationSettings() }
                 // Per-account read-state for the notification inbox. Keyed on
                 // pubKey so switching accounts gets a fresh cursor. `remember` here
                 // is intentionally keyed on pubKeyHex; a null pubKey (Loading /
@@ -1283,10 +1285,7 @@ private fun AppInner(
                 // guard against a stale ReadState leaking between accounts).
                 val notifReadState =
                     remember(loggedIn?.pubKeyHex) {
-                        loggedIn?.pubKeyHex?.let { pk ->
-                            com.vitorpamplona.amethyst.commons.moderation.notifications
-                                .PreferencesNotificationReadState(pk)
-                        }
+                        loggedIn?.pubKeyHex?.let { pk -> PreferencesNotificationReadState(pk) }
                     }
                 DisposableEffect(loggedIn?.pubKeyHex, notifDispatcher, localCache) {
                     val myPk = loggedIn?.pubKeyHex
@@ -1314,9 +1313,9 @@ private fun AppInner(
                     LocalScheduledPostStore provides scheduledPostStore,
                     com.vitorpamplona.amethyst.desktop.service.drafts.LocalNoteDraftStore provides noteDraftStore,
                     LocalHashtagSpamSettings provides hashtagSpamSettings,
-                    com.vitorpamplona.amethyst.desktop.ui.notifications.LocalNotificationDispatcher provides notifDispatcher,
-                    com.vitorpamplona.amethyst.desktop.ui.notifications.LocalNotificationSettings provides notifSettings,
-                    com.vitorpamplona.amethyst.desktop.ui.notifications.LocalNotificationReadState provides notifReadState,
+                    LocalNotificationDispatcher provides notifDispatcher,
+                    LocalNotificationSettings provides notifSettings,
+                    LocalNotificationReadState provides notifReadState,
                 ) {
                     when (accountState) {
                         is AccountState.Loading -> {

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/namecoin/NamecoinNameResolver.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip05DnsIdentifiers/namecoin/NamecoinNameResolver.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.quartz.nip05DnsIdentifiers.namecoin
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -236,7 +237,7 @@ class NamecoinNameResolver(
             try {
                 electrumxClient.nameShowWithFallback(parsed.namecoinName, serverListProvider())
                     ?: return null
-            } catch (e: kotlinx.coroutines.CancellationException) {
+            } catch (e: CancellationException) {
                 throw e
             } catch (e: NamecoinLookupException) {
                 // NameNotFound / NameExpired / ServersUnreachable → null per
@@ -316,7 +317,7 @@ class NamecoinNameResolver(
         return NamecoinImportResolver.expandImports(root) { name ->
             try {
                 electrumxClient.nameShowWithFallback(name, serverListProvider())?.value
-            } catch (e: kotlinx.coroutines.CancellationException) {
+            } catch (e: CancellationException) {
                 throw e
             } catch (e: NamecoinLookupException) {
                 // Best-effort: missing/expired/unreachable → contribute nothing.


### PR DESCRIPTION
Follow-up to the two nostr proposals merged into main just now — `82e72369` (desktop notification wiring) and `bdb4b03e` (namecoin exception leak). Both referenced types by fully-qualified name inside function bodies, which the Kotlin style rule in `.claude/CLAUDE.md` forbids. I merged them as authored rather than rewriting a contributor's patch during the merge; this is the cleanup.

**`NamecoinNameResolver`** — import `kotlinx.coroutines.CancellationException`. Both catch sites were inline-qualified: one added by the proposal, one already present. The sibling resolvers in this same package (`Nip05Client`, `UserHexResolver`) already import it, so this brings the file in line with its neighbours.

**`desktop/Main.kt`** — import the five notification symbols in the block the proposal touched: the two `Preferences*` factories and the three `Local*Notification*` CompositionLocals. Each occurs exactly once in the file, so no fully-qualified stragglers of those names are left behind, and collapsing the wrapped call sites makes the block read normally again.

## Scope

Deliberately limited to that block. `Main.kt` has roughly **130 other inline fully-qualified names** — the `CompositionLocalProvider` list alone mixes imported and qualified entries. Sweeping those is worth doing but belongs in its own change, not bolted onto a style follow-up where it would bury the actual fix in a few hundred lines of churn.

`:desktopApp:compileKotlin`, the namecoin test from the merged proposal, and `spotlessCheck` all pass. No behaviour change — imports and call-site spelling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)