### PR TITLE
fix(nav): switching between two pinned web-app tabs crashed onto the wrong one

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/navs/Nav.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/navs/Nav.kt
@@ -121,7 +121,28 @@ class Nav(
             }
             // Mark this entry as a tab root: hides the back arrow in canPop
             // and skips the horizontal slide in composableFromEnd.
-            controller.getBackStackEntry(route).savedStateHandle[BOTTOM_NAV_ROOT_KEY] = true
+            // saveState/restoreState are keyed by DESTINATION, and every pinned tab of one kind shares a
+            // single destination — all web apps are `Route.WebApp/{url}`, all pinned chats their own one
+            // pattern. So the restore above can hand back a *sibling* tab's saved entry: with two web apps
+            // pinned, tapping the second one landed on the first one's URL, and the lookup below then threw
+            // `No destination with route …WebApp/<url> is on the NavController's back stack`.
+            //
+            // When the entry we asked for isn't there, take the tab fresh (no restoreState, and no
+            // launchSingleTop — the top is the sibling we do not want to reuse). Its saved scroll/ViewModel
+            // state is not recoverable in that case, but the user lands on the tab they tapped. Tabs whose
+            // destination nothing else shares still restore normally, which is what this is here for.
+            val entry =
+                runCatching { controller.getBackStackEntry(route) }.getOrNull()
+                    ?: run {
+                        controller.navigate(route) {
+                            popUpTo(Route.Home) {
+                                inclusive = false
+                                saveState = true
+                            }
+                        }
+                        runCatching { controller.getBackStackEntry(route) }.getOrNull()
+                    }
+            entry?.savedStateHandle?.set(BOTTOM_NAV_ROOT_KEY, true)
         }
     }
 


### PR DESCRIPTION
## Summary

With two web apps pinned to the bottom bar, tapping the second one crashed with
`IllegalArgumentException: No destination with route Route.WebApp/<url> is on the NavController's back stack`.
`saveState`/`restoreState` are keyed by **destination**, and every pinned web app shares one
(`Route.WebApp/{url}`), so the restore handed back the *sibling* tab's saved entry instead of creating the
one that was asked for. The crash was the visible half — the navigation had already landed on the wrong
tab. When the requested entry isn't on the stack after the navigate, this takes the tab fresh instead.

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted (`spotlessCheck` green)
- [x] Ran `./gradlew :amethyst:compileFdroidDebugKotlin :amethyst:testFdroidDebugUnitTest`
- [x] Manually exercised the change (see notes below)

Notes:

**Device:** Samsung Galaxy Tab A7 Lite (SM-T220), Android 14 / SDK 34.

**Reproduced first**, with two web apps pinned to the bottom bar
(`http://localhost:8765/…` and `https://brainstorm.world/?q=Vitor`):

| step | before | after |
|---|---|---|
| fresh launch → tap either web-app tab | OK | OK |
| web app A → web app B | **crash** | loads B |
| web app B → web app A | **crash** | loads A |
| all 6 bottom-nav tabs, cycled ×2 | — | no fatals |

A fresh launch straight into either tab never crashed — only *switching between* two same-kind tabs did,
which is what pointed at the save/restore collision rather than the URL's `?q=` encoding.

**The crash was not the whole bug.** Instrumenting the navigate showed the entry that actually landed:

```
asked  = WebApp(url=https://brainstorm.world/?q=Vitor)
landed = url=http://localhost:8765/keyboard.html      ← the other tab
```

Confirmed visually too: tapping the brainstorm tab **selected and rendered localhost**. So a fix that only
stopped the throw (swallow it, or read `currentBackStackEntry`) would have left the user silently looking at
the wrong website. After the fix, each tab loads its own site with its query string applied.

**Scope:** the same collision applies to any two pinned tabs sharing a destination (chats, Concord
channels), which this covers too. In the colliding case that tab's saved scroll/ViewModel state is
unrecoverable — Navigation has no per-argument save slot — but the user lands on the tab they tapped. Tabs
whose destination nothing else shares still save and restore exactly as before, so the deliberate
ViewModel-preservation behaviour documented in `navBottomBar` is intact.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## AI assistance

- [x] Drafted with AI assistance, manually reviewed and tested

Found and fixed with Claude Code while device-testing an unrelated branch; reproduced on hardware before and
after.

## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license.
