### PR TITLE
Fix push registration to fail loudly on HTTP errors

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/RegisterAccounts.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/RegisterAccounts.kt
@@ -37,6 +37,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.coroutines.executeAsync
+import java.io.IOException
 
 class RegisterAccounts(
     private val accounts: List<AccountInfo>,
@@ -132,7 +133,16 @@ class RegisterAccounts(
         val client = client(url)
 
         client.newCall(request).executeAsync().use { response ->
-            Log.i(tag) { "Server registration ${response.isSuccessful}" }
+            // Must throw on failure: retryIfException only re-attempts when the block
+            // raises, and PushNotificationUtils only caches the token/account list
+            // after a clean return. Returning normally on an error response would
+            // mark this device as registered while push is silently dead until the
+            // token or the account list changes.
+            if (!response.isSuccessful) {
+                val reason = response.peekBody(MAX_ERROR_BODY_BYTES).string().ifBlank { response.message }
+                throw PushRegistrationException("Push registration failed at $url: HTTP ${response.code} $reason")
+            }
+            Log.i(tag) { "Server registration succeeded (HTTP ${response.code})" }
         }
     }
 
@@ -143,4 +153,14 @@ class RegisterAccounts(
             }
         }
     }
+
+    companion object {
+        /** Caps how much of an error response is buffered into the exception message. */
+        const val MAX_ERROR_BODY_BYTES = 512L
+    }
 }
+
+/** The push server rejected the registration. Retried by the caller's retry loop. */
+class PushRegistrationException(
+    message: String,
+) : IOException(message)


### PR DESCRIPTION
## Summary

The push registration flow was silently ignoring HTTP error responses from the server, which would mark the device as registered while push notifications remained silently broken. This change makes the registration fail explicitly on non-2xx responses so the retry loop can attempt recovery, and only caches the token/account list after a successful registration.

## Changes

- **Throw on HTTP errors**: `RegisterAccounts.registerWithServer()` now throws `PushRegistrationException` when the server returns a non-successful response, instead of logging and returning normally
- **Include error details**: The exception message includes the HTTP status code and up to 512 bytes of the response body to aid debugging
- **New exception type**: `PushRegistrationException` extends `IOException` so it integrates with the caller's retry loop (which only retries on exceptions)
- **Added import**: `java.io.IOException` for the new exception class

The key insight is that `PushNotificationUtils` only caches the token and account list after `registerWithServer()` returns cleanly. By throwing on errors, we ensure the device isn't marked as registered until the server actually accepts it.

## Test plan

- [ ] Ran `./gradlew spotlessApply` — repo is formatted
- [ ] Ran `./gradlew test` (or the relevant module's tests)
- [ ] Manually exercised the change (see notes below)

Notes: This is a defensive fix for the push notification registration path. The change is straightforward: convert silent failure (logging only) to explicit failure (throwing). Existing retry logic in the caller will handle the exception. No new test infrastructure needed — the exception will be caught by the existing retry loop in `PushNotificationUtils`.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01BEVyfwuhxWgiKYSihYZpAh