### PR TITLE
Fix fetchAllPages cropping streaming pages; normalize accessory timeouts to idle windows

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountConcordActions.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountConcordActions.kt
@@ -971,7 +971,7 @@ class AccountConcordActions(
         val filter = Filter(kinds = listOf(ConcordCommunityListEvent.KIND), authors = listOf(account.signer.pubKey))
         // Stock relays like relay.ditto.pub can be slow (~10–20s to first response), so give
         // the fetch a generous window to drain every relay before we pick the newest copy.
-        val events = account.client.fetchAll(filters = relays.associateWith { listOf(filter) }, timeoutMs = 30_000L)
+        val events = account.client.fetchAll(filters = relays.associateWith { listOf(filter) }, idleTimeoutMs = 30_000L)
         val newest = events.filterIsInstance<ConcordCommunityListEvent>().maxByOrNull { it.createdAt }
         val entryCount = newest?.let { runCatching { it.decrypt(account.signer).size }.getOrElse { -1 } } ?: 0
         Log.d(
@@ -1015,7 +1015,7 @@ class AccountConcordActions(
             }
         if (filters.isEmpty()) return
         val byRelay = filters.groupBy { it.relay }.mapValues { (_, group) -> group.map { it.filter } }
-        account.client.fetchAll(filters = byRelay, timeoutMs = 20_000L)
+        account.client.fetchAll(filters = byRelay, idleTimeoutMs = 20_000L)
     }
 
     /**

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountRelayGroupActions.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountRelayGroupActions.kt
@@ -133,7 +133,7 @@ class AccountRelayGroupActions(
         if (channelId == null && results.values.any { !it.accepted && it.message.contains("auth-required", ignoreCase = true) }) {
             account.client.fetchAllWithHooks(
                 filters = mapOf(relay to listOf(Filter(kinds = listOf(DmOpenEvent.KIND), limit = 1))),
-                timeoutMs = 8_000,
+                idleTimeoutMs = 8_000,
                 pendingOnAuthRequired = true,
             ) { _, _ -> false }
             results = account.client.publishAndCollectResults(signed, setOf(relay))

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/gateways/AccountNappletGateways.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/gateways/AccountNappletGateways.kt
@@ -255,7 +255,7 @@ class AccountNappletGateways(
                 emptyList()
             } else {
                 runCatching {
-                    account.client.fetchAll(filters = relays.associateWith { filters }, timeoutMs = QUERY_TIMEOUT.inWholeMilliseconds)
+                    account.client.fetchAll(filters = relays.associateWith { filters }, idleTimeoutMs = QUERY_TIMEOUT.inWholeMilliseconds)
                 }.getOrDefault(emptyList())
             }
         val fromCache = filters.flatMap { filter -> account.cache.filter(filter).mapNotNull { it.event } }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/gateways/NappletResourceFetcher.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/gateways/NappletResourceFetcher.kt
@@ -144,7 +144,7 @@ class NappletResourceFetcher(
         val relays = account.homeRelays.flow.value
         if (relays.isEmpty()) return null
         return runCatching {
-            account.client.fetchAll(filters = relays.associateWith { listOf(filter) }, timeoutMs = NOSTR_FETCH_TIMEOUT_MS)
+            account.client.fetchAll(filters = relays.associateWith { listOf(filter) }, idleTimeoutMs = NOSTR_FETCH_TIMEOUT_MS)
         }.getOrDefault(emptyList())
             .maxByOrNull { it.createdAt }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/AgentConsoleViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/AgentConsoleViewModel.kt
@@ -153,7 +153,7 @@ class AgentConsoleViewModel : ViewModel() {
         // (pendingOnAuthRequired) so it authenticates on the `auth-required` CLOSED and retries.
         account.client.fetchAllWithHooks(
             filters = relays.associateWith { filters },
-            timeoutMs = 8_000,
+            idleTimeoutMs = 8_000,
             pendingOnAuthRequired = true,
         ) { _, _ -> false }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/BuzzDmDiscovery.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/BuzzDmDiscovery.kt
@@ -97,7 +97,7 @@ private suspend fun runBuzzDmDiscovery(
     // rather than returning empty.
     account.client.fetchAllWithHooks(
         filters = relays.associateWith { discoveryFilters },
-        timeoutMs = 8_000,
+        idleTimeoutMs = 8_000,
         pendingOnAuthRequired = true,
     ) { relay, event ->
         (event as? MemberAddedNotificationEvent)?.let { recordDiscovery(me, it, relay) }
@@ -135,7 +135,7 @@ private suspend fun fetchDmMetadata(
             .groupBy({ it.value }, { it.key })
             .mapValues { (_, ids) -> listOf(Filter(kinds = RELAY_GROUP_METADATA_KINDS, tags = mapOf("d" to ids))) }
     if (byRelay.isEmpty()) return
-    account.client.fetchAllWithHooks(filters = byRelay, timeoutMs = 8_000, pendingOnAuthRequired = true) { _, _ -> false }
+    account.client.fetchAllWithHooks(filters = byRelay, idleTimeoutMs = 8_000, pendingOnAuthRequired = true) { _, _ -> false }
 }
 
 /**

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/BuzzDmListViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/BuzzDmListViewModel.kt
@@ -200,7 +200,7 @@ class BuzzDmListViewModel : ViewModel() {
             )
         account.client.fetchAllWithHooks(
             filters = relays.associateWith { filters },
-            timeoutMs = 8_000,
+            idleTimeoutMs = 8_000,
             pendingOnAuthRequired = true,
         ) { relay, event ->
             (event as? MemberAddedNotificationEvent)?.channel()?.let { memberChannels[it] = relay }
@@ -215,7 +215,7 @@ class BuzzDmListViewModel : ViewModel() {
                 .groupBy({ it.value }, { it.key })
                 .mapValues { (_, ids) -> listOf(Filter(kinds = RELAY_GROUP_METADATA_KINDS, tags = mapOf("d" to ids))) }
         if (byRelay.isEmpty()) return
-        account.client.fetchAllWithHooks(filters = byRelay, timeoutMs = 8_000, pendingOnAuthRequired = true) { _, _ -> false }
+        account.client.fetchAllWithHooks(filters = byRelay, idleTimeoutMs = 8_000, pendingOnAuthRequired = true) { _, _ -> false }
     }
 
     /**

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/BuzzRelayImportViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/buzz/BuzzRelayImportViewModel.kt
@@ -149,7 +149,7 @@ class BuzzRelayImportViewModel : ViewModel() {
                                     ),
                                 ),
                         ),
-                    timeoutMs = 8_000,
+                    idleTimeoutMs = 8_000,
                     pendingOnAuthRequired = true,
                 ) { _, event ->
                     (event as? MemberAddedNotificationEvent)?.channel()?.let { channelIds.add(it) }
@@ -172,7 +172,7 @@ class BuzzRelayImportViewModel : ViewModel() {
                                         Filter(kinds = listOf(SystemMessageEvent.KIND), tags = mapOf("h" to channelIds.toList())),
                                     ),
                             ),
-                        timeoutMs = 8_000,
+                        idleTimeoutMs = 8_000,
                         pendingOnAuthRequired = true,
                     ) { _, _ -> false }
                 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/eventsync/EventSync.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/relays/eventsync/EventSync.kt
@@ -502,7 +502,7 @@ class EventSync(
             try {
                 client.fetchAllPagesFromPool(
                     filters = perRelayFilters,
-                    timeoutMs = RELAY_TIMEOUT_MS,
+                    idleTimeoutMs = RELAY_TIMEOUT_MS,
                     maxConcurrentRelays = MAX_CONCURRENT_RELAYS,
                     onNewPage = { until, sourceRelay ->
                         _liveActivity.value.runningRelays[sourceRelay]

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/wizard/CashuWalletDiscovery.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/wizard/CashuWalletDiscovery.kt
@@ -199,7 +199,7 @@ class CashuWalletDiscovery(
                             fetchAllPages(
                                 relay = relay,
                                 filters = filters,
-                                timeoutMs = RELAY_TIMEOUT_MS,
+                                idleTimeoutMs = RELAY_TIMEOUT_MS,
                                 onEvent = onEvent,
                             )
                         }.onFailure {

--- a/amethyst/src/play/java/com/vitorpamplona/amethyst/appfunctions/AmethystAppFunctions.kt
+++ b/amethyst/src/play/java/com/vitorpamplona/amethyst/appfunctions/AmethystAppFunctions.kt
@@ -153,12 +153,12 @@ class AmethystAppFunctions {
 
         // Quartz's INostrClient.fetchAll handles subscribe → drain on
         // EOSE/closed/cannot-connect → unsubscribe → dedup by id → sort
-        // newest-first. Wraps everything in a withTimeoutOrNull(timeoutMs)
+        // newest-first. Wraps everything in a withTimeoutOrNull(idleTimeoutMs)
         // so a slow relay can't stall the dispatch.
         val events =
             client.fetchAll(
                 filters = relays.associateWith { listOf(filter) },
-                timeoutMs = GEMINI_FETCH_TIMEOUT_MS,
+                idleTimeoutMs = GEMINI_FETCH_TIMEOUT_MS,
             )
 
         val candidates =
@@ -397,7 +397,7 @@ class AmethystAppFunctions {
         return Amethyst.instance.client
             .fetchAll(
                 filters = relays.associateWith { listOf(filter) },
-                timeoutMs = GEMINI_FETCH_TIMEOUT_MS,
+                idleTimeoutMs = GEMINI_FETCH_TIMEOUT_MS,
             ).mapNotNull { it as? TextNoteEvent }
             .take(limit)
     }
@@ -449,7 +449,7 @@ class AmethystAppFunctions {
         val events =
             client.fetchAll(
                 filters = relays.associateWith { listOf(filter) },
-                timeoutMs = GEMINI_FETCH_TIMEOUT_MS,
+                idleTimeoutMs = GEMINI_FETCH_TIMEOUT_MS,
             )
 
         val hits =
@@ -521,7 +521,7 @@ class AmethystAppFunctions {
             client
                 .fetchAll(
                     filters = relays.associateWith { listOf(filter) },
-                    timeoutMs = GEMINI_FETCH_TIMEOUT_MS,
+                    idleTimeoutMs = GEMINI_FETCH_TIMEOUT_MS,
                 ).mapNotNull { it as? MetadataEvent }
                 .filter { it.pubKey == pubkey }
                 .maxByOrNull { it.createdAt }
@@ -569,7 +569,7 @@ class AmethystAppFunctions {
         val events =
             client.fetchAll(
                 filters = relays.associateWith { listOf(filter) },
-                timeoutMs = GEMINI_FETCH_TIMEOUT_MS,
+                idleTimeoutMs = GEMINI_FETCH_TIMEOUT_MS,
             )
 
         val hits =
@@ -643,7 +643,7 @@ class AmethystAppFunctions {
         val events =
             client.fetchAll(
                 filters = relays.associateWith { listOf(filter) },
-                timeoutMs = GEMINI_FETCH_TIMEOUT_MS,
+                idleTimeoutMs = GEMINI_FETCH_TIMEOUT_MS,
             )
 
         val hits =
@@ -686,7 +686,7 @@ class AmethystAppFunctions {
         val events =
             client.fetchAll(
                 filters = relays.associateWith { listOf(filter) },
-                timeoutMs = GEMINI_FETCH_TIMEOUT_MS,
+                idleTimeoutMs = GEMINI_FETCH_TIMEOUT_MS,
             )
 
         val hits =
@@ -733,7 +733,7 @@ class AmethystAppFunctions {
         val events =
             client.fetchAll(
                 filters = relays.associateWith { listOf(filter) },
-                timeoutMs = GEMINI_FETCH_TIMEOUT_MS,
+                idleTimeoutMs = GEMINI_FETCH_TIMEOUT_MS,
             )
 
         val hits =
@@ -785,7 +785,7 @@ class AmethystAppFunctions {
         val events =
             client.fetchAll(
                 filters = relays.associateWith { listOf(filter) },
-                timeoutMs = GEMINI_FETCH_TIMEOUT_MS,
+                idleTimeoutMs = GEMINI_FETCH_TIMEOUT_MS,
             )
 
         val receipts = events.mapNotNull { it as? LnZapEvent }
@@ -880,7 +880,7 @@ class AmethystAppFunctions {
             client
                 .fetchAll(
                     filters = relays.associateWith { listOf(filter) },
-                    timeoutMs = GEMINI_FETCH_TIMEOUT_MS,
+                    idleTimeoutMs = GEMINI_FETCH_TIMEOUT_MS,
                 ).mapNotNull { it as? GiftWrapEvent }
 
         val seen = HashSet<HexKey>()
@@ -947,7 +947,7 @@ class AmethystAppFunctions {
         val events =
             client.fetchAll(
                 filters = relays.associateWith { listOf(filter) },
-                timeoutMs = GEMINI_FETCH_TIMEOUT_MS,
+                idleTimeoutMs = GEMINI_FETCH_TIMEOUT_MS,
             )
 
         val hits =
@@ -991,7 +991,7 @@ class AmethystAppFunctions {
         val events =
             client.fetchAll(
                 filters = relays.associateWith { listOf(filter) },
-                timeoutMs = GEMINI_FETCH_TIMEOUT_MS,
+                idleTimeoutMs = GEMINI_FETCH_TIMEOUT_MS,
             )
 
         val streams =
@@ -1691,7 +1691,7 @@ class AmethystAppFunctions {
         return client
             .fetchAll(
                 filters = relays.associateWith { listOf(filter) },
-                timeoutMs = GEMINI_FETCH_TIMEOUT_MS,
+                idleTimeoutMs = GEMINI_FETCH_TIMEOUT_MS,
             ).mapNotNull { it as? MetadataEvent }
             .maxByOrNull { it.createdAt }
             ?.contactMetaData()
@@ -2027,7 +2027,7 @@ class AmethystAppFunctions {
         val events =
             client.fetchAll(
                 filters = relays.associateWith { listOf(filter) },
-                timeoutMs = GEMINI_FETCH_TIMEOUT_MS,
+                idleTimeoutMs = GEMINI_FETCH_TIMEOUT_MS,
             )
 
         val hits =

--- a/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/Context.kt
+++ b/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/Context.kt
@@ -547,7 +547,7 @@ class Context(
             if (needAuth.isEmpty()) break
             // A cheap REQ whose only purpose is to force the AUTH handshake to completion.
             val warmFilter = listOf(Filter(kinds = listOf(event.kind), limit = 1))
-            drain(needAuth.associateWith { warmFilter }, timeoutMs = 8_000, pendingOnAuthRequired = true)
+            drain(needAuth.associateWith { warmFilter }, idleTimeoutMs = 8_000, pendingOnAuthRequired = true)
             results = results + client.publishAndCollectResults(event, needAuth, timeoutSecs)
             attempt++
         }
@@ -565,7 +565,7 @@ class Context(
      * When [deadOut] is provided, every relay that reported it could not be
      * connected to (`onCannotConnect`) is added to it, so callers can prune
      * proven-dead relays from future routing instead of paying the full
-     * [timeoutMs] on them again. Slow-but-connected relays are NOT reported —
+     * [idleTimeoutMs] on them again. Slow-but-connected relays are NOT reported —
      * only hard connect failures, so a temporarily-busy relay isn't discarded.
      *
      * With [pendingOnAuthRequired], a relay that refuses the REQ with an
@@ -573,24 +573,24 @@ class Context(
      * NIP-42 responder answers the challenge and the client re-fires this same
      * subscription (`syncFilters`), so the post-auth events are collected instead of
      * returning empty. If auth never satisfies it, the relay simply falls through to
-     * the [timeoutMs]. Needed for Concord planes, whose kind-1059 wraps are served
+     * the [idleTimeoutMs]. Needed for Concord planes, whose kind-1059 wraps are served
      * only to a connection authenticated as the derived stream key.
      */
     suspend fun drain(
         filters: Map<NormalizedRelayUrl, List<Filter>>,
-        timeoutMs: Long = 8_000,
+        idleTimeoutMs: Long = 8_000,
         diagnoseSlow: Boolean = false,
         deadOut: MutableMap<NormalizedRelayUrl, DrainFailure>? = null,
         pendingOnAuthRequired: Boolean = false,
     ): List<Pair<NormalizedRelayUrl, Event>> =
         client.fetchAllWithHooks(
             filters = filters,
-            timeoutMs = timeoutMs,
+            idleTimeoutMs = idleTimeoutMs,
             pendingOnAuthRequired = pendingOnAuthRequired,
             deadOut = deadOut,
             onTimeout =
                 if (diagnoseSlow) {
-                    { stalled, doneReasons, collected -> logSlowDrain(timeoutMs, stalled, doneReasons, collected) }
+                    { stalled, doneReasons, collected -> logSlowDrain(idleTimeoutMs, stalled, doneReasons, collected) }
                 } else {
                     null
                 },
@@ -604,7 +604,7 @@ class Context(
      * "relay is slow" and "we never connected" are easy to tell apart.
      */
     private fun logSlowDrain(
-        timeoutMs: Long,
+        idleTimeoutMs: Long,
         stalled: Set<NormalizedRelayUrl>,
         doneReasons: Map<NormalizedRelayUrl, String>,
         collected: List<Pair<NormalizedRelayUrl, Event>>,
@@ -615,7 +615,7 @@ class Context(
         val slowDetail = stalled.take(12).joinToString(", ") { "${it.url}(${eventsPer[it] ?: 0}ev)" }
         val cannotDetail = cannot.entries.take(8).joinToString(", ") { "${it.key.url}=${it.value.removePrefix("cannot:").take(40)}" }
         System.err.println(
-            "[drain] timeout ${timeoutMs}ms: ${stalled.size} slow(no EOSE), ${cannot.size} cannot-connect, ${closed.size} closed" +
+            "[drain] timeout ${idleTimeoutMs}ms: ${stalled.size} slow(no EOSE), ${cannot.size} cannot-connect, ${closed.size} closed" +
                 (if (slowDetail.isNotEmpty()) " | slow: $slowDetail" else "") +
                 (if (cannotDetail.isNotEmpty()) " | cannot: $cannotDetail" else ""),
         )
@@ -641,12 +641,12 @@ class Context(
      */
     suspend fun drainAllPages(
         filters: Map<NormalizedRelayUrl, List<Filter>>,
-        timeoutMs: Long = 30_000,
+        idleTimeoutMs: Long = 30_000,
         maxConcurrentRelays: Int = 8,
     ): List<Pair<NormalizedRelayUrl, Event>> =
         client.fetchAllPagesFromPoolWithHooks(
             filters = filters,
-            timeoutMs = timeoutMs,
+            idleTimeoutMs = idleTimeoutMs,
             maxConcurrentRelays = maxConcurrentRelays,
         ) { _, event -> verifyAndStore(event) }
 

--- a/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/AwaitCommands.kt
+++ b/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/AwaitCommands.kt
@@ -112,7 +112,7 @@ object AwaitCommands {
                 val event =
                     ctx.client.fetchFirst(
                         filters = relays.associateWith { listOf(filter) },
-                        timeoutMs = 3_000,
+                        idleTimeoutMs = 3_000,
                     )
                 if (event is KeyPackageEvent) {
                     Output.emit(

--- a/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/DmCommands.kt
+++ b/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/DmCommands.kt
@@ -357,7 +357,7 @@ object DmCommands {
                     .groupBy { it.relay }
                     .mapValues { (_, v) -> v.map { it.filter } }
 
-            val raw = ctx.drain(filters, timeoutMs = timeoutSecs * 1000)
+            val raw = ctx.drain(filters, idleTimeoutMs = timeoutSecs * 1000)
 
             val messages = decryptDms(ctx, raw, peerHex)
             val out =
@@ -415,7 +415,7 @@ object DmCommands {
                         .groupBy { it.relay }
                         .mapValues { (_, v) -> v.map { it.filter } }
 
-                val raw = ctx.drain(filters, timeoutMs = 3_000)
+                val raw = ctx.drain(filters, idleTimeoutMs = 3_000)
                 val messages = decryptDms(ctx, raw, peerHex)
                 // Match against the text body for kind:14 and against the URL
                 // for kind:15 — both are exposed as `searchText` so callers

--- a/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/GitReadCommands.kt
+++ b/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/GitReadCommands.kt
@@ -103,7 +103,7 @@ object GitReadCommands {
                 ctx
                     .drainAllPages(
                         relays.associateWith { listOf(Filter(kinds = listOf(itemKind), tags = mapOf("a" to listOf(repoAddress)), limit = limit)) },
-                        timeoutMs = READ_TIMEOUT_MS,
+                        idleTimeoutMs = READ_TIMEOUT_MS,
                     ).asSequence()
                     .map { it.second }
                     .filter { it.kind == itemKind }
@@ -160,7 +160,7 @@ object GitReadCommands {
                         relays.associateWith {
                             listOf(Filter(kinds = STATUS_KINDS + listOf(CommentEvent.KIND, GitReplyEvent.KIND), tags = mapOf("e" to listOf(id))))
                         },
-                        timeoutMs = READ_TIMEOUT_MS,
+                        idleTimeoutMs = READ_TIMEOUT_MS,
                     ).map { it.second }
                     .distinctBy { it.id }
 
@@ -208,7 +208,7 @@ object GitReadCommands {
                 ctx
                     .drainAllPages(
                         relays.associateWith { listOf(Filter(kinds = STATUS_KINDS, tags = mapOf("e" to chunk))) },
-                        timeoutMs = READ_TIMEOUT_MS,
+                        idleTimeoutMs = READ_TIMEOUT_MS,
                     ).map { it.second }
             }.filterIsInstance<GitStatusEvent>()
             .distinctBy { it.id }

--- a/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/GroupAddMemberCommand.kt
+++ b/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/GroupAddMemberCommand.kt
@@ -97,7 +97,7 @@ object GroupAddMemberCommand {
                         client = ctx.client,
                         targetPubKey = pub,
                         relays = kpRelays,
-                        timeoutMs = 10_000,
+                        idleTimeoutMs = 10_000,
                     )
                 if (kpEvent == null) {
                     report.add(mapOf("pubkey" to pub, "status" to "no_key_package"))

--- a/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/KeyPackageCommands.kt
+++ b/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/KeyPackageCommands.kt
@@ -99,7 +99,7 @@ object KeyPackageCommands {
                     client = ctx.client,
                     targetPubKey = targetHex,
                     relays = relays,
-                    timeoutMs = 10_000,
+                    idleTimeoutMs = 10_000,
                 )
             if (event == null) {
                 return Output.error("not_found", "no KeyPackage for $targetHex on ${relays.size} relay(s)")

--- a/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/graperank/GrapeRankCrawl.kt
+++ b/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/graperank/GrapeRankCrawl.kt
@@ -287,7 +287,7 @@ object GrapeRankCrawl {
                             // Default null → pull EVERY follower each relay holds; --max
                             // N caps the total per relay for a quick spot check.
                             maxPerRelay = args.flag("max")?.toIntOrNull(),
-                            timeoutMs = args.timeoutMs(15),
+                            idleTimeoutMs = args.timeoutMs(15),
                             maxConcurrentRelays = relayConcurrency,
                             insertBatchSize = args.intFlag(FLAG_INSERT_BATCH, INSERT_BATCH_DEFAULT),
                         ),

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/nip17Dm/DmInboxRelayResolver.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/nip17Dm/DmInboxRelayResolver.kt
@@ -147,7 +147,7 @@ class DmInboxRelayResolver(
             if (writeRelays.isNotEmpty()) {
                 relays =
                     RecipientRelayFetcher
-                        .fetchRelayLists(unauthenticatedClient, pubkey, writeRelays, timeoutMs = 5_000L)
+                        .fetchRelayLists(unauthenticatedClient, pubkey, writeRelays, idleTimeoutMs = 5_000L)
                         .dmInbox
             }
         }

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/subscriptions/DesktopRelaySubscriptionsCoordinator.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/subscriptions/DesktopRelaySubscriptionsCoordinator.kt
@@ -221,7 +221,7 @@ class DesktopRelaySubscriptionsCoordinator(
                     val events =
                         client.fetchAll(
                             filters = indexRelays.associateWith { listOf(filter) },
-                            timeoutMs = 8.seconds.inWholeMilliseconds,
+                            idleTimeoutMs = 8.seconds.inWholeMilliseconds,
                         )
                     events.forEach { consumeEvent(it, null) }
                 }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/graperank/FollowerCrawler.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/graperank/FollowerCrawler.kt
@@ -75,14 +75,14 @@ class FollowerCrawler(
      *   stops paging once it's reached, so a non-null value cuts the crawl short at
      *   that many per relay. Leave it null for completeness; set it only to bound a
      *   spot check. The per-page size is the relay's own default either way.
-     * @param timeoutMs per-page EOSE timeout for a relay before its next page fires.
+     * @param idleTimeoutMs per-page EOSE timeout for a relay before its next page fires.
      * @param maxConcurrentRelays how many relays page at once (a global fan-out cap).
      * @param insertBatchSize verified events group-committed per [IEventStore.batchInsert].
      */
     class Config(
         val relays: Set<NormalizedRelayUrl>,
         val maxPerRelay: Int? = null,
-        val timeoutMs: Long = 15_000,
+        val idleTimeoutMs: Long = 15_000,
         val maxConcurrentRelays: Int = 16,
         val insertBatchSize: Int = 500,
     )
@@ -162,7 +162,7 @@ class FollowerCrawler(
 
                 client.fetchAllPagesFromPool(
                     filters = perRelay,
-                    timeoutMs = config.timeoutMs,
+                    idleTimeoutMs = config.idleTimeoutMs,
                     maxConcurrentRelays = config.maxConcurrentRelays,
                     onRelayComplete = { relay, total ->
                         if (total > 0) log("[followers] ${relay.url}: $total kind:3 pages drained")

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/marmot/RecipientRelayFetcher.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/marmot/RecipientRelayFetcher.kt
@@ -81,7 +81,7 @@ object RecipientRelayFetcher {
         client: INostrClient,
         pubKey: HexKey,
         seedRelays: Set<NormalizedRelayUrl>,
-        timeoutMs: Long = 8_000L,
+        idleTimeoutMs: Long = 8_000L,
     ): Lists {
         if (seedRelays.isEmpty()) return Lists(emptyList(), emptyList(), null)
 
@@ -99,7 +99,7 @@ object RecipientRelayFetcher {
         val events =
             client.fetchAll(
                 filters = seedRelays.associateWith { listOf(filter) },
-                timeoutMs = timeoutMs,
+                idleTimeoutMs = idleTimeoutMs,
             )
 
         var dm: ChatMessageRelayListEvent? = null

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/marmot/mip00KeyPackages/KeyPackageFetcher.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/marmot/mip00KeyPackages/KeyPackageFetcher.kt
@@ -75,11 +75,11 @@ object KeyPackageFetcher {
         client: INostrClient,
         targetPubKey: HexKey,
         relays: Set<NormalizedRelayUrl>,
-        timeoutMs: Long = 30_000,
+        idleTimeoutMs: Long = 30_000,
     ): KeyPackageEvent? {
         if (relays.isEmpty()) return null
         val filter = MarmotFilters.keyPackagesByAuthor(targetPubKey)
-        val events = client.fetchAll(filters = relays.associateWith { listOf(filter) }, timeoutMs = timeoutMs)
+        val events = client.fetchAll(filters = relays.associateWith { listOf(filter) }, idleTimeoutMs = idleTimeoutMs)
         // fetchAll returns events sorted by created_at DESC, so the first
         // KeyPackageEvent is the most recent one any relay had.
         return events.firstNotNullOfOrNull { it as? KeyPackageEvent }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/IdleWatchdog.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/IdleWatchdog.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.relay.client.accessories
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.concurrent.Volatile
+import kotlin.time.TimeSource
+
+/**
+ * Monotonic "last activity" marker for the idle watchdogs shared by the accessory
+ * fetch/sync loops. [bump] on every sign of life from the relay; [elapsedMs] reports
+ * the silence since the last bump (or since construction, before the first bump).
+ *
+ * This is the timeout convention for every accessory in this package: a `timeoutMs`
+ * (or `idleTimeoutMs`) is an **idle window measured from the relay's most recent
+ * message**, not a wall-clock deadline — an actively streaming relay is never cut
+ * off mid-delivery, only one that goes silent.
+ *
+ * [bump] is on the per-event hot path (a connection listener may bump for every
+ * message the relay sends — millions during a large download), so it must not
+ * allocate: a single [start] mark is taken once (unboxed field) and each bump only
+ * writes a `Long` of nanos-since-start into a `@Volatile` field. Reader threads
+ * write, the driver coroutine reads — visibility is all we need, so a plain volatile
+ * Long beats boxing a `ValueTimeMark` into an `AtomicReference` on every event.
+ */
+internal class IdleClock {
+    private val start = TimeSource.Monotonic.markNow()
+
+    @Volatile
+    private var lastNanos = 0L
+
+    fun bump() {
+        lastNanos = start.elapsedNow().inWholeNanoseconds
+    }
+
+    fun elapsedMs(): Long = (start.elapsedNow().inWholeNanoseconds - lastNanos) / 1_000_000
+}
+
+/**
+ * Receives the next item, giving up (returning `null`) only after [idleMs] elapse with
+ * no activity on [clock]. Because [clock] can be bumped by *any* relay message — not
+ * just items on this channel — unrelated progress (e.g. download events arriving during
+ * a reconcile wait) keeps pushing the deadline out. [idleMs] `<= 0` disables the
+ * watchdog: it waits until an item arrives (a disconnect is delivered as an item, so
+ * a dead socket still unblocks it).
+ */
+internal suspend fun <T> Channel<T>.receiveWithinIdle(
+    clock: IdleClock,
+    idleMs: Long,
+): T? {
+    if (idleMs <= 0) return receive()
+    while (true) {
+        val remaining = idleMs - clock.elapsedMs()
+        if (remaining <= 0) return null
+        val item = withTimeoutOrNull(remaining) { receive() }
+        if (item != null) return item
+        // Timed out with nothing on this channel. If other activity bumped the clock
+        // meanwhile, the next `remaining` is positive and we wait again; otherwise it
+        // is <= 0 on the next iteration and we give up.
+    }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/IdleWatchdog.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/IdleWatchdog.kt
@@ -30,10 +30,11 @@ import kotlin.time.TimeSource
  * fetch/sync loops. [bump] on every sign of life from the relay; [elapsedMs] reports
  * the silence since the last bump (or since construction, before the first bump).
  *
- * This is the timeout convention for every accessory in this package: a `timeoutMs`
- * (or `idleTimeoutMs`) is an **idle window measured from the relay's most recent
- * message**, not a wall-clock deadline — an actively streaming relay is never cut
- * off mid-delivery, only one that goes silent.
+ * This is the timeout convention for every accessory in this package: an
+ * `idleTimeoutMs` is an **idle window measured from the relay's most recent
+ * progress**, not a wall-clock deadline — an actively streaming relay is never cut
+ * off mid-delivery, only one that goes silent. The name is the contract: a
+ * parameter here is called `idleTimeoutMs` precisely because it is not a deadline.
  *
  * [bump] is on the per-event hot path (a connection listener may bump for every
  * message the relay sends — millions during a large download), so it must not

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NegentropyStoreSync.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NegentropyStoreSync.kt
@@ -298,7 +298,11 @@ class NegentropyStoreSync(
                     }
                 }
             try {
-                client.fetchAllPages(relay, listOf(filter), config.idleTimeoutMs) { event -> events.trySend(event) }
+                // Like fetchByIds, a download keeps a finite idle bound even when the
+                // whole-sync watchdog is disabled (idleTimeoutMs = 0) — a page that
+                // never EOSEs must not hang the sync forever.
+                val pageIdleMs = if (config.idleTimeoutMs > 0) config.idleTimeoutMs else DEFAULT_DOWNLOAD_IDLE_MS
+                client.fetchAllPages(relay, listOf(filter), pageIdleMs) { event -> events.trySend(event) }
             } finally {
                 events.close()
             }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientCountExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientCountExt.kt
@@ -38,9 +38,13 @@ import kotlinx.coroutines.withTimeoutOrNull
  * Sends a NIP-45 COUNT query to a single relay and suspends until
  * the result arrives or the timeout expires.
  *
+ * A COUNT exchange is a single response message, so [timeoutMs] here is
+ * trivially the package-wide idle-window convention (time since the most
+ * recent message): no message can arrive before the one that completes it.
+ *
  * @param relay Target relay to query.
  * @param filter The filter to count against.
- * @param timeoutMs How long to wait for a response (default 15 s).
+ * @param timeoutMs How long to wait for the response (default 15 s).
  * @return The [CountResult], or `null` on timeout.
  */
 suspend fun INostrClient.count(
@@ -88,13 +92,22 @@ suspend fun INostrClient.count(
  * (one filter per relay) and suspends until all results arrive
  * or the timeout expires.
  *
+ * [timeoutMs] is an **idle window measured from the most recent message**, not a
+ * wall-clock deadline for the whole batch — the package-wide accessory
+ * convention: each arriving COUNT result restarts it, so a large fan-out where
+ * results keep trickling in is never cut short; the wait only gives up after a
+ * full window with no relay answering. [maxTotalMs] (default 10x the idle
+ * window) is the wall-clock ceiling against a misbehaving relay re-sending
+ * results forever.
+ *
  * @param filters Map of relay -> filter to count.
- * @param timeoutMs How long to wait for all responses (default 15 s).
+ * @param timeoutMs Idle window between responses (default 15 s).
  * @return Map of relay -> [CountResult] for every relay that responded in time.
  */
 suspend fun INostrClient.count(
     filters: Map<NormalizedRelayUrl, List<Filter>>,
     timeoutMs: Long = 15_000,
+    maxTotalMs: Long = timeoutMs * 10,
 ): Map<NormalizedRelayUrl, CountResult> {
     if (filters.isEmpty()) return emptyMap()
 
@@ -125,10 +138,13 @@ suspend fun INostrClient.count(
 
     val results = mutableMapOf<NormalizedRelayUrl, CountResult>()
 
-    withTimeoutOrNull(timeoutMs) {
+    // Each receive is bounded by the idle window alone; every arriving result
+    // restarts it on the next loop iteration. The outer ceiling bounds the whole
+    // wait against a relay that keeps re-sending results.
+    withTimeoutOrNull(maxTotalMs) {
         while (results.size < filters.size) {
-            val (relay, result) = resultChannel.receive()
-            results[relay] = result
+            val next = withTimeoutOrNull(timeoutMs) { resultChannel.receive() } ?: break
+            results[next.first] = next.second
         }
     }
 
@@ -152,7 +168,7 @@ suspend fun INostrClient.count(
  *
  * @param relays List of relays to query.
  * @param filter The filter to count against.
- * @param timeoutMs How long to wait for all responses (default 15 s).
+ * @param timeoutMs Idle window between responses (default 15 s) — see [count].
  * @return A merged [CountResult], or `null` if no relay responded.
  */
 suspend fun INostrClient.countMerged(

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientCountExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientCountExt.kt
@@ -32,7 +32,9 @@ import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip45Count.HyperLogLog
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.coroutines.coroutineContext
 
 /**
  * Sends a NIP-45 COUNT query to a single relay and suspends until
@@ -146,6 +148,11 @@ suspend fun INostrClient.count(
             val progressed =
                 withTimeoutOrNull(idleTimeoutMs) {
                     while (true) {
+                        // Cancellation (this window expiring, or the caller giving up)
+                        // only lands at a suspension point, and receive() does not
+                        // suspend while the channel has buffered results — so check
+                        // explicitly rather than draining a backlog uninterruptibly.
+                        coroutineContext.ensureActive()
                         val (relay, result) = resultChannel.receive()
                         // put() returns the previous value: null means this relay
                         // had not answered yet, i.e. real progress.
@@ -154,6 +161,13 @@ suspend fun INostrClient.count(
                     true
                 }
             if (progressed == null) break
+        }
+
+        // A result can land after the last window closed but before we unsubscribe;
+        // it costs nothing to keep, and dropping it would understate the count.
+        while (true) {
+            val (relay, result) = resultChannel.tryReceive().getOrNull() ?: break
+            results[relay] = result
         }
     } finally {
         subIdToRelay.keys.forEach { unsubscribe(it) }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientCountExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientCountExt.kt
@@ -38,19 +38,19 @@ import kotlinx.coroutines.withTimeoutOrNull
  * Sends a NIP-45 COUNT query to a single relay and suspends until
  * the result arrives or the timeout expires.
  *
- * A COUNT exchange is a single response message, so [timeoutMs] here is
+ * A COUNT exchange is a single response message, so [idleTimeoutMs] here is
  * trivially the package-wide idle-window convention (time since the most
  * recent message): no message can arrive before the one that completes it.
  *
  * @param relay Target relay to query.
  * @param filter The filter to count against.
- * @param timeoutMs How long to wait for the response (default 15 s).
+ * @param idleTimeoutMs How long to wait for the response (default 15 s).
  * @return The [CountResult], or `null` on timeout.
  */
 suspend fun INostrClient.count(
     relay: NormalizedRelayUrl,
     filter: Filter,
-    timeoutMs: Long = 15_000,
+    idleTimeoutMs: Long = 15_000,
 ): CountResult? {
     val subId = newSubId()
     val resultChannel = Channel<CountResult>(UNLIMITED)
@@ -73,7 +73,7 @@ suspend fun INostrClient.count(
 
         count(subId = subId, filters = mapOf(relay to listOf(filter)))
 
-        withTimeoutOrNull(timeoutMs) {
+        withTimeoutOrNull(idleTimeoutMs) {
             resultChannel.receive()
         }
     } finally {
@@ -91,7 +91,7 @@ suspend fun INostrClient.count(
  * (one filter per relay) and suspends until all results arrive
  * or the timeout expires.
  *
- * [timeoutMs] is an **idle window measured from the most recent progress**, not a
+ * [idleTimeoutMs] is an **idle window measured from the most recent progress**, not a
  * wall-clock deadline for the whole batch — the package-wide accessory
  * convention: each *new* relay's COUNT result restarts it, so a large fan-out
  * where results keep trickling in is never cut short. A relay re-sending a result
@@ -101,12 +101,12 @@ suspend fun INostrClient.count(
  * discarding the partial map, which is why this returns whatever arrived instead.
  *
  * @param filters Map of relay -> filter to count.
- * @param timeoutMs Idle window between new responses (default 15 s).
+ * @param idleTimeoutMs Idle window between new responses (default 15 s).
  * @return Map of relay -> [CountResult] for every relay that responded in time.
  */
 suspend fun INostrClient.count(
     filters: Map<NormalizedRelayUrl, List<Filter>>,
-    timeoutMs: Long = 15_000,
+    idleTimeoutMs: Long = 15_000,
 ): Map<NormalizedRelayUrl, CountResult> {
     if (filters.isEmpty()) return emptyMap()
 
@@ -144,7 +144,7 @@ suspend fun INostrClient.count(
         // window per relay without needing a wall-clock ceiling.
         while (results.size < filters.size) {
             val progressed =
-                withTimeoutOrNull(timeoutMs) {
+                withTimeoutOrNull(idleTimeoutMs) {
                     while (true) {
                         val (relay, result) = resultChannel.receive()
                         // put() returns the previous value: null means this relay
@@ -177,20 +177,20 @@ suspend fun INostrClient.count(
  *
  * @param relays List of relays to query.
  * @param filter The filter to count against.
- * @param timeoutMs Idle window between responses (default 15 s) — see [count].
+ * @param idleTimeoutMs Idle window between responses (default 15 s) — see [count].
  * @return A merged [CountResult], or `null` if no relay responded.
  */
 suspend fun INostrClient.countMerged(
     relays: List<NormalizedRelayUrl>,
     filter: Filter,
-    timeoutMs: Long = 15_000,
+    idleTimeoutMs: Long = 15_000,
 ): CountResult? {
     if (relays.isEmpty()) return null
 
     val results =
         count(
             filters = relays.associateWith { listOf(filter) },
-            timeoutMs = timeoutMs,
+            idleTimeoutMs = idleTimeoutMs,
         )
 
     if (results.isEmpty()) return null

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientCountExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientCountExt.kt
@@ -98,7 +98,8 @@ suspend fun INostrClient.count(
  * results keep trickling in is never cut short; the wait only gives up after a
  * full window with no relay answering. [maxTotalMs] (default 10x the idle
  * window) is the wall-clock ceiling against a misbehaving relay re-sending
- * results forever.
+ * results forever; a non-positive value means uncapped (which also absorbs a
+ * `timeoutMs * 10` overflow from an effectively-infinite idle window).
  *
  * @param filters Map of relay -> filter to count.
  * @param timeoutMs Idle window between responses (default 15 s).
@@ -128,29 +129,32 @@ suspend fun INostrClient.count(
             }
         }
 
-    addConnectionListener(listener)
-
-    filters.forEach { (relay, filterList) ->
-        val subId = newSubId()
-        subIdToRelay[subId] = relay
-        count(subId = subId, filters = mapOf(relay to filterList))
-    }
-
     val results = mutableMapOf<NormalizedRelayUrl, CountResult>()
 
-    // Each receive is bounded by the idle window alone; every arriving result
-    // restarts it on the next loop iteration. The outer ceiling bounds the whole
-    // wait against a relay that keeps re-sending results.
-    withTimeoutOrNull(maxTotalMs) {
-        while (results.size < filters.size) {
-            val next = withTimeoutOrNull(timeoutMs) { resultChannel.receive() } ?: break
-            results[next.first] = next.second
-        }
-    }
+    try {
+        addConnectionListener(listener)
 
-    subIdToRelay.keys.forEach { unsubscribe(it) }
-    removeConnectionListener(listener)
-    resultChannel.close()
+        filters.forEach { (relay, filterList) ->
+            val subId = newSubId()
+            subIdToRelay[subId] = relay
+            count(subId = subId, filters = mapOf(relay to filterList))
+        }
+
+        // Each receive is bounded by the idle window alone; every arriving result
+        // restarts it on the next loop iteration. The outer ceiling bounds the whole
+        // wait against a relay that keeps re-sending results.
+        val ceiling = if (maxTotalMs <= 0) Long.MAX_VALUE else maxTotalMs
+        withTimeoutOrNull(ceiling) {
+            while (results.size < filters.size) {
+                val next = withTimeoutOrNull(timeoutMs) { resultChannel.receive() } ?: break
+                results[next.first] = next.second
+            }
+        }
+    } finally {
+        subIdToRelay.keys.forEach { unsubscribe(it) }
+        removeConnectionListener(listener)
+        resultChannel.close()
+    }
 
     return results
 }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientCountExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientCountExt.kt
@@ -68,23 +68,22 @@ suspend fun INostrClient.count(
             }
         }
 
-    addConnectionListener(listener)
+    return try {
+        addConnectionListener(listener)
 
-    val result =
-        try {
-            count(subId = subId, filters = mapOf(relay to listOf(filter)))
+        count(subId = subId, filters = mapOf(relay to listOf(filter)))
 
-            withTimeoutOrNull(timeoutMs) {
-                resultChannel.receive()
-            }
-        } finally {
-            unsubscribe(subId)
-            removeConnectionListener(listener)
+        withTimeoutOrNull(timeoutMs) {
+            resultChannel.receive()
         }
-
-    resultChannel.close()
-
-    return result
+    } finally {
+        // Every cleanup step belongs in the finally: closing the channel used to
+        // sit after it, so a throw (or cancellation) mid-wait skipped it while the
+        // sibling accessories all cleaned up fully.
+        unsubscribe(subId)
+        removeConnectionListener(listener)
+        resultChannel.close()
+    }
 }
 
 /**
@@ -92,23 +91,22 @@ suspend fun INostrClient.count(
  * (one filter per relay) and suspends until all results arrive
  * or the timeout expires.
  *
- * [timeoutMs] is an **idle window measured from the most recent message**, not a
+ * [timeoutMs] is an **idle window measured from the most recent progress**, not a
  * wall-clock deadline for the whole batch — the package-wide accessory
- * convention: each arriving COUNT result restarts it, so a large fan-out where
- * results keep trickling in is never cut short; the wait only gives up after a
- * full window with no relay answering. [maxTotalMs] (default 10x the idle
- * window) is the wall-clock ceiling against a misbehaving relay re-sending
- * results forever; a non-positive value means uncapped (which also absorbs a
- * `timeoutMs * 10` overflow from an effectively-infinite idle window).
+ * convention: each *new* relay's COUNT result restarts it, so a large fan-out
+ * where results keep trickling in is never cut short. A relay re-sending a result
+ * it already gave is not progress and does not restart the window, which makes
+ * the call self-bounding (at most one window per relay). A caller wanting a hard
+ * wall-clock bound has `withTimeoutOrNull(ms) { count(...) }` — at the cost of
+ * discarding the partial map, which is why this returns whatever arrived instead.
  *
  * @param filters Map of relay -> filter to count.
- * @param timeoutMs Idle window between responses (default 15 s).
+ * @param timeoutMs Idle window between new responses (default 15 s).
  * @return Map of relay -> [CountResult] for every relay that responded in time.
  */
 suspend fun INostrClient.count(
     filters: Map<NormalizedRelayUrl, List<Filter>>,
     timeoutMs: Long = 15_000,
-    maxTotalMs: Long = timeoutMs * 10,
 ): Map<NormalizedRelayUrl, CountResult> {
     if (filters.isEmpty()) return emptyMap()
 
@@ -140,15 +138,22 @@ suspend fun INostrClient.count(
             count(subId = subId, filters = mapOf(relay to filterList))
         }
 
-        // Each receive is bounded by the idle window alone; every arriving result
-        // restarts it on the next loop iteration. The outer ceiling bounds the whole
-        // wait against a relay that keeps re-sending results.
-        val ceiling = if (maxTotalMs <= 0) Long.MAX_VALUE else maxTotalMs
-        withTimeoutOrNull(ceiling) {
-            while (results.size < filters.size) {
-                val next = withTimeoutOrNull(timeoutMs) { resultChannel.receive() } ?: break
-                results[next.first] = next.second
-            }
+        // One idle window per new relay result. The inner loop absorbs repeats
+        // (a relay answering twice) inside the SAME window, so only genuinely
+        // new information pushes the deadline out — bounding the call at one
+        // window per relay without needing a wall-clock ceiling.
+        while (results.size < filters.size) {
+            val progressed =
+                withTimeoutOrNull(timeoutMs) {
+                    while (true) {
+                        val (relay, result) = resultChannel.receive()
+                        // put() returns the previous value: null means this relay
+                        // had not answered yet, i.e. real progress.
+                        if (results.put(relay, result) == null) break
+                    }
+                    true
+                }
+            if (progressed == null) break
         }
     } finally {
         subIdToRelay.keys.forEach { unsubscribe(it) }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllExt.kt
@@ -31,47 +31,47 @@ import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
 suspend fun INostrClient.fetchAll(
     relay: String,
     filter: Filter,
-    timeoutMs: Long = 30_000L,
-) = fetchAll(newSubId(), mapOf(RelayUrlNormalizer.normalize(relay) to listOf(filter)), timeoutMs)
+    idleTimeoutMs: Long = 30_000L,
+) = fetchAll(newSubId(), mapOf(RelayUrlNormalizer.normalize(relay) to listOf(filter)), idleTimeoutMs)
 
 suspend fun INostrClient.fetchAll(
     relay: String,
     filters: List<Filter>,
-    timeoutMs: Long = 30_000L,
-) = fetchAll(newSubId(), mapOf(RelayUrlNormalizer.normalize(relay) to filters), timeoutMs)
+    idleTimeoutMs: Long = 30_000L,
+) = fetchAll(newSubId(), mapOf(RelayUrlNormalizer.normalize(relay) to filters), idleTimeoutMs)
 
 suspend fun INostrClient.fetchAll(
     subscriptionId: String = newSubId(),
     relay: String,
     filters: List<Filter>,
-    timeoutMs: Long = 30_000L,
-) = fetchAll(subscriptionId, mapOf(RelayUrlNormalizer.normalize(relay) to filters), timeoutMs)
+    idleTimeoutMs: Long = 30_000L,
+) = fetchAll(subscriptionId, mapOf(RelayUrlNormalizer.normalize(relay) to filters), idleTimeoutMs)
 
 suspend fun INostrClient.fetchAll(
     relay: NormalizedRelayUrl,
     filter: Filter,
-    timeoutMs: Long = 30_000L,
-) = fetchAll(newSubId(), mapOf(relay to listOf(filter)), timeoutMs)
+    idleTimeoutMs: Long = 30_000L,
+) = fetchAll(newSubId(), mapOf(relay to listOf(filter)), idleTimeoutMs)
 
 suspend fun INostrClient.fetchAll(
     relay: NormalizedRelayUrl,
     filters: List<Filter>,
-    timeoutMs: Long = 30_000L,
-) = fetchAll(newSubId(), mapOf(relay to filters), timeoutMs)
+    idleTimeoutMs: Long = 30_000L,
+) = fetchAll(newSubId(), mapOf(relay to filters), idleTimeoutMs)
 
 suspend fun INostrClient.fetchAll(
     subscriptionId: String = newSubId(),
     relay: NormalizedRelayUrl,
     filters: List<Filter>,
-    timeoutMs: Long = 30_000L,
-) = fetchAll(subscriptionId, mapOf(relay to filters), timeoutMs)
+    idleTimeoutMs: Long = 30_000L,
+) = fetchAll(subscriptionId, mapOf(relay to filters), idleTimeoutMs)
 
 /**
  * Subscribe [filters], collect every (deduped) event, and return once every
  * relay reached a terminal state (EOSE, CLOSED, or cannot-connect) or the
- * line went quiet for [timeoutMs].
+ * line went quiet for [idleTimeoutMs].
  *
- * [timeoutMs] is an **idle window, not a hard cap**: every arriving event or
+ * [idleTimeoutMs] is an **idle window, not a hard cap**: every arriving event or
  * terminal signal resets it, so a slow relay actively streaming a large
  * backlog is never cropped mid-delivery. The fetch only gives up after a full
  * window of silence — or at the [maxTotalMs] wall-clock ceiling (default 10x
@@ -85,13 +85,13 @@ suspend fun INostrClient.fetchAll(
 suspend fun INostrClient.fetchAll(
     subscriptionId: String = newSubId(),
     filters: Map<NormalizedRelayUrl, List<Filter>>,
-    timeoutMs: Long = 30_000L,
-    maxTotalMs: Long = timeoutMs * 10,
+    idleTimeoutMs: Long = 30_000L,
+    maxTotalMs: Long = idleTimeoutMs * 10,
 ): List<Event> {
     val seenIds = mutableSetOf<HexKey>()
     return fetchAllWithHooks(
         filters = filters,
-        timeoutMs = timeoutMs,
+        idleTimeoutMs = idleTimeoutMs,
         subscriptionId = subscriptionId,
         maxTotalMs = maxTotalMs,
     ) { _, event -> seenIds.add(event.id) }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllPagesExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllPagesExt.kt
@@ -178,40 +178,53 @@ suspend fun INostrClient.fetchAllPages(
                         relay: NormalizedRelayUrl,
                         forFilters: List<Filter>?,
                     ) {
-                        clock.bump()
-                        received++
-                        // Drop a boundary-second event we already delivered on an
-                        // earlier page (the inclusive re-fetch returns it again).
-                        if (boundary != null && event.createdAt == boundary && event.id in seenAtBoundary) return
+                        // The bump is in a finally so it runs for EVERY event —
+                        // including the duplicate that returns early below, which is
+                        // still a sign of life — and, being a volatile write, runs
+                        // AFTER the counters below. That ordering matters: these
+                        // counters are written on the relay's reader thread and read
+                        // by the driver coroutine once the wait ends. The EOSE path
+                        // gets its happens-before from the channel, but the idle
+                        // path has no such edge, so without the release write the
+                        // driver could read a stale `pageMinTs` (ending the walk
+                        // early) or an unsafely published `idsAtPageMin`.
+                        try {
+                            received++
+                            // Drop a boundary-second event we already delivered on an
+                            // earlier page (the inclusive re-fetch returns it again).
+                            if (boundary != null && event.createdAt == boundary && event.id in seenAtBoundary) return
 
-                        // Count this event against every active filter it satisfies
-                        // (one event can match more than one). Only a non-search filter
-                        // may advance the `until` cursor: a search hit — possibly old,
-                        // relevance-ranked — must not drag the cursor back and make the
-                        // next page skip events a co-resident normal filter still needs.
-                        var atLeastOne = false
-                        var advancesCursor = false
-                        for ((index, filter) in activeFilters) {
-                            if (matchCountPerFilter[index] < (filter.limit ?: Int.MAX_VALUE) && filter.match(event)) {
-                                matchCountPerFilter[index]++
-                                atLeastOne = true
-                                if (filter.search == null) advancesCursor = true
-                            }
-                        }
-                        if (atLeastOne) {
-                            onEvent(event)
-                            delivered++
-                            // Track the oldest advancing second and the ids delivered
-                            // in it — that becomes the next boundary and its dedup set.
-                            if (advancesCursor) {
-                                if (event.createdAt < pageMinTs) {
-                                    pageMinTs = event.createdAt
-                                    idsAtPageMin.clear()
-                                    idsAtPageMin.add(event.id)
-                                } else if (event.createdAt == pageMinTs) {
-                                    idsAtPageMin.add(event.id)
+                            // Count this event against every active filter it satisfies
+                            // (one event can match more than one). Only a non-search filter
+                            // may advance the `until` cursor: a search hit — possibly old,
+                            // relevance-ranked — must not drag the cursor back and make the
+                            // next page skip events a co-resident normal filter still needs.
+                            var atLeastOne = false
+                            var advancesCursor = false
+                            for ((index, filter) in activeFilters) {
+                                if (matchCountPerFilter[index] < (filter.limit ?: Int.MAX_VALUE) && filter.match(event)) {
+                                    matchCountPerFilter[index]++
+                                    atLeastOne = true
+                                    if (filter.search == null) advancesCursor = true
                                 }
                             }
+                            if (atLeastOne) {
+                                onEvent(event)
+                                delivered++
+                                // Track the oldest advancing second and the ids delivered
+                                // in it — that becomes the next boundary and its dedup set.
+                                if (advancesCursor) {
+                                    if (event.createdAt < pageMinTs) {
+                                        pageMinTs = event.createdAt
+                                        idsAtPageMin.clear()
+                                        idsAtPageMin.add(event.id)
+                                    } else if (event.createdAt == pageMinTs) {
+                                        idsAtPageMin.add(event.id)
+                                    }
+                                }
+                            }
+                        } finally {
+                            clock.bump()
                         }
                     }
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllPagesExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllPagesExt.kt
@@ -241,12 +241,9 @@ suspend fun INostrClient.fetchAllPages(
             // ceiling means uncapped, mirroring the idle window's `<= 0` = disabled
             // convention (it also absorbs a `timeoutMs * 10` overflow from a caller
             // passing an effectively-infinite idle window).
-            if (maxPageMs <= 0 || maxPageMs == Long.MAX_VALUE) {
+            val ceiling = if (maxPageMs <= 0) Long.MAX_VALUE else maxPageMs
+            withTimeoutOrNull(ceiling) {
                 doneChannel.receiveWithinIdle(clock, timeoutMs)
-            } else {
-                withTimeoutOrNull(maxPageMs) {
-                    doneChannel.receiveWithinIdle(clock, timeoutMs)
-                }
             }
 
             unsubscribe(subId)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllPagesExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllPagesExt.kt
@@ -30,7 +30,6 @@ import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.ensureActive
-import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.coroutines.coroutineContext
 
 /**
@@ -76,9 +75,17 @@ import kotlin.coroutines.coroutineContext
  *   from the relay's **most recent message**, not from the page's start: every arriving
  *   event resets it, so a slow relay actively streaming a large page is never cropped
  *   mid-delivery. A page only gives up after this much silence without an EOSE.
- * @param maxPageMs   Hard wall-clock ceiling per page (default 10x the idle window) — the
- *   idle window alone is unbounded against a misbehaving relay that trickles events
- *   forever without ever sending EOSE. Pass [Long.MAX_VALUE] for an uncapped page.
+ *
+ *   Deliberately no wall-clock ceiling here, unlike [fetchAll]'s `maxTotalMs`. A ceiling
+ *   would bound one *page*, not this call: the loop below reacts to a page ending by
+ *   advancing the cursor and issuing the next REQ, so a relay trickling events forever
+ *   against an unbounded filter would just be re-paged forever — measurably so (see
+ *   NostrClientFetchAllPagesIdleTimeoutTest). Worse, cutting a page mid-stream advances
+ *   `until` to the oldest event received *so far*, which only preserves the set if the
+ *   relay streams strictly newest-first (NIP-01 recommends but does not require it) —
+ *   otherwise the not-yet-sent events above that cursor are skipped. What actually
+ *   bounds this walk is a [Filter.limit] (the documented way to cap a download) or
+ *   cancelling the caller, which the [ensureActive] at the top of each page honors.
  * @param onEvent     Called once for every distinct event delivered, in page order.
  * @return Total number of distinct events delivered across all pages.
  */
@@ -86,7 +93,6 @@ suspend fun INostrClient.fetchAllPages(
     relay: NormalizedRelayUrl,
     filters: List<Filter>,
     timeoutMs: Long = 30_000L,
-    maxPageMs: Long = timeoutMs * 10,
     onNewPage: ((Long) -> Unit)? = null,
     onEvent: (Event) -> Unit,
 ): Int {
@@ -237,14 +243,8 @@ suspend fun INostrClient.fetchAllPages(
 
             // Wait for the page's terminal signal (EOSE / CLOSED / cannot-connect),
             // giving up only after [timeoutMs] of silence — the wait resets on every
-            // event — or at the [maxPageMs] wall-clock ceiling. A non-positive
-            // ceiling means uncapped, mirroring the idle window's `<= 0` = disabled
-            // convention (it also absorbs a `timeoutMs * 10` overflow from a caller
-            // passing an effectively-infinite idle window).
-            val ceiling = if (maxPageMs <= 0) Long.MAX_VALUE else maxPageMs
-            withTimeoutOrNull(ceiling) {
-                doneChannel.receiveWithinIdle(clock, timeoutMs)
-            }
+            // arriving event, so an actively streaming page is never cut mid-delivery.
+            doneChannel.receiveWithinIdle(clock, timeoutMs)
 
             unsubscribe(subId)
             doneChannel.close()
@@ -297,7 +297,6 @@ suspend fun INostrClient.fetchAllPages(
     relay: String,
     filters: List<Filter>,
     timeoutMs: Long = 30_000L,
-    maxPageMs: Long = timeoutMs * 10,
     onNewPage: ((Long) -> Unit)? = null,
     onEvent: (Event) -> Unit,
 ): Int =
@@ -305,7 +304,6 @@ suspend fun INostrClient.fetchAllPages(
         relay = RelayUrlNormalizer.normalize(relay),
         filters = filters,
         timeoutMs = timeoutMs,
-        maxPageMs = maxPageMs,
         onNewPage = onNewPage,
         onEvent = onEvent,
     )

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllPagesExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllPagesExt.kt
@@ -201,7 +201,16 @@ suspend fun INostrClient.fetchAllPages(
                             // next page skip events a co-resident normal filter still needs.
                             var atLeastOne = false
                             var advancesCursor = false
-                            for ((index, filter) in activeFilters) {
+                            // Indexed loop, not `for ((i, f) in activeFilters)`: this runs for
+                            // EVERY event on the relay's reader thread (millions in a bulk
+                            // download) and the destructuring form allocates an Iterator per
+                            // event. Same reason quartz uses the `fast*` operators elsewhere
+                            // in hot event paths — those only cover Array, so a List needs
+                            // the index form.
+                            for (i in activeFilters.indices) {
+                                val active = activeFilters[i]
+                                val index = active.index
+                                val filter = active.value
                                 if (matchCountPerFilter[index] < (filter.limit ?: Int.MAX_VALUE) && filter.match(event)) {
                                     matchCountPerFilter[index]++
                                     atLeastOne = true

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllPagesExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllPagesExt.kt
@@ -71,7 +71,7 @@ import kotlin.coroutines.coroutineContext
  *
  * @param relay       The relay to query.
  * @param filters Filters to apply on every page (the `until` field is overwritten per page).
- * @param timeoutMs   Idle window per page — like every accessory timeout, it is measured
+ * @param idleTimeoutMs   Idle window per page — like every accessory timeout, it is measured
  *   from the relay's **most recent message**, not from the page's start: every arriving
  *   event resets it, so a slow relay actively streaming a large page is never cropped
  *   mid-delivery. A page only gives up after this much silence without an EOSE.
@@ -92,7 +92,7 @@ import kotlin.coroutines.coroutineContext
 suspend fun INostrClient.fetchAllPages(
     relay: NormalizedRelayUrl,
     filters: List<Filter>,
-    timeoutMs: Long = 30_000L,
+    idleTimeoutMs: Long = 30_000L,
     onNewPage: ((Long) -> Unit)? = null,
     onEvent: (Event) -> Unit,
 ): Int {
@@ -255,9 +255,9 @@ suspend fun INostrClient.fetchAllPages(
             subscribe(subId, mapOf(relay to activeFilters.map { it.value }), listener)
 
             // Wait for the page's terminal signal (EOSE / CLOSED / cannot-connect),
-            // giving up only after [timeoutMs] of silence — the wait resets on every
+            // giving up only after [idleTimeoutMs] of silence — the wait resets on every
             // arriving event, so an actively streaming page is never cut mid-delivery.
-            doneChannel.receiveWithinIdle(clock, timeoutMs)
+            doneChannel.receiveWithinIdle(clock, idleTimeoutMs)
 
             unsubscribe(subId)
             doneChannel.close()
@@ -309,14 +309,14 @@ suspend fun INostrClient.fetchAllPages(
 suspend fun INostrClient.fetchAllPages(
     relay: String,
     filters: List<Filter>,
-    timeoutMs: Long = 30_000L,
+    idleTimeoutMs: Long = 30_000L,
     onNewPage: ((Long) -> Unit)? = null,
     onEvent: (Event) -> Unit,
 ): Int =
     fetchAllPages(
         relay = RelayUrlNormalizer.normalize(relay),
         filters = filters,
-        timeoutMs = timeoutMs,
+        idleTimeoutMs = idleTimeoutMs,
         onNewPage = onNewPage,
         onEvent = onEvent,
     )

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllPagesExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllPagesExt.kt
@@ -72,7 +72,13 @@ import kotlin.coroutines.coroutineContext
  *
  * @param relay       The relay to query.
  * @param filters Filters to apply on every page (the `until` field is overwritten per page).
- * @param timeoutMs   Maximum time to wait for a single page's EOSE before giving up.
+ * @param timeoutMs   Idle window per page — like every accessory timeout, it is measured
+ *   from the relay's **most recent message**, not from the page's start: every arriving
+ *   event resets it, so a slow relay actively streaming a large page is never cropped
+ *   mid-delivery. A page only gives up after this much silence without an EOSE.
+ * @param maxPageMs   Hard wall-clock ceiling per page (default 10x the idle window) — the
+ *   idle window alone is unbounded against a misbehaving relay that trickles events
+ *   forever without ever sending EOSE. Pass [Long.MAX_VALUE] for an uncapped page.
  * @param onEvent     Called once for every distinct event delivered, in page order.
  * @return Total number of distinct events delivered across all pages.
  */
@@ -80,6 +86,7 @@ suspend fun INostrClient.fetchAllPages(
     relay: NormalizedRelayUrl,
     filters: List<Filter>,
     timeoutMs: Long = 30_000L,
+    maxPageMs: Long = timeoutMs * 10,
     onNewPage: ((Long) -> Unit)? = null,
     onEvent: (Event) -> Unit,
 ): Int {
@@ -144,6 +151,11 @@ suspend fun INostrClient.fetchAllPages(
 
         val doneChannel = Channel<Unit>(Channel.CONFLATED)
 
+        // Idle watchdog for this page: every arriving event bumps it, so the page's
+        // timeout measures silence since the relay's most recent message (the same
+        // convention as fetchAll and the negentropy sync), never total page time.
+        val clock = IdleClock()
+
         // Captured for the listener: the boundary second we re-fetch this page.
         val boundary = until
         var received = 0
@@ -160,6 +172,7 @@ suspend fun INostrClient.fetchAllPages(
                         relay: NormalizedRelayUrl,
                         forFilters: List<Filter>?,
                     ) {
+                        clock.bump()
                         received++
                         // Drop a boundary-second event we already delivered on an
                         // earlier page (the inclusive re-fetch returns it again).
@@ -222,8 +235,18 @@ suspend fun INostrClient.fetchAllPages(
 
             subscribe(subId, mapOf(relay to activeFilters.map { it.value }), listener)
 
-            withTimeoutOrNull(timeoutMs) {
-                doneChannel.receive()
+            // Wait for the page's terminal signal (EOSE / CLOSED / cannot-connect),
+            // giving up only after [timeoutMs] of silence — the wait resets on every
+            // event — or at the [maxPageMs] wall-clock ceiling. A non-positive
+            // ceiling means uncapped, mirroring the idle window's `<= 0` = disabled
+            // convention (it also absorbs a `timeoutMs * 10` overflow from a caller
+            // passing an effectively-infinite idle window).
+            if (maxPageMs <= 0 || maxPageMs == Long.MAX_VALUE) {
+                doneChannel.receiveWithinIdle(clock, timeoutMs)
+            } else {
+                withTimeoutOrNull(maxPageMs) {
+                    doneChannel.receiveWithinIdle(clock, timeoutMs)
+                }
             }
 
             unsubscribe(subId)
@@ -277,6 +300,7 @@ suspend fun INostrClient.fetchAllPages(
     relay: String,
     filters: List<Filter>,
     timeoutMs: Long = 30_000L,
+    maxPageMs: Long = timeoutMs * 10,
     onNewPage: ((Long) -> Unit)? = null,
     onEvent: (Event) -> Unit,
 ): Int =
@@ -284,6 +308,7 @@ suspend fun INostrClient.fetchAllPages(
         relay = RelayUrlNormalizer.normalize(relay),
         filters = filters,
         timeoutMs = timeoutMs,
+        maxPageMs = maxPageMs,
         onNewPage = onNewPage,
         onEvent = onEvent,
     )

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllPagesPoolExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllPagesPoolExt.kt
@@ -52,8 +52,8 @@ import kotlinx.coroutines.sync.Semaphore
  *   A `search` filter is fetched as a single relevance page — see [fetchAllPages].
  * @param timeoutMs per-page idle window handed to each relay's [fetchAllPages] —
  *   measured from that relay's most recent message (every event resets it), not
- *   from the page's start.
- * @param maxPageMs per-page wall-clock ceiling handed to each relay's [fetchAllPages].
+ *   from the page's start. As in [fetchAllPages] there is no wall-clock ceiling;
+ *   bound a relay's walk with a [Filter.limit], or cancel the caller.
  * @param maxConcurrentRelays upper bound on relays paginating at once (≥ 1).
  * @param onNewPage    optional `(until, relay)` tick before each non-first page.
  * @param onRelayStart optional hook fired as each relay's download begins.
@@ -64,7 +64,6 @@ import kotlinx.coroutines.sync.Semaphore
 suspend fun INostrClient.fetchAllPagesFromPool(
     filters: Map<NormalizedRelayUrl, List<Filter>>,
     timeoutMs: Long = 30_000L,
-    maxPageMs: Long = timeoutMs * 10,
     maxConcurrentRelays: Int = 8,
     onNewPage: ((until: Long, relay: NormalizedRelayUrl) -> Unit)? = null,
     onRelayStart: ((relay: NormalizedRelayUrl) -> Unit)? = null,
@@ -85,7 +84,6 @@ suspend fun INostrClient.fetchAllPagesFromPool(
                             relay = relay,
                             filters = filtersForRelay,
                             timeoutMs = timeoutMs,
-                            maxPageMs = maxPageMs,
                             onNewPage = onNewPage?.let { cb -> { until -> cb(until, relay) } },
                         ) { event -> onEvent(event, relay) }
                     onRelayComplete?.invoke(relay, total)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllPagesPoolExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllPagesPoolExt.kt
@@ -50,7 +50,7 @@ import kotlinx.coroutines.sync.Semaphore
  * @param filters  per-relay filter lists; the key set is the relays queried, in
  *   iteration order (pass a [LinkedHashMap]/`associateWith` result to control it).
  *   A `search` filter is fetched as a single relevance page — see [fetchAllPages].
- * @param timeoutMs per-page idle window handed to each relay's [fetchAllPages] —
+ * @param idleTimeoutMs per-page idle window handed to each relay's [fetchAllPages] —
  *   measured from that relay's most recent message (every event resets it), not
  *   from the page's start. As in [fetchAllPages] there is no wall-clock ceiling;
  *   bound a relay's walk with a [Filter.limit], or cancel the caller.
@@ -63,7 +63,7 @@ import kotlinx.coroutines.sync.Semaphore
  */
 suspend fun INostrClient.fetchAllPagesFromPool(
     filters: Map<NormalizedRelayUrl, List<Filter>>,
-    timeoutMs: Long = 30_000L,
+    idleTimeoutMs: Long = 30_000L,
     maxConcurrentRelays: Int = 8,
     onNewPage: ((until: Long, relay: NormalizedRelayUrl) -> Unit)? = null,
     onRelayStart: ((relay: NormalizedRelayUrl) -> Unit)? = null,
@@ -83,7 +83,7 @@ suspend fun INostrClient.fetchAllPagesFromPool(
                         fetchAllPages(
                             relay = relay,
                             filters = filtersForRelay,
-                            timeoutMs = timeoutMs,
+                            idleTimeoutMs = idleTimeoutMs,
                             onNewPage = onNewPage?.let { cb -> { until -> cb(until, relay) } },
                         ) { event -> onEvent(event, relay) }
                     onRelayComplete?.invoke(relay, total)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllPagesPoolExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllPagesPoolExt.kt
@@ -50,7 +50,10 @@ import kotlinx.coroutines.sync.Semaphore
  * @param filters  per-relay filter lists; the key set is the relays queried, in
  *   iteration order (pass a [LinkedHashMap]/`associateWith` result to control it).
  *   A `search` filter is fetched as a single relevance page — see [fetchAllPages].
- * @param timeoutMs per-page EOSE timeout handed to each relay's [fetchAllPages].
+ * @param timeoutMs per-page idle window handed to each relay's [fetchAllPages] —
+ *   measured from that relay's most recent message (every event resets it), not
+ *   from the page's start.
+ * @param maxPageMs per-page wall-clock ceiling handed to each relay's [fetchAllPages].
  * @param maxConcurrentRelays upper bound on relays paginating at once (≥ 1).
  * @param onNewPage    optional `(until, relay)` tick before each non-first page.
  * @param onRelayStart optional hook fired as each relay's download begins.
@@ -61,6 +64,7 @@ import kotlinx.coroutines.sync.Semaphore
 suspend fun INostrClient.fetchAllPagesFromPool(
     filters: Map<NormalizedRelayUrl, List<Filter>>,
     timeoutMs: Long = 30_000L,
+    maxPageMs: Long = timeoutMs * 10,
     maxConcurrentRelays: Int = 8,
     onNewPage: ((until: Long, relay: NormalizedRelayUrl) -> Unit)? = null,
     onRelayStart: ((relay: NormalizedRelayUrl) -> Unit)? = null,
@@ -81,6 +85,7 @@ suspend fun INostrClient.fetchAllPagesFromPool(
                             relay = relay,
                             filters = filtersForRelay,
                             timeoutMs = timeoutMs,
+                            maxPageMs = maxPageMs,
                             onNewPage = onNewPage?.let { cb -> { until -> cb(until, relay) } },
                         ) { event -> onEvent(event, relay) }
                     onRelayComplete?.invoke(relay, total)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllWithHooksExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllWithHooksExt.kt
@@ -257,7 +257,6 @@ suspend fun INostrClient.fetchAllWithHooks(
 suspend fun INostrClient.fetchAllPagesFromPoolWithHooks(
     filters: Map<NormalizedRelayUrl, List<Filter>>,
     timeoutMs: Long = 30_000L,
-    maxPageMs: Long = timeoutMs * 10,
     maxConcurrentRelays: Int = 8,
     onEvent: suspend (relay: NormalizedRelayUrl, event: Event) -> Boolean,
 ): List<Pair<NormalizedRelayUrl, Event>> {
@@ -289,7 +288,6 @@ suspend fun INostrClient.fetchAllPagesFromPoolWithHooks(
             fetchAllPagesFromPool(
                 filters = filters,
                 timeoutMs = timeoutMs,
-                maxPageMs = maxPageMs,
                 maxConcurrentRelays = maxConcurrentRelays,
             ) { event, relay -> eventChannel.trySend(relay to event) }
         } finally {

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllWithHooksExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllWithHooksExt.kt
@@ -255,6 +255,7 @@ suspend fun INostrClient.fetchAllWithHooks(
 suspend fun INostrClient.fetchAllPagesFromPoolWithHooks(
     filters: Map<NormalizedRelayUrl, List<Filter>>,
     timeoutMs: Long = 30_000L,
+    maxPageMs: Long = timeoutMs * 10,
     maxConcurrentRelays: Int = 8,
     onEvent: suspend (relay: NormalizedRelayUrl, event: Event) -> Boolean,
 ): List<Pair<NormalizedRelayUrl, Event>> {
@@ -286,6 +287,7 @@ suspend fun INostrClient.fetchAllPagesFromPoolWithHooks(
             fetchAllPagesFromPool(
                 filters = filters,
                 timeoutMs = timeoutMs,
+                maxPageMs = maxPageMs,
                 maxConcurrentRelays = maxConcurrentRelays,
             ) { event, relay -> eventChannel.trySend(relay to event) }
         } finally {

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllWithHooksExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllWithHooksExt.kt
@@ -41,13 +41,13 @@ import kotlinx.coroutines.withTimeoutOrNull
  * funnel every arriving event through the suspending [onEvent] hook (verify /
  * persist / filter — return `true` to keep it in the result), and return the
  * accepted `(relay, event)` pairs once every relay reached a terminal state
- * (EOSE, CLOSED, or cannot-connect) or the line went quiet for [timeoutMs].
+ * (EOSE, CLOSED, or cannot-connect) or the line went quiet for [idleTimeoutMs].
  *
- * [timeoutMs] is an **idle window, not a hard cap**: the clock only runs while
+ * [idleTimeoutMs] is an **idle window, not a hard cap**: the clock only runs while
  * the relays are silent, and every arriving event or terminal signal resets
  * it. A slow relay actively streaming a large backlog is therefore never
  * cropped mid-delivery — the fetch ends when the work is done or when nothing
- * has arrived for [timeoutMs] (a stall). The terminal conditions (EOSE /
+ * has arrived for [idleTimeoutMs] (a stall). The terminal conditions (EOSE /
  * CLOSED / cannot-connect per relay) are what bound the fetch; the timeout's
  * only job is detecting relays that will never reach one. [maxTotalMs]
  * (default 10x the idle window) is the wall-clock ceiling that keeps a
@@ -62,20 +62,20 @@ import kotlinx.coroutines.withTimeoutOrNull
  *    as a hard failure via [classifyDrainFailure] (connect refused / DNS / TLS /
  *    dead HTTP upgrade — NOT slow relays or 429s) is recorded, so callers can
  *    prune proven-dead relays from future routing instead of paying the full
- *    [timeoutMs] on them again.
+ *    [idleTimeoutMs] on them again.
  *  - **[pendingOnAuthRequired]** — a relay that refuses the REQ with an
  *    `auth-required:` CLOSED is kept pending rather than treated as terminal:
  *    the caller's NIP-42 responder answers the challenge and the client re-fires
  *    this same subscription, so the post-auth events are collected instead of
  *    returning empty. If auth never satisfies it, the relay simply falls through
- *    to the [timeoutMs].
+ *    to the [idleTimeoutMs].
  *  - **[onTimeout]** — diagnostic hook fired when the idle window elapsed with
  *    relays still pending: receives the stalled set, the terminal reasons seen so
  *    far (`"eose"` / `"closed:<msg>"` / `"cannot:<msg>"`), and what was collected.
  */
 suspend fun INostrClient.fetchAllWithHooks(
     filters: Map<NormalizedRelayUrl, List<Filter>>,
-    timeoutMs: Long = 8_000L,
+    idleTimeoutMs: Long = 8_000L,
     subscriptionId: String = newSubId(),
     pendingOnAuthRequired: Boolean = false,
     deadOut: MutableMap<NormalizedRelayUrl, DrainFailure>? = null,
@@ -87,10 +87,10 @@ suspend fun INostrClient.fetchAllWithHooks(
      * restores an upper bound while staying far above the idle window, so a
      * legitimately streaming relay still finishes its backlog. Pass
      * [Long.MAX_VALUE] for a deliberately uncapped drain; a non-positive value
-     * also uncaps (absorbing a `timeoutMs * 10` overflow from an
+     * also uncaps (absorbing an `idleTimeoutMs * 10` overflow from an
      * effectively-infinite idle window).
      */
-    maxTotalMs: Long = timeoutMs * 10,
+    maxTotalMs: Long = idleTimeoutMs * 10,
     onEvent: suspend (relay: NormalizedRelayUrl, event: Event) -> Boolean,
 ): List<Pair<NormalizedRelayUrl, Event>> {
     if (filters.isEmpty()) return emptyList()
@@ -190,7 +190,7 @@ suspend fun INostrClient.fetchAllWithHooks(
                 // Slow path: both dry — arm one idle wait for the next signal.
                 if (pending == null) {
                     val progressed =
-                        withTimeoutOrNull(timeoutMs) {
+                        withTimeoutOrNull(idleTimeoutMs) {
                             select<Unit> {
                                 eventChannel.onReceive { pending = it }
                                 doneChannel.onReceive { (relay, reason) ->
@@ -256,7 +256,7 @@ suspend fun INostrClient.fetchAllWithHooks(
  */
 suspend fun INostrClient.fetchAllPagesFromPoolWithHooks(
     filters: Map<NormalizedRelayUrl, List<Filter>>,
-    timeoutMs: Long = 30_000L,
+    idleTimeoutMs: Long = 30_000L,
     maxConcurrentRelays: Int = 8,
     onEvent: suspend (relay: NormalizedRelayUrl, event: Event) -> Boolean,
 ): List<Pair<NormalizedRelayUrl, Event>> {
@@ -287,7 +287,7 @@ suspend fun INostrClient.fetchAllPagesFromPoolWithHooks(
         try {
             fetchAllPagesFromPool(
                 filters = filters,
-                timeoutMs = timeoutMs,
+                idleTimeoutMs = idleTimeoutMs,
                 maxConcurrentRelays = maxConcurrentRelays,
             ) { event, relay -> eventChannel.trySend(relay to event) }
         } finally {

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllWithHooksExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllWithHooksExt.kt
@@ -86,7 +86,9 @@ suspend fun INostrClient.fetchAllWithHooks(
      * adversarial or misbehaving relay could pin the caller forever. The cap
      * restores an upper bound while staying far above the idle window, so a
      * legitimately streaming relay still finishes its backlog. Pass
-     * [Long.MAX_VALUE] for a deliberately uncapped drain.
+     * [Long.MAX_VALUE] for a deliberately uncapped drain; a non-positive value
+     * also uncaps (absorbing a `timeoutMs * 10` overflow from an
+     * effectively-infinite idle window).
      */
     maxTotalMs: Long = timeoutMs * 10,
     onEvent: suspend (relay: NormalizedRelayUrl, event: Event) -> Boolean,
@@ -144,7 +146,7 @@ suspend fun INostrClient.fetchAllWithHooks(
         coroutineScope {
             subscribe(subscriptionId, filters, listener)
             val watchdog =
-                if (maxTotalMs == Long.MAX_VALUE) {
+                if (maxTotalMs <= 0 || maxTotalMs == Long.MAX_VALUE) {
                     null
                 } else {
                     launch {

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchFirstExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchFirstExt.kt
@@ -64,10 +64,23 @@ suspend fun INostrClient.fetchFirst(
     filters: List<Filter>,
 ) = fetchFirst(subscriptionId, mapOf(relay to filters))
 
+/**
+ * Subscribe [filters], return the first event any relay delivers (or `null` when
+ * every relay reached a terminal state — EOSE, CLOSED, or cannot-connect — with
+ * nothing matching, or the line went quiet).
+ *
+ * [timeoutMs] is an **idle window measured from the most recent message**, not a
+ * wall-clock deadline — the package-wide accessory convention: every arriving
+ * signal (a terminal state from one relay of many) restarts it, so the fetch only
+ * gives up after a full window of total silence. [maxTotalMs] (default 10x the
+ * idle window) is the wall-clock ceiling that bounds a relay emitting endless
+ * terminal chatter (e.g. a CLOSED/reconnect loop) without ever delivering an event.
+ */
 suspend fun INostrClient.fetchFirst(
     subscriptionId: String = newSubId(),
     filters: Map<NormalizedRelayUrl, List<Filter>>,
     timeoutMs: Long = 30_000L,
+    maxTotalMs: Long = timeoutMs * 10,
 ): Event? {
     val eventChannel = Channel<Event>(UNLIMITED)
     val doneChannel = Channel<NormalizedRelayUrl>(UNLIMITED)
@@ -112,27 +125,34 @@ suspend fun INostrClient.fetchFirst(
     try {
         subscribe(subscriptionId, filters, listener)
 
-        withTimeoutOrNull(timeoutMs) {
+        // Each wait is bounded by the idle window alone; any arriving signal
+        // restarts it on the next loop iteration. The outer ceiling stays far
+        // above the window so legitimate multi-relay stragglers still land.
+        withTimeoutOrNull(maxTotalMs) {
             while (remaining.isNotEmpty()) {
-                select {
-                    eventChannel.onReceive { event ->
-                        result = event
-                        remaining.clear()
-                    }
-                    doneChannel.onReceive { relay ->
-                        // A relay sends its matching events before its EOSE, so an event may
-                        // already be buffered when this completion fires. select() picks a ready
-                        // clause at random, so without this drain we could treat the relay as done
-                        // and exit while its event still sits unread in the channel.
-                        val buffered = eventChannel.tryReceive().getOrNull()
-                        if (buffered != null) {
-                            result = buffered
-                            remaining.clear()
-                        } else {
-                            remaining.remove(relay)
+                val progressed =
+                    withTimeoutOrNull(timeoutMs) {
+                        select<Unit> {
+                            eventChannel.onReceive { event ->
+                                result = event
+                                remaining.clear()
+                            }
+                            doneChannel.onReceive { relay ->
+                                // A relay sends its matching events before its EOSE, so an event may
+                                // already be buffered when this completion fires. select() picks a ready
+                                // clause at random, so without this drain we could treat the relay as done
+                                // and exit while its event still sits unread in the channel.
+                                val buffered = eventChannel.tryReceive().getOrNull()
+                                if (buffered != null) {
+                                    result = buffered
+                                    remaining.clear()
+                                } else {
+                                    remaining.remove(relay)
+                                }
+                            }
                         }
                     }
-                }
+                if (progressed == null) break
             }
         }
     } finally {

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchFirstExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchFirstExt.kt
@@ -74,7 +74,9 @@ suspend fun INostrClient.fetchFirst(
  * signal (a terminal state from one relay of many) restarts it, so the fetch only
  * gives up after a full window of total silence. [maxTotalMs] (default 10x the
  * idle window) is the wall-clock ceiling that bounds a relay emitting endless
- * terminal chatter (e.g. a CLOSED/reconnect loop) without ever delivering an event.
+ * terminal chatter (e.g. a CLOSED/reconnect loop) without ever delivering an
+ * event; a non-positive value means uncapped (which also absorbs a
+ * `timeoutMs * 10` overflow from an effectively-infinite idle window).
  */
 suspend fun INostrClient.fetchFirst(
     subscriptionId: String = newSubId(),
@@ -128,7 +130,8 @@ suspend fun INostrClient.fetchFirst(
         // Each wait is bounded by the idle window alone; any arriving signal
         // restarts it on the next loop iteration. The outer ceiling stays far
         // above the window so legitimate multi-relay stragglers still land.
-        withTimeoutOrNull(maxTotalMs) {
+        val ceiling = if (maxTotalMs <= 0) Long.MAX_VALUE else maxTotalMs
+        withTimeoutOrNull(ceiling) {
             while (remaining.isNotEmpty()) {
                 val progressed =
                     withTimeoutOrNull(timeoutMs) {

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchFirstExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchFirstExt.kt
@@ -69,7 +69,7 @@ suspend fun INostrClient.fetchFirst(
  * every relay reached a terminal state — EOSE, CLOSED, or cannot-connect — with
  * nothing matching, or the line went quiet).
  *
- * [timeoutMs] is an **idle window measured from the most recent progress**, not a
+ * [idleTimeoutMs] is an **idle window measured from the most recent progress**, not a
  * wall-clock deadline — the package-wide accessory convention. Progress means a
  * signal that actually advances the fetch: an event, or the first terminal state
  * from a relay still being waited on. Repeat chatter from a relay already
@@ -86,7 +86,7 @@ suspend fun INostrClient.fetchFirst(
 suspend fun INostrClient.fetchFirst(
     subscriptionId: String = newSubId(),
     filters: Map<NormalizedRelayUrl, List<Filter>>,
-    timeoutMs: Long = 30_000L,
+    idleTimeoutMs: Long = 30_000L,
 ): Event? {
     val eventChannel = Channel<Event>(UNLIMITED)
     val doneChannel = Channel<NormalizedRelayUrl>(UNLIMITED)
@@ -137,7 +137,7 @@ suspend fun INostrClient.fetchFirst(
         // advance escapes to the outer loop and earns a fresh window.
         while (remaining.isNotEmpty()) {
             val progressed =
-                withTimeoutOrNull(timeoutMs) {
+                withTimeoutOrNull(idleTimeoutMs) {
                     while (true) {
                         val advanced =
                             select<Boolean> {

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchFirstExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchFirstExt.kt
@@ -69,20 +69,24 @@ suspend fun INostrClient.fetchFirst(
  * every relay reached a terminal state — EOSE, CLOSED, or cannot-connect — with
  * nothing matching, or the line went quiet).
  *
- * [timeoutMs] is an **idle window measured from the most recent message**, not a
- * wall-clock deadline — the package-wide accessory convention: every arriving
- * signal (a terminal state from one relay of many) restarts it, so the fetch only
- * gives up after a full window of total silence. [maxTotalMs] (default 10x the
- * idle window) is the wall-clock ceiling that bounds a relay emitting endless
- * terminal chatter (e.g. a CLOSED/reconnect loop) without ever delivering an
- * event; a non-positive value means uncapped (which also absorbs a
- * `timeoutMs * 10` overflow from an effectively-infinite idle window).
+ * [timeoutMs] is an **idle window measured from the most recent progress**, not a
+ * wall-clock deadline — the package-wide accessory convention. Progress means a
+ * signal that actually advances the fetch: an event, or the first terminal state
+ * from a relay still being waited on. Repeat chatter from a relay already
+ * accounted for (a CLOSED/reconnect loop) is *not* progress and does not restart
+ * the window — the same rule the negentropy watchdog applies to NOTICE/CLOSED
+ * error chatter, and what keeps a flapping relay from holding this open forever.
+ *
+ * That makes the call self-bounding: at most one progress signal per relay, each
+ * granting a fresh window. There is deliberately no ceiling parameter — a caller
+ * who wants a hard wall-clock bound already has one in
+ * `withTimeoutOrNull(ms) { fetchFirst(...) }`, which costs nothing here since a
+ * timed-out fetch returns `null` either way.
  */
 suspend fun INostrClient.fetchFirst(
     subscriptionId: String = newSubId(),
     filters: Map<NormalizedRelayUrl, List<Filter>>,
     timeoutMs: Long = 30_000L,
-    maxTotalMs: Long = timeoutMs * 10,
 ): Event? {
     val eventChannel = Channel<Event>(UNLIMITED)
     val doneChannel = Channel<NormalizedRelayUrl>(UNLIMITED)
@@ -127,37 +131,49 @@ suspend fun INostrClient.fetchFirst(
     try {
         subscribe(subscriptionId, filters, listener)
 
-        // Each wait is bounded by the idle window alone; any arriving signal
-        // restarts it on the next loop iteration. The outer ceiling stays far
-        // above the window so legitimate multi-relay stragglers still land.
-        val ceiling = if (maxTotalMs <= 0) Long.MAX_VALUE else maxTotalMs
-        withTimeoutOrNull(ceiling) {
-            while (remaining.isNotEmpty()) {
-                val progressed =
-                    withTimeoutOrNull(timeoutMs) {
-                        select<Unit> {
-                            eventChannel.onReceive { event ->
-                                result = event
-                                remaining.clear()
-                            }
-                            doneChannel.onReceive { relay ->
-                                // A relay sends its matching events before its EOSE, so an event may
-                                // already be buffered when this completion fires. select() picks a ready
-                                // clause at random, so without this drain we could treat the relay as done
-                                // and exit while its event still sits unread in the channel.
-                                val buffered = eventChannel.tryReceive().getOrNull()
-                                if (buffered != null) {
-                                    result = buffered
+        // One idle window per unit of progress. The inner loop keeps consuming
+        // non-progress signals INSIDE the same window, so repeat chatter from an
+        // already-accounted-for relay cannot push the deadline out; only a real
+        // advance escapes to the outer loop and earns a fresh window.
+        while (remaining.isNotEmpty()) {
+            val progressed =
+                withTimeoutOrNull(timeoutMs) {
+                    while (true) {
+                        val advanced =
+                            select<Boolean> {
+                                eventChannel.onReceive { event ->
+                                    result = event
                                     remaining.clear()
-                                } else {
-                                    remaining.remove(relay)
+                                    true
+                                }
+                                doneChannel.onReceive { relay ->
+                                    // A relay sends its matching events before its EOSE, so an event may
+                                    // already be buffered when this completion fires. select() picks a ready
+                                    // clause at random, so without this drain we could treat the relay as done
+                                    // and exit while its event still sits unread in the channel.
+                                    val buffered = eventChannel.tryReceive().getOrNull()
+                                    if (buffered != null) {
+                                        result = buffered
+                                        remaining.clear()
+                                        true
+                                    } else {
+                                        // Only the FIRST terminal signal from a relay we are still
+                                        // waiting on advances the fetch; a repeat is chatter.
+                                        remaining.remove(relay)
+                                    }
                                 }
                             }
-                        }
+                        if (advanced) break
                     }
-                if (progressed == null) break
-            }
+                    true
+                }
+            if (progressed == null) break
         }
+
+        // An event can land after the last terminal signal but before we
+        // unsubscribe; without this drain it would be dropped and the fetch
+        // would report "nothing found" while holding a match.
+        if (result == null) result = eventChannel.tryReceive().getOrNull()
     } finally {
         unsubscribe(subscriptionId)
         eventChannel.close()

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchFirstExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchFirstExt.kt
@@ -29,8 +29,10 @@ import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.coroutines.coroutineContext
 
 suspend fun INostrClient.fetchFirst(
     relay: String,
@@ -139,6 +141,12 @@ suspend fun INostrClient.fetchFirst(
             val progressed =
                 withTimeoutOrNull(idleTimeoutMs) {
                     while (true) {
+                        // Cancellation (this window expiring, or the caller giving up)
+                        // only lands at a suspension point, and select() completes
+                        // without suspending while either channel has something
+                        // buffered — so check explicitly rather than draining a
+                        // backlog of chatter uninterruptibly.
+                        coroutineContext.ensureActive()
                         val advanced =
                             select<Boolean> {
                                 eventChannel.onReceive { event ->

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientNegentropySyncExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientNegentropySyncExt.kt
@@ -47,14 +47,12 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
-import kotlin.concurrent.Volatile
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.concurrent.atomics.decrementAndFetch
 import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.coroutines.coroutineContext
 import kotlin.math.min
-import kotlin.time.TimeSource
 
 /**
  * Outcome of a successful [negentropySync] run.
@@ -1180,52 +1178,8 @@ internal val KEEP_ALIVE_ID = "f".repeat(64)
  * still honor "run until the socket drops".
  */
 private const val DEFAULT_CONNECT_TIMEOUT_MS = 30_000L
-private const val DEFAULT_DOWNLOAD_IDLE_MS = 60_000L
+internal const val DEFAULT_DOWNLOAD_IDLE_MS = 60_000L
 
-/**
- * Monotonic "last activity" marker for the idle watchdog. [bump] on every sign of
- * life from the relay; [elapsedMs] reports the silence since the last bump.
- *
- * [bump] is on the per-event hot path (the connection listener bumps for every
- * message the relay sends — millions during a large download), so it must not
- * allocate: a single [start] mark is taken once (unboxed field) and each bump only
- * writes a `Long` of nanos-since-start into a `@Volatile` field. Reader threads
- * write, the driver coroutine reads — visibility is all we need, so a plain volatile
- * Long beats boxing a `ValueTimeMark` into an `AtomicReference` on every event.
- */
-private class IdleClock {
-    private val start = TimeSource.Monotonic.markNow()
-
-    @Volatile
-    private var lastNanos = 0L
-
-    fun bump() {
-        lastNanos = start.elapsedNow().inWholeNanoseconds
-    }
-
-    fun elapsedMs(): Long = (start.elapsedNow().inWholeNanoseconds - lastNanos) / 1_000_000
-}
-
-/**
- * Receives the next item, giving up (returning `null`) only after [idleMs] elapse with
- * no activity on [clock]. Because [clock] is bumped by *any* relay message — not just
- * items on this channel — unrelated progress (e.g. download events arriving during a
- * reconcile wait) keeps pushing the deadline out. [idleMs] `<= 0` disables the
- * watchdog: it waits until an item arrives (a disconnect is delivered as an item, so
- * a dead socket still unblocks it).
- */
-private suspend fun <T> Channel<T>.receiveWithinIdle(
-    clock: IdleClock,
-    idleMs: Long,
-): T? {
-    if (idleMs <= 0) return receive()
-    while (true) {
-        val remaining = idleMs - clock.elapsedMs()
-        if (remaining <= 0) return null
-        val item = withTimeoutOrNull(remaining) { receive() }
-        if (item != null) return item
-        // Timed out with nothing on this channel. If other activity bumped the clock
-        // meanwhile, the next `remaining` is positive and we wait again; otherwise it
-        // is <= 0 on the next iteration and we give up.
-    }
-}
+// IdleClock and receiveWithinIdle — the idle-watchdog primitives this file
+// introduced — now live in IdleWatchdog.kt, shared by every accessory whose
+// timeout is measured from the relay's most recent message.

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientNegentropySyncExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientNegentropySyncExt.kt
@@ -1179,7 +1179,3 @@ internal val KEEP_ALIVE_ID = "f".repeat(64)
  */
 private const val DEFAULT_CONNECT_TIMEOUT_MS = 30_000L
 internal const val DEFAULT_DOWNLOAD_IDLE_MS = 60_000L
-
-// IdleClock and receiveWithinIdle — the idle-watchdog primitives this file
-// introduced — now live in IdleWatchdog.kt, shared by every accessory whose
-// timeout is measured from the relay's most recent message.

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/README.md
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/README.md
@@ -19,11 +19,24 @@ from the relay's most recent message**, never a wall-clock deadline: each arrivi
 event / result / terminal signal resets it, so an actively streaming relay is never
 cut off mid-delivery — the operation only gives up after a full window of silence.
 The shared primitives are in `IdleWatchdog.kt` (`IdleClock` + `receiveWithinIdle`);
-use them when writing a new accessory. Because an idle window alone is unbounded
-against a relay that trickles messages forever, the loops that could run away also
-take a hard wall-clock ceiling (`maxTotalMs` / `maxPageMs`, default 10x the idle
-window) as a backstop; a non-positive ceiling means uncapped. The one deliberate
-exception is the write side: `publishAndConfirm`'s `timeoutInSeconds` is a fixed
+use them when writing a new accessory.
+
+An idle window alone never expires against a relay that trickles messages forever,
+so the accessories that wait in **one** loop and then return — `fetchAll` /
+`fetchAllWithHooks`, `fetchFirst`, multi-relay `count` — also take a wall-clock
+ceiling (`maxTotalMs`, default 10x the idle window; non-positive means uncapped).
+There the ceiling genuinely ends the call.
+
+`fetchAllPages` deliberately has **no** ceiling. A per-page ceiling would bound a
+page, not the call: the paging loop reacts to a page ending by advancing the cursor
+and issuing the next `REQ`, so an endless trickle just gets re-paged forever (a
+ceiling of 400 ms against one measured 8 `REQ`s and no return). It also makes
+truncation unsafe — cutting a page mid-stream advances `until` to the oldest event
+received *so far*, which only preserves the set if the relay streams strictly
+newest-first, which NIP-01 recommends but does not require. Bound a paged download
+with the filter's `limit`, or by cancelling the caller.
+
+The write side is its own case: `publishAndConfirm`'s `timeoutInSeconds` is a fixed
 window to collect the `OK`s — a bounded confirmation round-trip, not a stream.
 
 ## One-shot reads (subscribe → collect → return)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/README.md
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/README.md
@@ -12,11 +12,23 @@ count, negentropy sync/reconcile) already exists.
 Import as `com.vitorpamplona.quartz.nip01Core.relay.client.accessories.<name>` (or
 `...client.reqs.<name>` for the flow/subscribe helpers).
 
+## Timeout convention
+
+Every `timeoutMs` / `idleTimeoutMs` in this package is an **idle window measured
+from the relay's most recent message**, never a wall-clock deadline: each arriving
+event / result / terminal signal resets it, so an actively streaming relay is never
+cut off mid-delivery — the operation only gives up after a full window of silence.
+The shared primitives are in `IdleWatchdog.kt` (`IdleClock` + `receiveWithinIdle`);
+use them when writing a new accessory. Because an idle window alone is unbounded
+against a relay that trickles messages forever, the loops that could run away also
+take a hard wall-clock ceiling (`maxTotalMs` / `maxPageMs`, default 10x the idle
+window) as a backstop.
+
 ## One-shot reads (subscribe → collect → return)
 
 | Function | File | Use when |
 | --- | --- | --- |
-| `fetchAll(relay, filter, timeoutMs)` | `NostrClientFetchAllExt` | Get every event matching a filter in one REQ, deduped by id, until EOSE or timeout. **No verify, no store** — just the events. |
+| `fetchAll(relay, filter, timeoutMs)` | `NostrClientFetchAllExt` | Get every event matching a filter in one REQ, deduped by id, until EOSE or a full idle window of silence. **No verify, no store** — just the events. |
 | `fetchFirst(relay, filter, timeoutMs)` | `NostrClientFetchFirstExt` | Get the first matching event and stop (returns `null` on none/timeout). |
 | `fetchAllPages(relay, filters, timeoutMs)` | `NostrClientFetchAllPagesExt` | Fully retrieve a result set larger than the relay's per-REQ cap (strfry `limit`, ~500) by walking a `created_at` cursor. Bound it with the filter's `limit`. |
 | `fetchAllPagesFromPool(filters, ...)` | `NostrClientFetchAllPagesPoolExt` | Same paging, across several relays at once, deduped across them. |

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/README.md
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/README.md
@@ -22,7 +22,9 @@ The shared primitives are in `IdleWatchdog.kt` (`IdleClock` + `receiveWithinIdle
 use them when writing a new accessory. Because an idle window alone is unbounded
 against a relay that trickles messages forever, the loops that could run away also
 take a hard wall-clock ceiling (`maxTotalMs` / `maxPageMs`, default 10x the idle
-window) as a backstop.
+window) as a backstop; a non-positive ceiling means uncapped. The one deliberate
+exception is the write side: `publishAndConfirm`'s `timeoutInSeconds` is a fixed
+window to collect the `OK`s — a bounded confirmation round-trip, not a stream.
 
 ## One-shot reads (subscribe → collect → return)
 
@@ -31,7 +33,7 @@ window) as a backstop.
 | `fetchAll(relay, filter, timeoutMs)` | `NostrClientFetchAllExt` | Get every event matching a filter in one REQ, deduped by id, until EOSE or a full idle window of silence. **No verify, no store** — just the events. |
 | `fetchFirst(relay, filter, timeoutMs)` | `NostrClientFetchFirstExt` | Get the first matching event and stop (returns `null` on none/timeout). |
 | `fetchAllPages(relay, filters, timeoutMs)` | `NostrClientFetchAllPagesExt` | Fully retrieve a result set larger than the relay's per-REQ cap (strfry `limit`, ~500) by walking a `created_at` cursor. Bound it with the filter's `limit`. |
-| `fetchAllPagesFromPool(filters, ...)` | `NostrClientFetchAllPagesPoolExt` | Same paging, across several relays at once, deduped across them. |
+| `fetchAllPagesFromPool(filters, ...)` | `NostrClientFetchAllPagesPoolExt` | Same paging, across several relays at once. No cross-relay dedup — the `WithHooks` variant below dedups. |
 | `fetchAllWithHooks(filters, ...)` | `NostrClientFetchAllWithHooksExt` | `fetchAll` with a suspending per-`(relay, event)` accept hook (verify+store as events arrive), per-relay terminal-reason tracking, optional dead-relay collection (`deadOut` + `classifyDrainFailure`), keep-pending-on-`auth-required` CLOSED (NIP-42 re-fire), and a timeout diagnostic hook. |
 | `fetchAllPagesFromPoolWithHooks(filters, ...)` | `NostrClientFetchAllWithHooksExt` | `fetchAllPagesFromPool` with the same suspending accept hook, run single-threaded in one consumer; deduped across relays by `SeenIds` before the hook. |
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/README.md
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/README.md
@@ -15,26 +15,36 @@ Import as `com.vitorpamplona.quartz.nip01Core.relay.client.accessories.<name>` (
 ## Timeout convention
 
 Every `timeoutMs` / `idleTimeoutMs` in this package is an **idle window measured
-from the relay's most recent message**, never a wall-clock deadline: each arriving
-event / result / terminal signal resets it, so an actively streaming relay is never
-cut off mid-delivery — the operation only gives up after a full window of silence.
-The shared primitives are in `IdleWatchdog.kt` (`IdleClock` + `receiveWithinIdle`);
-use them when writing a new accessory.
+from the relay's most recent progress**, never a wall-clock deadline: real progress
+resets it, so an actively streaming relay is never cut off mid-delivery — the
+operation only gives up after a full window of silence. The shared primitives are in
+`IdleWatchdog.kt` (`IdleClock` + `receiveWithinIdle`); use them in a new accessory.
 
-An idle window alone never expires against a relay that trickles messages forever,
-so the accessories that wait in **one** loop and then return — `fetchAll` /
-`fetchAllWithHooks`, `fetchFirst`, multi-relay `count` — also take a wall-clock
-ceiling (`maxTotalMs`, default 10x the idle window; non-positive means uncapped).
-There the ceiling genuinely ends the call.
+**Progress, not merely traffic.** A message that tells us nothing new — a relay
+re-CLOSEing after we already recorded it as done, a duplicate COUNT — must not
+restart the window, or a flapping relay keeps the call alive indefinitely. This is
+the rule the negentropy watchdog already applies to `NOTICE`/`CLOSED` chatter, and
+it is what makes `fetchFirst` and multi-relay `count` self-bounding: at most one
+window per relay.
 
-`fetchAllPages` deliberately has **no** ceiling. A per-page ceiling would bound a
-page, not the call: the paging loop reacts to a page ending by advancing the cursor
-and issuing the next `REQ`, so an endless trickle just gets re-paged forever (a
-ceiling of 400 ms against one measured 8 `REQ`s and no return). It also makes
-truncation unsafe — cutting a page mid-stream advances `until` to the oldest event
-received *so far*, which only preserves the set if the relay streams strictly
-newest-first, which NIP-01 recommends but does not require. Bound a paged download
-with the filter's `limit`, or by cancelling the caller.
+**No accessory takes a wall-clock ceiling parameter.** A hard bound composes at the
+call site — `withTimeoutOrNull(ms) { fetchFirst(...) }` — so duplicating it in every
+signature buys nothing. Prefer the idle window inside (the caller cannot implement
+it; it needs the message stream) and the wall clock outside. Two consequences worth
+knowing:
+
+- `fetchAllPages` has no ceiling and could not usefully have one. A per-page cap
+  bounds a *page*, not the call: the loop reacts to a page ending by advancing the
+  cursor and issuing the next `REQ`, so an endless trickle is just re-paged (a
+  400 ms cap measured 8 `REQ`s and no return). It also makes truncation unsafe —
+  cutting a page mid-stream advances `until` to the oldest event received *so far*,
+  which only preserves the set if the relay streams strictly newest-first, which
+  NIP-01 recommends but does not require. Bound a paged download with the filter's
+  `limit`, or by cancelling.
+- `fetchAll` / `fetchAllWithHooks` keep a pre-existing `maxTotalMs`, and it earns
+  its place: an endless *event* trickle there is genuine progress, so the call never
+  self-terminates, and the internal cap returns the events collected so far where an
+  external `withTimeoutOrNull` would discard them.
 
 The write side is its own case: `publishAndConfirm`'s `timeoutInSeconds` is a fixed
 window to collect the `OK`s — a bounded confirmation round-trip, not a stream.

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/README.md
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/README.md
@@ -14,11 +14,16 @@ Import as `com.vitorpamplona.quartz.nip01Core.relay.client.accessories.<name>` (
 
 ## Timeout convention
 
-Every `timeoutMs` / `idleTimeoutMs` in this package is an **idle window measured
-from the relay's most recent progress**, never a wall-clock deadline: real progress
-resets it, so an actively streaming relay is never cut off mid-delivery — the
-operation only gives up after a full window of silence. The shared primitives are in
-`IdleWatchdog.kt` (`IdleClock` + `receiveWithinIdle`); use them in a new accessory.
+Every wait in this package is an **idle window measured from the relay's most recent
+progress**, never a wall-clock deadline: real progress resets it, so an actively
+streaming relay is never cut off mid-delivery — the operation only gives up after a
+full window of silence. The shared primitives are in `IdleWatchdog.kt` (`IdleClock` +
+`receiveWithinIdle`); use them in a new accessory.
+
+**The parameter is named `idleTimeoutMs`, never `timeoutMs`** — the name is the
+contract, so a caller can't mistake it for a deadline. The sole exception is
+`publishAndConfirm`'s `timeoutInSeconds`, which genuinely *is* a fixed window (see
+below); the differing name is the tell.
 
 **Progress, not merely traffic.** A message that tells us nothing new — a relay
 re-CLOSEing after we already recorded it as done, a duplicate COUNT — must not
@@ -53,9 +58,9 @@ window to collect the `OK`s — a bounded confirmation round-trip, not a stream.
 
 | Function | File | Use when |
 | --- | --- | --- |
-| `fetchAll(relay, filter, timeoutMs)` | `NostrClientFetchAllExt` | Get every event matching a filter in one REQ, deduped by id, until EOSE or a full idle window of silence. **No verify, no store** — just the events. |
-| `fetchFirst(relay, filter, timeoutMs)` | `NostrClientFetchFirstExt` | Get the first matching event and stop (returns `null` on none/timeout). |
-| `fetchAllPages(relay, filters, timeoutMs)` | `NostrClientFetchAllPagesExt` | Fully retrieve a result set larger than the relay's per-REQ cap (strfry `limit`, ~500) by walking a `created_at` cursor. Bound it with the filter's `limit`. |
+| `fetchAll(relay, filter, idleTimeoutMs)` | `NostrClientFetchAllExt` | Get every event matching a filter in one REQ, deduped by id, until EOSE or a full idle window of silence. **No verify, no store** — just the events. |
+| `fetchFirst(relay, filter, idleTimeoutMs)` | `NostrClientFetchFirstExt` | Get the first matching event and stop (returns `null` on none/timeout). |
+| `fetchAllPages(relay, filters, idleTimeoutMs)` | `NostrClientFetchAllPagesExt` | Fully retrieve a result set larger than the relay's per-REQ cap (strfry `limit`, ~500) by walking a `created_at` cursor. Bound it with the filter's `limit`. |
 | `fetchAllPagesFromPool(filters, ...)` | `NostrClientFetchAllPagesPoolExt` | Same paging, across several relays at once. No cross-relay dedup — the `WithHooks` variant below dedups. |
 | `fetchAllWithHooks(filters, ...)` | `NostrClientFetchAllWithHooksExt` | `fetchAll` with a suspending per-`(relay, event)` accept hook (verify+store as events arrive), per-relay terminal-reason tracking, optional dead-relay collection (`deadOut` + `classifyDrainFailure`), keep-pending-on-`auth-required` CLOSED (NIP-42 re-fire), and a timeout diagnostic hook. |
 | `fetchAllPagesFromPoolWithHooks(filters, ...)` | `NostrClientFetchAllWithHooksExt` | `fetchAllPagesFromPool` with the same suspending accept hook, run single-threaded in one consumer; deduped across relays by `SeenIds` before the hook. |
@@ -79,7 +84,7 @@ window to collect the `OK`s — a bounded confirmation round-trip, not a stream.
 
 | Function | File | Use when |
 | --- | --- | --- |
-| `count(relay, filter, timeoutMs)` | `NostrClientCountExt` | NIP-45 `COUNT` against one relay (`null` on timeout / no support). |
+| `count(relay, filter, idleTimeoutMs)` | `NostrClientCountExt` | NIP-45 `COUNT` against one relay (`null` on timeout / no support). |
 | `countMerged(relays, filter, ...)` | `NostrClientCountExt` | Merged count across relays. |
 
 ## Negentropy (NIP-77)

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/FetchAllIdleTimeoutTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/FetchAllIdleTimeoutTest.kt
@@ -89,7 +89,7 @@ class FetchAllIdleTimeoutTest {
             val collected =
                 client.fetchAllWithHooks(
                     filters = mapOf(relay to listOf(Filter(kinds = listOf(1)))),
-                    timeoutMs = 300,
+                    idleTimeoutMs = 300,
                 ) { _, _ -> true }
             feeder.join()
             assertEquals(10, collected.size, "an actively streaming relay must never be cropped")
@@ -111,7 +111,7 @@ class FetchAllIdleTimeoutTest {
             val collected =
                 client.fetchAllWithHooks(
                     filters = mapOf(relay to listOf(Filter(kinds = listOf(1)))),
-                    timeoutMs = 300,
+                    idleTimeoutMs = 300,
                     onTimeout = { stalled, _, _ -> stalledRelays = stalled },
                 ) { _, _ -> true }
             assertEquals(2, collected.size, "events before the stall are kept")
@@ -136,7 +136,7 @@ class FetchAllIdleTimeoutTest {
             val events =
                 client.fetchAll(
                     filters = mapOf(relay to listOf(Filter(kinds = listOf(1)))),
-                    timeoutMs = 300,
+                    idleTimeoutMs = 300,
                 )
             feeder.join()
             assertEquals(10, events.size, "fetchAll shares the idle-window semantics")
@@ -162,7 +162,7 @@ class FetchAllIdleTimeoutTest {
             val collected =
                 client.fetchAllWithHooks(
                     filters = mapOf(relay to listOf(Filter(kinds = listOf(1)))),
-                    timeoutMs = 300,
+                    idleTimeoutMs = 300,
                     maxTotalMs = 1_000,
                     onTimeout = { stalled, _, _ -> stalledRelays = stalled },
                 ) { _, _ -> true }
@@ -186,7 +186,7 @@ class FetchAllIdleTimeoutTest {
             val collected =
                 client.fetchAllWithHooks(
                     filters = mapOf(relay to listOf(Filter(kinds = listOf(1)))),
-                    timeoutMs = 300,
+                    idleTimeoutMs = 300,
                 ) { _, _ -> true }
             assertEquals(1, collected.size)
             assertTrue(currentTime - start < 300, "a terminal EOSE must not wait out the window")

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/FetchFirstIdleTimeoutTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/FetchFirstIdleTimeoutTest.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -59,6 +60,8 @@ class FetchFirstIdleTimeoutTest {
 
     private val relayA = RelayUrlNormalizer.normalize("wss://a.example.com")
     private val relayB = RelayUrlNormalizer.normalize("wss://b.example.com")
+    private val relayC = RelayUrlNormalizer.normalize("wss://c.example.com")
+    private val relayD = RelayUrlNormalizer.normalize("wss://d.example.com")
 
     private fun event(i: Int) =
         Event(
@@ -74,28 +77,29 @@ class FetchFirstIdleTimeoutTest {
     private fun filters(vararg relays: NormalizedRelayUrl) = relays.associateWith { listOf(Filter(kinds = listOf(1))) }
 
     @Test
-    fun arrivingSignalsRestartTheIdleWindow() =
+    fun genuineProgressRestartsTheIdleWindow() =
         runTest {
             val client = ScriptedClient()
             launch {
-                // Terminal chatter every 250ms keeps the 300ms window alive long
-                // enough for the slow relay's event at 900ms — an absolute
+                // Each relay's FIRST terminal signal is real progress and buys a
+                // fresh window, carrying the fetch well past a single 300ms window
+                // so the slow relay's event at 900ms still lands. An absolute
                 // deadline would have returned null at 300ms.
                 delay(250)
                 client.listener!!.onClosed("rate limited", relayA, null)
                 delay(250)
-                client.listener!!.onClosed("rate limited", relayA, null)
+                client.listener!!.onClosed("rate limited", relayB, null)
                 delay(250)
-                client.listener!!.onClosed("rate limited", relayA, null)
+                client.listener!!.onClosed("rate limited", relayC, null)
                 delay(150)
-                client.listener!!.onEvent(event(1), false, relayB, null)
+                client.listener!!.onEvent(event(1), false, relayD, null)
             }
             val result =
                 client.fetchFirst(
-                    filters = filters(relayA, relayB),
+                    filters = filters(relayA, relayB, relayC, relayD),
                     timeoutMs = 300,
                 )
-            assertEquals(event(1).id, result?.id, "signals must restart the window; the slow relay's event still lands")
+            assertEquals(event(1).id, result?.id, "progress must restart the window; the slow relay's event still lands")
         }
 
     @Test
@@ -113,14 +117,16 @@ class FetchFirstIdleTimeoutTest {
         }
 
     @Test
-    fun wallClockCeilingStopsEndlessTerminalChatter() =
+    fun repeatTerminalChatterDoesNotRestartTheIdleWindow() =
         runTest {
             val client = ScriptedClient()
             val chatter =
                 launch {
                     // relayA re-CLOSEs forever (a reconnect loop); relayB never
-                    // answers. Every signal restarts the window, so only the
-                    // ceiling can end the wait.
+                    // answers. Only relayA's FIRST CLOSED is progress — it removes
+                    // relayA from `remaining`. The repeats say nothing new, so they
+                    // must not push the deadline out (the rule the negentropy
+                    // watchdog already uses for NOTICE/CLOSED chatter).
                     while (true) {
                         delay(200)
                         client.listener!!.onClosed("auth-required: again", relayA, null)
@@ -131,28 +137,52 @@ class FetchFirstIdleTimeoutTest {
                 client.fetchFirst(
                     filters = filters(relayA, relayB),
                     timeoutMs = 300,
-                    maxTotalMs = 1_000,
                 )
             chatter.cancel()
             assertNull(result)
-            assertEquals(1_000L, currentTime - start, "the ceiling must end an endlessly-restarted wait")
+            // First CLOSED at 200ms is the only progress; the window then expires
+            // 300ms later despite chatter at 400/600/800…
+            assertEquals(500L, currentTime - start, "repeat chatter must not keep the wait alive")
         }
 
     @Test
-    fun effectivelyInfiniteIdleWindowDoesNotOverflowTheCeiling() =
+    fun anEventArrivingAfterTheLastTerminalSignalIsStillReturned() =
         runTest {
             val client = ScriptedClient()
             launch {
                 delay(100)
-                client.listener!!.onEvent(event(1), false, relayA, null)
+                // The only relay EOSEs, emptying `remaining` and ending the loop —
+                // then its matching event lands before we unsubscribe. Without the
+                // post-loop drain this returns null while holding a match.
+                client.listener!!.onEose(relayA, null)
+                client.listener!!.onEvent(event(7), false, relayA, null)
             }
-            // Long.MAX_VALUE * 10 wraps to -10; the default ceiling must
-            // degrade to "uncapped", not to an instantly-expired wait.
             val result =
                 client.fetchFirst(
                     filters = filters(relayA),
-                    timeoutMs = Long.MAX_VALUE,
+                    timeoutMs = 300,
                 )
-            assertEquals(event(1).id, result?.id, "an overflowed default ceiling must mean uncapped, not instant timeout")
+            assertEquals(event(7).id, result?.id, "an event racing the final EOSE must not be dropped")
+        }
+
+    @Test
+    fun aHardWallClockBoundIsTheCallersToApply() =
+        runTest {
+            val client = ScriptedClient()
+            val chatter =
+                launch {
+                    while (true) {
+                        delay(50)
+                        client.listener!!.onClosed("flapping", relayA, null)
+                    }
+                }
+            // No ceiling parameter: composing withTimeoutOrNull at the call site
+            // is the wall-clock bound, and costs nothing because a timed-out
+            // fetchFirst yields null either way.
+            val start = currentTime
+            val result = withTimeoutOrNull(120) { client.fetchFirst(filters = filters(relayA, relayB), timeoutMs = 10_000) }
+            chatter.cancel()
+            assertNull(result)
+            assertEquals(120L, currentTime - start, "the caller's timeout bounds the call")
         }
 }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/FetchFirstIdleTimeoutTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/FetchFirstIdleTimeoutTest.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.relay.client.accessories
+
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.relay.client.EmptyNostrClient
+import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
+import com.vitorpamplona.quartz.nip01Core.relay.client.reqs.SubscriptionListener
+import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Pins [fetchFirst]'s timeout to the package-wide idle-window convention:
+ * [timeoutMs] is silence measured from the most recent relay signal, not an
+ * absolute deadline across the whole multi-relay wait — with [maxTotalMs] as
+ * the wall-clock ceiling.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class FetchFirstIdleTimeoutTest {
+    /** Captures the subscription listener so the test can play the relays. */
+    private class ScriptedClient : INostrClient by EmptyNostrClient() {
+        var listener: SubscriptionListener? = null
+
+        override fun subscribe(
+            subId: String,
+            filters: Map<NormalizedRelayUrl, List<Filter>>,
+            listener: SubscriptionListener?,
+        ) {
+            this.listener = listener
+        }
+    }
+
+    private val relayA = RelayUrlNormalizer.normalize("wss://a.example.com")
+    private val relayB = RelayUrlNormalizer.normalize("wss://b.example.com")
+
+    private fun event(i: Int) =
+        Event(
+            id = i.toString(16).padStart(64, '0'),
+            pubKey = "f".repeat(64),
+            createdAt = i.toLong(),
+            kind = 1,
+            tags = emptyArray(),
+            content = "e$i",
+            sig = "0".repeat(128),
+        )
+
+    private fun filters(vararg relays: NormalizedRelayUrl) = relays.associateWith { listOf(Filter(kinds = listOf(1))) }
+
+    @Test
+    fun arrivingSignalsRestartTheIdleWindow() =
+        runTest {
+            val client = ScriptedClient()
+            launch {
+                // Terminal chatter every 250ms keeps the 300ms window alive long
+                // enough for the slow relay's event at 900ms — an absolute
+                // deadline would have returned null at 300ms.
+                delay(250)
+                client.listener!!.onClosed("rate limited", relayA, null)
+                delay(250)
+                client.listener!!.onClosed("rate limited", relayA, null)
+                delay(250)
+                client.listener!!.onClosed("rate limited", relayA, null)
+                delay(150)
+                client.listener!!.onEvent(event(1), false, relayB, null)
+            }
+            val result =
+                client.fetchFirst(
+                    filters = filters(relayA, relayB),
+                    timeoutMs = 300,
+                )
+            assertEquals(event(1).id, result?.id, "signals must restart the window; the slow relay's event still lands")
+        }
+
+    @Test
+    fun totalSilenceReturnsNullAfterOneIdleWindow() =
+        runTest {
+            val client = ScriptedClient()
+            val start = currentTime
+            val result =
+                client.fetchFirst(
+                    filters = filters(relayA),
+                    timeoutMs = 300,
+                )
+            assertNull(result)
+            assertEquals(300L, currentTime - start, "a silent relay costs exactly one idle window")
+        }
+
+    @Test
+    fun wallClockCeilingStopsEndlessTerminalChatter() =
+        runTest {
+            val client = ScriptedClient()
+            val chatter =
+                launch {
+                    // relayA re-CLOSEs forever (a reconnect loop); relayB never
+                    // answers. Every signal restarts the window, so only the
+                    // ceiling can end the wait.
+                    while (true) {
+                        delay(200)
+                        client.listener!!.onClosed("auth-required: again", relayA, null)
+                    }
+                }
+            val start = currentTime
+            val result =
+                client.fetchFirst(
+                    filters = filters(relayA, relayB),
+                    timeoutMs = 300,
+                    maxTotalMs = 1_000,
+                )
+            chatter.cancel()
+            assertNull(result)
+            assertEquals(1_000L, currentTime - start, "the ceiling must end an endlessly-restarted wait")
+        }
+
+    @Test
+    fun effectivelyInfiniteIdleWindowDoesNotOverflowTheCeiling() =
+        runTest {
+            val client = ScriptedClient()
+            launch {
+                delay(100)
+                client.listener!!.onEvent(event(1), false, relayA, null)
+            }
+            // Long.MAX_VALUE * 10 wraps to -10; the default ceiling must
+            // degrade to "uncapped", not to an instantly-expired wait.
+            val result =
+                client.fetchFirst(
+                    filters = filters(relayA),
+                    timeoutMs = Long.MAX_VALUE,
+                )
+            assertEquals(event(1).id, result?.id, "an overflowed default ceiling must mean uncapped, not instant timeout")
+        }
+}

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/FetchFirstIdleTimeoutTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/FetchFirstIdleTimeoutTest.kt
@@ -38,10 +38,11 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 /**
- * Pins [fetchFirst]'s timeout to the package-wide idle-window convention:
- * [timeoutMs] is silence measured from the most recent relay signal, not an
- * absolute deadline across the whole multi-relay wait — with [maxTotalMs] as
- * the wall-clock ceiling.
+ * Pins [fetchFirst]'s timeout to the package-wide convention: `idleTimeoutMs` is
+ * silence measured from the most recent *progress*, not an absolute deadline
+ * across the whole multi-relay wait. Repeat chatter from a relay already
+ * accounted for is not progress, which is what makes the call self-bounding
+ * without a ceiling parameter — a hard bound is the caller's `withTimeoutOrNull`.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class FetchFirstIdleTimeoutTest {
@@ -97,7 +98,7 @@ class FetchFirstIdleTimeoutTest {
             val result =
                 client.fetchFirst(
                     filters = filters(relayA, relayB, relayC, relayD),
-                    timeoutMs = 300,
+                    idleTimeoutMs = 300,
                 )
             assertEquals(event(1).id, result?.id, "progress must restart the window; the slow relay's event still lands")
         }
@@ -110,7 +111,7 @@ class FetchFirstIdleTimeoutTest {
             val result =
                 client.fetchFirst(
                     filters = filters(relayA),
-                    timeoutMs = 300,
+                    idleTimeoutMs = 300,
                 )
             assertNull(result)
             assertEquals(300L, currentTime - start, "a silent relay costs exactly one idle window")
@@ -136,7 +137,7 @@ class FetchFirstIdleTimeoutTest {
             val result =
                 client.fetchFirst(
                     filters = filters(relayA, relayB),
-                    timeoutMs = 300,
+                    idleTimeoutMs = 300,
                 )
             chatter.cancel()
             assertNull(result)
@@ -160,7 +161,7 @@ class FetchFirstIdleTimeoutTest {
             val result =
                 client.fetchFirst(
                     filters = filters(relayA),
-                    timeoutMs = 300,
+                    idleTimeoutMs = 300,
                 )
             assertEquals(event(7).id, result?.id, "an event racing the final EOSE must not be dropped")
         }
@@ -180,7 +181,7 @@ class FetchFirstIdleTimeoutTest {
             // is the wall-clock bound, and costs nothing because a timed-out
             // fetchFirst yields null either way.
             val start = currentTime
-            val result = withTimeoutOrNull(120) { client.fetchFirst(filters = filters(relayA, relayB), timeoutMs = 10_000) }
+            val result = withTimeoutOrNull(120) { client.fetchFirst(filters = filters(relayA, relayB), idleTimeoutMs = 10_000) }
             chatter.cancel()
             assertNull(result)
             assertEquals(120L, currentTime - start, "the caller's timeout bounds the call")

--- a/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/NostrClientFetchAllPagesIdleTimeoutTest.kt
+++ b/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/NostrClientFetchAllPagesIdleTimeoutTest.kt
@@ -31,8 +31,10 @@ import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.TimeSource
 
@@ -49,7 +51,10 @@ import kotlin.time.TimeSource
 class NostrClientFetchAllPagesIdleTimeoutTest {
     /** Captures the subscription listener so the test can play a relay. */
     private class ScriptedClient : INostrClient by EmptyNostrClient() {
+        @Volatile
         var listener: SubscriptionListener? = null
+
+        @Volatile
         var subscribeCount = 0
 
         override fun subscribe(
@@ -64,16 +69,18 @@ class NostrClientFetchAllPagesIdleTimeoutTest {
 
     private val relay = RelayUrlNormalizer.normalize("wss://slow.example.com")
 
-    private fun event(i: Int) =
-        Event(
-            id = i.toString(16).padStart(64, '0'),
-            pubKey = "f".repeat(64),
-            createdAt = i.toLong(),
-            kind = 1,
-            tags = emptyArray(),
-            content = "e$i",
-            sig = "0".repeat(128),
-        )
+    private fun event(
+        i: Int,
+        createdAt: Long = i.toLong(),
+    ) = Event(
+        id = i.toString(16).padStart(64, '0'),
+        pubKey = "f".repeat(64),
+        createdAt = createdAt,
+        kind = 1,
+        tags = emptyArray(),
+        content = "e$i",
+        sig = "0".repeat(128),
+    )
 
     @Test
     fun streamingPageOutlivesTheIdleWindow() =
@@ -141,5 +148,44 @@ class NostrClientFetchAllPagesIdleTimeoutTest {
             assertEquals(2, total, "events delivered before the stall are kept")
             assertTrue(elapsedMs >= 300, "must wait out at least one idle window, took ${elapsedMs}ms")
             assertTrue(elapsedMs < 5_000, "a stalled page must end promptly after the idle window, took ${elapsedMs}ms")
+        }
+
+    /**
+     * Documents why [fetchAllPages] has no wall-clock ceiling, unlike the
+     * single-wait accessories (`fetchAll`/`fetchFirst`/`count`, whose `maxTotalMs`
+     * really does end the call).
+     *
+     * A per-page ceiling cannot bound this walk: when a page ends, the loop advances
+     * the cursor and fires the NEXT `REQ`, so an endless trickle against an unbounded
+     * filter is merely re-paged. This pins that reality — the walk runs until the
+     * caller cancels — so nobody re-adds a `maxPageMs` believing it caps anything.
+     * What actually bounds a download is the filter's `limit`.
+     */
+    @Test
+    fun anEndlessTrickleIsBoundedByCancellationNotByAWallClock() =
+        runBlocking {
+            val client = ScriptedClient()
+            var ts = 10_000_000L
+            var i = 1
+            val feeder =
+                launch {
+                    // Trickles forever, strictly decreasing created_at, never EOSE.
+                    while (true) {
+                        delay(40)
+                        client.listener?.onEvent(event(i++, ts--), false, relay, null)
+                    }
+                }
+
+            val returned =
+                withTimeoutOrNull(1_500) {
+                    client.fetchAllPages(
+                        relay = relay,
+                        filters = listOf(Filter(kinds = listOf(1))), // unbounded: no limit
+                        timeoutMs = 200,
+                    ) { }
+                }
+            feeder.cancel()
+
+            assertNull(returned, "an unbounded filter against an endless trickle ends only by cancellation")
         }
 }

--- a/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/NostrClientFetchAllPagesIdleTimeoutTest.kt
+++ b/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/NostrClientFetchAllPagesIdleTimeoutTest.kt
@@ -40,7 +40,7 @@ import kotlin.time.TimeSource
 
 /**
  * Pins [fetchAllPages]'s timeout to the package-wide idle-window convention:
- * `timeoutMs` is silence measured from the relay's MOST RECENT message, not a
+ * `idleTimeoutMs` is silence measured from the relay's MOST RECENT message, not a
  * wall-clock deadline for the page. A relay that keeps streaming — however
  * slowly — must never have a page cropped mid-delivery.
  *
@@ -106,7 +106,7 @@ class NostrClientFetchAllPagesIdleTimeoutTest {
                 client.fetchAllPages(
                     relay = relay,
                     filters = listOf(Filter(kinds = listOf(1), limit = 6)),
-                    timeoutMs = 500,
+                    idleTimeoutMs = 500,
                     onNewPage = { pages++ },
                 ) { got.add(it) }
             feeder.join()
@@ -140,7 +140,7 @@ class NostrClientFetchAllPagesIdleTimeoutTest {
                 client.fetchAllPages(
                     relay = relay,
                     filters = listOf(Filter(kinds = listOf(1), limit = 3)),
-                    timeoutMs = 300,
+                    idleTimeoutMs = 300,
                 ) { got.add(it) }
             feeder.join()
             val elapsedMs = start.elapsedNow().inWholeMilliseconds
@@ -151,9 +151,8 @@ class NostrClientFetchAllPagesIdleTimeoutTest {
         }
 
     /**
-     * Documents why [fetchAllPages] has no wall-clock ceiling, unlike the
-     * single-wait accessories (`fetchAll`/`fetchFirst`/`count`, whose `maxTotalMs`
-     * really does end the call).
+     * Documents why [fetchAllPages] has no wall-clock ceiling — nor should any
+     * accessory: a hard bound composes at the call site as `withTimeoutOrNull`.
      *
      * A per-page ceiling cannot bound this walk: when a page ends, the loop advances
      * the cursor and fires the NEXT `REQ`, so an endless trickle against an unbounded
@@ -181,7 +180,7 @@ class NostrClientFetchAllPagesIdleTimeoutTest {
                     client.fetchAllPages(
                         relay = relay,
                         filters = listOf(Filter(kinds = listOf(1))), // unbounded: no limit
-                        timeoutMs = 200,
+                        idleTimeoutMs = 200,
                     ) { }
                 }
             feeder.cancel()

--- a/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/NostrClientFetchAllPagesIdleTimeoutTest.kt
+++ b/quartz/src/jvmAndroidTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/NostrClientFetchAllPagesIdleTimeoutTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.relay
+
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.relay.client.EmptyNostrClient
+import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
+import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.fetchAllPages
+import com.vitorpamplona.quartz.nip01Core.relay.client.reqs.SubscriptionListener
+import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.TimeSource
+
+/**
+ * Pins [fetchAllPages]'s timeout to the package-wide idle-window convention:
+ * `timeoutMs` is silence measured from the relay's MOST RECENT message, not a
+ * wall-clock deadline for the page. A relay that keeps streaming — however
+ * slowly — must never have a page cropped mid-delivery.
+ *
+ * Real-clock ([runBlocking]) on purpose: the page watchdog is a monotonic
+ * `IdleClock` bumped from the socket reader thread, which virtual time can't
+ * exercise.
+ */
+class NostrClientFetchAllPagesIdleTimeoutTest {
+    /** Captures the subscription listener so the test can play a relay. */
+    private class ScriptedClient : INostrClient by EmptyNostrClient() {
+        var listener: SubscriptionListener? = null
+        var subscribeCount = 0
+
+        override fun subscribe(
+            subId: String,
+            filters: Map<NormalizedRelayUrl, List<Filter>>,
+            listener: SubscriptionListener?,
+        ) {
+            subscribeCount++
+            this.listener = listener
+        }
+    }
+
+    private val relay = RelayUrlNormalizer.normalize("wss://slow.example.com")
+
+    private fun event(i: Int) =
+        Event(
+            id = i.toString(16).padStart(64, '0'),
+            pubKey = "f".repeat(64),
+            createdAt = i.toLong(),
+            kind = 1,
+            tags = emptyArray(),
+            content = "e$i",
+            sig = "0".repeat(128),
+        )
+
+    @Test
+    fun streamingPageOutlivesTheIdleWindow() =
+        runBlocking {
+            val client = ScriptedClient()
+            val feeder =
+                launch {
+                    // 6 events, each arriving 150ms apart — every gap is under the
+                    // 500ms idle window, but the whole page (~950ms) far exceeds it.
+                    // The old hard per-page deadline truncated this mid-stream and
+                    // re-subscribed for another page; the idle window must not.
+                    repeat(6) { i ->
+                        delay(150)
+                        client.listener!!.onEvent(event(i + 1), false, relay, null)
+                    }
+                    delay(50)
+                    client.listener!!.onEose(relay, null)
+                }
+
+            var pages = 0
+            val got = mutableListOf<Event>()
+            val total =
+                client.fetchAllPages(
+                    relay = relay,
+                    filters = listOf(Filter(kinds = listOf(1), limit = 6)),
+                    timeoutMs = 500,
+                    onNewPage = { pages++ },
+                ) { got.add(it) }
+            feeder.join()
+
+            assertEquals(6, total, "a slowly-but-actively streaming page must never be cropped")
+            assertEquals(6, got.size)
+            assertEquals(1, client.subscribeCount, "the whole stream must arrive in ONE page — a hard deadline would truncate and re-subscribe")
+            assertEquals(0, pages, "no pagination should be needed")
+        }
+
+    @Test
+    fun silentRelayGivesUpOneIdleWindowAfterItsLastMessage() =
+        runBlocking {
+            val client = ScriptedClient()
+            val feeder =
+                launch {
+                    // Two quick events, then the relay goes quiet without EOSE: the
+                    // page must end ~one idle window after the LAST message.
+                    delay(50)
+                    client.listener!!.onEvent(event(1), false, relay, null)
+                    delay(50)
+                    client.listener!!.onEvent(event(2), false, relay, null)
+                }
+
+            val start = TimeSource.Monotonic.markNow()
+            val got = mutableListOf<Event>()
+            // limit = 3 keeps the filter unfulfilled, so only the stall can end the
+            // page; the events already delivered are kept and, since nothing older
+            // followed, the next page comes back empty and the walk terminates.
+            val total =
+                client.fetchAllPages(
+                    relay = relay,
+                    filters = listOf(Filter(kinds = listOf(1), limit = 3)),
+                    timeoutMs = 300,
+                ) { got.add(it) }
+            feeder.join()
+            val elapsedMs = start.elapsedNow().inWholeMilliseconds
+
+            assertEquals(2, total, "events delivered before the stall are kept")
+            assertTrue(elapsedMs >= 300, "must wait out at least one idle window, took ${elapsedMs}ms")
+            assertTrue(elapsedMs < 5_000, "a stalled page must end promptly after the idle window, took ${elapsedMs}ms")
+        }
+}

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/prodbench/BulkDownloadBenchmark.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/prodbench/BulkDownloadBenchmark.kt
@@ -141,7 +141,7 @@ class BulkDownloadBenchmark {
                             client.fetchAllPages(
                                 relay = relayUrl,
                                 filters = listOf(Filter(kinds = listOf(1), since = lo, until = hi)),
-                                timeoutMs = LOCAL_PAGE_TIMEOUT_MS,
+                                idleTimeoutMs = LOCAL_PAGE_TIMEOUT_MS,
                             ) { event ->
                                 count.incrementAndGet()
                                 bytes.addAndGet(event.content.length.toLong())
@@ -376,7 +376,7 @@ class BulkDownloadBenchmark {
                 client.fetchAllPages(
                     relay = relay,
                     filters = listOf(Filter(kinds = listOf(PROD_KIND), limit = PROD_MAX_EVENTS)),
-                    timeoutMs = 30_000L,
+                    idleTimeoutMs = 30_000L,
                     onNewPage = { pages++ },
                 ) { event ->
                     count.incrementAndGet()
@@ -672,7 +672,7 @@ class BulkDownloadBenchmark {
                 client.fetchAllPages(
                     relay = relay,
                     filters = listOf(Filter(kinds = listOf(PROD_KIND), limit = PROD_MAX_EVENTS)),
-                    timeoutMs = 30_000L,
+                    idleTimeoutMs = 30_000L,
                     onNewPage = { pages++ },
                 ) { event ->
                     count.incrementAndGet()

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/prodbench/ByIdFetchBenchmark.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/prodbench/ByIdFetchBenchmark.kt
@@ -280,7 +280,7 @@ class ByIdFetchBenchmark {
             client.fetchAllPages(
                 relay = relay,
                 filters = listOf(Filter(kinds = listOf(KIND))),
-                timeoutMs = ENUM_PAGE_TIMEOUT_MS,
+                idleTimeoutMs = ENUM_PAGE_TIMEOUT_MS,
             ) { event -> ids.add(event.id) }
             println("  enumerated ${ids.size} ids in %.1fs (paged, untimed baseline for the matrix)".format((System.nanoTime() - t) / 1e9))
             ids.toList()


### PR DESCRIPTION
## Summary

The relay-client accessories disagreed about what their timeout meant. `fetchAllPages` treated `timeoutMs` as a **hard per-page deadline**, while `fetchAll`, `fetchAllWithHooks` and the negentropy sync treated it as an **idle window** reset by every arriving message. This normalizes all of them to one rule — an idle window measured from the relay's most recent *progress* — and renames the parameter to `idleTimeoutMs` so the contract is visible at the call site rather than only in the KDoc.

This is a behaviour fix first and a rename second: under the old code a relay that was actively streaming a large page got cut off mid-delivery, and a relay slower than `timeoutMs` to send its first event was indistinguishable from a drained result set.

## What actually changed

**Bug: `fetchAllPages` truncated actively-streaming pages.** Its wait was `withTimeoutOrNull(timeoutMs) { doneChannel.receive() }`, and `doneChannel` only ever receives on EOSE/CLOSED/cannot-connect — events flowed through a separate listener callback and never pushed the deadline out. So the clock ran from `subscribe()` regardless of how much data was in flight. On timeout the loop advanced `until` to the oldest event seen and re-queried, silently dropping the rest of that page's window. A first page that timed out produced `received == 0`, which the loop reads as "drained" and terminates on — reporting success.

**Bug: chatter kept `fetchFirst` / `count` alive indefinitely.** Any arriving signal restarted the idle window, including a terminal signal from a relay already accounted for. One relay in a CLOSED/reconnect loop plus one silent relay meant the call never returned. Both now restart the window only on genuine progress — an event, or a relay's *first* terminal signal. This is the rule the negentropy watchdog already documents for `NOTICE`/`CLOSED` chatter. It also makes both calls self-bounding at one window per relay.

**Bug: `fetchFirst` could drop a match.** An event arriving after the last terminal signal but before `unsubscribe` was left unread in the channel and the fetch reported nothing found. Added the post-loop drain `fetchAllWithHooks` already had.

**Bug: `count(filters)` leaked its connection listener.** Cleanup ran without `try`/`finally`, unlike every sibling accessory, so a cancelled caller left the listener attached and the COUNT subscriptions open. It could also lose a result that arrived after the last window closed, understating the returned map.

**Bug: unsynchronized publication in `fetchAllPages`.** `received` / `delivered` / `pageMinTs` / `idsAtPageMin` are written on the relay's reader thread and read by the driver coroutine when the wait ends. The EOSE path gets happens-before from the channel; the idle path had none, so the driver could read a stale `pageMinTs` (ending the walk early) or an unsafely published `HashSet`. The volatile `IdleClock` bump now runs in a `finally`, covering every event — including the early-returning duplicate — and ordering after the counters.

**Perf: per-event iterator allocation.** `fetchAllPages` matched each event with `for ((i, f) in activeFilters)`. That destructuring form allocates an `Iterator` per event, on the reader thread, for the whole download — millions of short-lived objects in a bulk walk. Now an indexed loop, for the same reason quartz uses the `fast*` operators in hot event paths (those only cover `Array`, so a `List` needs the index form).

**No accessory takes a wall-clock ceiling parameter.** Two were added during this work and both were removed after review:

- `maxPageMs` on `fetchAllPages` bounded nothing. The wait sits inside `while (true)`; when a page ends the loop advances the cursor and fires the next `REQ`, so an endless trickle is merely re-paged. Measured against a relay trickling forever with an unbounded filter, `maxPageMs = 400` produced **8 `REQ`s and no return**. It also made truncation unsafe, since cutting a page mid-stream advances `until` to the oldest event received *so far* — only correct if the relay streams strictly newest-first, which NIP-01 recommends but does not require.
- `maxTotalMs` on `fetchFirst` / `count` duplicated what the caller already has: `withTimeoutOrNull(ms) { fetchFirst(...) }`. The idle window belongs inside (the caller cannot implement it — it needs the message stream); the wall clock belongs outside.

`fetchAll` / `fetchAllWithHooks` keep their **pre-existing** `maxTotalMs`, which does earn its place: an endless *event* trickle there is genuine progress, so the call never self-terminates, and the internal cap returns the events collected so far where an external timeout would discard them.

**Shared primitive.** `IdleClock` + `receiveWithinIdle` moved out of `NostrClientNegentropySyncExt` (where they were `private`) into `IdleWatchdog.kt`, and the convention is written down in the accessories `README.md`.

## Behaviour change to review

`NegentropyStoreSync` passed `config.idleTimeoutMs` straight into `fetchAllPages`. With the watchdog deliberately disabled (`idleTimeoutMs = 0`) that fed `0` into what was then a hard deadline, so **every page timed out instantly**. It now clamps to `DEFAULT_DOWNLOAD_IDLE_MS`, matching what `fetchByIds` already does. Worth confirming no caller relied on the old behaviour.

## Breaking change

The rename is **source-breaking for named-argument callers** of quartz. Positional callers are unaffected. All in-repo call sites are updated (`amethyst/`, `desktopApp/`, `cli/`, `commons/`, `geode/`). If external consumers matter here, deprecated `timeoutMs` overloads delegating to the new names would avoid the break — happy to add them.

Deliberately **not** renamed, because these are genuine wall-clock bounds and the differing name is the tell: `publishAndConfirm`'s `timeoutInSeconds` (one fixed window to collect the `OK`s), `GrapeRankCrawler.Config.timeoutMs` (a hard per-drain gate that also drives parking), and `Context.awaitReply`'s `timeoutMs`.

## Test plan

### Feature test plan

New tests, each written to fail against the old behaviour before the fix:

- `NostrClientFetchAllPagesIdleTimeoutTest` (real clock — the page watchdog is a monotonic `IdleClock` bumped from the socket reader thread, which virtual time can't exercise):
  - a page streaming 6 events at 150 ms gaps against a 500 ms window arrives as **one** un-truncated `REQ` (verified to fail against the old hard deadline, which truncated and re-subscribed);
  - a relay that goes silent gives up one window after its **last** message, not from page start;
  - an endless trickle against an unbounded filter is bounded by cancellation, not a wall clock — this one exists specifically to stop a `maxPageMs` being re-added on the belief that it caps the walk.
- `FetchFirstIdleTimeoutTest` (virtual time): genuine progress restarts the window; total silence returns `null` after exactly one window; repeat chatter does **not** restart it; an event racing the final EOSE is still returned; a hard bound composes at the call site.

### Regression test plan

- `./gradlew :quartz:jvmTest` — **3845 tests, 0 failures**, including the pre-existing paging, pool, negentropy sync/reconcile/fan-out, count, `fetchFirst` and `PoolRequestsConcurrency` suites that cover these accessories.
- One pre-existing test needed rewriting rather than fixing: `FetchFirstIdleTimeoutTest.arrivingSignalsRestartTheIdleWindow` encoded the old "any signal restarts the window" behaviour using repeat CLOSEDs from one relay. That is exactly the chatter this PR stops honouring, so the premise was wrong, not the code — it now drives progress from four distinct relays.
- Compile checked across every module and both Android flavours under `--rerun-tasks`, after a stale Gradle `UP-TO-DATE` and a flavour-specific source set (`amethyst/src/play/`) each hid a real breakage from an earlier check.
- Both flavours build to APK (per `CONTRIBUTING-WITH-AI.md` § *Build and install both flavours*):

```
$ ./gradlew :amethyst:assembleFdroidDebug :amethyst:assemblePlayDebug
> Task :amethyst:assembleFdroidDebug
> Task :amethyst:assemblePlayDebug

BUILD SUCCESSFUL in 4m 5s
179 actionable tasks: 56 executed, 3 from cache, 120 up-to-date
```

  (`install*Debug` needs an attached device; none available in this environment, so `assemble*` is as far as it goes here.)

Honest gaps, since CI will not cover them:

- **Not manually exercised on a device or emulator** — none available in this environment. The diff is a protocol/plumbing refactor in `quartz/` plus mechanical call-site renames, with no UI change.
- **Full `./gradlew test` across all modules was not completed** — the `commons` / `geode` suites exceeded my run budget. `:quartz:jvmTest` is complete and green.
- **`:amethyst:installPlayBenchmark` (R8-minified) not run.** The change touches no reflection, serialization, or `ViewModelProvider.Factory` path, so the usual missing-keep-rule failure mode does not apply here.

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests) — `:quartz:jvmTest` green (3845/3845); full multi-module `test` not completed, see above
- [ ] Manually exercised the change — not possible in this environment, see above

## Interop suites

Not run, and **not** claimable as N/A: the renamed call sites include `KeyPackageFetcher` (Marmot/MLS) and `DmInboxRelayResolver` (NIP-17 DM), and while those edits are rename-only, the timeout semantics *underneath* them changed. A maintainer with the harness should run the two suites below before merge.

- [ ] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes
- [ ] Marmot / MLS — `cli/tests/marmot/marmot-interop-headless.sh` (NIP-EE / `whitenoise-rs`)
- [ ] NIP-17 DM — `cli/tests/dm/dm-interop-headless.sh`
- [ ] Audio rooms manual — `cli/tests/nests/nests-interop.sh` (Amethyst ↔ nostrnests.com)
- [ ] MoQ-lite hang-tier — `:nestsClient:jvmTest -DnestsHangInterop=true`
- [ ] MoQ-lite browser-tier — `:nestsClient:jvmTest -DnestsBrowserInterop=true`
- [ ] QUIC interop-runner — `quic/interop/run-matrix.sh -s {aioquic,picoquic,quic-go,quinn}`

No wire-format change: no new event kind, tag form, or NIP interpretation. Only client-side timing and parameter naming.

## AI assistance

Drafted by Claude Code in a single session, with the design corrected twice under maintainer review — `maxPageMs` and then the remaining ceiling parameters were both challenged and removed, which is what led to the progress-vs-chatter rule. Automated tests were written and run as described above; **human review and on-device testing are still pending**, so the "manually reviewed and tested" box is deliberately left unticked.

- [ ] Drafted with AI assistance, manually reviewed and tested
- [ ] Written by hand

## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.

No new third-party dependencies are introduced by this PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZe1Pq2ejoHehdufhPDRgb