### PR TITLE
SyncCoverage: one band interval cannot speak for several kinds

### DIFF
--- a/geode/src/main/kotlin/com/vitorpamplona/geode/mirror/MirrorWorker.kt
+++ b/geode/src/main/kotlin/com/vitorpamplona/geode/mirror/MirrorWorker.kt
@@ -498,6 +498,12 @@ class MirrorWorker(
                 val syncStartedAt = TimeUtils.now()
                 var seenMin: Long? = null
                 var seenMax: Long? = null
+                // Per KIND as well as in aggregate: one interval for a
+                // multi-kind filter lets a long-lived kind vouch for a
+                // short-lived one, and the band then skips the interior for
+                // both. The aggregate is still tracked because the reconcile
+                // path records against the leg's floor, not per kind.
+                val seenByKind = mutableMapOf<Int, SyncCoverage.Span>()
 
                 fun observe(event: Event) {
                     // Same containment as the live path: even a trusted
@@ -509,6 +515,7 @@ class MirrorWorker(
                             seenMin = minOf(seenMin ?: event.createdAt, event.createdAt)
                             seenMax = maxOf(seenMax ?: event.createdAt, event.createdAt)
                         }
+                        SyncCoverage.observe(seenByKind, event.kind, event.createdAt)
                         handoff.trySendBlocking(event)
                     } else {
                         filtered.incrementAndGet()
@@ -537,6 +544,7 @@ class MirrorWorker(
                     } catch (e: NegentropySyncException) {
                         seenMin = null
                         seenMax = null
+                        seenByKind.clear()
                         // The watchdog matches negentropySync's default rather
                         // than fetchAllPages' shorter one: a paged catch-up
                         // sits behind the same slow upstreams.
@@ -558,6 +566,13 @@ class MirrorWorker(
                         seenMin,
                         seenMax?.coerceAtMost(syncStartedAt),
                         paged = true,
+                        // Capped the same way the aggregate is: one
+                        // future-dated event must not lift a kind's ceiling
+                        // past what was actually asked for.
+                        observedByKind =
+                            seenByKind.mapValues { (_, span) ->
+                                SyncCoverage.Span(span.min, span.max.coerceAtMost(syncStartedAt))
+                            },
                     )
                 } else {
                     val legFloor = leg.since ?: initialSince

--- a/geode/src/main/kotlin/com/vitorpamplona/geode/mirror/SyncCoverageFile.kt
+++ b/geode/src/main/kotlin/com/vitorpamplona/geode/mirror/SyncCoverageFile.kt
@@ -100,8 +100,7 @@ class SyncCoverageFile(
                 root.mapValues { (_, v) ->
                     val o = v.jsonObject
                     SyncCoverage.Band(
-                        o.getValue("min").jsonPrimitive.long,
-                        o.getValue("max").jsonPrimitive.long,
+                        spansOf(o),
                         o["complete"]?.jsonPrimitive?.boolean ?: false,
                         o["fullAt"]?.jsonPrimitive?.long ?: 0L,
                     )
@@ -110,6 +109,30 @@ class SyncCoverageFile(
         }.onFailure {
             Log.w("SyncCoverageFile") { "could not read ${file.path} (${it.message}); starting fresh" }
         }
+    }
+
+    /**
+     * The per-kind spans, or the single pre-split span read as covering every
+     * kind under [SyncCoverage.ALL_KINDS].
+     *
+     * A file written before coverage was tracked per kind carries only
+     * `min`/`max`, and that is exactly the over-wide claim per-kind spans
+     * exist to stop — so it is loaded as what it always meant rather than
+     * discarded, and the first paged walk that reports per kind replaces it.
+     * Dropping it instead would re-download every upstream's corpus once on
+     * upgrade, which is the cost bands exist to avoid.
+     */
+    private fun spansOf(o: JsonObject): Map<Int, SyncCoverage.Span> {
+        o["spans"]?.jsonObject?.let { spans ->
+            return spans.entries.associate { (kind, v) ->
+                val span = v.jsonObject
+                kind.toInt() to SyncCoverage.Span(span.getValue("min").jsonPrimitive.long, span.getValue("max").jsonPrimitive.long)
+            }
+        }
+        return mapOf(
+            SyncCoverage.ALL_KINDS to
+                SyncCoverage.Span(o.getValue("min").jsonPrimitive.long, o.getValue("max").jsonPrimitive.long),
+        )
     }
 
     @Synchronized
@@ -121,10 +144,30 @@ class SyncCoverageFile(
                         put(
                             key,
                             buildJsonObject {
+                                // min/max are the outer edges across every
+                                // kind, and are written for two readers: a
+                                // human debugging why an upstream re-synced,
+                                // and a ROLLBACK — a binary from before spans
+                                // were per kind reads these and behaves as it
+                                // always did, rather than failing to parse.
                                 put("min", band.minCreatedAt)
                                 put("max", band.maxCreatedAt)
                                 put("complete", band.complete)
                                 put("fullAt", band.fullAt)
+                                put(
+                                    "spans",
+                                    buildJsonObject {
+                                        band.spans.forEach { (kind, span) ->
+                                            put(
+                                                kind.toString(),
+                                                buildJsonObject {
+                                                    put("min", span.min)
+                                                    put("max", span.max)
+                                                },
+                                            )
+                                        }
+                                    },
+                                )
                             },
                         )
                     }

--- a/geode/src/test/kotlin/com/vitorpamplona/geode/mirror/SyncCoverageFileTest.kt
+++ b/geode/src/test/kotlin/com/vitorpamplona/geode/mirror/SyncCoverageFileTest.kt
@@ -20,8 +20,17 @@
  */
 package com.vitorpamplona.geode.mirror
 
+import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.SyncCoverage
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
+import com.vitorpamplona.quartz.utils.TimeUtils
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import kotlinx.serialization.json.put
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -126,5 +135,128 @@ class SyncCoverageFileTest {
         val clamped = clampToWindow(newerLeg, since = 1_000L, until = 2_000L)!!
         assertEquals(1_500L, clamped.since, "the band's ceiling wins over the window floor")
         assertEquals(2_000L, clamped.until)
+    }
+
+    @Test
+    fun `per-kind spans survive a restart, including the kindless sentinel`() {
+        // The file is the one place a per-kind band can be silently flattened
+        // back into the single interval it replaced, so the round trip is
+        // pinned rather than assumed — negative sentinel key included, since
+        // ALL_KINDS goes through toString()/toInt() like any other kind.
+        val mixed = Filter(kinds = listOf(0, 30382))
+        val anyKind = Filter(authors = listOf("a".repeat(64)))
+        val f = tempFile()
+        SyncCoverageFile(f).use {
+            it.coverage.record(
+                relay,
+                mixed,
+                null,
+                null,
+                paged = true,
+                observedByKind =
+                    mapOf(
+                        0 to SyncCoverage.Span(1_600_000_000L, 1_700_000_000L),
+                        30382 to SyncCoverage.Span(1_690_000_000L, 1_700_000_000L),
+                    ),
+            )
+            it.coverage.record(
+                relay,
+                anyKind,
+                null,
+                null,
+                paged = true,
+                observedByKind = mapOf(1 to SyncCoverage.Span(1_690_000_000L, 1_700_000_000L)),
+            )
+        }
+
+        SyncCoverageFile(f).use { reopened ->
+            val band = reopened.coverage.band(relay, mixed)!!
+            assertEquals(
+                mapOf(
+                    0 to SyncCoverage.Span(1_600_000_000L, 1_700_000_000L),
+                    30382 to SyncCoverage.Span(1_690_000_000L, 1_700_000_000L),
+                ),
+                band.spans,
+                "each kind keeps its own evidence across the restart",
+            )
+            // …and the restored band still narrows per kind, which is the half
+            // that would go unnoticed if only the fields round-tripped.
+            val legs = reopened.coverage.legs(relay, mixed)
+            assertEquals(4, legs.size, "the two kinds want different windows")
+
+            assertEquals(
+                mapOf(SyncCoverage.ALL_KINDS to SyncCoverage.Span(1_690_000_000L, 1_700_000_000L)),
+                reopened.coverage.band(relay, anyKind)!!.spans,
+                "the kindless sentinel survives its negative key",
+            )
+        }
+    }
+
+    @Test
+    fun `a file written before per-kind spans loads as the claim it always was`() {
+        // Only min/max, no `spans` — what every deployed state file holds today.
+        // Discarding it would re-download each upstream's corpus once on
+        // upgrade, so it loads under ALL_KINDS and narrows every kind exactly
+        // as it did before, until the first per-kind walk replaces it.
+        val mixed = Filter(kinds = listOf(0, 30382))
+        val f = tempFile()
+        val key = "${relay.url} ${mixed.toJson()}"
+        f.writeText(
+            Json.encodeToString(
+                JsonObject.serializer(),
+                buildJsonObject {
+                    put(
+                        key,
+                        buildJsonObject {
+                            put("min", 1_690_000_000L)
+                            put("max", 1_700_000_000L)
+                            put("complete", false)
+                            put("fullAt", TimeUtils.now())
+                        },
+                    )
+                },
+            ),
+        )
+
+        SyncCoverageFile(f).use { reopened ->
+            val band = reopened.coverage.band(relay, mixed)!!
+            assertEquals(mapOf(SyncCoverage.ALL_KINDS to SyncCoverage.Span(1_690_000_000L, 1_700_000_000L)), band.spans)
+            val legs = reopened.coverage.legs(relay, mixed)
+            assertEquals(2, legs.size, "one shared pair of legs — the old behaviour, exactly")
+            assertEquals(listOf(0, 30382), legs[0].kinds)
+        }
+    }
+
+    @Test
+    fun `a rolled-back reader still finds the outer edges it understands`() {
+        // A binary from before per-kind spans reads `min`/`max` and ignores
+        // `spans`. Those fields must therefore still be written, and must be
+        // the OUTER edges — anything narrower would make the old reader skip
+        // ground it has not covered.
+        val mixed = Filter(kinds = listOf(0, 30382))
+        val f = tempFile()
+        SyncCoverageFile(f).use {
+            it.coverage.record(
+                relay,
+                mixed,
+                null,
+                null,
+                paged = true,
+                observedByKind =
+                    mapOf(
+                        0 to SyncCoverage.Span(1_600_000_000L, 1_695_000_000L),
+                        30382 to SyncCoverage.Span(1_690_000_000L, 1_700_000_000L),
+                    ),
+            )
+        }
+
+        val written =
+            Json
+                .parseToJsonElement(f.readText())
+                .jsonObject.values
+                .single()
+                .jsonObject
+        assertEquals(1_600_000_000L, written.getValue("min").jsonPrimitive.long, "the oldest of any kind")
+        assertEquals(1_700_000_000L, written.getValue("max").jsonPrimitive.long, "the newest of any kind")
     }
 }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/SyncCoverage.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/SyncCoverage.kt
@@ -171,7 +171,12 @@ class SyncCoverage(
             byWindows.getOrPut(windows(filter, span, band.complete, floor)) { mutableListOf() }.add(kind)
         }
         return byWindows.flatMap { (windows, group) ->
-            windows.map { (since, until) -> filter.copy(kinds = group, since = since, until = until) }
+            // toList(): `group` is the mutable accumulator above, and handing
+            // the same instance to every Filter in the group would publish it
+            // through a public return value. Filters are treated as immutable
+            // everywhere else; this keeps that true by construction.
+            val kindsForGroup = group.toList()
+            windows.map { (since, until) -> filter.copy(kinds = kindsForGroup, since = since, until = until) }
         }
     }
 
@@ -244,11 +249,15 @@ class SyncCoverage(
         }
         if (!paged) return
 
+        // Read ONCE. `now` is a clock call, and this was invoking it twice per
+        // entry — so a 40-kind map took 80 readings, and worse, a span's floor
+        // and ceiling were judged against two different instants.
+        val at = now()
         if (observedByKind != null) {
             // Guarded per span for the same reason the aggregate is below.
             val plausible =
                 observedByKind.filterValues {
-                    isPlausible(it.min, now()) && isPlausible(it.max, now())
+                    isPlausible(it.min, at) && isPlausible(it.max, at)
                 }
             if (plausible.isEmpty()) return
             val named = filter.kinds
@@ -302,7 +311,7 @@ class SyncCoverage(
         // claim the whole timeline, and the leg outside it would ask for a
         // range nothing can be in, forever.
         if (observedMin == null || observedMax == null) return
-        if (!isPlausible(observedMin, now()) || !isPlausible(observedMax, now())) return
+        if (!isPlausible(observedMin, at) || !isPlausible(observedMax, at)) return
         put(url, filter, kinds.associateWith { Span(observedMin, observedMax) }, complete = false)
     }
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/SyncCoverage.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/SyncCoverage.kt
@@ -22,6 +22,7 @@ package com.vitorpamplona.quartz.nip01Core.relay.client.accessories
 
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quartz.utils.TimeUtils
 import com.vitorpamplona.quartz.utils.concurrent.ConcurrentMap
 
@@ -64,23 +65,55 @@ class SyncCoverage(
     private val now: () -> Long = { TimeUtils.now() },
     private val onChange: () -> Unit = {},
 ) {
+    /** A covered `created_at` interval, inclusive at both ends. */
+    data class Span(
+        val min: Long,
+        val max: Long,
+    ) {
+        fun widen(other: Span) = Span(minOf(min, other.min), maxOf(max, other.max))
+    }
+
     /**
      * What is already covered for one (relay, filter) pair.
+     *
+     * [spans] is PER KIND, and that is the whole point of it. A band used to
+     * hold one interval for the entire filter, which is a claim no multi-kind
+     * walk can support: ask for `kinds: [0, 30382]`, see profiles back to 2020
+     * and score cards only from 2025, and the band reads 2020..2026 — so the
+     * next run skips 2020..2025 for BOTH, and the score cards in that interior
+     * are never asked for again. A long-lived kind vouched for a short-lived
+     * one. Per kind, each carries only the evidence actually collected for it.
+     *
+     * Filters that name no kinds at all cannot be split, so they keep a single
+     * span under [ALL_KINDS] — the same claim as before, correctly scoped to
+     * the case where it is the only claim available.
      *
      * [complete] is the difference between "we walked this span" (a paged
      * fetch) and "we are in sync below this point" (a finished negentropy
      * reconcile, which compared the whole range). Only a complete band may
-     * skip its older leg.
+     * skip its older leg. It is a property of the BAND rather than of a span:
+     * a reconcile compares the filter's whole id set at once, so it either
+     * covers every kind in it or none.
      *
      * [fullAt] is when the last pass that started from nothing finished — the
      * clock for the periodic re-walk.
      */
     data class Band(
-        val minCreatedAt: Long,
-        val maxCreatedAt: Long,
+        val spans: Map<Int, Span>,
         val complete: Boolean = false,
         val fullAt: Long = 0,
-    )
+    ) {
+        /** The outer edges across every kind — for logging and for the file's compatibility fields. */
+        val minCreatedAt: Long get() = spans.values.minOfOrNull { it.min } ?: 0
+        val maxCreatedAt: Long get() = spans.values.maxOfOrNull { it.max } ?: 0
+
+        /** Widen each kind by its counterpart, keeping kinds only one side knows. */
+        fun widen(other: Band): Band {
+            val merged = spans.toMutableMap()
+            for ((kind, span) in other.spans) merged[kind] = merged[kind]?.widen(span) ?: span
+            return Band(merged, complete || other.complete, fullAt)
+        }
+    }
 
     private val bands = ConcurrentMap<String, Band>()
 
@@ -114,31 +147,68 @@ class SyncCoverage(
         // Time for another full pass: relays gain old events, and without
         // this the band's claim is never re-tested.
         if (isStale(band)) return listOf(filter)
-        val legs = mutableListOf<Filter>()
+        if (band.spans.isEmpty()) return listOf(filter)
 
-        // Older: up to and including the band's floor, but not past the
-        // filter's (or, when the filter has no `since`, the caller's
-        // [floor] — a sync window the filter itself must not carry, or it
-        // would change the band's key every run). A complete band compared
-        // its whole range already, but only down to the floor it ran
-        // against: a caller now reaching deeper — a raised backfill window
-        // — re-opens the span below the band.
+        val kinds = filter.kinds
+        if (kinds.isNullOrEmpty()) {
+            // Nothing to split by. One span, exactly as before.
+            return windows(filter, band.spans[ALL_KINDS], band.complete, floor)
+                .map { (since, until) -> filter.copy(since = since, until = until) }
+        }
+
+        // Per kind, then REGROUPED by the windows each one wants. Kinds whose
+        // coverage agrees — the overwhelmingly common case, and the only case
+        // at all until they diverge — collapse back into one ask, so a filter
+        // that used to produce two legs still produces two rather than two per
+        // kind. Only a kind whose evidence genuinely differs earns its own.
+        val byWindows = LinkedHashMap<List<Pair<Long?, Long?>>, MutableList<Int>>()
+        for (kind in kinds) {
+            // ALL_KINDS as the fallback: a band written before coverage was
+            // tracked per kind, restored from such a file. It carries the old,
+            // wider claim for every kind — the behaviour this replaces — and
+            // self-corrects on the first paged walk that reports per kind.
+            val span = band.spans[kind] ?: band.spans[ALL_KINDS]
+            byWindows.getOrPut(windows(filter, span, band.complete, floor)) { mutableListOf() }.add(kind)
+        }
+        return byWindows.flatMap { (windows, group) ->
+            windows.map { (since, until) -> filter.copy(kinds = group, since = since, until = until) }
+        }
+    }
+
+    /**
+     * The `(since, until)` pairs still outstanding for ONE span — the leg
+     * arithmetic, with the filter's own bounds applied and nothing else.
+     * A null [span] means no evidence at all, so the whole filter is wanted.
+     */
+    private fun windows(
+        filter: Filter,
+        span: Span?,
+        complete: Boolean,
+        floor: Long?,
+    ): List<Pair<Long?, Long?>> {
+        if (span == null) return listOf(filter.since to filter.until)
+        val out = mutableListOf<Pair<Long?, Long?>>()
+
+        // Older: up to and including the span's floor, but not past the
+        // filter's (or, when the filter has no `since`, the caller's [floor] —
+        // a sync window the filter itself must not carry, or it would change
+        // the band's key every run). A complete band compared its whole range
+        // already, but only down to the floor it ran against: a caller now
+        // reaching deeper — a raised backfill window — re-opens the span below.
         val since = filter.since ?: floor
         val wantsOlder =
-            if (band.complete) {
-                since != null && since < band.minCreatedAt
+            if (complete) {
+                since != null && since < span.min
             } else {
-                since == null || band.minCreatedAt >= since
+                since == null || span.min >= since
             }
-        if (wantsOlder) {
-            legs.add(filter.copy(until = minOf(band.minCreatedAt, filter.until ?: Long.MAX_VALUE)))
-        }
+        if (wantsOlder) out.add(filter.since to minOf(span.min, filter.until ?: Long.MAX_VALUE))
 
-        // Newer: from the band's ceiling on, but not past the filter's.
-        if (filter.until == null || band.maxCreatedAt <= filter.until) {
-            legs.add(filter.copy(since = maxOf(band.maxCreatedAt, filter.since ?: Long.MIN_VALUE)))
+        // Newer: from the span's ceiling on, but not past the filter's.
+        if (filter.until == null || span.max <= filter.until) {
+            out.add(maxOf(span.max, filter.since ?: Long.MIN_VALUE) to filter.until)
         }
-        return legs
+        return out
     }
 
     /**
@@ -162,20 +232,58 @@ class SyncCoverage(
         observedMax: Long?,
         paged: Boolean,
         reconciledThrough: Long? = null,
+        observedByKind: Map<Int, Span>? = null,
     ) {
         if (reconciledThrough != null) {
-            put(url, filter, observedMin ?: reconciledThrough, reconciledThrough, complete = true)
+            // A reconcile compares the filter's whole id set in one pass, so
+            // the span it earns is the same for every kind the filter names —
+            // no per-kind evidence needed or possible.
+            val span = Span(observedMin ?: reconciledThrough, reconciledThrough)
+            put(url, filter, kindsOf(filter).associateWith { span }, complete = true)
             return
         }
         if (!paged) return
+
+        if (observedByKind != null) {
+            // Guarded per span for the same reason the aggregate is below.
+            val plausible =
+                observedByKind.filterValues {
+                    isPlausible(it.min, now()) && isPlausible(it.max, now())
+                }
+            if (plausible.isEmpty()) return
+            put(url, filter, plausible, complete = false)
+            return
+        }
+
+        // No per-kind evidence. For a filter naming one kind (or none) the
+        // aggregate IS the per-kind answer and nothing is lost. For a filter
+        // naming several it is not: attributing one interval to all of them is
+        // exactly the over-claim [Band.spans] exists to stop, and a band that
+        // over-claims skips events silently — strictly worse than re-reading
+        // them. So record nothing and say why, once. The caller resumes as if
+        // it had no band, which is where it was before bands existed.
+        val kinds = kindsOf(filter)
+        if (kinds.size > 1) {
+            if (!warnedAboutUnattributed) {
+                warnedAboutUnattributed = true
+                Log.w("SyncCoverage") {
+                    "paged record for a ${kinds.size}-kind filter with no per-kind spans — no band recorded, so this " +
+                        "walk will not resume. Pass observedByKind (see SyncCoverage.observe) to earn one."
+                }
+            }
+            return
+        }
         // Guarded even though callers should filter with [isPlausible] per
         // event: a 1970 floor or a far-future ceiling would make the band
         // claim the whole timeline, and the leg outside it would ask for a
         // range nothing can be in, forever.
         if (observedMin == null || observedMax == null) return
         if (!isPlausible(observedMin, now()) || !isPlausible(observedMax, now())) return
-        put(url, filter, observedMin, observedMax, complete = false)
+        put(url, filter, kinds.associateWith { Span(observedMin, observedMax) }, complete = false)
     }
+
+    /** The kinds a band is keyed by: the filter's, or [ALL_KINDS] when it names none. */
+    private fun kindsOf(filter: Filter): List<Int> = filter.kinds?.takeIf { it.isNotEmpty() } ?: listOf(ALL_KINDS)
 
     /**
      * Widen (or reset) the band. A pass that ran because the previous band
@@ -185,22 +293,12 @@ class SyncCoverage(
     private fun put(
         url: NormalizedRelayUrl,
         filter: Filter,
-        min: Long,
-        max: Long,
+        spans: Map<Int, Span>,
         complete: Boolean,
     ) {
-        val fresh = Band(min, max, complete, now())
+        val fresh = Band(spans, complete, now())
         bands.merge(key(url, filter), fresh) { old, new ->
-            if (isStale(old)) {
-                new
-            } else {
-                Band(
-                    minOf(old.minCreatedAt, new.minCreatedAt),
-                    maxOf(old.maxCreatedAt, new.maxCreatedAt),
-                    old.complete || new.complete,
-                    old.fullAt,
-                )
-            }
+            if (isStale(old)) new else old.widen(new)
         }
         onChange()
     }
@@ -276,7 +374,45 @@ class SyncCoverage(
         return "${url.url} $fingerprint"
     }
 
+    // One line per process, not per walk: the point is to tell a caller it has
+    // not been migrated, and repeating it every leg would bury the log it is
+    // trying to be read in.
+    private var warnedAboutUnattributed = false
+
     companion object {
+        /**
+         * The span key for a filter that names no kinds, and the fallback for
+         * a band restored from a file written before spans were per kind.
+         * Negative because NIP-01 kinds are not.
+         */
+        const val ALL_KINDS = -1
+
+        /**
+         * Widen [into] with one event's stamp, so a caller can accumulate the
+         * per-kind evidence [record] wants as events arrive:
+         *
+         *     val seen = mutableMapOf<Int, SyncCoverage.Span>()
+         *     ... onEvent { SyncCoverage.observe(seen, it.kind, it.createdAt) }
+         *     coverage.record(url, filter, …, paged = true, observedByKind = seen)
+         *
+         * Implausible stamps are dropped here rather than by each caller —
+         * per EVENT, never over a leg's aggregate, because one misdated event
+         * among hundreds of thousands would otherwise discard the whole band.
+         *
+         * Not synchronized: it replaces a pair of plain `var`s at each call
+         * site and is meant for the same single-consumer callback.
+         */
+        fun observe(
+            into: MutableMap<Int, Span>,
+            kind: Int,
+            createdAt: Long,
+            now: Long = TimeUtils.now(),
+        ) {
+            if (!isPlausible(createdAt, now)) return
+            val one = Span(createdAt, createdAt)
+            into[kind] = into[kind]?.widen(one) ?: one
+        }
+
         // More filter instances than any deliberate configuration holds; only
         // a caller rebuilding filters per cycle ever reaches it.
         private const val MAX_FINGERPRINTS = 1_000

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/SyncCoverage.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/SyncCoverage.kt
@@ -251,7 +251,31 @@ class SyncCoverage(
                     isPlausible(it.min, now()) && isPlausible(it.max, now())
                 }
             if (plausible.isEmpty()) return
-            put(url, filter, plausible, complete = false)
+            val named = filter.kinds
+            val spans =
+                if (named.isNullOrEmpty()) {
+                    // A filter naming no kinds cannot be split, so [legs] reads
+                    // ALL_KINDS and nothing else. Storing what the walk saw per
+                    // kind would record a band no lookup can ever reach — it
+                    // would exist and do nothing. Collapse to the union, which
+                    // is the only claim such a filter can make.
+                    mapOf(ALL_KINDS to plausible.values.reduce { a, b -> a.widen(b) })
+                } else {
+                    // Only kinds the filter NAMES. A relay may answer with more
+                    // than it was asked for, and a caller whose containment
+                    // check runs against a different filter than the band is
+                    // keyed by passes those straight through. Keeping them
+                    // would be inert for [legs] — which looks up the filter's
+                    // own kinds — but NOT for [Band.minCreatedAt], which the
+                    // state file writes as its rollback-compat `min`/`max`. An
+                    // off-filter kind seen further back would widen those past
+                    // anything the filter's kinds support, so a binary from
+                    // before per-kind spans would read that file and
+                    // over-claim: this fix undone through the compat path.
+                    plausible.filterKeys { it in named }
+                }
+            if (spans.isEmpty()) return
+            put(url, filter, spans, complete = false)
             return
         }
 

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/SyncCoverageTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/SyncCoverageTest.kt
@@ -382,4 +382,124 @@ class SyncCoverageTest {
         val copy = Filter(kinds = listOf(30382), authors = (1..500).map { it.toString(16).padStart(64, '0') })
         assertEquals(1_700_001_000L, c.band(relay, copy)?.minCreatedAt, "identity caching must not change the key")
     }
+
+    // ---- per-kind spans: one interval cannot speak for several kinds -------
+
+    private val mixed = Filter(kinds = listOf(0, 30382))
+
+    /** Does any leg still ask [kind] about the instant [at]? */
+    private fun reaches(
+        legs: List<Filter>,
+        kind: Int,
+        at: Long,
+    ) = legs.any {
+        (it.kinds?.contains(kind) ?: true) &&
+            (it.since ?: Long.MIN_VALUE) <= at &&
+            at <= (it.until ?: Long.MAX_VALUE)
+    }
+
+    @Test
+    fun `a long-lived kind no longer vouches for a short-lived one`() {
+        // THE BUG. Ask for profiles and score cards together: the relay has
+        // profiles going back years and score cards only from last month. One
+        // interval per band recorded 2020..now for the pair, and the next run
+        // skipped that whole interior for BOTH — so score cards written inside
+        // it were never asked for again, and nothing anywhere said so.
+        val c = SyncCoverage()
+        c.record(
+            relay,
+            mixed,
+            null,
+            null,
+            paged = true,
+            observedByKind =
+                mapOf(
+                    0 to SyncCoverage.Span(1_600_000_000L, 1_700_000_000L),
+                    30382 to SyncCoverage.Span(1_690_000_000L, 1_700_000_000L),
+                ),
+        )
+        val legs = c.legs(relay, mixed)
+
+        assertTrue(!reaches(legs, 0, 1_650_000_000L), "kind 0 really was walked there — do not re-read it")
+        assertTrue(reaches(legs, 30382, 1_650_000_000L), "kind 30382 never was, and must still be asked")
+        // Both keep the ground they actually earned.
+        assertTrue(!reaches(legs, 30382, 1_695_000_000L), "…but not its own covered interior")
+        assertTrue(reaches(legs, 0, 1_500_000_000L), "and both still reach below everything walked")
+    }
+
+    @Test
+    fun `kinds whose coverage agrees stay a single ask`() {
+        // The cost control. Splitting per kind would turn two legs into two
+        // per kind on every filter, which is the common case made worse to fix
+        // the rare one. Kinds are regrouped by the windows they want, so
+        // identical coverage collapses back to exactly what it was before.
+        val c = SyncCoverage()
+        val span = SyncCoverage.Span(1_690_000_000L, 1_700_000_000L)
+        c.record(relay, mixed, null, null, paged = true, observedByKind = mapOf(0 to span, 30382 to span))
+
+        val legs = c.legs(relay, mixed)
+        assertEquals(2, legs.size, "two legs, not two per kind")
+        assertEquals(listOf(0, 30382), legs[0].kinds, "and both kinds ride in one ask")
+    }
+
+    @Test
+    fun `a multi-kind paged walk with no per-kind evidence earns no band`() {
+        // The caller did not say which kind it saw where, so the only band
+        // available is the over-wide one. Refused: a band that over-claims
+        // skips events silently, which is worse than re-reading them. The
+        // walk resumes from nothing, exactly as it did before bands existed.
+        val c = SyncCoverage()
+        c.record(relay, mixed, 1_690_000_000L, 1_700_000_000L, paged = true)
+
+        assertNull(c.band(relay, mixed))
+        assertEquals(listOf(mixed), c.legs(relay, mixed))
+
+        // A filter naming ONE kind is unaffected: there, the aggregate IS the
+        // per-kind answer and nothing was ever ambiguous about it.
+        c.record(relay, profiles, 1_690_000_000L, 1_700_000_000L, paged = true)
+        assertEquals(2, c.legs(relay, profiles).size)
+    }
+
+    @Test
+    fun `a finished reconcile covers every kind the filter names`() {
+        // Negentropy compares the filter's whole id set in one pass, so it
+        // either covers every kind in it or none — no per-kind evidence needed,
+        // and none invented.
+        val c = SyncCoverage()
+        c.record(relay, mixed, null, null, paged = false, reconciledThrough = 1_700_000_000L)
+
+        assertEquals(setOf(0, 30382), c.band(relay, mixed)!!.spans.keys)
+        val legs = c.legs(relay, mixed)
+        assertEquals(1, legs.size, "complete: no older leg, and one shared newer one")
+        assertEquals(1_700_000_000L, legs[0].since)
+    }
+
+    @Test
+    fun `a band restored from a pre-split file still narrows every kind`() {
+        // Files written before spans were per kind carry one interval. It is
+        // the old, wider claim — loaded as what it always meant rather than
+        // discarded, because discarding it would re-download every upstream's
+        // corpus once on upgrade. The first per-kind walk replaces it.
+        val seed = SyncCoverage()
+        // A plausible span, or record() correctly drops it and there is no key to read.
+        seed.record(relay, mixed, null, null, paged = true, observedByKind = mapOf(0 to SyncCoverage.Span(1_690_000_000L, 1_700_000_000L)))
+        val key = seed.export().keys.single()
+
+        val restored = SyncCoverage()
+        restored.restore(
+            mapOf(
+                key to
+                    SyncCoverage.Band(
+                        mapOf(SyncCoverage.ALL_KINDS to SyncCoverage.Span(1_690_000_000L, 1_700_000_000L)),
+                        complete = false,
+                        fullAt = now(),
+                    ),
+            ),
+        )
+
+        val legs = restored.legs(relay, mixed)
+        assertEquals(2, legs.size, "one shared pair of legs, which is the old behaviour exactly")
+        assertEquals(listOf(0, 30382), legs[0].kinds)
+        assertEquals(1_690_000_000L, legs[0].until)
+    }
 }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/SyncCoverageTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/SyncCoverageTest.kt
@@ -502,4 +502,61 @@ class SyncCoverageTest {
         assertEquals(listOf(0, 30382), legs[0].kinds)
         assertEquals(1_690_000_000L, legs[0].until)
     }
+
+    @Test
+    fun `a kind the filter never asked for cannot widen the band`() {
+        // A relay may answer with more than it was asked for. Those spans are
+        // inert for legs(), which only looks up the filter's own kinds — but
+        // NOT for Band.minCreatedAt, which the state file writes as its
+        // rollback-compat min/max. Left in, a stray kind seen further back
+        // would widen that past anything the filter's kinds support, and a
+        // binary from before per-kind spans would read the file and over-claim.
+        val c = SyncCoverage()
+        c.record(
+            relay,
+            profiles,
+            null,
+            null,
+            paged = true,
+            observedByKind =
+                mapOf(
+                    0 to SyncCoverage.Span(1_690_000_000L, 1_700_000_000L),
+                    // never asked for, and much older
+                    1 to SyncCoverage.Span(1_600_000_000L, 1_610_000_000L),
+                ),
+        )
+
+        val band = c.band(relay, profiles)!!
+        assertEquals(setOf(0), band.spans.keys, "only the kind the filter names")
+        assertEquals(1_690_000_000L, band.minCreatedAt, "…so the compat floor stays honest")
+    }
+
+    @Test
+    fun `per-kind evidence on a filter naming no kinds collapses to one span`() {
+        // Such a filter cannot be split, so legs() reads ALL_KINDS and nothing
+        // else. Storing per-kind spans here would record a band no lookup can
+        // reach — present in the file, doing nothing.
+        val anyKind = Filter(authors = listOf("a".repeat(64)))
+        val c = SyncCoverage()
+        c.record(
+            relay,
+            anyKind,
+            null,
+            null,
+            paged = true,
+            observedByKind =
+                mapOf(
+                    0 to SyncCoverage.Span(1_690_000_000L, 1_695_000_000L),
+                    30382 to SyncCoverage.Span(1_697_000_000L, 1_700_000_000L),
+                ),
+        )
+
+        val band = c.band(relay, anyKind)!!
+        assertEquals(setOf(SyncCoverage.ALL_KINDS), band.spans.keys)
+        assertEquals(1_690_000_000L, band.spans.getValue(SyncCoverage.ALL_KINDS).min, "the union, not one of them")
+        assertEquals(1_700_000_000L, band.spans.getValue(SyncCoverage.ALL_KINDS).max)
+        // …and it is actually USED, which is the half that was silently missing.
+        assertEquals(2, c.legs(relay, anyKind).size)
+        assertEquals(1_690_000_000L, c.legs(relay, anyKind)[0].until)
+    }
 }


### PR DESCRIPTION
## Summary

A `SyncCoverage` band held ONE `created_at` interval per `(relay, filter)`. For a filter naming several kinds that is a claim no walk can support: ask for `kinds: [0, 30382]`, find profiles going back years and score cards only from last month, and the band records `2020..now` for the pair — so the next run skips that whole interior for **both**, and score cards written inside it are never asked for again. A long-lived kind vouched for a short-lived one, silently.

`Band.spans` is now per kind, so each carries only the evidence actually collected for it. This is a correctness fix, not a feature: the failure mode is lost events with nothing on any log line to say so.

## What keeps the cost where it was

- **`legs()` regroups kinds by the windows they want.** Identical coverage — the common case, and the only case until kinds diverge — collapses back into one ask, so a filter that produced two legs still produces two rather than two per kind. Only a kind whose evidence genuinely differs earns its own.
- **A finished reconcile needs no per-kind evidence and is given none.** Negentropy compares the filter's whole id set in one pass, so it covers every kind in the filter or none. Only the **paged** path changed.
- **Filters naming no kinds** keep a single span under `ALL_KINDS` — the same claim as before, correctly scoped to the case where it is the only claim available.

`record()` gains `observedByKind`, and `SyncCoverage.observe()` accumulates it as events arrive — replacing the pair of hand-rolled `var`s each caller kept and folding the per-event `isPlausible` guard in with it.

A paged walk over a **multi-kind** filter that supplies none earns no band at all, loudly, once. Attributing one interval to every kind is exactly the over-claim being removed, and a band that over-claims skips events silently, which is worse than re-reading them. Single-kind filters are untouched — there the aggregate always was the per-kind answer.

### State file

Gains a per-kind `spans` object and keeps `min`/`max` as the outer edges, so a **rollback** to a binary from before this reads the file and behaves as it always did. A file written *before* this loads its one interval under `ALL_KINDS` — the old, wider claim, kept rather than discarded because discarding it would re-download every upstream's corpus once on upgrade. The first per-kind walk replaces it.

### Downstream note

Callers with multi-kind paged streams must pass `observedByKind` to keep resuming; `MirrorWorker` is migrated in this PR. Anything else on multi-kind paged filters will re-walk from scratch (correct, but not free) until it does the same.

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Ran the relevant modules' tests
- [ ] Manually exercised the change — see "Not done" below

```
$ ./gradlew :quartz:jvmTest :geode:test
BUILD SUCCESSFUL in 5m 32s
```

**All 26 pre-existing `SyncCoverageTest` cases pass unchanged**, which is the evidence single-kind behaviour did not move. Seven new cases cover the multi-kind interior, regrouping, the refusal, the reconcile path, the `ALL_KINDS` restore, and the two review findings below.

**The new behavioural tests were mutation-tested.** A straight revert does not compile (geode uses the new API), so the pre-fix rule was reinstated *in place* — `span = Span(band.minCreatedAt, band.maxCreatedAt)` in `legs()`, and the multi-kind refusal disabled:

```
SyncCoverageTest[jvm] > a multi-kind paged walk with no per-kind evidence earns no band[jvm] FAILED
SyncCoverageTest[jvm] > a long-lived kind no longer vouches for a short-lived one[jvm] FAILED
31 tests completed, 2 failed
```

Both pass with the fix in place.

**One flavour only, deliberately.** Per `CONTRIBUTING-WITH-AI.md` § Build and install both flavours: this is a pure `quartz/` protocol change plus its `geode/` (JVM server) caller. It touches no UI, no manifest, no Play-only dependency, and nothing under `amethyst/`. There is no flavour axis for it to differ along.

## Code review pass

Required by `CONTRIBUTING-WITH-AI.md`. A review pass over the first commit found **two** defects, both fixed in `74145ee` as their own commit rather than folded into the feature commit:

1. Spans for kinds the filter never named were stored as given — inert for `legs()`, but not for `Band.minCreatedAt`, which is what the state file writes as its rollback-compat `min`/`max`. A relay answering with more than it was asked for would push that floor below anything the filter's kinds support, so a rolled-back binary would read the file and over-claim. *This fix, undone through the compatibility path it added.*
2. `observedByKind` on a filter naming **no** kinds was stored per kind, while `legs()` for such a filter reads only `ALL_KINDS`. The band was recorded, persisted, and never consulted — a resume that silently did not resume.

Both live where the new per-kind path meets an old assumption: that `record()`'s input is already scoped to the filter, and that a band's keys are always the filter's kinds. Neither holds once callers supply the map themselves.

**Not done, and worth a maintainer's eye:** the gate asks for that review to come from a *different* agent or model. This one did not — it was a self-review by the same assistant, which the gate exists precisely to distrust. It found two real bugs, so it was not worthless, but it is not the independent pass the rule asks for. Flagging rather than ticking the box.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

`SyncCoverage` decides which `since`/`until` windows to *ask* for. It does not construct, parse, or alter any event.

## AI assistance

- [x] Drafted with AI assistance, manually reviewed and tested

Written by Claude Code. Origin: `SyncCoverage` was recently upstreamed from NosFabrica/vespa-relay (#3855), which still carried a fork of it; reconciling the two surfaced this as the one open defect in the shared version. The bug is live in a real multi-kind deployment (`kinds: [0, 10002, 30382]` on a paged stream), not hypothetical.

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BbLjD9kvo9X6875VMR1Ghs)_