### PR TITLE
fix(ime): settle the keyboard in Nav so every screen stops stranding imePadding

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/KeyboardState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/KeyboardState.kt
@@ -20,15 +20,11 @@
  */
 package com.vitorpamplona.amethyst.ui.navigation.bottombars
 
-import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.ime
-import androidx.compose.foundation.layout.imeAnimationTarget
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalDensity
 
@@ -59,41 +55,4 @@ fun keyboardAsState(): State<KeyboardState> {
             if (imeInsets.getBottom(density) > 0) KeyboardState.Opened else KeyboardState.Closed
         }
     }
-}
-
-/**
- * A [BackHandler] that lets the system dismiss the soft keyboard before it consumes back.
- *
- * Chat composers (and draft-saving editors) intercept back to flush a draft and pop the screen.
- * While the keyboard is up we do NOT consume back, so the system dismisses it first with its own
- * animation — which completes cleanly, and on recent Android follows the back gesture rather than
- * snapping. The next back runs [onBack] as before.
- *
- * This is a UX preference, not the safety mechanism: the actual pop-during-IME-animation race is
- * handled for every exit in the app by
- * [ImeSettler][com.vitorpamplona.amethyst.ui.navigation.navs.ImeSettler] on `Nav`, so [onBack] is
- * safe to run whenever it fires.
- *
- * The gate reads [WindowInsets.imeAnimationTarget] — where the IME is *heading* — not the animated
- * [WindowInsets.ime]. Gating on the animated value left a hole: it stays above zero for the whole
- * close animation, ~250ms in which the IME has already stopped consuming back but this handler was
- * still disabled, so a second back fell through to the NavController and popped the screen without
- * ever running [onBack] — silently dropping the draft it exists to save, since nothing else saves
- * one. The target flips to zero the moment the hide begins, so back keeps reaching [onBack]
- * throughout the animation.
- */
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-fun KeyboardAwareBackHandler(
-    enabled: Boolean = true,
-    onBack: () -> Unit,
-) {
-    val density = LocalDensity.current
-    val imeTarget = WindowInsets.imeAnimationTarget
-
-    val keyboardIsStaying by remember(density, imeTarget) {
-        derivedStateOf { imeTarget.getBottom(density) > 0 }
-    }
-
-    BackHandler(enabled = enabled && !keyboardIsStaying, onBack = onBack)
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/KeyboardState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/bottombars/KeyboardState.kt
@@ -30,15 +30,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withTimeoutOrNull
-import java.util.concurrent.atomic.AtomicBoolean
 
 enum class KeyboardState {
     Opened,
@@ -69,80 +61,26 @@ fun keyboardAsState(): State<KeyboardState> {
     }
 }
 
-/** How long to wait for the IME inset to reach zero before running the action anyway. */
-private const val IME_SETTLE_TIMEOUT_MS = 700L
-
-/**
- * Returns a runner that defers an action until the soft keyboard is fully off screen.
- *
- * Popping a screen while the keyboard is still up races the window animation against the IME's
- * close animation. On release builds — fast enough that the window animation wins — the IME
- * [WindowInsetsAnimationCompat][androidx.core.view.WindowInsetsAnimationCompat] is cancelled before
- * its terminal (zero) frame reaches Compose, so the shared `WindowInsets.ime` holder stays
- * "animating" and every `Modifier.imePadding()` in the app freezes at the keyboard height until a
- * later inset pass rebalances it (the "stuck IME padding" that survives leaving the screen).
- *
- * Any exit that leaves a keyboard-bearing screen has to serialize the two animations rather than
- * overlap them. With the keyboard already down the action runs inline — same frame, no behavior
- * change. With it up we dismiss the keyboard, wait for the inset to actually reach zero, and only
- * then act, so the IME animation always completes before the window animation begins.
- *
- * Re-entrant calls while an action is pending are dropped: the deferral widens the window in which
- * a second tap on a Post/Save button would fire the action twice.
- *
- * [IME_SETTLE_TIMEOUT_MS] bounds the wait — if the inset never reports zero (precisely the failure
- * this guards against) the action still runs, so a stale reading can never trap the user on screen.
- */
-@Composable
-fun rememberAfterKeyboardCloses(): (() -> Unit) -> Unit {
-    val density = LocalDensity.current
-    val imeInsets = WindowInsets.ime
-    val keyboard = LocalSoftwareKeyboardController.current
-    val focusManager = LocalFocusManager.current
-    val scope = rememberCoroutineScope()
-    val pending = remember { AtomicBoolean(false) }
-
-    return remember(density, imeInsets, keyboard, focusManager, scope, pending) {
-        { action: () -> Unit ->
-            if (imeInsets.getBottom(density) <= 0) {
-                action()
-            } else if (pending.compareAndSet(false, true)) {
-                // Clear focus first so nothing re-requests the IME as it retracts.
-                focusManager.clearFocus(true)
-                keyboard?.hide()
-                scope.launch {
-                    try {
-                        withTimeoutOrNull(IME_SETTLE_TIMEOUT_MS) {
-                            snapshotFlow { imeInsets.getBottom(density) }.first { it <= 0 }
-                        }
-                        action()
-                    } finally {
-                        pending.set(false)
-                    }
-                }
-            }
-        }
-    }
-}
-
 /**
  * A [BackHandler] that lets the system dismiss the soft keyboard before it consumes back.
  *
- * Chat composers (and draft-saving editors) intercept back to flush a draft and pop the screen,
- * which is the pop-during-IME-animation race described on [rememberAfterKeyboardCloses]. While the
- * keyboard is up we do NOT consume back, so the system dismisses it first with its own animation
- * (which completes cleanly, and on recent Android follows the back gesture). The next back runs
- * [onBack] as before.
+ * Chat composers (and draft-saving editors) intercept back to flush a draft and pop the screen.
+ * While the keyboard is up we do NOT consume back, so the system dismisses it first with its own
+ * animation — which completes cleanly, and on recent Android follows the back gesture rather than
+ * snapping. The next back runs [onBack] as before.
+ *
+ * This is a UX preference, not the safety mechanism: the actual pop-during-IME-animation race is
+ * handled for every exit in the app by
+ * [ImeSettler][com.vitorpamplona.amethyst.ui.navigation.navs.ImeSettler] on `Nav`, so [onBack] is
+ * safe to run whenever it fires.
  *
  * The gate reads [WindowInsets.imeAnimationTarget] — where the IME is *heading* — not the animated
  * [WindowInsets.ime]. Gating on the animated value left a hole: it stays above zero for the whole
  * close animation, ~250ms in which the IME has already stopped consuming back but this handler was
  * still disabled, so a second back fell through to the NavController and popped the screen without
- * ever running [onBack] — silently dropping the draft it exists to save. The target flips to zero
- * the moment the hide begins, so back keeps reaching [onBack] throughout.
- *
- * Re-enabling that early means [onBack] can now fire mid-animation, so it is routed through
- * [rememberAfterKeyboardCloses] to wait for the inset to settle before popping.
+ * ever running [onBack] — silently dropping the draft it exists to save, since nothing else saves
+ * one. The target flips to zero the moment the hide begins, so back keeps reaching [onBack]
+ * throughout the animation.
  */
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -152,11 +90,10 @@ fun KeyboardAwareBackHandler(
 ) {
     val density = LocalDensity.current
     val imeTarget = WindowInsets.imeAnimationTarget
-    val afterKeyboardCloses = rememberAfterKeyboardCloses()
 
     val keyboardIsStaying by remember(density, imeTarget) {
         derivedStateOf { imeTarget.getBottom(density) > 0 }
     }
 
-    BackHandler(enabled = enabled && !keyboardIsStaying) { afterKeyboardCloses(onBack) }
+    BackHandler(enabled = enabled && !keyboardIsStaying, onBack = onBack)
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/navs/ImeSettler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/navs/ImeSettler.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.navigation.navs
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.ime
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+
+/** How long to wait for the IME inset to reach zero before navigating anyway. */
+const val IME_SETTLE_TIMEOUT_MS = 700L
+
+/**
+ * Waits for the soft keyboard to be fully off screen. Installed on [Nav] so that every navigation
+ * in the app serializes the IME and window animations instead of overlapping them.
+ *
+ * Navigating while the keyboard is up races the window animation against the IME's close animation.
+ * On release builds — fast enough that the window animation wins — the IME
+ * [WindowInsetsAnimationCompat][androidx.core.view.WindowInsetsAnimationCompat] is cancelled before
+ * its terminal (zero) frame reaches Compose. `WindowInsets.ime` is a single app-wide holder, so it
+ * stays "animating" and every `Modifier.imePadding()` in the app — not just the screen being left —
+ * freezes at the keyboard height until some later inset pass happens to rebalance it.
+ *
+ * This is not a composer-screen problem, which is why it lives here rather than in the screens.
+ * Any destination that can hold focus in a text field can strand the padding on the way out, by any
+ * exit: a back gesture, a top-bar button, a bottom-nav tab, or tapping a result. Search is the
+ * clearest case — it focuses its field on arrival, so the keyboard is already up before the user
+ * has done anything, and every way out of it is a navigation.
+ */
+fun interface ImeSettler {
+    suspend fun settle()
+
+    companion object {
+        /** For [EmptyNav] and previews, where there is no window to read insets from. */
+        val None = ImeSettler { }
+    }
+}
+
+/**
+ * Reads the same animated `WindowInsets.ime` that drives `Modifier.imePadding()`, so the settler
+ * and the padding can never disagree about whether the keyboard is gone.
+ *
+ * Focus is cleared before hiding so nothing re-requests the IME as it retracts. The wait is bounded
+ * by [IME_SETTLE_TIMEOUT_MS] — if the inset never reports zero, which is precisely the failure this
+ * guards against, navigation still proceeds rather than stranding the user on the screen.
+ */
+@Composable
+fun rememberImeSettler(): ImeSettler {
+    val density = LocalDensity.current
+    val imeInsets = WindowInsets.ime
+    val keyboard = LocalSoftwareKeyboardController.current
+    val focusManager = LocalFocusManager.current
+
+    return remember(density, imeInsets, keyboard, focusManager) {
+        ImeSettler {
+            if (imeInsets.getBottom(density) > 0) {
+                focusManager.clearFocus(true)
+                keyboard?.hide()
+                withTimeoutOrNull(IME_SETTLE_TIMEOUT_MS) {
+                    snapshotFlow { imeInsets.getBottom(density) }.first { it <= 0 }
+                }
+            }
+        }
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/navs/Nav.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/navs/Nav.kt
@@ -44,6 +44,13 @@ import kotlin.reflect.KClass
 class Nav(
     val controller: NavHostController,
     override val navigationScope: CoroutineScope,
+    /**
+     * Awaited before every transition below. Leaving a screen while the soft keyboard is still
+     * animating strands `imePadding()` app-wide; see [ImeSettler]. Every in-app navigation goes
+     * through this class, so this is the one place that has to get it right — no screen, top bar
+     * or back handler needs to think about the keyboard on its way out.
+     */
+    private val ime: ImeSettler = ImeSettler.None,
 ) : INav {
     override val drawerState = DrawerState(DrawerValue.Closed)
 
@@ -63,6 +70,7 @@ class Nav(
 
     override fun nav(route: Route) {
         navigationScope.launch {
+            ime.settle()
             if (getRouteWithArguments(route::class, controller) != route) {
                 controller.navigate(route)
             }
@@ -71,6 +79,7 @@ class Nav(
 
     override fun nav(computeRoute: suspend () -> Route?) {
         navigationScope.launch {
+            ime.settle()
             val route = computeRoute()
             if (route != null && getRouteWithArguments(route::class, controller) != route) {
                 controller.navigate(route)
@@ -80,6 +89,7 @@ class Nav(
 
     override fun newStack(route: Route) {
         navigationScope.launch {
+            ime.settle()
             controller.navigate(route) {
                 popUpTo(route) {
                     inclusive = true
@@ -91,6 +101,7 @@ class Nav(
 
     override fun navBottomBar(route: Route) {
         navigationScope.launch {
+            ime.settle()
             controller.navigate(route) {
                 // Clear sibling bottom-nav entries but keep Home (the start
                 // destination) below, so back-swipe from any tab returns to
@@ -149,6 +160,7 @@ class Nav(
 
     override fun popBack() {
         navigationScope.launch {
+            ime.settle()
             controller.navigateUp()
         }
     }
@@ -159,6 +171,7 @@ class Nav(
         klass: KClass<T>,
     ) {
         navigationScope.launch {
+            ime.settle()
             controller.navigate(route) {
                 popUpTo(klass) { inclusive = true }
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/navs/RememberNavs.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/navs/RememberNavs.kt
@@ -29,9 +29,10 @@ import androidx.navigation.compose.rememberNavController
 fun rememberNav(): Nav {
     val navController = rememberNavController()
     val scope = rememberCoroutineScope()
+    val ime = rememberImeSettler()
 
-    return remember(navController, scope) {
-        Nav(navController, scope)
+    return remember(navController, scope, ime) {
+        Nav(navController, scope, ime)
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/ActionTopBar.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/topbars/ActionTopBar.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.ui.navigation.bottombars.rememberAfterKeyboardCloses
 import com.vitorpamplona.amethyst.ui.note.buttons.CloseButton
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.amethyst.ui.theme.HalfHorzPadding
@@ -46,10 +45,6 @@ fun ActionTopBar(
     onPost: () -> Unit,
     additionalActions: @Composable (() -> Unit)? = null,
 ) {
-    // Both exits pop the screen, and on a composer the keyboard is up while typing — the same
-    // pop-during-IME-animation race the back gesture avoids, just reached by a tap instead.
-    val afterKeyboardCloses = rememberAfterKeyboardCloses()
-
     ShorterTopAppBar(
         title = {
             if (titleRes != null) {
@@ -65,7 +60,7 @@ fun ActionTopBar(
         navigationIcon = {
             CloseButton(
                 modifier = HalfHorzPadding,
-                onPress = { afterKeyboardCloses(onCancel) },
+                onPress = onCancel,
             )
         },
         actions = {
@@ -75,7 +70,7 @@ fun ActionTopBar(
             Button(
                 modifier = HalfHorzPadding,
                 enabled = isActive(),
-                onClick = { afterKeyboardCloses(onPost) },
+                onClick = onPost,
             ) {
                 Text(text = stringRes(postRes))
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/GenericCommentPostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/GenericCommentPostScreen.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.note.nip22Comments
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
@@ -66,7 +67,6 @@ import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromGallery
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.actions.uploads.TakePictureButton
 import com.vitorpamplona.amethyst.ui.actions.uploads.TakeVideoButton
-import com.vitorpamplona.amethyst.ui.navigation.bottombars.KeyboardAwareBackHandler
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.PostingTopBar
 import com.vitorpamplona.amethyst.ui.note.BaseUserPicture
@@ -177,7 +177,7 @@ fun GenericCommentPostScreen(
 
     StrippingFailureDialog(postViewModel.strippingFailureConfirmation)
 
-    KeyboardAwareBackHandler {
+    BackHandler {
         accountViewModel.launchSigner {
             postViewModel.sendDraftSync()
             postViewModel.cancel()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/badges/award/AwardBadgeScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/badges/award/AwardBadgeScreen.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.badges.award
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -51,7 +52,6 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.ui.components.Nip05OrPubkeyLine
 import com.vitorpamplona.amethyst.model.User
-import com.vitorpamplona.amethyst.ui.navigation.bottombars.KeyboardAwareBackHandler
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.SavingTopBar
 import com.vitorpamplona.amethyst.ui.note.UserPicture
@@ -88,7 +88,7 @@ fun AwardBadgeScreen(
         onDispose { userSuggestions.reset() }
     }
 
-    KeyboardAwareBackHandler {
+    BackHandler {
         nav.popBack()
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/NewGroupDMScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/NewGroupDMScreen.kt
@@ -21,6 +21,7 @@
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.privateDM.send
 
 import android.net.Uri
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
 import androidx.compose.foundation.layout.Box
@@ -86,7 +87,6 @@ import com.vitorpamplona.amethyst.ui.actions.uploads.TakePictureButton
 import com.vitorpamplona.amethyst.ui.actions.uploads.TakeVideoButton
 import com.vitorpamplona.amethyst.ui.components.ThinPaddingTextField
 import com.vitorpamplona.amethyst.ui.components.ZoomableContentView
-import com.vitorpamplona.amethyst.ui.navigation.bottombars.KeyboardAwareBackHandler
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.navigation.routes.routeToMessage
@@ -169,7 +169,7 @@ fun NewGroupDMScreen(
 
     WatchAndLoadMyEmojiList(accountViewModel)
 
-    KeyboardAwareBackHandler {
+    BackHandler {
         accountViewModel.launchSigner {
             postViewModel.sendDraftSync()
             postViewModel.cancel()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/PrivateMessageEditFieldRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/PrivateMessageEditFieldRow.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.privateDM.send
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -59,7 +60,6 @@ import com.vitorpamplona.amethyst.ui.actions.UrlUserTagOutputTransformation
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromGallery
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.components.ThinPaddingTextField
-import com.vitorpamplona.amethyst.ui.navigation.bottombars.KeyboardAwareBackHandler
 import com.vitorpamplona.amethyst.ui.navigation.navs.EmptyNav
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.routeFor
@@ -110,7 +110,7 @@ fun PrivateMessageEditFieldRow(
     onSendNewMessage: () -> Unit,
     nav: INav,
 ) {
-    KeyboardAwareBackHandler {
+    BackHandler {
         if (channelScreenModel.message.text.isNotBlank()) {
             accountViewModel.launchSigner {
                 channelScreenModel.sendDraftSync()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/send/EditFieldRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/send/EditFieldRow.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.send
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -53,7 +54,6 @@ import com.vitorpamplona.amethyst.ui.actions.UrlUserTagOutputTransformation
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromGallery
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.components.ThinPaddingTextField
-import com.vitorpamplona.amethyst.ui.navigation.bottombars.KeyboardAwareBackHandler
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.creators.userSuggestions.ShowUserSuggestionList
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -78,7 +78,7 @@ fun EditFieldRow(
     onSendNewMessage: suspend () -> Unit,
     nav: INav,
 ) {
-    KeyboardAwareBackHandler {
+    BackHandler {
         accountViewModel.launchSigner {
             channelScreenModel.sendDraftSync()
             channelScreenModel.cancel()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip23LongForm/LongFormPostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip23LongForm/LongFormPostScreen.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.discover.nip23LongForm
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -95,7 +96,6 @@ import com.vitorpamplona.amethyst.ui.actions.uploads.TakeVideoButton
 import com.vitorpamplona.amethyst.ui.components.MyAsyncImage
 import com.vitorpamplona.amethyst.ui.components.ThinPaddingTextField
 import com.vitorpamplona.amethyst.ui.components.markdown.RenderContentAsMarkdown
-import com.vitorpamplona.amethyst.ui.navigation.bottombars.KeyboardAwareBackHandler
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.PostingTopBar
 import com.vitorpamplona.amethyst.ui.note.creators.contentWarning.ContentSensitivityExplainer
@@ -149,7 +149,7 @@ fun LongFormPostScreen(
 
     StrippingFailureDialog(postViewModel.strippingFailureConfirmation)
 
-    KeyboardAwareBackHandler {
+    BackHandler {
         accountViewModel.launchSigner {
             postViewModel.sendDraftSync()
             postViewModel.cancel()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/NewProductScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/NewProductScreen.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.discover.nip99Classifieds
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -52,7 +53,6 @@ import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromGallery
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.actions.uploads.TakePictureButton
 import com.vitorpamplona.amethyst.ui.actions.uploads.TakeVideoButton
-import com.vitorpamplona.amethyst.ui.navigation.bottombars.KeyboardAwareBackHandler
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.PostingTopBar
@@ -141,7 +141,7 @@ fun NewProductScreen(
 
     StrippingFailureDialog(postViewModel.strippingFailureConfirmation)
 
-    KeyboardAwareBackHandler {
+    BackHandler {
         accountViewModel.launchSigner {
             postViewModel.sendDraftSync()
             postViewModel.cancel()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostScreen.kt
@@ -23,6 +23,7 @@ package com.vitorpamplona.amethyst.ui.screen.loggedIn.home
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.net.Uri
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -92,7 +93,6 @@ import com.vitorpamplona.amethyst.ui.actions.uploads.VoiceMessagePreview
 import com.vitorpamplona.amethyst.ui.components.OutlinedThinPaddingTextField
 import com.vitorpamplona.amethyst.ui.components.ThinPaddingTextField
 import com.vitorpamplona.amethyst.ui.components.getActivity
-import com.vitorpamplona.amethyst.ui.navigation.bottombars.KeyboardAwareBackHandler
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.navigation.topbars.PostingTopBar
@@ -235,7 +235,7 @@ internal fun NewPostScreenInner(
 
     StrippingFailureDialog(postViewModel.strippingFailureConfirmation)
 
-    KeyboardAwareBackHandler {
+    BackHandler {
         accountViewModel.launchSigner {
             postViewModel.sendDraftSync()
             postViewModel.cancel()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/nip75Goals/NewGoalScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/nip75Goals/NewGoalScreen.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.home.nip75Goals
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -47,7 +48,6 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
-import com.vitorpamplona.amethyst.ui.navigation.bottombars.KeyboardAwareBackHandler
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.PostingTopBar
@@ -81,7 +81,7 @@ fun NewGoalScreen(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    KeyboardAwareBackHandler {
+    BackHandler {
         goalViewModel.cancel()
         nav.popBack()
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/publicMessages/NewPublicMessageScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/publicMessages/NewPublicMessageScreen.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications.publicMessages
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
 import androidx.compose.foundation.layout.Column
@@ -63,7 +64,6 @@ import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromGallery
 import com.vitorpamplona.amethyst.ui.actions.uploads.TakePictureButton
 import com.vitorpamplona.amethyst.ui.actions.uploads.TakeVideoButton
 import com.vitorpamplona.amethyst.ui.components.ThinPaddingTextField
-import com.vitorpamplona.amethyst.ui.navigation.bottombars.KeyboardAwareBackHandler
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.PostingTopBar
@@ -134,7 +134,7 @@ fun NewPublicMessageScreen(
 
     StrippingFailureDialog(postViewModel.strippingFailureConfirmation)
 
-    KeyboardAwareBackHandler {
+    BackHandler {
         accountViewModel.launchSigner {
             postViewModel.sendDraftSync()
             postViewModel.cancel()

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/workouts/NewWorkoutScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/workouts/NewWorkoutScreen.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.workouts
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -60,7 +61,6 @@ import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbol
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
-import com.vitorpamplona.amethyst.ui.navigation.bottombars.KeyboardAwareBackHandler
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
 import com.vitorpamplona.amethyst.ui.navigation.topbars.PostingTopBar
@@ -80,7 +80,7 @@ fun NewWorkoutScreen(
     postViewModel.init(accountViewModel)
     postViewModel.prefill(prefill)
 
-    KeyboardAwareBackHandler {
+    BackHandler {
         postViewModel.cancel()
         nav.popBack()
     }

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/navigation/NavImeSettleTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/ui/navigation/NavImeSettleTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.navigation
+
+import androidx.navigation.NavHostController
+import androidx.navigation.NavOptionsBuilder
+import com.vitorpamplona.amethyst.ui.navigation.navs.ImeSettler
+import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
+import com.vitorpamplona.amethyst.ui.navigation.routes.Route
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Leaving a screen while the soft keyboard is still animating strands `imePadding()` at keyboard
+ * height for the whole app, because `WindowInsets.ime` is a single shared holder. The fix is that
+ * [Nav] waits for the IME to be gone before it moves, so these assert the ordering rather than any
+ * visual result: every transition must settle the keyboard *first*.
+ *
+ * Without the settle calls in [Nav] each of these records only "navigate" and fails.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class NavImeSettleTest {
+    private fun controllerRecording(order: MutableList<String>): NavHostController =
+        mockk<NavHostController>(relaxed = true) {
+            every { navigate(any<Route>(), any<NavOptionsBuilder.() -> Unit>()) } answers
+                { order.add("navigate") }
+            every { navigate(any<Route>()) } answers { order.add("navigate") }
+            every { navigateUp() } answers {
+                order.add("navigate")
+                true
+            }
+        }
+
+    @Test
+    fun popBackSettlesTheKeyboardBeforeNavigating() =
+        runTest {
+            val order = mutableListOf<String>()
+            val nav = Nav(controllerRecording(order), this, ImeSettler { order.add("settle") })
+
+            nav.popBack()
+            advanceUntilIdle()
+
+            assertEquals(listOf("settle", "navigate"), order)
+        }
+
+    @Test
+    fun bottomBarSettlesTheKeyboardBeforeNavigating() =
+        runTest {
+            // The search tab focuses its field on arrival, so the keyboard is already up when the
+            // user taps another tab — the exit that has no BackHandler and no top bar to guard it.
+            val order = mutableListOf<String>()
+            val nav = Nav(controllerRecording(order), this, ImeSettler { order.add("settle") })
+
+            nav.navBottomBar(Route.Home)
+            advanceUntilIdle()
+
+            assertEquals(listOf("settle", "navigate"), order)
+        }
+
+    @Test
+    fun newStackSettlesTheKeyboardBeforeNavigating() =
+        runTest {
+            val order = mutableListOf<String>()
+            val nav = Nav(controllerRecording(order), this, ImeSettler { order.add("settle") })
+
+            nav.newStack(Route.Home)
+            advanceUntilIdle()
+
+            assertEquals(listOf("settle", "navigate"), order)
+        }
+
+    @Test
+    fun aSlowKeyboardStillHoldsTheNavigationBack() =
+        runTest {
+            // The real settler suspends for the length of the IME close animation. Navigation must
+            // wait for it, not fire alongside it — that overlap is the bug.
+            val order = mutableListOf<String>()
+            val nav =
+                Nav(
+                    controllerRecording(order),
+                    this,
+                    ImeSettler {
+                        delay(250)
+                        order.add("settle")
+                    },
+                )
+
+            nav.popBack()
+            assertEquals(emptyList<String>(), order)
+
+            advanceUntilIdle()
+            assertEquals(listOf("settle", "navigate"), order)
+        }
+}


### PR DESCRIPTION
## Summary

Leaving a screen while the soft keyboard is still animating strands `imePadding()` at keyboard height for the whole app — `WindowInsets.ime` is a single shared holder, so the padding survives leaving the screen that caused it. #3864 fixed this for the post composers, at their call sites. That was the wrong altitude: **Search strands it too**, and Search has no `BackHandler` and no top bar of ours, so none of #3864's patches would ever have covered it.

Search is the clearest case — it focuses its field on arrival, so the keyboard is up before the user has done anything, and every way out is a navigation: a bottom-nav tab, a tapped result, back. Any destination that can focus a text field can strand the padding on the way out, and there are 174 files with text input in this module, so enumerating screens was never going to converge.

Two facts make a central fix possible:

- Every in-app navigation goes through `INav` — there is not one `controller.navigate` outside `navigation/navs/`, and nothing touches `OnBackPressedDispatcher`, `navigateUp` or `popBackStack` directly.
- Every `Nav` method already runs inside `navigationScope.launch`.

So `Nav` awaits an `ImeSettler` before each transition. Keyboard down: it returns immediately and nothing changes. Keyboard up: it clears focus, hides the IME and waits for the inset to actually reach zero — bounded, so a stale inset can never strand the user on the screen — and the two animations never overlap. `ObservableNav` is `INav by sourceNav` and inherits it.

### This removes machinery rather than adding to it

With the race handled at the one chokepoint every screen leaves through, the per-call-site guards are no longer load-bearing and are deleted rather than left as a second mechanism:

- `ActionTopBar` goes back to plain callbacks. This also drops a composition-scoped deferral of `onPost`, so posting no longer depends on the top bar staying composed.
- **`KeyboardAwareBackHandler` is deleted entirely** and all 11 call sites revert to a plain `BackHandler`. Its job was to keep a composer's pop from racing the IME animation, and that pop is `nav.popBack()` in every one of those sites — exactly what the settler now serializes.

Deleting it also closes a data-loss path. Its mechanism was to *not* consume back while the keyboard was up and rely on the IME to consume it instead; on any device or API level where the IME does not, back reaches the `NavController`, which pops without ever running `onBack` and silently drops the draft, since nothing else saves one. A plain `BackHandler` always consumes, so the draft is always flushed.

**Behaviour change worth calling out:** back in a composer now saves the draft and leaves on the *first* press, where previously the first press dismissed the keyboard and the second left. The two-back convention is gone; the keyboard still retracts first, via the settler, before the screen goes.

`keyboardAsState()` is untouched — `AppBottomBar` uses it to hide the bottom bar while typing, which is a separate concern.

### Known gap

On a screen with no `BackHandler`, the system's back pops through the `NavController` directly rather than `Nav.popBack()`, so a second back landing inside the ~250 ms retraction can still race. Closing it needs a shell-level handler registered *after* the `NavHost` to outrank its back callback — a composition-order dependency subtle enough to break silently, so I'd rather it be a deliberate decision than smuggled in here.

## Test plan

### Feature test plan

**Not yet exercised on a device — see the caveat below.** The behaviour is pinned by `NavImeSettleTest` (new, 4 tests): each transition must settle the keyboard *before* it navigates, and a settler that suspends must hold the navigation back rather than run alongside it.

Verified it is a real regression test, not a tautology — with the six `ime.settle()` calls stripped from `Nav`:

```
NavImeSettleTest > aSlowKeyboardStillHoldsTheNavigationBack FAILED
NavImeSettleTest > bottomBarSettlesTheKeyboardBeforeNavigating FAILED
NavImeSettleTest > popBackSettlesTheKeyboardBeforeNavigating FAILED
NavImeSettleTest > newStackSettlesTheKeyboardBeforeNavigating FAILED
```

and green with them restored (`tests="4" skipped="0" failures="0" errors="0"`).

Both flavours, plus the R8-minified build — which matters specifically here, since per the original analysis in f734865a this race only reproduces on optimized builds where the window animation outruns the IME animation:

```
./gradlew :amethyst:assemblePlayDebug :amethyst:assembleFdroidDebug
BUILD SUCCESSFUL in 3m 58s

./gradlew :amethyst:assemblePlayBenchmark
BUILD SUCCESSFUL in 8m 31s
```

**What a reviewer still needs to do on a device** (release or benchmark build — it will not reproduce in `*-debug`): open Search so the keyboard auto-opens, then leave by each exit — another bottom-nav tab, a tapped result, back — and confirm no gap is left at the bottom of the destination screen or anywhere else in the app afterwards. Same for a reply composer via back, X and Post. Worth confirming the new one-press back in a composer feels right, since that is a deliberate behaviour change.

### Regression test plan

Touch points and verification:

- **Navigation itself** — `ImeSettler` is on the shared chokepoint every transition passes through, so a mistake here breaks all navigation. Verified: the settler short-circuits when the keyboard is down, so the overwhelmingly common path is unchanged (no suspension, same frame); `NavImeSettleTest` covers `popBack`, `navBottomBar` and `newStack`, and the full pre-push suite is green.
- **The composers fixed in #3864** — could regress by having their guards removed. Verified by inspection that every one of their exits ends in an `INav` call: `onCancel`/`onPost` on `ActionTopBar` and all 11 `BackHandler` bodies reach `nav.popBack()`, which now settles.
- **Draft saving** — was the risk in removing `KeyboardAwareBackHandler`, since nothing else saves a composer draft (`onCleared()` only closes the writing assistant, there is no autosave). Verified the plain `BackHandler` is unconditionally enabled, so `onBack` — and therefore `sendDraftSync()` — always runs; this is strictly safer than the gated handler it replaces.
- **`ObservableNav` / `EmptyNav` / `BouncingIntentNav`** — could miss the fix. Verified: `ObservableNav` delegates all six methods to the real `Nav`; `EmptyNav` is a no-op stub; `BouncingIntentNav` starts an Intent into `MainActivity` from the nests activity, a separate activity with its own insets, so it is not this race.
- **Bottom bar visibility** — reads `keyboardAsState()`, which is untouched by this PR.

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Ran the pre-push suite: `:quartz:jvmTest :commons:jvmTest :nestsClient:jvmTest :quic:jvmTest :amethyst:testPlayDebugUnitTest :cli:test` — green
- [ ] Manually exercised the change — **not done**, no Android device in the environment this was authored in. Flagging rather than ticking; this needs a maintainer pass on a release/benchmark build before merge.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## AI assistance

- [x] Drafted with AI assistance, manually reviewed and tested

Authored with Claude Code. Reviewed and statically verified as described above; the on-device manual pass is explicitly outstanding and called out in the test plan rather than claimed.

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfUMGWYu2uTSyh17JJonfN