### PR TITLE
perf: stop blocking coroutine workers on synchronous OkHttp calls

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/buzz/BuzzInviteMinter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/buzz/BuzzInviteMinter.kt
@@ -30,6 +30,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.coroutines.executeAsync
 
 /**
  * Mints a `block/buzz` workspace invite link by POSTing to the relay's **Buzz-specific**
@@ -86,7 +87,7 @@ object BuzzInviteMinter {
                     .post(bodyBytes.toRequestBody("application/json".toMediaType()))
                     .build()
 
-            okHttpClient(url).newCall(request).execute().use { response ->
+            okHttpClient(url).newCall(request).executeAsync().use { response ->
                 val payload = response.body.string()
                 val tree = runCatching { json.readTree(payload) }.getOrNull()
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/concord/ConcordCommunityImage.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/concord/ConcordCommunityImage.kt
@@ -30,6 +30,7 @@ import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.Request
+import okhttp3.coroutines.executeAsync
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 
@@ -70,7 +71,7 @@ fun rememberConcordImageModel(
                     if (!cacheFile.exists()) {
                         val client = accountViewModel.httpClientBuilder.okHttpClientForImage(pointer.url)
                         val ciphertext =
-                            client.newCall(Request.Builder().url(pointer.url).build()).execute().use { resp ->
+                            client.newCall(Request.Builder().url(pointer.url).build()).executeAsync().use { resp ->
                                 if (!resp.isSuccessful) return@runCatching null
                                 resp.body.bytes()
                             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/theme/RoomFontLoader.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/theme/RoomFontLoader.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.coroutines.executeAsync
 import java.io.File
 import java.security.MessageDigest
 
@@ -63,7 +64,7 @@ internal object RoomFontLoader {
             }.getOrNull()
         }
 
-    private fun ensureCached(
+    private suspend fun ensureCached(
         url: String,
         context: Context,
         clientFor: (String) -> OkHttpClient,
@@ -74,7 +75,7 @@ internal object RoomFontLoader {
 
         val client = clientFor(url)
         val request = Request.Builder().url(url).build()
-        client.newCall(request).execute().use { resp ->
+        client.newCall(request).executeAsync().use { resp ->
             if (!resp.isSuccessful) return null
             file.outputStream().use { out -> resp.body.byteStream().copyTo(out) }
         }

--- a/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/Context.kt
+++ b/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/Context.kt
@@ -74,6 +74,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.coroutines.executeAsync
 import java.lang.management.ManagementFactory
 import java.util.concurrent.TimeUnit
 
@@ -304,7 +305,7 @@ class Context(
                         .url(relay.toHttp())
                         .header("Accept", "application/nostr+json")
                         .build()
-                okhttp.newCall(request).execute().use { resp ->
+                okhttp.newCall(request).executeAsync().use { resp ->
                     resp.body.string().let { Nip11RelayInformation.fromJson(it) }
                 }
             }.getOrNull()

--- a/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/BuzzCommands.kt
+++ b/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/BuzzCommands.kt
@@ -57,6 +57,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.coroutines.executeAsync
 
 /**
  * `amy buzz …` — first-class access to the `block/buzz` workspace protocol, driving the
@@ -372,7 +373,7 @@ object BuzzCommands {
                         .url(url)
                         .get()
                         .build(),
-                ).execute()
+                ).executeAsync()
                 .use { it.code to it.body.string() }
         }
 
@@ -385,7 +386,7 @@ object BuzzCommands {
         withContext(Dispatchers.IO) {
             val builder = Request.Builder().url(url).post(body.toRequestBody(jsonMedia))
             if (auth != null) builder.header("Authorization", auth)
-            http.newCall(builder.build()).execute().use { it.code to it.body.string() }
+            http.newCall(builder.build()).executeAsync().use { it.code to it.body.string() }
         }
 
     /** `buzz post RELAY GID <text>` → publishes a kind-40002 stream message with an `h` tag. */

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/service/georelay/GeoRelayCsvLoader.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/service/georelay/GeoRelayCsvLoader.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.coroutines.executeAsync
 
 /**
  * Fetches and parses the live georelays CSV so the [GeoRelayDirectory] can route
@@ -44,7 +45,7 @@ class GeoRelayCsvLoader(
                     .url(url)
                     .get()
                     .build()
-            okHttpClient(url).newCall(request).execute().use { response ->
+            okHttpClient(url).newCall(request).executeAsync().use { response ->
                 if (response.isSuccessful) {
                     GeoRelayDirectory.parseCsv(response.body.string())
                 } else {

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/service/lnurl/LightningAddressResolver.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/service/lnurl/LightningAddressResolver.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.coroutines.executeAsync
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.net.URLEncoder
@@ -191,7 +192,7 @@ class LightningAddressResolver(
         withContext(Dispatchers.IO) {
             try {
                 val request = Request.Builder().url(url).build()
-                httpClient.newCall(request).execute().use { response ->
+                httpClient.newCall(request).executeAsync().use { response ->
                     if (response.isSuccessful) {
                         response.body.string()
                     } else {
@@ -222,7 +223,7 @@ class LightningAddressResolver(
                 }
 
                 val request = Request.Builder().url(url).build()
-                httpClient.newCall(request).execute().use { response ->
+                httpClient.newCall(request).executeAsync().use { response ->
                     // Return body even on error — caller extracts "reason" or "message" from JSON
                     response.body.string()
                 }

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/service/lnurl/OkHttpLnurlEndpointResolver.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/service/lnurl/OkHttpLnurlEndpointResolver.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.coroutines.executeAsync
 import kotlin.coroutines.cancellation.CancellationException
 
 /**
@@ -58,7 +59,7 @@ class OkHttpLnurlEndpointResolver(
             try {
                 val client = okHttpClient(url)
                 val request = Request.Builder().url(url).build()
-                client.newCall(request).execute().use { response ->
+                client.newCall(request).executeAsync().use { response ->
                     if (!response.isSuccessful) return@use null
                     val body = response.body.string()
                     val root = mapper.readTree(body) ?: return@use null

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/service/upload/BlossomClient.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/service/upload/BlossomClient.kt
@@ -36,6 +36,7 @@ import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
+import okhttp3.coroutines.executeAsync
 import okio.BufferedSink
 import okio.source
 import java.io.File
@@ -149,7 +150,7 @@ open class BlossomClient(
                         paymentProof?.headers()?.forEach { (name, value) -> addHeader(name, value) }
                     }.put(body)
                     .build()
-            okHttpClient.newCall(request).execute().use { response ->
+            okHttpClient.newCall(request).executeAsync().use { response ->
                 if (response.code in MIRROR_UNSUPPORTED_CODES) {
                     throw BlossomMirrorUnsupportedException(serverBaseUrl, response.code)
                 }
@@ -208,7 +209,7 @@ open class BlossomClient(
                     .apply { authHeader?.let { addHeader("Authorization", it) } }
                     .get()
                     .build()
-            okHttpClient.newCall(request).execute().use { response ->
+            okHttpClient.newCall(request).executeAsync().use { response ->
                 check402(response, serverBaseUrl)
                 if (!response.isSuccessful) {
                     val reason = response.headers[BlossomServerUrl.REASON_HEADER] ?: response.code.toString()
@@ -237,7 +238,7 @@ open class BlossomClient(
                     .apply { authHeader?.let { addHeader("Authorization", it) } }
                     .delete()
                     .build()
-            okHttpClient.newCall(request).execute().use { it.isSuccessful }
+            okHttpClient.newCall(request).executeAsync().use { it.isSuccessful }
         }
 
     /**
@@ -256,7 +257,7 @@ open class BlossomClient(
                     .head()
                     .build()
             try {
-                okHttpClient.newCall(request).execute().use { it.isSuccessful }
+                okHttpClient.newCall(request).executeAsync().use { it.isSuccessful }
             } catch (e: CancellationException) {
                 throw e
             } catch (_: Exception) {
@@ -289,7 +290,7 @@ open class BlossomClient(
                     .addHeader(BlossomServerUrl.X_CONTENT_TYPE_HEADER, contentType)
                     .apply { authHeader?.let { addHeader("Authorization", it) } }
                     .build()
-            okHttpClient.newCall(request).execute().use { response ->
+            okHttpClient.newCall(request).executeAsync().use { response ->
                 BlossomPreflightResult(
                     accepted = response.isSuccessful,
                     status = response.code,
@@ -313,7 +314,7 @@ open class BlossomClient(
                     .url(BlossomServerUrl.report(serverBaseUrl))
                     .put(reportEventJson.toRequestBody("application/json".toMediaType()))
                     .build()
-            okHttpClient.newCall(request).execute().use { it.isSuccessful }
+            okHttpClient.newCall(request).executeAsync().use { it.isSuccessful }
         }
 
     /**
@@ -335,7 +336,7 @@ open class BlossomClient(
                     .url(url)
                     .get()
                     .build()
-            okHttpClient.newCall(request).execute().use { response ->
+            okHttpClient.newCall(request).executeAsync().use { response ->
                 if (response.isSuccessful) response.body.bytes() else null
             }
         }
@@ -368,7 +369,7 @@ open class BlossomClient(
                     .apply { authHeader?.let { addHeader("Authorization", it) } }
                     .put(body)
                     .build()
-            okHttpClient.newCall(request).execute().use { parseDescriptor(it, serverBaseUrl) }
+            okHttpClient.newCall(request).executeAsync().use { parseDescriptor(it, serverBaseUrl) }
         }
 
     private fun parseDescriptor(

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
 
     // Networking
     implementation(libs.okhttp)
+    implementation(libs.okhttpCoroutines)
 
     // JSON
     implementation(libs.jackson.module.kotlin)

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/network/Nip11Fetcher.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/network/Nip11Fetcher.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import okhttp3.Request
+import okhttp3.coroutines.executeAsync
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -67,7 +68,7 @@ class Nip11Fetcher {
         }
     }
 
-    private fun fetchFromNetwork(url: NormalizedRelayUrl): Nip11RelayInformation? {
+    private suspend fun fetchFromNetwork(url: NormalizedRelayUrl): Nip11RelayInformation? {
         // FAIL-CLOSED: use currentClient() not getHttpClient()
         val client = DesktopHttpClient.currentClient()
         val httpUrl = url.toHttp()
@@ -78,7 +79,7 @@ class Nip11Fetcher {
                 .header("Accept", "application/nostr+json")
                 .build()
         return try {
-            client.newCall(request).execute().use { response ->
+            client.newCall(request).executeAsync().use { response ->
                 if (response.isSuccessful) {
                     val source = response.body.source()
                     source.request(MAX_RESPONSE_BYTES) // buffer up to limit

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/service/media/EncryptedMediaService.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/service/media/EncryptedMediaService.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.quartz.utils.ciphers.AESGCM
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.Request
+import okhttp3.coroutines.executeAsync
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -51,7 +52,7 @@ object EncryptedMediaService {
 
         return withContext(Dispatchers.IO) {
             val request = Request.Builder().url(url).build()
-            val response = httpClient.newCall(request).execute()
+            val response = httpClient.newCall(request).executeAsync()
             val encryptedBytes =
                 response.use {
                     if (!it.isSuccessful) throw RuntimeException("Download failed: ${it.code}")

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/service/media/ServerHealthCheck.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/service/media/ServerHealthCheck.kt
@@ -24,6 +24,7 @@ import com.vitorpamplona.amethyst.desktop.network.DesktopHttpClient
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.Request
+import okhttp3.coroutines.executeAsync
 
 object ServerHealthCheck {
     enum class ServerStatus {
@@ -45,7 +46,7 @@ object ServerHealthCheck {
                         .url(url)
                         .head()
                         .build()
-                val response = DesktopHttpClient.currentClient().newCall(request).execute()
+                val response = DesktopHttpClient.currentClient().newCall(request).executeAsync()
                 response.use {
                     if (it.isSuccessful || it.code == 405) ServerStatus.ONLINE else ServerStatus.OFFLINE
                 }

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/service/media/VideoThumbnailCache.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/service/media/VideoThumbnailCache.kt
@@ -27,6 +27,7 @@ import com.vitorpamplona.amethyst.desktop.network.DesktopHttpClient
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.Request
+import okhttp3.coroutines.executeAsync
 import org.jcodec.api.FrameGrab
 import org.jcodec.common.io.NIOUtils
 import org.jcodec.common.model.ColorSpace
@@ -122,7 +123,7 @@ object VideoThumbnailCache {
         }
     }
 
-    private fun extractFirstFrame(url: String): ImageBitmap? {
+    private suspend fun extractFirstFrame(url: String): ImageBitmap? {
         // For HLS we skip straight to ffmpeg — JCodec can't read m3u8.
         val isHls = url.contains(".m3u8", ignoreCase = true) || url.contains("/hls/", ignoreCase = true)
 
@@ -163,7 +164,7 @@ object VideoThumbnailCache {
      *
      * Cleans up zero-byte cache files on failure so a transient empty response isn't sticky.
      */
-    private fun downloadFirstChunk(url: String): Download? {
+    private suspend fun downloadFirstChunk(url: String): Download? {
         val hash = sha1Hex(url)
         val cached = File(downloadCacheDir, "$hash.mp4")
         if (cached.length() > 0L) return Download(cached, persistable = true)
@@ -171,7 +172,7 @@ object VideoThumbnailCache {
 
         var wrote = false
         var rangeHonored = false
-        DesktopHttpClient.currentClient().newCall(buildRangeRequest(url)).execute().use { resp ->
+        DesktopHttpClient.currentClient().newCall(buildRangeRequest(url)).executeAsync().use { resp ->
             if (!resp.isSuccessful && resp.code != 206) return null
             val contentType = resp.header("Content-Type")?.lowercase().orEmpty()
             if (contentType.startsWith("text/") || "html" in contentType) return null

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/ImportFollowListDialog.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/ImportFollowListDialog.kt
@@ -82,6 +82,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.coroutines.executeAsync
 import java.net.URLEncoder
 import java.util.concurrent.TimeUnit
 
@@ -141,7 +142,7 @@ private suspend fun resolveNip05Http(identifier: String): String? {
                     .readTimeout(10, TimeUnit.SECONDS)
                     .build()
             val request = Request.Builder().url(url).build()
-            val response = client.newCall(request).execute()
+            val response = client.newCall(request).executeAsync()
             response.use { resp ->
                 if (!resp.isSuccessful) return@withContext null
                 val body = resp.body.string()

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/media/AnimatedGifImage.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/media/AnimatedGifImage.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import okhttp3.Request
+import okhttp3.coroutines.executeAsync
 import org.jetbrains.skia.Bitmap
 import org.jetbrains.skia.Codec
 import org.jetbrains.skia.Data
@@ -131,10 +132,10 @@ fun AnimatedGifImage(
     }
 }
 
-private fun decodeGifFrames(url: String): GifFrames? =
+private suspend fun decodeGifFrames(url: String): GifFrames? =
     try {
         val request = Request.Builder().url(url).build()
-        val response = gifHttpClient.newCall(request).execute()
+        val response = gifHttpClient.newCall(request).executeAsync()
         val bytes = response.body.bytes()
 
         val skData = Data.makeFromBytes(bytes)

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/media/SaveMediaAction.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/media/SaveMediaAction.kt
@@ -24,6 +24,7 @@ import com.vitorpamplona.amethyst.desktop.network.DesktopHttpClient
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.Request
+import okhttp3.coroutines.executeAsync
 import java.awt.FileDialog
 import java.awt.Frame
 import java.io.File
@@ -59,7 +60,7 @@ object SaveMediaAction {
         return withContext(Dispatchers.IO) {
             try {
                 val request = Request.Builder().url(url).build()
-                val response = httpClient.newCall(request).execute()
+                val response = httpClient.newCall(request).executeAsync()
                 response.use { resp ->
                     if (!resp.isSuccessful) return@withContext null
                     val total = resp.body.contentLength()

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/wallet/WalletColumnScreen.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/ui/wallet/WalletColumnScreen.kt
@@ -62,6 +62,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
@@ -78,10 +80,16 @@ import com.vitorpamplona.quartz.lightning.LnInvoiceUtil
 import com.vitorpamplona.quartz.lightning.Lud06
 import com.vitorpamplona.quartz.nip47WalletConnect.Nip47WalletConnect.Nip47URINorm
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.coroutines.executeAsync
 import java.awt.Toolkit
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.StringSelection
+import java.io.IOException
 import java.text.NumberFormat
 import java.util.Locale
 
@@ -505,6 +513,46 @@ private fun classifyAndProcess(input: String): SendState {
     return SendState.Idle
 }
 
+/**
+ * Max bytes read from an LNURL endpoint. LUD-06 payRequest and LUD-16 invoice documents are a few
+ * hundred bytes; the body is buffered in memory, so a hostile or broken server needs a hard ceiling.
+ */
+private const val MAX_LNURL_RESPONSE_BYTES = 64 * 1024L
+
+/**
+ * GETs [url] and parses its size-capped JSON body.
+ *
+ * Connect, body read and parse all happen on [Dispatchers.IO] and the response is always closed:
+ * callers run inside a `LaunchedEffect` that resumes on the composition dispatcher and can be
+ * cancelled at any suspension point, so neither the blocking read nor the close can be left to them.
+ *
+ * LUD-06 servers report failures as HTTP 200 + `{"status":"ERROR","reason":…}`, so the body is
+ * parsed first and the status code is only surfaced when the body isn't usable JSON — otherwise
+ * the caller's `reason`/`message` extraction would be skipped for servers that use 4xx instead.
+ */
+private suspend fun fetchLnurlJson(
+    httpClient: OkHttpClient,
+    mapper: ObjectMapper,
+    url: String,
+): JsonNode =
+    withContext(Dispatchers.IO) {
+        val request = Request.Builder().url(url).build()
+        httpClient.newCall(request).executeAsync().use { response ->
+            val source = response.body.source()
+            // request() buffers up to N bytes and stops, but readUtf8() on the SOURCE would drain
+            // the whole stream regardless of what was buffered — so read the BUFFER to cap for real.
+            source.request(MAX_LNURL_RESPONSE_BYTES + 1)
+            if (source.buffer.size > MAX_LNURL_RESPONSE_BYTES) {
+                throw IOException("LNURL response exceeds $MAX_LNURL_RESPONSE_BYTES bytes")
+            }
+            val body = source.buffer.readUtf8()
+            runCatching { mapper.readTree(body) }.getOrNull()
+                ?: throw IOException(
+                    if (response.isSuccessful) "malformed LNURL response" else "HTTP ${response.code}",
+                )
+        }
+    }
+
 @Composable
 private fun SendDialog(
     onDismiss: () -> Unit,
@@ -529,18 +577,7 @@ private fun SendDialog(
         val state = sendState
         if (state is SendState.Resolving) {
             try {
-                val httpClient = DesktopHttpClient.currentClient()
-                val request =
-                    okhttp3.Request
-                        .Builder()
-                        .url(state.url)
-                        .build()
-                val response =
-                    kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
-                        httpClient.newCall(request).execute()
-                    }
-                val body = response.body.string()
-                val json = mapper.readTree(body)
+                val json = fetchLnurlJson(DesktopHttpClient.currentClient(), mapper, state.url)
                 val callback = json.get("callback")?.asText()?.ifBlank { null }
                 if (callback == null) {
                     val errorMsg = json.get("reason")?.asText() ?: json.get("message")?.asText() ?: "Invalid LNURL endpoint"
@@ -569,21 +606,10 @@ private fun SendDialog(
         val state = sendState
         if (state is SendState.FetchingInvoice) {
             try {
-                val httpClient = DesktopHttpClient.currentClient()
                 val urlBinder = if (state.callbackUrl.contains("?")) "&" else "?"
                 val encodedComment = java.net.URLEncoder.encode(state.comment, "utf-8")
                 val url = "${state.callbackUrl}${urlBinder}amount=${state.amountMilliSats}&comment=$encodedComment"
-                val request =
-                    okhttp3.Request
-                        .Builder()
-                        .url(url)
-                        .build()
-                val response =
-                    kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
-                        httpClient.newCall(request).execute()
-                    }
-                val body = response.body.string()
-                val json = mapper.readTree(body)
+                val json = fetchLnurlJson(DesktopHttpClient.currentClient(), mapper, url)
                 val pr = json.get("pr")?.asText()?.ifBlank { null }
                 if (pr != null) {
                     sendState = SendState.ReadyToPay(pr)

--- a/desktopApp/src/jvmTest/kotlin/com/vitorpamplona/amethyst/desktop/service/upload/BlossomClientTest.kt
+++ b/desktopApp/src/jvmTest/kotlin/com/vitorpamplona/amethyst/desktop/service/upload/BlossomClientTest.kt
@@ -24,11 +24,14 @@ import com.vitorpamplona.amethyst.commons.service.upload.BlossomClient
 import com.vitorpamplona.amethyst.commons.service.upload.BlossomMirrorUnsupportedException
 import com.vitorpamplona.quartz.nip01Core.core.toHexKey
 import com.vitorpamplona.quartz.utils.sha256.sha256
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import okhttp3.Call
+import okhttp3.Callback
 import okhttp3.Headers
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -45,6 +48,15 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class BlossomClientTest {
+    /**
+     * BlossomClient calls Call.executeAsync(), which drives [Call.enqueue] — not [Call.execute].
+     * Bridge the execute() stub set up above onto the async path so the response setup still applies.
+     */
+    private fun Call.answerAsyncFromExecuteStub() {
+        every { cancel() } just Runs
+        every { enqueue(any()) } answers { firstArg<Callback>().onResponse(this@answerAsyncFromExecuteStub, execute()) }
+    }
+
     private fun mockOkHttp(
         responseCode: Int,
         body: String = "",
@@ -65,6 +77,7 @@ class BlossomClientTest {
                 .headers(headers)
                 .body(body.toResponseBody())
                 .build()
+        mockCall.answerAsyncFromExecuteStub()
 
         return mockClient
     }
@@ -76,6 +89,7 @@ class BlossomClientTest {
             val request = firstArg<Request>()
             val call = mockk<Call>()
             every { call.execute() } returns handler(request)
+            call.answerAsyncFromExecuteStub()
             call
         }
         return mockClient
@@ -326,6 +340,7 @@ class BlossomClientTest {
                     .message("OK")
                     .body("""{"url":"https://example.com/hash"}""".toResponseBody())
                     .build()
+            mockCall.answerAsyncFromExecuteStub()
 
             val client = BlossomClient(mockClient)
             val file = File.createTempFile("test_", ".png")
@@ -366,6 +381,7 @@ class BlossomClientTest {
                     .message("OK")
                     .body("""{"url":"https://example.com/hash"}""".toResponseBody())
                     .build()
+            mockCall.answerAsyncFromExecuteStub()
 
             val client = BlossomClient(mockClient)
             val file = File.createTempFile("test_", ".png")

--- a/nestsClient/src/jvmAndroid/kotlin/com/vitorpamplona/nestsclient/OkHttpNestsClient.kt
+++ b/nestsClient/src/jvmAndroid/kotlin/com/vitorpamplona/nestsclient/OkHttpNestsClient.kt
@@ -31,6 +31,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
+import okhttp3.coroutines.executeAsync
 import java.io.EOFException
 import java.io.IOException
 import java.net.SocketException
@@ -167,7 +168,7 @@ class OkHttpNestsClient(
             val request = buildRequest()
             val response: Response =
                 try {
-                    httpClient(url).newCall(request).execute()
+                    httpClient(url).newCall(request).executeAsync()
                 } catch (e: SocketException) {
                     transportError = e
                     if (++transportAttempts >= MAX_TRANSPORT_RETRIES) throw NestsException("Failed to reach $url", e)

--- a/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip03Timestamp/okhttp/OkHttpBitcoinExplorer.kt
+++ b/quartz/src/jvmAndroid/kotlin/com/vitorpamplona/quartz/nip03Timestamp/okhttp/OkHttpBitcoinExplorer.kt
@@ -58,7 +58,7 @@ class OkHttpBitcoinExplorer(
                 .get()
                 .build()
 
-        return client.newCall(request).execute().use {
+        return client.newCall(request).executeAsync().use {
             if (it.isSuccessful) {
                 Log.d("OkHttpBlockstreamExplorer") { "$baseAPI/block/$hash" }
 


### PR DESCRIPTION
Removes the last synchronous OkHttp calls from long-lived runtime code, and fixes three real defects found in the LNURL path along the way.

## Why

`Dispatchers.IO` stamps a task `BlockingContext` **at dispatch time** — kotlinx's `CoroutineScheduler.executeTask` releases the worker's CPU permit purely on that flag, with no runtime detection of blocking. A blocking `execute()` therefore holds one of those elastic threads for an entire request. `executeAsync()` suspends until the response headers arrive and releases the thread across the round-trip.

Context: while investigating ANRs on an SM-T220 I measured the app running **76 `DefaultDispatcher` threads with 14–44 runnable on 8 cores**. This is one contributor to that oversubscription. It is **not** a fix for those ANRs — a wifi-off control showed ~92% of that CPU is relay ingest, which is a separate (persistence) problem.

## What

**1. `perf:` 27 call sites → `executeAsync()`** across `quartz`, `commons`, `amethyst`, `nestsClient`, `desktopApp`, `cli`. This was already the house pattern (63 existing uses); these were the stragglers. `desktopApp` gains `okhttp-coroutines` (Apache-2.0, same version as the okhttp it already ships).

The `withContext(Dispatchers.IO)` wrappers are **kept deliberately** — `executeAsync()` only suspends until headers, and `body.string()`/`bytes()` is still a blocking read. Moving those to `Dispatchers.Default` would hold its core-sized CPU permits and starve the pool.

**2. `fix:` the LNURL path in `WalletColumnScreen.SendDialog`**, which had three defects:

- **Blocking read on the UI thread.** Both effects returned the `Response` *out* of their `withContext(Dispatchers.IO)` and then called `response.body.string()` outside it. `LaunchedEffect` resumes on the composition dispatcher, so the blocking read ran on the EDT — the `withContext` gave the appearance of off-thread IO while doing almost none of it, since a request's cost is mostly the body transfer.
- **Response leak.** Never closed with `use { }`. Both effects are keyed on `sendState` and restart on every change, so cancellation between headers and body read leaked the connection.
- **No status check, unbounded body.** An HTML error page surfaced as a raw Jackson error, and the body was read without a size limit.

**3. `test:` `BlossomClientTest` fakes** now answer `Call.enqueue()`. They stubbed only `execute()`, which `executeAsync()` never calls.

## Two things reviewers should look at

**The size cap deliberately does not copy `Nip11Fetcher`'s pattern, because that pattern does not work.** okio's `readUtf8()` is `buffer.writeAll(source)` + `readUtf8()`, and `writeAll` drains the *entire* upstream — so `request(MAX)` only pre-buffers and never limits the read. Verified against okio 3.6.0 sources and proven with a scratch test: a 1 MB source with a 1 KB "cap" returned all 1,000,000 bytes. Reading from `source.buffer` after `request(MAX + 1)` caps for real. **`Nip11Fetcher.kt:81-88` still has this latent bug** — left for a separate change.

**The status check is not a hard `isSuccessful` gate.** LUD-06 servers report failures as HTTP 200 + `{"status":"ERROR","reason":…}`, and some use 4xx *with* a usable reason body, so throwing before parsing would discard the server's message. The body is parsed first; the status is surfaced only when the body isn't usable JSON.

## Not converted

`NipCommand.fetchText` and `RelayCommands.info` in the CLI. `amy` is a short-lived process whose `main` is `runBlocking { dispatch(argv) }` — no long-lived dispatcher pool or UI thread to protect, so blocking is by design there.

## Testing

- Full `./gradlew test` green (the pre-push hook caught the `BlossomClientTest` regression, now fixed).
- A throwaway test drove `GeoRelayCsvLoader.fetch()` over a real network call through the converted path: **395 geo relays** fetched. Not included in the diff.
- Debug APK installed and launched on an SM-T220: no crashes, no linkage errors.
- **Not runtime-verified:** the LNURL changes need the desktop app, a connected NWC wallet and a live lightning address. The size-cap and malformed-body branches are proven at the okio level only, not against a real hostile server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)