### PR TITLE
Stop COUNT from inheriting the default page size

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/server/policies/LimitsPolicy.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/server/policies/LimitsPolicy.kt
@@ -72,9 +72,13 @@ class LimitsPolicy(
         return PolicyResult.Accepted(if (clamped === cmd.filters) cmd else ReqCmd(cmd.subId, clamped))
     }
 
+    /**
+     * A COUNT is clamped by [RelayLimits.maxLimit] but NEVER given
+     * [RelayLimits.defaultLimit] — see [capLimits].
+     */
     override fun accept(cmd: CountCmd): PolicyResult<CountCmd> {
         subscriptionRejection(cmd.queryId, cmd.filters)?.let { return PolicyResult.Rejected(it) }
-        val clamped = clampLimits(cmd.filters)
+        val clamped = capLimits(cmd.filters)
         return PolicyResult.Accepted(if (clamped === cmd.filters) cmd else CountCmd(cmd.queryId, clamped))
     }
 
@@ -104,6 +108,28 @@ class LimitsPolicy(
         if (limits.maxLimit == null && limits.defaultLimit == null) return filters
         if (filters.none { targetLimit(it.limit) != it.limit }) return filters
         return filters.map { it.copy(limit = targetLimit(it.limit)) }
+    }
+
+    /**
+     * Cap what a COUNT asks for, without inventing a page size for it.
+     *
+     * `defaultLimit` answers "how many events should a REQ return when the
+     * client names no limit". A COUNT returns no events, so that question has
+     * no meaning for it — and applying the answer anyway turns every unbounded
+     * COUNT into `min(matches, defaultLimit)`.
+     *
+     * Silently: a relay holding 12,289,614 profiles replied `{"count":500}`,
+     * which is a plausible-looking number, so a client cannot tell it from the
+     * truth. The kinds that happened to fall under the default were correct,
+     * which is what made it survive.
+     *
+     * `maxLimit` still applies, because a client that explicitly asks to count
+     * at most N is asking a question this relay may bound.
+     */
+    private fun capLimits(filters: List<Filter>): List<Filter> {
+        val max = limits.maxLimit ?: return filters
+        if (filters.none { it.limit != null && it.limit!! > max }) return filters
+        return filters.map { if (it.limit != null && it.limit!! > max) it.copy(limit = max) else it }
     }
 
     private fun targetLimit(current: Int?): Int? =

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/server/RelayLimitsTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/server/RelayLimitsTest.kt
@@ -30,6 +30,7 @@ import com.vitorpamplona.quartz.nip01Core.relay.server.policies.PolicyResult
 import com.vitorpamplona.quartz.nip01Core.relay.server.policies.RelayLimits
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class RelayLimitsTest {
@@ -151,6 +152,39 @@ class RelayLimitsTest {
         val result = policy.accept(ReqCmd("s", listOf(Filter(kinds = listOf(1))))) as PolicyResult.Accepted
         assertEquals(
             50,
+            result.cmd.filters
+                .single()
+                .limit,
+        )
+    }
+
+    @Test
+    fun countNeverGetsTheDefaultLimit() {
+        // A COUNT returns no events, so "how many should a REQ return by
+        // default" is not a question it asked. Applying the answer anyway turns
+        // every unbounded COUNT into min(matches, defaultLimit) — a relay
+        // holding 12,289,614 profiles replied {"count":500}, which is plausible
+        // enough that no client can tell it from the truth.
+        val policy = LimitsPolicy(RelayLimits(defaultLimit = 50, maxLimit = 100))
+
+        val result = policy.accept(CountCmd("q", listOf(Filter(kinds = listOf(1))))) as PolicyResult.Accepted
+
+        assertNull(
+            result.cmd.filters
+                .single()
+                .limit,
+        )
+    }
+
+    @Test
+    fun countStillHonoursAnExplicitMaxLimit() {
+        // Asking to count at most N is a question the relay may bound.
+        val policy = LimitsPolicy(RelayLimits(defaultLimit = 50, maxLimit = 100))
+
+        val result = policy.accept(CountCmd("q", listOf(Filter(kinds = listOf(1), limit = 900)))) as PolicyResult.Accepted
+
+        assertEquals(
+            100,
             result.cmd.filters
                 .single()
                 .limit,


### PR DESCRIPTION
A relay holding **12,289,614** profiles answers:

```
-> ["COUNT","c1",{"kinds":[0]}]
<- ["COUNT","c1",{"count":500}]
```

`LimitsPolicy` ran the same `clampLimits` over `CountCmd` as over `ReqCmd`, so an unbounded COUNT was given `RelayLimits.defaultLimit` and the store then counted at most that many.

`defaultLimit` answers *"how many events should a REQ return when the client names none"*. A COUNT returns no events, so the question has no meaning for it — and applying the answer anyway silently turns every unbounded COUNT into `min(matches, defaultLimit)`.

## Why it survived

The wrong answer is plausible. Measured on a live relay, kinds under the default were correct and everything above it capped at exactly the same number:

| kind | COUNT said | actual |
|---|---|---|
| 0 profiles | **500** | 12,289,614 |
| 1 notes | 0 | 0 ✓ |
| 10002 relay lists | **500** | millions |
| 10040 provider lists | 271 | 271 ✓ |
| 30382 trust assertions | **500** | ~36,000,000 |

Nothing errors, nothing logs, and two of the five answers are right. A client cannot distinguish `{"count":500}` from the truth.

## The fix

`maxLimit` still applies to a COUNT — a client asking to count *at most N* is asking something a relay may legitimately bound. Only the invented default is dropped.

Two tests: an unbounded COUNT keeps `limit = null`, and an explicit oversized `limit` is still clamped to `maxLimit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)