### PR TITLE
Make the left drawer configurable

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -150,6 +150,7 @@ import com.vitorpamplona.amethyst.service.relayClient.reqCommand.nwc.NWCPaymentF
 import com.vitorpamplona.amethyst.service.uploads.FileHeader
 import com.vitorpamplona.amethyst.ui.actions.NewMessageTagger
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.BottomBarEntry
+import com.vitorpamplona.amethyst.ui.navigation.bottombars.NavBarItem
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.EventProcessor
 import com.vitorpamplona.quartz.buzz.threading.buzzThread
 import com.vitorpamplona.quartz.buzz.threading.buzzThreadReply
@@ -954,6 +955,9 @@ class Account(
      * re-seeds from this flow). Pair a `true` result with [sendNewAppSpecificData] to publish.
      */
     fun applyBottomBarItems(items: List<BottomBarEntry>): Boolean = settings.changeBottomBarItems(items)
+
+    /** The drawer counterpart of [applyBottomBarItems] — same synchronous-apply, publish-after contract. */
+    fun applyHiddenDrawerItems(items: Set<NavBarItem>): Boolean = settings.changeHiddenDrawerItems(items)
 
     suspend fun toggleChatroomPin(room: ChatroomKey) {
         settings.toggleChatroomPin(room)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -39,6 +39,8 @@ import com.vitorpamplona.amethyst.model.nip60Cashu.CashuPreferences
 import com.vitorpamplona.amethyst.ui.actions.mediaServers.DEFAULT_MEDIA_SERVERS
 import com.vitorpamplona.amethyst.ui.actions.mediaServers.ServerName
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.BottomBarEntry
+import com.vitorpamplona.amethyst.ui.navigation.bottombars.NavBarItem
+import com.vitorpamplona.amethyst.ui.navigation.drawer.DrawerItemVisibility
 import com.vitorpamplona.amethyst.ui.screen.FeedDefinition
 import com.vitorpamplona.quartz.concord.cord02Community.ConcordCommunityListEvent
 import com.vitorpamplona.quartz.experimental.ephemChat.list.EphemeralChatListEvent
@@ -495,6 +497,18 @@ class AccountSettings(
     fun changeBottomBarItems(newItems: List<BottomBarEntry>): Boolean {
         if (syncedSettings.navigation.bottomBarItems.value != newItems) {
             syncedSettings.navigation.bottomBarItems.tryEmit(newItems)
+            saveAccountSettings()
+            return true
+        }
+        return false
+    }
+
+    fun changeHiddenDrawerItems(newItems: Set<NavBarItem>): Boolean {
+        // Sanitize on the way in as well as on the way out: a caller must never be able to persist
+        // Settings as hidden, which would leave no route back to the screen that hides rows.
+        val sanitized = DrawerItemVisibility.sanitize(newItems)
+        if (syncedSettings.navigation.hiddenDrawerItems.value != sanitized) {
+            syncedSettings.navigation.hiddenDrawerItems.tryEmit(sanitized)
             saveAccountSettings()
             return true
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettings.kt
@@ -25,6 +25,10 @@ import com.vitorpamplona.amethyst.commons.audio.VisualizerStyle
 import com.vitorpamplona.amethyst.commons.service.pow.PoWCategory
 import com.vitorpamplona.amethyst.commons.service.pow.PoWPolicy
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.BottomBarEntry
+import com.vitorpamplona.amethyst.ui.navigation.bottombars.NavBarItem
+import com.vitorpamplona.amethyst.ui.navigation.bottombars.navBarItemsFromNames
+import com.vitorpamplona.amethyst.ui.navigation.bottombars.toNames
+import com.vitorpamplona.amethyst.ui.navigation.drawer.DrawerItemVisibility
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications.equalImmutableLists
 import com.vitorpamplona.quartz.nip17Dm.base.ChatroomKey
 import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
@@ -83,6 +87,7 @@ class AccountSyncedSettings(
     val navigation =
         AccountNavigationPreferences(
             MutableStateFlow(internalSettings.navigation.bottomBarItems),
+            MutableStateFlow(DrawerItemVisibility.sanitize(navBarItemsFromNames(internalSettings.navigation.hiddenDrawerItems))),
         )
 
     fun toInternal(): AccountSyncedSettingsInternal =
@@ -124,7 +129,11 @@ class AccountSyncedSettings(
                         .map { it.id }
                         .sorted(),
                 ),
-            navigation = AccountNavigationPreferencesInternal(navigation.bottomBarItems.value),
+            navigation =
+                AccountNavigationPreferencesInternal(
+                    navigation.bottomBarItems.value,
+                    navigation.hiddenDrawerItems.value.toNames(),
+                ),
         )
 
     fun updateFrom(syncedSettingsInternal: AccountSyncedSettingsInternal) {
@@ -220,6 +229,11 @@ class AccountSyncedSettings(
         val newBottomBarItems = syncedSettingsInternal.navigation.bottomBarItems
         if (navigation.bottomBarItems.value != newBottomBarItems) {
             navigation.bottomBarItems.tryEmit(newBottomBarItems)
+        }
+
+        val newHiddenDrawerItems = DrawerItemVisibility.sanitize(navBarItemsFromNames(syncedSettingsInternal.navigation.hiddenDrawerItems))
+        if (navigation.hiddenDrawerItems.value != newHiddenDrawerItems) {
+            navigation.hiddenDrawerItems.tryEmit(newHiddenDrawerItems)
         }
     }
 
@@ -322,6 +336,8 @@ class AccountMediaPreferences(
 @Stable
 class AccountNavigationPreferences(
     val bottomBarItems: MutableStateFlow<List<BottomBarEntry>>,
+    /** Drawer rows switched off by the user. Empty = the stock drawer; see DrawerItemVisibility. */
+    val hiddenDrawerItems: MutableStateFlow<Set<NavBarItem>>,
 )
 
 @Stable

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettingsInternal.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettingsInternal.kt
@@ -170,6 +170,15 @@ class AccountNavigationPreferencesInternal(
     // favorite apps, and individual joined chats/groups). Defaulted so blobs
     // written before this field existed decode to the app's current defaults.
     var bottomBarItems: List<BottomBarEntry> = DefaultBottomBarEntries,
+    // The drawer (side menu) rows the user switched off, as NavBarItem *names*.
+    // Empty by default, which is what makes a newly shipped destination visible
+    // to everyone without a migration — see DrawerItemVisibility.
+    //
+    // Stored as strings rather than the enum on purpose: an id written by a
+    // newer client would fail the enum decoder and take the whole synced-settings
+    // blob down with it, so unknown names are dropped on read instead (the same
+    // approach AccountPoWPreferencesInternal.enabledCategories takes).
+    var hiddenDrawerItems: List<String> = emptyList(),
 )
 
 @Serializable

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -263,6 +263,7 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.BlockedUsersScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.BottomBarSettingsScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.CallSettingsScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.ComposeSettingsScreen
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.DrawerSettingsScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.HiddenWordsScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.HomeTabsSettingsScreen
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.MessagesSettingsScreen
@@ -578,6 +579,7 @@ fun BuildNavigation(
         composableFromEnd<Route.MessagesSettings> { MessagesSettingsScreen(accountViewModel, nav) }
         composableFromEnd<Route.AudioVisualizerSettings> { AudioVisualizerSettingsScreen(accountViewModel, nav) }
         composableFromEnd<Route.BottomBarSettings> { BottomBarSettingsScreen(accountViewModel, nav) }
+        composableFromEnd<Route.DrawerSettings> { DrawerSettingsScreen(accountViewModel, nav) }
         composableFromEnd<Route.HomeTabsSettings> { HomeTabsSettingsScreen(accountViewModel, nav) }
         composableFromEnd<Route.ProfileUiSettings> { ProfileUiSettingsScreen(accountViewModel, nav) }
         composableFromEnd<Route.VideoPlayerSettings> { VideoPlayerSettingsScreen(accountViewModel, nav) }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/NavBarItem.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/NavBarItem.kt
@@ -20,7 +20,6 @@
  */
 package com.vitorpamplona.amethyst.ui.navigation.bottombars
 
-import android.os.Build
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbol
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
@@ -29,8 +28,9 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import kotlinx.serialization.Serializable
 
 /**
- * Stable identifiers for every drawer destination that the user can pin to the bottom bar.
- * Order in this enum has no semantic meaning — the user picks a subset and an order at runtime.
+ * Stable identifiers for every destination the navigation surfaces can show — the bottom bar pins a
+ * subset in a user-chosen order, the drawer lists them under fixed headings (see DrawerSections).
+ * Order in this enum has no semantic meaning.
  */
 @Serializable
 enum class NavBarItem {
@@ -83,6 +83,18 @@ enum class NavBarItem {
     SETTINGS,
     FAVORITE_ALGO_FEEDS,
 }
+
+private val NavBarItemsByName = NavBarItem.entries.associateBy { it.name }
+
+/**
+ * Parses persisted [NavBarItem] names, silently dropping any this build doesn't know — a settings
+ * blob synced from a newer client can name a destination that doesn't exist here yet, and that must
+ * degrade to "ignore this one row" rather than failing the decode of the whole blob.
+ */
+fun navBarItemsFromNames(names: Collection<String>): Set<NavBarItem> = names.mapNotNullTo(mutableSetOf()) { NavBarItemsByName[it] }
+
+/** The inverse of [navBarItemsFromNames]; sorted so the serialized form is deterministic. */
+fun Set<NavBarItem>.toNames(): List<String> = map { it.name }.sorted()
 
 data class NavBarItemDef(
     val id: NavBarItem,
@@ -443,34 +455,6 @@ val DefaultBottomBarItems: List<NavBarItem> =
 /** The default bottom bar as unified entries (all built-in; favorites are added by the user). */
 val DefaultBottomBarEntries: List<BottomBarEntry> = DefaultBottomBarItems.map { BottomBarEntry.BuiltIn(it) }
 
-// Ordered membership lists for each drawer section. The drawer renders these by looking up
-// each id in NavBarCatalog, so adding a new screen only requires editing the catalog + the
-// matching section list below — not two separate files.
-val DrawerNavigateItems: List<NavBarItem> =
-    listOf(
-        NavBarItem.HOME,
-        NavBarItem.MESSAGES,
-        NavBarItem.VIDEO,
-        NavBarItem.BROWSER,
-        NavBarItem.DISCOVER,
-        NavBarItem.NOTIFICATIONS,
-    )
-
-val DrawerYouItems: List<NavBarItem> =
-    listOf(
-        NavBarItem.PROFILE,
-        NavBarItem.MY_LISTS,
-        NavBarItem.BOOKMARKS,
-        NavBarItem.WEB_BOOKMARKS,
-        NavBarItem.DRAFTS,
-        NavBarItem.SCHEDULED_POSTS,
-        NavBarItem.INTEREST_SETS,
-        NavBarItem.BLOSSOM_DATA,
-        NavBarItem.EMOJI_PACKS,
-        NavBarItem.WALLET,
-        NavBarItem.NOSTR_SIGNER,
-    )
-
 /**
  * A titled, collapsible group of selectable destinations in the bottom-bar settings picker. The
  * catalog's [linkedMapOf] insertion order is hand-maintained and reads as scattered in the flat
@@ -567,39 +551,4 @@ val BottomBarCategories: List<NavBarCategory> =
                 NavBarItem.SETTINGS,
             ),
         ),
-    )
-
-val DrawerFeedsItems: List<NavBarItem> =
-    listOfNotNull(
-        NavBarItem.ARTICLES,
-        NavBarItem.PICTURES,
-        NavBarItem.SHORTS,
-        NavBarItem.LONGS,
-        NavBarItem.PODCAST_EPISODES,
-        NavBarItem.PODCASTS,
-        NavBarItem.MUSIC_TRACKS,
-        NavBarItem.MUSIC_PLAYLISTS,
-        NavBarItem.POLLS,
-        NavBarItem.PRODUCTS,
-        NavBarItem.WORKOUTS,
-        NavBarItem.GIT_REPOSITORIES,
-        NavBarItem.HIGHLIGHTS,
-        NavBarItem.LIVE_STREAMS,
-        NavBarItem.NESTS,
-        NavBarItem.COMMUNITIES,
-        NavBarItem.PUBLIC_CHATS,
-        NavBarItem.RELAY_GROUPS,
-        NavBarItem.CONCORD,
-        NavBarItem.GEOHASH_CHATS,
-        NavBarItem.CALENDARS,
-        NavBarItem.CALENDAR_COLLECTIONS,
-        NavBarItem.SOFTWARE_APPS,
-        // Favorites can be pinned as inline tabs that render on a cross-process surface
-        // (SurfaceControlViewHost), which needs API 30+. Gate the whole grid on R+ for that reason.
-        NavBarItem.FAVORITE_APPS.takeIf { Build.VERSION.SDK_INT >= Build.VERSION_CODES.R },
-        NavBarItem.NAPPLETS,
-        NavBarItem.NSITES,
-        NavBarItem.FOLLOW_PACKS,
-        NavBarItem.BADGES,
-        NavBarItem.EMOJI_SETS,
     )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/NavBarItem.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/NavBarItem.kt
@@ -463,6 +463,7 @@ val DefaultBottomBarEntries: List<BottomBarEntry> = DefaultBottomBarItems.map { 
  */
 data class NavBarCategory(
     val titleRes: Int,
+    val icon: MaterialSymbol,
     val items: List<NavBarItem>,
 )
 
@@ -475,6 +476,7 @@ val BottomBarCategories: List<NavBarCategory> =
     listOf(
         NavBarCategory(
             R.string.bottom_bar_category_main,
+            MaterialSymbols.Home,
             listOf(
                 NavBarItem.HOME,
                 NavBarItem.MESSAGES,
@@ -485,6 +487,7 @@ val BottomBarCategories: List<NavBarCategory> =
         ),
         NavBarCategory(
             R.string.bottom_bar_category_chats,
+            MaterialSymbols.Group,
             listOf(
                 NavBarItem.PUBLIC_CHATS,
                 NavBarItem.RELAY_GROUPS,
@@ -494,6 +497,7 @@ val BottomBarCategories: List<NavBarCategory> =
         ),
         NavBarCategory(
             R.string.bottom_bar_category_you,
+            MaterialSymbols.AccountCircle,
             listOf(
                 NavBarItem.PROFILE,
                 NavBarItem.MY_LISTS,
@@ -511,6 +515,7 @@ val BottomBarCategories: List<NavBarCategory> =
         ),
         NavBarCategory(
             R.string.bottom_bar_category_feeds,
+            MaterialSymbols.Subscriptions,
             listOf(
                 NavBarItem.ARTICLES,
                 NavBarItem.LONGS,
@@ -537,6 +542,7 @@ val BottomBarCategories: List<NavBarCategory> =
         ),
         NavBarCategory(
             R.string.bottom_bar_category_apps,
+            MaterialSymbols.Apps,
             listOf(
                 NavBarItem.BROWSER,
                 NavBarItem.FAVORITE_APPS,
@@ -547,6 +553,7 @@ val BottomBarCategories: List<NavBarCategory> =
         ),
         NavBarCategory(
             R.string.bottom_bar_category_other,
+            MaterialSymbols.Settings,
             listOf(
                 NavBarItem.SETTINGS,
             ),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerContent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerContent.kt
@@ -648,8 +648,7 @@ fun CatalogSection(
     val onBackground = MaterialTheme.colorScheme.onBackground
 
     val visible = remember(section, hidden) { DrawerItemVisibility.visibleItems(section, hidden) }
-    val hasFixedRows = section.id == DrawerSectionId.CREATE || section.id == DrawerSectionId.SYSTEM
-    if (visible.isEmpty() && !hasFixedRows) return
+    if (visible.isEmpty() && !section.hasFixedRows) return
 
     CollapsibleSection(title = section.titleRes) {
         when (section.id) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerContent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerContent.kt
@@ -63,6 +63,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -105,9 +106,6 @@ import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUse
 import com.vitorpamplona.amethyst.ui.components.CreateTextWithEmoji
 import com.vitorpamplona.amethyst.ui.components.RobohashFallbackAsyncImage
 import com.vitorpamplona.amethyst.ui.layouts.PermanentDrawerWidth
-import com.vitorpamplona.amethyst.ui.navigation.bottombars.DrawerFeedsItems
-import com.vitorpamplona.amethyst.ui.navigation.bottombars.DrawerNavigateItems
-import com.vitorpamplona.amethyst.ui.navigation.bottombars.DrawerYouItems
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.NavBarCatalog
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.NavBarItem
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.NavBarItemDef
@@ -584,42 +582,17 @@ fun ListContent(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
+    // Per-account, synced through the NIP-78 app-specific data event, and edited on the
+    // Side Menu settings screen. Empty (the default) means the full stock drawer.
+    val hidden by accountViewModel.hiddenDrawerItemsFlow().collectAsStateWithLifecycle()
+
     Column(modifier) {
-        CatalogSection(R.string.drawer_section_you, DrawerYouItems, accountViewModel, nav)
-        CatalogSection(R.string.drawer_section_navigate, DrawerNavigateItems, accountViewModel, nav)
-        CatalogSection(R.string.drawer_section_feeds, DrawerFeedsItems, accountViewModel, nav)
-
-        CollapsibleSection(title = R.string.drawer_section_create) {
-            NavigationRow(
-                title = R.string.share_hls_video,
-                icon = MaterialSymbols.SettingsInputAntenna,
-                tint = MaterialTheme.colorScheme.onBackground,
-                nav = nav,
-                route = Route.NewHlsVideo,
-            )
-
-            if (isDebug) {
-                NavigationRow(
-                    title = R.string.route_chess,
-                    icon = MaterialSymbols.ChessKnight,
-                    tint = MaterialTheme.colorScheme.onBackground,
-                    nav = nav,
-                    route = Route.Chess,
-                )
-            }
-        }
-
-        CollapsibleSection(title = R.string.drawer_section_system) {
-            IconRowRelays(
-                accountViewModel = accountViewModel,
-                onClick = {
-                    nav.closeDrawer()
-                    nav.nav(Route.EditRelays)
-                },
-            )
-
-            NavBarCatalog[NavBarItem.SETTINGS]?.let {
-                CatalogNavigationRow(it, MaterialTheme.colorScheme.onBackground, accountViewModel, nav)
+        DrawerSections.forEach { section ->
+            // Keyed by section: hiding the last row of a section removes it from the drawer
+            // entirely, and without a key the sections below would slide up into its slots and
+            // inherit its CollapsibleSection expanded/collapsed state.
+            key(section.id) {
+                CatalogSection(section, hidden, accountViewModel, nav)
             }
         }
 
@@ -634,22 +607,65 @@ fun ListContent(
     }
 }
 
+/** The Create section's rows — composer entry points, none of which is a catalog destination. */
+@Composable
+private fun CreateRows(nav: INav) {
+    NavigationRow(
+        title = R.string.share_hls_video,
+        icon = MaterialSymbols.SettingsInputAntenna,
+        tint = MaterialTheme.colorScheme.onBackground,
+        nav = nav,
+        route = Route.NewHlsVideo,
+    )
+
+    if (isDebug) {
+        NavigationRow(
+            title = R.string.route_chess,
+            icon = MaterialSymbols.ChessKnight,
+            tint = MaterialTheme.colorScheme.onBackground,
+            nav = nav,
+            route = Route.Chess,
+        )
+    }
+}
+
 /**
- * Renders a drawer section by iterating [ids] and looking each one up in [NavBarCatalog].
- * Profile gets the primary-colored tint; every other item uses onBackground.
+ * Renders one drawer section: its fixed rows, if it has any, then the catalog rows the user hasn't
+ * switched off. Profile gets the primary-colored tint; every other item uses onBackground.
+ *
+ * A section with nothing left to show renders nothing at all — an empty, permanently collapsed
+ * heading is just noise. Two sections always have something: Create is entirely fixed rows, and
+ * System carries the relay-status row (not a catalog destination — it shows a live counter).
  */
 @Composable
 fun CatalogSection(
-    titleRes: Int,
-    ids: List<NavBarItem>,
+    section: DrawerSection,
+    hidden: Set<NavBarItem>,
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
     val primary = MaterialTheme.colorScheme.primary
     val onBackground = MaterialTheme.colorScheme.onBackground
 
-    CollapsibleSection(title = titleRes) {
-        ids.forEach { id ->
+    val visible = remember(section, hidden) { DrawerItemVisibility.visibleItems(section, hidden) }
+    val hasFixedRows = section.id == DrawerSectionId.CREATE || section.id == DrawerSectionId.SYSTEM
+    if (visible.isEmpty() && !hasFixedRows) return
+
+    CollapsibleSection(title = section.titleRes) {
+        when (section.id) {
+            DrawerSectionId.CREATE -> CreateRows(nav)
+            DrawerSectionId.SYSTEM ->
+                IconRowRelays(
+                    accountViewModel = accountViewModel,
+                    onClick = {
+                        nav.closeDrawer()
+                        nav.nav(Route.EditRelays)
+                    },
+                )
+            else -> {}
+        }
+
+        visible.forEach { id ->
             NavBarCatalog[id]?.let { def ->
                 val tint = if (def.id == NavBarItem.PROFILE) primary else onBackground
                 if (def.id == NavBarItem.SCHEDULED_POSTS) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerItemVisibility.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerItemVisibility.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.navigation.drawer
+
+import com.vitorpamplona.amethyst.ui.navigation.bottombars.NavBarItem
+
+/**
+ * Which drawer rows the user cannot hide.
+ *
+ * Settings is the only one, and it is mandatory for a specific reason: it is the route back to the
+ * screen that hides rows in the first place. Hiding it would let a user lock themselves out of their
+ * own configuration. Everything else the drawer always shows — the profile header, the relay-status
+ * row, the account switcher and the version/QR footer — is fixed chrome rather than a catalog row,
+ * so it is present by construction and never appears in the hidden set.
+ */
+val MandatoryDrawerItems: Set<NavBarItem> = setOf(NavBarItem.SETTINGS)
+
+/**
+ * Pure show/hide rules for the drawer's catalog rows, kept free of Compose and Android so they are
+ * exercised directly by unit tests (DrawerItemVisibilityTest) rather than only through the UI.
+ *
+ * The per-account preference stores the **hidden** items rather than the visible ones. That choice is
+ * what makes a newly added destination appear for everyone automatically: a row nobody has ever
+ * hidden simply isn't in the set, so it renders. Storing the visible list instead would freeze each
+ * account's drawer at the moment they first touched the setting, and every later release would have
+ * to migrate saved lists to introduce a screen.
+ */
+object DrawerItemVisibility {
+    fun isVisible(
+        hidden: Set<NavBarItem>,
+        item: NavBarItem,
+    ): Boolean = item in MandatoryDrawerItems || item !in hidden
+
+    /** Hides [item] if shown, shows it if hidden. Mandatory items never change (see [MandatoryDrawerItems]). */
+    fun toggle(
+        hidden: Set<NavBarItem>,
+        item: NavBarItem,
+    ): Set<NavBarItem> =
+        when {
+            item in MandatoryDrawerItems -> hidden
+            item in hidden -> hidden - item
+            else -> hidden + item
+        }
+
+    /**
+     * Drops mandatory rows from the set. The persistence layer is the single place this is enforced —
+     * it runs on decode, on an external sync, and on every write — so a value synced from another
+     * client (or from a build where the row wasn't mandatory yet) can't strand Settings as hidden.
+     *
+     * Ids that no section renders are deliberately *kept*: on a device where a row is gated off (see
+     * DrawerFeedsItems' API-30 gate on Favorite Apps) it matches nothing and costs nothing, and
+     * preserving it means editing the drawer on that device doesn't silently clear the choice the
+     * user made on another one.
+     */
+    fun sanitize(hidden: Set<NavBarItem>): Set<NavBarItem> = hidden - MandatoryDrawerItems
+
+    /** The rows of [section] to render, in the section's fixed order. */
+    fun visibleItems(
+        section: DrawerSection,
+        hidden: Set<NavBarItem>,
+    ): List<NavBarItem> = section.items.filter { isVisible(hidden, it) }
+
+    /** How many of [section]'s rows are currently hidden — shown on the collapsed section header. */
+    fun hiddenCount(
+        section: DrawerSection,
+        hidden: Set<NavBarItem>,
+    ): Int = section.items.count { !isVisible(hidden, it) }
+
+    /** Whether [section] has any row the user is allowed to switch off — gates its bulk actions. */
+    fun hasHideableRows(section: DrawerSection): Boolean = section.items.any { it !in MandatoryDrawerItems }
+
+    /** Hides every row of [section] that can be hidden, leaving the mandatory ones. */
+    fun hideAll(
+        hidden: Set<NavBarItem>,
+        section: DrawerSection,
+    ): Set<NavBarItem> = hidden + section.items.filter { it !in MandatoryDrawerItems }
+
+    /** Shows every row of [section] again. */
+    fun showAll(
+        hidden: Set<NavBarItem>,
+        section: DrawerSection,
+    ): Set<NavBarItem> = hidden - section.items.toSet()
+
+    /** Total hidden rows across every section — the count the settings screen shows at the top. */
+    fun totalHidden(hidden: Set<NavBarItem>): Int = DrawerSections.sumOf { hiddenCount(it, hidden) }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerSections.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerSections.kt
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.navigation.drawer
+
+import android.os.Build
+import androidx.compose.runtime.Immutable
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbol
+import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
+import com.vitorpamplona.amethyst.ui.navigation.bottombars.NavBarCatalog
+import com.vitorpamplona.amethyst.ui.navigation.bottombars.NavBarItem
+
+/**
+ * The drawer's layout: which destinations it lists, under which heading, in which order.
+ *
+ * One list drives two screens — [ListContent] renders the visible rows of each section, and the Side
+ * Menu settings screen renders the same sections as its show/hide catalog. Adding a destination to a
+ * section's list therefore surfaces it in the drawer *and* in its configuration screen without
+ * touching either, and DrawerSectionsTest fails the build if a newly added [NavBarCatalog] id isn't
+ * filed into exactly one section.
+ *
+ * Section order and within-section order are fixed and not user-editable: the drawer is a menu, and a
+ * menu whose headings move around is harder to learn, not easier. The only per-account choice is
+ * which rows are visible — see [DrawerItemVisibility].
+ */
+@Immutable
+data class DrawerSection(
+    val id: DrawerSectionId,
+    val titleRes: Int,
+    val icon: MaterialSymbol,
+    val items: List<NavBarItem>,
+)
+
+/**
+ * Identifies a section for the handful of rendering rules that are specific to one. Matching on this
+ * rather than on a section's object identity keeps those rules working if the list is ever mapped or
+ * copied — a `DrawerSections.map { it.copy(...) }` would silently defeat an `===` check, with no
+ * compile error and nothing to fail a test.
+ */
+enum class DrawerSectionId {
+    YOU,
+    NAVIGATE,
+    FEEDS,
+
+    /** Composer entry points. Carries no catalog destinations, so nothing in it is configurable. */
+    CREATE,
+
+    /** Also renders the relay-status row, which isn't a catalog destination (it shows a live counter). */
+    SYSTEM,
+}
+
+private val DrawerNavigateItems: List<NavBarItem> =
+    listOf(
+        NavBarItem.HOME,
+        NavBarItem.MESSAGES,
+        NavBarItem.VIDEO,
+        NavBarItem.BROWSER,
+        NavBarItem.DISCOVER,
+        NavBarItem.NOTIFICATIONS,
+    )
+
+private val DrawerYouItems: List<NavBarItem> =
+    listOf(
+        NavBarItem.PROFILE,
+        NavBarItem.MY_LISTS,
+        NavBarItem.BOOKMARKS,
+        NavBarItem.WEB_BOOKMARKS,
+        NavBarItem.DRAFTS,
+        NavBarItem.SCHEDULED_POSTS,
+        NavBarItem.INTEREST_SETS,
+        NavBarItem.FAVORITE_ALGO_FEEDS,
+        NavBarItem.BLOSSOM_DATA,
+        NavBarItem.EMOJI_PACKS,
+        NavBarItem.WALLET,
+        NavBarItem.NOSTR_SIGNER,
+    )
+
+private val DrawerFeedsItems: List<NavBarItem> =
+    listOfNotNull(
+        NavBarItem.ARTICLES,
+        NavBarItem.PICTURES,
+        NavBarItem.SHORTS,
+        NavBarItem.LONGS,
+        NavBarItem.PODCAST_EPISODES,
+        NavBarItem.PODCASTS,
+        NavBarItem.MUSIC_TRACKS,
+        NavBarItem.MUSIC_PLAYLISTS,
+        NavBarItem.POLLS,
+        NavBarItem.PRODUCTS,
+        NavBarItem.WORKOUTS,
+        NavBarItem.GIT_REPOSITORIES,
+        NavBarItem.HIGHLIGHTS,
+        NavBarItem.LIVE_STREAMS,
+        NavBarItem.NESTS,
+        NavBarItem.COMMUNITIES,
+        NavBarItem.PUBLIC_CHATS,
+        NavBarItem.RELAY_GROUPS,
+        NavBarItem.CONCORD,
+        NavBarItem.GEOHASH_CHATS,
+        NavBarItem.CALENDARS,
+        NavBarItem.CALENDAR_COLLECTIONS,
+        NavBarItem.SOFTWARE_APPS,
+        // Favorites can be pinned as inline tabs that render on a cross-process surface
+        // (SurfaceControlViewHost), which needs API 30+. Gate the whole grid on R+ for that reason.
+        NavBarItem.FAVORITE_APPS.takeIf { Build.VERSION.SDK_INT >= Build.VERSION_CODES.R },
+        NavBarItem.NAPPLETS,
+        NavBarItem.NSITES,
+        NavBarItem.FOLLOW_PACKS,
+        NavBarItem.BADGES,
+        NavBarItem.EMOJI_SETS,
+    )
+
+val DrawerSections: List<DrawerSection> =
+    listOf(
+        DrawerSection(DrawerSectionId.YOU, R.string.drawer_section_you, MaterialSymbols.AccountCircle, DrawerYouItems),
+        DrawerSection(DrawerSectionId.NAVIGATE, R.string.drawer_section_navigate, MaterialSymbols.Home, DrawerNavigateItems),
+        DrawerSection(DrawerSectionId.FEEDS, R.string.drawer_section_feeds, MaterialSymbols.Subscriptions, DrawerFeedsItems),
+        DrawerSection(DrawerSectionId.CREATE, R.string.drawer_section_create, MaterialSymbols.Edit, emptyList()),
+        DrawerSection(DrawerSectionId.SYSTEM, R.string.drawer_section_system, MaterialSymbols.Settings, listOf(NavBarItem.SETTINGS)),
+    )
+
+fun drawerSection(id: DrawerSectionId): DrawerSection = DrawerSections.first { it.id == id }
+
+/**
+ * Catalog ids deliberately absent from every [DrawerSections] list, with the reason. Only Favorite
+ * Apps qualifies: [DrawerFeedsItems] gates it on API 30+ (its inline tabs need SurfaceControlViewHost),
+ * so on older devices the row simply doesn't exist. DrawerSectionsTest allows exactly these to be
+ * missing, and fails on anything else — that's what keeps a newly added destination from silently
+ * skipping both the drawer and its settings screen.
+ */
+val SdkGatedDrawerItems: Set<NavBarItem> = setOf(NavBarItem.FAVORITE_APPS)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerSections.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/drawer/DrawerSections.kt
@@ -47,6 +47,12 @@ data class DrawerSection(
     val titleRes: Int,
     val icon: MaterialSymbol,
     val items: List<NavBarItem>,
+    /**
+     * True for a section that renders rows of its own on top of its catalog items (see [CatalogSection]).
+     * Such a section stays in the drawer even with every catalog row switched off, and — since a fixed
+     * row is not a catalog destination — it never appears in the Side Menu settings screen's counts.
+     */
+    val hasFixedRows: Boolean = false,
 )
 
 /**
@@ -133,11 +139,9 @@ val DrawerSections: List<DrawerSection> =
         DrawerSection(DrawerSectionId.YOU, R.string.drawer_section_you, MaterialSymbols.AccountCircle, DrawerYouItems),
         DrawerSection(DrawerSectionId.NAVIGATE, R.string.drawer_section_navigate, MaterialSymbols.Home, DrawerNavigateItems),
         DrawerSection(DrawerSectionId.FEEDS, R.string.drawer_section_feeds, MaterialSymbols.Subscriptions, DrawerFeedsItems),
-        DrawerSection(DrawerSectionId.CREATE, R.string.drawer_section_create, MaterialSymbols.Edit, emptyList()),
-        DrawerSection(DrawerSectionId.SYSTEM, R.string.drawer_section_system, MaterialSymbols.Settings, listOf(NavBarItem.SETTINGS)),
+        DrawerSection(DrawerSectionId.CREATE, R.string.drawer_section_create, MaterialSymbols.Edit, emptyList(), hasFixedRows = true),
+        DrawerSection(DrawerSectionId.SYSTEM, R.string.drawer_section_system, MaterialSymbols.Settings, listOf(NavBarItem.SETTINGS), hasFixedRows = true),
     )
-
-fun drawerSection(id: DrawerSectionId): DrawerSection = DrawerSections.first { it.id == id }
 
 /**
  * Catalog ids deliberately absent from every [DrawerSections] list, with the reason. Only Favorite

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
@@ -457,6 +457,8 @@ sealed class Route {
 
     @Serializable object BottomBarSettings : Route()
 
+    @Serializable object DrawerSettings : Route()
+
     @Serializable object HomeTabsSettings : Route()
 
     @Serializable object ProfileUiSettings : Route()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -93,6 +93,7 @@ import com.vitorpamplona.amethyst.ui.actions.MediaSaverToDisk
 import com.vitorpamplona.amethyst.ui.actions.NewMessageTagger
 import com.vitorpamplona.amethyst.ui.components.toasts.ToastManager
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.BottomBarEntry
+import com.vitorpamplona.amethyst.ui.navigation.bottombars.NavBarItem
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.note.ZapAmountCommentNotification
 import com.vitorpamplona.amethyst.ui.note.ZapraiserStatus
@@ -1985,6 +1986,15 @@ class AccountViewModel(
         }
 
     fun bottomBarItemsFlow(): StateFlow<List<BottomBarEntry>> = account.settings.syncedSettings.navigation.bottomBarItems
+
+    fun hiddenDrawerItemsFlow(): StateFlow<Set<NavBarItem>> = account.settings.syncedSettings.navigation.hiddenDrawerItems
+
+    /** Same ordering contract as [changeBottomBarItems]: apply on the caller's thread, publish off it. */
+    fun changeHiddenDrawerItems(items: Set<NavBarItem>) {
+        if (account.applyHiddenDrawerItems(items)) {
+            launchSigner { account.sendNewAppSpecificData() }
+        }
+    }
 
     fun changeBottomBarItems(items: List<BottomBarEntry>) {
         // Apply to the reactive flow synchronously on the caller (UI) thread so rapid edits stay

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/BottomBarSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/BottomBarSettingsScreen.kt
@@ -22,11 +22,6 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkVertically
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGestures
@@ -50,7 +45,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -97,7 +91,6 @@ import com.vitorpamplona.amethyst.ui.navigation.topbars.TopBarWithBackButton
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.mockAccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
-import com.vitorpamplona.amethyst.ui.theme.Size20dp
 import com.vitorpamplona.amethyst.ui.theme.ThemeComparisonRow
 import com.vitorpamplona.quartz.concord.cord02Community.ConcordCommunityListEntry
 import com.vitorpamplona.quartz.nip51Lists.simpleGroupList.GroupTag
@@ -115,11 +108,6 @@ private val ExpandableItems =
 
 /** Soft guidance, not a hard cap: a Material bottom bar reads best at ~5 tabs. */
 private const val RECOMMENDED_SLOTS = 5
-
-// Reveal expandable sections by unrolling straight down from the top edge (the default AnimatedVisibility
-// enter also expands horizontally from the bottom-end, which reads as a diagonal slide from the top-left).
-private val SectionExpand = expandVertically(expandFrom = Alignment.Top) + fadeIn()
-private val SectionCollapse = shrinkVertically(shrinkTowards = Alignment.Top) + fadeOut()
 
 @Composable
 @Preview(device = "spec:width=2100px,height=2340px,dpi=440")
@@ -157,6 +145,13 @@ fun BottomBarSettingsContent(accountViewModel: AccountViewModel) {
     // All pin/unpin/reorder logic lives in the holder (unit-tested); the composable only renders and
     // forwards events. Each persist republishes the account's NIP-78 settings event. syncFrom re-seeds
     // when the saved list changes elsewhere without clobbering a drag.
+    //
+    // Deliberately unkeyed. The holder captures this `accountViewModel` in its persist lambda, so a
+    // holder that outlived an account switch would write account A's edits to account B. It cannot:
+    // SetAccountCentricViewModelStore wraps the whole logged-in tree in `key(account.signer.pubKey)`,
+    // so a switch disposes this composable (and the NavController with it) and re-runs this remember
+    // against the new account's ViewModel. Keying on accountViewModel here would be a no-op that
+    // implies the subtree survives a switch — if that ever becomes true, this comment is the bug.
     val state = remember { BottomBarSettingsState(savedItems) { accountViewModel.changeBottomBarItems(it) } }
     LaunchedEffect(savedItems) { state.syncFrom(savedItems) }
 
@@ -177,19 +172,12 @@ fun BottomBarSettingsContent(accountViewModel: AccountViewModel) {
         // --- The editable bar: a real preview you drag to reorder and tap ✕ to remove from. ---
         EditableBarCard(state, pinned, accountViewModel)
 
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = Size20dp),
-            horizontalArrangement = Arrangement.End,
-        ) {
-            TextButton(onClick = { state.restoreDefault() }) {
-                Text(stringRes(R.string.bottom_bar_settings_restore_default))
-            }
-        }
+        RestoreDefaultRow(onClick = { state.restoreDefault() })
 
         Spacer(Modifier.height(4.dp))
 
         // --- Available catalogue, grouped into collapsible category cards. ---
-        SectionHeader(title = stringRes(R.string.bottom_bar_settings_available))
+        PickerSectionHeader(title = stringRes(R.string.bottom_bar_settings_available))
 
         BottomBarCategories.forEach { category ->
             CategoryCard(
@@ -217,60 +205,43 @@ private fun EditableBarCard(
     pinned: List<BottomBarEntry>,
     accountViewModel: AccountViewModel,
 ) {
-    val accent = MaterialTheme.colorScheme.primary
-    Surface(
-        shape = RoundedCornerShape(22.dp),
-        color = accent.copy(alpha = 0.07f),
-        border = BorderStroke(1.dp, accent.copy(alpha = 0.22f)),
-        modifier = Modifier.fillMaxWidth().padding(horizontal = Size20dp, vertical = 4.dp),
-    ) {
-        Column(Modifier.padding(14.dp)) {
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(bottom = 10.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text = stringRes(R.string.bottom_bar_settings_pinned),
-                    style = MaterialTheme.typography.labelMedium,
-                    color = accent,
-                    fontWeight = FontWeight.Bold,
-                )
-                Text(
-                    text = "${pinned.size} / $RECOMMENDED_SLOTS",
-                    style = MaterialTheme.typography.labelMedium,
-                    color = if (pinned.size > RECOMMENDED_SLOTS) MaterialTheme.colorScheme.error else accent,
-                    fontWeight = FontWeight.Bold,
-                )
-            }
-
-            Surface(
-                shape = RoundedCornerShape(16.dp),
-                color = MaterialTheme.colorScheme.background,
-                shadowElevation = 3.dp,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                if (pinned.isEmpty()) {
-                    Box(Modifier.fillMaxWidth().height(60.dp), contentAlignment = Alignment.Center) {
-                        Text(
-                            stringRes(R.string.bottom_bar_settings_pinned_empty),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(horizontal = 16.dp),
-                        )
-                    }
-                } else {
-                    EditableBar(state, pinned, accountViewModel)
-                }
-            }
-
+    PickerHeroCard(
+        title = stringRes(R.string.bottom_bar_settings_pinned),
+        trailing = {
             Text(
-                text = stringRes(R.string.bottom_bar_settings_reorder_hint),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(top = 8.dp),
+                text = "${pinned.size} / $RECOMMENDED_SLOTS",
+                style = MaterialTheme.typography.labelMedium,
+                color = if (pinned.size > RECOMMENDED_SLOTS) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.Bold,
             )
+        },
+    ) {
+        Surface(
+            shape = RoundedCornerShape(16.dp),
+            color = MaterialTheme.colorScheme.background,
+            shadowElevation = 3.dp,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            if (pinned.isEmpty()) {
+                Box(Modifier.fillMaxWidth().height(60.dp), contentAlignment = Alignment.Center) {
+                    Text(
+                        stringRes(R.string.bottom_bar_settings_pinned_empty),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                    )
+                }
+            } else {
+                EditableBar(state, pinned, accountViewModel)
+            }
         }
+
+        Text(
+            text = stringRes(R.string.bottom_bar_settings_reorder_hint),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = 8.dp),
+        )
     }
 }
 
@@ -470,72 +441,33 @@ private fun CategoryCard(
     accountViewModel: AccountViewModel,
     onTogglePin: (BottomBarEntry) -> Unit,
 ) {
-    Surface(
-        shape = RoundedCornerShape(16.dp),
-        color = MaterialTheme.colorScheme.surface,
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
-        modifier = Modifier.fillMaxWidth().padding(horizontal = Size20dp, vertical = 5.dp),
+    CatalogCard(
+        icon = categoryIcon(category.titleRes),
+        title = stringRes(category.titleRes),
+        expanded = expanded,
+        onToggleExpand = onToggleExpand,
     ) {
-        Column {
-            Row(
-                modifier = Modifier.fillMaxWidth().clickable(onClick = onToggleExpand).padding(13.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                Box(
-                    modifier =
-                        Modifier
-                            .size(34.dp)
-                            .clip(RoundedCornerShape(11.dp))
-                            .background(MaterialTheme.colorScheme.surfaceVariant),
-                    contentAlignment = Alignment.Center,
+        category.items.forEach { item ->
+            val def = NavBarCatalog[item] ?: return@forEach
+            val entry = BottomBarEntry.BuiltIn(item)
+            if (item in ExpandableItems) {
+                ExpandableAvailableRow(
+                    icon = def.icon,
+                    label = stringRes(def.labelRes),
+                    pinned = entry.stableKey in pinnedKeys,
+                    expanded = expandedItems[item] ?: false,
+                    onTogglePin = { onTogglePin(entry) },
+                    onToggleExpand = { expandedItems[item] = !(expandedItems[item] ?: false) },
                 ) {
-                    Icon(
-                        symbol = categoryIcon(category.titleRes),
-                        contentDescription = null,
-                        modifier = Modifier.size(20.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
+                    PickerChildren(item, pinnedKeys, accountViewModel, onTogglePin)
                 }
-                Text(
-                    text = stringRes(category.titleRes),
-                    style = MaterialTheme.typography.titleSmall,
-                    modifier = Modifier.weight(1f),
+            } else {
+                AvailableRow(
+                    leading = { LeadingGlyph(def.icon) },
+                    label = stringRes(def.labelRes),
+                    pinned = entry.stableKey in pinnedKeys,
+                    onToggle = { onTogglePin(entry) },
                 )
-                Icon(
-                    symbol = if (expanded) MaterialSymbols.ExpandLess else MaterialSymbols.ExpandMore,
-                    contentDescription = null,
-                    modifier = Modifier.size(24.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-
-            AnimatedVisibility(visible = expanded, enter = SectionExpand, exit = SectionCollapse) {
-                Column(Modifier.padding(bottom = 6.dp)) {
-                    category.items.forEach { item ->
-                        val def = NavBarCatalog[item] ?: return@forEach
-                        val entry = BottomBarEntry.BuiltIn(item)
-                        if (item in ExpandableItems) {
-                            ExpandableAvailableRow(
-                                icon = def.icon,
-                                label = stringRes(def.labelRes),
-                                pinned = entry.stableKey in pinnedKeys,
-                                expanded = expandedItems[item] ?: false,
-                                onTogglePin = { onTogglePin(entry) },
-                                onToggleExpand = { expandedItems[item] = !(expandedItems[item] ?: false) },
-                            ) {
-                                PickerChildren(item, pinnedKeys, accountViewModel, onTogglePin)
-                            }
-                        } else {
-                            AvailableRow(
-                                leading = { LeadingGlyph(def.icon) },
-                                label = stringRes(def.labelRes),
-                                pinned = entry.stableKey in pinnedKeys,
-                                onToggle = { onTogglePin(entry) },
-                            )
-                        }
-                    }
-                }
             }
         }
     }
@@ -757,18 +689,6 @@ private fun ConcordServerPickerGroup(
 // Rows & shared bits
 // ------------------------------------------------------------------------------------------------
 
-/**
- * Start padding per nesting depth: 0 = a top-level catalog row, 1 = an item under an expandable
- * category (a favorite, or a relay/community "server" row), 2 = a room nested under its server (a
- * NIP-29 group under its relay, or a Concord channel under its community).
- */
-private fun indentPadding(level: Int) =
-    when (level) {
-        0 -> 13.dp
-        1 -> 24.dp
-        else -> 40.dp
-    }
-
 @Composable
 private fun AvailableRow(
     leading: @Composable () -> Unit,
@@ -777,23 +697,12 @@ private fun AvailableRow(
     onToggle: () -> Unit,
     indentLevel: Int = 0,
 ) {
-    Row(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .clickable(onClick = onToggle)
-                .padding(start = indentPadding(indentLevel), end = 13.dp, top = 7.dp, bottom = 7.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    CatalogRow(
+        leading = leading,
+        label = label,
+        onToggle = onToggle,
+        indentLevel = indentLevel,
     ) {
-        leading()
-        Text(
-            text = label,
-            style = MaterialTheme.typography.bodyLarge,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f),
-        )
         AddPill(added = pinned, onClick = onToggle)
     }
 }
@@ -838,52 +747,18 @@ private fun ExpandableAvailableRow(
     }
 }
 
-/**
- * Outlined "Add" that fills to "Added" once pinned — states the action and its result. Both states
- * share one Row body (only color/border/tint differ) so the pill keeps a constant height and the rows
- * stay aligned whether an item is added or not.
- */
+/** Outlined "Add" that fills to "Added" once pinned — states the action and its result. */
 @Composable
 private fun AddPill(
     added: Boolean,
     onClick: () -> Unit,
 ) {
-    val accent = MaterialTheme.colorScheme.primary
-    val content = if (added) MaterialTheme.colorScheme.onPrimary else accent
-    Surface(
-        shape = CircleShape,
-        color = if (added) accent else Color.Transparent,
-        border = if (added) null else BorderStroke(1.dp, accent),
-    ) {
-        Row(
-            modifier = Modifier.clickable(onClick = onClick).padding(horizontal = 14.dp, vertical = 7.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
-            Icon(
-                symbol = if (added) MaterialSymbols.Check else MaterialSymbols.Add,
-                contentDescription = null,
-                modifier = Modifier.size(15.dp),
-                tint = content,
-            )
-            Text(
-                text = stringRes(if (added) R.string.bottom_bar_settings_added else R.string.bottom_bar_settings_add),
-                style = MaterialTheme.typography.labelLarge,
-                color = content,
-            )
-        }
-    }
-}
-
-/** A category/destination glyph in a soft accent-tinted circle. */
-@Composable
-private fun LeadingGlyph(icon: MaterialSymbol) {
-    Box(
-        modifier = Modifier.size(34.dp).clip(CircleShape).background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)),
-        contentAlignment = Alignment.Center,
-    ) {
-        Icon(symbol = icon, contentDescription = null, modifier = Modifier.size(19.dp), tint = MaterialTheme.colorScheme.primary)
-    }
+    TogglePill(
+        on = added,
+        label = stringRes(if (added) R.string.bottom_bar_settings_added else R.string.bottom_bar_settings_add),
+        icon = if (added) MaterialSymbols.Check else MaterialSymbols.Add,
+        onClick = onClick,
+    )
 }
 
 /** A favorite web-app / nsite / napplet's real favicon in a tinted circle (glyph fallback). */
@@ -900,30 +775,6 @@ private fun FavoriteLeading(app: FavoriteApp) {
             iconModel = rememberFavoriteIconModel(app),
         )
     }
-}
-
-@Composable
-private fun SectionHeader(title: String) {
-    Text(
-        text = title,
-        style = MaterialTheme.typography.labelMedium,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        fontWeight = FontWeight.Bold,
-        modifier = Modifier.padding(start = Size20dp, end = Size20dp, top = 18.dp, bottom = 6.dp),
-    )
-}
-
-@Composable
-private fun EmptyChildHint(
-    textRes: Int,
-    indentLevel: Int = 1,
-) {
-    Text(
-        text = stringRes(textRes),
-        style = MaterialTheme.typography.bodySmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(start = indentPadding(indentLevel), end = 13.dp, top = 6.dp, bottom = 6.dp),
-    )
 }
 
 private fun categoryIcon(titleRes: Int): MaterialSymbol =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/BottomBarSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/BottomBarSettingsScreen.kt
@@ -54,7 +54,6 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -91,6 +90,7 @@ import com.vitorpamplona.amethyst.ui.navigation.topbars.TopBarWithBackButton
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.mockAccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.amethyst.ui.theme.Size22Modifier
 import com.vitorpamplona.amethyst.ui.theme.ThemeComparisonRow
 import com.vitorpamplona.quartz.concord.cord02Community.ConcordCommunityListEntry
 import com.vitorpamplona.quartz.nip51Lists.simpleGroupList.GroupTag
@@ -158,8 +158,8 @@ fun BottomBarSettingsContent(accountViewModel: AccountViewModel) {
     val pinned = state.pinned
     val pinnedKeys = remember(pinned) { state.pinnedKeys() }
 
-    val expandedCategories = remember { mutableStateMapOf<Int, Boolean>() }
-    val expandedItems = remember { mutableStateMapOf<NavBarItem, Boolean>() }
+    val expandedCategories = rememberExpandedKeys<Int>()
+    val expandedItems = rememberExpandedKeys<NavBarItem>()
 
     Column(
         modifier =
@@ -183,8 +183,8 @@ fun BottomBarSettingsContent(accountViewModel: AccountViewModel) {
             CategoryCard(
                 category = category,
                 pinnedKeys = pinnedKeys,
-                expanded = expandedCategories[category.titleRes] ?: false,
-                onToggleExpand = { expandedCategories[category.titleRes] = !(expandedCategories[category.titleRes] ?: false) },
+                expanded = expandedCategories.isExpanded(category.titleRes),
+                onToggleExpand = { expandedCategories.toggle(category.titleRes) },
                 expandedItems = expandedItems,
                 accountViewModel = accountViewModel,
                 onTogglePin = state::togglePin,
@@ -437,12 +437,12 @@ private fun CategoryCard(
     pinnedKeys: Set<String>,
     expanded: Boolean,
     onToggleExpand: () -> Unit,
-    expandedItems: SnapshotStateMap<NavBarItem, Boolean>,
+    expandedItems: ExpandedKeys<NavBarItem>,
     accountViewModel: AccountViewModel,
     onTogglePin: (BottomBarEntry) -> Unit,
 ) {
     CatalogCard(
-        icon = categoryIcon(category.titleRes),
+        icon = category.icon,
         title = stringRes(category.titleRes),
         expanded = expanded,
         onToggleExpand = onToggleExpand,
@@ -455,9 +455,9 @@ private fun CategoryCard(
                     icon = def.icon,
                     label = stringRes(def.labelRes),
                     pinned = entry.stableKey in pinnedKeys,
-                    expanded = expandedItems[item] ?: false,
+                    expanded = expandedItems.isExpanded(item),
                     onTogglePin = { onTogglePin(entry) },
-                    onToggleExpand = { expandedItems[item] = !(expandedItems[item] ?: false) },
+                    onToggleExpand = { expandedItems.toggle(item) },
                 ) {
                     PickerChildren(item, pinnedKeys, accountViewModel, onTogglePin)
                 }
@@ -717,27 +717,15 @@ private fun ExpandableAvailableRow(
     onToggleExpand: () -> Unit,
     children: @Composable () -> Unit,
 ) {
-    Row(
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .clickable(onClick = onToggleExpand)
-                .padding(start = 13.dp, end = 13.dp, top = 7.dp, bottom = 7.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    CatalogRow(
+        leading = { LeadingGlyph(icon) },
+        label = label,
+        onToggle = onToggleExpand,
     ) {
-        LeadingGlyph(icon)
-        Text(
-            text = label,
-            style = MaterialTheme.typography.bodyLarge,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f),
-        )
         Icon(
             symbol = if (expanded) MaterialSymbols.ExpandLess else MaterialSymbols.ExpandMore,
             contentDescription = stringRes(R.string.bottom_bar_settings_expand),
-            modifier = Modifier.size(22.dp),
+            modifier = Size22Modifier,
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         AddPill(added = pinned, onClick = onTogglePin)
@@ -776,16 +764,6 @@ private fun FavoriteLeading(app: FavoriteApp) {
         )
     }
 }
-
-private fun categoryIcon(titleRes: Int): MaterialSymbol =
-    when (titleRes) {
-        R.string.bottom_bar_category_main -> MaterialSymbols.Home
-        R.string.bottom_bar_category_chats -> MaterialSymbols.Group
-        R.string.bottom_bar_category_you -> MaterialSymbols.AccountCircle
-        R.string.bottom_bar_category_feeds -> MaterialSymbols.Subscriptions
-        R.string.bottom_bar_category_apps -> MaterialSymbols.Apps
-        else -> MaterialSymbols.Settings
-    }
 
 // ------------------------------------------------------------------------------------------------
 // Leading/label resolution for a pinned entry (built-in glyph, favorite icon, or group avatar).

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/DrawerSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/DrawerSettingsScreen.kt
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
+import com.vitorpamplona.amethyst.ui.navigation.bottombars.NavBarCatalog
+import com.vitorpamplona.amethyst.ui.navigation.drawer.DrawerItemVisibility
+import com.vitorpamplona.amethyst.ui.navigation.drawer.DrawerSection
+import com.vitorpamplona.amethyst.ui.navigation.drawer.DrawerSectionId
+import com.vitorpamplona.amethyst.ui.navigation.drawer.DrawerSections
+import com.vitorpamplona.amethyst.ui.navigation.drawer.MandatoryDrawerItems
+import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
+import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.topbars.TopBarWithBackButton
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.mockAccountViewModel
+import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.amethyst.ui.theme.ThemeComparisonRow
+
+@Composable
+@Preview(device = "spec:width=2100px,height=2340px,dpi=440")
+fun DrawerSettingsScreenPreview() {
+    ThemeComparisonRow {
+        DrawerSettingsScreen(
+            mockAccountViewModel(),
+            EmptyNav(),
+        )
+    }
+}
+
+@Composable
+fun DrawerSettingsScreen(
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    Scaffold(
+        topBar = {
+            TopBarWithBackButton(stringRes(id = R.string.drawer_settings), nav)
+        },
+    ) { padding ->
+        Column(Modifier.padding(padding)) {
+            DrawerSettingsContent(accountViewModel)
+        }
+    }
+}
+
+/**
+ * Show/hide editor for the side menu's rows. It renders [DrawerSections] directly — the very list the
+ * drawer renders — so a destination added to a section shows up here with no work, and a row that
+ * exists here always exists there.
+ */
+@Composable
+fun DrawerSettingsContent(accountViewModel: AccountViewModel) {
+    // Per-account, synced through the NIP-78 app-specific data event.
+    val savedHidden by accountViewModel.hiddenDrawerItemsFlow().collectAsStateWithLifecycle()
+
+    // All show/hide logic lives in the holder (unit-tested); the composable only renders and forwards
+    // events. Each edit republishes the account's NIP-78 settings event. syncFrom re-seeds when the
+    // saved set changes elsewhere.
+    //
+    // Deliberately unkeyed. The holder captures this `accountViewModel` in its persist lambda, so a
+    // holder that outlived an account switch would write account A's edits to account B. It cannot:
+    // SetAccountCentricViewModelStore wraps the whole logged-in tree in `key(account.signer.pubKey)`,
+    // so a switch disposes this composable (and the NavController with it) and re-runs this remember
+    // against the new account's ViewModel. Keying on accountViewModel here would be a no-op that
+    // implies the subtree survives a switch — if that ever becomes true, this comment is the bug.
+    val state = remember { DrawerSettingsState(savedHidden) { accountViewModel.changeHiddenDrawerItems(it) } }
+    LaunchedEffect(savedHidden) { state.syncFrom(savedHidden) }
+
+    // Sections start collapsed: expanded, they are ~50 rows of scrolling. The header's hidden
+    // counter is what tells the user which one to open.
+    val expandedSections = remember { mutableStateMapOf<DrawerSectionId, Boolean>() }
+
+    // derivedStateOf so a toggle that leaves this total unchanged doesn't re-run the whole screen
+    // body — every SectionCard below reads the same coarse `hidden` state.
+    val totalHidden by remember { derivedStateOf { state.totalHidden() } }
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState()),
+    ) {
+        Spacer(Modifier.height(12.dp))
+
+        SummaryCard(totalHidden)
+
+        RestoreDefaultRow(onClick = { state.restoreDefault() })
+
+        Spacer(Modifier.height(4.dp))
+
+        PickerSectionHeader(title = stringRes(R.string.drawer_settings_sections))
+
+        // A section with no catalog rows has nothing to configure (Create is composer entry points),
+        // so it isn't listed here even though the drawer renders it.
+        DrawerSections.forEach { section ->
+            if (section.items.isEmpty()) return@forEach
+            SectionCard(
+                section = section,
+                state = state,
+                expanded = expandedSections[section.id] ?: false,
+                onToggleExpand = { expandedSections[section.id] = !(expandedSections[section.id] ?: false) },
+            )
+        }
+
+        Spacer(Modifier.height(24.dp))
+    }
+}
+
+/** What the setting does and how far from stock the menu currently is. */
+@Composable
+private fun SummaryCard(totalHidden: Int) {
+    PickerHeroCard(
+        title = stringRes(R.string.drawer_settings_title),
+        trailing = {
+            Text(
+                text = stringRes(R.string.drawer_settings_hidden_count, totalHidden),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.Bold,
+            )
+        },
+    ) {
+        Text(
+            text = stringRes(R.string.drawer_settings_description),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun SectionCard(
+    section: DrawerSection,
+    state: DrawerSettingsState,
+    expanded: Boolean,
+    onToggleExpand: () -> Unit,
+) {
+    // Each card reads the same coarse `hidden` state, so without derivedStateOf a toggle in one
+    // section would recompose (and re-count) all of them.
+    val hiddenHere by remember(section) { derivedStateOf { state.hiddenCount(section) } }
+
+    CatalogCard(
+        icon = section.icon,
+        title = stringRes(section.titleRes),
+        expanded = expanded,
+        onToggleExpand = onToggleExpand,
+        trailing = {
+            if (hiddenHere > 0) {
+                Text(
+                    text = stringRes(R.string.drawer_settings_hidden_count, hiddenHere),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+    ) {
+        // Bulk actions: turning ~29 feed rows off one at a time is the kind of chore that makes
+        // people give up halfway and leave the menu in a worse state than they found it.
+        if (DrawerItemVisibility.hasHideableRows(section)) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(start = 6.dp, end = 6.dp),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(onClick = { state.showAll(section) }) {
+                    Text(stringRes(R.string.drawer_settings_show_all))
+                }
+                TextButton(onClick = { state.hideAll(section) }) {
+                    Text(stringRes(R.string.drawer_settings_hide_all))
+                }
+            }
+        }
+
+        section.items.forEach { item ->
+            val def = NavBarCatalog[item] ?: return@forEach
+            val mandatory = item in MandatoryDrawerItems
+            val visible = state.isVisible(item)
+            CatalogRow(
+                leading = { LeadingGlyph(def.icon) },
+                label = stringRes(def.labelRes),
+                onToggle = if (mandatory) null else ({ state.toggle(item) }),
+            ) {
+                VisibilityPill(visible = visible, mandatory = mandatory, onClick = { state.toggle(item) })
+            }
+        }
+    }
+}
+
+/**
+ * Filled "Visible" / outlined "Hidden" — the bottom bar's Add/Added pill, saying what this screen
+ * says instead. A mandatory row gets a locked "Always on" badge: it reads as deliberately fixed
+ * rather than as a control that ignores taps.
+ */
+@Composable
+private fun VisibilityPill(
+    visible: Boolean,
+    mandatory: Boolean,
+    onClick: () -> Unit,
+) {
+    TogglePill(
+        on = visible,
+        label =
+            stringRes(
+                when {
+                    mandatory -> R.string.drawer_settings_always_on
+                    visible -> R.string.drawer_settings_visible
+                    else -> R.string.drawer_settings_hidden
+                },
+            ),
+        icon =
+            when {
+                mandatory -> MaterialSymbols.Lock
+                visible -> MaterialSymbols.Visibility
+                else -> MaterialSymbols.VisibilityOff
+            },
+        enabled = !mandatory,
+        onClick = onClick,
+    )
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/DrawerSettingsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/DrawerSettingsScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -113,11 +112,9 @@ fun DrawerSettingsContent(accountViewModel: AccountViewModel) {
 
     // Sections start collapsed: expanded, they are ~50 rows of scrolling. The header's hidden
     // counter is what tells the user which one to open.
-    val expandedSections = remember { mutableStateMapOf<DrawerSectionId, Boolean>() }
+    val expandedSections = rememberExpandedKeys<DrawerSectionId>()
 
-    // derivedStateOf so a toggle that leaves this total unchanged doesn't re-run the whole screen
-    // body — every SectionCard below reads the same coarse `hidden` state.
-    val totalHidden by remember { derivedStateOf { state.totalHidden() } }
+    val totalHidden = state.totalHidden()
 
     Column(
         modifier =
@@ -142,8 +139,8 @@ fun DrawerSettingsContent(accountViewModel: AccountViewModel) {
             SectionCard(
                 section = section,
                 state = state,
-                expanded = expandedSections[section.id] ?: false,
-                onToggleExpand = { expandedSections[section.id] = !(expandedSections[section.id] ?: false) },
+                expanded = expandedSections.isExpanded(section.id),
+                onToggleExpand = { expandedSections.toggle(section.id) },
             )
         }
 
@@ -241,22 +238,18 @@ private fun VisibilityPill(
     mandatory: Boolean,
     onClick: () -> Unit,
 ) {
+    // One branch decides both halves of the pill, so a label can't drift away from its glyph.
+    val (labelRes, icon) =
+        when {
+            mandatory -> R.string.drawer_settings_always_on to MaterialSymbols.Lock
+            visible -> R.string.drawer_settings_visible to MaterialSymbols.Visibility
+            else -> R.string.drawer_settings_hidden to MaterialSymbols.VisibilityOff
+        }
+
     TogglePill(
         on = visible,
-        label =
-            stringRes(
-                when {
-                    mandatory -> R.string.drawer_settings_always_on
-                    visible -> R.string.drawer_settings_visible
-                    else -> R.string.drawer_settings_hidden
-                },
-            ),
-        icon =
-            when {
-                mandatory -> MaterialSymbols.Lock
-                visible -> MaterialSymbols.Visibility
-                else -> MaterialSymbols.VisibilityOff
-            },
+        label = stringRes(labelRes),
+        icon = icon,
         enabled = !mandatory,
         onClick = onClick,
     )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/DrawerSettingsState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/DrawerSettingsState.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.vitorpamplona.amethyst.ui.navigation.bottombars.NavBarItem
+import com.vitorpamplona.amethyst.ui.navigation.drawer.DrawerItemVisibility
+import com.vitorpamplona.amethyst.ui.navigation.drawer.DrawerSection
+
+/**
+ * State holder for the Side Menu settings screen: owns the set of switched-off drawer rows and the
+ * show / hide / restore-default operations, so the composable only renders and forwards events.
+ *
+ * The rules themselves live in [DrawerItemVisibility] (pure, unit-tested); this adds only the Compose
+ * state and the write-through to the account's synced settings. Unlike the bottom bar there is no
+ * transient/commit split — a toggle is a single discrete edit, not a drag, so every change persists
+ * immediately.
+ *
+ * No sanitizing here: every value in is either already sanitized by the persistence layer or produced
+ * by a [DrawerItemVisibility] operation that can't introduce a mandatory row, and the write side
+ * sanitizes again anyway. One authority, not three.
+ */
+@Stable
+class DrawerSettingsState(
+    initial: Set<NavBarItem>,
+    private val persist: (Set<NavBarItem>) -> Unit,
+) {
+    var hidden by mutableStateOf(initial)
+        private set
+
+    fun isVisible(item: NavBarItem): Boolean = DrawerItemVisibility.isVisible(hidden, item)
+
+    fun toggle(item: NavBarItem) = update(DrawerItemVisibility.toggle(hidden, item))
+
+    fun hiddenCount(section: DrawerSection): Int = DrawerItemVisibility.hiddenCount(section, hidden)
+
+    fun totalHidden(): Int = DrawerItemVisibility.totalHidden(hidden)
+
+    fun showAll(section: DrawerSection) = update(DrawerItemVisibility.showAll(hidden, section))
+
+    fun hideAll(section: DrawerSection) = update(DrawerItemVisibility.hideAll(hidden, section))
+
+    /** Back to the stock drawer: nothing hidden. */
+    fun restoreDefault() = update(emptySet())
+
+    /**
+     * Re-seed from an external change (the saved settings flow emitted) without re-persisting. A no-op
+     * when equal, so the echo of our own [persist] doesn't fight an in-progress edit.
+     */
+    fun syncFrom(items: Set<NavBarItem>) {
+        if (items != hidden) hidden = items
+    }
+
+    private fun update(newHidden: Set<NavBarItem>) {
+        if (newHidden == hidden) return
+        hidden = newHidden
+        persist(newHidden)
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/NavPickerUi.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/NavPickerUi.kt
@@ -1,0 +1,330 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.settings
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
+import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbol
+import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
+import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.amethyst.ui.theme.SimpleImage35Modifier
+import com.vitorpamplona.amethyst.ui.theme.Size10dp
+import com.vitorpamplona.amethyst.ui.theme.Size12dp
+import com.vitorpamplona.amethyst.ui.theme.Size13dp
+import com.vitorpamplona.amethyst.ui.theme.Size14dp
+import com.vitorpamplona.amethyst.ui.theme.Size15Modifier
+import com.vitorpamplona.amethyst.ui.theme.Size18dp
+import com.vitorpamplona.amethyst.ui.theme.Size19Modifier
+import com.vitorpamplona.amethyst.ui.theme.Size20Modifier
+import com.vitorpamplona.amethyst.ui.theme.Size20dp
+import com.vitorpamplona.amethyst.ui.theme.Size22dp
+import com.vitorpamplona.amethyst.ui.theme.Size24Modifier
+import com.vitorpamplona.amethyst.ui.theme.Size24dp
+import com.vitorpamplona.amethyst.ui.theme.Size34dp
+import com.vitorpamplona.amethyst.ui.theme.Size40dp
+import com.vitorpamplona.amethyst.ui.theme.Size6dp
+
+/**
+ * The shared visual language of the navigation-configuration screens — the Bottom Navigation Bar
+ * picker and the Side Menu picker. Both present the same shape (collapsible cards of catalog rows,
+ * each row a glyph + label + a pill stating its current state), so the pieces live here once and
+ * each screen supplies only its own semantics: the bottom bar pins and reorders entries, the side
+ * menu switches rows on and off.
+ *
+ * [SectionExpand]/[SectionCollapse] reveal expandable sections by unrolling straight down from the
+ * top edge (the default AnimatedVisibility enter also expands horizontally from the bottom-end,
+ * which reads as a diagonal slide from the top-left).
+ */
+val SectionExpand = expandVertically(expandFrom = Alignment.Top) + fadeIn()
+val SectionCollapse = shrinkVertically(shrinkTowards = Alignment.Top) + fadeOut()
+
+/**
+ * Start padding per nesting depth: 0 = a top-level catalog row, 1 = an item under an expandable
+ * category (a favorite, or a relay/community "server" row), 2 = a room nested under its server (a
+ * NIP-29 group under its relay, or a Concord channel under its community).
+ */
+fun indentPadding(level: Int) =
+    when (level) {
+        0 -> Size13dp
+        1 -> Size24dp
+        else -> Size40dp
+    }
+
+@Composable
+fun PickerSectionHeader(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(start = Size20dp, end = Size20dp, top = Size18dp, bottom = Size6dp),
+    )
+}
+
+/** A category/destination glyph in a soft accent-tinted circle. */
+@Composable
+fun LeadingGlyph(icon: MaterialSymbol) {
+    Box(
+        modifier = SimpleImage35Modifier.background(MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(symbol = icon, contentDescription = null, modifier = Size19Modifier, tint = MaterialTheme.colorScheme.primary)
+    }
+}
+
+@Composable
+fun EmptyChildHint(
+    textRes: Int,
+    indentLevel: Int = 1,
+) {
+    Text(
+        text = stringRes(textRes),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(start = indentPadding(indentLevel), end = Size13dp, top = Size6dp, bottom = Size6dp),
+    )
+}
+
+/**
+ * One catalog row: leading visual, label, and a caller-supplied [trailing] state control. Tapping
+ * anywhere on the row runs [onToggle]; pass null for a row whose state can't change (a mandatory
+ * side-menu item), which also drops the ripple so the row doesn't advertise an action it won't take.
+ */
+@Composable
+fun CatalogRow(
+    leading: @Composable () -> Unit,
+    label: String,
+    onToggle: (() -> Unit)?,
+    indentLevel: Int = 0,
+    trailing: @Composable () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .let { if (onToggle != null) it.clickable(onClick = onToggle) else it }
+                .padding(start = indentPadding(indentLevel), end = Size13dp, top = 7.dp, bottom = 7.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Size12dp),
+    ) {
+        leading()
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        trailing()
+    }
+}
+
+/**
+ * The state pill at the end of a catalog row: outlined in the "off" state, filled in the "on" state —
+ * so it states both the current state and, by contrast, that it can be changed. Both states share one
+ * Row body (only color/border/tint differ) so the pill keeps a constant height and rows stay aligned.
+ *
+ * [enabled] false renders the pill as a locked, non-interactive badge — used for a row the user isn't
+ * allowed to switch off.
+ */
+@Composable
+fun TogglePill(
+    on: Boolean,
+    label: String,
+    icon: MaterialSymbol,
+    enabled: Boolean = true,
+    onClick: () -> Unit,
+) {
+    val accent = MaterialTheme.colorScheme.primary
+    val container = if (enabled) accent else MaterialTheme.colorScheme.surfaceVariant
+    val content =
+        when {
+            !enabled -> MaterialTheme.colorScheme.onSurfaceVariant
+            on -> MaterialTheme.colorScheme.onPrimary
+            else -> accent
+        }
+    Surface(
+        shape = CircleShape,
+        color = if (on) container else Color.Transparent,
+        border = if (on) null else BorderStroke(1.dp, content),
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .let { if (enabled) it.clickable(onClick = onClick) else it }
+                    .padding(horizontal = Size14dp, vertical = 7.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Icon(
+                symbol = icon,
+                contentDescription = null,
+                modifier = Size15Modifier,
+                tint = content,
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelLarge,
+                color = content,
+            )
+        }
+    }
+}
+
+/**
+ * A collapsible card holding catalog rows. [trailing] renders between the title and the chevron —
+ * the side menu puts its "n hidden" counter there; the bottom bar leaves it empty.
+ */
+@Composable
+fun CatalogCard(
+    icon: MaterialSymbol,
+    title: String,
+    expanded: Boolean,
+    onToggleExpand: () -> Unit,
+    trailing: @Composable () -> Unit = {},
+    content: @Composable () -> Unit,
+) {
+    Surface(
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surface,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+        modifier = Modifier.fillMaxWidth().padding(horizontal = Size20dp, vertical = 5.dp),
+    ) {
+        Column {
+            Row(
+                modifier = Modifier.fillMaxWidth().clickable(onClick = onToggleExpand).padding(Size13dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(Size12dp),
+            ) {
+                Box(
+                    modifier =
+                        Modifier
+                            .size(Size34dp)
+                            .clip(RoundedCornerShape(11.dp))
+                            .background(MaterialTheme.colorScheme.surfaceVariant),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        symbol = icon,
+                        contentDescription = null,
+                        modifier = Size20Modifier,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleSmall,
+                    modifier = Modifier.weight(1f),
+                )
+                trailing()
+                Icon(
+                    symbol = if (expanded) MaterialSymbols.ExpandLess else MaterialSymbols.ExpandMore,
+                    contentDescription = null,
+                    modifier = Size24Modifier,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            AnimatedVisibility(visible = expanded, enter = SectionExpand, exit = SectionCollapse) {
+                Column(Modifier.padding(bottom = Size6dp)) { content() }
+            }
+        }
+    }
+}
+
+/**
+ * The accent-tinted card each picker opens with: a bold title, an optional [trailing] status, and a
+ * body. The bottom bar puts its editable preview bar in the body; the side menu puts its description.
+ */
+@Composable
+fun PickerHeroCard(
+    title: String,
+    trailing: @Composable () -> Unit = {},
+    content: @Composable () -> Unit,
+) {
+    val accent = MaterialTheme.colorScheme.primary
+    Surface(
+        shape = RoundedCornerShape(Size22dp),
+        color = accent.copy(alpha = 0.07f),
+        border = BorderStroke(1.dp, accent.copy(alpha = 0.22f)),
+        modifier = Modifier.fillMaxWidth().padding(horizontal = Size20dp, vertical = 4.dp),
+    ) {
+        Column(Modifier.padding(Size14dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(bottom = Size10dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = accent,
+                    fontWeight = FontWeight.Bold,
+                )
+                trailing()
+            }
+
+            content()
+        }
+    }
+}
+
+/** The end-aligned "Restore Default" action both pickers put under their hero card. */
+@Composable
+fun RestoreDefaultRow(onClick: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = Size20dp),
+        horizontalArrangement = Arrangement.End,
+    ) {
+        TextButton(onClick = onClick) {
+            Text(stringRes(R.string.bottom_bar_settings_restore_default))
+        }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/NavPickerUi.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/NavPickerUi.kt
@@ -42,6 +42,9 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -90,12 +93,31 @@ val SectionCollapse = shrinkVertically(shrinkTowards = Alignment.Top) + fadeOut(
  * category (a favorite, or a relay/community "server" row), 2 = a room nested under its server (a
  * NIP-29 group under its relay, or a Concord channel under its community).
  */
-fun indentPadding(level: Int) =
+private fun indentPadding(level: Int) =
     when (level) {
         0 -> Size13dp
         1 -> Size24dp
         else -> Size40dp
     }
+
+/**
+ * Which collapsible rows of a picker are currently open, keyed by whatever identifies a row (a
+ * section id, a string-resource id, a catalog item). Absent means collapsed, so the initial state
+ * costs nothing and no list has to be seeded.
+ */
+@Stable
+class ExpandedKeys<K> {
+    private val open = mutableStateMapOf<K, Boolean>()
+
+    fun isExpanded(key: K): Boolean = open[key] == true
+
+    fun toggle(key: K) {
+        open[key] = !isExpanded(key)
+    }
+}
+
+@Composable
+fun <K> rememberExpandedKeys(): ExpandedKeys<K> = remember { ExpandedKeys() }
 
 @Composable
 fun PickerSectionHeader(title: String) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/SettingsCatalogBuilder.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/settings/SettingsCatalogBuilder.kt
@@ -72,6 +72,7 @@ fun buildSettingsCatalog(
                     symEntry(R.string.reactions_settings, MaterialSymbols.ThumbUp, R.string.reactions_settings_search_keywords, Route.ReactionsSettings),
                     symEntry(R.string.messages_settings, MaterialSymbols.Mail, R.string.messages_settings_search_keywords, Route.MessagesSettings),
                     symEntry(R.string.bottom_bar_settings, MaterialSymbols.Dashboard, R.string.bottom_bar_search_keywords, Route.BottomBarSettings),
+                    symEntry(R.string.drawer_settings, MaterialSymbols.AutoMirrored.ViewList, R.string.drawer_search_keywords, Route.DrawerSettings),
                     symEntry(R.string.video_player_settings, MaterialSymbols.VideoSettings, R.string.video_player_search_keywords, Route.VideoPlayerSettings),
                     symEntry(R.string.audio_visualizer_settings, MaterialSymbols.MusicNote, R.string.audio_visualizer_search_keywords, Route.AudioVisualizerSettings),
                     symEntry(R.string.favorite_dvms_title, MaterialSymbols.AutoAwesome, R.string.favorite_dvms_search_keywords, Route.EditFavoriteAlgoFeeds),

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -2378,6 +2378,7 @@
     <string name="compose_search_keywords" translatable="false">draft, posting, editor, auto-save, signature, proof of work, pow, mining, nip-13</string>
     <string name="reactions_settings_search_keywords" translatable="false">emoji, reactions, like</string>
     <string name="bottom_bar_search_keywords" translatable="false">navigation, tabs, nav bar</string>
+    <string name="drawer_search_keywords" translatable="false">side menu, drawer, hamburger, sections, hide, show</string>
     <string name="home_tabs_search_keywords" translatable="false">tabs, feeds, threads, conversations</string>
     <string name="profile_ui_search_keywords" translatable="false">profile, layout</string>
     <string name="backup_keys_search_keywords" translatable="false">nsec, private key, seed, mnemonic, export</string>
@@ -3512,6 +3513,16 @@
     <string name="bottom_bar_category_feeds">Feeds</string>
     <string name="bottom_bar_category_apps">Apps &amp; Web</string>
     <string name="bottom_bar_category_other">Other</string>
+    <string name="drawer_settings">Side Menu</string>
+    <string name="drawer_settings_title">Your side menu</string>
+    <string name="drawer_settings_description">Open a section and switch off the rows you never use. Settings always stays visible, so you can always get back here. Section order is fixed.</string>
+    <string name="drawer_settings_sections">Sections</string>
+    <string name="drawer_settings_hidden_count">%1$d hidden</string>
+    <string name="drawer_settings_visible">Visible</string>
+    <string name="drawer_settings_hidden">Hidden</string>
+    <string name="drawer_settings_always_on">Always on</string>
+    <string name="drawer_settings_show_all">Show all</string>
+    <string name="drawer_settings_hide_all">Hide all</string>
     <string name="home_tabs_settings">Home Tabs</string>
     <string name="home_tabs_settings_description">Pick which tabs appear on the Home screen. When only one tab is active the tab bar is hidden.</string>
     <string name="home_tab_everything">Everything</string>

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/model/preferences/DrawerPersistenceTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/model/preferences/DrawerPersistenceTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.model.preferences
+
+import com.vitorpamplona.amethyst.model.AccountNavigationPreferencesInternal
+import com.vitorpamplona.amethyst.ui.navigation.bottombars.NavBarItem
+import com.vitorpamplona.amethyst.ui.navigation.bottombars.navBarItemsFromNames
+import com.vitorpamplona.amethyst.ui.navigation.bottombars.toNames
+import com.vitorpamplona.quartz.nip01Core.core.JsonMapper
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Locks the per-account side-menu persistence. The hidden rows ride along in the same NIP-78
+ * app-specific data blob as the bottom bar, so every account keeps its own menu and it syncs across
+ * the user's devices.
+ */
+class DrawerPersistenceTest {
+    @Test
+    fun defaultIsAnUntouchedMenu() {
+        val decoded = JsonMapper.fromJson<AccountNavigationPreferencesInternal>(JsonMapper.toJson(AccountNavigationPreferencesInternal()))
+
+        assertEquals(emptyList<String>(), decoded.hiddenDrawerItems)
+    }
+
+    @Test
+    fun blobWrittenBeforeTheFieldExistedDecodesToAnUntouchedMenu() {
+        // Every existing account is in this state, and so is every account that never opens the
+        // screen — which is exactly why the preference stores hidden rows rather than visible ones.
+        val decoded = JsonMapper.fromJson<AccountNavigationPreferencesInternal>("{}")
+
+        assertEquals(emptyList<String>(), decoded.hiddenDrawerItems)
+    }
+
+    @Test
+    fun hiddenRowsRoundTripThroughTheSyncedSettingsBlob() {
+        val hidden = setOf(NavBarItem.DRAFTS, NavBarItem.BADGES)
+
+        val json = JsonMapper.toJson(AccountNavigationPreferencesInternal(hiddenDrawerItems = hidden.toNames()))
+        val decoded = JsonMapper.fromJson<AccountNavigationPreferencesInternal>(json)
+
+        assertEquals(hidden, navBarItemsFromNames(decoded.hiddenDrawerItems))
+    }
+
+    @Test
+    fun serializedFormIsDeterministic() {
+        // Two equal sets must produce byte-identical JSON, or a republish that changed nothing would
+        // still look like a change and churn the account's NIP-78 event.
+        val a = JsonMapper.toJson(AccountNavigationPreferencesInternal(hiddenDrawerItems = setOf(NavBarItem.DRAFTS, NavBarItem.BADGES).toNames()))
+        val b = JsonMapper.toJson(AccountNavigationPreferencesInternal(hiddenDrawerItems = setOf(NavBarItem.BADGES, NavBarItem.DRAFTS).toNames()))
+
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun anIdFromANewerClientIsDroppedInsteadOfFailingTheWholeBlob() {
+        // The names are stored as strings precisely for this: decoding them as the enum would throw
+        // and take every other synced setting down with it.
+        val json = """{"hiddenDrawerItems":["DRAFTS","SOME_SCREEN_FROM_THE_FUTURE"]}"""
+
+        val decoded = JsonMapper.fromJson<AccountNavigationPreferencesInternal>(json)
+
+        assertEquals(setOf(NavBarItem.DRAFTS), navBarItemsFromNames(decoded.hiddenDrawerItems))
+    }
+}

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/navigation/DrawerItemVisibilityTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/navigation/DrawerItemVisibilityTest.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.navigation
+
+import com.vitorpamplona.amethyst.ui.navigation.bottombars.NavBarItem
+import com.vitorpamplona.amethyst.ui.navigation.drawer.DrawerItemVisibility
+import com.vitorpamplona.amethyst.ui.navigation.drawer.DrawerSectionId
+import com.vitorpamplona.amethyst.ui.navigation.drawer.drawerSection
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.DrawerSettingsState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The show/hide rules behind the Side Menu settings screen, exercised without the UI.
+ *
+ * The preference stores what is *hidden*, so the interesting cases are the empty set (a stock drawer,
+ * and the state every new install and every newly shipped destination starts in) and the mandatory
+ * rows, which no code path may switch off.
+ */
+class DrawerItemVisibilityTest {
+    private val you = drawerSection(DrawerSectionId.YOU)
+    private val system = drawerSection(DrawerSectionId.SYSTEM)
+
+    @Test
+    fun nothingHiddenMeansEverythingVisible() {
+        val visible = DrawerItemVisibility.visibleItems(you, emptySet())
+
+        assertEquals(you.items, visible)
+        assertEquals(0, DrawerItemVisibility.hiddenCount(you, emptySet()))
+    }
+
+    @Test
+    fun toggleHidesThenShows() {
+        val once = DrawerItemVisibility.toggle(emptySet(), NavBarItem.DRAFTS)
+        assertEquals(setOf(NavBarItem.DRAFTS), once)
+        assertFalse(DrawerItemVisibility.isVisible(once, NavBarItem.DRAFTS))
+
+        val twice = DrawerItemVisibility.toggle(once, NavBarItem.DRAFTS)
+        assertEquals(emptySet<NavBarItem>(), twice)
+        assertTrue(DrawerItemVisibility.isVisible(twice, NavBarItem.DRAFTS))
+    }
+
+    @Test
+    fun aHiddenRowDropsOutOfItsSectionKeepingTheOrderOfTheRest() {
+        val hidden = setOf(NavBarItem.DRAFTS)
+        val visible = DrawerItemVisibility.visibleItems(you, hidden)
+
+        assertEquals(you.items.filter { it != NavBarItem.DRAFTS }, visible)
+        assertEquals(1, DrawerItemVisibility.hiddenCount(you, hidden))
+    }
+
+    @Test
+    fun settingsCannotBeHidden() {
+        // The escape hatch: hiding Settings would leave no route back to the screen that hides rows.
+        assertEquals(emptySet<NavBarItem>(), DrawerItemVisibility.toggle(emptySet(), NavBarItem.SETTINGS))
+        assertTrue(DrawerItemVisibility.isVisible(setOf(NavBarItem.SETTINGS), NavBarItem.SETTINGS))
+    }
+
+    @Test
+    fun sanitizeStripsMandatoryItemsSyncedFromElsewhere() {
+        // Another client (or an older build) could put Settings in the set; reading it back must not
+        // strand the row as hidden-yet-unhideable.
+        val sanitized = DrawerItemVisibility.sanitize(setOf(NavBarItem.SETTINGS, NavBarItem.DRAFTS))
+
+        assertEquals(setOf(NavBarItem.DRAFTS), sanitized)
+    }
+
+    @Test
+    fun sanitizeKeepsIdsThisDeviceDoesNotRender() {
+        // Favorite Apps is gated off below API 30. Editing the menu on such a device must not clear
+        // the choice the same account made on a newer one.
+        val sanitized = DrawerItemVisibility.sanitize(setOf(NavBarItem.FAVORITE_APPS))
+
+        assertEquals(setOf(NavBarItem.FAVORITE_APPS), sanitized)
+    }
+
+    @Test
+    fun hideAllLeavesTheMandatoryRowsOfASection() {
+        val hidden = DrawerItemVisibility.hideAll(emptySet(), system)
+
+        assertTrue(DrawerItemVisibility.isVisible(hidden, NavBarItem.SETTINGS))
+        assertEquals(0, DrawerItemVisibility.hiddenCount(system, hidden))
+    }
+
+    @Test
+    fun aSectionOfOnlyMandatoryRowsHasNothingToHide() {
+        // What gates the section's bulk Show all / Hide all actions.
+        assertFalse(DrawerItemVisibility.hasHideableRows(system))
+        assertTrue(DrawerItemVisibility.hasHideableRows(you))
+    }
+
+    @Test
+    fun hideAllThenShowAllRoundTripsASection() {
+        val hidden = DrawerItemVisibility.hideAll(emptySet(), you)
+        assertEquals(you.items.size, DrawerItemVisibility.hiddenCount(you, hidden))
+
+        val shown = DrawerItemVisibility.showAll(hidden, you)
+        assertEquals(emptySet<NavBarItem>(), shown)
+    }
+
+    @Test
+    fun showAllOnlyTouchesItsOwnSection() {
+        val hidden = DrawerItemVisibility.hideAll(DrawerItemVisibility.hideAll(emptySet(), you), system)
+
+        val shown = DrawerItemVisibility.showAll(hidden, system)
+
+        assertEquals(you.items.size, DrawerItemVisibility.hiddenCount(you, shown))
+    }
+
+    @Test
+    fun stateHolderPersistsEveryEditAndRestoresDefaults() {
+        val saved = mutableListOf<Set<NavBarItem>>()
+        val state = DrawerSettingsState(emptySet()) { saved.add(it) }
+
+        state.toggle(NavBarItem.DRAFTS)
+        state.toggle(NavBarItem.BOOKMARKS)
+
+        assertEquals(listOf(setOf(NavBarItem.DRAFTS), setOf(NavBarItem.DRAFTS, NavBarItem.BOOKMARKS)), saved)
+        assertEquals(2, state.totalHidden())
+
+        state.restoreDefault()
+
+        assertEquals(emptySet<NavBarItem>(), state.hidden)
+        assertEquals(0, state.totalHidden())
+        assertEquals(emptySet<NavBarItem>(), saved.last())
+    }
+
+    @Test
+    fun stateHolderDoesNotRepublishANoOpEdit() {
+        // Tapping a mandatory row must not republish the account's NIP-78 settings event.
+        val saved = mutableListOf<Set<NavBarItem>>()
+        val state = DrawerSettingsState(emptySet()) { saved.add(it) }
+
+        state.toggle(NavBarItem.SETTINGS)
+        state.restoreDefault()
+
+        assertTrue(saved.isEmpty())
+    }
+}

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/navigation/DrawerItemVisibilityTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/navigation/DrawerItemVisibilityTest.kt
@@ -23,7 +23,7 @@ package com.vitorpamplona.amethyst.navigation
 import com.vitorpamplona.amethyst.ui.navigation.bottombars.NavBarItem
 import com.vitorpamplona.amethyst.ui.navigation.drawer.DrawerItemVisibility
 import com.vitorpamplona.amethyst.ui.navigation.drawer.DrawerSectionId
-import com.vitorpamplona.amethyst.ui.navigation.drawer.drawerSection
+import com.vitorpamplona.amethyst.ui.navigation.drawer.DrawerSections
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.settings.DrawerSettingsState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -38,8 +38,8 @@ import org.junit.Test
  * rows, which no code path may switch off.
  */
 class DrawerItemVisibilityTest {
-    private val you = drawerSection(DrawerSectionId.YOU)
-    private val system = drawerSection(DrawerSectionId.SYSTEM)
+    private val you = DrawerSections.first { it.id == DrawerSectionId.YOU }
+    private val system = DrawerSections.first { it.id == DrawerSectionId.SYSTEM }
 
     @Test
     fun nothingHiddenMeansEverythingVisible() {

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/navigation/DrawerSectionsTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/navigation/DrawerSectionsTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.navigation
+
+import com.vitorpamplona.amethyst.ui.navigation.bottombars.NavBarCatalog
+import com.vitorpamplona.amethyst.ui.navigation.drawer.DrawerSectionId
+import com.vitorpamplona.amethyst.ui.navigation.drawer.DrawerSections
+import com.vitorpamplona.amethyst.ui.navigation.drawer.MandatoryDrawerItems
+import com.vitorpamplona.amethyst.ui.navigation.drawer.SdkGatedDrawerItems
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The drawer and its settings screen both render [DrawerSections], so a destination missing from
+ * every section is invisible in both places at once — no compiler error, no crash, just a screen
+ * nobody can reach from the menu. These pin the invariants that keep that from happening quietly.
+ */
+class DrawerSectionsTest {
+    @Test
+    fun everyCatalogItemAppearsInADrawerSection() {
+        val sectioned = DrawerSections.flatMap { it.items }.toSet()
+        val missing = NavBarCatalog.keys - sectioned
+
+        assertEquals(
+            "a catalog destination is in no drawer section — add it to one in NavBarItem.kt, " +
+                "or to SdkGatedDrawerItems with the reason it can't be there",
+            emptySet<Any>(),
+            missing - SdkGatedDrawerItems,
+        )
+    }
+
+    @Test
+    fun noItemIsListedInTwoSections() {
+        val sectioned = DrawerSections.flatMap { it.items }
+
+        assertEquals("an item is listed in more than one drawer section", sectioned.size, sectioned.toSet().size)
+    }
+
+    @Test
+    fun everySectionedItemResolvesInTheCatalog() {
+        // The drawer looks each id up in NavBarCatalog and skips misses, so an id with no catalog
+        // entry would silently render nothing while still occupying a row in the settings screen.
+        DrawerSections.forEach { section ->
+            section.items.forEach { item ->
+                assertTrue("$item has no NavBarCatalog entry", NavBarCatalog.containsKey(item))
+            }
+        }
+    }
+
+    @Test
+    fun sectionsAreOrderedWithCreateBetweenFeedsAndSystem() {
+        // The drawer renders DrawerSections in order, so this list *is* the menu's layout. Create sits
+        // between the feeds and System, and is the one section with nothing configurable in it.
+        assertEquals(
+            listOf(
+                DrawerSectionId.YOU,
+                DrawerSectionId.NAVIGATE,
+                DrawerSectionId.FEEDS,
+                DrawerSectionId.CREATE,
+                DrawerSectionId.SYSTEM,
+            ),
+            DrawerSections.map { it.id },
+        )
+        assertEquals(emptyList<Any>(), DrawerSections.first { it.id == DrawerSectionId.CREATE }.items)
+    }
+
+    @Test
+    fun everySectionHasItsOwnId() {
+        val ids = DrawerSections.map { it.id }
+
+        assertEquals("two sections share a DrawerSectionId", ids.size, ids.toSet().size)
+    }
+
+    @Test
+    fun mandatoryItemsAreActuallyRenderedByASection() {
+        // A mandatory item that no section renders would be unhideable *and* invisible — the worst
+        // of both. Settings is mandatory precisely because it is the way back to this configuration.
+        val sectioned = DrawerSections.flatMap { it.items }.toSet()
+
+        assertTrue("a mandatory drawer item is in no section", sectioned.containsAll(MandatoryDrawerItems))
+    }
+}

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/navigation/DrawerSectionsTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/navigation/DrawerSectionsTest.kt
@@ -91,6 +91,22 @@ class DrawerSectionsTest {
     }
 
     @Test
+    fun aSectionWithNoCatalogItemsRendersFixedRowsOrNothingAtAll() {
+        // hasFixedRows is declared on the section but consumed by CatalogSection's `when (section.id)`,
+        // in another file — so the flag and the branch that honours it can drift apart with no compile
+        // error. A section that carries neither is unreachable in both directions at once: the settings
+        // screen skips it on items.isEmpty(), and CatalogSection returns before rendering a heading.
+        val unreachable = DrawerSections.filter { it.items.isEmpty() && !it.hasFixedRows }
+
+        assertEquals(
+            "a drawer section has no catalog items and no fixed rows, so it renders nowhere — " +
+                "give it items, set hasFixedRows and a branch in CatalogSection, or delete it",
+            emptyList<Any>(),
+            unreachable.map { it.id },
+        )
+    }
+
+    @Test
     fun mandatoryItemsAreActuallyRenderedByASection() {
         // A mandatory item that no section renders would be unhideable *and* invisible — the worst
         // of both. Settings is mandatory precisely because it is the way back to this configuration.


### PR DESCRIPTION
Some users might prefer less features:

<img width="200" alt="Screenshot_20260805-214959" src="https://github.com/user-attachments/assets/e8e9e801-a382-4194-bf76-c101f537ff80" /> <img width="200" alt="Screenshot_20260805-215014" src="https://github.com/user-attachments/assets/3a12e48b-7ad5-47ae-91c1-f33b12a44e11" />

Adds Settings → Side Menu, a show/hide editor for the left drawer's rows, mirroring the existing Bottom Navigation Bar picker. Sections and item order are fixed; visibility is the only per-account choice.

Both screens now render `DrawerSections` — the same list the drawer itself renders — so a destination added to a section appears in the drawer and in its settings screen with no extra work, and `DrawerSectionsTest` fails the build if a new `NavBarCatalog` id isn't filed into a section.

The preference stores what is **hidden**, not what is shown. That is what lets a destination shipped in a later release appear for every account with no migration; storing the visible list would freeze each account's drawer at the moment they first opened the screen. It persists as enum names rather than the enum itself, so an unknown id from a newer client is dropped on read instead of throwing and taking the whole synced-settings blob down with it.

Settings is the one row that cannot be hidden — it is the route back to this screen. It renders a locked "Always on" badge rather than a toggle that ignores taps. Drawer chrome (profile header, relay status, account switcher, version footer) stays fixed; those aren't catalog rows and have no id to store.

Also folds the two picker screens onto shared UI in `NavPickerUi.kt` (`CatalogRow`, `ExpandedKeys`), replaces `categoryIcon()`'s string-resource `when` with a declared `icon` field on `NavBarCategory`, and adds `FAVORITE_ALGO_FEEDS` to the You section — the one catalog destination no drawer section listed, surfaced by the new coverage test.

Per-account, synced across devices over the NIP-78 app-specific data event.

## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
