### PR TITLE
nip50Search: search grammar + weighted field extraction; nip01Core: shared store-semantics rules

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/cache/projection/EventStoreProjection.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/cache/projection/EventStoreProjection.kt
@@ -25,12 +25,13 @@ import com.vitorpamplona.quartz.nip01Core.core.AddressableEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.isReplaceable
+import com.vitorpamplona.quartz.nip01Core.core.supersedes
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.store.ObservableEventStore
 import com.vitorpamplona.quartz.nip01Core.store.ObservableEventStore.StoreChange
+import com.vitorpamplona.quartz.nip01Core.store.owner
 import com.vitorpamplona.quartz.nip09Deletions.DeletionEvent
 import com.vitorpamplona.quartz.nip40Expiration.isExpirationBefore
-import com.vitorpamplona.quartz.nip59Giftwrap.wraps.GiftWrapEvent
 import com.vitorpamplona.quartz.nip62RequestToVanish.RequestToVanishEvent
 import com.vitorpamplona.quartz.utils.SortedList
 import com.vitorpamplona.quartz.utils.TimeUtils
@@ -342,19 +343,14 @@ class EventStoreProjection<T : Event>(
         private fun supersedes(
             new: Event,
             existing: Event,
-        ): Boolean =
-            when {
-                new.createdAt > existing.createdAt -> true
-                new.createdAt < existing.createdAt -> false
-                else -> new.id < existing.id
-            }
+        ): Boolean = new.supersedes(existing)
 
         /**
          * Owner pubkey for ownership checks (NIP-09 author match,
          * NIP-62 vanish target). For GiftWrap the owner is the p-tag
          * recipient; for everything else it's `event.pubKey`.
          */
-        private fun ownerOf(event: Event): HexKey = (event as? GiftWrapEvent)?.recipientPubKey() ?: event.pubKey
+        private fun ownerOf(event: Event): HexKey = event.owner()
 
         /**
          * created_at DESC, id ASC. Sort keys are frozen at slot

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/core/ReplaceableSupersession.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/core/ReplaceableSupersession.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.core
+
+/**
+ * The NIP-01 replaceable/addressable supersession rule: the winner of an
+ * address is the highest `created_at`, with ties broken by the LEXICALLY
+ * SMALLEST id. True when THIS event beats [existing] — equal events (same id)
+ * do not supersede themselves. One rule, shared by every store; the SQLite
+ * triggers encode the same comparison in SQL.
+ */
+fun Event.supersedes(existing: Event): Boolean =
+    when {
+        createdAt > existing.createdAt -> true
+        createdAt < existing.createdAt -> false
+        else -> id < existing.id
+    }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/filters/FilterIndex.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/filters/FilterIndex.kt
@@ -22,6 +22,7 @@ package com.vitorpamplona.quartz.nip01Core.relay.filters
 
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.tags.isIndexableTagName
 import kotlinx.collections.immutable.PersistentMap
 import kotlinx.collections.immutable.PersistentSet
 import kotlinx.collections.immutable.persistentHashMapOf
@@ -238,7 +239,7 @@ class FilterIndex<S : Any> {
         s.kinds[event.kind]?.let { result.addAll(it) }
         if (s.tags.isNotEmpty()) {
             for (tag in event.tags) {
-                if (tag.size >= 2 && tag[0].length == 1) {
+                if (tag.size >= 2 && isIndexableTagName(tag[0])) {
                     s.tags[tag[0]]?.get(tag[1])?.let { result.addAll(it) }
                 }
             }
@@ -348,14 +349,14 @@ class FilterIndex<S : Any> {
         if (!filter.tags.isNullOrEmpty()) {
             val first =
                 filter.tags.entries.firstOrNull {
-                    it.key.length == 1 && it.value.isNotEmpty()
+                    isIndexableTagName(it.key) && it.value.isNotEmpty()
                 }
             if (first != null) return first.value.map { TagKey(first.key, it) }
         }
         if (!filter.tagsAll.isNullOrEmpty()) {
             val first =
                 filter.tagsAll.entries.firstOrNull {
-                    it.key.length == 1 && it.value.isNotEmpty()
+                    isIndexableTagName(it.key) && it.value.isNotEmpty()
                 }
             if (first != null) return first.value.map { TagKey(first.key, it) }
         }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/server/backend/IngestQueue.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/server/backend/IngestQueue.kt
@@ -22,6 +22,7 @@ package com.vitorpamplona.quartz.nip01Core.relay.server.backend
 
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.store.IEventStore
+import com.vitorpamplona.quartz.nip01Core.store.RejectionReason
 import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -292,7 +293,7 @@ class IngestQueue(
                     store.batchInsert(toInsert)
                 } catch (e: Throwable) {
                     Log.w("IngestQueue") { "batchInsert failed for ${toInsert.size} events: ${e.message}" }
-                    val reason = e.message ?: e::class.simpleName ?: "insert failed"
+                    val reason = e.message ?: e::class.simpleName ?: RejectionReason.INSERT_FAILED
                     List(toInsert.size) { IEventStore.InsertOutcome.Rejected(reason) }
                 }
             }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/EventOwner.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/EventOwner.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.store
+
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip59Giftwrap.wraps.GiftWrapEvent
+
+/**
+ * The pubkey that CONTROLS this event for ownership checks — NIP-09 deletion
+ * authority and NIP-62 vanish targeting. A gift wrap (kind 1059) is signed by
+ * a random one-time key, so control belongs to its p-tag RECIPIENT (the
+ * recipient deletes the wraps addressed to them); every other event is
+ * controlled by its author. One rule, shared by every store — do not re-derive
+ * it inline.
+ */
+fun Event.owner(): HexKey = (this as? GiftWrapEvent)?.recipientPubKey() ?: pubKey

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/IEventStore.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/IEventStore.kt
@@ -122,7 +122,7 @@ interface IEventStore : AutoCloseable {
                 insert(event)
                 InsertOutcome.Accepted
             } catch (e: Throwable) {
-                InsertOutcome.Rejected(e.message ?: e::class.simpleName ?: "insert failed")
+                InsertOutcome.Rejected(e.message ?: e::class.simpleName ?: RejectionReason.INSERT_FAILED)
             }
         }
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/ObservableEventStore.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/ObservableEventStore.kt
@@ -114,7 +114,7 @@ class ObservableEventStore(
             if (event.kind.isEphemeral()) {
                 outcomes[i] =
                     if (event.isExpired()) {
-                        IEventStore.InsertOutcome.Rejected("blocked: Cannot insert an expired event")
+                        IEventStore.InsertOutcome.Rejected(RejectionReason.EXPIRED)
                     } else {
                         IEventStore.InsertOutcome.Accepted
                     }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/RejectionReason.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/RejectionReason.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.store
+
+/**
+ * The machine-readable insert-rejection vocabulary, shared by every
+ * [IEventStore] implementation so the same condition always rejects with the
+ * same words — a caller tallying [IEventStore.InsertOutcome.Rejected] reasons,
+ * or a relay building `OK false` frames, must never see two stores spell
+ * "duplicate" differently.
+ *
+ * NIP-01: an `OK false` message SHOULD begin with a single-word
+ * machine-readable prefix followed by `:`. The `PREFIX_*` constants are that
+ * vocabulary; the full-sentence constants are the standard reasons the
+ * built-in stores emit. `replaced:` is not in NIP-01 but is the de-facto
+ * prefix (strfry and others) for a replaceable event that lost to a stored
+ * newer version — distinct from `duplicate:` (the exact event is already
+ * held).
+ */
+object RejectionReason {
+    // The NIP-01 machine-readable prefixes.
+    const val PREFIX_DUPLICATE = "duplicate:"
+    const val PREFIX_POW = "pow:"
+    const val PREFIX_BLOCKED = "blocked:"
+    const val PREFIX_RATE_LIMITED = "rate-limited:"
+    const val PREFIX_INVALID = "invalid:"
+    const val PREFIX_RESTRICTED = "restricted:"
+    const val PREFIX_ERROR = "error:"
+
+    /** De-facto prefix (not in NIP-01) for a stale version of a replaceable/addressable event. */
+    const val PREFIX_REPLACED = "replaced:"
+
+    // The standard store reasons.
+    const val DUPLICATE = "duplicate: already have this event"
+    const val EXPIRED = "blocked: Cannot insert an expired event"
+    const val DELETED = "blocked: a deletion event exists"
+    const val VANISHED = "blocked: a request to vanish event exists"
+    const val REPLACED = "replaced: a newer version exists"
+    const val INSERT_FAILED = "error: insert failed"
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/RejectionReason.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/RejectionReason.kt
@@ -28,24 +28,20 @@ package com.vitorpamplona.quartz.nip01Core.store
  * "duplicate" differently.
  *
  * NIP-01: an `OK false` message SHOULD begin with a single-word
- * machine-readable prefix followed by `:`. The `PREFIX_*` constants are that
- * vocabulary; the full-sentence constants are the standard reasons the
- * built-in stores emit. `replaced:` is not in NIP-01 but is the de-facto
- * prefix (strfry and others) for a replaceable event that lost to a stored
- * newer version — distinct from `duplicate:` (the exact event is already
- * held).
+ * machine-readable prefix followed by `:`. The full-sentence constants here
+ * are the standard reasons the built-in stores emit. `replaced:` is not in
+ * NIP-01 but is the de-facto prefix (strfry and others) for a replaceable
+ * event that lost to a stored newer version — distinct from `duplicate:`
+ * (the exact event is already held).
  */
 object RejectionReason {
-    // The NIP-01 machine-readable prefixes.
-    const val PREFIX_DUPLICATE = "duplicate:"
-    const val PREFIX_POW = "pow:"
-    const val PREFIX_BLOCKED = "blocked:"
-    const val PREFIX_RATE_LIMITED = "rate-limited:"
-    const val PREFIX_INVALID = "invalid:"
-    const val PREFIX_RESTRICTED = "restricted:"
-    const val PREFIX_ERROR = "error:"
-
-    /** De-facto prefix (not in NIP-01) for a stale version of a replaceable/addressable event. */
+    /**
+     * The NIP-01 prefix vocabulary itself lives in
+     * [com.vitorpamplona.quartz.nip01Core.relay.commands.toClient.MachineReadablePrefix]
+     * — use its `format`/`parse` instead of hand-writing prefixes. The one
+     * prefix that enum lacks is the de-facto (not in NIP-01) word for a stale
+     * version of a replaceable/addressable event:
+     */
     const val PREFIX_REPLACED = "replaced:"
 
     // The standard store reasons.

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/EventIndexesModule.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/EventIndexesModule.kt
@@ -25,7 +25,7 @@ import com.vitorpamplona.quartz.nip01Core.core.AddressSerializer
 import com.vitorpamplona.quartz.nip01Core.core.AddressableEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.OptimizedJsonMapper
-import com.vitorpamplona.quartz.nip59Giftwrap.wraps.GiftWrapEvent
+import com.vitorpamplona.quartz.nip01Core.store.owner
 
 class EventIndexesModule(
     val hasher: (db: SQLiteConnection) -> TagNameValueHasher,
@@ -206,12 +206,8 @@ class EventIndexesModule(
         val kindLong = event.kind.toLong()
         val pubkeyHash = hasher.hash(event.pubKey)
 
-        val eventOwnerHash =
-            if (event is GiftWrapEvent) {
-                event.recipientPubKey()?.let { hasher.hash(it) } ?: pubkeyHash
-            } else {
-                pubkeyHash
-            }
+        val ownerKey = event.owner()
+        val eventOwnerHash = if (ownerKey == event.pubKey) pubkeyHash else hasher.hash(ownerKey)
 
         val eTagHash = hasher.hashETag(event.id)
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/ExpirationModule.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/ExpirationModule.kt
@@ -22,6 +22,7 @@ package com.vitorpamplona.quartz.nip01Core.store.sqlite
 
 import androidx.sqlite.SQLiteConnection
 import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.store.RejectionReason
 import com.vitorpamplona.quartz.nip40Expiration.expiration
 
 class ExpirationModule : IModule {
@@ -44,7 +45,7 @@ class ExpirationModule : IModule {
             FOR EACH ROW
             BEGIN
                 -- Check for existing newer record
-                SELECT RAISE(ABORT, 'blocked: this event is expired')
+                SELECT RAISE(ABORT, '${RejectionReason.EXPIRED}')
                 WHERE NEW.expiration <= unixepoch();
             END;
             """.trimIndent(),

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/IndexingStrategy.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/IndexingStrategy.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.quartz.nip01Core.store.sqlite
 
 import com.vitorpamplona.quartz.nip01Core.core.Tag
+import com.vitorpamplona.quartz.nip01Core.tags.isIndexableTagName
 
 interface IndexingStrategy {
     /**
@@ -165,5 +166,5 @@ class DefaultIndexingStrategy(
     override fun shouldIndex(
         kind: Int,
         tag: Tag,
-    ) = tag.size >= 2 && tag[0].length == 1
+    ) = tag.size >= 2 && isIndexableTagName(tag[0])
 }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/SQLiteEventStore.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/SQLiteEventStore.kt
@@ -37,6 +37,7 @@ import com.vitorpamplona.quartz.nip01Core.store.FtsReindexProgress
 import com.vitorpamplona.quartz.nip01Core.store.IEventStore
 import com.vitorpamplona.quartz.nip01Core.store.IdAndTime
 import com.vitorpamplona.quartz.nip01Core.store.RawEvent
+import com.vitorpamplona.quartz.nip01Core.store.RejectionReason
 import com.vitorpamplona.quartz.nip09Deletions.DeletionEvent
 import com.vitorpamplona.quartz.nip40Expiration.isExpired
 import com.vitorpamplona.quartz.nip50Search.strippingSearchExtensions
@@ -433,7 +434,7 @@ class SQLiteEventStore(
     }
 
     suspend fun insertEvent(event: Event) {
-        if (event.isExpired()) throw SQLiteException("blocked: Cannot insert an expired event")
+        if (event.isExpired()) throw SQLiteException(RejectionReason.EXPIRED)
         if (event.kind.isEphemeral()) return
 
         pool.useWriter { db ->
@@ -489,7 +490,7 @@ class SQLiteEventStore(
         delta: LiveIndexDelta?,
     ): IEventStore.InsertOutcome {
         if (event.isExpired()) {
-            return IEventStore.InsertOutcome.Rejected("blocked: Cannot insert an expired event")
+            return IEventStore.InsertOutcome.Rejected(RejectionReason.EXPIRED)
         }
         if (event.kind.isEphemeral()) return IEventStore.InsertOutcome.Accepted
 
@@ -509,7 +510,7 @@ class SQLiteEventStore(
             // ROLLBACK shouldn't mask the original cause.
             runCatching { db.execSQL("ROLLBACK TRANSACTION TO SAVEPOINT $sp") }
             runCatching { db.execSQL("RELEASE SAVEPOINT $sp") }
-            IEventStore.InsertOutcome.Rejected(e.message ?: e::class.simpleName ?: "insert failed")
+            IEventStore.InsertOutcome.Rejected(e.message ?: e::class.simpleName ?: RejectionReason.INSERT_FAILED)
         }
     }
 
@@ -518,7 +519,7 @@ class SQLiteEventStore(
         private val delta: LiveIndexDelta?,
     ) : IEventStore.ITransaction {
         override fun insert(event: Event) {
-            if (event.isExpired()) throw SQLiteException("blocked: Cannot insert an expired event")
+            if (event.isExpired()) throw SQLiteException(RejectionReason.EXPIRED)
             if (event.kind.isEphemeral()) return
 
             innerInsertEvent(event, db, delta)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/tags/IndexableTagName.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/tags/IndexableTagName.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.tags
+
+/**
+ * Whether [name] is a tag name the NIP-01 `#x` filter space can address: a
+ * single ASCII LETTER (`a`-`z` / `A`-`Z`), per NIP-01's "single-letter
+ * (a-zA-Z) English-alphabet letters". Deliberately stricter than
+ * `length == 1`: a `"5"` or `"#"` tag name is not filterable and indexing
+ * it would let stores disagree about which tags `#x` filters reach.
+ */
+fun isIndexableTagName(name: String): Boolean = name.length == 1 && (name[0] in 'a'..'z' || name[0] in 'A'..'Z')

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip50Search/IndexableFields.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip50Search/IndexableFields.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip50Search
+
+/**
+ * An event's searchable text decomposed by ROLE, for full-text backends that
+ * weight fields instead of indexing one concatenated blob
+ * ([SearchableEvent.indexableContent]'s flat form). Produced per kind by
+ * [SearchFieldExtractor].
+ *
+ * A kind is either PROFILE-shaped ([Profile] — kind-0-style identity: kind 0
+ * itself, app handlers) or CONTENT-shaped ([Tiered] — title above summary
+ * above body). The shape is part of the value, so a consumer discriminates on
+ * the type instead of keeping its own list of profile kinds. Both shapes
+ * carry a website role — a profile's homepage ([Profile.website]), or a
+ * content kind's affiliation URLs ([Tiered.websites]: repo, trackers,
+ * bookmarked page) — declared on each shape rather than the interface, so
+ * [None] answers no question that doesn't apply to it.
+ *
+ * Multi-valued roles are carried UNJOINED, as lists: which separator to use —
+ * or whether to index the values separately — is the backend's decision, and
+ * once values are pre-joined a backend can't unmix them. All strings are
+ * trimmed and non-empty.
+ */
+sealed interface IndexableFields {
+    fun isEmpty(): Boolean
+
+    /** No searchable text — the extraction result for non-searchable kinds. */
+    data object None : IndexableFields {
+        override fun isEmpty(): Boolean = true
+    }
+
+    /** Kind-0-shaped identity, each field in its own role. An all-null value means "profile-shaped kind, nothing indexable". */
+    data class Profile(
+        val name: String? = null,
+        val displayName: String? = null,
+        val about: String? = null,
+        val nip05: String? = null,
+        val lud16: String? = null,
+        val website: String? = null,
+    ) : IndexableFields {
+        override fun isEmpty(): Boolean = this == EMPTY
+
+        private companion object {
+            val EMPTY = Profile()
+        }
+    }
+
+    /**
+     * Content decomposed by priority tier: [primary] (title-like values),
+     * [secondary] (summary/description-like values), [text] (the body — the
+     * one inherently single-valued role), plus the raw [hashtags] and
+     * [locations] tag values.
+     */
+    data class Tiered(
+        val primary: List<String> = emptyList(),
+        val secondary: List<String> = emptyList(),
+        val text: String? = null,
+        val hashtags: List<String> = emptyList(),
+        val locations: List<String> = emptyList(),
+        val websites: List<String> = emptyList(),
+    ) : IndexableFields {
+        override fun isEmpty(): Boolean = this == EMPTY
+
+        private companion object {
+            val EMPTY = Tiered()
+        }
+    }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip50Search/IndexableFields.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip50Search/IndexableFields.kt
@@ -37,8 +37,9 @@ package com.vitorpamplona.quartz.nip50Search
  *
  * Multi-valued roles are carried UNJOINED, as lists: which separator to use —
  * or whether to index the values separately — is the backend's decision, and
- * once values are pre-joined a backend can't unmix them. All strings are
- * trimmed and non-empty.
+ * once values are pre-joined a backend can't unmix them. Values produced by
+ * [SearchFieldExtractor] are trimmed and non-empty; the types themselves do
+ * not enforce it.
  */
 sealed interface IndexableFields {
     fun isEmpty(): Boolean
@@ -48,7 +49,13 @@ sealed interface IndexableFields {
         override fun isEmpty(): Boolean = true
     }
 
-    /** Kind-0-shaped identity, each field in its own role. An all-null value means "profile-shaped kind, nothing indexable". */
+    /**
+     * Kind-0-shaped identity, each field in its own role. [SearchFieldExtractor]
+     * never RETURNS an empty Profile — extract() normalizes every empty shape
+     * to [None] — so an all-null value only exists mid-extraction or when
+     * hand-built. Note the equality trap for hand-built values: an empty
+     * shape isEmpty() but is not equal to [None].
+     */
     data class Profile(
         val name: String? = null,
         val displayName: String? = null,

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip50Search/SearchFieldExtractor.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip50Search/SearchFieldExtractor.kt
@@ -1,0 +1,486 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip50Search
+
+import com.vitorpamplona.quartz.buzz.agentProfiles.AgentProfileEvent
+import com.vitorpamplona.quartz.buzz.apPersonas.PersonaEvent
+import com.vitorpamplona.quartz.buzz.managedAgents.ManagedAgentEvent
+import com.vitorpamplona.quartz.buzz.teams.TeamEvent
+import com.vitorpamplona.quartz.buzz.workflow.WorkflowDefEvent
+import com.vitorpamplona.quartz.experimental.agora.FundraiserEvent
+import com.vitorpamplona.quartz.experimental.audio.track.AudioTrackEvent
+import com.vitorpamplona.quartz.experimental.fitness.workout.ExerciseTemplateEvent
+import com.vitorpamplona.quartz.experimental.fitness.workout.WorkoutRecordEvent
+import com.vitorpamplona.quartz.experimental.interactiveStories.InteractiveStoryBaseEvent
+import com.vitorpamplona.quartz.experimental.music.playlist.MusicPlaylistEvent
+import com.vitorpamplona.quartz.experimental.music.track.MusicTrackEvent
+import com.vitorpamplona.quartz.experimental.nip82SoftwareApps.application.SoftwareApplicationEvent
+import com.vitorpamplona.quartz.experimental.nipsOnNostr.NipTextEvent
+import com.vitorpamplona.quartz.feedDefinition.FeedDefinitionEvent
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
+import com.vitorpamplona.quartz.nip01Core.tags.hashtags.hashtags
+import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
+import com.vitorpamplona.quartz.nip14Subject.subject
+import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
+import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelCreateEvent
+import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelMetadataEvent
+import com.vitorpamplona.quartz.nip29RelayGroups.metadata.GroupMetadataEvent
+import com.vitorpamplona.quartz.nip30CustomEmoji.pack.EmojiPackEvent
+import com.vitorpamplona.quartz.nip34Git.issue.GitIssueEvent
+import com.vitorpamplona.quartz.nip34Git.pr.GitPullRequestEvent
+import com.vitorpamplona.quartz.nip34Git.repository.GitRepositoryEvent
+import com.vitorpamplona.quartz.nip35Torrents.TorrentEvent
+import com.vitorpamplona.quartz.nip51Lists.appCurationSet.AppCurationSetEvent
+import com.vitorpamplona.quartz.nip51Lists.articleCurationSet.ArticleCurationSetEvent
+import com.vitorpamplona.quartz.nip51Lists.bookmarkList.BookmarkListEvent
+import com.vitorpamplona.quartz.nip51Lists.bookmarkList.OldBookmarkListEvent
+import com.vitorpamplona.quartz.nip51Lists.followList.FollowListEvent
+import com.vitorpamplona.quartz.nip51Lists.interestSet.InterestSetEvent
+import com.vitorpamplona.quartz.nip51Lists.labeledBookmarkList.LabeledBookmarkListEvent
+import com.vitorpamplona.quartz.nip51Lists.mediaStarterPack.MediaStarterPackEvent
+import com.vitorpamplona.quartz.nip51Lists.peopleList.PeopleListEvent
+import com.vitorpamplona.quartz.nip51Lists.pictureCurationSet.PictureCurationSetEvent
+import com.vitorpamplona.quartz.nip51Lists.relaySets.RelaySetEvent
+import com.vitorpamplona.quartz.nip51Lists.releaseArtifactSet.ReleaseArtifactSetEvent
+import com.vitorpamplona.quartz.nip51Lists.videoCurationSet.VideoCurationSetEvent
+import com.vitorpamplona.quartz.nip52Calendar.appt.day.CalendarDateSlotEvent
+import com.vitorpamplona.quartz.nip52Calendar.appt.time.CalendarTimeSlotEvent
+import com.vitorpamplona.quartz.nip52Calendar.calendar.CalendarEvent
+import com.vitorpamplona.quartz.nip53LiveActivities.clip.LiveActivitiesClipEvent
+import com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.MeetingRoomEvent
+import com.vitorpamplona.quartz.nip53LiveActivities.meetingSpaces.MeetingSpaceEvent
+import com.vitorpamplona.quartz.nip53LiveActivities.streaming.LiveActivitiesEvent
+import com.vitorpamplona.quartz.nip54Wiki.WikiNoteEvent
+import com.vitorpamplona.quartz.nip58Badges.definition.BadgeDefinitionEvent
+import com.vitorpamplona.quartz.nip5aStaticWebsites.NamedSiteEvent
+import com.vitorpamplona.quartz.nip5aStaticWebsites.RootSiteEvent
+import com.vitorpamplona.quartz.nip5dNapplets.NamedNappletEvent
+import com.vitorpamplona.quartz.nip5dNapplets.NappletSnapshotEvent
+import com.vitorpamplona.quartz.nip5dNapplets.RootNappletEvent
+import com.vitorpamplona.quartz.nip68Picture.PictureEvent
+import com.vitorpamplona.quartz.nip71Video.AddressableVideoEvent
+import com.vitorpamplona.quartz.nip71Video.RegularVideoEvent
+import com.vitorpamplona.quartz.nip72ModCommunities.definition.CommunityDefinitionEvent
+import com.vitorpamplona.quartz.nip75ZapGoals.GoalEvent
+import com.vitorpamplona.quartz.nip7DThreads.ThreadEvent
+import com.vitorpamplona.quartz.nip84Highlights.HighlightEvent
+import com.vitorpamplona.quartz.nip89AppHandlers.definition.AppDefinitionEvent
+import com.vitorpamplona.quartz.nip94FileMetadata.FileHeaderEvent
+import com.vitorpamplona.quartz.nip99Classifieds.ClassifiedsEvent
+import com.vitorpamplona.quartz.nipB0WebBookmarks.WebBookmarkEvent
+import com.vitorpamplona.quartz.nipC0CodeSnippets.CodeSnippetEvent
+import com.vitorpamplona.quartz.nipF4Podcasts.episode.PodcastEpisodeEvent
+import com.vitorpamplona.quartz.nipF4Podcasts.metadata.PodcastMetadataEvent
+
+/**
+ * Decomposes every [SearchableEvent] into [IndexableFields] by priority tier:
+ * title-like accessors primary, summary/description secondary, body tertiary,
+ * with hashtag and location tags carried raw beside the tiers. Each explicit
+ * branch splits exactly the accessors that kind's `indexableContent()`
+ * concatenates — keep the two in sync when a kind's parsing changes. Kinds
+ * without an explicit branch fall back to the [SearchableEvent] branch (whole
+ * `indexableContent()` in the tertiary tier), so EVERY searchable kind,
+ * current or future, is extracted.
+ *
+ * A kind may also fill the profile roles when it carries that shape: kind
+ * 31990 goes through the kind-0 fields wholesale, and any kind with a
+ * homepage/site URL fills [IndexableFields.websites]. Hashtags and `location`
+ * tags are filled SYSTEMICALLY by the [tiers] funnel every content branch
+ * uses, so recall never depends on a branch remembering them.
+ *
+ * Non-searchable kinds return [IndexableFields.None]. The extraction is
+ * derived data baked into the build: stores should re-derive after upgrades
+ * (see [com.vitorpamplona.quartz.nip01Core.store.IEventStore.reindexFullTextSearch]).
+ */
+object SearchFieldExtractor {
+    /** Empty extractions always come back as [IndexableFields.None], whatever shape produced them. */
+    fun extract(event: Event): IndexableFields = base(event).let { if (it.isEmpty()) IndexableFields.None else it }
+
+    private fun base(event: Event): IndexableFields =
+        when (event) {
+            // kind 0 -> the profile fields, each in its own role.
+            is MetadataEvent -> {
+                val md = event.contactMetaData()
+                if (md == null) {
+                    IndexableFields.Profile()
+                } else {
+                    IndexableFields.Profile(
+                        name = clean(md.name),
+                        displayName = clean(md.displayName),
+                        about = clean(md.about),
+                        nip05 = clean(md.nip05),
+                        lud16 = clean(md.lud16),
+                        website = clean(md.website),
+                    )
+                }
+            }
+
+            is LongTextNoteEvent -> {
+                tiers(event, event.title(), event.summary(), event.content)
+            }
+
+            is WikiNoteEvent -> {
+                tiers(event, event.title(), event.summary(), event.content)
+            }
+
+            is ClassifiedsEvent -> {
+                tiers(event, event.title(), event.summary(), event.content)
+            }
+
+            is GitRepositoryEvent -> {
+                tiers(event, listOf(event.name()), listOf(event.description()), event.content, websites = event.webs())
+            }
+
+            is GitIssueEvent -> {
+                tiers(event, event.subject(), null, event.content)
+            }
+
+            is GitPullRequestEvent -> {
+                tiers(event, event.subject(), null, event.content)
+            }
+
+            is CommunityDefinitionEvent -> {
+                tiers(event, listOf(event.name()), listOf(event.description(), event.rules()), event.content)
+            }
+
+            is EmojiPackEvent -> {
+                tiers(event, event.titleOrName(), event.description(), event.content)
+            }
+
+            is ChannelCreateEvent -> {
+                event.channelInfo().let { tiers(event, it.name, it.about, null) }
+            }
+
+            is ChannelMetadataEvent -> {
+                event.channelInfo().let { tiers(event, it.name, it.about, null) }
+            }
+
+            is PictureEvent -> {
+                tiers(event, event.title(), null, event.content)
+            }
+
+            is RegularVideoEvent -> {
+                tiers(event, event.title(), null, event.content)
+            }
+
+            is AddressableVideoEvent -> {
+                tiers(event, event.title(), null, event.content)
+            }
+
+            // Torrents are searched by FILE NAME above all — index the file
+            // list into the secondary tier, trackers as the affiliation URL.
+            is TorrentEvent -> {
+                tiers(event, listOf(event.title()), event.files().map { it.fileName }, event.content, websites = event.trackers())
+            }
+
+            is ThreadEvent -> {
+                tiers(event, event.title(), null, event.content)
+            }
+
+            is FundraiserEvent -> {
+                tiers(event, event.title(), null, event.content)
+            }
+
+            is NipTextEvent -> {
+                tiers(event, event.title(), null, event.content)
+            }
+
+            is ExerciseTemplateEvent -> {
+                tiers(event, event.title(), null, event.content)
+            }
+
+            is WorkoutRecordEvent -> {
+                tiers(event, event.title(), null, event.content)
+            }
+
+            is CalendarEvent -> {
+                tiers(event, event.title(), null, event.content)
+            }
+
+            is LiveActivitiesClipEvent -> {
+                tiers(event, event.title(), null, event.content)
+            }
+
+            is CalendarDateSlotEvent -> {
+                tiers(event, event.title(), event.summary(), event.content)
+            }
+
+            is CalendarTimeSlotEvent -> {
+                tiers(event, event.title(), event.summary(), event.content)
+            }
+
+            is LiveActivitiesEvent -> {
+                tiers(event, event.title(), event.summary(), event.content, website = event.streaming())
+            }
+
+            is InteractiveStoryBaseEvent -> {
+                tiers(event, event.title(), event.summary(), event.content)
+            }
+
+            is MeetingSpaceEvent -> {
+                tiers(event, event.room(), event.summary(), event.content)
+            }
+
+            is MeetingRoomEvent -> {
+                tiers(event, event.title(), event.summary(), null)
+            }
+
+            // Code snippets are searched by language/runtime as much as name —
+            // fold those keywords into the secondary tier, repo as affiliation.
+            is CodeSnippetEvent -> {
+                tiers(
+                    event,
+                    listOf(event.snippetName()),
+                    listOf(event.snippetDescription(), event.language(), event.extension(), event.runtime()),
+                    event.content,
+                    websites = listOf(event.repo()),
+                )
+            }
+
+            is BadgeDefinitionEvent -> {
+                tiers(event, event.name(), event.description(), event.content)
+            }
+
+            is MusicPlaylistEvent -> {
+                tiers(event, event.title(), event.description(), event.content)
+            }
+
+            is MusicTrackEvent -> {
+                tiers(event, listOf(event.title()), listOf(event.artist(), event.album()), event.content)
+            }
+
+            is SoftwareApplicationEvent -> {
+                tiers(event, listOf(event.name()), listOf(event.summary()), event.content, websites = listOf(event.url(), event.repository()))
+            }
+
+            is PodcastEpisodeEvent -> {
+                tiers(event, event.title(), event.description(), event.content)
+            }
+
+            is PodcastMetadataEvent -> {
+                tiers(event, listOf(event.title()), listOf(event.description()), null, websites = event.websites())
+            }
+
+            is GroupMetadataEvent -> {
+                tiers(event, event.name(), event.about(), null)
+            }
+
+            is InterestSetEvent -> {
+                tiers(event, event.title(), event.description(), null)
+            }
+
+            is FollowListEvent -> {
+                tiers(event, event.title(), event.description(), null)
+            }
+
+            is MediaStarterPackEvent -> {
+                tiers(event, event.title(), event.description(), null)
+            }
+
+            is PictureCurationSetEvent -> {
+                tiers(event, event.title(), event.description(), null)
+            }
+
+            is ArticleCurationSetEvent -> {
+                tiers(event, event.title(), event.description(), null)
+            }
+
+            is VideoCurationSetEvent -> {
+                tiers(event, event.title(), event.description(), null)
+            }
+
+            is ReleaseArtifactSetEvent -> {
+                tiers(event, event.title(), event.description(), null)
+            }
+
+            is AppCurationSetEvent -> {
+                tiers(event, event.title(), event.description(), null)
+            }
+
+            is RelaySetEvent -> {
+                tiers(event, event.title(), event.description(), null)
+            }
+
+            // A web bookmark IS its URL — route it to the affiliation website
+            // field so the bookmark is findable by its domain.
+            is WebBookmarkEvent -> {
+                tiers(event, event.title(), event.description(), null, website = event.url())
+            }
+
+            is NamedSiteEvent -> {
+                tiers(event, event.title(), event.description(), null)
+            }
+
+            is RootSiteEvent -> {
+                tiers(event, event.title(), event.description(), null)
+            }
+
+            is RootNappletEvent -> {
+                tiers(event, event.title(), event.description(), null)
+            }
+
+            is NappletSnapshotEvent -> {
+                tiers(event, event.title(), event.description(), null)
+            }
+
+            is NamedNappletEvent -> {
+                tiers(event, event.title(), event.description(), null)
+            }
+
+            is FeedDefinitionEvent -> {
+                tiers(event, event.title(), null, null)
+            }
+
+            is LabeledBookmarkListEvent -> {
+                tiers(event, event.titleOrName(), event.description(), null)
+            }
+
+            is PeopleListEvent -> {
+                tiers(event, event.titleOrName(), event.description(), null)
+            }
+
+            is BookmarkListEvent -> {
+                tiers(event, event.title(), null, null)
+            }
+
+            is OldBookmarkListEvent -> {
+                tiers(event, event.title(), null, null)
+            }
+
+            is GoalEvent -> {
+                tiers(event, null, event.summary(), event.content)
+            }
+
+            is HighlightEvent -> {
+                tiers(event, emptyList(), listOf(event.comment(), event.context()), event.content)
+            }
+
+            is FileHeaderEvent -> {
+                tiers(event, null, event.summary(), event.content)
+            }
+
+            is AudioTrackEvent -> {
+                tiers(event, event.subject(), null, null)
+            }
+
+            // Buzz agent/workspace kinds carry their metadata as JSON in `content`;
+            // split each decoded object the way its indexableContent() concatenates it.
+            is AgentProfileEvent -> {
+                event.profileOrNull()?.let { tiers(event, listOf(it.name, it.displayName), emptyList(), null) } ?: tiers(event, null, null, null)
+            }
+
+            is PersonaEvent -> {
+                event.personaOrNull()?.let { tiers(event, it.displayName, null, it.systemPrompt) } ?: tiers(event, null, null, null)
+            }
+
+            is ManagedAgentEvent -> {
+                event.agentOrNull()?.let { tiers(event, it.name, null, it.systemPrompt) } ?: tiers(event, null, null, null)
+            }
+
+            is TeamEvent -> {
+                event.teamOrNull()?.let { tiers(event, it.name, it.description, it.instructions) } ?: tiers(event, null, null, null)
+            }
+
+            is WorkflowDefEvent -> {
+                tiers(event, event.name(), null, event.content)
+            }
+
+            // kind 31990 — the app handler's metadata IS a UserMetadata clone,
+            // so route it through the kind-0 profile fields: an app's
+            // @-handle and site get the same treatment a person's do.
+            is AppDefinitionEvent -> {
+                val md = event.appMetaData()
+                if (md == null) {
+                    IndexableFields.Profile()
+                } else {
+                    IndexableFields.Profile(
+                        // Per NIP-24 the deprecated `username` folds into `name`.
+                        name = clean(md.name ?: md.username),
+                        displayName = clean(md.displayName),
+                        about = clean(md.about),
+                        nip05 = clean(md.nip05),
+                        lud16 = clean(md.lud16),
+                        website = clean(md.website),
+                    )
+                }
+            }
+
+            // kind 1 LAST among the explicit branches: several kinds extend the
+            // text-note base, and their own branches above must win.
+            is TextNoteEvent -> {
+                tiers(event, event.subject(), null, event.content)
+            }
+
+            // Everything else Quartz can search, current or future: the whole
+            // indexableContent lands in the tertiary tier.
+            is SearchableEvent -> {
+                tiers(event, null, null, event.indexableContent())
+            }
+
+            else -> {
+                IndexableFields.None
+            }
+        }
+
+    /** Single-value convenience over the list funnel — most kinds carry one title, one summary, one body. */
+    private fun tiers(
+        event: Event,
+        primary: String?,
+        secondary: String?,
+        text: String?,
+        website: String? = null,
+    ) = tiers(event, listOf(primary), listOf(secondary), text, listOf(website))
+
+    /**
+     * The one funnel every content branch uses — [IndexableFields.Tiered.hashtags]
+     * and [IndexableFields.Tiered.locations] are filled here, so no branch can
+     * forget them. Values stay UNJOINED: separator choices belong to the backend.
+     */
+    private fun tiers(
+        event: Event,
+        primary: List<String?>,
+        secondary: List<String?>,
+        text: String?,
+        websites: List<String?> = emptyList(),
+    ) = IndexableFields.Tiered(
+        primary = cleanAll(primary),
+        secondary = cleanAll(secondary),
+        text = clean(text),
+        hashtags = cleanAll(event.tags.hashtags()),
+        locations = locationValues(event),
+        websites = cleanAll(websites),
+    )
+
+    /** Trim and drop empties at the single funnel every derived string passes through. */
+    private fun clean(s: String?): String? = s?.trim()?.ifEmpty { null }
+
+    private fun cleanAll(parts: List<String?>): List<String> = parts.mapNotNull { clean(it) }
+
+    /**
+     * Every `location` tag value, on ANY kind. Deliberately a raw scan, not a
+     * typed accessor: Quartz's LocationTag classes are per-NIP (calendar,
+     * picture, classifieds) and only those kinds expose locations(), while
+     * this funnel must also catch location tags on kinds whose class doesn't
+     * model them.
+     */
+    private fun locationValues(event: Event): List<String> = event.tags.mapNotNull { tag -> tag.getOrNull(1)?.trim()?.takeIf { tag.getOrNull(0) == "location" && it.isNotEmpty() } }
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip50Search/SearchFieldExtractor.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip50Search/SearchFieldExtractor.kt
@@ -424,8 +424,8 @@ object SearchFieldExtractor {
                 }
             }
 
-            // kind 1 LAST among the explicit branches: several kinds extend the
-            // text-note base, and their own branches above must win.
+            // kind 1 LAST among the explicit branches, defensively: a future
+            // kind extending the text-note base must hit its own branch first.
             is TextNoteEvent -> {
                 tiers(event, event.subject(), null, event.content)
             }
@@ -482,5 +482,5 @@ object SearchFieldExtractor {
      * this funnel must also catch location tags on kinds whose class doesn't
      * model them.
      */
-    private fun locationValues(event: Event): List<String> = event.tags.mapNotNull { tag -> tag.getOrNull(1)?.trim()?.takeIf { tag.getOrNull(0) == "location" && it.isNotEmpty() } }
+    private fun locationValues(event: Event): List<String> = event.tags.mapNotNull { tag -> if (tag.getOrNull(0) != "location") null else clean(tag.getOrNull(1)) }
 }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip50Search/SearchQuery.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip50Search/SearchQuery.kt
@@ -210,7 +210,10 @@ class SearchQuery(
                     }
                 }
                 if (token.length > 1 && token[0] == '-') {
-                    notTerms += token.trimStart('-')
+                    // All-dash tokens ("--") strip to nothing: an
+                    // exclude-nothing token is dropped, not surfaced — an
+                    // empty exclusion would round-trip into a required "-".
+                    token.trimStart('-').takeIf { it.isNotEmpty() }?.let { notTerms += it }
                     continue
                 }
                 if (terms.isNotEmpty()) terms.append(' ')

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip50Search/SearchQuery.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip50Search/SearchQuery.kt
@@ -28,43 +28,70 @@ import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
  * NIP-50 defines the [com.vitorpamplona.quartz.nip01Core.relay.filters.Filter.search]
  * field as "a string describing a query in a human-readable form", optionally
  * carrying `key:value` extension tokens such as `domain:example.com` or
- * `language:en`. This class splits that raw string into the free-text [terms]
- * and the recognized [extensions], giving relays (and search redirectors) a
- * typed view of the query instead of forcing each one to re-parse the string.
+ * `language:en`. This class splits that raw string into the free-text [terms],
+ * the Google-style term syntax ([phrases], [notPhrases], [notTerms]), and the
+ * recognized [extensions], giving relays (and search redirectors) a typed view
+ * of the query instead of forcing each one to re-parse the string.
  *
  * Example:
  * ```
- * val q = SearchQuery.parse("best nostr apps domain:example.com language:en")
- * q.terms      // "best nostr apps"
+ * val q = SearchQuery.parse("best \"nostr apps\" -spam domain:example.com")
+ * q.terms      // "best"
+ * q.phrases    // ["nostr apps"]
+ * q.notTerms   // ["spam"]
  * q.domain     // "example.com"
- * q.language   // "en"
  * ```
  *
- * ## Tokenization
+ * ## Parse order (load-bearing)
  *
- * The string is split on whitespace. A token is treated as an extension when:
- * - it contains a `:`,
- * - the part before the `:` is a non-empty run of lowercase ASCII letters
- *   (`a`–`z`), and
- * - the part after the `:` is non-empty and does not start with `//` (so URLs
- *   like `https://example.com` stay in [terms]).
+ * Quoted spans are lifted off the RAW string FIRST, then the residual is
+ * tokenized for extensions, then `-word` exclusions split off. The order
+ * matters twice over: the extension pass is quote-blind, so a span ending in
+ * an extension-shaped token (`"pizza sort:rank" -spam`) would otherwise lose
+ * its closing quote and the unclosed quote would swallow the rest of the
+ * query; and lifting first lets quotes protect extension-shaped tokens —
+ * `"include:spam"` is the phrase [include, spam], not an extension.
  *
- * Everything else is free text. Per NIP-50 unknown extensions are kept (so they
- * can be forwarded to a backend) — relays "SHOULD ignore extensions they don't
- * support", which this models by simply not having a typed accessor for them;
- * they remain readable through [extensions] / [extension].
+ * ## Term syntax
  *
- * Extension keys are matched case-sensitively against the lowercase forms
- * documented by NIP-50. Duplicate keys keep the last occurrence.
+ * - A `"quoted span"` is an exact-phrase requirement ([phrases]); `-"…"` is a
+ *   phrase exclusion ([notPhrases]). A quote opens a span only at a token
+ *   boundary — mid-token quotes stay ordinary characters. An unclosed span
+ *   runs to the end of the string. Empty spans are dropped, but a positive
+ *   phrase keeps content a text index may not hold ("⚡"): it is an
+ *   unsatisfiable requirement the backend turns into provably-no-match —
+ *   dropping it here would silently flip that into match-all.
+ * - A leading `-` on a 2+ character token makes it an exclusion ([notTerms],
+ *   all leading dashes stripped); a lone `-` stays an ordinary term. There is
+ *   no `-extension` syntax: extension keys are strictly `a`–`z`, so
+ *   `-include:spam` fails the key test and becomes the excluded literal.
+ *
+ * ## Extension tokenization
+ *
+ * The residual is split on whitespace. A token is treated as an extension when
+ * it contains a `:`, the part before the `:` is a non-empty run of lowercase
+ * ASCII letters (`a`–`z`), and the part after is non-empty and does not start
+ * with `//` (so URLs like `https://example.com` stay in [terms]). Per NIP-50
+ * unknown extensions are kept (readable through [extensions] / [extension]) so
+ * they can be forwarded to a backend; relays "SHOULD ignore extensions they
+ * don't support". Extension keys are matched case-sensitively against the
+ * lowercase forms documented by NIP-50. Duplicate keys keep the last
+ * occurrence.
  */
 class SearchQuery(
-    /** The human-readable search terms with all extension tokens removed. */
+    /** The loose human-readable search terms: extensions, phrases, and exclusions all removed. */
     val terms: String,
     /**
      * All recognized `key:value` extension tokens, in the order they appeared.
      * Known keys: [INCLUDE], [DOMAIN], [LANGUAGE], [SENTIMENT], [NSFW].
      */
     val extensions: Map<String, String>,
+    /** Exact-phrase requirements (`"nostr apps"`), quotes removed, in order. */
+    val phrases: List<String> = emptyList(),
+    /** Exact-phrase exclusions (`-"nostr apps"`), quotes removed, in order. */
+    val notPhrases: List<String> = emptyList(),
+    /** Single-word exclusions (`-spam`), dashes removed, in order. */
+    val notTerms: List<String> = emptyList(),
 ) {
     /** `true` when the query carries the `include:spam` token (NIP-50: disable spam filtering). */
     val includeSpam: Boolean
@@ -93,20 +120,41 @@ class SearchQuery(
     val nsfwIncluded: Boolean
         get() = nsfw ?: true
 
+    /**
+     * Whether the query REQUIRES any text — loose terms or phrases. Exclusions
+     * alone don't count: an exclusions-only query is plain recall minus the
+     * excluded words, not a ranked text search.
+     */
+    val hasText: Boolean
+        get() = terms.isNotEmpty() || phrases.isNotEmpty()
+
     /** Returns the raw value of an arbitrary extension key (including unknown ones), or null. */
     fun extension(key: String): String? = extensions[key]
 
-    /** Returns true when there are no free-text terms (the query is extensions-only or empty). */
+    /** Returns true when there are no loose free-text terms. Phrases don't count — see [hasText] for "any required text". */
     fun isTermsEmpty(): Boolean = terms.isEmpty()
 
     /**
-     * Re-assembles a canonical NIP-50 search string: the free-text [terms]
-     * followed by each `key:value` extension. Useful for a redirector that
-     * normalizes the incoming query before forwarding it to a backend.
+     * Re-assembles a canonical NIP-50 search string: the free-text [terms],
+     * then each `"phrase"`, `-exclusion`, `-"phrase exclusion"`, and
+     * `key:value` extension. Canonical, not order-preserving. Useful for a
+     * redirector that normalizes the incoming query before forwarding it.
      */
     fun toSearchString(): String =
         buildString {
             append(terms)
+            for (phrase in phrases) {
+                if (isNotEmpty()) append(' ')
+                append('"').append(phrase).append('"')
+            }
+            for (word in notTerms) {
+                if (isNotEmpty()) append(' ')
+                append('-').append(word)
+            }
+            for (phrase in notPhrases) {
+                if (isNotEmpty()) append(' ')
+                append("-\"").append(phrase).append('"')
+            }
             for ((key, value) in extensions) {
                 if (isNotEmpty()) append(' ')
                 append(key).append(':').append(value)
@@ -134,20 +182,24 @@ class SearchQuery(
 
         private val WHITESPACE = Regex("\\s+")
 
-        /** Empty query — no terms and no extensions. */
+        /** Empty query — no terms, no syntax, no extensions. */
         val EMPTY = SearchQuery("", emptyMap())
 
         /**
          * Parses a raw NIP-50 [search] string into a [SearchQuery]. A null or
-         * blank input yields [EMPTY].
+         * blank input yields [EMPTY]. See the class KDoc for the grammar and
+         * why the quote pass runs before the extension pass.
          */
         fun parse(search: String?): SearchQuery {
             if (search.isNullOrBlank()) return EMPTY
 
+            val quoted = liftQuotedSpans(search)
             val extensions = LinkedHashMap<String, String>()
             val terms = StringBuilder()
+            val notTerms = ArrayList<String>()
 
-            for (token in search.trim().split(WHITESPACE)) {
+            for (token in quoted.residual.trim().split(WHITESPACE)) {
+                if (token.isEmpty()) continue
                 val colon = token.indexOf(':')
                 if (colon > 0 && colon < token.length - 1) {
                     val key = token.substring(0, colon)
@@ -157,18 +209,60 @@ class SearchQuery(
                         continue
                     }
                 }
+                if (token.length > 1 && token[0] == '-') {
+                    notTerms += token.trimStart('-')
+                    continue
+                }
                 if (terms.isNotEmpty()) terms.append(' ')
                 terms.append(token)
             }
 
-            return SearchQuery(terms.toString(), extensions)
+            return SearchQuery(terms.toString(), extensions, quoted.phrases, quoted.notPhrases, notTerms)
         }
 
         private fun isExtensionKey(key: String): Boolean = key.isNotEmpty() && key.all { it in 'a'..'z' }
 
+        /** The quoted spans lifted off the raw text, plus the residual for the extension and `-word` passes. */
+        private class QuotedSpans(
+            val phrases: List<String>,
+            val notPhrases: List<String>,
+            val residual: String,
+        )
+
+        /** Stage one, over the RAW string: lift every `"…"` / `-"…"` span. See the class KDoc for the rules. */
+        private fun liftQuotedSpans(text: String): QuotedSpans {
+            val phrases = ArrayList<String>()
+            val notPhrases = ArrayList<String>()
+            val residual = StringBuilder()
+            var i = 0
+            var boundary = true
+            while (i < text.length) {
+                val c = text[i]
+                val neg = c == '-' && i + 1 < text.length && text[i + 1] == '"'
+                if (boundary && (c == '"' || neg)) {
+                    val start = i + if (neg) 2 else 1
+                    val close = text.indexOf('"', start)
+                    val end = if (close < 0) text.length else close
+                    val span = text.substring(start, end).trim()
+                    i = if (close < 0) text.length else close + 1
+                    if (span.isNotEmpty()) {
+                        if (neg) notPhrases += span else phrases += span
+                    }
+                    // The lifted span's place stays a token boundary for what follows.
+                    residual.append(' ')
+                } else {
+                    residual.append(c)
+                    boundary = c.isWhitespace()
+                    i++
+                }
+            }
+            return QuotedSpans(phrases, notPhrases, residual.toString())
+        }
+
         /**
          * Returns [search] with every `key:value` extension token removed,
-         * leaving only the free-text terms (tokenized as in [parse]).
+         * leaving the free-text query (terms, phrases, and exclusions,
+         * re-assembled as in [toSearchString]).
          *
          * Backends that hand the search string to an engine with its own
          * query syntax — e.g. SQLite FTS, where `:` is column-filter
@@ -184,7 +278,8 @@ class SearchQuery(
         fun stripExtensions(search: String?): String? {
             if (search.isNullOrBlank()) return search
             val parsed = parse(search)
-            return if (parsed.extensions.isEmpty()) search else parsed.terms
+            if (parsed.extensions.isEmpty()) return search
+            return SearchQuery(parsed.terms, emptyMap(), parsed.phrases, parsed.notPhrases, parsed.notTerms).toSearchString()
         }
     }
 }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip50Search/SearchFieldExtractorTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip50Search/SearchFieldExtractorTest.kt
@@ -20,9 +20,11 @@
  */
 package com.vitorpamplona.quartz.nip50Search
 
+import com.vitorpamplona.quartz.buzz.agentProfiles.AgentProfileEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
+import com.vitorpamplona.quartz.nip17Dm.messages.ChatMessageEvent
 import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
 import com.vitorpamplona.quartz.nip35Torrents.TorrentEvent
 import com.vitorpamplona.quartz.nip89AppHandlers.definition.AppDefinitionEvent
@@ -113,6 +115,27 @@ class SearchFieldExtractorTest {
         // Kind 7 reactions are not SearchableEvent.
         val reaction = Event("8".repeat(64), alice, 1L, 7, emptyArray(), "+", "")
         assertEquals(IndexableFields.None, SearchFieldExtractor.extract(reaction))
+    }
+
+    @Test
+    fun unmappedSearchableKindsFallBackToTheTextTier() {
+        val fields = SearchFieldExtractor.extract(ChatMessageEvent("a".repeat(64), alice, 1L, emptyArray(), "hello group", ""))
+        assertEquals(IndexableFields.Tiered(text = "hello group"), fields)
+    }
+
+    @Test
+    fun blankContentKindsNormalizeToNone() {
+        val fields = SearchFieldExtractor.extract(TextNoteEvent("b".repeat(64), alice, 1L, emptyArray(), "   ", ""))
+        assertEquals(IndexableFields.None, fields)
+    }
+
+    @Test
+    fun unparseableBuzzContentStillIndexesItsHashtags() {
+        // The branch finds no text, but the tiers() funnel still carries the
+        // event's raw tags — the one subtle reachability seam of the port.
+        val tags = arrayOf(arrayOf("t", "agents"))
+        val fields = SearchFieldExtractor.extract(AgentProfileEvent("c".repeat(64), alice, 1L, tags, "not json", ""))
+        assertEquals(IndexableFields.Tiered(hashtags = listOf("agents")), fields)
     }
 
     @Test

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip50Search/SearchFieldExtractorTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip50Search/SearchFieldExtractorTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip50Search
+
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
+import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
+import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
+import com.vitorpamplona.quartz.nip35Torrents.TorrentEvent
+import com.vitorpamplona.quartz.nip89AppHandlers.definition.AppDefinitionEvent
+import com.vitorpamplona.quartz.nipB0WebBookmarks.WebBookmarkEvent
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SearchFieldExtractorTest {
+    private val alice = "a1".repeat(32)
+
+    @Test
+    fun kind0DecomposesIntoTheProfileRoles() {
+        val content = """{"name":"vitor","display_name":"Vitor P","about":"builds nostr","nip05":"vitor@vitorpamplona.com","lud16":"me@wallet.com","website":"https://vitorpamplona.com","picture":"https://x/y.jpg"}"""
+        val fields = SearchFieldExtractor.extract(MetadataEvent("1".repeat(64), alice, 1L, emptyArray(), content, ""))
+        assertEquals(
+            IndexableFields.Profile(
+                name = "vitor",
+                displayName = "Vitor P",
+                about = "builds nostr",
+                nip05 = "vitor@vitorpamplona.com",
+                lud16 = "me@wallet.com",
+                website = "https://vitorpamplona.com",
+            ),
+            fields,
+        )
+    }
+
+    @Test
+    fun longFormDecomposesIntoTitleSummaryHashtagsContent() {
+        val tags = arrayOf(arrayOf("d", "post"), arrayOf("title", "My Post"), arrayOf("summary", "tl;dr"), arrayOf("t", "nostr"), arrayOf("t", "search"))
+        val fields = SearchFieldExtractor.extract(LongTextNoteEvent("2".repeat(64), alice, 1L, tags, "the whole article", ""))
+        assertEquals(IndexableFields.Tiered(primary = listOf("My Post"), secondary = listOf("tl;dr"), text = "the whole article", hashtags = listOf("nostr", "search")), fields)
+    }
+
+    @Test
+    fun notesUseTheSubjectAndHashtags() {
+        val tags = arrayOf(arrayOf("subject", "meetup"), arrayOf("t", "brazil"))
+        val fields = SearchFieldExtractor.extract(TextNoteEvent("3".repeat(64), alice, 1L, tags, "see you there", ""))
+        assertEquals(IndexableFields.Tiered(primary = listOf("meetup"), text = "see you there", hashtags = listOf("brazil")), fields)
+    }
+
+    @Test
+    fun locationTagsAreCarriedRawLikeHashtags() {
+        val tags = arrayOf(arrayOf("location", "Rio de Janeiro"))
+        val fields = SearchFieldExtractor.extract(TextNoteEvent("4".repeat(64), alice, 1L, tags, "gm", ""))
+        assertEquals(IndexableFields.Tiered(text = "gm", locations = listOf("Rio de Janeiro")), fields)
+    }
+
+    @Test
+    fun torrentsIndexFileNamesAndTrackers() {
+        val tags =
+            arrayOf(
+                arrayOf("title", "Great Torrent"),
+                arrayOf("file", "episode1.mkv"),
+                arrayOf("file", "episode2.mkv"),
+                arrayOf("tracker", "https://tracker.example.com"),
+            )
+        val fields = SearchFieldExtractor.extract(TorrentEvent("5".repeat(64), alice, 1L, tags, "a series", ""))
+        assertEquals(
+            IndexableFields.Tiered(
+                primary = listOf("Great Torrent"),
+                // Unjoined: the backend decides how file names are indexed.
+                secondary = listOf("episode1.mkv", "episode2.mkv"),
+                text = "a series",
+                websites = listOf("https://tracker.example.com"),
+            ),
+            fields,
+        )
+    }
+
+    @Test
+    fun webBookmarksAreFindableByTheirUrl() {
+        // NIP-B0: the d tag carries the URL scheme-less; url() re-adds https://.
+        val tags = arrayOf(arrayOf("d", "vitorpamplona.com/post"), arrayOf("title", "A Post"))
+        val fields = SearchFieldExtractor.extract(WebBookmarkEvent("6".repeat(64), alice, 1L, tags, "", ""))
+        assertEquals(IndexableFields.Tiered(primary = listOf("A Post"), websites = listOf("https://vitorpamplona.com/post")), fields)
+    }
+
+    @Test
+    fun appHandlerMetadataReusesTheProfileRoles() {
+        val content = """{"name":"CoolApp","about":"an app","website":"https://coolapp.example"}"""
+        val fields = SearchFieldExtractor.extract(AppDefinitionEvent("7".repeat(64), alice, 1L, arrayOf(arrayOf("d", "x")), content, ""))
+        assertEquals(IndexableFields.Profile(name = "CoolApp", about = "an app", website = "https://coolapp.example"), fields)
+    }
+
+    @Test
+    fun nonSearchableKindsExtractNothing() {
+        // Kind 7 reactions are not SearchableEvent.
+        val reaction = Event("8".repeat(64), alice, 1L, 7, emptyArray(), "+", "")
+        assertEquals(IndexableFields.None, SearchFieldExtractor.extract(reaction))
+    }
+
+    @Test
+    fun profileShapesNeverGetHashtagFolding() {
+        // Hashtags/locations are filled only by the tiers() funnel, which
+        // profile branches never use: a kind-0 with t-tags stays a pure
+        // profile (and an empty one normalizes to None).
+        val tags = arrayOf(arrayOf("t", "nostr"))
+        val fields = SearchFieldExtractor.extract(MetadataEvent("9".repeat(64), alice, 1L, tags, "{}", ""))
+        assertEquals(IndexableFields.None, fields)
+    }
+}

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip50Search/SearchQueryTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip50Search/SearchQueryTest.kt
@@ -199,4 +199,121 @@ class SearchQueryTest {
         assertSame(plain, mixed[0])
         assertEquals("bitcoin", mixed[1].search)
     }
+
+    // ---- quoted phrases and -word exclusions --------------------------------
+
+    @Test
+    fun quotedSpanBecomesPhrase() {
+        val q = SearchQuery.parse("best \"nostr apps\" today")
+        assertEquals("best today", q.terms)
+        assertEquals(listOf("nostr apps"), q.phrases)
+        assertTrue(q.notPhrases.isEmpty())
+        assertTrue(q.hasText)
+    }
+
+    @Test
+    fun negatedQuotedSpanBecomesPhraseExclusion() {
+        val q = SearchQuery.parse("pizza -\"pineapple pizza\"")
+        assertEquals("pizza", q.terms)
+        assertEquals(listOf("pineapple pizza"), q.notPhrases)
+        assertTrue(q.phrases.isEmpty())
+    }
+
+    @Test
+    fun minusWordBecomesExclusion() {
+        val q = SearchQuery.parse("pizza -pineapple")
+        assertEquals("pizza", q.terms)
+        assertEquals(listOf("pineapple"), q.notTerms)
+        // Exclusions alone are not required text.
+        assertFalse(SearchQuery.parse("-pineapple").hasText)
+    }
+
+    @Test
+    fun loneMinusStaysATerm() {
+        val q = SearchQuery.parse("a - b")
+        assertEquals("a - b", q.terms)
+        assertTrue(q.notTerms.isEmpty())
+    }
+
+    @Test
+    fun allLeadingDashesAreStripped() {
+        assertEquals(listOf("word"), SearchQuery.parse("--word").notTerms)
+    }
+
+    @Test
+    fun quotesProtectExtensionShapedTokens() {
+        // The quote pass runs BEFORE the extension pass, so a quoted
+        // extension-shaped token is a phrase, not an extension.
+        val q = SearchQuery.parse("\"include:spam\"")
+        assertEquals(listOf("include:spam"), q.phrases)
+        assertFalse(q.includeSpam)
+        assertTrue(q.extensions.isEmpty())
+    }
+
+    @Test
+    fun spanEndingInExtensionKeepsTrailingExclusion() {
+        // Quote-blind extension parsing would eat the closing quote of
+        // "pizza include:spam" and swallow the trailing -word; the quote-first
+        // order keeps the exclusion an exclusion.
+        val q = SearchQuery.parse("\"pizza include:spam\" -pineapple")
+        assertEquals(listOf("pizza include:spam"), q.phrases)
+        assertEquals(listOf("pineapple"), q.notTerms)
+        assertTrue(q.extensions.isEmpty())
+    }
+
+    @Test
+    fun minusOnExtensionShapedTokenExcludesTheLiteral() {
+        // There is no `-extension` syntax: keys are strictly a-z, so the `-`
+        // makes the whole token an excluded literal.
+        val q = SearchQuery.parse("pizza -include:spam")
+        assertEquals(listOf("include:spam"), q.notTerms)
+        assertFalse(q.includeSpam)
+    }
+
+    @Test
+    fun unclosedQuoteRunsToEnd() {
+        val q = SearchQuery.parse("\"nostr apps today")
+        assertEquals(listOf("nostr apps today"), q.phrases)
+        assertEquals("", q.terms)
+    }
+
+    @Test
+    fun midTokenQuoteStaysOrdinary() {
+        val q = SearchQuery.parse("don\"t panic")
+        assertEquals("don\"t panic", q.terms)
+        assertTrue(q.phrases.isEmpty())
+    }
+
+    @Test
+    fun emptySpansAreDropped() {
+        val q = SearchQuery.parse("a \"\" b -\"\"")
+        assertEquals("a b", q.terms)
+        assertTrue(q.phrases.isEmpty())
+        assertTrue(q.notPhrases.isEmpty())
+    }
+
+    @Test
+    fun phrasesComposeWithExtensions() {
+        val q = SearchQuery.parse("\"nostr apps\" best domain:example.com -spam")
+        assertEquals("best", q.terms)
+        assertEquals(listOf("nostr apps"), q.phrases)
+        assertEquals(listOf("spam"), q.notTerms)
+        assertEquals("example.com", q.domain)
+    }
+
+    @Test
+    fun toSearchStringRoundTripsFullGrammar() {
+        val q = SearchQuery.parse("best \"nostr apps\" -spam -\"bad phrase\" domain:example.com")
+        assertEquals("best \"nostr apps\" -spam -\"bad phrase\" domain:example.com", q.toSearchString())
+    }
+
+    @Test
+    fun stripExtensionsKeepsPhrasesAndExclusions() {
+        assertEquals(
+            "best \"nostr apps\" -spam",
+            SearchQuery.stripExtensions("best \"nostr apps\" -spam language:en"),
+        )
+        // No extensions -> the original string comes back untouched.
+        assertEquals("best \"nostr apps\" -spam", SearchQuery.stripExtensions("best \"nostr apps\" -spam"))
+    }
 }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip50Search/SearchQueryTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip50Search/SearchQueryTest.kt
@@ -308,6 +308,33 @@ class SearchQueryTest {
     }
 
     @Test
+    fun allDashTokensAreDroppedNotEmptied() {
+        // "--" strips to nothing; surfacing an empty exclusion would
+        // round-trip into a required "-" term.
+        val q = SearchQuery.parse("a --")
+        assertEquals("a", q.terms)
+        assertTrue(q.notTerms.isEmpty())
+        assertEquals("a", SearchQuery.parse(q.toSearchString()).terms)
+        assertEquals("", SearchQuery.stripExtensions("-- include:spam"))
+    }
+
+    @Test
+    fun consecutiveSpansEachLift() {
+        val q = SearchQuery.parse("\"a\"\"b\" -\"c\"")
+        assertEquals(listOf("a", "b"), q.phrases)
+        assertEquals(listOf("c"), q.notPhrases)
+        assertEquals("", q.terms)
+    }
+
+    @Test
+    fun textAfterClosingQuoteIsItsOwnTerm() {
+        // The lifted span's place stays a token boundary for what follows.
+        val q = SearchQuery.parse("\"a b\"c")
+        assertEquals(listOf("a b"), q.phrases)
+        assertEquals("c", q.terms)
+    }
+
+    @Test
     fun stripExtensionsKeepsPhrasesAndExclusions() {
         assertEquals(
             "best \"nostr apps\" -spam",


### PR DESCRIPTION
## Summary

Upstreams the backend-agnostic pieces of `vespa-eventstore` so every `IEventStore` shares one implementation instead of re-deriving them: `SearchQuery` now parses Google-style `"exact phrase"` / `-"phrase"` / `-word` syntax (quote pass deliberately before the extension pass), `SearchFieldExtractor` + `IndexableFields` decompose every `SearchableEvent` into weighted roles (sealed `Profile`/`Tiered` shapes, multi-valued roles carried unjoined so separator/weighting choices stay with the backend), and `RejectionReason` centralizes the insert-rejection vocabulary. A final commit merges three rules that each existed as multiple independent copies — `Event.owner()` (NIP-09/62 authority), `Event.supersedes()` (NIP-01 replaceable tiebreak), and `isIndexableTagName()` (NIP-01 `#x` space, a–zA-Z).

Two deliberate behavior changes to call out: `isIndexableTagName` tightens the four former `length == 1` checks, so single-char **non-letter** tag names (`"5"`, `"#"`) are no longer indexed/matched — NIP-01's filter space cannot address them anyway; and the expired-event SQL trigger + `IngestQueue` batch fallback now reject with the same `RejectionReason` words as every other path (`blocked: Cannot insert an expired event`, `error: insert failed`).

## Test plan

- [x] Ran `./gradlew :quartz:spotlessApply` — repo is formatted
- [x] Ran `./gradlew :quartz:jvmTest` — full module suite green, including 30+ new tests
- [ ] Manually exercised the change (library code — the new unit tests are the exercise; see notes)

Notes / screenshots:

Environment was a Linux container with JVM only (no Android SDK / Apple toolchain), so the `androidHostTest`/iOS/native targets and the app flavours were **not** built locally — everything touched is `commonMain`/`commonTest`, but CI needs to cover the other targets. New tests pin: the quote-before-extension ordering (`"include:spam"` stays a phrase), unclosed/mid-token/consecutive quotes, `--` dropping instead of round-tripping into a required `-` term, per-kind extraction for kind 0 / long-form / notes / torrents / bookmarks / app handlers, the profile-shapes-never-get-hashtag-folding guarantee, blank-content normalization to `None`, and the unparseable-buzz-content hashtag seam. The branch was additionally audited by differential comparison against the downstream `vespa-eventstore` implementation it was extracted from (~20 hand-traced grammar inputs; all 67 extractor branches).

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

(The tag-indexing tightening changes which tags `#x` filters reach in the SQLite store, but none of the listed suites exercise that path.)

## AI assistance

- [x] Drafted with AI assistance, manually reviewed and tested

Authored with Claude Code in an interactive session directed by the repo owner; every design decision (sealed shapes, unjoined lists, per-shape website fields, the tag-name tightening) was made or approved by the maintainer in-session.

## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfwV3xgMSmfxy16ujGPxGW

---
_Generated by [Claude Code](https://claude.ai/code/session_01MfwV3xgMSmfxy16ujGPxGW)_