### PR TITLE
fix(quartz): update NIP-66 relay records instead of rebuilding them

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip66RelayMonitor/reachability/RelayReachabilityStore.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip66RelayMonitor/reachability/RelayReachabilityStore.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.quartz.nip66RelayMonitor.reachability
 
+import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
@@ -30,6 +31,8 @@ import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.networkType
 import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.requirement
 import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.rtt
 import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.tags.NetworkType
+import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.tags.NetworkTypeTag
+import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.tags.RequirementTag
 import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.tags.RttType
 import com.vitorpamplona.quartz.utils.TimeUtils
 
@@ -139,8 +142,9 @@ class RelayReachabilityStore(
         now: Long = TimeUtils.now(),
         rttOpenMs: Long = 0,
     ) {
-        for (relay in reachable) writeOne(relay, up = true, now, rttOpenMs)
-        for (relay in dead) if (relay !in reachable) writeOne(relay, up = false, now, rttOpenMs)
+        val current = currentRecords(reachable + dead)
+        for (relay in reachable) writeOne(relay, up = true, now, rttOpenMs, current[relay])
+        for (relay in dead) if (relay !in reachable) writeOne(relay, up = false, now, rttOpenMs, current[relay])
     }
 
     /**
@@ -154,8 +158,9 @@ class RelayReachabilityStore(
         dead: Set<NormalizedRelayUrl>,
         now: Long = TimeUtils.now(),
     ) {
-        for ((relay, rtt) in reachableRttMs) writeOne(relay, up = true, now, rtt.coerceAtLeast(0))
-        for (relay in dead) if (relay !in reachableRttMs) writeOne(relay, up = false, now, 0)
+        val current = currentRecords(reachableRttMs.keys + dead)
+        for ((relay, rtt) in reachableRttMs) writeOne(relay, up = true, now, rtt.coerceAtLeast(0), current[relay])
+        for (relay in dead) if (relay !in reachableRttMs) writeOne(relay, up = false, now, 0, current[relay])
     }
 
     /**
@@ -171,10 +176,11 @@ class RelayReachabilityStore(
         observations: Collection<RelayObserver.Observation>,
         now: Long = TimeUtils.now(),
     ): Int {
+        val reported = observations.filter { it.reachable || it.error != null }
+        val current = currentRecords(reported.map { it.url })
         var written = 0
-        for (o in observations) {
-            if (!o.reachable && o.error == null) continue
-            writeObserved(o, now)
+        for (o in reported) {
+            writeObserved(o, now, current[o.url])
             written++
         }
         return written
@@ -183,9 +189,14 @@ class RelayReachabilityStore(
     private suspend fun writeObserved(
         o: RelayObserver.Observation,
         now: Long,
+        current: RelayDiscoveryEvent?,
     ) {
+        // `R` is included in the owned set here and NOT in [writeOne]: an
+        // observation knows whether this relay challenged us, so it may clear a
+        // requirement that no longer holds. writeOne never learns that, so it
+        // leaves the tag alone rather than deleting what it cannot re-measure.
         val template =
-            RelayDiscoveryEvent.build(o.url, createdAt = now) {
+            edit(o.url, now, current, OWNED_LIVENESS + RequirementTag.TAG_NAME) {
                 networkType(networkTypeOf(o.url))
                 if (o.reachable) {
                     // Liveness is the presence of rtt-open, per NIP-66. A relay we
@@ -210,16 +221,91 @@ class RelayReachabilityStore(
         up: Boolean,
         now: Long,
         rttOpenMs: Long,
+        current: RelayDiscoveryEvent?,
     ) {
         val template =
-            RelayDiscoveryEvent.build(relay, createdAt = now) {
+            edit(relay, now, current, OWNED_LIVENESS) {
                 networkType(networkTypeOf(relay))
                 if (up) rtt(RttType.OPEN, rttOpenMs)
             }
         store.insert(signer.sign(template))
     }
 
+    /**
+     * Build this monitor's next record for [relay] as an EDIT of [current]
+     * rather than a fresh document.
+     *
+     * A 30166 is addressable, so a relay has exactly one record per monitor —
+     * and this class is not necessarily its only writer. Anything else keeping
+     * per-relay knowledge under the same identity (an operator marking a relay
+     * as a mirror of another, a crawler recording which kinds it served) writes
+     * into this same slot, and a build-from-scratch silently deletes it. The
+     * result still signs, still parses, and still reads as a valid NIP-66
+     * record — it just says less than it did, and the reader downstream has no
+     * way to know something was lost.
+     *
+     * [owned] is what this writer measured and may therefore replace.
+     * Everything else is carried across untouched, including tags this version
+     * of quartz has never heard of.
+     *
+     * The timestamp is `max(now, current + 1)`, not `now`: a store enforcing
+     * replaceable semantics REJECTS a record that is not strictly newer than
+     * the one it replaces, and two writers inside the same second — or a peer
+     * whose clock runs ahead of ours — are ordinary. An update lost that way is
+     * indistinguishable from one that had nothing to say.
+     */
+    private fun edit(
+        relay: NormalizedRelayUrl,
+        now: Long,
+        current: RelayDiscoveryEvent?,
+        owned: Set<String>,
+        measured: TagArrayBuilder<RelayDiscoveryEvent>.() -> Unit,
+    ) = RelayDiscoveryEvent.build(
+        relay,
+        current?.content ?: "",
+        createdAt = maxOf(now, (current?.createdAt ?: 0L) + 1),
+    ) {
+        current?.tags?.forEach { tag ->
+            if (tag.firstOrNull() != "d" && tag.firstOrNull() !in owned) add(tag)
+        }
+        measured()
+    }
+
+    /**
+     * This monitor's own current record for each relay, in one query.
+     *
+     * Only OUR records: merging another monitor's tags into a document signed
+     * with this key would republish their claims as ours.
+     */
+    private suspend fun currentRecords(relays: Collection<NormalizedRelayUrl>): Map<NormalizedRelayUrl, RelayDiscoveryEvent> {
+        if (relays.isEmpty()) return emptyMap()
+        val held =
+            store.query<RelayDiscoveryEvent>(
+                Filter(
+                    kinds = listOf(RelayDiscoveryEvent.KIND),
+                    authors = listOf(signer.pubKey),
+                    tags = mapOf("d" to relays.map { it.url }.distinct()),
+                ),
+            )
+        val out = HashMap<NormalizedRelayUrl, RelayDiscoveryEvent>(held.size)
+        for (ev in held) {
+            val relay = ev.relay() ?: continue
+            val seen = out[relay]
+            if (seen == null || ev.createdAt > seen.createdAt) out[relay] = ev
+        }
+        return out
+    }
+
     companion object {
+        /**
+         * The tags this class measures on every write, and may therefore
+         * replace. A dead record must be able to CLEAR a stale rtt — liveness
+         * is the presence of `rtt-open` — so all three rtt types are owned even
+         * though only `rtt-open` is written by every path.
+         */
+        private val OWNED_LIVENESS =
+            setOf(NetworkTypeTag.TAG_NAME, RttType.OPEN.tagName, RttType.READ.tagName, RttType.WRITE.tagName)
+
         /** Default freshness window: a relay's status is trusted for a day, then re-probed. */
         const val DEFAULT_TTL_SECONDS = 24L * 60 * 60
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip66RelayMonitor/reachability/RelayReachabilityStore.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip66RelayMonitor/reachability/RelayReachabilityStore.kt
@@ -143,8 +143,8 @@ class RelayReachabilityStore(
         rttOpenMs: Long = 0,
     ) {
         val current = currentRecords(reachable + dead)
-        for (relay in reachable) writeOne(relay, up = true, now, rttOpenMs, current[relay])
-        for (relay in dead) if (relay !in reachable) writeOne(relay, up = false, now, rttOpenMs, current[relay])
+        for (relay in reachable) writeSafely { writeOne(relay, up = true, now, rttOpenMs, current[relay]) }
+        for (relay in dead) if (relay !in reachable) writeSafely { writeOne(relay, up = false, now, rttOpenMs, current[relay]) }
     }
 
     /**
@@ -159,8 +159,8 @@ class RelayReachabilityStore(
         now: Long = TimeUtils.now(),
     ) {
         val current = currentRecords(reachableRttMs.keys + dead)
-        for ((relay, rtt) in reachableRttMs) writeOne(relay, up = true, now, rtt.coerceAtLeast(0), current[relay])
-        for (relay in dead) if (relay !in reachableRttMs) writeOne(relay, up = false, now, 0, current[relay])
+        for ((relay, rtt) in reachableRttMs) writeSafely { writeOne(relay, up = true, now, rtt.coerceAtLeast(0), current[relay]) }
+        for (relay in dead) if (relay !in reachableRttMs) writeSafely { writeOne(relay, up = false, now, 0, current[relay]) }
     }
 
     /**
@@ -180,23 +180,44 @@ class RelayReachabilityStore(
         val current = currentRecords(reported.map { it.url })
         var written = 0
         for (o in reported) {
-            writeObserved(o, now, current[o.url])
-            written++
+            if (writeSafely { writeObserved(o, now, current[o.url]) }) written++
         }
         return written
     }
+
+    /**
+     * Run one relay's write, keeping its failure to that relay.
+     *
+     * The read-modify-write below spans a store round trip and [IEventStore]
+     * offers no read inside a transaction, so a concurrent writer to the same
+     * address can still win the race — and on a store enforcing replaceable
+     * semantics our now-stale insert is REJECTED. Unisolated, that one throw
+     * ends the loop and drops every relay after it; the run reports fewer
+     * records than it measured and nothing says why.
+     */
+    private inline fun writeSafely(write: () -> Unit): Boolean =
+        try {
+            write()
+            true
+        } catch (e: Exception) {
+            false
+        }
 
     private suspend fun writeObserved(
         o: RelayObserver.Observation,
         now: Long,
         current: RelayDiscoveryEvent?,
     ) {
-        // `R` is included in the owned set here and NOT in [writeOne]: an
-        // observation knows whether this relay challenged us, so it may clear a
-        // requirement that no longer holds. writeOne never learns that, so it
-        // leaves the tag alone rather than deleting what it cannot re-measure.
+        // Owns the `auth` REQUIREMENT VALUE, not the whole `R` tag name: an
+        // observation learns whether this relay challenged us and may clear
+        // that, but `R payment`, `R pow` and the negated forms — written by
+        // RelayProber among others — are somebody else's measurement.
         val template =
-            edit(o.url, now, current, OWNED_LIVENESS + RequirementTag.TAG_NAME) {
+            edit(o.url, now, current, { tag ->
+                tag.firstOrNull() == NetworkTypeTag.TAG_NAME ||
+                    tag.firstOrNull() in ALL_RTT ||
+                    (tag.firstOrNull() == RequirementTag.TAG_NAME && tag.getOrNull(1) == AUTH_REQUIREMENT)
+            }) {
                 networkType(networkTypeOf(o.url))
                 if (o.reachable) {
                     // Liveness is the presence of rtt-open, per NIP-66. A relay we
@@ -211,7 +232,7 @@ class RelayReachabilityStore(
                 // Observed, not read off NIP-11: this relay actually challenged
                 // us. A relay advertising open reads and then demanding AUTH is
                 // exactly what a monitor exists to catch.
-                if (o.authRequired) requirement("auth")
+                if (o.authRequired) requirement(AUTH_REQUIREMENT)
             }
         store.insert(signer.sign(template))
     }
@@ -223,8 +244,19 @@ class RelayReachabilityStore(
         rttOpenMs: Long,
         current: RelayDiscoveryEvent?,
     ) {
+        // Owns every rtt only when writing a DEAD record: liveness is the
+        // presence of rtt-open, so a relay that went down must lose all of
+        // them. On the reachable path it owns rtt-open alone — deleting a
+        // `rtt-read` this call never measured is the same silent loss this
+        // whole change exists to stop.
+        val owned =
+            if (up) {
+                { tag: Array<String> -> tag.firstOrNull() == NetworkTypeTag.TAG_NAME || tag.firstOrNull() == RttType.OPEN.tagName }
+            } else {
+                { tag: Array<String> -> tag.firstOrNull() == NetworkTypeTag.TAG_NAME || tag.firstOrNull() in ALL_RTT }
+            }
         val template =
-            edit(relay, now, current, OWNED_LIVENESS) {
+            edit(relay, now, current, owned) {
                 networkType(networkTypeOf(relay))
                 if (up) rtt(RttType.OPEN, rttOpenMs)
             }
@@ -244,29 +276,40 @@ class RelayReachabilityStore(
      * record — it just says less than it did, and the reader downstream has no
      * way to know something was lost.
      *
-     * [owned] is what this writer measured and may therefore replace.
-     * Everything else is carried across untouched, including tags this version
-     * of quartz has never heard of.
+     * [owns] decides what this writer measured and may therefore replace — a
+     * predicate rather than a set of names, because ownership is sometimes per
+     * VALUE: an observation may clear `R auth` without touching the `R pow`
+     * another writer measured. Everything it does not claim is carried across
+     * untouched, including tags this version of quartz has never heard of.
      *
      * The timestamp is `max(now, current + 1)`, not `now`: a store enforcing
      * replaceable semantics REJECTS a record that is not strictly newer than
      * the one it replaces, and two writers inside the same second — or a peer
-     * whose clock runs ahead of ours — are ordinary. An update lost that way is
-     * indistinguishable from one that had nothing to say.
+     * whose clock runs slightly ahead — are ordinary. An update lost that way
+     * is indistinguishable from one that had nothing to say.
+     *
+     * That bump is CAPPED at [MAX_FUTURE_SKEW_SECONDS] past `now`. Without a
+     * ceiling a `created_at` that once landed in the future is sticky: every
+     * later edit derives from the bad value and never re-anchors, so the record
+     * never ages out of [snapshot]'s TTL window (a stale `isKnownDead` that can
+     * never expire) and relays enforcing future-timestamp limits reject
+     * everything this monitor publishes for that relay. Capped, a pathological
+     * record costs the updates made while `now` catches up — bounded, and it
+     * heals itself — instead of poisoning the slot permanently.
      */
     private fun edit(
         relay: NormalizedRelayUrl,
         now: Long,
         current: RelayDiscoveryEvent?,
-        owned: Set<String>,
+        owns: (Array<String>) -> Boolean,
         measured: TagArrayBuilder<RelayDiscoveryEvent>.() -> Unit,
     ) = RelayDiscoveryEvent.build(
         relay,
         current?.content ?: "",
-        createdAt = maxOf(now, (current?.createdAt ?: 0L) + 1),
+        createdAt = minOf(maxOf(now, (current?.createdAt ?: 0L) + 1), now + MAX_FUTURE_SKEW_SECONDS),
     ) {
         current?.tags?.forEach { tag ->
-            if (tag.firstOrNull() != "d" && tag.firstOrNull() !in owned) add(tag)
+            if (tag.firstOrNull() != "d" && !owns(tag)) add(tag)
         }
         measured()
     }
@@ -279,32 +322,47 @@ class RelayReachabilityStore(
      */
     private suspend fun currentRecords(relays: Collection<NormalizedRelayUrl>): Map<NormalizedRelayUrl, RelayDiscoveryEvent> {
         if (relays.isEmpty()) return emptyMap()
-        val held =
-            store.query<RelayDiscoveryEvent>(
-                Filter(
-                    kinds = listOf(RelayDiscoveryEvent.KIND),
-                    authors = listOf(signer.pubKey),
-                    tags = mapOf("d" to relays.map { it.url }.distinct()),
-                ),
-            )
-        val out = HashMap<NormalizedRelayUrl, RelayDiscoveryEvent>(held.size)
-        for (ev in held) {
-            val relay = ev.relay() ?: continue
-            val seen = out[relay]
-            if (seen == null || ev.createdAt > seen.createdAt) out[relay] = ev
+        val out = HashMap<NormalizedRelayUrl, RelayDiscoveryEvent>()
+        // CHUNKED: a `d` filter binds one host parameter per url, and callers
+        // pass the whole relay universe — RelayProber's own measurement puts
+        // that at 16,507. A bundled SQLite refuses past 32,766 variables, and
+        // the throw would land BEFORE anything was written, losing an entire
+        // probe run's records rather than one relay's.
+        for (chunk in relays.map { it.url }.distinct().chunked(RELAYS_PER_QUERY)) {
+            val held =
+                store.query<RelayDiscoveryEvent>(
+                    Filter(kinds = listOf(RelayDiscoveryEvent.KIND), authors = listOf(signer.pubKey), tags = mapOf("d" to chunk)),
+                )
+            for (ev in held) {
+                val relay = ev.relay() ?: continue
+                val seen = out[relay]
+                if (seen == null || ev.createdAt > seen.createdAt) out[relay] = ev
+            }
         }
         return out
     }
 
     companion object {
+        /** Every rtt tag name. A DEAD record must clear all of them: liveness is the presence of `rtt-open`. */
+        private val ALL_RTT = setOf(RttType.OPEN.tagName, RttType.READ.tagName, RttType.WRITE.tagName)
+
+        /** The one NIP-66 requirement an observation can prove: the relay challenged us. */
+        const val AUTH_REQUIREMENT = "auth"
+
         /**
-         * The tags this class measures on every write, and may therefore
-         * replace. A dead record must be able to CLEAR a stale rtt — liveness
-         * is the presence of `rtt-open` — so all three rtt types are owned even
-         * though only `rtt-open` is written by every path.
+         * How far past `now` an edit may stamp itself to clear a record that
+         * is already ahead of the clock. Enough to cover ordinary skew between
+         * two writers; small enough that a pathological record heals in
+         * minutes rather than never. See [edit].
          */
-        private val OWNED_LIVENESS =
-            setOf(NetworkTypeTag.TAG_NAME, RttType.OPEN.tagName, RttType.READ.tagName, RttType.WRITE.tagName)
+        const val MAX_FUTURE_SKEW_SECONDS = 60L
+
+        /**
+         * Urls per `d` lookup. Well under a bundled SQLite's 32,766-variable
+         * ceiling, and in the same range as the author chunking elsewhere in
+         * this codebase.
+         */
+        const val RELAYS_PER_QUERY = 500
 
         /** Default freshness window: a relay's status is trusted for a day, then re-probed. */
         const val DEFAULT_TTL_SECONDS = 24L * 60 * 60

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip66RelayMonitor/reachability/RelayReachabilityStore.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip66RelayMonitor/reachability/RelayReachabilityStore.kt
@@ -35,6 +35,7 @@ import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.tags.NetworkTypeTag
 import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.tags.RequirementTag
 import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.tags.RttType
 import com.vitorpamplona.quartz.utils.TimeUtils
+import kotlinx.coroutines.CancellationException
 
 /**
  * A durable, shareable relay-reachability cache backed by an [IEventStore] as
@@ -143,8 +144,10 @@ class RelayReachabilityStore(
         rttOpenMs: Long = 0,
     ) {
         val current = currentRecords(reachable + dead)
-        for (relay in reachable) writeSafely { writeOne(relay, up = true, now, rttOpenMs, current[relay]) }
-        for (relay in dead) if (relay !in reachable) writeSafely { writeOne(relay, up = false, now, rttOpenMs, current[relay]) }
+        val up = reachable.toList()
+        val down = dead.filterNot { it in reachable }
+        eachRelay(up.size) { i -> writeOne(up[i], up = true, now, rttOpenMs, current[up[i]]) }
+        eachRelay(down.size) { i -> writeOne(down[i], up = false, now, rttOpenMs, current[down[i]]) }
     }
 
     /**
@@ -159,8 +162,10 @@ class RelayReachabilityStore(
         now: Long = TimeUtils.now(),
     ) {
         val current = currentRecords(reachableRttMs.keys + dead)
-        for ((relay, rtt) in reachableRttMs) writeSafely { writeOne(relay, up = true, now, rtt.coerceAtLeast(0), current[relay]) }
-        for (relay in dead) if (relay !in reachableRttMs) writeSafely { writeOne(relay, up = false, now, 0, current[relay]) }
+        val up = reachableRttMs.toList()
+        val down = dead.filterNot { it in reachableRttMs }
+        eachRelay(up.size) { i -> writeOne(up[i].first, up = true, now, up[i].second.coerceAtLeast(0), current[up[i].first]) }
+        eachRelay(down.size) { i -> writeOne(down[i], up = false, now, 0, current[down[i]]) }
     }
 
     /**
@@ -178,46 +183,53 @@ class RelayReachabilityStore(
     ): Int {
         val reported = observations.filter { it.reachable || it.error != null }
         val current = currentRecords(reported.map { it.url })
-        var written = 0
-        for (o in reported) {
-            if (writeSafely { writeObserved(o, now, current[o.url]) }) written++
-        }
-        return written
+        return eachRelay(reported.size) { i -> writeObserved(reported[i], now, current[reported[i].url]) }
     }
 
     /**
-     * Run one relay's write, keeping its failure to that relay.
+     * Run every relay's write, then fail if any of them did.
      *
-     * The read-modify-write below spans a store round trip and [IEventStore]
-     * offers no read inside a transaction, so a concurrent writer to the same
-     * address can still win the race — and on a store enforcing replaceable
-     * semantics our now-stale insert is REJECTED. Unisolated, that one throw
-     * ends the loop and drops every relay after it; the run reports fewer
-     * records than it measured and nothing says why.
+     * The read-modify-write spans a store round trip and [IEventStore] offers
+     * no read inside a transaction, so a concurrent writer to the same address
+     * can win the race and our now-stale insert is REJECTED. One such throw
+     * must not end the loop and drop every relay after it — but it must not
+     * vanish either: [RelayObserver.collectUnreported] has already cleared the
+     * flags by the time this runs, so a swallowed failure loses the
+     * measurement for good and the caller cannot tell an empty run from a
+     * failed one. So: attempt all, remember the first failure, rethrow it.
+     *
+     * Cancellation is never caught. A shutdown flush wrapped in `withTimeout`
+     * — the pattern [RelayMonitor.close] prescribes — would otherwise be
+     * unabortable, grinding through every remaining relay with each write
+     * throwing and being swallowed.
      */
-    private inline fun writeSafely(write: () -> Unit): Boolean =
-        try {
-            write()
-            true
-        } catch (e: Exception) {
-            false
+    private suspend inline fun eachRelay(
+        count: Int,
+        write: (Int) -> Unit,
+    ): Int {
+        var first: Exception? = null
+        var written = 0
+        for (i in 0 until count) {
+            try {
+                write(i)
+                written++
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                if (first == null) first = e
+            }
         }
+        first?.let { throw it }
+        return written
+    }
 
     private suspend fun writeObserved(
         o: RelayObserver.Observation,
         now: Long,
         current: RelayDiscoveryEvent?,
     ) {
-        // Owns the `auth` REQUIREMENT VALUE, not the whole `R` tag name: an
-        // observation learns whether this relay challenged us and may clear
-        // that, but `R payment`, `R pow` and the negated forms — written by
-        // RelayProber among others — are somebody else's measurement.
         val template =
-            edit(o.url, now, current, { tag ->
-                tag.firstOrNull() == NetworkTypeTag.TAG_NAME ||
-                    tag.firstOrNull() in ALL_RTT ||
-                    (tag.firstOrNull() == RequirementTag.TAG_NAME && tag.getOrNull(1) == AUTH_REQUIREMENT)
-            }) {
+            edit(o.url, now, current, ::ownsLiveness) {
                 networkType(networkTypeOf(o.url))
                 if (o.reachable) {
                     // Liveness is the presence of rtt-open, per NIP-66. A relay we
@@ -244,19 +256,8 @@ class RelayReachabilityStore(
         rttOpenMs: Long,
         current: RelayDiscoveryEvent?,
     ) {
-        // Owns every rtt only when writing a DEAD record: liveness is the
-        // presence of rtt-open, so a relay that went down must lose all of
-        // them. On the reachable path it owns rtt-open alone — deleting a
-        // `rtt-read` this call never measured is the same silent loss this
-        // whole change exists to stop.
-        val owned =
-            if (up) {
-                { tag: Array<String> -> tag.firstOrNull() == NetworkTypeTag.TAG_NAME || tag.firstOrNull() == RttType.OPEN.tagName }
-            } else {
-                { tag: Array<String> -> tag.firstOrNull() == NetworkTypeTag.TAG_NAME || tag.firstOrNull() in ALL_RTT }
-            }
         val template =
-            edit(relay, now, current, owned) {
+            edit(relay, now, current, ::ownsLiveness) {
                 networkType(networkTypeOf(relay))
                 if (up) rtt(RttType.OPEN, rttOpenMs)
             }
@@ -288,14 +289,15 @@ class RelayReachabilityStore(
      * whose clock runs slightly ahead — are ordinary. An update lost that way
      * is indistinguishable from one that had nothing to say.
      *
-     * That bump is CAPPED at [MAX_FUTURE_SKEW_SECONDS] past `now`. Without a
-     * ceiling a `created_at` that once landed in the future is sticky: every
-     * later edit derives from the bad value and never re-anchors, so the record
-     * never ages out of [snapshot]'s TTL window (a stale `isKnownDead` that can
-     * never expire) and relays enforcing future-timestamp limits reject
-     * everything this monitor publishes for that relay. Capped, a pathological
-     * record costs the updates made while `now` catches up — bounded, and it
-     * heals itself — instead of poisoning the slot permanently.
+     * The bump is deliberately NOT capped to some window past `now`. Capping
+     * it looks prudent and is worse: a record already further ahead than the
+     * cap can then never be replaced at all, because every stamp we are willing
+     * to write is older than what is stored, so the relay's live/dead verdict
+     * freezes until the wall clock catches up. It does not even buy the thing
+     * it appears to — [snapshot] selects on `since` alone, so a future-stamped
+     * record sits inside the freshness window either way. A record stamped
+     * ahead of the clock is a defect in whatever produced it; this class's job
+     * is to keep updating it, not to freeze it.
      */
     private fun edit(
         relay: NormalizedRelayUrl,
@@ -306,13 +308,42 @@ class RelayReachabilityStore(
     ) = RelayDiscoveryEvent.build(
         relay,
         current?.content ?: "",
-        createdAt = minOf(maxOf(now, (current?.createdAt ?: 0L) + 1), now + MAX_FUTURE_SKEW_SECONDS),
+        createdAt = maxOf(now, (current?.createdAt ?: 0L) + 1),
     ) {
         current?.tags?.forEach { tag ->
             if (tag.firstOrNull() != "d" && !owns(tag)) add(tag)
         }
         measured()
     }
+
+    /**
+     * The tags this class measures, and may therefore replace.
+     *
+     * Everything here expires together with the record: a 30166 carries ONE
+     * `created_at` for the whole document, so a tag carried across is re-dated
+     * as a current measurement. Keeping a `rtt-read` from an earlier
+     * observation beside a fresh `rtt-open` would republish a stale latency as
+     * today's — and [RelayObserver] documents exactly how wrong a queued rtt
+     * can be. So this class's own liveness facts are rewritten wholesale on
+     * every write, including clearing `R auth` when nothing re-asserts it: a
+     * permanent auth flag is worse than a missing one, because it discourages
+     * the very connection that could clear it.
+     *
+     * Both polarities of the auth requirement are owned. Owning only the
+     * positive form let `R !auth` survive while `requirement("auth")` appended
+     * the opposite, publishing a record that asserted both at once.
+     *
+     * Everything NOT matched here — `R pow`, `R payment`, annotations another
+     * writer keeps on this address, tags this version has never heard of — is
+     * somebody else's measurement and is carried across untouched.
+     */
+    private fun ownsLiveness(tag: Array<String>): Boolean =
+        when (tag.firstOrNull()) {
+            NetworkTypeTag.TAG_NAME -> true
+            in ALL_RTT -> true
+            RequirementTag.TAG_NAME -> tag.getOrNull(1) in AUTH_REQUIREMENT_FORMS
+            else -> false
+        }
 
     /**
      * This monitor's own current record for each relay, in one query.
@@ -324,10 +355,13 @@ class RelayReachabilityStore(
         if (relays.isEmpty()) return emptyMap()
         val out = HashMap<NormalizedRelayUrl, RelayDiscoveryEvent>()
         // CHUNKED: a `d` filter binds one host parameter per url, and callers
-        // pass the whole relay universe — RelayProber's own measurement puts
-        // that at 16,507. A bundled SQLite refuses past 32,766 variables, and
-        // the throw would land BEFORE anything was written, losing an entire
-        // probe run's records rather than one relay's.
+        // pass the whole relay universe — the fan-out this module measures
+        // itself against is 16,507 relays (see RelayObserver). Measured on
+        // BundledSQLiteDriver, 32,765 `d` values pass and 32,766 fails with
+        // "too many SQL variables"; the throw lands BEFORE anything is
+        // written, so an entire probe run's records are lost rather than one
+        // relay's. The headroom here is deliberate — the ceiling is a property
+        // of the driver, not of this query.
         for (chunk in relays.map { it.url }.distinct().chunked(RELAYS_PER_QUERY)) {
             val held =
                 store.query<RelayDiscoveryEvent>(
@@ -349,13 +383,8 @@ class RelayReachabilityStore(
         /** The one NIP-66 requirement an observation can prove: the relay challenged us. */
         const val AUTH_REQUIREMENT = "auth"
 
-        /**
-         * How far past `now` an edit may stamp itself to clear a record that
-         * is already ahead of the clock. Enough to cover ordinary skew between
-         * two writers; small enough that a pathological record heals in
-         * minutes rather than never. See [edit].
-         */
-        const val MAX_FUTURE_SKEW_SECONDS = 60L
+        /** Both polarities, so an update cannot leave the record asserting `auth` and `!auth` at once. */
+        private val AUTH_REQUIREMENT_FORMS = setOf(AUTH_REQUIREMENT, "!$AUTH_REQUIREMENT")
 
         /**
          * Urls per `d` lookup. Well under a bundled SQLite's 32,766-variable

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip66RelayMonitor/reachability/RelayReachabilityStoreTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip66RelayMonitor/reachability/RelayReachabilityStoreTest.kt
@@ -186,12 +186,16 @@ class RelayReachabilityStoreTest {
         }
 
     /**
-     * Without a ceiling the bump is sticky: a record that once landed in the
-     * future is derived from forever, so it never ages out of the TTL window
-     * and relays enforcing future-timestamp limits reject every publish.
+     * A record stamped ahead of the clock is a defect in whatever produced it.
+     * Capping our stamp to some window past `now` looks prudent and is worse:
+     * every stamp we would write is then older than what is stored, so the
+     * insert is rejected and the relay's live/dead verdict freezes until the
+     * wall clock catches up. It does not even buy freshness — snapshot()
+     * selects on `since` alone, so the future record is inside the window
+     * either way.
      */
     @Test
-    fun `a record already far in the future is never pushed further ahead`() =
+    fun `a record stamped ahead of the clock can still be updated`() =
         runBlocking {
             val store = store()
             val signer = NostrSignerInternal(KeyPair())
@@ -201,17 +205,17 @@ class RelayReachabilityStoreTest {
             cache.recordProbed(mapOf(live1 to 120L), emptySet(), now = now + 86_400)
             cache.recordProbed(mapOf(live1 to 131L), emptySet(), now = now)
 
-            val held =
-                store
-                    .query<RelayDiscoveryEvent>(
-                        Filter(kinds = listOf(RelayDiscoveryEvent.KIND), authors = listOf(signer.pubKey), tags = mapOf("d" to listOf(live1.url))),
-                    ).maxByOrNull { it.createdAt }
-            assertEquals(now + 86_400, held?.createdAt, "the pathological stamp was carried forward instead of capped")
+            assertEquals("131", tagsOf(store, signer, live1).first { it[0] == RttType.OPEN.tagName }[1])
         }
 
-    /** writeOne measures rtt-open only; deleting a read/write latency it never took is the loss this guards. */
+    /**
+     * A 30166 carries ONE created_at, so a carried tag is re-dated as a current
+     * measurement. This class's own liveness facts must therefore be rewritten
+     * wholesale, or a stale rtt-read is republished as today's number — which
+     * aggregators rank on.
+     */
     @Test
-    fun `a reachable update keeps latencies it did not measure`() =
+    fun `a later observation does not re-date an older latency`() =
         runBlocking {
             val store = store()
             val signer = NostrSignerInternal(KeyPair())
@@ -226,8 +230,79 @@ class RelayReachabilityStoreTest {
             cache.recordProbed(mapOf(live1 to 120L), emptySet(), now = 1_700_000_100)
 
             val after = tagsOf(store, signer, live1)
-            assertEquals("55", after.first { it[0] == RttType.READ.tagName }[1], "rtt-read was deleted by a writer that never measured it")
+            assertTrue(RttType.READ.tagName !in names(after), "a stale rtt-read was carried onto a fresh record")
             assertEquals("120", after.first { it[0] == RttType.OPEN.tagName }[1])
+        }
+
+    /**
+     * Only [writeObserved] can clear `auth`, and it needs a connection the flag
+     * discourages — so carrying it forward would make it permanent. It expires
+     * with the rest of this class's liveness facts.
+     */
+    @Test
+    fun `an auth requirement does not outlive the observation that set it`() =
+        runBlocking {
+            val store = store()
+            val signer = NostrSignerInternal(KeyPair())
+            val cache = RelayReachabilityStore(store, signer, ttlSeconds = 3600)
+
+            val walled = RelayObserver()
+            walled.record(live1, true, 100L, null)
+            walled.observationOf(live1)?.authRequired = true
+            cache.record(walled.collectUnreported(), now = 1_700_000_000)
+            assertTrue(RequirementTag.TAG_NAME in names(tagsOf(store, signer, live1)))
+
+            cache.recordProbed(mapOf(live1 to 120L), emptySet(), now = 1_700_000_100)
+
+            assertTrue(RequirementTag.TAG_NAME !in names(tagsOf(store, signer, live1)), "the auth wall became permanent")
+        }
+
+    /** Owning only the positive form left `!auth` in place while appending `auth`. */
+    @Test
+    fun `an update never leaves the record asserting both auth polarities`() =
+        runBlocking {
+            val store = store()
+            val signer = NostrSignerInternal(KeyPair())
+            val cache = RelayReachabilityStore(store, signer, ttlSeconds = 3600)
+
+            cache.recordProbed(mapOf(live1 to 120L), emptySet(), now = 1_700_000_000)
+            val existing = tagsOf(store, signer, live1)
+            val negated =
+                RelayDiscoveryEvent.build(live1, "", createdAt = 1_700_000_001) {
+                    existing.forEach { if (it.firstOrNull() != "d") add(it) }
+                    add(arrayOf(RequirementTag.TAG_NAME, "!auth"))
+                }
+            store.insert(signer.sign(negated))
+
+            val walled = RelayObserver()
+            walled.record(live1, true, 100L, null)
+            walled.observationOf(live1)?.authRequired = true
+            cache.record(walled.collectUnreported(), now = 1_700_000_002)
+
+            val reqs = tagsOf(store, signer, live1).filter { it[0] == RequirementTag.TAG_NAME }.map { it[1] }
+            assertEquals(listOf(RelayReachabilityStore.AUTH_REQUIREMENT), reqs, "record asserts contradictory requirements: " + reqs)
+        }
+
+    /**
+     * collectUnreported() has already cleared the flags by the time a write
+     * runs, so a swallowed failure loses the measurement for good and an empty
+     * run is indistinguishable from a failed one.
+     */
+    @Test
+    fun `a failing write is reported, not swallowed`() =
+        runBlocking {
+            val store = store()
+            val signer = NostrSignerInternal(KeyPair())
+            val cache = RelayReachabilityStore(store, signer, ttlSeconds = 3600)
+            store.close()
+
+            var threw = false
+            try {
+                cache.recordProbed(mapOf(live1 to 120L, live2 to 130L), emptySet(), now = 1_700_000_000)
+            } catch (e: Exception) {
+                threw = true
+            }
+            assertTrue(threw, "every write failed and the run reported success")
         }
 
     /** An observation proves `R auth` and nothing else; other requirements belong to whoever measured them. */

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip66RelayMonitor/reachability/RelayReachabilityStoreTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip66RelayMonitor/reachability/RelayReachabilityStoreTest.kt
@@ -29,6 +29,7 @@ import com.vitorpamplona.quartz.nip01Core.store.sqlite.DefaultIndexingStrategy
 import com.vitorpamplona.quartz.nip01Core.store.sqlite.EventStore
 import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.RelayDiscoveryEvent
 import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.tags.NetworkType
+import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.tags.RequirementTag
 import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.tags.RttType
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
@@ -176,10 +177,99 @@ class RelayReachabilityStoreTest {
             val signer = NostrSignerInternal(KeyPair())
             val cache = RelayReachabilityStore(store, signer, ttlSeconds = 3600)
 
-            cache.recordProbed(mapOf(live1 to 120L), emptySet(), now = 1_700_003_600)
+            // Ordinary skew: the record ahead of our clock by seconds, which is
+            // what two writers or a slightly fast peer produce.
+            cache.recordProbed(mapOf(live1 to 120L), emptySet(), now = 1_700_000_010)
             cache.recordProbed(mapOf(live1 to 131L), emptySet(), now = 1_700_000_000)
 
             assertEquals("131", tagsOf(store, signer, live1).first { it[0] == RttType.OPEN.tagName }[1])
+        }
+
+    /**
+     * Without a ceiling the bump is sticky: a record that once landed in the
+     * future is derived from forever, so it never ages out of the TTL window
+     * and relays enforcing future-timestamp limits reject every publish.
+     */
+    @Test
+    fun `a record already far in the future is never pushed further ahead`() =
+        runBlocking {
+            val store = store()
+            val signer = NostrSignerInternal(KeyPair())
+            val cache = RelayReachabilityStore(store, signer, ttlSeconds = 3600)
+            val now = 1_700_000_000L
+
+            cache.recordProbed(mapOf(live1 to 120L), emptySet(), now = now + 86_400)
+            cache.recordProbed(mapOf(live1 to 131L), emptySet(), now = now)
+
+            val held =
+                store
+                    .query<RelayDiscoveryEvent>(
+                        Filter(kinds = listOf(RelayDiscoveryEvent.KIND), authors = listOf(signer.pubKey), tags = mapOf("d" to listOf(live1.url))),
+                    ).maxByOrNull { it.createdAt }
+            assertEquals(now + 86_400, held?.createdAt, "the pathological stamp was carried forward instead of capped")
+        }
+
+    /** writeOne measures rtt-open only; deleting a read/write latency it never took is the loss this guards. */
+    @Test
+    fun `a reachable update keeps latencies it did not measure`() =
+        runBlocking {
+            val store = store()
+            val signer = NostrSignerInternal(KeyPair())
+            val cache = RelayReachabilityStore(store, signer, ttlSeconds = 3600)
+
+            val observed = RelayObserver()
+            observed.record(live1, true, 100L, null)
+            observed.observationOf(live1)?.rttReadMs = 55L
+            cache.record(observed.collectUnreported(), now = 1_700_000_000)
+            assertTrue(RttType.READ.tagName in names(tagsOf(store, signer, live1)))
+
+            cache.recordProbed(mapOf(live1 to 120L), emptySet(), now = 1_700_000_100)
+
+            val after = tagsOf(store, signer, live1)
+            assertEquals("55", after.first { it[0] == RttType.READ.tagName }[1], "rtt-read was deleted by a writer that never measured it")
+            assertEquals("120", after.first { it[0] == RttType.OPEN.tagName }[1])
+        }
+
+    /** An observation proves `R auth` and nothing else; other requirements belong to whoever measured them. */
+    @Test
+    fun `an observation clears only the auth requirement`() =
+        runBlocking {
+            val store = store()
+            val signer = NostrSignerInternal(KeyPair())
+            val cache = RelayReachabilityStore(store, signer, ttlSeconds = 3600)
+
+            cache.recordProbed(mapOf(live1 to 120L), emptySet(), now = 1_700_000_000)
+            val existing = tagsOf(store, signer, live1)
+            val withReqs =
+                RelayDiscoveryEvent.build(live1, "", createdAt = 1_700_000_001) {
+                    existing.forEach { if (it.firstOrNull() != "d") add(it) }
+                    add(arrayOf(RequirementTag.TAG_NAME, "pow"))
+                    add(arrayOf(RequirementTag.TAG_NAME, RelayReachabilityStore.AUTH_REQUIREMENT))
+                }
+            store.insert(signer.sign(withReqs))
+
+            // Reached without a challenge: auth no longer holds, pow was never ours.
+            val observed = RelayObserver()
+            observed.record(live1, true, 100L, null)
+            cache.record(observed.collectUnreported(), now = 1_700_000_002)
+
+            val after = tagsOf(store, signer, live1).filter { it[0] == RequirementTag.TAG_NAME }.map { it[1] }
+            assertTrue("pow" in after, "another writer's requirement was erased: " + after)
+            assertTrue(RelayReachabilityStore.AUTH_REQUIREMENT !in after, "auth should have been cleared: " + after)
+        }
+
+    /** One `d` filter binds one host parameter per url, and callers pass the whole relay universe. */
+    @Test
+    fun `a flush wider than one query chunk still writes every relay`() =
+        runBlocking {
+            val store = store()
+            val signer = NostrSignerInternal(KeyPair())
+            val cache = RelayReachabilityStore(store, signer, ttlSeconds = 3600)
+            val many = (0 until RelayReachabilityStore.RELAYS_PER_QUERY * 2 + 7).map { RelayUrlNormalizer.normalize("wss://r" + it + ".example.com") }
+
+            cache.record(reachable = many.toSet(), dead = emptySet(), now = 1_700_000_000)
+
+            assertEquals(many.size, cache.snapshot(now = 1_700_000_100).live.size)
         }
 
     /** A relay that went down must lose its rtt, or it still reads as live. */

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip66RelayMonitor/reachability/RelayReachabilityStoreTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip66RelayMonitor/reachability/RelayReachabilityStoreTest.kt
@@ -21,11 +21,15 @@
 package com.vitorpamplona.quartz.nip66RelayMonitor.reachability
 
 import com.vitorpamplona.quartz.nip01Core.crypto.KeyPair
+import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
 import com.vitorpamplona.quartz.nip01Core.store.sqlite.DefaultIndexingStrategy
 import com.vitorpamplona.quartz.nip01Core.store.sqlite.EventStore
+import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.RelayDiscoveryEvent
 import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.tags.NetworkType
+import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.tags.RttType
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -110,4 +114,106 @@ class RelayReachabilityStoreTest {
         // A host that merely contains ".onion" as a substring is clearnet, not Tor.
         assertEquals(NetworkType.CLEARNET, RelayReachabilityStore.networkTypeOf(fakeOnion))
     }
+    // ---- one address, more than one writer ---------------------------------
+
+    private suspend fun tagsOf(
+        store: EventStore,
+        signer: NostrSignerInternal,
+        relay: NormalizedRelayUrl,
+    ): List<Array<String>> =
+        store
+            .query<RelayDiscoveryEvent>(
+                Filter(kinds = listOf(RelayDiscoveryEvent.KIND), authors = listOf(signer.pubKey), tags = mapOf("d" to listOf(relay.url))),
+            ).maxByOrNull { it.createdAt }
+            ?.tags
+            ?.toList()
+            .orEmpty()
+
+    private fun names(tags: List<Array<String>>) = tags.mapNotNull { it.firstOrNull() }.toSet()
+
+    /**
+     * A 30166 is addressable, so this monitor has one record per relay — and it
+     * is not necessarily the only thing writing per-relay knowledge under that
+     * identity. A record rebuilt from this writer's own tags deletes the rest,
+     * and the loss is invisible: the event still signs and still parses.
+     */
+    @Test
+    fun `an update keeps tags this writer does not own`() =
+        runBlocking {
+            val store = store()
+            val signer = NostrSignerInternal(KeyPair())
+            val cache = RelayReachabilityStore(store, signer, ttlSeconds = 3600)
+
+            cache.recordProbed(mapOf(live1 to 120L), emptySet(), now = 1_700_000_000)
+            // Something else records what it knows about the same relay,
+            // keeping what the monitor already put there.
+            val existing = tagsOf(store, signer, live1)
+            val withExtra =
+                RelayDiscoveryEvent.build(live1, "", createdAt = 1_700_000_001) {
+                    existing.forEach { if (it.firstOrNull() != "d") add(it) }
+                    add(arrayOf("redirect", "wss://canonical.example.com/"))
+                }
+            store.insert(signer.sign(withExtra))
+
+            cache.recordProbed(mapOf(live1 to 131L), emptySet(), now = 1_700_000_002)
+
+            val after = tagsOf(store, signer, live1)
+            assertTrue("redirect" in names(after), "the update erased another writer's tag: ${names(after)}")
+            // ...and still replaced what it does own.
+            assertEquals("131", after.first { it[0] == RttType.OPEN.tagName }[1])
+        }
+
+    /**
+     * A store enforcing replaceable semantics rejects a record that is not
+     * strictly newer than the one it replaces. Two writers inside one second,
+     * or a peer whose clock runs ahead, are ordinary — and an update lost that
+     * way looks exactly like one that had nothing to say.
+     */
+    @Test
+    fun `an update lands even when the record it replaces is newer than the clock`() =
+        runBlocking {
+            val store = store()
+            val signer = NostrSignerInternal(KeyPair())
+            val cache = RelayReachabilityStore(store, signer, ttlSeconds = 3600)
+
+            cache.recordProbed(mapOf(live1 to 120L), emptySet(), now = 1_700_003_600)
+            cache.recordProbed(mapOf(live1 to 131L), emptySet(), now = 1_700_000_000)
+
+            assertEquals("131", tagsOf(store, signer, live1).first { it[0] == RttType.OPEN.tagName }[1])
+        }
+
+    /** A relay that went down must lose its rtt, or it still reads as live. */
+    @Test
+    fun `a dead update clears the rtt it replaces`() =
+        runBlocking {
+            val store = store()
+            val signer = NostrSignerInternal(KeyPair())
+            val cache = RelayReachabilityStore(store, signer, ttlSeconds = 3600)
+
+            cache.recordProbed(mapOf(live1 to 120L), emptySet(), now = 1_700_000_000)
+            cache.record(reachable = emptySet(), dead = setOf(live1), now = 1_700_000_100)
+
+            assertTrue(RttType.OPEN.tagName !in names(tagsOf(store, signer, live1)))
+            assertTrue(cache.snapshot(now = 1_700_000_200).isKnownDead(live1))
+        }
+
+    /** Only OUR records merge: republishing another monitor's tags under this key would launder their claims. */
+    @Test
+    fun `another monitor's record is not merged into ours`() =
+        runBlocking {
+            val store = store()
+            val signer = NostrSignerInternal(KeyPair())
+            val other = NostrSignerInternal(KeyPair())
+            val cache = RelayReachabilityStore(store, signer, ttlSeconds = 3600)
+
+            val theirs =
+                RelayDiscoveryEvent.build(live1, "", createdAt = 1_700_000_000) {
+                    add(arrayOf("redirect", "wss://not-ours.example.com/"))
+                }
+            store.insert(other.sign(theirs))
+
+            cache.recordProbed(mapOf(live1 to 120L), emptySet(), now = 1_700_000_100)
+
+            assertTrue("redirect" !in names(tagsOf(store, signer, live1)))
+        }
 }


### PR DESCRIPTION
## Summary

A kind:30166 is addressable, so `RelayReachabilityStore` keeps exactly one record per (monitor, relay) — but it is not necessarily the only thing writing per-relay knowledge under that identity. Both write paths built the record from their own tags and inserted it, so **every update deleted whatever else was in that slot**. Writing is now an edit: read this monitor's current record, carry across every tag the writer does not own, and replace only what it measured.

Found while adding a "this url is an alias of that one" tag alongside the monitor in a downstream crawler. The record went `[d, n, rtt-open]` → `[d, redirect]` on our write, and the monitor's next observation turned it back into `[d, n, rtt-open]`. Nothing looks wrong at any point — the event still signs, still parses, still reads as a valid NIP-66 record. It just says less than it did, and the reader downstream cannot tell.

Reproduction on `main`, both write paths (`recordProbed`, and the `RelayObserver` path that fires on every ordinary dial):

```
after monitor    d:…, n:clearnet, rtt-open:120
after our write  d:…, n:clearnet, rtt-open:120, redirect:wss://canonical/…
after monitor2   d:…, n:clearnet, rtt-open:131          ← redirect gone
```

Three rules the merge follows, each of which I got wrong at least once and fixed under review:

- **Ownership is everything this class measures, and nothing else.** `n`, all three `rtt-*`, and both polarities of `R auth` are rewritten wholesale on every write; `R pow`, `R payment`, and anything unrecognised are carried across. Narrower ownership is tempting and wrong: a 30166 carries ONE `created_at`, so a carried tag is re-dated as a *current* measurement — a stale `rtt-read` beside a fresh `rtt-open` republishes a latency aggregators rank on, and `RelayObserver` documents how wrong a queued rtt can be. Carrying `R auth` forward is worse: only an observation can clear it, and that needs the connection the flag discourages, so it becomes permanent — a regression against the rebuild this replaces.
- **`created_at` is `max(now, current + 1)`, uncapped.** A store enforcing replaceable semantics rejects a record that is not strictly newer, and two writers inside one second — or a peer slightly ahead — are ordinary. Capping the bump to a window past `now` looks prudent and is worse: a record already further ahead can then never be replaced, so the relay's verdict freezes until the wall clock catches up. It buys nothing either, since `snapshot()` selects on `since` alone and a future-stamped record is inside the window regardless.
- **Only our own records merge.** Folding another monitor's tags into a document signed with this key would republish their claims as ours.

Reads are batched and chunked at 500 urls: callers pass the whole relay universe (the fan-out this module measures itself against is 16,507 relays) and a bundled SQLite refuses past its variable ceiling — measured here, 32,765 `d` values pass and 32,766 fails with `too many SQL variables`. The throw lands *before* anything is written, so an entire run's records are lost rather than one relay's.

Per-relay failures are isolated but never swallowed: every relay is attempted, then the first real failure is rethrown. `CancellationException` propagates immediately, so a shutdown flush wrapped in `withTimeout` — the pattern `RelayMonitor.close()` prescribes — can still abort. Silently dropping a failure would lose the measurement for good, since `collectUnreported()` has already cleared the flags by then.

**Known limitations, documented in the code:**

- The read-modify-write spans a store round trip and `IEventStore` exposes no read inside a transaction, so a concurrent writer to the same address can still win the race and get our now-stale insert rejected. Not closable at this layer.
- `RelayProber.toDiscoveryEventTemplate` still builds from scratch. A consumer following its KDoc (sign with the monitor key, insert) will wipe a merged record. Left out of this PR to keep it to one fix — happy to follow up if you'd like it in the same change.

No new tag, kind, or NIP interpretation is introduced — the change is strictly "stop deleting tags we did not write".

## Test plan

Pure `quartz/` protocol fix, no flavour-specific code, so no Play/F-Droid builds — `commonMain` only, verified on the JVM target.

- [x] Ran `./gradlew :quartz:spotlessApply` — repo is formatted
- [x] Ran `./gradlew :quartz:jvmTest` — **4,078 tests, 0 failures**

```
BUILD SUCCESSFUL in 5m 07s
quartz jvmTest: tests=4078 failures=0 errors=0
```

### Feature test plan

Eleven new cases in `RelayReachabilityStoreTest`. I verified which of them actually fail on `main` by reverting the source file and keeping the tests — **five are regression tests for the reported bug**, the rest guard code paths that do not exist on `main`:

Fail on `main`, pass after (regression tests for the bug):

- a foreign tag survives an update
- an update against a record stamped ahead of the clock still lands
- a record stamped ahead of the clock can still be updated
- a later observation does not re-date an older latency
- an observation clears only the auth requirement

Pass on `main` too — guards on the new merge path, not evidence of the bug:

- a dead update clears the rtt it replaces (merge must not break liveness)
- another monitor's record is not merged into ours (merge must not over-reach)
- a flush wider than one query chunk still writes every relay (guards the chunking)
- an auth requirement does not outlive the observation that set it
- an update never leaves the record asserting both auth polarities
- a failing write is reported, not swallowed

### Regression test plan

Touch points and verification:

- **`snapshot()` liveness semantics** — could regress if a dead update stopped clearing `rtt-open`, since liveness is that tag's presence — verified by `a dead update clears the rtt it replaces` asserting `isKnownDead`, plus the four pre-existing tests (`recordsAndReloadsReachability`, `aFreshSuccessfulOpenOverridesAnEarlierDeadMark`, `recordsOlderThanTheTtlAreIgnored`, `onionRelayIsTaggedTorNetwork`) passing unchanged.
- **`record(observations)` return count** — still "number of records written"; failures now rethrow rather than being counted as skips.
- **Shutdown path** — could regress through the new per-relay guard swallowing cancellation — verified by rethrowing `CancellationException` explicitly, matching `Nip05Client`/`UserHexResolver`.
- **Write volume per flush** — one extra query per 500 relays, not per relay; one insert per relay as before.
- **Everything else in quartz** — the full `:quartz:jvmTest` suite (4,078) passes; no other module was touched.

Not run: the interop suites — this change cannot affect wire bytes, decoded audio, MLS state or DM envelopes.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## AI assistance

- [x] Drafted with AI assistance, manually reviewed and tested

Per `CONTRIBUTING-WITH-AI.md`, the diff went through two separate review passes by a different agent than wrote it, and both found real defects:

- **First pass** (on `9ce0fb9`): missing chunking, uncapped timestamp, `writeOne` deleting latencies it never measured, `R` owned by name instead of value, unisolated race. Fixed in `a81c43e`.
- **Second pass** (on the fixed state): the guard swallowing `CancellationException` and hiding failures, the timestamp *cap* freezing updates, `R auth` becoming permanent, `!auth` surviving alongside `auth`, and `RelayProber.toDiscoveryEventTemplate` still rebuilding. Fixed in `56eec42` — three of them by reversing choices the first fix introduced.

An earlier revision of this description claimed all new tests fail on `main`. That was wrong and is corrected above; I checked it by actually reverting the source rather than asserting it.

No prior issue exists for this bug; it was found in the wild and the fix was requested directly by the maintainer, so the "post a research summary on the issue first" step was skipped by agreement rather than oversight.

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.