### PR TITLE
Rename parameters for clarity and consistency

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Dao.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Dao.kt
@@ -29,7 +29,7 @@ import com.vitorpamplona.quartz.nip01Core.core.HexKey
  * needing the full [LocalCache] API.
  */
 interface Dao {
-    fun getOrCreateUser(hex: HexKey): User
+    fun getOrCreateUser(pubkey: HexKey): User
 
     fun getOrCreateNote(hex: HexKey): Note
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -685,12 +685,12 @@ object LocalCache : ILocalCache, ICacheProvider, Dao {
 
     fun load(keys: Set<String>): Set<User> = keys.mapNotNullTo(mutableSetOf(), ::checkGetOrCreateUser)
 
-    override fun getOrCreateUser(hex: HexKey): User {
-        require(isValidHex(key = hex)) { "$hex is not a valid hex" }
+    override fun getOrCreateUser(pubkey: HexKey): User {
+        require(isValidHex(key = pubkey)) { "$pubkey is not a valid hex" }
         // Pass `this` as the UserContext — User now resolves each pinned
         // addressable note (kind:10002 / 10050 / 10019) lazily on first
         // read, instead of all-or-nothing at construction time.
-        return users.getOrCreate(hex) { User(it, userContext) }
+        return users.getOrCreate(pubkey) { User(it, userContext) }
     }
 
     /** [UserContext] bridge to this cache's addressable lookup. */

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -2106,7 +2106,7 @@ class AccountViewModel(
 
     fun checkGetOrCreateUser(key: HexKey): User? = LocalCache.checkGetOrCreateUser(key)
 
-    override fun getOrCreateUser(hex: HexKey): User = LocalCache.getOrCreateUser(hex)
+    override fun getOrCreateUser(pubkey: HexKey): User = LocalCache.getOrCreateUser(pubkey)
 
     fun getUserIfExists(hex: HexKey): User? = LocalCache.getUserIfExists(hex)
 

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/NewMessageTaggerKeyParseTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/NewMessageTaggerKeyParseTest.kt
@@ -39,7 +39,7 @@ import org.junit.Test
 class NewMessageTaggerKeyParseTest {
     val dao: Dao =
         object : Dao {
-            override fun getOrCreateUser(hex: String): User = User(hex) { addr -> getOrCreateAddressableNoteInternal(addr) }
+            override fun getOrCreateUser(pubkey: String): User = User(pubkey) { addr -> getOrCreateAddressableNoteInternal(addr) }
 
             override fun getOrCreateNote(hex: String) =
                 com.vitorpamplona.amethyst.model

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/cache/ICacheProvider.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/cache/ICacheProvider.kt
@@ -93,7 +93,7 @@ interface ICacheProvider {
      * @param address The note's ID in address format
      * @return The AddressableNote (existing or newly created)
      */
-    fun getOrCreateAddressableNote(key: Address): AddressableNote
+    fun getOrCreateAddressableNote(address: Address): AddressableNote
 
     /**
      * Gets the event stream for cache updates.

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/ThreadAssemblerTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/ThreadAssemblerTest.kt
@@ -181,7 +181,7 @@ class ThreadAssemblerTest {
 
         override fun checkGetOrCreateNote(hexKey: HexKey): Note? = notesById[hexKey]
 
-        override fun getOrCreateAddressableNote(key: Address): AddressableNote = error("not used by ThreadAssembler in this test")
+        override fun getOrCreateAddressableNote(address: Address): AddressableNote = error("not used by ThreadAssembler in this test")
 
         override fun getEventStream(): ICacheEventStream = error("not used by ThreadAssembler in this test")
 

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/concord/ConcordChannelListLeaveTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/concord/ConcordChannelListLeaveTest.kt
@@ -90,7 +90,7 @@ class ConcordChannelListLeaveTest {
 
         override fun checkGetOrCreateNote(hexKey: HexKey): Note? = null
 
-        override fun getOrCreateAddressableNote(key: Address): AddressableNote = AddressableNote(key)
+        override fun getOrCreateAddressableNote(address: Address): AddressableNote = AddressableNote(address)
 
         override fun getEventStream(): ICacheEventStream = error("not used")
 

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/concord/ConcordListLateArrivalTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/concord/ConcordListLateArrivalTest.kt
@@ -88,7 +88,7 @@ class ConcordListLateArrivalTest {
 
         override fun checkGetOrCreateNote(hexKey: HexKey): Note? = null
 
-        override fun getOrCreateAddressableNote(key: Address): AddressableNote = notes.getOrPut(key.toValue()) { AddressableNote(key) }
+        override fun getOrCreateAddressableNote(address: Address): AddressableNote = notes.getOrPut(address.toValue()) { AddressableNote(address) }
 
         override fun getEventStream(): ICacheEventStream = error("not used")
 

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/ui/note/ReplyContextTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/ui/note/ReplyContextTest.kt
@@ -121,7 +121,7 @@ class ReplyContextTest {
 
         override fun checkGetOrCreateNote(hexKey: HexKey): Note? = notesById[hexKey]
 
-        override fun getOrCreateAddressableNote(key: Address): AddressableNote = error("not used by ReplyContext.from")
+        override fun getOrCreateAddressableNote(address: Address): AddressableNote = error("not used by ReplyContext.from")
 
         override fun getEventStream(): ICacheEventStream = error("not used by ReplyContext.from")
 

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/cache/DesktopLocalCache.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/cache/DesktopLocalCache.kt
@@ -904,9 +904,9 @@ class DesktopLocalCache : ICacheProvider {
             Note(hexKey)
         }
 
-    override fun getOrCreateAddressableNote(key: Address): AddressableNote =
-        addressableNotes.getOrCreate(key.toValue()) {
-            AddressableNote(key)
+    override fun getOrCreateAddressableNote(address: Address): AddressableNote =
+        addressableNotes.getOrCreate(address.toValue()) {
+            AddressableNote(address)
         }
 
     // ----- Channel operations -----

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/server/policies/LimitsPolicy.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/server/policies/LimitsPolicy.kt
@@ -128,8 +128,8 @@ class LimitsPolicy(
      */
     private fun capLimits(filters: List<Filter>): List<Filter> {
         val max = limits.maxLimit ?: return filters
-        if (filters.none { it.limit != null && it.limit!! > max }) return filters
-        return filters.map { if (it.limit != null && it.limit!! > max) it.copy(limit = max) else it }
+        if (filters.none { it.limit != null && it.limit > max }) return filters
+        return filters.map { if (it.limit != null && it.limit > max) it.copy(limit = max) else it }
     }
 
     private fun targetLimit(current: Int?): Int? =

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip66RelayMonitor/reachability/RelayProberFlowTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip66RelayMonitor/reachability/RelayProberFlowTest.kt
@@ -327,9 +327,9 @@ class RelayProberFlowTest {
             }
             check.join()
 
-            val verdict = result!![fast]!!
-            assertEquals(true, verdict.writeAccepted, "the listed relay's OK must still be awaited and recorded")
-            assertNull(result!![foreign], "the foreign relay must not appear in the result")
+            val verdicts = result!!
+            assertEquals(true, verdicts[fast]!!.writeAccepted, "the listed relay's OK must still be awaited and recorded")
+            assertNull(verdicts[foreign], "the foreign relay must not appear in the result")
         }
 
     @Test

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/prodbench/NegentropyStallRepro.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/prodbench/NegentropyStallRepro.kt
@@ -103,10 +103,10 @@ class NegentropyStallRepro {
                 object : WebSocketListener {
                     override fun onOpen(
                         pingMillis: Int,
-                        usingCompression: Boolean,
+                        compression: Boolean,
                     ) {
-                        log("  [<-open] ${url.url} ping=${pingMillis}ms deflate=$usingCompression")
-                        out.onOpen(pingMillis, usingCompression)
+                        log("  [<-open] ${url.url} ping=${pingMillis}ms deflate=$compression")
+                        out.onOpen(pingMillis, compression)
                     }
 
                     override suspend fun onMessage(text: String) {
@@ -130,10 +130,10 @@ class NegentropyStallRepro {
                     override fun onFailure(
                         t: Throwable,
                         code: Int?,
-                        errorMessage: String?,
+                        response: String?,
                     ) {
-                        log("  [<-failure] ${url.url} code=$code msg=$errorMessage err=${t.message}")
-                        out.onFailure(t, code, errorMessage)
+                        log("  [<-failure] ${url.url} code=$code msg=$response err=${t.message}")
+                        out.onFailure(t, code, response)
                     }
                 }
 


### PR DESCRIPTION
## Summary

Rename function parameters across multiple files to use more descriptive and consistent naming conventions. Changes include:
- `hex` → `pubkey` in user-related methods (clearer intent for public key parameters)
- `key` → `address` in addressable note methods (matches the `Address` type)
- `usingCompression` → `compression` (shorter, idiomatic)
- `errorMessage` → `response` (more accurate for WebSocket responses)
- `verdict` → `verdicts` (correct plural form for a map of results)
- Removed unnecessary null-coalescing operators (`!!`) where the value is already checked for null

These changes improve code readability and reduce confusion about parameter semantics without altering behavior.

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Ran `./gradlew test` — all tests pass
- [x] N/A — change is parameter renaming only, no behavioral changes

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_017X7C797zGYsiui5yj1JQcY