### PR TITLE
feat(desktop): per-visible metadata + reaction loading via shared finders in commons

### DIFF
--- a/.claude/skills/relay-client/SKILL.md
+++ b/.claude/skills/relay-client/SKILL.md
@@ -94,6 +94,32 @@ class MetadataFilterAssembler(
 
 Assemblers stay pure — no state, no I/O. They're the composition seam: `FeedMetadataCoordinator` takes a list of visible notes and assembles a single metadata filter covering every referenced pubkey.
 
+## Per-visible loading — the canonical entry points (`observeUser*` / `observeNote*`)
+
+Prefer these over hand-rolled "load metadata for this list" calls. They are the shared,
+KMP way to load data **only for what's on screen** — a composable subscribes while it is in
+composition and unsubscribes ~30s after it leaves (or the app backgrounds). Both live in
+`commons/relayClient/`:
+
+- **Per user** (`relayClient/user/`): `observeUserInfo/Picture/Banner/AboutMe/Name(user)`
+  each open a composition-scoped `UserFinderFilterAssemblerSubscription(user)` **and** return
+  reactive `State`. Metadata (kind 0 + relay lists) loads for on-screen users only, coalesced
+  into one batched REQ per relay for the whole visible set.
+- **Per note** (`relayClient/event/`): `EventFinderFilterAssemblerSubscription(note)` loads a
+  note's interactions (reactions / zaps / reposts / replies) while it is composed. Android's
+  `observeNote*` display observers layer on top of the same subscription.
+
+Both read front-end-provided CompositionLocals — `LocalUserFinder` / `LocalUserFinderAccount`
+(reused by the event finder) / `LocalEventFinder` — provided once near the composition root
+(Android `AppModules`, Desktop `Main.kt` via its subscriptions coordinator). The account seam
+is the narrow `UserFinderAccount` (snapshot relay-hint getters), NOT the fat `IAccount`.
+`error()` defaults mean these must never be reached from a composition without a relay client
+(e.g. the Android `:napplet` sandbox).
+
+The load-once, viewport-batch path (`FeedMetadataCoordinator.loadMetadataForNotes` /
+`loadMetadataBatched`) is superseded for foreground loading; `MetadataPreloader` remains only
+as an optional off-screen background warmer.
+
 ## Preloaders
 
 `MetadataPreloader` is the "I need metadata for 200 pubkeys, but don't melt my CPU or the relay" path. It uses `MetadataRateLimiter` (token bucket) to throttle bulk fetches and group them into relay-friendly chunks.

--- a/.github/workflows/smoke-test-desktop.yml
+++ b/.github/workflows/smoke-test-desktop.yml
@@ -92,13 +92,29 @@ jobs:
           chmod +x scripts/relax-deb-libicu.sh
           scripts/relax-deb-libicu.sh desktopApp/build/compose/binaries/main-release/deb/*.deb
 
+      # Mirrors the same step in create-release.yml so this job exercises the
+      # exact .deb release ships. libskiko-linux-arm64.so has libEGL.so.1 in
+      # DT_NEEDED and jpackage does not scan lib/app/ for Depends, so without
+      # this the arm64 app dies at startup with
+      #   UnsatisfiedLinkError: libEGL.so.1: cannot open shared object file
+      # See scripts/add-deb-libegl-dep.sh for the full rationale.
+      - name: Add libegl1 dep to arm64 .deb
+        run: |
+          set -euo pipefail
+          chmod +x scripts/add-deb-libegl-dep.sh
+          scripts/add-deb-libegl-dep.sh desktopApp/build/compose/binaries/main-release/deb/*.deb
+
       - name: Install .deb
         run: |
+          # Installed via apt (not `dpkg -i`) so the .deb's declared Depends are
+          # actually resolved — that is what pulls in libegl1 on the arm64
+          # runner, which does not ship it preinstalled.
+          #
           # jpackage's post-install script runs xdg-desktop-menu which fails
           # on CI runners ("No writable system menu directory"). The files are
           # extracted successfully; only the menu registration fails. Allow the
-          # dpkg error, then verify the binary was actually installed.
-          sudo dpkg -i desktopApp/build/compose/binaries/main-release/deb/*.deb || true
+          # install error, then verify the binary was actually installed.
+          sudo apt-get install -y ./desktopApp/build/compose/binaries/main-release/deb/*.deb || true
           echo "Installed files:"
           dpkg -L amethyst | head -30
           # Fail if the binary wasn't actually extracted

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -32,7 +32,6 @@ import com.vitorpamplona.amethyst.commons.connectedApps.signers.NostrSignerPermi
 import com.vitorpamplona.amethyst.commons.connectedApps.signers.NostrSignerPermissionStore
 import com.vitorpamplona.amethyst.commons.defaults.Constants
 import com.vitorpamplona.amethyst.commons.defaults.DefaultIndexerRelayList
-import com.vitorpamplona.amethyst.commons.defaults.DefaultSearchRelayList
 import com.vitorpamplona.amethyst.commons.marmot.MarmotManager
 import com.vitorpamplona.amethyst.commons.model.IAccount
 import com.vitorpamplona.amethyst.commons.model.buzz.BuzzRelayDialect
@@ -382,7 +381,11 @@ class Account(
 
     override fun outboxHomeRelays(): Set<NormalizedRelayUrl> = nip65RelayList.allFlowNoDefaults.value + privateStorageRelayList.flow.value + localRelayList.flow.value
 
-    override fun searchRelays(): Set<NormalizedRelayUrl> = (trustedRelayList.flow.value + searchRelayList.flow.value.ifEmpty { DefaultSearchRelayList }).toSet()
+    // searchRelayList.flow already applies the DefaultSearchRelayList fallback internally
+    // (SearchRelayListState.normalizeSearchRelayListWithBackup), so no ifEmpty needed here.
+    override fun searchRelays(): Set<NormalizedRelayUrl> = (trustedRelayList.flow.value + searchRelayList.flow.value).toSet()
+
+    override fun searchOnlyRelays(): Set<NormalizedRelayUrl> = searchRelayList.flow.value
 
     override fun followPlusAllMineWithSearchRelays(): Set<NormalizedRelayUrl> = followPlusAllMineWithSearch.flow.value
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -30,6 +30,9 @@ import com.vitorpamplona.amethyst.commons.connectedApps.nip46.Nip46ClientStore
 import com.vitorpamplona.amethyst.commons.connectedApps.signers.InMemoryNostrSignerPermissionStore
 import com.vitorpamplona.amethyst.commons.connectedApps.signers.NostrSignerPermissionLedger
 import com.vitorpamplona.amethyst.commons.connectedApps.signers.NostrSignerPermissionStore
+import com.vitorpamplona.amethyst.commons.defaults.Constants
+import com.vitorpamplona.amethyst.commons.defaults.DefaultIndexerRelayList
+import com.vitorpamplona.amethyst.commons.defaults.DefaultSearchRelayList
 import com.vitorpamplona.amethyst.commons.marmot.MarmotManager
 import com.vitorpamplona.amethyst.commons.model.IAccount
 import com.vitorpamplona.amethyst.commons.model.buzz.BuzzRelayDialect
@@ -59,6 +62,7 @@ import com.vitorpamplona.amethyst.commons.model.nip85TrustedAssertions.ContactCa
 import com.vitorpamplona.amethyst.commons.model.nip85TrustedAssertions.ContactCardsState
 import com.vitorpamplona.amethyst.commons.model.nip85TrustedAssertions.TrustProviderListDecryptionCache
 import com.vitorpamplona.amethyst.commons.model.privateChats.hasEncryptedContent
+import com.vitorpamplona.amethyst.commons.relayClient.user.UserFinderAccount
 import com.vitorpamplona.amethyst.commons.relayauth.RelayAuthCustomToggles
 import com.vitorpamplona.amethyst.commons.relayauth.RelayAuthPermissionStore
 import com.vitorpamplona.amethyst.commons.richtext.RichTextParser
@@ -286,6 +290,7 @@ import com.vitorpamplona.quartz.nip72ModCommunities.rules.CommunityRulesEvent
 import com.vitorpamplona.quartz.nip72ModCommunities.rules.tags.KindRuleTag
 import com.vitorpamplona.quartz.nip72ModCommunities.rules.tags.PubkeyRuleTag
 import com.vitorpamplona.quartz.nip72ModCommunities.rules.tags.WotTag
+import com.vitorpamplona.quartz.nip85TrustedAssertions.list.tags.ServiceProviderTag
 import com.vitorpamplona.quartz.nip88Polls.poll.PollEvent
 import com.vitorpamplona.quartz.nip88Polls.response.PollResponseEvent
 import com.vitorpamplona.quartz.nip89AppHandlers.clientTag.NostrSignerWithClientTag
@@ -354,7 +359,8 @@ class Account(
     relayAuthPermissionStore: RelayAuthPermissionStore = InMemoryRelayAuthPermissionStore(),
     signerPermissionStore: NostrSignerPermissionStore = InMemoryNostrSignerPermissionStore(),
     nip46ClientStore: Nip46ClientStore = InMemoryNip46ClientStore(),
-) : IAccount {
+) : IAccount,
+    UserFinderAccount {
     private var userProfileCache: User? = null
 
     override fun userProfile(): User = userProfileCache ?: cache.getOrCreateUser(signer.pubKey).also { userProfileCache = it }
@@ -365,6 +371,30 @@ class Account(
     override val hiddenWordsCase: List<DualCase> get() = hiddenUsers.flow.value.hiddenWordsCase
     override val hiddenUsersHashCodes: Set<Int> get() = hiddenUsers.flow.value.hiddenUsersHashCodes
     override val spammersHashCodes: Set<Int> get() = hiddenUsers.flow.value.spammersHashCodes
+
+    // UserFinderAccount — narrow, read-only relay-hint view used by the shared
+    // per-user metadata + per-note event finders (moved to commons). Snapshot
+    // getters read `.value` fresh on every filter rebuild. userFinderPubkeyHex
+    // doubles as the attribution pubkey for ExplainedFilter.accountPubKeys.
+    override val userFinderPubkeyHex: HexKey get() = userProfile().pubkeyHex
+
+    override fun indexRelays(): Set<NormalizedRelayUrl> = indexerRelayList.flow.value.ifEmpty { DefaultIndexerRelayList }
+
+    override fun outboxHomeRelays(): Set<NormalizedRelayUrl> = nip65RelayList.allFlowNoDefaults.value + privateStorageRelayList.flow.value + localRelayList.flow.value
+
+    override fun searchRelays(): Set<NormalizedRelayUrl> = (trustedRelayList.flow.value + searchRelayList.flow.value.ifEmpty { DefaultSearchRelayList }).toSet()
+
+    override fun followPlusAllMineWithSearchRelays(): Set<NormalizedRelayUrl> = followPlusAllMineWithSearch.flow.value
+
+    override fun commonRelays(): Set<NormalizedRelayUrl> = followSharedOutboxesOrProxy.flow.value.ifEmpty { Constants.eventFinderRelays }
+
+    override fun cardHomeRelays(): Set<NormalizedRelayUrl> = homeRelays.flow.value
+
+    override fun trustProvider(): ServiceProviderTag? = trustProviderList.liveUserRankProvider.value
+
+    override fun followerCountProvider(): ServiceProviderTag? = trustProviderList.liveUserFollowerCount.value
+
+    override fun declaredFollowsByOutboxRelay(): Map<NormalizedRelayUrl, Set<HexKey>> = declaredFollowsPerOutboxRelay.value
 
     val userMetadata = UserMetadataState(signer, cache, scope, settings)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -679,7 +679,7 @@ object LocalCache : ILocalCache, ICacheProvider, Dao {
 
     fun observeLatestNote(filter: Filter) = observeNotes(filter).map { it.firstOrNull() }
 
-    fun checkGetOrCreateUser(key: String): User? = runCatching { getOrCreateUser(key) }.getOrNull()
+    override fun checkGetOrCreateUser(key: String): User? = runCatching { getOrCreateUser(key) }.getOrNull()
 
     fun load(keys: List<String>): List<User> = keys.mapNotNull(::checkGetOrCreateUser)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -479,7 +479,7 @@ object LocalCache : ILocalCache, ICacheProvider, Dao {
     @Volatile
     var lnurlEndpointResolver: LnurlEndpointResolver? = null
 
-    val relayHints = HintIndexer()
+    override val relayHints = HintIndexer()
 
     /**
      * Cashu mint URL directory, populated passively as

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/indexerRelays/IndexerRelayListState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/indexerRelays/IndexerRelayListState.kt
@@ -62,6 +62,17 @@ class IndexerRelayListState(
 
     suspend fun normalizeIndexerRelayListWithBackupNoDefaults(note: Note): Set<NormalizedRelayUrl> = indexListEvent(note)?.let { decryptionCache.relays(it) } ?: emptySet()
 
+    /**
+     * The account's indexer relays, **never empty** — [normalizeIndexerRelayListWithBackup]
+     * substitutes [DefaultIndexerRelayList] both when there is no kind:10086 and when the
+     * one we have decodes to zero relays. Callers assembling metadata / relay-list REQs read
+     * this and can rely on getting a usable set; use [flowNoDefaults] instead to show or diff
+     * what the user actually configured.
+     *
+     * Seeded with [DefaultIndexerRelayList] rather than `emptySet()`, for the same reason as
+     * the search list: `flowOn(IO)` makes the first real emission asynchronous, so an
+     * `emptySet()` seed left a window where `.value` contradicted the contract above.
+     */
     val flow =
         getIndexerRelayListFlow()
             .map { normalizeIndexerRelayListWithBackup(it.note) }
@@ -70,7 +81,7 @@ class IndexerRelayListState(
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
-                emptySet(),
+                DefaultIndexerRelayList,
             )
 
     val flowNoDefaults =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/indexerRelays/IndexerRelayListState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/indexerRelays/IndexerRelayListState.kt
@@ -63,14 +63,25 @@ class IndexerRelayListState(
     suspend fun normalizeIndexerRelayListWithBackupNoDefaults(note: Note): Set<NormalizedRelayUrl> = indexListEvent(note)?.let { decryptionCache.relays(it) } ?: emptySet()
 
     /**
+     * Same resolution as [normalizeIndexerRelayListWithBackup] but non-suspending, for use as the
+     * [flow] seed. Reads the event's public tags plus any *already decrypted* private tags; it
+     * never asks the signer, so it cannot block or hit a NIP-46 round trip.
+     *
+     * At login `indexerListNote.event` is usually still null and this resolves through
+     * `settings.backupIndexRelayList`, restored from LocalPreferences — so an account with public
+     * indexer relays gets its own relays immediately instead of the defaults.
+     */
+    fun normalizeIndexerRelayListPrecached(note: Note): Set<NormalizedRelayUrl> = indexListEvent(note)?.let { decryptionCache.cachedRelays(it) }?.ifEmpty { null } ?: DefaultIndexerRelayList
+
+    /**
      * The account's indexer relays, **never empty** — [normalizeIndexerRelayListWithBackup]
      * substitutes [DefaultIndexerRelayList] both when there is no kind:10086 and when the
      * one we have decodes to zero relays. Callers assembling metadata / relay-list REQs read
      * this and can rely on getting a usable set; use [flowNoDefaults] instead to show or diff
      * what the user actually configured.
      *
-     * Seeded with [DefaultIndexerRelayList] rather than `emptySet()`, for the same reason as
-     * the search list: `flowOn(IO)` makes the first real emission asynchronous, so an
+     * Seeded via [normalizeIndexerRelayListPrecached] rather than `emptySet()`, for the same
+     * reason as the search list: `flowOn(IO)` makes the first real emission asynchronous, so an
      * `emptySet()` seed left a window where `.value` contradicted the contract above.
      */
     val flow =
@@ -81,7 +92,7 @@ class IndexerRelayListState(
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
-                DefaultIndexerRelayList,
+                normalizeIndexerRelayListPrecached(indexerListNote),
             )
 
     val flowNoDefaults =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/searchRelays/SearchRelayListState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/searchRelays/SearchRelayListState.kt
@@ -63,14 +63,26 @@ class SearchRelayListState(
     suspend fun normalizeSearchRelayListWithBackupNoDefaults(note: Note): Set<NormalizedRelayUrl> = searchListEvent(note)?.let { decryptionCache.relays(it) } ?: emptySet()
 
     /**
+     * Same resolution as [normalizeSearchRelayListWithBackup] but non-suspending, for use as the
+     * [flow] seed. Reads the event's public tags plus any *already decrypted* private tags; it
+     * never asks the signer, so it cannot block or hit a NIP-46 round trip.
+     *
+     * At login `searchListNote.event` is usually still null and this resolves through
+     * `settings.backupSearchRelayList`, restored from LocalPreferences — so an account with public
+     * search relays gets its own relays immediately instead of the defaults. Accounts whose relays
+     * are exclusively private fall back to [DefaultSearchRelayList] until the first decrypt lands.
+     */
+    fun normalizeSearchRelayListPrecached(note: Note): Set<NormalizedRelayUrl> = searchListEvent(note)?.let { decryptionCache.cachedRelays(it) }?.ifEmpty { null } ?: DefaultSearchRelayList
+
+    /**
      * The account's search relays, **never empty** — [normalizeSearchRelayListWithBackup]
      * substitutes [DefaultSearchRelayList] both when there is no kind:10007 and when the
      * one we have decodes to zero relays. Callers assembling NIP-50 REQs read this and can
      * rely on getting a usable set; use [flowNoDefaults] instead to show or diff what the
      * user actually configured.
      *
-     * Seeded with [DefaultSearchRelayList] rather than `emptySet()`: `flowOn(IO)` means the
-     * first real emission can never be synchronous with `stateIn`, so an `emptySet()` seed
+     * Seeded via [normalizeSearchRelayListPrecached] rather than `emptySet()`: `flowOn(IO)` means
+     * the first real emission can never be synchronous with `stateIn`, so an `emptySet()` seed
      * left a window where `.value` contradicted the "never empty" contract above and search
      * silently queried nothing. That window is unbounded for a NIP-46 signer whose list has
      * private entries, since the first emission waits on a remote decrypt.
@@ -83,7 +95,7 @@ class SearchRelayListState(
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
-                DefaultSearchRelayList,
+                normalizeSearchRelayListPrecached(searchListNote),
             )
 
     val flowNoDefaults =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/searchRelays/SearchRelayListState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/searchRelays/SearchRelayListState.kt
@@ -62,6 +62,19 @@ class SearchRelayListState(
 
     suspend fun normalizeSearchRelayListWithBackupNoDefaults(note: Note): Set<NormalizedRelayUrl> = searchListEvent(note)?.let { decryptionCache.relays(it) } ?: emptySet()
 
+    /**
+     * The account's search relays, **never empty** — [normalizeSearchRelayListWithBackup]
+     * substitutes [DefaultSearchRelayList] both when there is no kind:10007 and when the
+     * one we have decodes to zero relays. Callers assembling NIP-50 REQs read this and can
+     * rely on getting a usable set; use [flowNoDefaults] instead to show or diff what the
+     * user actually configured.
+     *
+     * Seeded with [DefaultSearchRelayList] rather than `emptySet()`: `flowOn(IO)` means the
+     * first real emission can never be synchronous with `stateIn`, so an `emptySet()` seed
+     * left a window where `.value` contradicted the "never empty" contract above and search
+     * silently queried nothing. That window is unbounded for a NIP-46 signer whose list has
+     * private entries, since the first emission waits on a remote decrypt.
+     */
     val flow =
         getSearchRelayListFlow()
             .map { normalizeSearchRelayListWithBackup(it.note) }
@@ -70,7 +83,7 @@ class SearchRelayListState(
             .stateIn(
                 scope,
                 SharingStarted.Eagerly,
-                emptySet(),
+                DefaultSearchRelayList,
             )
 
     val flowNoDefaults =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/eoseManagers/AccountScopedSingleSubNoEoseCacheEoseManager.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/eoseManagers/AccountScopedSingleSubNoEoseCacheEoseManager.kt
@@ -18,31 +18,29 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.service.relayClient.reqCommand.nwc
+package com.vitorpamplona.amethyst.service.relayClient.eoseManagers
 
 import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.SingleSubNoEoseCacheEoseManager
+import com.vitorpamplona.amethyst.service.relayClient.AccountScopedQuery
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
-import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 
-class NWCPaymentWatcherSubAssembler(
+/**
+ * Amethyst variant of [SingleSubNoEoseCacheEoseManager] that restores single-account
+ * attribution for [AccountScopedQuery] keys.
+ *
+ * The commons base is account-agnostic (attribution defaults to null) so it can live in
+ * commonMain. Query states that carry an [Account] (home feed, channels, notifications, …)
+ * subclass this so their single-account REQs still show up attributed in "Active Relay
+ * Subscriptions".
+ *
+ * Keyed on [AccountScopedQuery] rather than a concrete query-state type: the home feed uses
+ * HomeQueryState, notifications use AccountQueryState, and checking one concrete class filed the
+ * other under "not attributed" despite both being built from a single account's data.
+ */
+abstract class AccountScopedSingleSubNoEoseCacheEoseManager<T>(
     client: INostrClient,
-    allKeys: () -> Set<NWCPaymentQueryState>,
-) : SingleSubNoEoseCacheEoseManager<NWCPaymentQueryState>(client, allKeys) {
-    override fun updateFilter(keys: List<NWCPaymentQueryState>): List<RelayBasedFilter>? {
-        if (keys.isEmpty()) return null
-
-        return keys.groupBy { it.relay }.map { relayGroup ->
-            val replyingToPayments = relayGroup.value.mapTo(mutableSetOf()) { it.replyingToHex }
-            val aboutUsers = relayGroup.value.mapTo(mutableSetOf()) { it.toUserHex }
-
-            if (replyingToPayments.isEmpty()) return null
-
-            RelayBasedFilter(
-                relay = relayGroup.key,
-                filter = filterNWCPaymentsFromRequests(replyingToPayments, aboutUsers),
-            )
-        }
-    }
-
-    override fun distinct(key: NWCPaymentQueryState) = key.replyingToHex
+    allKeys: () -> Set<T>,
+    invalidateAfterEose: Boolean = false,
+) : SingleSubNoEoseCacheEoseManager<T>(client, allKeys, invalidateAfterEose) {
+    override fun accountPubKeyOf(key: Any?): String? = (key as? AccountScopedQuery)?.account?.userProfile()?.pubkeyHex
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/account/follows/FilterFindFollowMetadataForKey.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/account/follows/FilterFindFollowMetadataForKey.kt
@@ -23,13 +23,13 @@ package com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.follow
 import com.vitorpamplona.amethyst.commons.defaults.Constants
 import com.vitorpamplona.amethyst.commons.defaults.DefaultIndexerRelayList
 import com.vitorpamplona.amethyst.commons.defaults.DefaultSearchRelayList
+import com.vitorpamplona.amethyst.commons.relayClient.user.pickRelaysToLoadUsers
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.User
 import com.vitorpamplona.amethyst.service.relays.EOSEAccountFast
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
-import com.vitorpamplona.quartz.utils.mapOfSet
 
 fun pickRelaysToLoadUsers(
     users: Set<User>,
@@ -68,6 +68,7 @@ fun pickRelaysToLoadUsers(
 
     return pickRelaysToLoadUsers(
         users,
+        LocalCache.relayHints,
         indexRelays - cannotConnectRelays,
         homeRelays - cannotConnectRelays,
         searchRelays - cannotConnectRelays,
@@ -77,121 +78,3 @@ fun pickRelaysToLoadUsers(
         hasTried,
     )
 }
-
-fun pickRelaysToLoadUsers(
-    users: Set<User>,
-    indexRelays: Set<NormalizedRelayUrl>,
-    homeRelays: Set<NormalizedRelayUrl>,
-    searchRelays: Set<NormalizedRelayUrl>,
-    connected: Set<NormalizedRelayUrl>,
-    commonRelays: Set<NormalizedRelayUrl>,
-    cannotConnectRelays: Set<NormalizedRelayUrl>,
-    hasTried: EOSEAccountFast<User>,
-): Map<NormalizedRelayUrl, Set<HexKey>> =
-    mapOfSet {
-        users.forEachIndexed { _, key ->
-            val tried = (hasTried.since(key)?.keys ?: emptySet()) + cannotConnectRelays
-
-            val outbox = key.authorRelayList()?.writeRelaysNorm()
-
-            if (!outbox.isNullOrEmpty()) {
-                // If there is a home, get from it.
-
-                // if it tried all outbox relays, stop.
-                // the UserWatch will take over from here.
-                val leftToTry = (outbox - tried)
-                leftToTry.forEach {
-                    add(it, key.pubkeyHex)
-                }
-            } else {
-                // if not, tries hints first.
-                val hints = key.allUsedRelays() + LocalCache.relayHints.hintsForKey(key.pubkeyHex)
-
-                val leftToTryOnHints = hints - tried
-
-                leftToTryOnHints.forEach {
-                    add(it, key.pubkeyHex)
-                }
-
-                // if there are only a few hints, broadens the search
-                if (leftToTryOnHints.size < 3) {
-                    // This creates a pre-deterministic order of the array such that
-                    // if this function is called twice, it returns the same arrays
-                    // which gets ignored by the relay client if we send it twice
-                    val indexRelaysLeftToTry =
-                        (indexRelays - tried).sortedBy { relay ->
-                            key.pubkeyHex.hashCode() xor relay.url.hashCode()
-                        }
-                    // This creates a pre-deterministic order of the array such that
-                    // if this function is called twice, it returns the same arrays
-                    // which gets ignored by the relay client if we send it twice
-                    val homeRelaysLeftToTry =
-                        (homeRelays - tried).sortedBy { relay ->
-                            key.pubkeyHex.hashCode() xor relay.url.hashCode()
-                        }
-
-                    // picks one at random to avoid overloading these relays
-                    if (users.size > 300) {
-                        if (indexRelaysLeftToTry.size >= 2) {
-                            add(indexRelaysLeftToTry[0], key.pubkeyHex)
-                            add(indexRelaysLeftToTry[1], key.pubkeyHex)
-                        } else if (indexRelaysLeftToTry.size == 1) {
-                            add(indexRelaysLeftToTry.first(), key.pubkeyHex)
-                        }
-
-                        homeRelaysLeftToTry.forEach {
-                            add(it, key.pubkeyHex)
-                        }
-                    } else {
-                        indexRelaysLeftToTry.forEach {
-                            add(it, key.pubkeyHex)
-                        }
-
-                        homeRelaysLeftToTry.forEach {
-                            add(it, key.pubkeyHex)
-                        }
-                    }
-
-                    if (indexRelaysLeftToTry.size < 2) {
-                        val searchRelaysLeftToTry = searchRelays - tried
-
-                        searchRelaysLeftToTry.forEach {
-                            add(it, key.pubkeyHex)
-                        }
-
-                        val connectedRelaysLeftToTry =
-                            (connected - tried)
-                                .sortedBy { relay ->
-                                    key.pubkeyHex.hashCode() xor relay.url.hashCode()
-                                }.take(100)
-
-                        // picks one at random to avoid overloading these relays
-                        if (users.size > 300) {
-                            connectedRelaysLeftToTry.take(20).forEach {
-                                add(it, key.pubkeyHex)
-                            }
-                        } else {
-                            connectedRelaysLeftToTry.forEach {
-                                add(it, key.pubkeyHex)
-                            }
-                        }
-
-                        if (searchRelaysLeftToTry.size < 2) {
-                            // This creates a pre-deterministic order of the array such that
-                            // if this function is called twice, it returns the same arrays
-                            // which gets ignored by the relay client if we send it twice
-                            val allRelaysLeftToTry =
-                                (commonRelays - tried)
-                                    .sortedBy { relay ->
-                                        key.pubkeyHex.hashCode() xor relay.url.hashCode()
-                                    }.take(100)
-
-                            allRelaysLeftToTry.forEach {
-                                add(it, key.pubkeyHex)
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/channel/nip28PublicChats/ChannelLoaderSubAssembler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/channel/nip28PublicChats/ChannelLoaderSubAssembler.kt
@@ -20,7 +20,7 @@
  */
 package com.vitorpamplona.amethyst.service.relayClient.reqCommand.channel.nip28PublicChats
 
-import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.SingleSubNoEoseCacheEoseManager
+import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.AccountScopedSingleSubNoEoseCacheEoseManager
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.channel.ChannelFinderQueryState
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
@@ -37,7 +37,7 @@ import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 class ChannelLoaderSubAssembler(
     client: INostrClient,
     allKeys: () -> Set<ChannelFinderQueryState>,
-) : SingleSubNoEoseCacheEoseManager<ChannelFinderQueryState>(client, allKeys, invalidateAfterEose = true) {
+) : AccountScopedSingleSubNoEoseCacheEoseManager<ChannelFinderQueryState>(client, allKeys, invalidateAfterEose = true) {
     override fun updateFilter(keys: List<ChannelFinderQueryState>): List<RelayBasedFilter> = filterMissingChannelsById(keys)
 
     override fun distinct(key: ChannelFinderQueryState) = key.channel

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/EventFinderShims.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/EventFinderShims.kt
@@ -21,30 +21,30 @@
 package com.vitorpamplona.amethyst.service.relayClient.reqCommand.event
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.LifecycleAwareKeyDataSourceSubscription
-import com.vitorpamplona.amethyst.model.Account
+import com.vitorpamplona.amethyst.commons.relayClient.event.EventFinderFilterAssemblerSubscription
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 
+/**
+ * Back-compat aliases: the per-note event finder moved to commons
+ * (`com.vitorpamplona.amethyst.commons.relayClient.event`). Existing Android call
+ * sites that reference these by their old names resolve here.
+ */
+typealias EventFinderFilterAssembler = com.vitorpamplona.amethyst.commons.relayClient.event.EventFinderFilterAssembler
+
+typealias EventFinderQueryState = com.vitorpamplona.amethyst.commons.relayClient.event.EventFinderQueryState
+
+/**
+ * Android convenience overload: pulls the account + shared event-finder data source
+ * out of [accountViewModel] and delegates to the commons subscription. `Account`
+ * is-a `UserFinderAccount`, so no adaptation is needed.
+ */
 @Composable
 fun EventFinderFilterAssemblerSubscription(
     note: Note,
     accountViewModel: AccountViewModel,
-) = EventFinderFilterAssemblerSubscription(note, accountViewModel.account, accountViewModel.dataSources().eventFinder)
-
-@Composable
-fun EventFinderFilterAssemblerSubscription(
-    note: Note,
-    account: Account,
-    dataSource: EventFinderFilterAssembler,
-) {
-    // different screens get different states
-    // even if they are tracking the same tag.
-    val state =
-        remember(note, account) {
-            EventFinderQueryState(note, account)
-        }
-
-    LifecycleAwareKeyDataSourceSubscription(state, dataSource)
-}
+) = EventFinderFilterAssemblerSubscription(
+    note,
+    accountViewModel.account,
+    accountViewModel.dataSources().eventFinder,
+)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/user/UserFinderShims.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/user/UserFinderShims.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.relayClient.reqCommand.user
+
+/**
+ * Back-compat aliases: the per-user metadata finder moved to commons
+ * (`com.vitorpamplona.amethyst.commons.relayClient.user`). Existing Android call
+ * sites that reference these by their old names resolve here.
+ */
+typealias UserFinderFilterAssembler = com.vitorpamplona.amethyst.commons.relayClient.user.UserFinderFilterAssembler
+
+typealias UserFinderQueryState = com.vitorpamplona.amethyst.commons.relayClient.user.UserFinderQueryState

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/searchCommand/subassemblies/FilterByAddress.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/searchCommand/subassemblies/FilterByAddress.kt
@@ -20,9 +20,9 @@
  */
 package com.vitorpamplona.amethyst.service.relayClient.searchCommand.subassemblies
 
+import com.vitorpamplona.amethyst.commons.relayClient.event.loaders.filterMissingAddressables
+import com.vitorpamplona.amethyst.commons.relayClient.event.loaders.potentialRelaysToFindAddress
 import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.filterMissingAddressables
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.potentialRelaysToFindAddress
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip19Bech32.entities.NAddress
@@ -37,7 +37,7 @@ fun filterByAddress(
     val list =
         mapOfSet {
             if (note.event == null) {
-                potentialRelaysToFindAddress(note).ifEmpty { default }.forEach { relayUrl ->
+                potentialRelaysToFindAddress(LocalCache, note).ifEmpty { default }.forEach { relayUrl ->
                     add(relayUrl, note.address)
                 }
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/searchCommand/subassemblies/FilterByEvent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/searchCommand/subassemblies/FilterByEvent.kt
@@ -45,9 +45,9 @@ fun filterByEvent(
 
             // loads threading that is event-based
             note.replyTo?.forEach { parentNote ->
-                if (parentNote !is AddressableNote && note.event == null) {
-                    potentialRelaysToFindEvent(LocalCache, note).ifEmpty { default }.forEach { relayUrl ->
-                        add(relayUrl, note.idHex)
+                if (parentNote !is AddressableNote && parentNote.event == null) {
+                    potentialRelaysToFindEvent(LocalCache, parentNote).ifEmpty { default }.forEach { relayUrl ->
+                        add(relayUrl, parentNote.idHex)
                     }
                 }
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/searchCommand/subassemblies/FilterByEvent.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/searchCommand/subassemblies/FilterByEvent.kt
@@ -20,10 +20,10 @@
  */
 package com.vitorpamplona.amethyst.service.relayClient.searchCommand.subassemblies
 
+import com.vitorpamplona.amethyst.commons.relayClient.event.loaders.filterMissingEvents
+import com.vitorpamplona.amethyst.commons.relayClient.event.loaders.potentialRelaysToFindEvent
 import com.vitorpamplona.amethyst.model.AddressableNote
 import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.filterMissingEvents
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.potentialRelaysToFindEvent
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
@@ -38,7 +38,7 @@ fun filterByEvent(
     val list =
         mapOfSet {
             if (note !is AddressableNote && note.event == null) {
-                potentialRelaysToFindEvent(note).ifEmpty { default }.forEach { relayUrl ->
+                potentialRelaysToFindEvent(LocalCache, note).ifEmpty { default }.forEach { relayUrl ->
                     add(relayUrl, note.idHex)
                 }
             }
@@ -46,7 +46,7 @@ fun filterByEvent(
             // loads threading that is event-based
             note.replyTo?.forEach { parentNote ->
                 if (parentNote !is AddressableNote && note.event == null) {
-                    potentialRelaysToFindEvent(note).ifEmpty { default }.forEach { relayUrl ->
+                    potentialRelaysToFindEvent(LocalCache, note).ifEmpty { default }.forEach { relayUrl ->
                         add(relayUrl, note.idHex)
                     }
                 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relays/EOSE.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relays/EOSE.kt
@@ -28,6 +28,7 @@ import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 typealias EOSERelayList = com.vitorpamplona.amethyst.commons.relays.EOSERelayList
 typealias SincePerRelayMap = com.vitorpamplona.amethyst.commons.relays.SincePerRelayMap
 typealias MutableTime = com.vitorpamplona.amethyst.commons.relays.MutableTime
+typealias EOSEAccountFast<T> = com.vitorpamplona.amethyst.commons.relays.EOSEAccountFast<T>
 
 open class EOSEByKey<U : Any>(
     cacheSize: Int = 200,
@@ -112,61 +113,4 @@ open class EOSEAccountKey<U : Any>(
         relayUrl: NormalizedRelayUrl,
         time: Long,
     ) = addOrUpdate(user, listCode, relayUrl, time)
-}
-
-class EOSEAccountFast<T : Any>(
-    cacheSize: Int = 20,
-) {
-    private val users: LruCache<T, EOSERelayList> = LruCache(cacheSize)
-    private val lock = Any()
-
-    fun addOrUpdate(
-        user: T,
-        relayUrl: NormalizedRelayUrl,
-        time: Long,
-    ) {
-        synchronized(lock) {
-            val relayList = users[user]
-            if (relayList == null) {
-                val newList = EOSERelayList()
-                users.put(user, newList)
-
-                newList.addOrUpdate(relayUrl, time)
-            } else {
-                relayList.addOrUpdate(relayUrl, time)
-            }
-        }
-    }
-
-    fun removeEveryoneBut(list: Set<T>) {
-        synchronized(lock) {
-            users.snapshot().forEach {
-                if (it.key !in list) {
-                    users.remove(it.key)
-                }
-            }
-        }
-    }
-
-    fun removeDataFor(user: T) {
-        synchronized(lock) {
-            users.remove(user)
-        }
-    }
-
-    fun since(key: T): SincePerRelayMap? =
-        synchronized(lock) {
-            users[key]?.relayList?.toMutableMap()
-        }
-
-    fun sinceRelaySet(key: T): Set<NormalizedRelayUrl>? =
-        synchronized(lock) {
-            users[key]?.relayList?.keys?.toSet()
-        }
-
-    fun newEose(
-        user: T,
-        relayUrl: NormalizedRelayUrl,
-        time: Long,
-    ) = addOrUpdate(user, relayUrl, time)
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -50,6 +50,9 @@ import androidx.navigation.compose.composable
 import com.vitorpamplona.amethyst.Amethyst
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.nipACWebRtcCalls.CallState
+import com.vitorpamplona.amethyst.commons.relayClient.event.LocalEventFinder
+import com.vitorpamplona.amethyst.commons.relayClient.user.LocalUserFinder
+import com.vitorpamplona.amethyst.commons.relayClient.user.LocalUserFinderAccount
 import com.vitorpamplona.amethyst.service.crashreports.DisplayCrashMessages
 import com.vitorpamplona.amethyst.service.relayClient.notifyCommand.compose.DisplayNotifyMessages
 import com.vitorpamplona.amethyst.service.resourceusage.DisplayResourceUsageAlert
@@ -341,6 +344,15 @@ fun AppNavigation(
     CompositionLocalProvider(
         LocalScreenLayout provides screenLayout,
         LocalTabReselectCoordinator provides tabReselectCoordinator,
+        // Provide the shared finder CompositionLocals so any commons composable that
+        // uses the no-arg observeUser*/EventFinderFilterAssemblerSubscription(note)
+        // overloads works when rendered on Android (they error() if unprovided). Android's
+        // own UI uses the AccountViewModel overloads and doesn't strictly need these, but
+        // providing them removes the runtime trap for shared composables reaching the
+        // logged-in tree. (The :napplet process never renders these composables.)
+        LocalUserFinder provides accountViewModel.dataSources().userFinder,
+        LocalUserFinderAccount provides accountViewModel.account,
+        LocalEventFinder provides accountViewModel.dataSources().eventFinder,
     ) {
         AccountSwitcherAndLeftDrawerLayout(accountViewModel, accountSessionManager, nav) {
             Box(Modifier.fillMaxSize()) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/datasource/FilterHashtagLabels.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/hashtag/datasource/FilterHashtagLabels.kt
@@ -20,12 +20,12 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.hashtag.datasource
 
+import com.vitorpamplona.amethyst.commons.relayClient.event.loaders.filterMissingEvents
+import com.vitorpamplona.amethyst.commons.relayClient.event.loaders.potentialRelaysToFindEvent
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.ExplainedFilter
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.SubPurpose
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.filterMissingEvents
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.potentialRelaysToFindEvent
 import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
@@ -93,7 +93,7 @@ fun filterHashtagLabels(
                     val target = LocalCache.getNoteIfExists(targetId)
                     if (target?.event == null) {
                         val targetNote = LocalCache.getOrCreateNote(targetId)
-                        potentialRelaysToFindEvent(targetNote).ifEmpty { relays }.forEach { relayUrl ->
+                        potentialRelaysToFindEvent(LocalCache, targetNote).ifEmpty { relays }.forEach { relayUrl ->
                             add(relayUrl, targetId)
                         }
                     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/datasources/subassembies/FilterMissingEventsForThread.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/datasources/subassembies/FilterMissingEventsForThread.kt
@@ -21,11 +21,12 @@
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.threadview.datasources.subassembies
 
 import com.vitorpamplona.amethyst.commons.model.ThreadAssembler
+import com.vitorpamplona.amethyst.commons.relayClient.event.loaders.filterMissingAddressables
+import com.vitorpamplona.amethyst.commons.relayClient.event.loaders.filterMissingEvents
+import com.vitorpamplona.amethyst.commons.relayClient.event.loaders.potentialRelaysToFindAddress
+import com.vitorpamplona.amethyst.commons.relayClient.event.loaders.potentialRelaysToFindEvent
 import com.vitorpamplona.amethyst.model.AddressableNote
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.filterMissingAddressables
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.filterMissingEvents
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.potentialRelaysToFindAddress
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.potentialRelaysToFindEvent
+import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.utils.mapOfSet
@@ -37,14 +38,14 @@ fun filterMissingEventsForThread(
     val missingEvents =
         mapOfSet {
             if (threadInfo.root.event == null && threadInfo.root !is AddressableNote) {
-                potentialRelaysToFindEvent(threadInfo.root).ifEmpty { defaultRelays }.forEach { relayUrl ->
+                potentialRelaysToFindEvent(LocalCache, threadInfo.root).ifEmpty { defaultRelays }.forEach { relayUrl ->
                     add(relayUrl, threadInfo.root.idHex)
                 }
             }
 
             threadInfo.allNotes.forEach {
                 if (it !is AddressableNote && it.event == null) {
-                    potentialRelaysToFindEvent(it).ifEmpty { defaultRelays }.forEach { relayUrl ->
+                    potentialRelaysToFindEvent(LocalCache, it).ifEmpty { defaultRelays }.forEach { relayUrl ->
                         add(relayUrl, it.idHex)
                     }
                 }
@@ -59,14 +60,14 @@ fun filterMissingEventsForThread(
                 // note's aTag idHex into the hex-keyed event-hint index, which throws
                 // on the non-hex string and kills the whole filter build — leaving a
                 // thread opened on an uncached naddr permanently unfetched.
-                potentialRelaysToFindAddress(rootNote).ifEmpty { defaultRelays }.forEach { relayUrl ->
+                potentialRelaysToFindAddress(LocalCache, rootNote).ifEmpty { defaultRelays }.forEach { relayUrl ->
                     add(relayUrl, rootNote.address)
                 }
             }
 
             threadInfo.allNotes.forEach {
                 if (it is AddressableNote && it.event == null) {
-                    potentialRelaysToFindAddress(it).ifEmpty { defaultRelays }.forEach { relayUrl ->
+                    potentialRelaysToFindAddress(LocalCache, it).ifEmpty { defaultRelays }.forEach { relayUrl ->
                         add(relayUrl, it.address)
                     }
                 }

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/model/nip51Lists/PrecachedRelayListSeedTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/model/nip51Lists/PrecachedRelayListSeedTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.model.nip51Lists
+
+import com.vitorpamplona.amethyst.model.nip51Lists.searchRelays.SearchRelayListDecryptionCache
+import com.vitorpamplona.quartz.nip01Core.crypto.KeyPair
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
+import com.vitorpamplona.quartz.nip50Search.SearchRelayListEvent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the non-suspending seed that [SearchRelayListState.flow] is initialized with.
+ *
+ * The seed exists so `.value` is never empty before the first async emission lands (see the
+ * KDoc on `flow`). For it to be an improvement over just using the curated defaults, reading an
+ * account's *public* relays must work with no signer involvement at all — otherwise a NIP-46
+ * account would still block. These tests pin that property.
+ */
+class PrecachedRelayListSeedTest {
+    private val relayA = RelayUrlNormalizer.normalize("wss://relay.example.com")
+    private val relayB = RelayUrlNormalizer.normalize("wss://other.example.com")
+
+    /**
+     * The load-bearing claim: public relay tags are readable synchronously. `cachedRelays` is
+     * non-suspending, so if this returned empty the seed would silently degrade to the defaults
+     * for every account.
+     */
+    @Test
+    fun cachedRelays_readsPublicRelaysWithoutDecrypting() =
+        runTest {
+            val signer = NostrSignerInternal(KeyPair())
+            val event = SearchRelayListEvent.create(relays = listOf(relayA, relayB), signer = signer)
+
+            val relays = SearchRelayListDecryptionCache(signer).cachedRelays(event)
+
+            assertEquals(setOf(relayA, relayB), relays)
+        }
+
+    /**
+     * A kind:10007 with no relays must read as empty here, so the seed's `?.ifEmpty { null }`
+     * arm hands over to the curated defaults rather than seeding an empty set.
+     */
+    @Test
+    fun cachedRelays_emptyListReadsEmptySoTheSeedCanFallBack() =
+        runTest {
+            val signer = NostrSignerInternal(KeyPair())
+            val event = SearchRelayListEvent.create(relays = emptyList(), signer = signer)
+
+            val relays = SearchRelayListDecryptionCache(signer).cachedRelays(event)
+
+            assertTrue(relays.isEmpty())
+        }
+
+    /**
+     * Reading another account's list must not blow up or leak a decrypt attempt — the private
+     * cache refuses to build for a foreign pubkey, so only the public tags come back.
+     */
+    @Test
+    fun cachedRelays_foreignAuthorStillYieldsPublicRelays() =
+        runTest {
+            val author = NostrSignerInternal(KeyPair())
+            val reader = NostrSignerInternal(KeyPair())
+            val event = SearchRelayListEvent.create(relays = listOf(relayA), signer = author)
+
+            val relays = SearchRelayListDecryptionCache(reader).cachedRelays(event)
+
+            assertEquals(setOf(relayA), relays)
+        }
+}

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/loaders/AddressableAuthorRelayLoaderSubAssemblerTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/service/relayClient/reqCommand/event/loaders/AddressableAuthorRelayLoaderSubAssemblerTest.kt
@@ -20,11 +20,12 @@
  */
 package com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders
 
+import com.vitorpamplona.amethyst.commons.relayClient.event.loaders.AddressableAuthorRelayLoaderSubAssembler
+import com.vitorpamplona.amethyst.commons.relayClient.user.UserFinderFilterAssembler
+import com.vitorpamplona.amethyst.commons.relayClient.user.UserFinderQueryState
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.EventFinderQueryState
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinderFilterAssembler
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinderQueryState
 import com.vitorpamplona.quartz.nip01Core.core.Address
 import io.mockk.every
 import io.mockk.mockk

--- a/commons/ARCHITECTURE.md
+++ b/commons/ARCHITECTURE.md
@@ -101,7 +101,7 @@ they are shared across the GUI apps. Treat as GUI-shared, not strictly headless.
 ### Relay client
 | Package        | UI? | Purpose |
 |----------------|-----|---------|
-| `relayClient`  | no  | Compose-scoped subscription managers, filter assemblers, EOSE managers, preloaders. (Despite a `composeSubscriptionManagers` subpackage name, this is subscription-lifecycle logic, not UI.) |
+| `relayClient`  | no  | Compose-scoped subscription managers, filter assemblers, EOSE managers, preloaders. (Despite a `composeSubscriptionManagers` subpackage name, this is subscription-lifecycle logic, not UI.) The canonical **per-visible loading** entry points live here: `relayClient/user/` (`observeUser*` — kind-0 metadata) and `relayClient/event/` (`EventFinderFilterAssemblerSubscription`/`observeNote*` — reactions/zaps/reposts). See the `relay-client` skill. |
 | `relays`       | no  | Low-level EOSE/relay-timing bookkeeping (`EOSECache`, `EOSERelayList`). |
 
 ### Platform abstractions (`expect`/`actual`)

--- a/commons/build.gradle.kts
+++ b/commons/build.gradle.kts
@@ -297,6 +297,10 @@ val verifyKmpPurity by tasks.registering {
                 "Thread.sleep" to "use kotlinx.coroutines.delay or platform-specific actual",
                 "java.util.UUID" to "use kotlin.uuid.Uuid",
                 "kotlin.jvm.Synchronized" to "use KmpLock.withLock {}",
+                // The bare call, not just the annotation: `synchronized(lock) {}` resolves
+                // from kotlin-stdlib-jvm with no import, so it compiles on Android/JVM and
+                // only fails at the iOS compile step. Catch it here instead.
+                "synchronized(" to "`synchronized` is JVM-only — use KmpLock.withLock {}",
                 "kotlin.jvm.Volatile" to "use kotlin.concurrent.Volatile",
             )
         val offenders =

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/cache/ICacheProvider.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/cache/ICacheProvider.kt
@@ -142,5 +142,15 @@ interface ICacheProvider {
      */
     fun getOrCreateUser(pubkey: HexKey): User?
 
+    /**
+     * Gets or creates a User by public key hex, swallowing any failure.
+     * Used by the event-finder relay-hint scan, which touches many potentially
+     * malformed pubkeys and must never throw mid-scan.
+     *
+     * @param key The user's public key in hex format
+     * @return The User (existing or newly created), or null on failure
+     */
+    fun checkGetOrCreateUser(key: HexKey): User? = runCatching { getOrCreateUser(key) }.getOrNull()
+
     fun justConsumeMyOwnEvent(event: Event): Boolean
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/cache/ICacheProvider.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/cache/ICacheProvider.kt
@@ -27,6 +27,7 @@ import com.vitorpamplona.amethyst.commons.model.User
 import com.vitorpamplona.quartz.nip01Core.core.Address
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.hints.HintIndexer
 
 /**
  * Cache provider interface for accessing cached Notes, Users, and Channels.
@@ -41,6 +42,13 @@ import com.vitorpamplona.quartz.nip01Core.core.HexKey
  * - Platform-agnostic model layer
  */
 interface ICacheProvider {
+    /**
+     * NIP-hints index (event/address/pubkey → relay) accumulated from consumed
+     * events. Used by the shared user/event finder assemblers to discover which
+     * relays are likely to hold a given user's metadata or a missing event.
+     */
+    val relayHints: HintIndexer
+
     /**
      * Gets a channel by Note reference.
      * Used for resolving relay hints for channel messages.

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/eoseManagers/SingleSubNoEoseCacheEoseManager.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/eoseManagers/SingleSubNoEoseCacheEoseManager.kt
@@ -18,11 +18,9 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.service.relayClient.eoseManagers
+package com.vitorpamplona.amethyst.commons.relayClient.eoseManagers
 
-import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.BaseEoseManager
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.attributedTo
-import com.vitorpamplona.amethyst.service.relayClient.AccountScopedQuery
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
@@ -85,9 +83,10 @@ abstract class SingleSubNoEoseCacheEoseManager<T>(
     /**
      * The account behind [key], when the key is account-scoped. Null for keys about other users.
      *
-     * Keyed on [AccountScopedQuery] rather than a concrete query-state type: the home feed uses
-     * HomeQueryState, notifications use AccountQueryState, and checking one concrete class filed the
-     * other under "not attributed" despite both being built from a single account's data.
+     * Account-agnostic in commons: front ends that want single-account attribution override this
+     * (see the amethyst `AccountScopedSingleSubNoEoseCacheEoseManager`, which reads
+     * `(key as? AccountScopedQuery)?.account?.userProfile()?.pubkeyHex`). The default returns null,
+     * so pooled / cross-account subscriptions are filed as "not attributed".
      */
-    private fun accountPubKeyOf(key: Any?): String? = (key as? AccountScopedQuery)?.account?.userProfile()?.pubkeyHex
+    open fun accountPubKeyOf(key: Any?): String? = null
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/EventFinderFilterAssembler.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/EventFinderFilterAssembler.kt
@@ -18,36 +18,35 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.service.relayClient.reqCommand.event
+package com.vitorpamplona.amethyst.commons.relayClient.event
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.commons.relayClient.composeSubscriptionManagers.ComposeSubscriptionManager
-import com.vitorpamplona.amethyst.model.Account
-import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.service.relayClient.AccountScopedQuery
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.AddressableAuthorRelayLoaderSubAssembler
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders.NoteEventLoaderSubAssembler
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.watchers.EventWatcherSubAssembler
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinderFilterAssembler
+import com.vitorpamplona.amethyst.commons.relayClient.event.loaders.AddressableAuthorRelayLoaderSubAssembler
+import com.vitorpamplona.amethyst.commons.relayClient.event.loaders.NoteEventLoaderSubAssembler
+import com.vitorpamplona.amethyst.commons.relayClient.event.watchers.EventWatcherSubAssembler
+import com.vitorpamplona.amethyst.commons.relayClient.user.UserFinderAccount
+import com.vitorpamplona.amethyst.commons.relayClient.user.UserFinderFilterAssembler
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 
 // This allows multiple screen to be listening to tags, even the same tag
 @Stable
 class EventFinderQueryState(
     val note: Note,
-    override val account: Account,
-) : AccountScopedQuery
+    val account: UserFinderAccount,
+)
 
 @Stable
 class EventFinderFilterAssembler(
     client: INostrClient,
-    cache: LocalCache,
+    cache: ICacheProvider,
     userFinder: UserFinderFilterAssembler,
 ) : ComposeSubscriptionManager<EventFinderQueryState>() {
     val group =
         listOf(
-            NoteEventLoaderSubAssembler(client, ::allKeys),
+            NoteEventLoaderSubAssembler(client, cache, ::allKeys),
             EventWatcherSubAssembler(client, ::allKeys),
             AddressableAuthorRelayLoaderSubAssembler(cache, ::allKeys, userFinder),
         )

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/EventFinderFilterAssemblerSubscription.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/EventFinderFilterAssemblerSubscription.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.relayClient.event
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.LifecycleAwareKeyDataSourceSubscription
+import com.vitorpamplona.amethyst.commons.relayClient.user.LocalUserFinderAccount
+import com.vitorpamplona.amethyst.commons.relayClient.user.UserFinderAccount
+
+/**
+ * The shared per-note event data source (reactions / zaps / reposts / replies /
+ * OTS / references) for the current front end. Provided once near the composition
+ * root (Android via AppModules, Desktop via its subscriptions coordinator).
+ * Reading it without a provider is a programming error — the per-note observers
+ * must never be reachable from a composition that has no relay client (e.g. the
+ * Android `:napplet` sandbox process).
+ *
+ * The *account* half is reused from the user-finder: [LocalUserFinderAccount]
+ * already carries the narrow relay-hint seam the event loaders need.
+ */
+val LocalEventFinder =
+    staticCompositionLocalOf<EventFinderFilterAssembler> {
+        error("LocalEventFinder not provided")
+    }
+
+/**
+ * Subscribes to relay updates for [note]'s interactions (reactions, zaps,
+ * reposts, replies, …) for as long as this composable is in composition,
+ * coalesced with every other on-screen note into batched REQs by [dataSource].
+ *
+ * Like the user-finder, because a `LazyColumn` composes only the visible window
+ * (+ a small prefetch buffer) this means "load interactions only for notes
+ * currently on screen" — [LifecycleAwareKeyDataSourceSubscription] unsubscribes
+ * ~30s after the row leaves composition or the app is backgrounded.
+ */
+@Composable
+fun EventFinderFilterAssemblerSubscription(
+    note: Note,
+    account: UserFinderAccount,
+    dataSource: EventFinderFilterAssembler,
+) {
+    // Different screens get their own query-state instance even when tracking
+    // the same note; the assembler dedups to one REQ per note.
+    val state =
+        remember(note, account) {
+            EventFinderQueryState(note, account)
+        }
+
+    LifecycleAwareKeyDataSourceSubscription(state, dataSource)
+}
+
+/**
+ * Convenience overload that reads the front end's [LocalEventFinder] and
+ * [LocalUserFinderAccount] from the composition.
+ */
+@Composable
+fun EventFinderFilterAssemblerSubscription(note: Note) {
+    EventFinderFilterAssemblerSubscription(
+        note = note,
+        account = LocalUserFinderAccount.current,
+        dataSource = LocalEventFinder.current,
+    )
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/loaders/AddressableAuthorRelayLoaderSubAssembler.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/loaders/AddressableAuthorRelayLoaderSubAssembler.kt
@@ -18,15 +18,15 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders
+package com.vitorpamplona.amethyst.commons.relayClient.event.loaders
 
+import com.vitorpamplona.amethyst.commons.model.AddressableNote
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.IEoseManager
+import com.vitorpamplona.amethyst.commons.relayClient.event.EventFinderQueryState
+import com.vitorpamplona.amethyst.commons.relayClient.user.UserFinderFilterAssembler
+import com.vitorpamplona.amethyst.commons.relayClient.user.UserFinderQueryState
 import com.vitorpamplona.amethyst.commons.service.BundledUpdate
-import com.vitorpamplona.amethyst.model.AddressableNote
-import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.EventFinderQueryState
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinderFilterAssembler
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinderQueryState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 
@@ -41,7 +41,7 @@ import kotlinx.coroutines.IO
  * relay list arrives, [EventFinderFilterAssembler] is invalidated and can query the correct relay.
  */
 class AddressableAuthorRelayLoaderSubAssembler(
-    val cache: LocalCache,
+    val cache: ICacheProvider,
     val allKeys: () -> Set<EventFinderQueryState>,
     val userFinder: UserFinderFilterAssembler,
 ) : IEoseManager {
@@ -69,7 +69,7 @@ class AddressableAuthorRelayLoaderSubAssembler(
             val note = key.note
             if (note is AddressableNote && note.event == null) {
                 val author = cache.getOrCreateUser(note.address.pubKeyHex)
-                if (author.authorRelayList() == null) {
+                if (author != null && author.authorRelayList() == null) {
                     needed.add(UserFinderQueryState(author, key.account))
                 }
             }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/loaders/AddressableAuthorRelayLoaderSubAssembler.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/loaders/AddressableAuthorRelayLoaderSubAssembler.kt
@@ -27,6 +27,8 @@ import com.vitorpamplona.amethyst.commons.relayClient.event.EventFinderQueryStat
 import com.vitorpamplona.amethyst.commons.relayClient.user.UserFinderFilterAssembler
 import com.vitorpamplona.amethyst.commons.relayClient.user.UserFinderQueryState
 import com.vitorpamplona.amethyst.commons.service.BundledUpdate
+import com.vitorpamplona.amethyst.commons.util.KmpLock
+import com.vitorpamplona.amethyst.commons.util.withLock
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 
@@ -46,8 +48,9 @@ class AddressableAuthorRelayLoaderSubAssembler(
     val userFinder: UserFinderFilterAssembler,
 ) : IEoseManager {
     // Private monitor: @Synchronized locks on `this`, which leaves the instance's monitor
-    // reachable to anything holding a reference to this assembler.
-    private val lock = Any()
+    // reachable to anything holding a reference to this assembler. KmpLock (not `synchronized`)
+    // because this file lives in commonMain and must compile for the iOS targets too.
+    private val lock = KmpLock()
 
     // Only ever touched while holding [lock]. See commit() and destroy().
     private var activeSubscriptions: Set<UserFinderQueryState> = emptySet()
@@ -92,7 +95,7 @@ class AddressableAuthorRelayLoaderSubAssembler(
      * never call back into this class. Revisit if that changes.
      */
     private fun commit(needed: Set<UserFinderQueryState>) {
-        synchronized(lock) {
+        lock.withLock {
             if (destroyed) return
 
             userFinder.subscribe((needed - activeSubscriptions).toList())
@@ -103,7 +106,7 @@ class AddressableAuthorRelayLoaderSubAssembler(
     }
 
     override fun destroy() {
-        synchronized(lock) {
+        lock.withLock {
             destroyed = true
             bundler.cancel()
             userFinder.unsubscribe(activeSubscriptions.toList())

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/loaders/FilterMissingAddressables.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/loaders/FilterMissingAddressables.kt
@@ -18,33 +18,36 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders
+package com.vitorpamplona.amethyst.commons.relayClient.event.loaders
 
+import com.vitorpamplona.amethyst.commons.model.AddressableNote
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+import com.vitorpamplona.amethyst.commons.relayClient.event.EventFinderQueryState
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.ExplainedFilter
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.SubPurpose
-import com.vitorpamplona.amethyst.model.AddressableNote
-import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.EventFinderQueryState
 import com.vitorpamplona.quartz.nip01Core.core.Address
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.utils.mapOfSet
 
-fun potentialRelaysToFindAddress(note: AddressableNote): Set<NormalizedRelayUrl> {
+fun potentialRelaysToFindAddress(
+    cache: ICacheProvider,
+    note: AddressableNote,
+): Set<NormalizedRelayUrl> {
     val set = mutableSetOf<NormalizedRelayUrl>()
 
-    LocalCache.getOrCreateUser(note.address.pubKeyHex).outboxRelays()?.let {
+    cache.getOrCreateUser(note.address.pubKeyHex)?.outboxRelays()?.let {
         set.addAll(it)
     }
 
-    set.addAll(LocalCache.relayHints.hintsForAddress(note.idHex))
+    set.addAll(cache.relayHints.hintsForAddress(note.idHex))
 
-    LocalCache.getAnyChannel(note)?.relays()?.let { set.addAll(it) }
+    cache.getAnyChannel(note)?.relays()?.let { set.addAll(it) }
 
     note.replyTo?.forEach { parentNote ->
         set.addAll(parentNote.relays)
 
-        LocalCache.getAnyChannel(parentNote)?.relays()?.let { set.addAll(it) }
+        cache.getAnyChannel(parentNote)?.relays()?.let { set.addAll(it) }
 
         parentNote.author?.inboxRelays()?.let { set.addAll(it) }
     }
@@ -52,7 +55,7 @@ fun potentialRelaysToFindAddress(note: AddressableNote): Set<NormalizedRelayUrl>
     note.replies.forEach { childNote ->
         set.addAll(childNote.relays)
 
-        LocalCache.getAnyChannel(childNote)?.relays()?.let { set.addAll(it) }
+        cache.getAnyChannel(childNote)?.relays()?.let { set.addAll(it) }
 
         childNote.author?.outboxRelays()?.let { set.addAll(it) }
     }
@@ -72,13 +75,16 @@ fun potentialRelaysToFindAddress(note: AddressableNote): Set<NormalizedRelayUrl>
     return set
 }
 
-fun filterMissingAddressables(keys: List<EventFinderQueryState>): List<RelayBasedFilter> {
+fun filterMissingAddressables(
+    cache: ICacheProvider,
+    keys: List<EventFinderQueryState>,
+): List<RelayBasedFilter> {
     val addressesPerRelay =
         mapOfSet {
             keys.forEach { key ->
-                val default = key.account.followPlusAllMineWithSearch.flow.value
+                val default = key.account.followPlusAllMineWithSearchRelays()
                 if (key.note is AddressableNote && key.note.event == null) {
-                    potentialRelaysToFindAddress(key.note).ifEmpty { default }.forEach { relayUrl ->
+                    potentialRelaysToFindAddress(cache, key.note).ifEmpty { default }.forEach { relayUrl ->
                         add(relayUrl, key.note.address)
                     }
                 }
@@ -86,7 +92,7 @@ fun filterMissingAddressables(keys: List<EventFinderQueryState>): List<RelayBase
                 // loads threading that is event-based
                 key.note.replyTo?.forEach { note ->
                     if (note is AddressableNote && note.event == null) {
-                        potentialRelaysToFindAddress(note).ifEmpty { default }.forEach { relayUrl ->
+                        potentialRelaysToFindAddress(cache, note).ifEmpty { default }.forEach { relayUrl ->
                             add(relayUrl, note.address)
                         }
                     }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/loaders/FilterMissingEvents.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/loaders/FilterMissingEvents.kt
@@ -18,33 +18,36 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders
+package com.vitorpamplona.amethyst.commons.relayClient.event.loaders
 
+import com.vitorpamplona.amethyst.commons.model.AddressableNote
 import com.vitorpamplona.amethyst.commons.model.Channel
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+import com.vitorpamplona.amethyst.commons.relayClient.event.EventFinderQueryState
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.ExplainedFilter
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.SubPurpose
-import com.vitorpamplona.amethyst.model.AddressableNote
-import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.EventFinderQueryState
 import com.vitorpamplona.quartz.nip01Core.hints.PubKeyHintProvider
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.utils.mapOfSet
 
-fun potentialRelaysToFindEvent(note: Note): Set<NormalizedRelayUrl> {
+fun potentialRelaysToFindEvent(
+    cache: ICacheProvider,
+    note: Note,
+): Set<NormalizedRelayUrl> {
     val set = mutableSetOf<NormalizedRelayUrl>()
 
-    set.addAll(LocalCache.relayHints.hintsForEvent(note.idHex))
+    set.addAll(cache.relayHints.hintsForEvent(note.idHex))
 
     note.author?.outboxRelays()?.let { set.addAll(it) }
 
-    LocalCache.getAnyChannel(note)?.relays()?.let { set.addAll(it) }
+    cache.getAnyChannel(note)?.relays()?.let { set.addAll(it) }
 
     note.replyTo?.forEach { parentNote ->
         set.addAll(parentNote.relays)
 
-        LocalCache.getAnyChannel(parentNote)?.relays()?.let { set.addAll(it) }
+        cache.getAnyChannel(parentNote)?.relays()?.let { set.addAll(it) }
 
         parentNote.author?.inboxRelays()?.let { set.addAll(it) }
     }
@@ -52,7 +55,7 @@ fun potentialRelaysToFindEvent(note: Note): Set<NormalizedRelayUrl> {
     note.replies.forEach { childNote ->
         set.addAll(childNote.relays)
 
-        LocalCache.getAnyChannel(childNote)?.relays()?.let { set.addAll(it) }
+        cache.getAnyChannel(childNote)?.relays()?.let { set.addAll(it) }
 
         childNote.author?.outboxRelays()?.let { set.addAll(it) }
     }
@@ -81,7 +84,7 @@ fun potentialRelaysToFindEvent(note: Note): Set<NormalizedRelayUrl> {
                 val noteEvent = parent.event
                 if (noteEvent is PubKeyHintProvider) {
                     noteEvent.linkedPubKeys().forEach { potentialAuthor ->
-                        LocalCache.checkGetOrCreateUser(potentialAuthor)?.let { potentialAuthor ->
+                        cache.checkGetOrCreateUser(potentialAuthor)?.let { potentialAuthor ->
                             potentialAuthor.outboxRelays()?.let { set.addAll(it) }
                             potentialAuthor.inboxRelays()?.let { set.addAll(it) }
                         }
@@ -98,18 +101,21 @@ fun potentialRelaysToFindEvent(note: Note): Set<NormalizedRelayUrl> {
     return set
 }
 
-fun filterMissingEvents(keys: List<EventFinderQueryState>): List<RelayBasedFilter> {
+fun filterMissingEvents(
+    cache: ICacheProvider,
+    keys: List<EventFinderQueryState>,
+): List<RelayBasedFilter> {
     val eventsPerRelay =
         mapOfSet {
             keys.forEach { key ->
-                val default = key.account.followPlusAllMineWithSearch.flow.value
+                val default = key.account.followPlusAllMineWithSearchRelays()
 
                 if (key.note !is AddressableNote && key.note.event == null) {
-                    potentialRelaysToFindEvent(key.note).ifEmpty { default }.forEach { relayUrl ->
+                    potentialRelaysToFindEvent(cache, key.note).ifEmpty { default }.forEach { relayUrl ->
                         add(relayUrl, key.note.idHex)
                     }
 
-                    key.account.searchRelayList.flow.value.forEach { relayUrl ->
+                    key.account.searchRelays().forEach { relayUrl ->
                         add(relayUrl, key.note.idHex)
                     }
                 }
@@ -117,7 +123,7 @@ fun filterMissingEvents(keys: List<EventFinderQueryState>): List<RelayBasedFilte
                 // loads threading that is event-based
                 key.note.replyTo?.forEach { note ->
                     if (note !is AddressableNote && note.event == null) {
-                        potentialRelaysToFindEvent(note).ifEmpty { default }.forEach { relayUrl ->
+                        potentialRelaysToFindEvent(cache, note).ifEmpty { default }.forEach { relayUrl ->
                             add(relayUrl, note.idHex)
                         }
                     }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/loaders/FilterMissingEvents.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/loaders/FilterMissingEvents.kt
@@ -115,7 +115,7 @@ fun filterMissingEvents(
                         add(relayUrl, key.note.idHex)
                     }
 
-                    key.account.searchRelays().forEach { relayUrl ->
+                    key.account.searchOnlyRelays().forEach { relayUrl ->
                         add(relayUrl, key.note.idHex)
                     }
                 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/loaders/NoteEventLoaderSubAssembler.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/loaders/NoteEventLoaderSubAssembler.kt
@@ -18,21 +18,28 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.loaders
+package com.vitorpamplona.amethyst.commons.relayClient.event.loaders
 
-import com.vitorpamplona.amethyst.service.relayClient.eoseManagers.SingleSubNoEoseCacheEoseManager
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.EventFinderQueryState
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.SingleSubNoEoseCacheEoseManager
+import com.vitorpamplona.amethyst.commons.relayClient.event.EventFinderQueryState
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 
 class NoteEventLoaderSubAssembler(
     client: INostrClient,
+    val cache: ICacheProvider,
     allKeys: () -> Set<EventFinderQueryState>,
 ) : SingleSubNoEoseCacheEoseManager<EventFinderQueryState>(client, allKeys, invalidateAfterEose = true) {
     override fun updateFilter(keys: List<EventFinderQueryState>) =
         listOfNotNull(
-            filterMissingEvents(keys),
-            filterMissingAddressables(keys),
+            filterMissingEvents(cache, keys),
+            filterMissingAddressables(cache, keys),
         ).flatten()
 
     override fun distinct(key: EventFinderQueryState) = key.note
+
+    // Attribute to the account that owns this subscription, when a single account is watching.
+    // Deduped by pubkey hex, not by account identity, so two objects for the same logged-in user
+    // don't look like two accounts and suppress attribution.
+    override fun accountPubKeyOf(key: Any?): String? = (key as? EventFinderQueryState)?.account?.userFinderPubkeyHex
 }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/watchers/EventWatcherSubAssembler.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/watchers/EventWatcherSubAssembler.kt
@@ -18,15 +18,15 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.watchers
+package com.vitorpamplona.amethyst.commons.relayClient.event.watchers
 
+import com.vitorpamplona.amethyst.commons.model.AddressableNote
+import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.SingleSubEoseManager
-import com.vitorpamplona.amethyst.model.AddressableNote
-import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.EventFinderQueryState
-import com.vitorpamplona.amethyst.service.relays.EOSEAccountFast
-import com.vitorpamplona.amethyst.service.relays.MutableTime
-import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
+import com.vitorpamplona.amethyst.commons.relayClient.event.EventFinderQueryState
+import com.vitorpamplona.amethyst.commons.relays.EOSEAccountFast
+import com.vitorpamplona.amethyst.commons.relays.MutableTime
+import com.vitorpamplona.amethyst.commons.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
@@ -67,7 +67,7 @@ class EventWatcherSubAssembler(
         // the same logged-in user would look like two accounts and suppress attribution entirely.
         val soleAccountPubKey =
             keys
-                .mapTo(mutableSetOf()) { it.account.userProfile().pubkeyHex }
+                .mapTo(mutableSetOf()) { it.account.userFinderPubkeyHex }
                 .singleOrNull()
 
         return groupByRelayPresence(lastNotesOnFilter, latestEOSEs)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/watchers/FilterRepliesAndReactionsToAddresses.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/watchers/FilterRepliesAndReactionsToAddresses.kt
@@ -18,12 +18,12 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.watchers
+package com.vitorpamplona.amethyst.commons.relayClient.event.watchers
 
+import com.vitorpamplona.amethyst.commons.model.AddressableNote
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.ExplainedFilter
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.SubPurpose
-import com.vitorpamplona.amethyst.model.AddressableNote
-import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
+import com.vitorpamplona.amethyst.commons.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.experimental.attestations.attestation.AttestationEvent
 import com.vitorpamplona.quartz.experimental.zapPolls.ZapPollEvent
 import com.vitorpamplona.quartz.nip01Core.core.HexKey

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/watchers/FilterRepliesAndReactionsToNotes.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/watchers/FilterRepliesAndReactionsToNotes.kt
@@ -20,12 +20,12 @@
  */
 @file:Suppress("DEPRECATION")
 
-package com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.watchers
+package com.vitorpamplona.amethyst.commons.relayClient.event.watchers
 
+import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.ExplainedFilter
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.SubPurpose
-import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
+import com.vitorpamplona.amethyst.commons.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.experimental.attestations.attestation.AttestationEvent
 import com.vitorpamplona.quartz.experimental.edits.TextNoteModificationEvent
 import com.vitorpamplona.quartz.experimental.zapPolls.ZapPollEvent

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/PickRelaysToLoadUsers.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/PickRelaysToLoadUsers.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.relayClient.user
+
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.relays.EOSEAccountFast
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.hints.HintIndexer
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.utils.mapOfSet
+
+fun pickRelaysToLoadUsers(
+    users: Set<User>,
+    relayHints: HintIndexer,
+    indexRelays: Set<NormalizedRelayUrl>,
+    homeRelays: Set<NormalizedRelayUrl>,
+    searchRelays: Set<NormalizedRelayUrl>,
+    connected: Set<NormalizedRelayUrl>,
+    commonRelays: Set<NormalizedRelayUrl>,
+    cannotConnectRelays: Set<NormalizedRelayUrl>,
+    hasTried: EOSEAccountFast<User>,
+): Map<NormalizedRelayUrl, Set<HexKey>> =
+    mapOfSet {
+        users.forEachIndexed { _, key ->
+            val tried = (hasTried.since(key)?.keys ?: emptySet()) + cannotConnectRelays
+
+            val outbox = key.authorRelayList()?.writeRelaysNorm()
+
+            if (!outbox.isNullOrEmpty()) {
+                // If there is a home, get from it.
+
+                // if it tried all outbox relays, stop.
+                // the UserWatch will take over from here.
+                val leftToTry = (outbox - tried)
+                leftToTry.forEach {
+                    add(it, key.pubkeyHex)
+                }
+            } else {
+                // if not, tries hints first.
+                val hints = key.allUsedRelays() + relayHints.hintsForKey(key.pubkeyHex)
+
+                val leftToTryOnHints = hints - tried
+
+                leftToTryOnHints.forEach {
+                    add(it, key.pubkeyHex)
+                }
+
+                // if there are only a few hints, broadens the search
+                if (leftToTryOnHints.size < 3) {
+                    // This creates a pre-deterministic order of the array such that
+                    // if this function is called twice, it returns the same arrays
+                    // which gets ignored by the relay client if we send it twice
+                    val indexRelaysLeftToTry =
+                        (indexRelays - tried).sortedBy { relay ->
+                            key.pubkeyHex.hashCode() xor relay.url.hashCode()
+                        }
+                    // This creates a pre-deterministic order of the array such that
+                    // if this function is called twice, it returns the same arrays
+                    // which gets ignored by the relay client if we send it twice
+                    val homeRelaysLeftToTry =
+                        (homeRelays - tried).sortedBy { relay ->
+                            key.pubkeyHex.hashCode() xor relay.url.hashCode()
+                        }
+
+                    // picks one at random to avoid overloading these relays
+                    if (users.size > 300) {
+                        if (indexRelaysLeftToTry.size >= 2) {
+                            add(indexRelaysLeftToTry[0], key.pubkeyHex)
+                            add(indexRelaysLeftToTry[1], key.pubkeyHex)
+                        } else if (indexRelaysLeftToTry.size == 1) {
+                            add(indexRelaysLeftToTry.first(), key.pubkeyHex)
+                        }
+
+                        homeRelaysLeftToTry.forEach {
+                            add(it, key.pubkeyHex)
+                        }
+                    } else {
+                        indexRelaysLeftToTry.forEach {
+                            add(it, key.pubkeyHex)
+                        }
+
+                        homeRelaysLeftToTry.forEach {
+                            add(it, key.pubkeyHex)
+                        }
+                    }
+
+                    if (indexRelaysLeftToTry.size < 2) {
+                        val searchRelaysLeftToTry = searchRelays - tried
+
+                        searchRelaysLeftToTry.forEach {
+                            add(it, key.pubkeyHex)
+                        }
+
+                        val connectedRelaysLeftToTry =
+                            (connected - tried)
+                                .sortedBy { relay ->
+                                    key.pubkeyHex.hashCode() xor relay.url.hashCode()
+                                }.take(100)
+
+                        // picks one at random to avoid overloading these relays
+                        if (users.size > 300) {
+                            connectedRelaysLeftToTry.take(20).forEach {
+                                add(it, key.pubkeyHex)
+                            }
+                        } else {
+                            connectedRelaysLeftToTry.forEach {
+                                add(it, key.pubkeyHex)
+                            }
+                        }
+
+                        if (searchRelaysLeftToTry.size < 2) {
+                            // This creates a pre-deterministic order of the array such that
+                            // if this function is called twice, it returns the same arrays
+                            // which gets ignored by the relay client if we send it twice
+                            val allRelaysLeftToTry =
+                                (commonRelays - tried)
+                                    .sortedBy { relay ->
+                                        key.pubkeyHex.hashCode() xor relay.url.hashCode()
+                                    }.take(100)
+
+                            allRelaysLeftToTry.forEach {
+                                add(it, key.pubkeyHex)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/UserFinderAccount.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/UserFinderAccount.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.relayClient.user
+
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip85TrustedAssertions.list.tags.ServiceProviderTag
+
+/**
+ * Narrow, read-only view of a logged-in account that the user-finder
+ * subscription layer needs to route metadata / relay-list / report /
+ * contact-card REQs for *other* users.
+ *
+ * This is deliberately NOT part of [IAccount][com.vitorpamplona.amethyst.commons.model.IAccount]:
+ * `IAccount` is a behavioral capability interface for the *acting* user
+ * (sending DMs, gift wraps, MLS groups). The relay hints needed to *discover
+ * other users' metadata* are a separate concern, so they live on their own
+ * narrow interface (ISP).
+ *
+ * All accessors are **snapshot getters** read fresh on every filter rebuild —
+ * matching the prior direct `account.xxx.flow.value` reads. Relay-list changes
+ * therefore take effect on the next subscription invalidation without any
+ * captured-snapshot staleness.
+ *
+ * Platforms implement this on their concrete account (Android `Account`,
+ * Desktop `DesktopIAccount`). Fields with no backing on a platform degrade
+ * safely: Desktop has no NIP-85 trust-provider subsystem wired, so
+ * [trustProvider] returns null and [declaredFollowsByOutboxRelay] returns an
+ * empty map — contact-card and report discovery become best-effort there.
+ */
+interface UserFinderAccount {
+    /** This account's own pubkey (hex). */
+    val userFinderPubkeyHex: HexKey
+
+    /** Index/discovery relays, with the platform default fallback already applied. */
+    fun indexRelays(): Set<NormalizedRelayUrl>
+
+    /** Home/write relays used for outbox discovery (nip65 + private storage + local). */
+    fun outboxHomeRelays(): Set<NormalizedRelayUrl>
+
+    /** Search relays (trusted + search), with the default fallback applied. */
+    fun searchRelays(): Set<NormalizedRelayUrl>
+
+    /**
+     * Follow + all-mine + search relays, used by the per-note event-finder to
+     * place "missing event" / "missing addressable" REQs (reactions, zaps,
+     * reposts, replies) when a note references content no relay has yet placed.
+     * Snapshot getter, same contract as the others.
+     */
+    fun followPlusAllMineWithSearchRelays(): Set<NormalizedRelayUrl>
+
+    /** Shared-outbox / proxy relays used as the broad common fallback. */
+    fun commonRelays(): Set<NormalizedRelayUrl>
+
+    /** Home relays used specifically for NIP-51 contact-card (kind 30382) discovery. */
+    fun cardHomeRelays(): Set<NormalizedRelayUrl>
+
+    /** NIP-85 trusted-assertions rank provider, or null when unsupported (e.g. Desktop). */
+    fun trustProvider(): ServiceProviderTag?
+
+    /**
+     * NIP-85 follower-count rank provider, or null when unsupported (e.g. Desktop).
+     * Read by the contact-card sub-assembler alongside [trustProvider].
+     */
+    fun followerCountProvider(): ServiceProviderTag?
+
+    /**
+     * Declared follows keyed by the relay they were declared on, used to trust
+     * report authors. Empty when the platform has no follow-graph-per-relay data.
+     */
+    fun declaredFollowsByOutboxRelay(): Map<NormalizedRelayUrl, Set<HexKey>>
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/UserFinderAccount.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/UserFinderAccount.kt
@@ -56,8 +56,17 @@ interface UserFinderAccount {
     /** Home/write relays used for outbox discovery (nip65 + private storage + local). */
     fun outboxHomeRelays(): Set<NormalizedRelayUrl>
 
-    /** Search relays (trusted + search), with the default fallback applied. */
+    /** Search relays (trusted + own search list), for the user-finder's search-tier fallback. */
     fun searchRelays(): Set<NormalizedRelayUrl>
+
+    /**
+     * Just this account's own NIP-51 search relay list — WITHOUT the trusted-relay
+     * union that [searchRelays] adds. This is the narrow set the per-note event
+     * finder fans "missing event" REQs to, matching the pre-extraction
+     * `account.searchRelayList` read (reusing [searchRelays] there would have
+     * unintentionally widened the fan-out to trusted relays).
+     */
+    fun searchOnlyRelays(): Set<NormalizedRelayUrl>
 
     /**
      * Follow + all-mine + search relays, used by the per-note event-finder to

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/UserFinderFilterAssembler.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/UserFinderFilterAssembler.kt
@@ -18,18 +18,16 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.service.relayClient.reqCommand.user
+package com.vitorpamplona.amethyst.commons.relayClient.user
 
 import androidx.compose.runtime.Stable
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.commons.relayClient.composeSubscriptionManagers.ComposeSubscriptionManager
-import com.vitorpamplona.amethyst.model.Account
-import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.model.User
-import com.vitorpamplona.amethyst.service.relayClient.AccountScopedQuery
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.loaders.UserOutboxFinderSubAssembler
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.watchers.UserCardsSubAssembler
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.watchers.UserReportsSubAssembler
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.watchers.UserWatcherSubAssembler
+import com.vitorpamplona.amethyst.commons.relayClient.user.loaders.UserOutboxFinderSubAssembler
+import com.vitorpamplona.amethyst.commons.relayClient.user.watchers.UserCardsSubAssembler
+import com.vitorpamplona.amethyst.commons.relayClient.user.watchers.UserReportsSubAssembler
+import com.vitorpamplona.amethyst.commons.relayClient.user.watchers.UserWatcherSubAssembler
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.RelayOfflineTracker
 
@@ -37,13 +35,13 @@ import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.RelayOfflineT
 @Stable
 class UserFinderQueryState(
     val user: User,
-    override val account: Account,
-) : AccountScopedQuery
+    val account: UserFinderAccount,
+)
 
 @Stable
 class UserFinderFilterAssembler(
     client: INostrClient,
-    cache: LocalCache,
+    cache: ICacheProvider,
     failureTracker: RelayOfflineTracker,
 ) : ComposeSubscriptionManager<UserFinderQueryState>() {
     val group =

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/UserFinderSubscription.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/UserFinderSubscription.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.relayClient.user
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.LifecycleAwareKeyDataSourceSubscription
+
+/**
+ * The shared per-user metadata data source for the current front end. A front
+ * end provides this once near its composition root (Android via AppModules,
+ * Desktop via its subscriptions coordinator). Reading it without a provider is
+ * a programming error — the `observeUser*` composables must never be reachable
+ * from a composition that has no relay client (e.g. the Android `:napplet`
+ * sandbox process).
+ */
+val LocalUserFinder =
+    staticCompositionLocalOf<UserFinderFilterAssembler> {
+        error("LocalUserFinder not provided")
+    }
+
+/**
+ * The current logged-in account, in the narrow [UserFinderAccount] view the
+ * finder needs to route REQs. Provided alongside [LocalUserFinder].
+ */
+val LocalUserFinderAccount =
+    staticCompositionLocalOf<UserFinderAccount> {
+        error("LocalUserFinderAccount not provided")
+    }
+
+/**
+ * Subscribes to relay updates for [user]'s metadata (and relay list / reports /
+ * contact cards) for as long as this composable is in composition, coalesced
+ * with every other on-screen user into batched REQs by [dataSource].
+ *
+ * Because a `LazyColumn` composes only the visible window (+ a small prefetch
+ * buffer), this naturally means "load metadata only for users currently on
+ * screen" — the [LifecycleAwareKeyDataSourceSubscription] unsubscribes ~30s
+ * after the row leaves composition or the app is backgrounded.
+ */
+@Composable
+fun UserFinderFilterAssemblerSubscription(
+    user: User,
+    account: UserFinderAccount,
+    dataSource: UserFinderFilterAssembler,
+) {
+    // Different screens get their own query-state instance even when tracking
+    // the same user; the assembler dedups to one REQ per pubkey.
+    val state = remember(user, account) { UserFinderQueryState(user, account) }
+
+    LifecycleAwareKeyDataSourceSubscription(state, dataSource)
+}
+
+/**
+ * Convenience overload that reads the front end's [LocalUserFinder] and
+ * [LocalUserFinderAccount] from the composition.
+ */
+@Composable
+fun UserFinderFilterAssemblerSubscription(user: User) {
+    UserFinderFilterAssemblerSubscription(
+        user = user,
+        account = LocalUserFinderAccount.current,
+        dataSource = LocalUserFinder.current,
+    )
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/UserMetadataObservers.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/UserMetadataObservers.kt
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.relayClient.user
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.remember
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.nip01Core.UserInfo
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+
+/**
+ * Shared, platform-agnostic observers for a single user's metadata (kind 0).
+ *
+ * Each observer both (a) opens a composition-scoped relay subscription for the
+ * user via [UserFinderFilterAssemblerSubscription] — so metadata is fetched only
+ * while the user is on screen — and (b) collects the resulting cache flow so the
+ * UI recomposes when the metadata arrives. The `(user)` overloads read the
+ * front end's [LocalUserFinder] / [LocalUserFinderAccount]; the explicit-param
+ * overloads are for callers that already hold both (and for tests).
+ *
+ * These are metadata-only. Richer per-user observers that depend on account
+ * subsystems not yet in commons (contact-card petnames, follow counts,
+ * bookmarks, statuses) remain in the Android layer for now and layer on top of
+ * the same subscription.
+ */
+@Composable
+fun observeUserInfo(
+    user: User,
+    userFinder: UserFinderFilterAssembler,
+    account: UserFinderAccount,
+): State<UserInfo?> {
+    UserFinderFilterAssemblerSubscription(user, account, userFinder)
+    return user.metadata().flow.collectAsStateWithLifecycle()
+}
+
+@Composable
+fun observeUserInfo(user: User): State<UserInfo?> = observeUserInfo(user, LocalUserFinder.current, LocalUserFinderAccount.current)
+
+@Composable
+fun observeUserPicture(
+    user: User,
+    userFinder: UserFinderFilterAssembler,
+    account: UserFinderAccount,
+): State<String?> {
+    UserFinderFilterAssemblerSubscription(user, account, userFinder)
+
+    val flow =
+        remember(user) {
+            user
+                .metadata()
+                .flow
+                .map { it?.info?.picture }
+                .distinctUntilChanged()
+        }
+
+    return flow.collectAsStateWithLifecycle(
+        user
+            .metadataOrNull()
+            ?.flow
+            ?.value
+            ?.info
+            ?.picture,
+    )
+}
+
+@Composable
+fun observeUserPicture(user: User): State<String?> = observeUserPicture(user, LocalUserFinder.current, LocalUserFinderAccount.current)
+
+@Composable
+fun observeUserBanner(
+    user: User,
+    userFinder: UserFinderFilterAssembler,
+    account: UserFinderAccount,
+): State<String?> {
+    UserFinderFilterAssemblerSubscription(user, account, userFinder)
+
+    val flow =
+        remember(user) {
+            user
+                .metadata()
+                .flow
+                .map { it?.info?.banner }
+                .distinctUntilChanged()
+        }
+
+    return flow.collectAsStateWithLifecycle(
+        user
+            .metadataOrNull()
+            ?.flow
+            ?.value
+            ?.info
+            ?.banner,
+    )
+}
+
+@Composable
+fun observeUserBanner(user: User): State<String?> = observeUserBanner(user, LocalUserFinder.current, LocalUserFinderAccount.current)
+
+@Composable
+fun observeUserAboutMe(
+    user: User,
+    userFinder: UserFinderFilterAssembler,
+    account: UserFinderAccount,
+): State<String> {
+    UserFinderFilterAssemblerSubscription(user, account, userFinder)
+
+    val flow =
+        remember(user) {
+            user
+                .metadata()
+                .flow
+                .map { it?.info?.about ?: "" }
+                .distinctUntilChanged()
+        }
+
+    return flow.collectAsStateWithLifecycle(
+        user
+            .metadataOrNull()
+            ?.flow
+            ?.value
+            ?.info
+            ?.about ?: "",
+    )
+}
+
+@Composable
+fun observeUserAboutMe(user: User): State<String> = observeUserAboutMe(user, LocalUserFinder.current, LocalUserFinderAccount.current)
+
+/**
+ * The user's best available display name from their own metadata (kind 0),
+ * falling back to a truncated pubkey. Metadata-only: it does NOT apply the
+ * viewing account's private contact-card petname (that stays in the Android
+ * layer, which wraps this).
+ */
+@Composable
+fun observeUserName(
+    user: User,
+    userFinder: UserFinderFilterAssembler,
+    account: UserFinderAccount,
+): State<String> {
+    UserFinderFilterAssemblerSubscription(user, account, userFinder)
+
+    val flow =
+        remember(user) {
+            user
+                .metadata()
+                .flow
+                .map { it?.info?.bestName() ?: user.toBestDisplayName() }
+                .distinctUntilChanged()
+        }
+
+    return flow.collectAsStateWithLifecycle(user.toBestDisplayName())
+}
+
+@Composable
+fun observeUserName(user: User): State<String> = observeUserName(user, LocalUserFinder.current, LocalUserFinderAccount.current)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/loaders/UserOutboxFinderSubAssembler.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/loaders/UserOutboxFinderSubAssembler.kt
@@ -18,18 +18,18 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.loaders
+package com.vitorpamplona.amethyst.commons.relayClient.user.loaders
 
 import com.vitorpamplona.amethyst.commons.defaults.DefaultIndexerRelayList
 import com.vitorpamplona.amethyst.commons.defaults.DefaultSearchRelayList
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.BaseEoseManager
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.ExplainedFilter
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.SubPurpose
-import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.model.User
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.account.follows.pickRelaysToLoadUsers
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinderQueryState
-import com.vitorpamplona.amethyst.service.relays.EOSEAccountFast
+import com.vitorpamplona.amethyst.commons.relayClient.user.UserFinderQueryState
+import com.vitorpamplona.amethyst.commons.relayClient.user.pickRelaysToLoadUsers
+import com.vitorpamplona.amethyst.commons.relays.EOSEAccountFast
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
@@ -44,7 +44,7 @@ import com.vitorpamplona.quartz.utils.TimeUtils
 
 class UserOutboxFinderSubAssembler(
     client: INostrClient,
-    val cache: LocalCache,
+    val cache: ICacheProvider,
     val failureTracker: RelayOfflineTracker,
     allKeys: () -> Set<UserFinderQueryState>,
 ) : BaseEoseManager<UserFinderQueryState>(client, allKeys) {
@@ -108,19 +108,37 @@ class UserOutboxFinderSubAssembler(
         // and the users being resolved are whoever is on screen rather than anyone's follow list — so
         // with several accounts active there is no single honest owner for a given filter, and
         // splitting the sweep per account would re-issue the same lookups once per account.
-        // Deduped by pubkey, not by `Account`: that class uses identity equality, so two objects for
-        // the same logged-in user would look like two accounts and suppress attribution entirely.
+        // Deduped by pubkey, not by account identity: two objects for the same logged-in user would
+        // look like two accounts and suppress attribution entirely.
         val soleAccountPubKey =
             accounts
-                .mapTo(mutableSetOf()) { it.userProfile().pubkeyHex }
+                .mapTo(mutableSetOf()) { it.userFinderPubkeyHex }
                 .singleOrNull()
+
+        // Union of every asking account's relay tiers. The UserFinderAccount getters already apply the
+        // platform default fallbacks (index/search), matching the prior outer pickRelaysToLoadUsers.
+        val cannotConnect = failureTracker.cannotConnectRelays
+        val indexRelays = mutableSetOf<NormalizedRelayUrl>()
+        val homeRelays = mutableSetOf<NormalizedRelayUrl>()
+        val searchRelays = mutableSetOf<NormalizedRelayUrl>()
+        val commonRelays = mutableSetOf<NormalizedRelayUrl>()
+        accounts.forEach { account ->
+            indexRelays.addAll(account.indexRelays())
+            homeRelays.addAll(account.outboxHomeRelays())
+            searchRelays.addAll(account.searchRelays())
+            commonRelays.addAll(account.commonRelays())
+        }
 
         val perRelayKeysBoth =
             pickRelaysToLoadUsers(
                 noOutboxList,
-                accounts,
+                cache.relayHints,
+                indexRelays - cannotConnect,
+                homeRelays - cannotConnect,
+                searchRelays - cannotConnect,
                 connectedRelays,
-                failureTracker.cannotConnectRelays,
+                commonRelays - cannotConnect,
+                cannotConnect,
                 hasTried,
             )
 

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/watchers/FilterReportsToKey.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/watchers/FilterReportsToKey.kt
@@ -18,7 +18,7 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.watchers
+package com.vitorpamplona.amethyst.commons.relayClient.user.watchers
 
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.ExplainedFilter
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.SubPurpose

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/watchers/FilterUserMetadataForKey.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/watchers/FilterUserMetadataForKey.kt
@@ -18,16 +18,16 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.watchers
+package com.vitorpamplona.amethyst.commons.relayClient.user.watchers
 
+import com.vitorpamplona.amethyst.commons.model.User
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.ExplainedFilter
 import com.vitorpamplona.amethyst.commons.relayClient.subscriptions.SubPurpose
-import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.model.User
-import com.vitorpamplona.amethyst.service.relays.EOSEAccountFast
+import com.vitorpamplona.amethyst.commons.relays.EOSEAccountFast
 import com.vitorpamplona.quartz.experimental.nipA3.PaymentTargetsEvent
 import com.vitorpamplona.quartz.marmot.mip00KeyPackages.KeyPackageRelayListEvent
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.hints.HintIndexer
 import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
@@ -60,6 +60,7 @@ val UserMetadataForKeyKinds =
 
 fun filterUserMetadataForKey(
     authors: Set<User>,
+    relayHints: HintIndexer,
     indexRelays: Set<NormalizedRelayUrl>,
     cannotConnectRelays: Set<NormalizedRelayUrl>,
     since: EOSEAccountFast<User>,
@@ -72,7 +73,7 @@ fun filterUserMetadataForKey(
                 val relays =
                     when {
                         outbox == null ->
-                            key.allUsedRelays() + LocalCache.relayHints.hintsForKey(key.pubkeyHex) + indexRelays
+                            key.allUsedRelays() + relayHints.hintsForKey(key.pubkeyHex) + indexRelays
                         // Outbox is published but exhausted (every relay either EOSE'd
                         // or is known-unreachable) and metadata is still missing —
                         // widen to indexers so a misconfigured outbox doesn't strand

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/watchers/UserCardsSubAssembler.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/watchers/UserCardsSubAssembler.kt
@@ -18,24 +18,27 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.watchers
+package com.vitorpamplona.amethyst.commons.relayClient.user.watchers
 
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.commons.model.toHexSet
+import com.vitorpamplona.amethyst.commons.relayClient.assemblers.filterContactCardsToTargetKeysFromTrustedAccountsInTheRelay
 import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.SingleSubEoseManager
-import com.vitorpamplona.amethyst.model.Account
-import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.model.User
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinderQueryState
-import com.vitorpamplona.amethyst.service.relays.MutableTime
-import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
+import com.vitorpamplona.amethyst.commons.relayClient.user.UserFinderQueryState
+import com.vitorpamplona.amethyst.commons.relays.MutableTime
+import com.vitorpamplona.amethyst.commons.relays.SincePerRelayMap
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip01Core.tags.dTag.DTag
+import com.vitorpamplona.quartz.utils.mapOfSet
 
-class UserReportsSubAssembler(
+class UserCardsSubAssembler(
     client: INostrClient,
-    val cache: LocalCache,
+    val cache: ICacheProvider,
     allKeys: () -> Set<UserFinderQueryState>,
 ) : SingleSubEoseManager<UserFinderQueryState>(client, allKeys) {
     override fun newEose(
@@ -44,9 +47,12 @@ class UserReportsSubAssembler(
         filters: List<Filter>?,
     ) {
         filters?.forEach { filter ->
-            filter.tags?.get("p")?.forEach {
+            // kind:30382 addresses the target user in the d-tag (the key the
+            // filter builder uses). Reading any other tag leaves the per-user
+            // EOSEs unset and forces full re-downloads with since = null.
+            filter.tags?.get(DTag.TAG_NAME)?.forEach {
                 val targetUser = cache.getUserIfExists(it)
-                targetUser?.reportsOrNull()?.latestEOSEs?.newEose(relay, time)
+                targetUser?.cardsOrNull()?.latestEOSEs?.newEose(relay, time)
             }
         }
         super.newEose(relay, time, filters)
@@ -58,45 +64,58 @@ class UserReportsSubAssembler(
     ): List<RelayBasedFilter>? {
         if (keys.isEmpty()) return null
 
-        val accounts = keys.mapTo(mutableSetOf()) { it.account }
-
-        // Ignore reports for people that we are following.
         val lastUsersOnFilter = keys.mapTo(mutableSetOf()) { it.user }
 
         if (lastUsersOnFilter.isEmpty()) return null
 
-        // One pass per account, never a union. "Whose follows wrote this report" is the whole point of
-        // the filter, so merging every logged-in account's follow list into one per-relay map both made
-        // the result unattributable and asked one account's follows of another account's outbox relays.
-        return accounts.flatMap { account -> filtersFor(account, lastUsersOnFilter) }.ifEmpty { null }
-    }
+        val accounts = keys.mapTo(mutableSetOf()) { it.account }
 
-    private fun filtersFor(
-        account: Account,
-        lastUsersOnFilter: Set<User>,
-    ): List<RelayBasedFilter> {
-        val accountPubKey = account.userProfile().pubkeyHex
+        // Attributed only when one account is asking: the trusted-author sets below are pooled across
+        // accounts, so with several active none of them owns a given filter.
+        val soleAccountPubKey =
+            accounts
+                .mapTo(mutableSetOf()) { it.userFinderPubkeyHex }
+                .singleOrNull()
 
-        return account.declaredFollowsPerOutboxRelay.value
+        val trustedAccounts: Map<NormalizedRelayUrl, Set<HexKey>> =
+            mapOfSet {
+                accounts.forEach { account ->
+                    account.cardHomeRelays().forEach {
+                        add(it, account.userFinderPubkeyHex)
+                    }
+                }
+                accounts.map { it.trustProvider() }.forEach { provider ->
+                    if (provider != null) {
+                        add(provider.relayUrl, provider.pubkey)
+                    }
+                }
+                accounts.map { it.followerCountProvider() }.forEach { provider ->
+                    if (provider != null) {
+                        add(provider.relayUrl, provider.pubkey)
+                    }
+                }
+            }
+
+        return trustedAccounts
             .flatMap { (relay, trustedUsersInThisRelay) ->
-                // this relay + accounts are where we could find reports.
+                // this relay + accounts are where we could find cards.
                 // we might have already loaded them, so let's separate new targets that were checked before from the others
                 val groups = groupByRelayPresence(lastUsersOnFilter, relay)
                 val trustedAccounts = trustedUsersInThisRelay.sorted()
                 listOfNotNull(
-                    filterReportsToKeysFromTrusted(
+                    filterContactCardsToTargetKeysFromTrustedAccountsInTheRelay(
+                        accountPubKey = soleAccountPubKey,
                         targets = groups.usersWithoutEose.toHexSet(),
                         trustedAccounts = trustedAccounts,
                         relay = relay,
                         since = null,
-                        accountPubKey = accountPubKey,
                     ),
-                    filterReportsToKeysFromTrusted(
+                    filterContactCardsToTargetKeysFromTrustedAccountsInTheRelay(
+                        accountPubKey = soleAccountPubKey,
                         targets = groups.usersWithEose.toHexSet(),
                         trustedAccounts = trustedAccounts,
                         relay = relay,
                         since = findMinimumEOSEsForUsers(groups.usersWithEose, relay),
-                        accountPubKey = accountPubKey,
                     ),
                 )
             }
@@ -117,7 +136,7 @@ class UserReportsSubAssembler(
             targetUsers.groupBy { user ->
                 relay in
                     user
-                        .reports()
+                        .cards()
                         .latestEOSEs.relayList.keys
             }
 
@@ -134,7 +153,7 @@ class UserReportsSubAssembler(
         var min: MutableTime? = null
 
         users.forEach {
-            val eose = it.reports().latestEOSEs.since()[relay]
+            val eose = it.cards().latestEOSEs.since()[relay]
             if (min != null && eose != null) {
                 min.updateIfOlder(eose.time)
             } else if (eose != null) {

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/watchers/UserReportsSubAssembler.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/watchers/UserReportsSubAssembler.kt
@@ -18,27 +18,24 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.watchers
+package com.vitorpamplona.amethyst.commons.relayClient.user.watchers
 
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.commons.model.toHexSet
-import com.vitorpamplona.amethyst.commons.relayClient.assemblers.filterContactCardsToTargetKeysFromTrustedAccountsInTheRelay
 import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.SingleSubEoseManager
-import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.model.User
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinderQueryState
-import com.vitorpamplona.amethyst.service.relays.MutableTime
-import com.vitorpamplona.amethyst.service.relays.SincePerRelayMap
-import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.amethyst.commons.relayClient.user.UserFinderAccount
+import com.vitorpamplona.amethyst.commons.relayClient.user.UserFinderQueryState
+import com.vitorpamplona.amethyst.commons.relays.MutableTime
+import com.vitorpamplona.amethyst.commons.relays.SincePerRelayMap
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.pool.RelayBasedFilter
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
-import com.vitorpamplona.quartz.nip01Core.tags.dTag.DTag
-import com.vitorpamplona.quartz.utils.mapOfSet
 
-class UserCardsSubAssembler(
+class UserReportsSubAssembler(
     client: INostrClient,
-    val cache: LocalCache,
+    val cache: ICacheProvider,
     allKeys: () -> Set<UserFinderQueryState>,
 ) : SingleSubEoseManager<UserFinderQueryState>(client, allKeys) {
     override fun newEose(
@@ -47,12 +44,9 @@ class UserCardsSubAssembler(
         filters: List<Filter>?,
     ) {
         filters?.forEach { filter ->
-            // kind:30382 addresses the target user in the d-tag (the key the
-            // filter builder uses). Reading any other tag leaves the per-user
-            // EOSEs unset and forces full re-downloads with since = null.
-            filter.tags?.get(DTag.TAG_NAME)?.forEach {
+            filter.tags?.get("p")?.forEach {
                 val targetUser = cache.getUserIfExists(it)
-                targetUser?.cardsOrNull()?.latestEOSEs?.newEose(relay, time)
+                targetUser?.reportsOrNull()?.latestEOSEs?.newEose(relay, time)
             }
         }
         super.newEose(relay, time, filters)
@@ -64,58 +58,46 @@ class UserCardsSubAssembler(
     ): List<RelayBasedFilter>? {
         if (keys.isEmpty()) return null
 
+        val accounts = keys.mapTo(mutableSetOf()) { it.account }
+
+        // Ignore reports for people that we are following.
         val lastUsersOnFilter = keys.mapTo(mutableSetOf()) { it.user }
 
         if (lastUsersOnFilter.isEmpty()) return null
 
-        val accounts = keys.mapTo(mutableSetOf()) { it.account }
+        // One pass per account, never a union. "Whose follows wrote this report" is the whole point of
+        // the filter, so merging every logged-in account's follow list into one per-relay map both made
+        // the result unattributable and asked one account's follows of another account's outbox relays.
+        return accounts.flatMap { account -> filtersFor(account, lastUsersOnFilter) }.ifEmpty { null }
+    }
 
-        // Attributed only when one account is asking: the trusted-author sets below are pooled across
-        // accounts, so with several active none of them owns a given filter.
-        val soleAccountPubKey =
-            accounts
-                .mapTo(mutableSetOf()) { it.userProfile().pubkeyHex }
-                .singleOrNull()
+    private fun filtersFor(
+        account: UserFinderAccount,
+        lastUsersOnFilter: Set<User>,
+    ): List<RelayBasedFilter> {
+        val accountPubKey = account.userFinderPubkeyHex
 
-        val trustedAccounts: Map<NormalizedRelayUrl, Set<HexKey>> =
-            mapOfSet {
-                accounts.forEach { account ->
-                    account.homeRelays.flow.value.forEach {
-                        add(it, account.userProfile().pubkeyHex)
-                    }
-                }
-                accounts.map { it.trustProviderList.liveUserRankProvider.value }.forEach { provider ->
-                    if (provider != null) {
-                        add(provider.relayUrl, provider.pubkey)
-                    }
-                }
-                accounts.map { it.trustProviderList.liveUserFollowerCount.value }.forEach { provider ->
-                    if (provider != null) {
-                        add(provider.relayUrl, provider.pubkey)
-                    }
-                }
-            }
-
-        return trustedAccounts
+        return account
+            .declaredFollowsByOutboxRelay()
             .flatMap { (relay, trustedUsersInThisRelay) ->
-                // this relay + accounts are where we could find cards.
+                // this relay + accounts are where we could find reports.
                 // we might have already loaded them, so let's separate new targets that were checked before from the others
                 val groups = groupByRelayPresence(lastUsersOnFilter, relay)
                 val trustedAccounts = trustedUsersInThisRelay.sorted()
                 listOfNotNull(
-                    filterContactCardsToTargetKeysFromTrustedAccountsInTheRelay(
-                        accountPubKey = soleAccountPubKey,
+                    filterReportsToKeysFromTrusted(
                         targets = groups.usersWithoutEose.toHexSet(),
                         trustedAccounts = trustedAccounts,
                         relay = relay,
                         since = null,
+                        accountPubKey = accountPubKey,
                     ),
-                    filterContactCardsToTargetKeysFromTrustedAccountsInTheRelay(
-                        accountPubKey = soleAccountPubKey,
+                    filterReportsToKeysFromTrusted(
                         targets = groups.usersWithEose.toHexSet(),
                         trustedAccounts = trustedAccounts,
                         relay = relay,
                         since = findMinimumEOSEsForUsers(groups.usersWithEose, relay),
+                        accountPubKey = accountPubKey,
                     ),
                 )
             }
@@ -136,7 +118,7 @@ class UserCardsSubAssembler(
             targetUsers.groupBy { user ->
                 relay in
                     user
-                        .cards()
+                        .reports()
                         .latestEOSEs.relayList.keys
             }
 
@@ -153,7 +135,7 @@ class UserCardsSubAssembler(
         var min: MutableTime? = null
 
         users.forEach {
-            val eose = it.cards().latestEOSEs.since()[relay]
+            val eose = it.reports().latestEOSEs.since()[relay]
             if (min != null && eose != null) {
                 min.updateIfOlder(eose.time)
             } else if (eose != null) {

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/watchers/UserWatcherSubAssembler.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayClient/user/watchers/UserWatcherSubAssembler.kt
@@ -18,14 +18,13 @@
  * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.watchers
+package com.vitorpamplona.amethyst.commons.relayClient.user.watchers
 
-import com.vitorpamplona.amethyst.commons.defaults.DefaultIndexerRelayList
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.commons.relayClient.eoseManagers.BaseEoseManager
-import com.vitorpamplona.amethyst.model.LocalCache
-import com.vitorpamplona.amethyst.model.User
-import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinderQueryState
-import com.vitorpamplona.amethyst.service.relays.EOSEAccountFast
+import com.vitorpamplona.amethyst.commons.relayClient.user.UserFinderQueryState
+import com.vitorpamplona.amethyst.commons.relays.EOSEAccountFast
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.RelayOfflineTracker
@@ -37,7 +36,7 @@ import com.vitorpamplona.quartz.utils.TimeUtils
 
 class UserWatcherSubAssembler(
     client: INostrClient,
-    val cache: LocalCache,
+    val cache: ICacheProvider,
     val failureTracker: RelayOfflineTracker,
     allKeys: () -> Set<UserFinderQueryState>,
 ) : BaseEoseManager<UserFinderQueryState>(client, allKeys) {
@@ -100,20 +99,18 @@ class UserWatcherSubAssembler(
         // account and the users are whoever is on screen, so with several askers none of them owns it.
         val soleAccountPubKey =
             keys
-                .mapTo(mutableSetOf()) { it.account.userProfile().pubkeyHex }
+                .mapTo(mutableSetOf()) { it.account.userFinderPubkeyHex }
                 .singleOrNull()
 
         val indexRelays = mutableSetOf<NormalizedRelayUrl>()
         keys.mapTo(mutableSetOf()) { it.account }.forEach {
-            indexRelays.addAll(
-                it.indexerRelayList.flow.value
-                    .ifEmpty { DefaultIndexerRelayList },
-            )
+            indexRelays.addAll(it.indexRelays())
         }
 
         val newFilters =
             filterUserMetadataForKey(
                 users,
+                cache.relayHints,
                 indexRelays,
                 failureTracker.cannotConnectRelays,
                 latestEOSEs,

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relays/EOSEAccountFast.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relays/EOSEAccountFast.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.relays
+
+import androidx.collection.LruCache
+import com.vitorpamplona.amethyst.commons.util.KmpLock
+import com.vitorpamplona.amethyst.commons.util.withLock
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+
+/**
+ * Per-key EOSE tracker keyed by an arbitrary [T] (a `User`, a pubkey, …), used
+ * by the relay-subscription assemblers to remember which relays already EOSE'd
+ * for a given key so the next filter assembly can add a `since` and avoid a full
+ * re-download.
+ *
+ * KMP-pure: uses [KmpLock] instead of `synchronized(...)` so it compiles for the
+ * iOS targets `commons` builds for. Moved out of `amethyst.service.relays` so the
+ * shared user/event finder assemblers can live in `commonMain`. The old location
+ * keeps a `typealias` for source compatibility.
+ */
+class EOSEAccountFast<T : Any>(
+    cacheSize: Int = 20,
+) {
+    private val users: LruCache<T, EOSERelayList> = LruCache(cacheSize)
+    private val lock = KmpLock()
+
+    fun addOrUpdate(
+        user: T,
+        relayUrl: NormalizedRelayUrl,
+        time: Long,
+    ) {
+        lock.withLock {
+            val relayList = users[user]
+            if (relayList == null) {
+                val newList = EOSERelayList()
+                users.put(user, newList)
+
+                newList.addOrUpdate(relayUrl, time)
+            } else {
+                relayList.addOrUpdate(relayUrl, time)
+            }
+        }
+    }
+
+    fun removeEveryoneBut(list: Set<T>) {
+        lock.withLock {
+            users.snapshot().forEach {
+                if (it.key !in list) {
+                    users.remove(it.key)
+                }
+            }
+        }
+    }
+
+    fun removeDataFor(user: T) {
+        lock.withLock {
+            users.remove(user)
+        }
+    }
+
+    fun since(key: T): SincePerRelayMap? =
+        lock.withLock {
+            users[key]?.relayList?.toMutableMap()
+        }
+
+    fun sinceRelaySet(key: T): Set<NormalizedRelayUrl>? =
+        lock.withLock {
+            users[key]?.relayList?.keys?.toSet()
+        }
+
+    fun newEose(
+        user: T,
+        relayUrl: NormalizedRelayUrl,
+        time: Long,
+    ) = addOrUpdate(user, relayUrl, time)
+}

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/UserSearchCard.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/components/UserSearchCard.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontFamily
@@ -39,6 +40,7 @@ import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
 import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.relayClient.user.observeUserInfo
 import com.vitorpamplona.amethyst.commons.resources.Res
 import com.vitorpamplona.amethyst.commons.resources.accessibility_navigate
 import com.vitorpamplona.amethyst.commons.resources.accessibility_user_avatar
@@ -51,6 +53,12 @@ import org.jetbrains.compose.resources.stringResource
  * @param badge Optional overlay drawn on top of the avatar (bottom-right
  *   by convention). Used by Desktop for the WoT trust-score chip; Android
  *   call sites leave it null. Forwarded to [UserAvatar].
+ *
+ * Loads the user's kind-0 metadata only while the card is composed via
+ * [observeUserInfo], so a search-results list only fetches metadata for the
+ * users currently on screen (coalesced into the shared finder's batched REQs).
+ * Requires [LocalUserFinder]/[LocalUserFinderAccount] in scope — provided at
+ * the Desktop logged-in roots; this card is Desktop-only.
  */
 @Composable
 fun UserSearchCard(
@@ -59,6 +67,8 @@ fun UserSearchCard(
     modifier: Modifier = Modifier,
     badge: @Composable (BoxScope.() -> Unit)? = null,
 ) {
+    val metadata by observeUserInfo(user)
+
     Card(
         modifier =
             modifier
@@ -76,7 +86,7 @@ fun UserSearchCard(
         ) {
             UserAvatar(
                 userHex = user.pubkeyHex,
-                pictureUrl = user.profilePicture(),
+                pictureUrl = metadata?.info?.picture ?: user.profilePicture(),
                 size = 40.dp,
                 contentDescription = stringResource(Res.string.accessibility_user_avatar),
                 badge = badge,
@@ -84,11 +94,11 @@ fun UserSearchCard(
 
             Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    user.toBestDisplayName(),
+                    metadata?.info?.bestName() ?: user.toBestDisplayName(),
                     style = MaterialTheme.typography.titleSmall,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
-                val nip05 = user.metadataOrNull()?.nip05()
+                val nip05 = metadata?.info?.nip05 ?: user.metadataOrNull()?.nip05()
                 if (nip05 != null) {
                     Text(
                         nip05,

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/ThreadAssemblerTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/ThreadAssemblerTest.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.quartz.nip01Core.core.Address
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.hints.HintIndexer
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
 import com.vitorpamplona.quartz.nip22Comments.CommentEvent
 import com.vitorpamplona.quartz.nip25Reactions.ReactionEvent
@@ -172,6 +173,8 @@ class ThreadAssemblerTest {
         private val notesById: Map<HexKey, Note>,
     ) : ICacheProvider {
         override fun getAnyChannel(note: Note): Channel? = null
+
+        override val relayHints = HintIndexer()
 
         override fun getUserIfExists(pubkey: HexKey): User? = null
 

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/concord/ConcordChannelListLeaveTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/concord/ConcordChannelListLeaveTest.kt
@@ -33,6 +33,7 @@ import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.hexToByteArray
 import com.vitorpamplona.quartz.nip01Core.crypto.KeyPair
+import com.vitorpamplona.quartz.nip01Core.hints.HintIndexer
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -81,6 +82,8 @@ class ConcordChannelListLeaveTest {
 
     private class StubCache : ICacheProvider {
         override fun getAnyChannel(note: Note): Channel? = null
+
+        override val relayHints = HintIndexer()
 
         override fun getUserIfExists(pubkey: HexKey): User? = null
 

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/concord/ConcordListLateArrivalTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/concord/ConcordListLateArrivalTest.kt
@@ -33,6 +33,7 @@ import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.hexToByteArray
 import com.vitorpamplona.quartz.nip01Core.crypto.KeyPair
+import com.vitorpamplona.quartz.nip01Core.hints.HintIndexer
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -79,6 +80,8 @@ class ConcordListLateArrivalTest {
         private val notes = HashMap<String, AddressableNote>()
 
         override fun getAnyChannel(note: Note): Channel? = null
+
+        override val relayHints = HintIndexer()
 
         override fun getUserIfExists(pubkey: HexKey): User? = null
 

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/ui/note/ReplyContextTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/ui/note/ReplyContextTest.kt
@@ -29,6 +29,7 @@ import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.quartz.nip01Core.core.Address
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.hints.HintIndexer
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -112,6 +113,8 @@ class ReplyContextTest {
         private val users: Map<HexKey, User> = emptyMap(),
     ) : ICacheProvider {
         override fun getAnyChannel(note: Note): Channel? = null
+
+        override val relayHints = HintIndexer()
 
         override fun getUserIfExists(pubkey: HexKey): User? = users[pubkey]
 

--- a/commons/src/jvmTest/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/EventFinderFilterAssemblyTest.kt
+++ b/commons/src/jvmTest/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/EventFinderFilterAssemblyTest.kt
@@ -20,18 +20,22 @@
  */
 package com.vitorpamplona.amethyst.commons.relayClient.event
 
+import com.vitorpamplona.amethyst.commons.model.AddressableNote
 import com.vitorpamplona.amethyst.commons.model.Channel
 import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.amethyst.commons.model.User
 import com.vitorpamplona.amethyst.commons.model.cache.ICacheEventStream
 import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.amethyst.commons.relayClient.event.loaders.filterMissingEvents
+import com.vitorpamplona.amethyst.commons.relayClient.user.UserFinderAccount
 import com.vitorpamplona.quartz.nip01Core.core.Address
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.hints.HintIndexer
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip85TrustedAssertions.list.tags.ServiceProviderTag
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -74,6 +78,43 @@ class EventFinderFilterAssemblyTest {
     }
 
     /**
+     * The per-note event finder fans a missing event out to the account's own
+     * search relays ([UserFinderAccount.searchOnlyRelays]) plus the
+     * follow/mine/search default — NOT the trusted-relay union that
+     * [UserFinderAccount.searchRelays] adds. Regression guard for reusing the
+     * wrong getter here (which would silently widen every missing-event REQ to
+     * trusted relays).
+     */
+    @Test
+    fun `filterMissingEvents(keys) uses searchOnlyRelays, not the trusted searchRelays union`() {
+        val searchOnly = NormalizedRelayUrl("wss://search.test/")
+        val trustedExtra = NormalizedRelayUrl("wss://trusted.test/") // only in searchRelays()
+        val default = NormalizedRelayUrl("wss://default.test/") // followPlusAllMineWithSearchRelays()
+
+        val account =
+            object : StubAccount() {
+                override fun searchOnlyRelays() = setOf(searchOnly)
+
+                override fun searchRelays() = setOf(searchOnly, trustedExtra)
+
+                override fun followPlusAllMineWithSearchRelays() = setOf(default)
+            }
+
+        // event == null and not addressable → a "missing event"; no author/replies,
+        // and the stub cache has empty relay hints, so potentialRelaysToFindEvent is
+        // empty and the code falls back to the default relays + searchOnlyRelays.
+        val note = Note("a".repeat(64))
+
+        val filters = filterMissingEvents(StubCache(), listOf(EventFinderQueryState(note, account)))
+        val relays = filters.map { it.relay }.toSet()
+
+        assertTrue("search-only relay carries the missing-event REQ", searchOnly in relays)
+        assertTrue("follow/mine/search default carries it", default in relays)
+        assertFalse("trusted relay (only in searchRelays) must NOT be fanned out to", trustedExtra in relays)
+        filters.forEach { assertEquals(listOf(note.idHex), it.filter.ids) }
+    }
+
+    /**
      * The new default [ICacheProvider.checkGetOrCreateUser] must swallow a
      * malformed-key throw and return null (the event-finder follows pubkey hints
      * parsed out of arbitrary events, some of which are junk).
@@ -106,7 +147,7 @@ class EventFinderFilterAssemblyTest {
 
         override fun checkGetOrCreateNote(hexKey: HexKey): Note? = null
 
-        override fun getOrCreateAddressableNote(key: Address): com.vitorpamplona.amethyst.commons.model.AddressableNote = error("unused")
+        override fun getOrCreateAddressableNote(key: Address): AddressableNote = error("unused")
 
         override fun getEventStream(): ICacheEventStream = error("unused")
 
@@ -115,5 +156,30 @@ class EventFinderFilterAssemblyTest {
         override fun getOrCreateUser(pubkey: HexKey): User? = null
 
         override fun justConsumeMyOwnEvent(event: Event): Boolean = false
+    }
+
+    /** Minimal [UserFinderAccount] returning nothing; override the relevant getters per test. */
+    private open class StubAccount : UserFinderAccount {
+        override val userFinderPubkeyHex: HexKey = "00".repeat(32)
+
+        override fun indexRelays(): Set<NormalizedRelayUrl> = emptySet()
+
+        override fun outboxHomeRelays(): Set<NormalizedRelayUrl> = emptySet()
+
+        override fun searchRelays(): Set<NormalizedRelayUrl> = emptySet()
+
+        override fun searchOnlyRelays(): Set<NormalizedRelayUrl> = emptySet()
+
+        override fun followPlusAllMineWithSearchRelays(): Set<NormalizedRelayUrl> = emptySet()
+
+        override fun commonRelays(): Set<NormalizedRelayUrl> = emptySet()
+
+        override fun cardHomeRelays(): Set<NormalizedRelayUrl> = emptySet()
+
+        override fun trustProvider(): ServiceProviderTag? = null
+
+        override fun followerCountProvider(): ServiceProviderTag? = null
+
+        override fun declaredFollowsByOutboxRelay(): Map<NormalizedRelayUrl, Set<HexKey>> = emptyMap()
     }
 }

--- a/commons/src/jvmTest/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/EventFinderFilterAssemblyTest.kt
+++ b/commons/src/jvmTest/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/EventFinderFilterAssemblyTest.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.relayClient.event
+
+import com.vitorpamplona.amethyst.commons.model.Channel
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheEventStream
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+import com.vitorpamplona.amethyst.commons.relayClient.event.loaders.filterMissingEvents
+import com.vitorpamplona.quartz.nip01Core.core.Address
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.hints.HintIndexer
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the extracted (Phase 2b) per-note event-finder filter assembly
+ * and the [ICacheProvider] seam it relies on.
+ */
+class EventFinderFilterAssemblyTest {
+    private val relay1 = NormalizedRelayUrl("wss://relay1.test/")
+    private val relay2 = NormalizedRelayUrl("wss://relay2.test/")
+
+    /**
+     * One batched `ids` filter per relay — NOT one filter per event id — and the
+     * ids are sorted deterministically so REQs dedup across rebuilds.
+     */
+    @Test
+    fun `filterMissingEvents batches one filter per relay with sorted ids`() {
+        val filters =
+            filterMissingEvents(
+                mapOf(
+                    relay1 to setOf("bbbb", "aaaa", "cccc"),
+                    relay2 to setOf("dddd"),
+                ),
+            )
+
+        assertEquals("one batched filter per relay", 2, filters.size)
+
+        val r1 = filters.first { it.relay == relay1 }
+        assertEquals(listOf("aaaa", "bbbb", "cccc"), r1.filter.ids)
+
+        val r2 = filters.first { it.relay == relay2 }
+        assertEquals(listOf("dddd"), r2.filter.ids)
+    }
+
+    @Test
+    fun `filterMissingEvents skips relays with no ids and empty input`() {
+        assertTrue(filterMissingEvents(emptyMap()).isEmpty())
+        assertTrue(filterMissingEvents(mapOf(relay1 to emptySet())).isEmpty())
+    }
+
+    /**
+     * The new default [ICacheProvider.checkGetOrCreateUser] must swallow a
+     * malformed-key throw and return null (the event-finder follows pubkey hints
+     * parsed out of arbitrary events, some of which are junk).
+     */
+    @Test
+    fun `checkGetOrCreateUser tolerates a throwing getOrCreateUser`() {
+        val throwing =
+            object : StubCache() {
+                override fun getOrCreateUser(pubkey: HexKey): User? = throw IllegalArgumentException("bad key")
+            }
+        assertNull(throwing.checkGetOrCreateUser("not-a-key"))
+    }
+
+    @Test
+    fun `checkGetOrCreateUser passes through a null result`() {
+        assertNull(StubCache().checkGetOrCreateUser("00"))
+    }
+
+    /** Minimal [ICacheProvider] that returns nothing; override per test. */
+    private open class StubCache : ICacheProvider {
+        override val relayHints = HintIndexer()
+
+        override fun getAnyChannel(note: Note): Channel? = null
+
+        override fun getUserIfExists(pubkey: HexKey): User? = null
+
+        override fun countUsers(predicate: (String, User) -> Boolean): Int = 0
+
+        override fun getNoteIfExists(hexKey: HexKey): Note? = null
+
+        override fun checkGetOrCreateNote(hexKey: HexKey): Note? = null
+
+        override fun getOrCreateAddressableNote(key: Address): com.vitorpamplona.amethyst.commons.model.AddressableNote = error("unused")
+
+        override fun getEventStream(): ICacheEventStream = error("unused")
+
+        override fun hasBeenDeleted(event: Any): Boolean = false
+
+        override fun getOrCreateUser(pubkey: HexKey): User? = null
+
+        override fun justConsumeMyOwnEvent(event: Event): Boolean = false
+    }
+}

--- a/desktopApp/plans/2026-08-06-shared-metadata-loading-upstream-reconciliation-plan.md
+++ b/desktopApp/plans/2026-08-06-shared-metadata-loading-upstream-reconciliation-plan.md
@@ -1,0 +1,110 @@
+# Shared Metadata Loading — Upstream Reconciliation Plan
+*Redo the commons extraction of the per-user metadata finder and per-note event finder on top of current `upstream/main`, abandoning the stale rebase of `worktree-plan-shared-metadata-loading` (`682c6000f5`).*
+
+## 0. Executive summary of what changed under us
+
+Upstream re-architected the same subsystem but **also completed the model-sharing prerequisite we depended on**:
+
+- `amethyst.model.User`, `UserContext`, `Note` are now **typealiases** to `commons.model.*` (`amethyst/model/User.kt`). `SincePerRelayMap`, `MutableTime`, `EOSERelayList` are typealiases to `commons.relays.*` (`amethyst/service/relays/EOSE.kt`). Finder bodies are already type-compatible with commonMain.
+- `LocalCache` is an `object` implementing `commons.model.cache.ICacheProvider` (exposes `getUserIfExists`, `getNoteIfExists`, `getOrCreateUser`, `relayHints`, …). The finders call exactly these.
+- **Two new cross-cutting mechanisms**:
+  1. `AccountScopedQuery { val account: amethyst.model.Account }` — implemented by `UserFinderQueryState`/`EventFinderQueryState` so base managers can attribute subscriptions to an account.
+  2. `ExplainedFilter`/`SubPurpose` (already in commons) — every emitted filter is tagged with its purpose.
+
+**Most important finding:** the base **commons** managers never read `.account`. Attribution lives in *amethyst-side* managers (`PerUserEoseManager`, `PerUniqueIdEoseManager`, …) and each reads exactly `(key as? AccountScopedQuery)?.account?.userProfile()?.pubkeyHex` — **only a pubkey hex**. AND the four finder sub-assemblers extend the **commons** base managers, not the amethyst attribution managers — they attribute *inline* by computing `soleAccountPubKey` and passing `accountPubKeys` into their `ExplainedFilter`s. So the finders do not depend on the amethyst attribution managers; they need only a pubkey.
+
+## A. Map of upstream's current subsystem
+
+### User side — `amethyst/.../reqCommand/user/`
+- `UserFinderFilterAssembler.kt` — `UserFinderQueryState(user, override val account: Account) : AccountScopedQuery`; groups `UserOutboxFinderSubAssembler`, `UserWatcherSubAssembler`, `UserReportsSubAssembler`, `UserCardsSubAssembler`.
+- `UserFinderFilterAssemblerSubscription.kt` — composable entry (`(user, accountViewModel)`) + `UserFinderByParentFilterAssemblerSubscription`; uses `AccountViewModel.account`, `dataSources().userFinder`, commons `LifecycleAwareKeyDataSourceSubscription`.
+- `UserObservers.kt` — `observeUser*`.
+- `loaders/UserOutboxFinderSubAssembler.kt` — extends commons `BaseEoseManager`; reads `it.account` → `pickRelaysToLoadUsers(...)`; emits `ExplainedFilter(purpose = RELAY_LISTS, accountPubKeys = listOfNotNull(soleAccountPubKey))`.
+- `watchers/UserWatcherSubAssembler.kt` — commons `BaseEoseManager`; reads `account.indexerRelayList.flow.value`; calls `filterUserMetadataForKey(...)`.
+- `watchers/FilterUserMetadataForKey.kt` — emits `ExplainedFilter(PROFILE_METADATA, …)`; reads `LocalCache.relayHints.hintsForKey(...)` **statically** (the one non-injected cache ref).
+- `watchers/UserReportsSubAssembler.kt` — commons `SingleSubEoseManager`; reads `account.declaredFollowsPerOutboxRelay.value`, `account.userProfile().pubkeyHex`.
+- `watchers/UserCardsSubAssembler.kt` — commons `SingleSubEoseManager`; reads `account.homeRelays.flow.value`, `account.trustProviderList.liveUserRankProvider`, `…liveUserFollowerCount`, `account.userProfile().pubkeyHex`; emits `filterContactCardsToTargetKeysFromTrustedAccountsInTheRelay(...)` (already in commons `assemblers/ContactCardFilters.kt`).
+
+### Event side — `amethyst/.../reqCommand/event/`
+- `EventFinderFilterAssembler.kt` — `EventFinderQueryState(note, override val account: Account) : AccountScopedQuery`; groups `NoteEventLoaderSubAssembler`, `EventWatcherSubAssembler`, `AddressableAuthorRelayLoaderSubAssembler(cache, ::allKeys, userFinder)`.
+- `EventFinderFilterAssemblerSubscription.kt` — reads `accountViewModel.account`, `dataSources().eventFinder`.
+- `EventObservers.kt` — `observeNote*` (one UI-only spot reads `accountViewModel.account.userProfile().pubkeyHex` for a moderator check).
+- `loaders/NoteEventLoaderSubAssembler.kt`; `loaders/FilterMissingEvents.kt` (reads `key.account.followPlusAllMineWithSearch.flow.value`, `key.account.searchRelayList.flow.value`; `SubPurpose.REFERENCED_EVENTS`); `loaders/FilterMissingAddressables.kt` (`REFERENCED_EVENTS`).
+- `loaders/AddressableAuthorRelayLoaderSubAssembler.kt` — constructs `UserFinderQueryState(author, key.account)`.
+- `watchers/EventWatcherSubAssembler.kt` — commons `SingleSubEoseManager`; reads `it.account.userProfile().pubkeyHex` (attribution only); calls `filterRepliesAndReactionsToNotes/Addresses(...)`.
+- `watchers/FilterRepliesAndReactionsToNotes.kt`, `FilterRepliesAndReactionsToAddresses.kt` — emit `ExplainedFilter(ENGAGEMENT, …)`.
+
+### Base managers and attribution
+- commons `BaseEoseManager`, `PerKeyEoseManager`, `SingleSubEoseManager` — **account-agnostic**.
+- amethyst `PerUserEoseManager`, `PerUniqueIdEoseManager`, `PerUserAndFollowListEoseManager`, `SingleSubNoEoseCacheEoseManager` — do `f.attributedTo(pk)` where `pk = (key as? AccountScopedQuery).account.userProfile().pubkeyHex`. The finder sub-assemblers do NOT use these; they attribute inline.
+- `ExplainedFilter.attributedTo(accountPubKey: HexKey)`; `SubPurpose`/`SubPurposeGroup` — commonMain.
+
+## B. Account-seam decision — CHOSEN
+
+**Keep `UserFinderAccount` as the narrow commons seam, carrying the attribution pubkey via `userFinderPubkeyHex`. Do NOT move `AccountScopedQuery` to commons. Drop `AccountScopedQuery` from the two finder query states.**
+
+Justification (grounded in code):
+1. Attribution reduces to `.userProfile().pubkeyHex` — a `HexKey`, already on `UserFinderAccount.userFinderPubkeyHex`.
+2. The loaders' account reads are all snapshot relay-hint / follow-graph getters — exactly the `UserFinderAccount` surface (+2 additions).
+3. `AccountScopedQuery` is declared over `amethyst.model.Account` and implemented by ~66 amethyst query states — can't move without dragging `Account`.
+4. The finder query states never flow through the amethyst attribution managers, so they don't need `AccountScopedQuery` at all → dropping it removes the collision.
+
+Seam shape (commons `UserFinderAccount`), = our old branch + 2 additions:
+```kotlin
+interface UserFinderAccount {
+    val userFinderPubkeyHex: HexKey            // attribution pubkey → ExplainedFilter.accountPubKeys
+    fun indexRelays(): Set<NormalizedRelayUrl>
+    fun outboxHomeRelays(): Set<NormalizedRelayUrl>
+    fun searchRelays(): Set<NormalizedRelayUrl>
+    fun followPlusAllMineWithSearchRelays(): Set<NormalizedRelayUrl>
+    fun commonRelays(): Set<NormalizedRelayUrl>
+    fun cardHomeRelays(): Set<NormalizedRelayUrl>
+    fun trustProvider(): ServiceProviderTag?
+    fun followerCountProvider(): ServiceProviderTag?   // NEW (UserCards reads liveUserFollowerCount)
+    fun declaredFollowsByOutboxRelay(): Map<NormalizedRelayUrl, Set<HexKey>>
+}
+```
+`EventFinderQueryState` reuses `UserFinderAccount` (needs only follow+search relays + pubkey). Attribution: `soleAccountPubKey = keys.map { it.account.userFinderPubkeyHex }.singleOrNull()` → `accountPubKeys = listOfNotNull(soleAccountPubKey)`.
+
+## C. SubPurpose mapping (preserve upstream tags across the move)
+
+| Moved helper | SubPurpose |
+|---|---|
+| `FilterUserMetadataForKey` (kind 0 bundle) | `PROFILE_METADATA` (runsInBackground) |
+| `UserOutboxFinderSubAssembler` | `RELAY_LISTS` |
+| `UserCardsSubAssembler` → `ContactCardFilters` (already commons) | unchanged |
+| `UserReportsSubAssembler` → `filterReportsToKeysFromTrusted` | `MODERATION` |
+| `EventWatcherSubAssembler` → replies/reactions | `ENGAGEMENT` |
+| `NoteEventLoader` → `FilterMissingEvents/Addressables` | `REFERENCED_EVENTS` |
+
+`ExplainedFilter`/`SubPurpose`/`attributedTo`/`ContactCardFilters` are already commonMain + iOS-pure. Only change: `accountPubKeys` sourced from `userFinderPubkeyHex`.
+
+## D. Portable-unchanged vs must-rework
+
+**Unchanged (body identical after package move + seam swap):** the filter builders (`FilterUserMetadataForKey`, `FilterReportsToKey`, `FilterMissingEvents/Addressables`, `FilterRepliesAndReactionsToNotes/Addresses`), `observeUser*`/`observeNote*`, `UserFinderAccount` + CompositionLocals, `pickRelaysToLoadUsers` inner overload.
+
+**Must rework:**
+1. **Move `EOSEAccountFast<T>`** (`amethyst/service/relays/EOSE.kt`) to commons `relays/` + amethyst typealias — prereq for the loaders. (Purity risk: verify no `System.currentTimeMillis`/`Thread.sleep`.)
+2. **`LocalCache.relayHints` static ref** in `FilterUserMetadataForKey` → injected `cache.relayHints` (add `val relayHints: HintIndexer` to `ICacheProvider`; LocalCache already has it).
+3. **Account-seam swap** across the four user sub-assemblers + event loaders/watchers (getter-for-flow mapping listed in §B).
+4. **`pickRelaysToLoadUsers`** — feed commons inner overload from `UserFinderAccount` getters (amethyst keeps a thin `Account`→relay-set wrapper).
+5. **Drop `AccountScopedQuery`** from the two finder query states (verified no amethyst attribution manager consumes them).
+6. `AddressableAuthorRelayLoaderSubAssembler` — `UserFinderQueryState(author, key.account)` now takes `UserFinderAccount`. Clean.
+
+**Desktop wiring (Phase 3/3b old plan) — unaffected:** `observeUser*`, `EventFinderFilterAssemblerSubscription(note)`, Locals, DM/search/notifications adoption, fast index-relay warm-up. `DesktopIAccount` adds `followerCountProvider() = null` (already degrades trust/declaredFollows).
+
+## E. Phase / commit sequence (fresh branch `feat/shared-metadata-loading-v2` off `upstream/main`)
+
+Cherry-pick *content*, not commits. Gates after each commons/amethyst commit: `:commons:verifyKmpPurity`, `:amethyst:compilePlayDebugKotlin`, `:commons:compileKotlinJvm` + `:desktopApp:compileKotlinJvm`.
+
+- **Phase 0 — prereqs:** (0a) move `EOSEAccountFast` → commons + typealias; (0b) add `relayHints` to `ICacheProvider`.
+- **Phase 1 — seam:** (1a) add commons `UserFinderAccount` (+`followerCountProvider()`); (1b) `Account implements UserFinderAccount`.
+- **Phase 2 — user finder → commons:** (2a) filter builders + `pickRelaysToLoadUsers` inner; (2b) the 4 sub-assemblers; (2c) `UserFinderFilterAssembler`+`UserFinderQueryState` (drop `AccountScopedQuery`) + amethyst typealias shim + commons `UserFinderSubscription`/Locals; keep composable subscription in amethyst delegating.
+- **Phase 3 — event finder → commons:** (3a) filter builders; (3b) loaders/watchers + addressable bridge; (3c) assembler+state (drop `AccountScopedQuery`) + shim + `LocalEventFinder` + `observeNote*` to commons.
+- **Phase 4 — Desktop wiring:** (4a) `DesktopIAccount implements UserFinderAccount`; (4b) provide Locals in `Main.kt`, wire DM/search/notifications + warm-up onto `observeUser*`/`EventFinderFilterAssemblerSubscription`.
+- **Phase 5 — cleanup & tests:** delete dead originals; run `ExplainedFilterTest` + finder tests + full `:commons:check`.
+
+### Risk callouts
+- `EOSEAccountFast` purity is the likeliest `verifyKmpPurity` tripwire.
+- Preserve inline `soleAccountPubKey` attribution so "Active Relay Subscriptions" still files single-account REQs correctly (and shows "not attributed" when accounts pool relays — don't regress to per-account splitting).
+- Do NOT re-introduce `AccountScopedQuery` on the two finder states; if a future upstream manager consumes them, add a thin amethyst adapter instead of widening the commons seam.

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/Main.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/Main.kt
@@ -81,8 +81,11 @@ import com.vitorpamplona.amethyst.commons.moderation.PreferencesHashtagSpamSetti
 import com.vitorpamplona.amethyst.commons.moderation.notifications.PreferencesNotificationReadState
 import com.vitorpamplona.amethyst.commons.moderation.notifications.PreferencesNotificationSettings
 import com.vitorpamplona.amethyst.commons.relayClient.auth.AuthApprovalBanner
+import com.vitorpamplona.amethyst.commons.relayClient.event.LocalEventFinder
 import com.vitorpamplona.amethyst.commons.relayClient.nip17Dm.DmInboxRelayResolver
 import com.vitorpamplona.amethyst.commons.relayClient.nip17Dm.unwrapAndUnsealOrNull
+import com.vitorpamplona.amethyst.commons.relayClient.user.LocalUserFinder
+import com.vitorpamplona.amethyst.commons.relayClient.user.LocalUserFinderAccount
 import com.vitorpamplona.amethyst.commons.scheduledposts.ScheduledPostStatus
 import com.vitorpamplona.amethyst.commons.wot.LocalWoTReady
 import com.vitorpamplona.amethyst.commons.wot.LocalWoTService
@@ -1470,6 +1473,9 @@ private fun AppInner(
                                 LocalNamecoinService provides namecoinService,
                                 LocalSpamExemptKeys provides spamExemptKeys,
                                 com.vitorpamplona.amethyst.desktop.model.LocalDesktopIAccount provides iAccount,
+                                LocalUserFinder provides subscriptionsCoordinator.userFinder,
+                                LocalUserFinderAccount provides iAccount,
+                                LocalEventFinder provides subscriptionsCoordinator.eventFinder,
                             ) {
                                 val pendingAuthApprovals by authCoordinator.pendingApprovals.collectAsState()
                                 Column(modifier = Modifier.fillMaxSize()) {
@@ -2114,6 +2120,9 @@ fun MainContent(
         LocalRelayCategories provides relayCategories,
         LocalBlossomServers provides iAccount.blossomServerList.flow,
         com.vitorpamplona.amethyst.desktop.model.LocalDesktopIAccount provides iAccount,
+        LocalUserFinder provides subscriptionsCoordinator.userFinder,
+        LocalUserFinderAccount provides iAccount,
+        LocalEventFinder provides subscriptionsCoordinator.eventFinder,
         com.vitorpamplona.amethyst.desktop.ui.LocalSnackbarHost provides snackbarHostState,
         com.vitorpamplona.amethyst.desktop.ui.relay.LocalAccountRelays provides accountRelays,
         com.vitorpamplona.amethyst.desktop.ui.deck.LocalDesktopCache provides localCache,

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/cache/DesktopLocalCache.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/cache/DesktopLocalCache.kt
@@ -35,6 +35,7 @@ import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.crypto.checkSignature
 import com.vitorpamplona.quartz.nip01Core.crypto.verify
+import com.vitorpamplona.quartz.nip01Core.hints.HintIndexer
 import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.tags.aTag.taggedAddresses
@@ -89,6 +90,9 @@ class DesktopLocalCache : ICacheProvider {
     val notes = LargeSoftCache<HexKey, Note>()
     val addressableNotes = LargeSoftCache<String, AddressableNote>()
     private val deletedEvents = ConcurrentHashMap.newKeySet<HexKey>()
+
+    /** NIP-hints index accumulated from consumed events (event/address/pubkey → relay). */
+    override val relayHints = HintIndexer()
 
     val eventStream = DesktopCacheEventStream()
 

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/model/DesktopIAccount.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/model/DesktopIAccount.kt
@@ -35,6 +35,7 @@ import com.vitorpamplona.amethyst.commons.model.nipB7Blossom.BlossomServerListSt
 import com.vitorpamplona.amethyst.commons.model.privateChats.ChatroomList
 import com.vitorpamplona.amethyst.commons.moderation.PreferencesSensitiveContentSettings
 import com.vitorpamplona.amethyst.commons.relayClient.nip17Dm.DmInboxRelayResolver
+import com.vitorpamplona.amethyst.commons.relayClient.user.UserFinderAccount
 import com.vitorpamplona.amethyst.desktop.account.AccountState
 import com.vitorpamplona.amethyst.desktop.cache.DesktopLocalCache
 import com.vitorpamplona.amethyst.desktop.network.RelayConnectionManager
@@ -64,6 +65,7 @@ import com.vitorpamplona.quartz.nip57Zaps.IPrivateZapsDecryptionCache
 import com.vitorpamplona.quartz.nip57Zaps.PrivateZapCache
 import com.vitorpamplona.quartz.nip59Giftwrap.wraps.GiftWrapEvent
 import com.vitorpamplona.quartz.nip65RelayList.AdvertisedRelayListEvent
+import com.vitorpamplona.quartz.nip85TrustedAssertions.list.tags.ServiceProviderTag
 import com.vitorpamplona.quartz.nip89AppHandlers.clientTag.NostrSignerWithClientTag
 import com.vitorpamplona.quartz.utils.DualCase
 import kotlinx.coroutines.CoroutineScope
@@ -92,10 +94,41 @@ class DesktopIAccount(
     private val scope: CoroutineScope,
     private val accountRelays: DesktopAccountRelays? = null,
     val dmInboxResolver: DmInboxRelayResolver? = null,
-) : IAccount {
+) : IAccount,
+    UserFinderAccount {
     override val signer: NostrSigner = NostrSignerWithClientTag(accountState.signer, CLIENT_TAG_NAME)
 
     override val pubKey: String = accountState.pubKeyHex
+
+    // UserFinderAccount — Desktop's relay-hint view for the shared per-user
+    // metadata subscription layer. Desktop has no separate indexer/search relay
+    // lists nor a NIP-85 trust provider, so it routes discovery through its
+    // connected relays + NIP-65 outbox and degrades trust/reports to null/empty
+    // (contact-card ranking + report loading are best-effort here — see
+    // UserFinderAccount).
+    override val userFinderPubkeyHex: HexKey get() = pubKey
+
+    override fun indexRelays(): Set<NormalizedRelayUrl> = relayManager.connectedRelays.value
+
+    override fun outboxHomeRelays(): Set<NormalizedRelayUrl> = nip65RelayList.allFlowNoDefaults.value + relayManager.connectedRelays.value
+
+    override fun searchRelays(): Set<NormalizedRelayUrl> = relayManager.connectedRelays.value
+
+    // Desktop has no merged follow/mine/search relay-list subsystem; route
+    // missing-event discovery through the connected relays (same degrade path
+    // as the other hints above).
+    override fun followPlusAllMineWithSearchRelays(): Set<NormalizedRelayUrl> = relayManager.connectedRelays.value
+
+    override fun commonRelays(): Set<NormalizedRelayUrl> = relayManager.connectedRelays.value
+
+    override fun cardHomeRelays(): Set<NormalizedRelayUrl> = nip65RelayList.allFlowNoDefaults.value
+
+    override fun trustProvider(): ServiceProviderTag? = null
+
+    // Desktop has no NIP-85 rank/follower providers wired (same as trustProvider).
+    override fun followerCountProvider(): ServiceProviderTag? = null
+
+    override fun declaredFollowsByOutboxRelay(): Map<NormalizedRelayUrl, Set<HexKey>> = emptyMap()
 
     // ----- State Classes (pin important notes via strong refs for GC retention) -----
 

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/model/DesktopIAccount.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/model/DesktopIAccount.kt
@@ -114,6 +114,9 @@ class DesktopIAccount(
 
     override fun searchRelays(): Set<NormalizedRelayUrl> = relayManager.connectedRelays.value
 
+    // Desktop has no separate NIP-51 search relay list; degrade to connected relays.
+    override fun searchOnlyRelays(): Set<NormalizedRelayUrl> = relayManager.connectedRelays.value
+
     // Desktop has no merged follow/mine/search relay-list subsystem; route
     // missing-event discovery through the connected relays (same degrade path
     // as the other hints above).

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/subscriptions/DesktopRelaySubscriptionsCoordinator.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/subscriptions/DesktopRelaySubscriptionsCoordinator.kt
@@ -22,8 +22,10 @@ package com.vitorpamplona.amethyst.desktop.subscriptions
 
 import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.amethyst.commons.relayClient.assemblers.FeedMetadataCoordinator
+import com.vitorpamplona.amethyst.commons.relayClient.event.EventFinderFilterAssembler
 import com.vitorpamplona.amethyst.commons.relayClient.preload.MetadataPreloader
 import com.vitorpamplona.amethyst.commons.relayClient.preload.MetadataRateLimiter
+import com.vitorpamplona.amethyst.commons.relayClient.user.UserFinderFilterAssembler
 import com.vitorpamplona.amethyst.commons.service.BasicBundledInsert
 import com.vitorpamplona.amethyst.commons.wot.OutboxCacheGateway
 import com.vitorpamplona.amethyst.commons.wot.OutboxDispatcher
@@ -32,6 +34,7 @@ import com.vitorpamplona.amethyst.desktop.model.DesktopDmRelayState
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
+import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.RelayOfflineTracker
 import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.fetchAll
 import com.vitorpamplona.quartz.nip01Core.relay.client.reqs.SubscriptionListener
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
@@ -83,6 +86,32 @@ class DesktopRelaySubscriptionsCoordinator(
     private val indexRelays: Set<NormalizedRelayUrl>,
     private val localCache: DesktopLocalCache,
 ) {
+    /**
+     * Tracks relays that refuse to connect, so the shared user-finder skips
+     * them when picking discovery relays. Self-registers as a client listener.
+     */
+    private val failureTracker = RelayOfflineTracker(client)
+
+    /**
+     * The shared, composition-scoped per-user metadata subscription assembler
+     * (moved to commons). Desktop composables reach it via [LocalUserFinder]
+     * (provided in Main.kt) and subscribe per visible user through
+     * `observeUserPicture(user)` / `observeUserInfo(user)`, so metadata loads
+     * only for on-screen users. Coalesces every subscribed user into batched
+     * REQs — no per-avatar REQ storm.
+     */
+    val userFinder = UserFinderFilterAssembler(client, localCache, failureTracker)
+
+    /**
+     * The shared, composition-scoped per-note event subscription assembler
+     * (reactions / zaps / reposts / replies, moved to commons). Desktop note
+     * rows reach it via [LocalEventFinder] (provided in Main.kt) and subscribe
+     * per visible note through `EventFinderFilterAssemblerSubscription(note)`, so
+     * interactions load only for on-screen notes. Composes [userFinder] to
+     * resolve authors of not-yet-cached addressable notes.
+     */
+    val eventFinder = EventFinderFilterAssembler(client, localCache, userFinder)
+
     // Rate limiter: 20 requests per second to avoid flooding relays
     private val rateLimiter = MetadataRateLimiter(maxRequestsPerSecond = 20, scope = scope)
 

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/FeedScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/FeedScreen.kt
@@ -95,6 +95,10 @@ import com.vitorpamplona.amethyst.commons.model.nip02FollowList.FollowAction
 import com.vitorpamplona.amethyst.commons.model.nip05DnsIdentifiers.namecoin.NamecoinResolveState
 import com.vitorpamplona.amethyst.commons.model.nip25Reactions.ReactionAction
 import com.vitorpamplona.amethyst.commons.nip64Chess.RelaySyncStatus
+import com.vitorpamplona.amethyst.commons.relayClient.event.EventFinderFilterAssemblerSubscription
+import com.vitorpamplona.amethyst.commons.relayClient.user.UserFinderFilterAssemblerSubscription
+import com.vitorpamplona.amethyst.commons.relayClient.user.observeUserName
+import com.vitorpamplona.amethyst.commons.relayClient.user.observeUserPicture
 import com.vitorpamplona.amethyst.commons.richtext.UrlParser
 import com.vitorpamplona.amethyst.commons.search.AdvancedSearchBarState
 import com.vitorpamplona.amethyst.commons.search.QuerySerializer
@@ -268,6 +272,20 @@ private fun FeedNoteCardBody(
     myPubKeyHex: String? = null,
     onFollow: ((String) -> Unit)? = null,
 ) {
+    // Load this note author's metadata (kind 0 + relay lists) only while this
+    // card is composed — i.e. on or near screen. The shared commons finder
+    // coalesces every visible author into batched REQs, giving per-row,
+    // visibility-scoped metadata loading that matches Android's model.
+    val cardAuthor = note.author
+    if (cardAuthor != null) {
+        UserFinderFilterAssemblerSubscription(cardAuthor)
+    }
+
+    // Load this note's interactions (reactions / zaps / reposts / replies) only
+    // while the card is composed — the per-note counterpart to the author
+    // subscription above, coalesced into batched REQs by the shared event finder.
+    EventFinderFilterAssemblerSubscription(note)
+
     if (event is PollEvent) {
         DesktopPollCard(
             note = note,
@@ -751,17 +769,19 @@ fun FeedScreen(
         }
     }
 
-    // Viewport-aware metadata loading: only fetch for visible notes + buffer
-    // Uses snapshotFlow to avoid per-frame recomposition from scroll observation
+    // Fast first-paint warm-up: one batched kind-0 REQ straight to the index
+    // relays for the first visible authors. The per-row UserFinder subscriptions
+    // (in FeedNoteCardBody) are the source of truth — they do NIP-65 outbox
+    // routing and tear down off-screen — but their two-hop discovery is slower to
+    // first paint, so this immediate batch fills names/avatars instantly. Also
+    // prefetches reactions + referenced (repost/quote) notes for the initial set.
     LaunchedEffect(feedState, subscriptionsCoordinator) {
         if (subscriptionsCoordinator == null || feedState !is FeedState.Loaded) return@LaunchedEffect
-        val loadedFeed = feedState as FeedState.Loaded
 
-        // Initial load: batch metadata for first visible notes immediately
         val initialNotes = viewModel.feedState.visibleNotes().take(30)
         if (initialNotes.isNotEmpty()) {
             val authors = initialNotes.mapNotNull { it.author?.pubkeyHex }.distinct()
-            subscriptionsCoordinator.loadMetadataBatched(authors)
+            if (authors.isNotEmpty()) subscriptionsCoordinator.loadMetadataBatched(authors)
             subscriptionsCoordinator.loadMetadataForNotes(initialNotes)
         }
     }
@@ -988,7 +1008,11 @@ fun FeedScreen(
                     val loadedState by state.feed.collectAsState()
                     val lazyListState = homeFeedLazyListState
 
-                    // Viewport-aware scroll observation: fetch metadata for newly visible notes
+                    // Fast-path warm-up on scroll: batch a kind-0 REQ to index
+                    // relays for authors entering the viewport (+10 buffer), so
+                    // names/avatars paint immediately. Complementary to the per-row
+                    // FeedNoteCardBody subscriptions, which remain the source of
+                    // truth (outbox routing + off-screen teardown).
                     LaunchedEffect(lazyListState, loadedState) {
                         if (subscriptionsCoordinator == null) return@LaunchedEffect
                         val feedList = loadedState.list
@@ -999,7 +1023,7 @@ fun FeedScreen(
                             if (info.visibleItemsInfo.isEmpty()) return@snapshotFlow -1 to -1
                             info.visibleItemsInfo.first().index to info.visibleItemsInfo.last().index
                         }.distinctUntilChanged()
-                            .debounce(500)
+                            .debounce(300)
                             .collect { (first, last) ->
                                 if (first < 0) return@collect
                                 val from = (first - 10).coerceAtLeast(0)
@@ -1974,15 +1998,9 @@ private fun ExpandedNoteContent(
     // Get reply notes from cache — recompute when replies change
     val replyNotes = remember(repliesState) { note.replies.sortedByDescending { it.createdAt() } }
 
-    // Load metadata for reply authors
-    LaunchedEffect(replyNotes, subscriptionsCoordinator) {
-        if (subscriptionsCoordinator != null && replyNotes.isNotEmpty()) {
-            val authors = replyNotes.mapNotNull { it.event?.pubKey }.distinct()
-            if (authors.isNotEmpty()) {
-                subscriptionsCoordinator.loadMetadataBatched(authors)
-            }
-        }
-    }
+    // Reply-author metadata (kind 0) is loaded per-row: each CommentItem below
+    // opens its own composition-scoped observeUser* subscription, so metadata
+    // loads for on-screen replies only and tears down when the thread closes.
 
     Column(modifier = Modifier.padding(top = 8.dp)) {
         // Comments card
@@ -2022,24 +2040,30 @@ private fun ExpandedNoteContent(
                 replyNotes.take(5).forEachIndexed { index, replyNote ->
                     val replyEvent = replyNote.event
                     val flowSet = remember(replyNote) { replyNote.flow() }
-                    val metadataState by flowSet.metadata.stateFlow.collectAsState()
                     val reactionsState by flowSet.reactions.stateFlow.collectAsState()
                     val zapsState by flowSet.zaps.stateFlow.collectAsState()
 
                     DisposableEffect(replyNote) { onDispose { replyNote.clearFlow() } }
 
-                    val author =
-                        remember(replyEvent?.pubKey, metadataState) {
-                            replyEvent?.pubKey?.let { localCache.getUserIfExists(it) }
-                        }
+                    // Load this reply's own interactions (reactions/zaps) only
+                    // while the comment row is composed.
+                    EventFinderFilterAssemblerSubscription(replyNote)
+
+                    // Load + observe this reply author's metadata only while the
+                    // comment row is composed; observeUser* both subscribes and
+                    // drives recomposition when kind-0 arrives.
+                    val replyAuthorPubKey = replyEvent?.pubKey
+                    val author = remember(replyAuthorPubKey, localCache) { replyAuthorPubKey?.let { localCache.getOrCreateUser(it) } }
+                    val authorName = author?.let { observeUserName(it).value }
+                    val authorPicture = author?.let { observeUserPicture(it).value }
                     val reactionCount = remember(reactionsState) { replyNote.countReactions() }
                     val zapAmount = remember(zapsState) { replyNote.zapsAmount }
 
                     CommentItem(
-                        authorName = author?.toBestDisplayName() ?: replyEvent?.pubKey?.take(8) ?: "",
+                        authorName = authorName ?: replyAuthorPubKey?.take(8) ?: "",
                         authorHandle = author?.pubkeyNpub()?.take(16)?.let { "@$it..." } ?: "",
-                        authorAvatarUrl = author?.profilePicture(),
-                        authorPubKeyHex = replyEvent?.pubKey ?: "",
+                        authorAvatarUrl = authorPicture,
+                        authorPubKeyHex = replyAuthorPubKey ?: "",
                         content = replyEvent?.content ?: "",
                         timeAgo = (replyEvent?.createdAt ?: 0L).toTimeAgo(),
                         reactionCount = reactionCount,

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/NotificationsScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/NotificationsScreen.kt
@@ -67,6 +67,8 @@ import com.vitorpamplona.amethyst.commons.moderation.notifications.NotificationK
 import com.vitorpamplona.amethyst.commons.moderation.notifications.PreferencesNotificationReadState
 import com.vitorpamplona.amethyst.commons.moderation.notifications.PreferencesNotificationSettings
 import com.vitorpamplona.amethyst.commons.moderation.notifications.nowEpochSeconds
+import com.vitorpamplona.amethyst.commons.relayClient.user.observeUserName
+import com.vitorpamplona.amethyst.commons.relayClient.user.observeUserPicture
 import com.vitorpamplona.amethyst.commons.state.EventCollectionState
 import com.vitorpamplona.amethyst.commons.ui.components.EmptyState
 import com.vitorpamplona.amethyst.commons.ui.components.LoadingState
@@ -654,10 +656,11 @@ private fun AggregateCard(
                     horizontalArrangement = Arrangement.spacedBy((-4).dp),
                 ) {
                     reactorPubKeys.take(5).forEach { pk ->
-                        val user = remember(pk, metadataVersion) { localCache.getUserIfExists(pk) }
+                        val user = remember(pk, localCache) { localCache.getOrCreateUser(pk) }
+                        val picture by observeUserPicture(user)
                         UserAvatar(
                             userHex = pk,
-                            pictureUrl = user?.profilePicture(),
+                            pictureUrl = picture,
                             size = 20.dp,
                             modifier = Modifier.clickable { onNavigateToProfile(pk) },
                         )
@@ -694,15 +697,17 @@ private fun AggregateCard(
                                 .clickable { onNavigateToProfile(pk) }
                                 .padding(vertical = 3.dp),
                     ) {
-                        val user = remember(pk, metadataVersion) { localCache.getUserIfExists(pk) }
+                        val user = remember(pk, localCache) { localCache.getOrCreateUser(pk) }
+                        val picture by observeUserPicture(user)
+                        val name by observeUserName(user)
                         UserAvatar(
                             userHex = pk,
-                            pictureUrl = user?.profilePicture(),
+                            pictureUrl = picture,
                             size = 22.dp,
                         )
                         Spacer(Modifier.size(6.dp))
                         Text(
-                            user?.toBestDisplayName() ?: pk.take(12),
+                            name,
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurface,
                         )
@@ -821,14 +826,17 @@ fun NotificationCard(
     // actual zap sender lives in the nested zap request. effectiveAuthorPubKey
     // returns the right one per kind.
     val pk = notification.effectiveAuthorPubKey
-    val user = remember(pk, metadataVersion, localCache) { localCache?.getUserIfExists(pk) }
+    // Load + observe the actor's metadata only while this card is composed.
+    // localCache is only null in previews/defaults; guard the observers so we
+    // never touch LocalUserFinder off the provider tree.
+    val user = remember(pk, localCache) { localCache?.getOrCreateUser(pk) }
+    val observedName = user?.let { observeUserName(it).value }
+    val observedPicture = user?.let { observeUserPicture(it).value }
     val displayName =
-        remember(user, metadataVersion, pk) {
-            user?.toBestDisplayName()
-                ?: pk.hexToByteArrayOrNull()?.toNpub()?.take(12)
-                ?: pk.take(12)
-        }
-    val pictureUrl = remember(user, metadataVersion) { user?.profilePicture() }
+        observedName
+            ?: pk.hexToByteArrayOrNull()?.toNpub()?.take(12)
+            ?: pk.take(12)
+    val pictureUrl = observedPicture
 
     val unread by remember(notification.timestamp, lastReadAt) {
         derivedStateOf { notification.timestamp > lastReadAt }

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/SearchScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/SearchScreen.kt
@@ -349,19 +349,12 @@ fun SearchScreen(
             }
     }
 
-    // Load author metadata for incoming note results. NIP-50 search relays
-    // typically don't return kind-0 metadata alongside notes, and the
-    // subscription explicitly drops MetadataEvents anyway — so display name
-    // and avatar arrive only after we explicitly fetch them from index
-    // relays via the coordinator.
-    LaunchedEffect(noteResults, subscriptionsCoordinator) {
-        val coordinator = subscriptionsCoordinator ?: return@LaunchedEffect
-        if (noteResults.isEmpty()) return@LaunchedEffect
-        val authors = noteResults.map { it.pubKey }.distinct()
-        if (authors.isNotEmpty()) {
-            coordinator.loadMetadataBatched(authors)
-        }
-    }
+    // Note-result author metadata (kind 0) is no longer batch-fetched here.
+    // Each result renders through NoteCard, which opens its own composition-scoped
+    // UserFinderFilterAssembler subscription — so the author's metadata is fetched
+    // from index/outbox relays per on-screen result and torn down when scrolled off.
+    // (NIP-50 search relays don't return kind-0 and the subscription drops
+    // MetadataEvents; the per-row finder covers that gap.)
 
     // Fetch interactions (incl. kind-1018 poll responses) for poll results so their
     // tallies populate — NIP-50 search returns the polls but not their responses.

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/ThreadScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/ThreadScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -194,12 +193,10 @@ fun ThreadScreen(
         onDispose { subId?.let { coordinator.releaseInteractions(it) } }
     }
 
-    // Load metadata for thread authors via coordinator
-    LaunchedEffect(threadNotes, subscriptionsCoordinator) {
-        if (subscriptionsCoordinator != null && threadNotes.isNotEmpty()) {
-            subscriptionsCoordinator.loadMetadataForNotes(threadNotes)
-        }
-    }
+    // Thread-author metadata + note interactions now load per row: each thread
+    // note renders through NoteCard, which opens composition-scoped UserFinder +
+    // EventFinder subscriptions. (requestInteractions above remains the thread's
+    // explicit interaction-refresh path.)
 
     // Fetch quoted notes referenced in thread content
     val quotedNoteIds =

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/chats/ChatroomHeader.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/chats/ChatroomHeader.kt
@@ -29,12 +29,15 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.relayClient.user.observeUserName
+import com.vitorpamplona.amethyst.commons.relayClient.user.observeUserPicture
 import com.vitorpamplona.amethyst.commons.resources.Res
 import com.vitorpamplona.amethyst.commons.resources.accessibility_user_avatar
 import com.vitorpamplona.amethyst.commons.ui.components.UserAvatar
@@ -59,6 +62,10 @@ fun ChatroomHeader(
     modifier: Modifier = ChatStdPadding,
     onClick: () -> Unit,
 ) {
+    // Load + observe the partner's metadata only while this header is composed.
+    val picture by observeUserPicture(user)
+    val name by observeUserName(user)
+
     Column(
         Modifier
             .fillMaxWidth()
@@ -68,14 +75,14 @@ fun ChatroomHeader(
             Row(verticalAlignment = Alignment.CenterVertically) {
                 UserAvatar(
                     userHex = user.pubkeyHex,
-                    pictureUrl = user.profilePicture(),
+                    pictureUrl = picture,
                     size = ChatSize34dp,
                     contentDescription = stringResource(Res.string.accessibility_user_avatar),
                 )
 
                 Column(modifier = Modifier.padding(start = 10.dp)) {
                     Text(
-                        text = user.toBestDisplayName(),
+                        text = name,
                         style = MaterialTheme.typography.titleSmall,
                         fontWeight = FontWeight.Bold,
                         maxLines = 1,
@@ -107,7 +114,12 @@ fun GroupChatroomHeader(
     modifier: Modifier = ChatStdPadding,
     onClick: () -> Unit,
 ) {
-    val participants = users.joinToString(", ") { it.toBestDisplayName() }
+    // Load + observe each participant's metadata only while this header is
+    // composed, so names and the group-icon avatar update as kind-0 arrives.
+    // forEach is inline, so the @Composable observeUserName call is legal here.
+    val participantNames = mutableListOf<String>()
+    users.forEach { participantNames.add(observeUserName(it).value) }
+    val participants = participantNames.joinToString(", ")
     Column(
         modifier =
             Modifier
@@ -121,9 +133,10 @@ fun GroupChatroomHeader(
             Row(verticalAlignment = Alignment.CenterVertically) {
                 // Show first user's avatar as the group icon
                 users.firstOrNull()?.let { firstUser ->
+                    val firstUserPicture by observeUserPicture(firstUser)
                     UserAvatar(
                         userHex = firstUser.pubkeyHex,
-                        pictureUrl = firstUser.profilePicture(),
+                        pictureUrl = firstUserPicture,
                         size = ChatSize34dp,
                         contentDescription = stringResource(Res.string.accessibility_user_avatar),
                     )

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/chats/ConversationListPane.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/chats/ConversationListPane.kt
@@ -66,6 +66,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
+import com.vitorpamplona.amethyst.commons.relayClient.user.observeUserPicture
 import com.vitorpamplona.amethyst.commons.ui.components.UserAvatar
 import com.vitorpamplona.amethyst.desktop.ui.components.ToggleableTimeAgoText
 import com.vitorpamplona.quartz.nip17Dm.base.ChatroomKey
@@ -320,9 +321,12 @@ private fun ConversationCard(
         val firstUser = item.users.firstOrNull()
         Box {
             if (firstUser != null) {
+                // Load + observe the conversation's primary user only while this
+                // row is composed (i.e. on screen in the list).
+                val firstUserPicture by observeUserPicture(firstUser)
                 UserAvatar(
                     userHex = firstUser.pubkeyHex,
-                    pictureUrl = firstUser.profilePicture(),
+                    pictureUrl = firstUserPicture,
                     size = 40.dp,
                 )
             } else if (item.isGroup) {

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/note/NoteCard.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/note/NoteCard.kt
@@ -56,6 +56,8 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.vitorpamplona.amethyst.commons.model.EmptyTagList
 import com.vitorpamplona.amethyst.commons.model.ImmutableListOfLists
+import com.vitorpamplona.amethyst.commons.relayClient.event.EventFinderFilterAssemblerSubscription
+import com.vitorpamplona.amethyst.commons.relayClient.user.UserFinderFilterAssemblerSubscription
 import com.vitorpamplona.amethyst.commons.richtext.CachedRichTextParser
 import com.vitorpamplona.amethyst.commons.richtext.RichTextParser
 import com.vitorpamplona.amethyst.commons.richtext.UrlParser
@@ -63,6 +65,7 @@ import com.vitorpamplona.amethyst.commons.ui.note.ReplyContext
 import com.vitorpamplona.amethyst.commons.ui.note.ReplyToLabel
 import com.vitorpamplona.amethyst.desktop.cache.DesktopLocalCache
 import com.vitorpamplona.amethyst.desktop.ui.components.ToggleableTimeAgoText
+import com.vitorpamplona.amethyst.desktop.ui.deck.LocalDesktopCache
 import com.vitorpamplona.amethyst.desktop.ui.media.AnimatedGifImage
 import com.vitorpamplona.amethyst.desktop.ui.media.AudioPlayer
 import com.vitorpamplona.amethyst.desktop.ui.media.DesktopVideoPlayer
@@ -112,6 +115,25 @@ fun NoteCard(
     replyContext: ReplyContext? = null,
     onNavigateToThread: ((String) -> Unit)? = null,
 ) {
+    // Load the author's metadata (kind 0) only while this card is composed —
+    // i.e. on/near screen. This one call covers every screen that renders
+    // through NoteCard (profile, thread, bookmarks, search); the shared commons
+    // finder coalesces all visible authors into batched REQs.
+    val noteCardCache = LocalDesktopCache.current
+    val noteCardAuthor = remember(note.pubKeyHex, noteCardCache) { noteCardCache?.getOrCreateUser(note.pubKeyHex) }
+    if (noteCardAuthor != null) {
+        UserFinderFilterAssemblerSubscription(noteCardAuthor)
+    }
+
+    // Load this note's interactions (reactions / zaps / reposts / replies) only
+    // while the card is composed — covers every NoteCard surface (profile, thread,
+    // bookmarks, search, quoted embeds). Guarded on cache presence so previews
+    // (no LocalDesktopCache → no LocalEventFinder) don't hit the provider default.
+    val noteCardNote = remember(note.id, noteCardCache) { noteCardCache?.getNoteIfExists(note.id) }
+    if (noteCardNote != null) {
+        EventFinderFilterAssemblerSubscription(noteCardNote)
+    }
+
     val urls = remember(note.content) { UrlParser().parseValidUrls(note.content) }
     val imageUrls =
         remember(urls) {

--- a/quartz/build.gradle.kts
+++ b/quartz/build.gradle.kts
@@ -424,6 +424,10 @@ val verifyKmpPurity by tasks.registering {
                 "Thread.sleep" to "use kotlinx.coroutines.delay or platform-specific actual",
                 "java.util.UUID" to "use kotlin.uuid.Uuid",
                 "kotlin.jvm.Synchronized" to "use a KMP lock primitive",
+                // The bare call, not just the annotation: `synchronized(lock) {}` resolves
+                // from kotlin-stdlib-jvm with no import, so it compiles on Android/JVM and
+                // only fails at the iOS compile step. Catch it here instead.
+                "synchronized(" to "`synchronized` is JVM-only — use a KMP lock primitive",
                 "kotlin.jvm.Volatile" to "use kotlin.concurrent.Volatile",
             )
         val offenders =


### PR DESCRIPTION
## Summary

Desktop currently loads user metadata (kind 0) and note interactions (reactions/zaps/reposts/replies) with a load-once, viewport-batch path that misses non-feed avatars and never unsubscribes. This PR adopts Android's composition-scoped per-visible model on Desktop: metadata and interactions load **only for on-screen users/notes** and tear down when they scroll off. To share the logic, the per-user metadata finder and the per-note event finder are moved from `amethyst/service/relayClient/reqCommand/{user,event}/` into `commons/relayClient/{user,event}/` behind a narrow `UserFinderAccount` seam, then wired into Desktop.

This is built **on top of** the recent subscription-observability work (`AccountScopedQuery`, `SubPurpose`/`ExplainedFilter`): the moved finders keep emitting the same purpose-tagged filters and preserve per-account attribution — they just source the attribution pubkey from the narrow seam (`UserFinderAccount.userFinderPubkeyHex`) instead of the full `Account`, so the finder query states no longer need to carry `Account` and could drop `AccountScopedQuery`. Android behaviour is unchanged (typealias shim files keep every existing call site compiling; `UserObservers`/`EventObservers` stay in amethyst).

Draft: the automated gates below are all green and the branch merges cleanly onto `main`, but the full manual Desktop pass is still in progress — see the test plan.

## Test plan

### Feature test plan

Automated (all green on this branch):
- `./gradlew :commons:jvmTest` — incl. `EventFinderFilterAssemblyTest` (batched-filter assembly + the `ICacheProvider.checkGetOrCreateUser` seam).
- `./gradlew :commons:verifyKmpPurity` — the moved finders are iOS-pure in commonMain.
- `./gradlew :amethyst:compilePlayDebugKotlin` and `:amethyst:compileFdroidDebugKotlin` — both flavours compile.
- `./gradlew :desktopApp:compileKotlin` and `:desktopApp:run` — app launches, logs in, and loads (OutboxDispatcher / WoT active).
- `./gradlew spotlessApply` — formatted.

Manual (Desktop, macOS — **in progress**, full sheet in `desktopApp/plans/2026-08-10-shared-metadata-loading-v2-manual-testing.md`):
- Scroll Home → visible authors' avatars/names populate; scrolling doesn't REQ the whole list at once.
- Open a never-viewed profile / thread / people-search / DM / notifications → avatars + names populate per on-screen user.
- Reaction/zap counts populate for visible posts.
- Active Relay Subscriptions screen still attributes `PROFILE_METADATA` / `RELAY_LISTS` / `ENGAGEMENT` / `REFERENCED_EVENTS` REQs to the account (verifies attribution survived dropping `AccountScopedQuery`).

### Regression test plan

Touch points and verification:
- **Android metadata/reaction loading** — the finders moved out from under it — verified: `:amethyst:compilePlayDebugKotlin` green via the `UserFinderShims`/`EventFinderShims` typealiases; `UserObservers`/`EventObservers` unchanged. On-device manual pass pending.
- **`Account` (added `UserFinderAccount` impl)** — could break account construction — verified: compiles both flavours; getters are thin snapshot reads over existing relay-list state.
- **Other callers of the moved loader functions** (thread view, hashtag feed, global search, channel/NWC sub-assemblers) — repointed at the commons functions + threaded `LocalCache` — verified: they compile; `filterMissingEvents`/`potentialRelaysToFindEvent` behaviour preserved. Manual thread/hashtag/search "load an uncached note" pass pending (sheet D5).
- **`SingleSubNoEoseCacheEoseManager` move** — its two other callers must keep attribution — verified: `ChannelLoaderSubAssembler` uses a new amethyst `AccountScopedSingleSubNoEoseCacheEoseManager` subclass; `NWCPaymentWatcher` never attributed (behaviour preserved).
- **Account switch** — could leak cached metadata/REQs across accounts — pending manual (sheet D2).
- **iOS/KMP source-set discipline** — new commonMain code must stay pure — verified: `verifyKmpPurity` green; `EOSEAccountFast` moved to commons with a KMP lock (no `synchronized`).
- **Release-minified build** — not run; accepting the risk: the change introduces no new reflection/serialization/ViewModel-factory paths (it's relay subscription-assembly + Compose wiring). Flag for a reviewer to require `installPlayBenchmark` if desired.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes. The finders assemble kind-0 / kind-7 / referenced-event REQ filters; `SubPurpose`/`ExplainedFilter` tags are client-side only and never sent. No DM/MLS/audio/QUIC paths touched.

## AI assistance

- [x] Drafted with AI assistance, manually reviewed and tested

Built with Claude Code. The commons extraction was reconciled against the current `main`'s `AccountScopedQuery`/`SubPurpose` refactor; per-file rationale is in `desktopApp/plans/2026-08-06-shared-metadata-loading-upstream-reconciliation-plan.md`.

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.
