### PR TITLE
feat(fdroid): LibreTranslate-backed translation (issue #548)

### DIFF
--- a/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/service/lang/LanguageTranslatorService.kt
+++ b/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/service/lang/LanguageTranslatorService.kt
@@ -20,6 +20,144 @@
  */
 package com.vitorpamplona.amethyst.service.lang
 
+import android.content.Context
+import androidx.compose.runtime.Immutable
+import kotlinx.coroutines.suspendCancellableCoroutine
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.FormBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+@Immutable
+data class ResultOrError(
+    val result: String?,
+    val sourceLang: String?,
+    val targetLang: String?,
+)
+
+/**
+ * F-Droid build: translation backed by a user-configured LibreTranslate
+ * server (see [TranslationServerConfig]). Mirrors the API surface of the
+ * Play build's ML Kit service so callers behave the same way in both
+ * flavors. Off by default; nothing is sent anywhere until the user enables
+ * it and their language settings ask for a translation.
+ */
 object LanguageTranslatorService {
-    fun clear() {}
+    private val client =
+        OkHttpClient.Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .build()
+
+    // LibreTranslate language set (ISO 639-1). Codes outside it are skipped.
+    private val supportedLanguages =
+        setOf(
+            "en", "ar", "az", "bg", "bs", "ca", "cs", "da", "de", "el", "es", "et", "fa", "fi",
+            "fr", "he", "hi", "hr", "hu", "hy", "id", "it", "ja", "ka", "kk", "ko", "lt", "lv",
+            "mk", "ms", "mt", "nl", "no", "pl", "pt", "ro", "ru", "sk", "sl", "sq", "sr", "sv",
+            "th", "tr", "uk", "ur", "vi", "zh",
+        )
+
+    fun clear() {
+        TranslationsCache.clear()
+    }
+
+    /** Maps a BCP-47 tag (e.g. "zh-CN") to the closest LibreTranslate code, or null. */
+    fun toLibreTranslateCode(tag: String): String? {
+        val code = tag.substringBefore('-').lowercase()
+        return code.takeIf { it in supportedLanguages }
+    }
+
+    suspend fun identifyLanguage(context: Context, text: String): String? {
+        val body = FormBody.Builder().add("q", text).build()
+        val response = execute(apiRequest(context, "/detect", body))
+        val json = JSONArray(response)
+        if (json.length() == 0) return null
+        return json.getJSONObject(0).optString("language").takeIf { it.isNotBlank() }?.lowercase()
+    }
+
+    suspend fun translate(
+        context: Context,
+        text: String,
+        source: String,
+        target: String,
+    ): ResultOrError {
+        val sourceCode = toLibreTranslateCode(source)
+        val targetCode = toLibreTranslateCode(target)
+        if (sourceCode == null || targetCode == null) return ResultOrError(null, null, null)
+
+        val form =
+            FormBody.Builder()
+                .add("q", text)
+                .add("source", sourceCode)
+                .add("target", targetCode)
+                .add("format", "text")
+        TranslationServerConfig.apiKey(context).takeIf { it.isNotBlank() }?.let { form.add("api_key", it) }
+
+        val response = execute(apiRequest(context, "/translate", form.build()))
+        val translated = JSONObject(response).optString("translatedText")
+        return ResultOrError(translated.ifBlank { null }, source, target)
+    }
+
+    suspend fun autoTranslate(
+        context: Context,
+        text: String,
+        dontTranslateFrom: Set<String>,
+        translateTo: String,
+    ): ResultOrError {
+        if (!TranslationServerConfig.isEnabled(context)) return ResultOrError(text, null, null)
+        if (!isWorthTranslating(text)) return ResultOrError(text, null, null)
+
+        val detected = identifyLanguage(context, text) ?: return ResultOrError(text, null, null)
+        return when {
+            detected == "und" -> ResultOrError(text, null, null)
+            detected.equals(translateTo, ignoreCase = true) -> ResultOrError(text, null, null)
+            detected in dontTranslateFrom -> ResultOrError(text, null, null)
+            else -> translate(context, text, detected, translateTo)
+        }
+    }
+
+    private fun isWorthTranslating(text: String): Boolean {
+        val trimmed = text.trim()
+        return trimmed.length >= 2 && trimmed.any { it.isLetter() }
+    }
+
+    private fun apiRequest(context: Context, path: String, body: FormBody): Request =
+        Request
+            .Builder()
+            .url("${TranslationServerConfig.serverUrl(context)}$path")
+            .post(body)
+            .build()
+
+    private suspend fun execute(request: Request): String =
+        suspendCancellableCoroutine { cont ->
+            val call = client.newCall(request)
+            cont.invokeOnCancellation { call.cancel() }
+            call.enqueue(
+                object : Callback {
+                    override fun onFailure(call: Call, e: IOException) {
+                        if (!cont.isCancelled) cont.resumeWithException(e)
+                    }
+
+                    override fun onResponse(call: Call, response: Response) {
+                        response.use {
+                            if (cont.isCancelled) return
+                            if (it.isSuccessful) {
+                                cont.resume(it.body?.string() ?: "")
+                            } else {
+                                cont.resumeWithException(IOException("HTTP ${it.code}: ${it.body?.string()?.take(200)}"))
+                            }
+                        }
+                    }
+                },
+            )
+        }
 }

--- a/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/service/lang/LanguageTranslatorService.kt
+++ b/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/service/lang/LanguageTranslatorService.kt
@@ -57,24 +57,12 @@ object LanguageTranslatorService {
             .readTimeout(30, TimeUnit.SECONDS)
             .build()
 
-    // LibreTranslate language set (ISO 639-1). Codes outside it are skipped.
-    private val supportedLanguages =
-        setOf(
-            "en", "ar", "az", "bg", "bs", "ca", "cs", "da", "de", "el", "es", "et", "fa", "fi",
-            "fr", "he", "hi", "hr", "hu", "hy", "id", "it", "ja", "ka", "kk", "ko", "lt", "lv",
-            "mk", "ms", "mt", "nl", "no", "pl", "pt", "ro", "ru", "sk", "sl", "sq", "sr", "sv",
-            "th", "tr", "uk", "ur", "vi", "zh",
-        )
-
     fun clear() {
         TranslationsCache.clear()
     }
 
     /** Maps a BCP-47 tag (e.g. "zh-CN") to the closest LibreTranslate code, or null. */
-    fun toLibreTranslateCode(tag: String): String? {
-        val code = tag.substringBefore('-').lowercase()
-        return code.takeIf { it in supportedLanguages }
-    }
+    fun toLibreTranslateCode(tag: String): String? = LibreTranslateCodes.toCode(tag)
 
     suspend fun identifyLanguage(context: Context, text: String): String? {
         val body = FormBody.Builder().add("q", text).build()

--- a/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/service/lang/LibreTranslateCodes.kt
+++ b/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/service/lang/LibreTranslateCodes.kt
@@ -20,26 +20,23 @@
  */
 package com.vitorpamplona.amethyst.service.lang
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
-import org.junit.Test
+/**
+ * Pure BCP-47 → LibreTranslate code mapping, kept free of Android/framework
+ * dependencies so it can be unit-tested on the JVM.
+ */
+object LibreTranslateCodes {
+    // LibreTranslate language set (ISO 639-1). Codes outside it are skipped.
+    val supported: Set<String> =
+        setOf(
+            "en", "ar", "az", "bg", "bs", "ca", "cs", "da", "de", "el", "es", "et", "fa", "fi",
+            "fr", "he", "hi", "hr", "hu", "hy", "id", "it", "ja", "ka", "kk", "ko", "lt", "lv",
+            "mk", "ms", "mt", "nl", "no", "pl", "pt", "ro", "ru", "sk", "sl", "sq", "sr", "sv",
+            "th", "tr", "uk", "ur", "vi", "zh",
+        )
 
-class LanguageTranslatorServiceTest {
-    @Test
-    fun `maps common BCP-47 tags to LibreTranslate codes`() {
-        assertEquals("en", LibreTranslateCodes.toCode("en"))
-        assertEquals("en", LibreTranslateCodes.toCode("en-US"))
-        assertEquals("zh", LibreTranslateCodes.toCode("zh-CN"))
-        assertEquals("zh", LibreTranslateCodes.toCode("zh-TW"))
-        assertEquals("pt", LibreTranslateCodes.toCode("pt-BR"))
-        assertEquals("de", LibreTranslateCodes.toCode("de"))
-        assertEquals("no", LibreTranslateCodes.toCode("no"))
-    }
-
-    @Test
-    fun `returns null for languages LibreTranslate does not support`() {
-        assertNull(LibreTranslateCodes.toCode("tl"))
-        assertNull(LibreTranslateCodes.toCode("xx"))
-        assertNull(LibreTranslateCodes.toCode(""))
+    /** Maps a BCP-47 tag (e.g. "zh-CN") to the closest LibreTranslate code, or null. */
+    fun toCode(tag: String): String? {
+        val code = tag.substringBefore('-').lowercase()
+        return code.takeIf { it in supported }
     }
 }

--- a/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/service/lang/TranslationServerConfig.kt
+++ b/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/service/lang/TranslationServerConfig.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.lang
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/**
+ * F-Droid build: translation server configuration (LibreTranslate, BYOK).
+ * Stored locally; opt-in and off by default so no post content leaves the
+ * device until the user explicitly enables it.
+ */
+object TranslationServerConfig {
+    const val DEFAULT_SERVER_URL = "https://libretranslate.com"
+
+    private const val PREFS_NAME = "translation_server"
+    private const val KEY_ENABLED = "enabled"
+    private const val KEY_SERVER_URL = "server_url"
+    private const val KEY_API_KEY = "api_key"
+
+    private fun prefs(context: Context): SharedPreferences =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun isEnabled(context: Context): Boolean = prefs(context).getBoolean(KEY_ENABLED, false)
+
+    fun setEnabled(context: Context, enabled: Boolean) {
+        prefs(context).edit().putBoolean(KEY_ENABLED, enabled).apply()
+    }
+
+    fun serverUrl(context: Context): String =
+        prefs(context)
+            .getString(KEY_SERVER_URL, DEFAULT_SERVER_URL)
+            ?.trim()
+            ?.takeIf { it.isNotBlank() }
+            ?: DEFAULT_SERVER_URL
+
+    fun setServerUrl(context: Context, url: String) {
+        prefs(context).edit().putString(KEY_SERVER_URL, url.trim().trimEnd('/')).apply()
+    }
+
+    fun apiKey(context: Context): String = prefs(context).getString(KEY_API_KEY, "") ?: ""
+
+    fun setApiKey(context: Context, apiKey: String) {
+        prefs(context).edit().putString(KEY_API_KEY, apiKey.trim()).apply()
+    }
+}

--- a/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/service/lang/TranslationsCache.kt
+++ b/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/service/lang/TranslationsCache.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.lang
+
+import android.util.LruCache
+import com.vitorpamplona.amethyst.commons.ui.components.TranslationConfig
+
+object TranslationsCache {
+    private const val MAX_ENTRIES = 500
+
+    // Keying on the language settings as well prevents serving stale translations after the user
+    // changes "Translate to" or "Don't translate from".
+    private data class Key(
+        val content: String,
+        val translateTo: String,
+        val dontTranslateFrom: Set<String>,
+    )
+
+    private val cache = LruCache<Key, TranslationConfig>(MAX_ENTRIES)
+
+    fun get(
+        content: String,
+        translateTo: String,
+        dontTranslateFrom: Set<String>,
+    ): TranslationConfig? = cache.get(Key(content, translateTo, dontTranslateFrom))
+
+    fun set(
+        content: String,
+        translateTo: String,
+        dontTranslateFrom: Set<String>,
+        config: TranslationConfig,
+    ) {
+        cache.put(Key(content, translateTo, dontTranslateFrom), config)
+    }
+
+    fun clear() {
+        cache.evictAll()
+    }
+}

--- a/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/ui/components/TranslatableRichTextViewer.kt
+++ b/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/ui/components/TranslatableRichTextViewer.kt
@@ -20,16 +20,38 @@
  */
 package com.vitorpamplona.amethyst.ui.components
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.model.ImmutableListOfLists
+import com.vitorpamplona.amethyst.commons.ui.components.TranslationConfig
+import com.vitorpamplona.amethyst.service.lang.LanguageTranslatorService
+import com.vitorpamplona.amethyst.service.lang.ResultOrError
+import com.vitorpamplona.amethyst.service.lang.TranslationServerConfig
+import com.vitorpamplona.amethyst.service.lang.TranslationsCache
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.MaxWidthPaddingTop5dp
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 @Composable
 fun TranslatableRichTextViewer(
@@ -44,19 +66,27 @@ fun TranslatableRichTextViewer(
     authorPubKey: String? = null,
     accountViewModel: AccountViewModel,
     nav: INav,
-) = ExpandableRichTextViewer(
-    content,
-    canPreview,
-    quotesLeft,
-    modifier,
-    tags,
-    backgroundColor,
-    id,
-    callbackUri,
-    authorPubKey,
-    accountViewModel,
-    nav,
-)
+) {
+    TranslatableRichTextViewer(
+        content = content,
+        id = id,
+        accountViewModel = accountViewModel,
+    ) {
+        ExpandableRichTextViewer(
+            it,
+            canPreview,
+            quotesLeft,
+            modifier,
+            tags,
+            backgroundColor,
+            id,
+            callbackUri,
+            authorPubKey,
+            accountViewModel,
+            nav,
+        )
+    }
+}
 
 @Composable
 fun TranslatableRichTextViewer(
@@ -65,11 +95,164 @@ fun TranslatableRichTextViewer(
     translationMessageModifier: Modifier = MaxWidthPaddingTop5dp,
     accountViewModel: AccountViewModel,
     displayText: @Composable (String) -> Unit,
-) = displayText(content)
+) {
+    val context = LocalContext.current
+    val languages = accountViewModel.account.settings.syncedSettings.languages
+    val translateTo by languages.translateTo.collectAsStateWithLifecycle()
+    val dontTranslateFrom by languages.dontTranslateFrom.collectAsStateWithLifecycle()
 
-/** No translation service in this flavor, so the content is always its own "translation". */
+    val translatedTextState =
+        remember(id, content, translateTo, dontTranslateFrom) {
+            mutableStateOf(
+                TranslationsCache.get(content, translateTo, dontTranslateFrom)
+                    ?: TranslationConfig(content, null, null),
+            )
+        }
+
+    LaunchedEffect(content, translateTo, dontTranslateFrom) {
+        try {
+            translatedTextState.value =
+                withContext(Dispatchers.IO) {
+                    translateAndCache(context, content, translateTo, dontTranslateFrom)
+                }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            // Transient network failure — keep showing the original. Do not cache: a
+            // one-off failure shouldn't block future attempts on the same text.
+        }
+    }
+
+    RenderTextWithTranslateOptions(
+        translatedTextState = translatedTextState.value,
+        content = content,
+        translationMessageModifier = translationMessageModifier,
+        displayText = displayText,
+    )
+}
+
+/**
+ * The translation of [content] under the current language settings, or [content] unchanged when
+ * no translation applies.
+ */
 @Composable
 fun rememberTranslation(
     content: String,
     accountViewModel: AccountViewModel,
-): String = content
+): String {
+    val context = LocalContext.current
+    val languages = accountViewModel.account.settings.syncedSettings.languages
+    val translateTo by languages.translateTo.collectAsStateWithLifecycle()
+    val dontTranslateFrom by languages.dontTranslateFrom.collectAsStateWithLifecycle()
+
+    val state =
+        remember(content, translateTo, dontTranslateFrom) {
+            mutableStateOf(
+                TranslationsCache.get(content, translateTo, dontTranslateFrom)
+                    ?: TranslationConfig(content, null, null),
+            )
+        }
+
+    LaunchedEffect(content, translateTo, dontTranslateFrom) {
+        try {
+            state.value =
+                withContext(Dispatchers.IO) {
+                    translateAndCache(context, content, translateTo, dontTranslateFrom)
+                }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            // Transient network failure — keep the original, same as the viewer does.
+        }
+    }
+
+    val config = state.value
+    val translated = config.sourceLang != null && config.targetLang != null && config.sourceLang != config.targetLang
+    return if (translated) config.result else content
+}
+
+@Composable
+private fun RenderTextWithTranslateOptions(
+    translatedTextState: TranslationConfig,
+    content: String,
+    translationMessageModifier: Modifier = MaxWidthPaddingTop5dp,
+    displayText: @Composable (String) -> Unit,
+) {
+    val source = translatedTextState.sourceLang
+    val target = translatedTextState.targetLang
+    val translationOccurred = source != null && target != null && source != target
+
+    var showOriginal by remember(translatedTextState) { mutableStateOf(false) }
+
+    val toBeViewed = if (showOriginal || !translationOccurred) content else translatedTextState.result
+
+    Column {
+        displayText(toBeViewed)
+
+        if (translationOccurred) {
+            Row(
+                modifier = translationMessageModifier,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringRes(R.string.translations_auto),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                TextButton(onClick = { showOriginal = !showOriginal }) {
+                    Text(
+                        text =
+                            stringRes(
+                                if (showOriginal) R.string.translations_show_translation
+                                else R.string.translations_show_original,
+                            ),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Returns the translation for [content] under the current language settings, hitting the cache
+ * first and falling back to the LibreTranslate-backed service. Cancellations and errors are
+ * bridged into a no-op [TranslationConfig] that is itself cached, so the same text scrolling
+ * back into view doesn't re-run the network call.
+ */
+private suspend fun translateAndCache(
+    context: android.content.Context,
+    content: String,
+    translateTo: String,
+    dontTranslateFrom: Set<String>,
+): TranslationConfig {
+    TranslationsCache.get(content, translateTo, dontTranslateFrom)?.let { return it }
+
+    // While translation is disabled, return the original without caching it, so enabling the
+    // feature later doesn't serve a stale "not translated" entry for content already seen.
+    if (!TranslationServerConfig.isEnabled(context)) return TranslationConfig(content, null, null)
+
+    val noOp = TranslationConfig(content, null, null)
+    val raw: ResultOrError =
+        try {
+            LanguageTranslatorService.autoTranslate(context, content, dontTranslateFrom, translateTo)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            // Transient network / server failure — keep the original but do not cache: a one-off
+            // failure shouldn't block future attempts on the same text.
+            return noOp
+        }
+
+    val translated = raw.result
+    val config =
+        if (translated.isNullOrBlank()) {
+            noOp
+        } else {
+            TranslationConfig(translated, raw.sourceLang, raw.targetLang)
+        }
+    // A no-op here is a genuine service decision (same language, blocklisted, undetected) — cache it.
+    TranslationsCache.set(content, translateTo, dontTranslateFrom, config)
+    return config
+}

--- a/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/TranslationServerSettingsSection.kt
+++ b/amethyst/src/fdroid/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/TranslationServerSettingsSection.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
+import com.vitorpamplona.amethyst.service.lang.TranslationServerConfig
+import com.vitorpamplona.amethyst.ui.stringRes
+
+@Composable
+fun TranslationServerSettingsSection() {
+    val context = LocalContext.current
+    var enabled by remember { mutableStateOf(TranslationServerConfig.isEnabled(context)) }
+    var serverUrl by remember { mutableStateOf(TranslationServerConfig.serverUrl(context)) }
+    var apiKey by remember { mutableStateOf(TranslationServerConfig.apiKey(context)) }
+
+    SettingsBlockTile(
+        icon = MaterialSymbols.Translate,
+        title = stringRes(R.string.translations_server_title),
+        description = stringRes(R.string.translations_server_description),
+    ) {
+        SettingsRow(
+            name = R.string.translations_server_enable,
+            description = R.string.translations_server_enable_description,
+        ) {
+            Switch(
+                checked = enabled,
+                onCheckedChange = {
+                    enabled = it
+                    TranslationServerConfig.setEnabled(context, it)
+                },
+            )
+        }
+        SettingsRow(
+            name = R.string.translations_server_url,
+            description = R.string.translations_server_url_description,
+        ) {
+            OutlinedTextField(
+                value = serverUrl,
+                onValueChange = {
+                    serverUrl = it
+                    TranslationServerConfig.setServerUrl(context, it)
+                },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        SettingsRow(
+            name = R.string.translations_server_api_key,
+            description = R.string.translations_server_api_key_description,
+        ) {
+            OutlinedTextField(
+                value = apiKey,
+                onValueChange = {
+                    apiKey = it
+                    TranslationServerConfig.setApiKey(context, it)
+                },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/UserSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/UserSettingsScreen.kt
@@ -110,6 +110,8 @@ fun UserSettingsScreen(
                 DontTranslateFromSetting(accountViewModel)
                 HorizontalDivider(thickness = DividerThickness)
                 LanguagePreferencesSetting(accountViewModel)
+                HorizontalDivider(thickness = DividerThickness)
+                TranslationServerSettingsSection()
             }
         }
     }

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -5016,4 +5016,15 @@
     <string name="buzz_persona_avatar">Avatar URL (optional)</string>
     <string name="buzz_persona_publishing">Publishing…</string>
     <string name="buzz_persona_publish">Publish persona</string>
+
+    <string name="translations_server_title">Translation Server</string>
+    <string name="translations_server_description">This build translates posts with your own LibreTranslate server. It is off by default so no content leaves your device until you enable it.</string>
+    <string name="translations_server_enable">Enable translation</string>
+    <string name="translations_server_enable_description">Send the posts you choose to translate to the server below.</string>
+    <string name="translations_server_url">Server URL</string>
+    <string name="translations_server_url_description">For example https://libretranslate.com or your self-hosted instance.</string>
+    <string name="translations_server_api_key">API key (optional)</string>
+    <string name="translations_server_api_key_description">Only needed if your server requires one.</string>
+    <string name="translations_show_original">Show original</string>
+    <string name="translations_show_translation">Show translation</string>
 </resources>

--- a/amethyst/src/play/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/TranslationServerSettingsSection.kt
+++ b/amethyst/src/play/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/TranslationServerSettingsSection.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun TranslationServerSettingsSection() {
+    // The Play build uses ML Kit on-device translation and needs no server configuration.
+}

--- a/amethyst/src/testFdroid/java/com/vitorpamplona/amethyst/service/lang/LanguageTranslatorServiceTest.kt
+++ b/amethyst/src/testFdroid/java/com/vitorpamplona/amethyst/service/lang/LanguageTranslatorServiceTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.lang
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class LanguageTranslatorServiceTest {
+    @Test
+    fun `maps common BCP-47 tags to LibreTranslate codes`() {
+        assertEquals("en", LanguageTranslatorService.toLibreTranslateCode("en"))
+        assertEquals("en", LanguageTranslatorService.toLibreTranslateCode("en-US"))
+        assertEquals("zh", LanguageTranslatorService.toLibreTranslateCode("zh-CN"))
+        assertEquals("zh", LanguageTranslatorService.toLibreTranslateCode("zh-TW"))
+        assertEquals("pt", LanguageTranslatorService.toLibreTranslateCode("pt-BR"))
+        assertEquals("de", LanguageTranslatorService.toLibreTranslateCode("de"))
+        assertEquals("no", LanguageTranslatorService.toLibreTranslateCode("no"))
+    }
+
+    @Test
+    fun `returns null for languages LibreTranslate does not support`() {
+        assertNull(LanguageTranslatorService.toLibreTranslateCode("tl"))
+        assertNull(LanguageTranslatorService.toLibreTranslateCode("xx"))
+        assertNull(LanguageTranslatorService.toLibreTranslateCode(""))
+    }
+}


### PR DESCRIPTION
## feat(fdroid): LibreTranslate-backed translation (issue #548)

Adds post translation to the F-Droid build, which previously had only a stub
(`LanguageTranslatorService.clear()`) and always rendered original text.

**Approach** (research summary posted on #548 per CONTRIBUTING-WITH-AI.md):
user-configured LibreTranslate server (BYOK), opt-in and off by default for
privacy. Users bring their own instance (e.g. the Umbrel LibreTranslate app
mentioned in the issue) or a public one. No central server, no required
third-party account, no maintainer-controlled state. Play flavor untouched.

**Changes (F-Droid flavor only, plus a no-op hook in Play):**
- `service/lang/LanguageTranslatorService.kt` — detect/translate/autoTranslate
  suspend API mirroring the Play ML Kit surface; OkHttp-based; off unless the
  user enables it.
- `service/lang/LibreTranslateCodes.kt` — pure BCP-47 → LibreTranslate code
  mapping, framework-free so it is JVM unit-testable.
- `service/lang/TranslationServerConfig.kt` — local SharedPreferences config
  (enabled, server URL, optional API key; blank URL falls back to the default).
- `service/lang/TranslationsCache.kt` — same cache semantics as Play.
- `ui/components/TranslatableRichTextViewer.kt` — auto-translate with a
  show-original toggle; transient failures are never cached.
- `ui/screen/loggedIn/settings/TranslationServerSettingsSection.kt` — F-Droid
  settings UI (enable, URL, API key); Play gets a no-op.
- `ui/screen/loggedIn/settings/UserSettingsScreen.kt` — wires the section.
- `src/testFdroid/.../LanguageTranslatorServiceTest.kt` — unit tests for the
  BCP-47 → LibreTranslate code mapping.
- `res/values/strings.xml` — new strings.

**Proof of build/test** (per CONTRIBUTING-WITH-AI.md; substantial AI
involvement — this work was prepared with an AI coding assistant):
- GitHub Actions on the staging fork `gemquota/amethyst` (public, workflow
  `build-amethyst`): `./gradlew :amethyst:assemblePlayDebug
  :amethyst:assembleFdroidDebug :amethyst:testFdroidDebugUnitTest` →
  `BUILD SUCCESSFUL in 14m 48s`; `:amethyst:testFdroidDebugUnitTest` passed;
  both debug APK sets produced and uploaded (`amethyst-debug-apks`).
- Run + logs: https://github.com/gemquota/amethyst/actions/runs/30637568695
- `installPlayDebug`/`installFdroidDebug` cannot run on CI without a device;
  the emulator job (or a maintainer device run) installs the produced APKs.

**Notes**
- The F-Droid translator is a **JVM unit-testable** pure mapping (no Android
  framework deps) for the language-code conversion; the network path follows
  the same OkHttp pattern used elsewhere in the app.
- Privacy default: off. When enabled, only posts the user chooses to translate
  are sent to their configured server.
