### PR TITLE
Fix ServiceType parsing to handle edge cases safely

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip85TrustedAssertions/list/tags/ServiceType.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip85TrustedAssertions/list/tags/ServiceType.kt
@@ -33,15 +33,16 @@ data class ServiceType(
         ) = "$kind:$type"
 
         fun parse(serviceType: String): ServiceType? {
-            val (kindStr, type) = serviceType.split(":", limit = 2)
-            val kind = kindStr.toIntOrNull() ?: return null
-            return ServiceType(kind, type)
+            val divider = serviceType.indexOf(':')
+            if (divider < 0 || divider == serviceType.length - 1) return null
+            val kind = serviceType.substring(0, divider).toIntOrNull() ?: return null
+            return ServiceType(kind, serviceType.substring(divider + 1))
         }
 
         fun isOfKind(
             serviceType: String,
             kind: String,
-        ) = serviceType.startsWith(kind) && serviceType[kind.length] == ':'
+        ) = serviceType.length > kind.length && serviceType.startsWith(kind) && serviceType[kind.length] == ':'
     }
 }
 

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/experimental/nip85TrustedAssertions/ServiceTypeParserTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/experimental/nip85TrustedAssertions/ServiceTypeParserTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.experimental.nip85TrustedAssertions
+
+import com.vitorpamplona.quartz.nip85TrustedAssertions.list.tags.ServiceType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ServiceTypeParserTest {
+    @Test
+    fun parseValid() {
+        assertEquals(ServiceType(30382, "rank"), ServiceType.parse("30382:rank"))
+    }
+
+    @Test
+    fun parseKeepsColonsInTheType() {
+        assertEquals(ServiceType(30382, "rank:extra"), ServiceType.parse("30382:rank:extra"))
+    }
+
+    @Test
+    fun parseWithoutSeparator() {
+        // a `["client", "nostria"]` tag ends up here. Must not crash.
+        assertNull(ServiceType.parse("client"))
+    }
+
+    @Test
+    fun parseEmpty() {
+        assertNull(ServiceType.parse(""))
+    }
+
+    @Test
+    fun parseWithoutKind() {
+        assertNull(ServiceType.parse(":rank"))
+    }
+
+    @Test
+    fun parseWithoutType() {
+        assertNull(ServiceType.parse("30382:"))
+    }
+
+    @Test
+    fun parseNonNumericKind() {
+        assertNull(ServiceType.parse("client:nostria"))
+    }
+
+    @Test
+    fun isOfKindMatches() {
+        assertTrue(ServiceType.isOfKind("30382:rank", "30382"))
+    }
+
+    @Test
+    fun isOfKindOnPrefixWithoutSeparator() {
+        // "30382" starts with "30382" but has no `:` at that position. Must not crash.
+        assertFalse(ServiceType.isOfKind("30382", "30382"))
+        assertFalse(ServiceType.isOfKind("", ""))
+        assertFalse(ServiceType.isOfKind("303820:rank", "30382"))
+        assertFalse(ServiceType.isOfKind("30383:rank", "30382"))
+    }
+}


### PR DESCRIPTION
## Summary

Fixed `ServiceType.parse()` and `ServiceType.isOfKind()` to safely handle edge cases where the input string lacks a colon separator or has malformed structure. The original implementation used `split()` which could throw or produce unexpected results; the new implementation uses `indexOf()` with explicit bounds checking.

Changes:
- `parse()` now validates that a colon exists and is not at the end of the string before attempting to extract kind and type
- `isOfKind()` now checks that the string is long enough before accessing the character at `kind.length`
- Added comprehensive unit tests covering valid inputs, missing separators, empty strings, and non-numeric kinds

## Test plan

- [x] Ran `./gradlew test` — new `ServiceTypeParserTest` passes all 9 test cases
- [x] Existing tests pass

The new test suite (`ServiceTypeParserTest.kt`) covers:
- Valid parsing: `"30382:rank"` → `ServiceType(30382, "rank")`
- Colons in type: `"30382:rank:extra"` → `ServiceType(30382, "rank:extra")`
- Missing separator: `"client"` → `null`
- Empty string: `""` → `null`
- Missing kind: `":rank"` → `null`
- Missing type: `"30382:"` → `null`
- Non-numeric kind: `"client:nostria"` → `null`
- `isOfKind()` matching and non-matching cases with proper boundary checks

## Interop suites

- [x] N/A — change is internal parsing logic for NIP-85 trusted assertions, does not affect wire bytes or protocol encoding

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_0112ysMEzSaezH9mXFteNt13