### PR TITLE
Test: Type ExplainedFilter.copy() result as base Filter

### DIFF
--- a/commons/src/jvmTest/kotlin/com/vitorpamplona/amethyst/commons/relayClient/subscriptions/ExplainedFilterTest.kt
+++ b/commons/src/jvmTest/kotlin/com/vitorpamplona/amethyst/commons/relayClient/subscriptions/ExplainedFilterTest.kt
@@ -108,7 +108,9 @@ class ExplainedFilterTest {
      */
     @Test
     fun `copy preserves the purpose`() {
-        val advanced = explained().copy(since = 1_785_379_272)
+        // Typed as the base Filter so the is-check below stays a runtime assertion — with the
+        // override's covariant return type inferred, the compiler would prove it true statically.
+        val advanced: Filter = explained().copy(since = 1_785_379_272)
 
         assertTrue("copy() must stay an ExplainedFilter", advanced is ExplainedFilter)
         assertEquals(SubPurpose.NOTIFICATIONS, advanced.purposeOrNull())


### PR DESCRIPTION
## Summary

Updated `ExplainedFilterTest.copy()` to explicitly type the result as the base `Filter` class rather than relying on type inference. This ensures the runtime `is` check remains a meaningful assertion rather than a compile-time tautology, and documents the covariant return type behavior of the `copy()` override.

## Test plan

- [x] Ran `./gradlew test` — `ExplainedFilterTest.copy()` passes with the type annotation in place

The change is a test-only modification that improves test clarity without affecting production code. The explicit `Filter` type annotation forces the runtime type check to remain a real assertion (not statically provable by the compiler), which better documents the intent that `ExplainedFilter.copy()` preserves the runtime type despite the covariant return type.

## Interop suites

- [x] N/A — change is test-only, affects no wire bytes or runtime behavior

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_012KG9YkeFp6zyth5J364DLF