### PR TITLE
Fix URL detection to exclude quotes from parsed URLs

### DIFF
--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParserQuotedUrlTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/RichTextParserQuotedUrlTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.richtext
+
+import com.vitorpamplona.amethyst.commons.model.EmptyTagList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * A quoted host name (`this bridge-relay "relay.momostr.pink" doesn't appear`) used to be
+ * detected with the opening quote glued onto it, so the rendered link read
+ * `"relay.momostr.pink` and pointed at a host that doesn't exist. Quotes are not host
+ * characters, so they must be left in the surrounding text on both sides.
+ */
+class RichTextParserQuotedUrlTest {
+    private fun segmentsOf(text: String) =
+        RichTextParser()
+            .parseText(text, EmptyTagList, null)
+            .paragraphs
+            .flatMap { it.words }
+
+    @Test
+    fun quotedSchemelessUrlKeepsQuotesOutOfTheLink() {
+        val segments =
+            segmentsOf(
+                "It seems like this bridge-relay \"relay.momostr.pink\" doesn't appear in the feed",
+            ).filterIsInstance<SchemelessUrlSegment>()
+
+        assertEquals(listOf("relay.momostr.pink"), segments.map { it.segmentText })
+    }
+
+    @Test
+    fun quotedUrlWithSchemeKeepsQuotesOutOfTheLink() {
+        val segments =
+            segmentsOf(
+                "the docs are at \"https://example.com/some/page?a=b\" if you need them",
+            ).filterIsInstance<LinkSegment>()
+
+        assertEquals(listOf("https://example.com/some/page?a=b"), segments.map { it.segmentText })
+    }
+
+    @Test
+    fun quotedRelayUrlKeepsQuotesOutOfTheLink() {
+        val segments =
+            segmentsOf("add \"wss://relay.momostr.pink\" to your list")
+                .filterIsInstance<RelayUrlSegment>()
+
+        assertEquals(listOf("wss://relay.momostr.pink"), segments.map { it.segmentText })
+    }
+
+    @Test
+    fun apostrophesInProseDontCreateLinks() {
+        val segments = segmentsOf("it doesn't appear until you go into the authors' accounts")
+
+        assertEquals(emptyList(), segments.filterIsInstance<SchemelessUrlSegment>())
+        assertEquals(emptyList(), segments.filterIsInstance<LinkSegment>())
+    }
+}

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/UrlParserTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/richtext/UrlParserTest.kt
@@ -350,6 +350,34 @@ class UrlParserTest {
         )
 
     @Test
+    fun testQuotedRelayName() =
+        test(
+            "It seems like this bridge-relay \"relay.momostr.pink\" doesn't appear in the feed at all",
+            Urls(withoutScheme = setOf("relay.momostr.pink")),
+        )
+
+    @Test
+    fun testSingleQuotedRelayName() =
+        test(
+            "It seems like this bridge-relay 'relay.momostr.pink' doesn't appear in the feed at all",
+            Urls(withoutScheme = setOf("relay.momostr.pink")),
+        )
+
+    @Test
+    fun testQuotedUrlWithScheme() =
+        test(
+            "the docs are at \"https://example.com/some/page?a=b\" if you need them",
+            Urls(withScheme = setOf("https://example.com/some/page?a=b")),
+        )
+
+    @Test
+    fun testQuotedRelayUrl() =
+        test(
+            "add \"wss://relay.momostr.pink\" to your list",
+            Urls(relayUrls = setOf("wss://relay.momostr.pink")),
+        )
+
+    @Test
     fun testBlossom() {
         val blossom = "blossom:b1674191a88ec5cdd733e4240a81803105dc412d6c6708d53ab94fc248f4f553.pdf?xs=cdn.satellite.earth"
         test(blossom, Urls(blossomUris = setOf(blossom)))

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/utils/urldetector/detection/UrlDetector.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/utils/urldetector/detection/UrlDetector.kt
@@ -659,8 +659,14 @@ class UrlDetector(
         // if the url is valid and greater then 0
         if (state == ReadEndState.ValidUrl && buffer.isNotEmpty()) {
             var url = buffer.toString()
-            val last = url.lastOrNull()
-            if (last != null && last in CANNOT_END_URLS_WITH && !url.endsOnBalancedCloser(last)) {
+            // Strips the whole punctuation tail, not just its last character: the path, query and
+            // fragment readers only stop on a space, so a quoted link closing a sentence arrives
+            // here as `https://host/path".` and a single drop would leave the quote glued on.
+            // Each round re-checks the balance, so a url that legitimately ends in a matched
+            // closer (`…/Bitcoin_(disambiguation)`) still stops the strip.
+            while (true) {
+                val last = url.lastOrNull() ?: break
+                if (last !in CANNOT_END_URLS_WITH || url.endsOnBalancedCloser(last)) break
                 url = url.dropLast(1)
             }
             if (url.isNotEmpty()) urlList.add(currentUrlMarker.createUrl(url))

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/utils/urldetector/detection/UrlDetector.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/utils/urldetector/detection/UrlDetector.kt
@@ -91,7 +91,17 @@ class UrlDetector(
         while (!reader.eof()) {
             // read the next char to process.
             when (val curr = reader.read()) {
-                ' ' -> {
+                // A quote can never be part of a host name, so a note that wraps a bare domain in
+                // quotes (`the relay "relay.example.com" is down`) must not glue the opening quote
+                // onto the url. Quotes therefore end the current token exactly like a space does.
+                // Kept as literals (instead of `in QUOTES`) so this hot branch stays a tableswitch;
+                // the list must mirror [QUOTES], which the punctuation round-trip test enforces.
+                ' ', '"', '\'', '`',
+                '\u00AB', '\u00BB',
+                '\u2018', '\u2019', '\u201A', '\u201B',
+                '\u201C', '\u201D', '\u201E', '\u201F',
+                '\u2039', '\u203A',
+                -> {
                     // space found; if we have a scheme, attempt to read the domain before resetting
                     if (buffer.isNotEmpty() && hasScheme) {
                         reader.goBack()
@@ -719,6 +729,30 @@ class UrlDetector(
                 "$it//"
             }
 
+        /**
+         * Quotes never belong to a url. The opening side is already dropped when [readDefault]
+         * breaks the token on them, but the closing side can still be swallowed by the path,
+         * query or fragment readers (which only stop on a space), so it is stripped on [readEnd].
+         */
+        val QUOTES =
+            setOf(
+                '"',
+                '\'',
+                '`',
+                '\u00AB',
+                '\u00BB',
+                '\u2018',
+                '\u2019',
+                '\u201A',
+                '\u201B',
+                '\u201C',
+                '\u201D',
+                '\u201E',
+                '\u201F',
+                '\u2039',
+                '\u203A',
+            )
+
         val CANNOT_BEGIN_URLS_WITH =
             setOf(
                 ',',
@@ -734,7 +768,7 @@ class UrlDetector(
                 '\u3002',
                 '\uFF0E',
                 '\uFF61',
-            )
+            ) + QUOTES
 
         val CANNOT_END_URLS_WITH =
             setOf(
@@ -752,6 +786,6 @@ class UrlDetector(
                 '\u3002',
                 '\uFF0E',
                 '\uFF61',
-            )
+            ) + QUOTES
     }
 }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/utils/urldetector/detection/UriDetectionTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/utils/urldetector/detection/UriDetectionTest.kt
@@ -907,6 +907,29 @@ class UriDetectionTest {
     }
 
     @Test
+    fun testWholePunctuationTailIsStripped() {
+        // The path/query/fragment readers only stop on a space, so a quoted link that closes a
+        // sentence reaches readEnd as `https://host/path".` — every trailing delimiter has to go,
+        // not just the last one.
+        runTest("He linked \"https://example.com/some/path\".", "https://example.com/some/path")
+        runTest("(see \"https://example.com/some/path\")", "https://example.com/some/path")
+        runTest("read \"https://example.com/a?b=c\", then go", "https://example.com/a?b=c")
+        runTest("\"https://example.com/x\"!", "https://example.com/x")
+        runTest("\"https://example.com/x#frag\"...", "https://example.com/x#frag")
+        runTest("wait... example.com/path...", "example.com/path")
+
+        // a balanced closer still stops the strip, even behind a longer tail.
+        runTest(
+            "(see https://en.wikipedia.org/wiki/Bitcoin_(disambiguation))",
+            "https://en.wikipedia.org/wiki/Bitcoin_(disambiguation)",
+        )
+        runTest(
+            "[link](https://en.wikipedia.org/wiki/Bitcoin_(disambiguation)).",
+            "https://en.wikipedia.org/wiki/Bitcoin_(disambiguation)",
+        )
+    }
+
+    @Test
     fun testApostropheStillEndsTheHostForGroupInviteLinks() {
         // NIP-29 invite links are `<relay>'<groupId>`; UrlParser recovers the suffix from the
         // content, so the detector must keep reporting the relay url alone.

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/utils/urldetector/detection/UriDetectionTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/utils/urldetector/detection/UriDetectionTest.kt
@@ -882,6 +882,38 @@ class UriDetectionTest {
         runTest("visit example.com,", "example.com")
     }
 
+    @Test
+    fun testQuotedUrlsDropTheQuotes() {
+        // a bare domain wrapped in quotes must not glue the opening quote onto the host.
+        runTest(
+            "It seems like this bridge-relay \"relay.momostr.pink\" doesn't appear in the feed",
+            "relay.momostr.pink",
+        )
+
+        UrlDetector.QUOTES.forEach { quote ->
+            runTest("$quote relay.momostr.pink $quote", "relay.momostr.pink")
+            runTest("${quote}relay.momostr.pink$quote", "relay.momostr.pink")
+            runTest("${quote}wss://relay.momostr.pink$quote", "wss://relay.momostr.pink")
+
+            // the closing quote is swallowed by the path/query/fragment readers, which only stop
+            // on a space, so it has to be stripped at the end of the url instead.
+            runTest("say ${quote}https://example.com/foo$quote out", "https://example.com/foo")
+            runTest("say ${quote}https://example.com/foo?a=b$quote out", "https://example.com/foo?a=b")
+            runTest("say ${quote}https://example.com/foo#b$quote out", "https://example.com/foo#b")
+
+            // a quote glued to the previous word is a boundary too: `href="www.google.com"`.
+            runTest("href=${quote}www.google.com$quote", "www.google.com")
+        }
+    }
+
+    @Test
+    fun testApostropheStillEndsTheHostForGroupInviteLinks() {
+        // NIP-29 invite links are `<relay>'<groupId>`; UrlParser recovers the suffix from the
+        // content, so the detector must keep reporting the relay url alone.
+        runTest("wss://relay.example.com'groupid", "wss://relay.example.com")
+        runTest("wss://relay.example.com'groupid?code=xyz", "wss://relay.example.com")
+    }
+
     private fun runTest(
         text: String,
         vararg expected: String?,


### PR DESCRIPTION
## Summary

Quoted URLs (e.g., `"relay.momostr.pink"` or `"https://example.com"`) were being parsed with the opening quote glued to the hostname, resulting in invalid URLs like `"relay.momostr.pink`. This fix treats quote characters as token boundaries in the URL detector, ensuring quotes are excluded from the parsed URL on both sides.

The change handles all common quote styles: ASCII quotes (`"`, `'`, `` ` ``), guillemets (`«`, `»`), and Unicode quotation marks (U+2018–U+201F, U+2039–U+203A).

## Test plan

- [x] Ran `./gradlew test` — all new and existing tests pass
  - Added `RichTextParserQuotedUrlTest` with 4 test cases covering schemeless URLs, URLs with schemes, relay URLs, and apostrophes in prose
  - Added 2 test cases to `UriDetectionTest` covering all quote variants and NIP-29 invite links (which use apostrophes as delimiters)
  - Added 4 test cases to `UrlParserTest` covering quoted relay names and URLs with various quote styles

## Interop suites

- [x] N/A — change only affects URL parsing in text, does not affect wire bytes or protocol state

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01GKCAegYMF9V9Nb8FHcMvT7