### PR TITLE
Quartz: give SyncCoverage's persistence a typed band key

### DIFF
--- a/geode/src/main/kotlin/com/vitorpamplona/geode/mirror/SyncCoverageFile.kt
+++ b/geode/src/main/kotlin/com/vitorpamplona/geode/mirror/SyncCoverageFile.kt
@@ -96,15 +96,22 @@ class SyncCoverageFile(
         if (!file.isFile) return
         runCatching {
             val root = Json.parseToJsonElement(file.readText()).jsonObject
+            // The file's key is the joined form, decoded by the class that
+            // mints it — this layer never has to know the separator. A key it
+            // cannot read names no pair and is dropped, which costs one
+            // upstream's re-walk rather than the whole file.
             coverage.restore(
-                root.mapValues { (_, v) ->
-                    val o = v.jsonObject
-                    SyncCoverage.Band(
-                        spansOf(o),
-                        o["complete"]?.jsonPrimitive?.boolean ?: false,
-                        o["fullAt"]?.jsonPrimitive?.long ?: 0L,
-                    )
-                },
+                root.entries
+                    .mapNotNull { (k, v) ->
+                        val key = SyncCoverage.BandKey.decode(k) ?: return@mapNotNull null
+                        val o = v.jsonObject
+                        key to
+                            SyncCoverage.Band(
+                                spansOf(o),
+                                o["complete"]?.jsonPrimitive?.boolean ?: false,
+                                o["fullAt"]?.jsonPrimitive?.long ?: 0L,
+                            )
+                    }.toMap(),
             )
         }.onFailure {
             Log.w("SyncCoverageFile") { "could not read ${file.path} (${it.message}); starting fresh" }
@@ -142,7 +149,7 @@ class SyncCoverageFile(
                 buildJsonObject {
                     coverage.export().forEach { (key, band) ->
                         put(
-                            key,
+                            key.encode(),
                             buildJsonObject {
                                 // min/max are the outer edges across every
                                 // kind, and are written for two readers: a

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/SyncCoverage.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/SyncCoverage.kt
@@ -49,8 +49,10 @@ import com.vitorpamplona.quartz.utils.concurrent.ConcurrentMap
  * occasional and self-heal on the next filter change or full re-walk.
  *
  * Persistence is the caller's: [export] the map on a schedule and [restore]
- * it at startup. [onChange] fires whenever a band changes, so a persistence
- * layer can mark itself dirty without polling.
+ * it at startup, both keyed by [BandKey] so a file layer can lay the two
+ * halves out however it likes without having to know how a key is spelled.
+ * [onChange] fires whenever a band changes, so a persistence layer can mark
+ * itself dirty without polling.
  *
  * Not to be confused with the `relay.client.paging` package: its
  * `RelayLoadingCursors` are in-memory POSITIONS for demand-driven UI paging
@@ -65,6 +67,41 @@ class SyncCoverage(
     private val now: () -> Long = { TimeUtils.now() },
     private val onChange: () -> Unit = {},
 ) {
+    /**
+     * What one band is about: the relay's url, and the filter as [Filter.toJson]
+     * renders it.
+     *
+     * A pair, not a joined string, for two reasons. A persistence layer needs
+     * the halves — one that lays its file out by relay, or by filter, or by
+     * both, had to split the key back apart, and the separator was folklore it
+     * could only learn by reading this class. And on the hot path a joined key
+     * COPIES the filter's json on every lookup: `legs()` runs once per relay
+     * per cycle, an author-scoped filter's json runs to tens of thousands of
+     * characters, and a fan-out over thousands of relays paid that copy — plus
+     * a fresh hash over all of it, since a newly built string has none cached —
+     * on every one of them. A pair hashes the two halves it already holds.
+     *
+     * [encode] and [decode] are the joined form, kept HERE so a file that wants
+     * one key per line still gets the separator from the class that mints it.
+     * A normalized relay url contains no space, which is what makes splitting
+     * at the first one exact.
+     */
+    data class BandKey(
+        val relay: String,
+        val filter: String,
+    ) {
+        fun encode(): String = "$relay $filter"
+
+        companion object {
+            /** The inverse of [encode], or null for a key that names no pair. */
+            fun decode(key: String): BandKey? {
+                val at = key.indexOf(' ')
+                if (at <= 0 || at == key.length - 1) return null
+                return BandKey(key.substring(0, at), key.substring(at + 1))
+            }
+        }
+    }
+
     /** A covered `created_at` interval, inclusive at both ends. */
     data class Span(
         val min: Long,
@@ -115,7 +152,7 @@ class SyncCoverage(
         }
     }
 
-    private val bands = ConcurrentMap<String, Band>()
+    private val bands = ConcurrentMap<BandKey, Band>()
 
     // filter -> its canonical json. Filter.toJson() runs to tens of thousands
     // of characters for author-scoped filters, and a fan-out keys once per
@@ -379,10 +416,10 @@ class SyncCoverage(
     fun size(): Int = bands.size()
 
     /** A point-in-time copy of every band, for a persistence layer to write out. */
-    fun export(): Map<String, Band> = bands.snapshot()
+    fun export(): Map<BandKey, Band> = bands.snapshot()
 
     /** Load previously [export]ed bands, e.g. at startup. */
-    fun restore(entries: Map<String, Band>) {
+    fun restore(entries: Map<BandKey, Band>) {
         for ((key, band) in entries) bands[key] = band
     }
 
@@ -395,7 +432,7 @@ class SyncCoverage(
     private fun key(
         url: NormalizedRelayUrl,
         filter: Filter,
-    ): String {
+    ): BandKey {
         val fingerprint =
             fingerprints[filter]
                 ?: filter.toJson().also {
@@ -404,7 +441,7 @@ class SyncCoverage(
                     // pays the toJson each time instead of growing the heap.
                     if (fingerprints.size() < MAX_FINGERPRINTS) fingerprints[filter] = it
                 }
-        return "${url.url} $fingerprint"
+        return BandKey(url.url, fingerprint)
     }
 
     // One line per process, not per walk: the point is to tell a caller it has

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/SyncCoverageTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/SyncCoverageTest.kt
@@ -355,6 +355,26 @@ class SyncCoverageTest {
     }
 
     @Test
+    fun `a band key round-trips through the joined form a file writes`() {
+        // A file that wants one key per line joins and splits with these, so
+        // the separator stays in the class that mints the key instead of being
+        // rediscovered by every persistence layer downstream.
+        val c = SyncCoverage()
+        c.record(relay, profiles, 1_700_001_000L, 1_700_002_000L, paged = true)
+        val key = c.export().keys.single()
+
+        assertEquals(relay.url, key.relay)
+        assertEquals(profiles.toJson(), key.filter)
+        assertEquals(key, SyncCoverage.BandKey.decode(key.encode()))
+
+        // A key naming no pair is refused rather than read as a relay with an
+        // empty filter, which would key a band nothing can ever look up.
+        assertNull(SyncCoverage.BandKey.decode("no-space-here"))
+        assertNull(SyncCoverage.BandKey.decode(" {\"kinds\":[0]}"))
+        assertNull(SyncCoverage.BandKey.decode("wss://relay.example/ "))
+    }
+
+    @Test
     fun `onChange fires when a band changes so persistence can mark dirty`() {
         var changes = 0
         val c = SyncCoverage(onChange = { changes++ })


### PR DESCRIPTION
## Summary

`SyncCoverage.export`/`restore` handed back `Map<String, Band>`, where the string was the class's **internal** key — `"<relay-url> <filter-json>"`. That works for a persistence layer that writes the key back verbatim, and nothing else: a layer wanting its own layout (one object per relay, per filter, or nested by both) had to split the key apart, and the separator was folklore it could only learn by reading `SyncCoverage`. This replaces it with a `BandKey(relay, filter)` pair, keeping the joined form as `encode()`/`decode()` for files that do want one key per line.

It is also a hot-path fix. `key()` built a *new* string on every lookup, so `legs()` over a fan-out copied the filter's json — tens of thousands of characters for an author-scoped filter — once per relay per cycle, then hashed all of it, since a freshly-built string carries no cached hash. The pair hashes two halves it already holds: the url, and the fingerprint instance the cache directly above it already returns.

No behaviour change. The same pairs key the same bands, `geode`'s on-disk format is byte-for-byte identical, and a file written before this reads back through `decode`.

## Test plan

### Feature test plan

```
./gradlew :quartz:jvmTest :geode:test --rerun-tasks     # BUILD SUCCESSFUL in 6m 58s
./gradlew :quartz:spotlessApply :geode:spotlessApply
```

- `:quartz:jvmTest` — 4,045 tests, 0 failures. Includes a new `SyncCoverageTest` case, `a band key round-trips through the joined form a file writes`: asserts `key.relay == relay.url`, `key.filter == filter.toJson()`, `decode(encode()) == key`, and that a key naming no pair (`"no-space-here"`, a leading space, a trailing space) decodes to null rather than to a relay with an empty filter.
- `:geode:test` — 146 tests, 0 failures, including `SyncCoverageFileTest`, which round-trips a real file through the changed save/load path and asserts per-kind spans survive.
- Both re-run with `--rerun-tasks`, so none of the above is a cached result.

`:cli:test` is **not** in that scope, and the reason is worth stating: it hangs in this sandbox. Five of its classes pass (39 tests, 0 failures) and the task then stalls indefinitely on something network-touching. `cli/` contains no reference to `SyncCoverage` (grepped), so nothing in this diff reaches it — but I could not run it to completion and am not claiming otherwise.

### Regression test plan

Touch points and verification:

- **`SyncCoverage`'s own lookups** (`legs`, `record`, `band`, `coveringWindow`) — all four go through `key()`, so a key type that hashed or compared differently would silently mint a second band per pair and re-walk every relay's corpus. Verified: the full `SyncCoverageTest` suite (34 cases) passes unchanged, including the band-narrowing, staleness, per-kind span and `export`/`restore` round-trip cases.
- **`geode`'s `SyncCoverageFile`** — the only `export`/`restore` caller in the repo (grepped). Failure mode: a file written by an older build stops loading, and every upstream re-downloads its corpus once. Verified: format unchanged (`key.encode()` on save, `BandKey.decode` on load); `SyncCoverageFileTest` passes, which writes and re-reads a file. An unreadable key is now dropped per-entry instead of taking the whole file down.
- **Pre-existing files on disk** — same failure mode, one release later. Verified by the `decode` tests above: the exact string the old `key()` produced round-trips to the same pair.
- **KMP source sets** — `BandKey` is a plain data class in `commonMain` with no platform imports.

Not verified, stated rather than omitted:

- **No flavour builds.** This is a pure `quartz/` + `geode/` change with no Android surface, which `CONTRIBUTING-WITH-AI.md` allows to build one flavour — but this environment has no Android SDK, so neither `installPlayDebug` nor `installFdroidDebug` was attempted. Nothing in the diff touches `amethyst/`, the manifest, ProGuard rules, or any Play-only dependency.
- **No cross-agent code-review pass.** The § *Code review pass before opening the PR* gate asks for a review by a different agent or model; the session that wrote this diff was not permitted to spawn one. The diff is 3 files and the risk is concentrated in one place — whether `BandKey` keys identically to the old string — which the round-trip tests above pin directly. Happy to run the pass and push a follow-up commit if you'd rather have it before merge.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

The key is process-internal and the one file format it reaches is unchanged.

## AI assistance

- [x] Drafted with AI assistance, manually reviewed and tested

Written by Claude Code at the maintainer's request, as the upstream half of a downstream change in [`vespa-relay`](https://github.com/NosFabrica/vespa-relay/pull/80) that nests its own state files by stream/filter/relay and currently splits quartz's key at the first space to do it. Reviewed by the authoring session and covered by the tests listed above; see the two explicit gaps under *Regression test plan*.

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4ybZPdhCxM3fyeB7uEdTp