### PR TITLE
perf(nip73): prefetch external-content preview URLs

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/feeds/PrefetchFeedMedia.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/feeds/PrefetchFeedMedia.kt
@@ -51,6 +51,8 @@ import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
 import com.vitorpamplona.quartz.nip14Subject.subject
 import com.vitorpamplona.quartz.nip22Comments.CommentEvent
 import com.vitorpamplona.quartz.nip71Video.image
+import com.vitorpamplona.quartz.nip73ExternalIds.scope
+import com.vitorpamplona.quartz.nip73ExternalIds.urls.UrlId
 import com.vitorpamplona.quartz.nip92IMeta.IMetaTag
 import com.vitorpamplona.quartz.nip92IMeta.imetas
 import com.vitorpamplona.quartz.nip94FileMetadata.tags.MimeTypeTag
@@ -313,10 +315,10 @@ private class WarmTargets {
 
 /**
  * Collects everything worth warming for this note. Reads NIP-92 imeta tags (every
- * kind), then the free-text body: text notes and comments go through the shared
- * render cache — which both warms the renderer and yields a fully classified body
- * — while every other kind gets a cheap URL scan. Returns null only when the note
- * has no event.
+ * kind), the NIP-73 external-content scope (kind 1111 only), then the free-text
+ * body: text notes and comments go through the shared render cache — which both
+ * warms the renderer and yields a fully classified body — while every other kind
+ * gets a cheap URL scan. Returns null only when the note has no event.
  */
 private fun Note.collectWarmTargets(): WarmTargets? {
     val ev = event ?: return null
@@ -334,6 +336,13 @@ private fun Note.collectWarmTargets(): WarmTargets? {
     // `m`/`dim`, not imeta (FileHeaderEvent and the gallery/file kinds). The generic
     // imetas() above misses these entirely.
     targets.addFileHeaderMedia(ev)
+
+    // NIP-73 external-content scope. Only kind 1111 carries one, so the type check
+    // keeps every other kind out of the tag walk. Reuses scope() — the same accessor
+    // the renderer uses — so we only warm a URL that will actually be shown.
+    if (ev is CommentEvent) {
+        (ev.scope() as? UrlId)?.let { targets.link(it.url) }
+    }
 
     // Free-text body. The reproducible-key kinds parse through the shared cache
     // (which also warms the render); everything else is scanned for URLs only.


### PR DESCRIPTION
Closes #3817. Follow-up to #3810 — the one review item from @davotoula deferred out of that PR.

`collectWarmTargets()` harvested link URLs from note content but not from NIP-73 `I`-tag scopes, so the external-content preview cards popped in mid-scroll while every other link preview was warmed ahead of view.

Per @vitorpamplona's note on the issue, this is gated on `is CommentEvent` so only kind 1111 walks the tags — other kinds don't touch that path at all.

It reuses `scope()`, the same accessor the renderer uses, so a URL is only warmed when it will actually be shown (a geohash-rooted comment that also carries a URL tag won't trigger a wasted fetch). The existing `showUrlPreview()` data-saver gate already wraps `targets.links` in `warm()`, so this inherits it.

## Test plan

- [x] Verified on a physical device against a real NIP-73 URL-scoped kind 1111 comment — card renders, no crash, no regression.
- [x] `./gradlew spotlessApply`
- [x] `./gradlew :amethyst:compileFdroidDebugKotlin`