### PR TITLE
fix(quartz): merge probe verdicts into the record they replace

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip66RelayMonitor/reachability/RelayProber.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip66RelayMonitor/reachability/RelayProber.kt
@@ -39,6 +39,8 @@ import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.RelayDiscoveryEvent
 import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.networkType
 import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.requirement
 import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.rtt
+import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.tags.NetworkTypeTag
+import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.tags.RequirementTag
 import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.tags.RttType
 import com.vitorpamplona.quartz.utils.TimeUtils
 import com.vitorpamplona.quartz.utils.concurrent.ConcurrentMap
@@ -430,8 +432,18 @@ class RelayProber(
 fun RelayProber.Verdict.toDiscoveryEventTemplate(
     createdAt: Long = TimeUtils.now(),
     readWrite: RelayProber.ReadWriteVerdict? = null,
+    current: RelayDiscoveryEvent? = null,
 ): EventTemplate<RelayDiscoveryEvent> =
-    RelayDiscoveryEvent.build(relay, createdAt = createdAt) {
+    RelayDiscoveryEvent.build(
+        relay,
+        current?.content ?: "",
+        // Strictly newer than what it replaces, or a store enforcing
+        // replaceable semantics rejects it and the probe is lost silently.
+        createdAt = maxOf(createdAt, (current?.createdAt ?: 0L) + 1),
+    ) {
+        current?.tags?.forEach { tag ->
+            if (tag.firstOrNull() != "d" && !probeOwns(tag, readWrite != null)) add(tag)
+        }
         networkType(RelayReachabilityStore.networkTypeOf(relay))
         if (reachable) rtt(RttType.OPEN, rttOpenMs.coerceAtLeast(0))
         if (readWrite != null) {
@@ -441,6 +453,37 @@ fun RelayProber.Verdict.toDiscoveryEventTemplate(
         val authWalled =
             error?.startsWith("closed:auth-required") == true ||
                 readWrite?.writeMessage?.startsWith("auth-required") == true
-        if (authWalled) requirement("auth")
-        if (readWrite?.writeMessage?.startsWith("pow:") == true) requirement("pow")
+        if (authWalled) requirement(RelayReachabilityStore.AUTH_REQUIREMENT)
+        if (readWrite?.writeMessage?.startsWith("pow:") == true) requirement(POW_REQUIREMENT)
+    }
+
+/** The NIP-66 requirement a write probe can prove, alongside `auth`. */
+private const val POW_REQUIREMENT = "pow"
+
+/**
+ * What a probe verdict measured, and may therefore replace in [current].
+ *
+ * A 30166 carries ONE `created_at`, so any tag carried across is re-dated as a
+ * current measurement — this verdict's own facts must be rewritten wholesale or
+ * a stale latency is republished as today's number.
+ *
+ * [hasReadWrite] narrows it: without a [RelayProber.ReadWriteVerdict] this probe
+ * never exercised the write path, so `R pow` is somebody else's finding and is
+ * carried across rather than deleted. Both polarities of each requirement are
+ * owned, so an update cannot leave the record asserting `pow` and `!pow` at once.
+ */
+private fun probeOwns(
+    tag: Array<String>,
+    hasReadWrite: Boolean,
+): Boolean =
+    when (tag.firstOrNull()) {
+        NetworkTypeTag.TAG_NAME -> true
+        RttType.OPEN.tagName, RttType.READ.tagName, RttType.WRITE.tagName -> true
+        RequirementTag.TAG_NAME ->
+            when (tag.getOrNull(1)) {
+                RelayReachabilityStore.AUTH_REQUIREMENT, "!" + RelayReachabilityStore.AUTH_REQUIREMENT -> true
+                POW_REQUIREMENT, "!" + POW_REQUIREMENT -> hasReadWrite
+                else -> false
+            }
+        else -> false
     }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip66RelayMonitor/reachability/RelayProberFlowTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip66RelayMonitor/reachability/RelayProberFlowTest.kt
@@ -34,6 +34,7 @@ import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
 import com.vitorpamplona.quartz.nip01Core.signers.EventTemplate
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
+import com.vitorpamplona.quartz.nip66RelayMonitor.discovery.RelayDiscoveryEvent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -472,4 +473,58 @@ class RelayProberFlowTest {
 
             assertTrue(listOf("n", "tor") in tagsOf(template))
         }
+    // ---- merging into an existing record ----------------------------------
+
+    /**
+     * A 30166 is addressable, so a consumer that follows this function's KDoc —
+     * sign with the monitor key, insert — replaces whatever else is on that
+     * address. Built from the verdict alone it deletes it.
+     */
+    @Test
+    fun probeTemplateKeepsTagsItDidNotMeasure() {
+        val verdict = RelayProber.Verdict(fast, reachable = true, rttOpenMs = 120, rttEoseMs = 200, error = null)
+        val existing =
+            RelayDiscoveryEvent(
+                "id",
+                "pubkey",
+                1_000,
+                arrayOf(
+                    arrayOf("d", fast.url),
+                    arrayOf("R", "pow"),
+                    arrayOf("redirect", "wss://canonical.example.com/"),
+                ),
+                "",
+                "sig",
+            )
+
+        val tags = tagsOf(verdict.toDiscoveryEventTemplate(createdAt = 2_000, current = existing))
+
+        assertTrue(listOf("redirect", "wss://canonical.example.com/") in tags, "a foreign tag was deleted: $tags")
+        // No write probe ran, so `R pow` is somebody else's finding.
+        assertTrue(listOf("R", "pow") in tags, "an unmeasured requirement was deleted: $tags")
+    }
+
+    /** With a write verdict the probe DOES measure pow, so a stale one must not be re-dated. */
+    @Test
+    fun probeTemplateReplacesRequirementsItDidMeasure() {
+        val verdict = RelayProber.Verdict(fast, reachable = true, rttOpenMs = 120, rttEoseMs = 200, error = null)
+        val existing =
+            RelayDiscoveryEvent("id", "pubkey", 1_000, arrayOf(arrayOf("d", fast.url), arrayOf("R", "pow")), "", "sig")
+        val clean = RelayProber.ReadWriteVerdict(fast, rttReadMs = 10, rttWriteMs = 20, writeAccepted = true, writeMessage = null)
+
+        val tags = tagsOf(verdict.toDiscoveryEventTemplate(createdAt = 2_000, readWrite = clean, current = existing))
+
+        assertTrue(listOf("R", "pow") !in tags, "a stale requirement was carried onto a fresh measurement: $tags")
+    }
+
+    /** Replaceable ordering: an update not strictly newer is rejected and lost. */
+    @Test
+    fun probeTemplateStampsPastTheRecordItReplaces() {
+        val verdict = RelayProber.Verdict(fast, reachable = true, rttOpenMs = 120, rttEoseMs = 200, error = null)
+        val existing = RelayDiscoveryEvent("id", "pubkey", 9_000, arrayOf(arrayOf("d", fast.url)), "", "sig")
+
+        val template = verdict.toDiscoveryEventTemplate(createdAt = 2_000, current = existing)
+
+        assertTrue(template.createdAt > 9_000, "stamped ${template.createdAt}, which cannot replace 9000")
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to #3882, which made `RelayReachabilityStore` edit a relay's kind:30166 instead of rebuilding it. `RelayProber.Verdict.toDiscoveryEventTemplate` was the remaining co-writer on that address: it builds from the verdict alone, so a consumer following its own KDoc — sign with the monitor key, insert — wipes whatever else is there, undoing the merge for exactly the writer #3882 set out to protect. It was called out as a known limitation in that PR; this closes it.

It now takes the current record and carries across every tag the verdict did not measure, on the same rules — with one difference that matters:

- **Ownership is per writer, and this one measures more than the store does.** A write probe determines `pow` from the OK message, so `R pow` is its own finding and must not be re-dated from an older record. Without a `ReadWriteVerdict` it never exercised the write path, so the same tag is somebody else's and is carried across untouched. That is why `probeOwns` takes a `hasReadWrite` flag rather than a fixed set: the identical tag is owned or foreign depending on what this run actually did.
- **Both polarities of each requirement are owned**, so an update cannot leave the record asserting `pow` and `!pow` at once.
- **`created_at` is `max(requested, current + 1)`** — a store enforcing replaceable semantics rejects anything not strictly newer, and the probe would be lost with nothing to show for the round trip.

The `current` parameter defaults to null, so every existing caller keeps today's behaviour and the change is additive.

## Test plan

Pure `quartz/` protocol fix, `commonMain` only, no flavour-specific code — verified on the JVM target, so no Play/F-Droid builds.

- [x] Ran `./gradlew :quartz:spotlessApply` — repo is formatted
- [x] Ran `./gradlew :quartz:jvmTest` — **4,081 tests, 0 failures**

```
BUILD SUCCESSFUL in 5m 47s
quartz jvmTest: tests=4081 failures=0 errors=0
```

### Feature test plan

Three new cases in `RelayProberFlowTest`, all exercising the new `current` argument (they cannot fail on `main`, since the parameter does not exist there — they guard the new path rather than reproduce a prior defect):

- `probeTemplateKeepsTagsItDidNotMeasure` — a foreign `redirect` tag and an unmeasured `R pow` both survive a probe that ran without a write verdict.
- `probeTemplateReplacesRequirementsItDidMeasure` — with a `ReadWriteVerdict`, a stale `R pow` is replaced rather than carried onto a fresh measurement.
- `probeTemplateStampsPastTheRecordItReplaces` — a verdict stamped at 2,000 against a record at 9,000 lands past it instead of being silently rejected.

The bug itself is demonstrated in #3882's description; this function's contribution to it is that a caller signing and inserting its template replaces the merged record.

### Regression test plan

Touch points and verification:

- **Existing `toDiscoveryEventTemplate` callers** — could regress if the added parameter changed default behaviour — it defaults to null, and the eight pre-existing template tests in `RelayProberFlowTest` (liveness/network tags, auth from `closed:auth-required`, pow from the write message, rtt-read/write only with a verdict) pass unchanged.
- **`RelayReachabilityStore` merge from #3882** — shares `AUTH_REQUIREMENT` and `networkTypeOf` with this function — its 15 tests pass unchanged.
- **Everything else in quartz** — the full `:quartz:jvmTest` suite (4,081) passes; no other module was touched.

Not run: the interop suites — this change cannot affect wire bytes, decoded audio, MLS state or DM envelopes.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## AI assistance

- [x] Drafted with AI assistance, manually reviewed and tested

Per `CONTRIBUTING-WITH-AI.md`: this change was surfaced by a review pass on #3882 by a separate agent, which flagged `toDiscoveryEventTemplate` as still rebuilding. The ownership asymmetry above (`pow` owned only when the write path ran) came out of applying that review's reasoning to this writer rather than copying the store's rule.

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BaFz1uoWbWo8TcXUYeDyq1)_