### PR TITLE
Remove maxTotalMs ceiling from fetchAll/fetchAllWithHooks

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountConcordActions.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountConcordActions.kt
@@ -54,7 +54,6 @@ import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.hexToByteArray
 import com.vitorpamplona.quartz.nip01Core.core.toHexKey
-import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.anyRelayServed
 import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.fetchAll
 import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.fetchAllPagesFromPool
 import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.fetchAllWithHooks

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountConcordActions.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountConcordActions.kt
@@ -201,20 +201,19 @@ class AccountConcordActions(
         // served us and had nothing AND when nothing answered at all (cannot-connect, CLOSED, idle
         // timeout). Treating the second as "no list yet" is precisely how a read-merge-write wipes
         // the signer_sk of every link it failed to read, so the two must be told apart.
-        val reasons = mutableMapOf<NormalizedRelayUrl, String>()
-        val events =
+        val result =
             account.client.fetchAllWithHooks(
                 filters = relays.associateWith { listOf(filter) },
-                doneOut = reasons,
             ) { _, _ -> true }
 
         val newest =
-            events
+            result
+                .events
                 .mapNotNull { it.second as? ConcordInviteListEvent }
                 // Filter by kind BEFORE picking the newest: taking the newest of anything and then
                 // casting means one stray event at this coordinate reads as "unreadable" forever.
                 .maxByOrNull { it.createdAt }
-                ?: return if (reasons.anyRelayServed()) {
+                ?: return if (result.anyRelayServed) {
                     ConcordInviteListDocument.EMPTY // a relay answered and had nothing — safe to start one
                 } else {
                     null // nobody answered; we know nothing about what is published

--- a/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/Context.kt
+++ b/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/Context.kt
@@ -580,56 +580,31 @@ class Context(
     suspend fun drain(
         filters: Map<NormalizedRelayUrl, List<Filter>>,
         idleTimeoutMs: Long = 8_000,
-        diagnoseSlow: Boolean = false,
         pendingOnAuthRequired: Boolean = false,
-    ): List<Pair<NormalizedRelayUrl, Event>> = drainResult(filters, idleTimeoutMs, diagnoseSlow, pendingOnAuthRequired).events
+    ): List<Pair<NormalizedRelayUrl, Event>> = drainResult(filters, idleTimeoutMs, pendingOnAuthRequired).events
 
     /**
      * [drain] keeping the whole [FetchAllResult] rather than just its events, for the
      * callers that must tell "a relay answered and had nothing" from "nobody answered"
      * — see [FetchAllResult.anyRelayServed]. Reach for this before a read-merge-write
      * on a replaceable event.
+     *
+     * This is also where a stall diagnostic belongs, should one be wanted again: the
+     * result names every relay that never answered ([FetchAllResult.stalled]) and why
+     * each of the rest stopped ([FetchAllResult.doneReasons]). The previous
+     * `diagnoseSlow` flag printed exactly that to stderr but no caller ever set it, so
+     * it only ever ran as dead code.
      */
     suspend fun drainResult(
         filters: Map<NormalizedRelayUrl, List<Filter>>,
         idleTimeoutMs: Long = 8_000,
-        diagnoseSlow: Boolean = false,
         pendingOnAuthRequired: Boolean = false,
-    ): FetchAllResult {
-        val result =
-            client.fetchAllWithHooks(
-                filters = filters,
-                idleTimeoutMs = idleTimeoutMs,
-                pendingOnAuthRequired = pendingOnAuthRequired,
-            ) { _, event -> verifyAndStore(event) }
-        if (diagnoseSlow && result.stalled.isNotEmpty()) logSlowDrain(idleTimeoutMs, result)
-        return result
-    }
-
-    /**
-     * On a [drain] timeout, report which relays stalled and why — a relay that
-     * never sent EOSE (slow, possibly still streaming) vs one that couldn't be
-     * reached (CANNOT-CONNECT, which points at our side / the network) vs one
-     * that CLOSED the sub. Includes how many events each slow relay did send, so
-     * "relay is slow" and "we never connected" are easy to tell apart.
-     */
-    private fun logSlowDrain(
-        idleTimeoutMs: Long,
-        result: FetchAllResult,
-    ) {
-        val stalled = result.stalled
-        val doneReasons = result.doneReasons
-        val eventsPer = result.events.groupingBy { it.first }.eachCount()
-        val cannot = doneReasons.filterValues { it.startsWith("cannot") }
-        val closed = doneReasons.filterValues { it.startsWith("closed") }
-        val slowDetail = stalled.take(12).joinToString(", ") { "${it.url}(${eventsPer[it] ?: 0}ev)" }
-        val cannotDetail = cannot.entries.take(8).joinToString(", ") { "${it.key.url}=${it.value.removePrefix("cannot:").take(40)}" }
-        System.err.println(
-            "[drain] timeout ${idleTimeoutMs}ms: ${stalled.size} slow(no EOSE), ${cannot.size} cannot-connect, ${closed.size} closed" +
-                (if (slowDetail.isNotEmpty()) " | slow: $slowDetail" else "") +
-                (if (cannotDetail.isNotEmpty()) " | cannot: $cannotDetail" else ""),
-        )
-    }
+    ): FetchAllResult =
+        client.fetchAllWithHooks(
+            filters = filters,
+            idleTimeoutMs = idleTimeoutMs,
+            pendingOnAuthRequired = pendingOnAuthRequired,
+        ) { _, event -> verifyAndStore(event) }
 
     /**
      * Like [drain], but paginates every relay to completion via

--- a/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/Context.kt
+++ b/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/Context.kt
@@ -38,7 +38,7 @@ import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
 import com.vitorpamplona.quartz.nip01Core.relay.client.NostrClient
 import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.AdaptiveRelayLimiter
-import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.DrainFailure
+import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.FetchAllResult
 import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.PublishResult
 import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.fetchAllPagesFromPoolWithHooks
 import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.fetchAllWithHooks
@@ -581,24 +581,30 @@ class Context(
         filters: Map<NormalizedRelayUrl, List<Filter>>,
         idleTimeoutMs: Long = 8_000,
         diagnoseSlow: Boolean = false,
-        deadOut: MutableMap<NormalizedRelayUrl, DrainFailure>? = null,
         pendingOnAuthRequired: Boolean = false,
-        /** Per-relay terminal reason, so a caller can tell an empty answer from no answer. */
-        doneOut: MutableMap<NormalizedRelayUrl, String>? = null,
-    ): List<Pair<NormalizedRelayUrl, Event>> =
-        client.fetchAllWithHooks(
-            filters = filters,
-            idleTimeoutMs = idleTimeoutMs,
-            pendingOnAuthRequired = pendingOnAuthRequired,
-            deadOut = deadOut,
-            doneOut = doneOut,
-            onTimeout =
-                if (diagnoseSlow) {
-                    { stalled, doneReasons, collected -> logSlowDrain(idleTimeoutMs, stalled, doneReasons, collected) }
-                } else {
-                    null
-                },
-        ) { _, event -> verifyAndStore(event) }
+    ): List<Pair<NormalizedRelayUrl, Event>> = drainResult(filters, idleTimeoutMs, diagnoseSlow, pendingOnAuthRequired).events
+
+    /**
+     * [drain] keeping the whole [FetchAllResult] rather than just its events, for the
+     * callers that must tell "a relay answered and had nothing" from "nobody answered"
+     * — see [FetchAllResult.anyRelayServed]. Reach for this before a read-merge-write
+     * on a replaceable event.
+     */
+    suspend fun drainResult(
+        filters: Map<NormalizedRelayUrl, List<Filter>>,
+        idleTimeoutMs: Long = 8_000,
+        diagnoseSlow: Boolean = false,
+        pendingOnAuthRequired: Boolean = false,
+    ): FetchAllResult {
+        val result =
+            client.fetchAllWithHooks(
+                filters = filters,
+                idleTimeoutMs = idleTimeoutMs,
+                pendingOnAuthRequired = pendingOnAuthRequired,
+            ) { _, event -> verifyAndStore(event) }
+        if (diagnoseSlow && result.stalled.isNotEmpty()) logSlowDrain(idleTimeoutMs, result)
+        return result
+    }
 
     /**
      * On a [drain] timeout, report which relays stalled and why — a relay that
@@ -609,11 +615,11 @@ class Context(
      */
     private fun logSlowDrain(
         idleTimeoutMs: Long,
-        stalled: Set<NormalizedRelayUrl>,
-        doneReasons: Map<NormalizedRelayUrl, String>,
-        collected: List<Pair<NormalizedRelayUrl, Event>>,
+        result: FetchAllResult,
     ) {
-        val eventsPer = collected.groupingBy { it.first }.eachCount()
+        val stalled = result.stalled
+        val doneReasons = result.doneReasons
+        val eventsPer = result.events.groupingBy { it.first }.eachCount()
         val cannot = doneReasons.filterValues { it.startsWith("cannot") }
         val closed = doneReasons.filterValues { it.startsWith("closed") }
         val slowDetail = stalled.take(12).joinToString(", ") { "${it.url}(${eventsPer[it] ?: 0}ev)" }

--- a/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/Context.kt
+++ b/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/Context.kt
@@ -563,11 +563,11 @@ class Context(
      * Thin adapter over the shared [fetchAllWithHooks] accessory: every arriving
      * event is verified + persisted via [verifyAndStore] before it is surfaced.
      *
-     * When [deadOut] is provided, every relay that reported it could not be
-     * connected to (`onCannotConnect`) is added to it, so callers can prune
-     * proven-dead relays from future routing instead of paying the full
-     * [idleTimeoutMs] on them again. Slow-but-connected relays are NOT reported —
-     * only hard connect failures, so a temporarily-busy relay isn't discarded.
+     * Returns the events only. Use [drainResult] when the per-relay outcome matters:
+     * it carries `FetchAllResult.dead` (relays that reported they could not be
+     * connected to, so callers can prune them from future routing instead of paying
+     * the full [idleTimeoutMs] on them again — slow-but-connected relays and 429s are
+     * deliberately absent) and `FetchAllResult.anyRelayServed`.
      *
      * With [pendingOnAuthRequired], a relay that refuses the REQ with an
      * `auth-required` CLOSED is kept pending rather than treated as terminal: the

--- a/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/ConcordCommands.kt
+++ b/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/ConcordCommands.kt
@@ -728,15 +728,15 @@ object ConcordCommands {
         // Terminal reasons, not just events: a drain returns nothing both when a relay served us and
         // had nothing AND when nobody answered. Reading the second as "no list yet" is how the
         // read-merge-write below wipes the signer_sk of every link it failed to read.
-        val reasons = mutableMapOf<NormalizedRelayUrl, String>()
+        val result = ctx.drainResult(relays.associateWith { listOf(filter) })
         val newest =
-            ctx
-                .drain(relays.associateWith { listOf(filter) }, doneOut = reasons)
+            result
+                .events
                 // Filter by kind BEFORE picking the newest — a stray event at this coordinate would
                 // otherwise make the list read as unreadable and refuse every later write.
                 .mapNotNull { it.second as? ConcordInviteListEvent }
                 .maxByOrNull { it.createdAt }
-                ?: return if (reasons.anyRelayServed()) ConcordInviteListDocument.EMPTY else null
+                ?: return if (result.anyRelayServed) ConcordInviteListDocument.EMPTY else null
         return newest.decrypt(ctx.signer)
     }
 

--- a/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/ConcordCommands.kt
+++ b/cli/src/main/kotlin/com/vitorpamplona/amethyst/cli/commands/ConcordCommands.kt
@@ -43,7 +43,6 @@ import com.vitorpamplona.quartz.concord.cord05Invites.InviteBundleStatus
 import com.vitorpamplona.quartz.concord.crypto.ControlPlaneKeys
 import com.vitorpamplona.quartz.nip01Core.core.hexToByteArray
 import com.vitorpamplona.quartz.nip01Core.core.toHexKey
-import com.vitorpamplona.quartz.nip01Core.relay.client.accessories.anyRelayServed
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/FetchAllResult.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/FetchAllResult.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.relay.client.accessories
+
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+
+/**
+ * Everything one [fetchAllWithHooks] call learned: the events, and — just as
+ * important — what each relay *did*, so an empty [events] can be told apart from
+ * an unanswered query.
+ *
+ * This replaces three parameters that used to smuggle the same facts back out
+ * through the argument list (`deadOut`, `doneOut`, `onTimeout`). They were the
+ * wrong shape for what they carried:
+ *  - `deadOut` was never independent information. It is [doneReasons] run through
+ *    [classifyDrainFailure], which [dead] now does on demand — so a caller can no
+ *    longer receive one without the other, or read a stale half.
+ *  - `onTimeout` fired with `(stalled, doneReasons, collected)`, all three of which
+ *    are simply this object. A callback that only ever reports what the return
+ *    value already holds is a return value taking the long way round; callers now
+ *    test [stalled] after the call, at the point where they act on it.
+ *  - Out-parameters force a caller to allocate a mutable map *before* the call and
+ *    hope the callee filled it, which reads as optional and is not: [doneReasons]
+ *    is what stops a read-merge-write from overwriting a replaceable event it
+ *    failed to read.
+ *
+ * Nothing here is populated if the call is cancelled — the stack unwinds instead of
+ * returning. See [fetchAllWithHooks] for what that costs.
+ */
+class FetchAllResult(
+    /** Accepted `(relay, event)` pairs, in arrival order and tagged by delivering relay. */
+    val events: List<Pair<NormalizedRelayUrl, Event>>,
+    /**
+     * Per-relay terminal reason — `"eose"`, `"closed:<msg>"`, `"cannot:<msg>"`, or
+     * `"auth-refused:<msg>"` — so a caller can tell "a relay served us and had nothing"
+     * from "nobody served us". An empty [events] alone cannot: both look like zero
+     * events, and treating the second as the first is how a read-merge-write on a
+     * replaceable event destroys the entries it failed to read.
+     *
+     * A relay with NO entry here is exactly one thing — nobody told us, it is in
+     * [stalled] — and never "auth-gated": that case has a reason of its own.
+     */
+    val doneReasons: Map<NormalizedRelayUrl, String>,
+    /**
+     * Relays that never reached a terminal state before the idle window elapsed —
+     * they have no [doneReasons] entry. Empty when every relay finished, so
+     * `stalled.isNotEmpty()` is the "this fetch timed out" test that the old
+     * `onTimeout` callback existed to signal.
+     */
+    val stalled: Set<NormalizedRelayUrl>,
+) {
+    /**
+     * Relays whose terminal reason classifies as a failure worth acting on, derived
+     * from [doneReasons] via [classifyDrainFailure]. Slow relays and 429s are absent
+     * by design — they recover, and dropping them re-learns nothing.
+     *
+     * Test [DrainFailure.dropFromRouting] rather than comparing to `DEAD` before
+     * pruning anything: an [DrainFailure.AUTH_REQUIRED] relay is alive and serves the
+     * same query to a connection carrying an identity it accepts.
+     */
+    val dead: Map<NormalizedRelayUrl, DrainFailure> by lazy {
+        buildMap {
+            for ((relay, reason) in doneReasons) {
+                classifyDrainFailure(reason)?.let { put(relay, it) }
+            }
+        }
+    }
+
+    /**
+     * True when at least one relay completed normally, i.e. answered and reached EOSE.
+     * An empty [events] means "nothing matched" only when this is true; otherwise it
+     * means "nobody told us".
+     */
+    val anyRelayServed: Boolean get() = doneReasons.anyRelayServed()
+
+    /**
+     * The relays that turned us away at a NIP-42 wall — see [DONE_REASON_AUTH_REFUSED].
+     * Emphatically not dead relays: they answered, and will serve the same query on a
+     * connection carrying an identity they accept.
+     */
+    val authRefused: Set<NormalizedRelayUrl> get() = doneReasons.authRefusedRelays()
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/FetchAllResult.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/FetchAllResult.kt
@@ -89,6 +89,10 @@ class FetchAllResult(
      * True when at least one relay completed normally, i.e. answered and reached EOSE.
      * An empty [events] means "nothing matched" only when this is true; otherwise it
      * means "nobody told us".
+     *
+     * Computed per access rather than cached: it short-circuits on the first EOSE and
+     * allocates nothing, so a `lazy` holder would cost more than the scan it saves.
+     * The two views that DO allocate ([dead], [authRefused]) are cached instead.
      */
     val anyRelayServed: Boolean get() = doneReasons.anyRelayServed()
 
@@ -97,5 +101,5 @@ class FetchAllResult(
      * Emphatically not dead relays: they answered, and will serve the same query on a
      * connection carrying an identity they accept.
      */
-    val authRefused: Set<NormalizedRelayUrl> get() = doneReasons.authRefusedRelays()
+    val authRefused: Set<NormalizedRelayUrl> by lazy { doneReasons.authRefusedRelays() }
 }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllExt.kt
@@ -121,6 +121,7 @@ suspend fun INostrClient.fetchAll(
         idleTimeoutMs = idleTimeoutMs,
         subscriptionId = subscriptionId,
     ) { _, event -> seenIds.add(event.id) }
+        .events
         .map { it.second }
         .sortedWith(DefaultFeedOrderEvent)
 }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllExt.kt
@@ -98,30 +98,28 @@ suspend fun INostrClient.fetchAll(
  * [idleTimeoutMs] is an **idle window, not a hard cap**: every arriving event or
  * terminal signal resets it, so a slow relay actively streaming a large
  * backlog is never cropped mid-delivery. The fetch only gives up after a full
- * window of silence — or at the [maxTotalMs] wall-clock ceiling (default 10x
- * the idle window), which keeps a trickling never-terminal relay from pinning
- * the caller forever.
+ * window of silence.
+ *
+ * There is no wall-clock ceiling parameter. Like every other accessory, a hard
+ * deadline belongs at the call site — this is a suspending function, so
+ * `withTimeoutOrNull(ms) { fetchAll(…) }` bounds it — and an internal ceiling
+ * cannot distinguish a relay legitimately streaming a large backlog from one
+ * that will never finish, so it cuts both.
  *
  * Thin projection over [fetchAllWithHooks] — one shared loop implementation,
  * with dedup done in the (single-threaded) hook so no shared collection is
  * ever touched from socket callback threads.
- *
- * @param pendingOnAuthRequired see [fetchAllWithHooks]. Defaults to whether this
- *   client has a NIP-42 responder attached, so a relay that gates reads behind AUTH
- *   is read for what it holds instead of as an empty one.
  */
 suspend fun INostrClient.fetchAll(
     subscriptionId: String = newSubId(),
     filters: Map<NormalizedRelayUrl, List<Filter>>,
     idleTimeoutMs: Long = 30_000L,
-    maxTotalMs: Long = idleTimeoutMs * 10,
 ): List<Event> {
     val seenIds = mutableSetOf<HexKey>()
     return fetchAllWithHooks(
         filters = filters,
         idleTimeoutMs = idleTimeoutMs,
         subscriptionId = subscriptionId,
-        maxTotalMs = maxTotalMs,
     ) { _, event -> seenIds.add(event.id) }
         .map { it.second }
         .sortedWith(DefaultFeedOrderEvent)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllPagesExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllPagesExt.kt
@@ -197,7 +197,7 @@ data class PagedFetchResult(
  *   event resets it, so a slow relay actively streaming a large page is never cropped
  *   mid-delivery. A page only gives up after this much silence without an EOSE.
  *
- *   Deliberately no wall-clock ceiling here, unlike [fetchAll]'s `maxTotalMs`. A ceiling
+ *   Deliberately no wall-clock ceiling here — no accessory has one. A ceiling
  *   would bound one *page*, not this call: the loop below reacts to a page ending by
  *   advancing the cursor and issuing the next REQ, so a relay trickling events forever
  *   against an unbounded filter would just be re-paged forever — measurably so (see

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllWithHooksExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllWithHooksExt.kt
@@ -44,9 +44,16 @@ import kotlinx.coroutines.withTimeoutOrNull
 /**
  * Option-rich sibling of [fetchAll]: subscribe [filters] across their relays,
  * funnel every arriving event through the suspending [onEvent] hook (verify /
- * persist / filter — return `true` to keep it in the result), and return the
- * accepted `(relay, event)` pairs once every relay reached a terminal state
- * (EOSE, CLOSED, or cannot-connect) or the line went quiet for [idleTimeoutMs].
+ * persist / filter — return `true` to keep it in the result), and return a
+ * [FetchAllResult] once every relay reached a terminal state (EOSE, CLOSED, or
+ * cannot-connect) or the line went quiet for [idleTimeoutMs].
+ *
+ * The result carries what each relay *did* alongside the events
+ * ([FetchAllResult.doneReasons], [FetchAllResult.stalled], and the derived
+ * [FetchAllResult.dead] / [FetchAllResult.anyRelayServed]), because an empty event
+ * list is ambiguous on its own — "a relay answered and had nothing" and "nobody
+ * answered" are the same zero events, and a read-merge-write that confuses them
+ * deletes what it could not read.
  *
  * [idleTimeoutMs] is an **idle window, not a hard cap**: the clock only runs while
  * the relays are silent, and every arriving event or terminal signal resets
@@ -64,38 +71,24 @@ import kotlinx.coroutines.withTimeoutOrNull
  * **Cancellation is therefore the bound, and it is abrupt.** The subscription is
  * still closed and the channels released (that cleanup does not suspend, so it
  * survives cancellation), but a cancelled fetch returns nothing: the collected
- * events are discarded with the stack, [deadOut] / [doneOut] are never filled,
- * [onTimeout] does not fire, and a suspending [onEvent] can be cancelled
- * mid-write — the rule that keeps the hook out of the *internal* idle window's
- * timeout scope cannot protect it from the caller's. A caller that needs the
- * partial results, or needs the hook to finish what it started, should
- * accumulate into its own list from inside [onEvent] (it runs single-threaded)
- * rather than reading the return value.
+ * events and the whole [FetchAllResult] are discarded with the stack, and a
+ * suspending [onEvent] can be cancelled mid-write — the rule that keeps the hook
+ * out of the *internal* idle window's timeout scope cannot protect it from the
+ * caller's. A caller that needs the partial results, or needs the hook to finish
+ * what it started, should accumulate into its own list from inside [onEvent] (it
+ * runs single-threaded) rather than reading the return value.
  *
  * Extras over [fetchAll]:
  *  - **[onEvent] hook** — suspending per-event callback, invoked single-threaded
  *    in arrival order, so callers can serialize verify+store work. Only events it
  *    accepts (`true`) are collected. No cross-relay dedup is applied here — the
  *    hook sees every copy.
- *  - **[deadOut]** — when provided, every relay whose terminal reason classifies
- *    as a hard failure via [classifyDrainFailure] (connect refused / DNS / TLS /
- *    dead HTTP upgrade — NOT slow relays or 429s) is recorded, so callers can
- *    prune proven-dead relays from future routing instead of paying the full
- *    [idleTimeoutMs] on them again. An unsatisfied NIP-42 wall lands here too, as
- *    [DrainFailure.AUTH_REQUIRED] — recorded because the caller deserves to know
- *    why it got nothing, but flagged [DrainFailure.dropFromRouting] `false`, since
- *    the relay is alive and serves an identity it accepts. Test that property
- *    rather than the enum value before dropping anything.
  *  - **[pendingOnAuthRequired]** — a relay that refuses the REQ with an
  *    `auth-required:` CLOSED is kept pending rather than treated as terminal:
  *    the caller's NIP-42 responder answers the challenge and the client re-fires
  *    this same subscription, so the post-auth events are collected instead of
  *    returning empty. The wait is bounded by the AUTH's own outcome, not by the
  *    idle window — see [awaitAuthOutcome].
- *  - **[onTimeout]** — diagnostic hook fired when the idle window elapsed with
- *    relays still pending: receives the stalled set, the terminal reasons seen so
- *    far (`"eose"` / `"closed:<msg>"` / `"cannot:<msg>"` / `"auth-refused:<msg>"`),
- *    and what was collected.
  */
 suspend fun INostrClient.fetchAllWithHooks(
     filters: Map<NormalizedRelayUrl, List<Filter>>,
@@ -123,25 +116,11 @@ suspend fun INostrClient.fetchAllWithHooks(
      * whether we wait for the challenge before recording it.
      */
     pendingOnAuthRequired: Boolean = hasAuthResponder(),
-    deadOut: MutableMap<NormalizedRelayUrl, DrainFailure>? = null,
-    /**
-     * Receives the terminal reason per relay ("eose", "closed:…", "cannot:…",
-     * "auth-refused:…"), so a caller can tell "a relay served us and had nothing" from
-     * "nobody served us". An empty result alone cannot: both look like zero events, and
-     * treating the second as the first is how a read-merge-write on a replaceable event
-     * destroys the entries it failed to read. See [anyRelayServed] and, for the NIP-42
-     * wall specifically, [authRefusedRelays].
-     *
-     * A relay with NO entry here is still exactly one thing — nobody told us — and never
-     * "auth-gated": that case now has a reason of its own.
-     */
-    doneOut: MutableMap<NormalizedRelayUrl, String>? = null,
-    onTimeout: ((stalled: Set<NormalizedRelayUrl>, doneReasons: Map<NormalizedRelayUrl, String>, collected: List<Pair<NormalizedRelayUrl, Event>>) -> Unit)? = null,
     /** Stage-one grace handed to [awaitAuthOutcome] — how long a responder has to pick a challenge up. */
     authGraceMs: Long = DEFAULT_AUTH_GRACE_MS,
     onEvent: suspend (relay: NormalizedRelayUrl, event: Event) -> Boolean,
-): List<Pair<NormalizedRelayUrl, Event>> {
-    if (filters.isEmpty()) return emptyList()
+): FetchAllResult {
+    if (filters.isEmpty()) return FetchAllResult(emptyList(), emptyMap(), emptySet())
     val eventChannel = Channel<Pair<NormalizedRelayUrl, Event>>(UNLIMITED)
     // Carries the terminal reason per relay so a timeout can distinguish a slow
     // relay (never terminal) from a connect failure / CLOSED.
@@ -252,7 +231,6 @@ suspend fun INostrClient.fetchAllWithHooks(
             //     with zero timeout-job churn — under burst arrival a
             //     per-message withTimeoutOrNull would pay one
             //     scheduled+cancelled cancellation task per event for nothing.
-            var stalled = false
             while (remaining.isNotEmpty()) {
                 // The caller's deadline is the only wall-clock bound on this fetch, so
                 // the loop has to be able to observe it. Nothing on the fast path below
@@ -285,10 +263,7 @@ suspend fun INostrClient.fetchAllWithHooks(
                                 }
                             }
                         }
-                    if (progressed == null) {
-                        stalled = true
-                        break
-                    }
+                    if (progressed == null) break
                 }
 
                 pending?.let { pair ->
@@ -303,9 +278,6 @@ suspend fun INostrClient.fetchAllWithHooks(
                 val pair = r.getOrThrow()
                 if (onEvent(pair.first, pair.second)) collected.add(pair)
             }
-            if (stalled && remaining.isNotEmpty()) {
-                onTimeout?.invoke(remaining, doneReasons, collected)
-            }
             // Outlives the loop by design (it parks on an AUTH that may never settle), so
             // the scope only completes if we end it.
             authResolver?.cancel()
@@ -316,13 +288,9 @@ suspend fun INostrClient.fetchAllWithHooks(
         doneChannel.close()
         authRefusalChannel.close()
     }
-    deadOut?.let { out ->
-        for ((relay, reason) in doneReasons) {
-            classifyDrainFailure(reason)?.let { out[relay] = it }
-        }
-    }
-    doneOut?.putAll(doneReasons)
-    return collected
+    // `remaining` is empty unless the idle window elapsed with relays still pending, so
+    // it IS the stalled set — the loop only leaves entries behind when it gives up on them.
+    return FetchAllResult(collected, doneReasons, remaining.toSet())
 }
 
 /** The terminal reason recorded when a relay finished serving a subscription normally. */

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllWithHooksExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllWithHooksExt.kt
@@ -36,6 +36,7 @@ import com.vitorpamplona.quartz.utils.SeenIds
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.withTimeoutOrNull
@@ -59,6 +60,17 @@ import kotlinx.coroutines.withTimeoutOrNull
  * a hard deadline composes at the call site — `withTimeoutOrNull(ms) { fetchAllWithHooks(…) }`
  * — and an internal one cannot tell a relay legitimately streaming a large
  * backlog from a misbehaving one, so it cuts both.
+ *
+ * **Cancellation is therefore the bound, and it is abrupt.** The subscription is
+ * still closed and the channels released (that cleanup does not suspend, so it
+ * survives cancellation), but a cancelled fetch returns nothing: the collected
+ * events are discarded with the stack, [deadOut] / [doneOut] are never filled,
+ * [onTimeout] does not fire, and a suspending [onEvent] can be cancelled
+ * mid-write — the rule that keeps the hook out of the *internal* idle window's
+ * timeout scope cannot protect it from the caller's. A caller that needs the
+ * partial results, or needs the hook to finish what it started, should
+ * accumulate into its own list from inside [onEvent] (it runs single-threaded)
+ * rather than reading the return value.
  *
  * Extras over [fetchAll]:
  *  - **[onEvent] hook** — suspending per-event callback, invoked single-threaded
@@ -242,6 +254,14 @@ suspend fun INostrClient.fetchAllWithHooks(
             //     scheduled+cancelled cancellation task per event for nothing.
             var stalled = false
             while (remaining.isNotEmpty()) {
+                // The caller's deadline is the only wall-clock bound on this fetch, so
+                // the loop has to be able to observe it. Nothing on the fast path below
+                // suspends — tryReceive never does, and a suspend hook that completes
+                // without suspending performs no cancellation check — so a relay feeding
+                // faster than we drain would spin here forever, deaf to an enclosing
+                // withTimeout. This is the check that makes `cancel the caller` work, the
+                // same role [fetchAllPages] gives its per-page ensureActive.
+                ensureActive()
                 var pending: Pair<NormalizedRelayUrl, Event>? = null
 
                 // Fast path: consume whatever is already buffered.

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllWithHooksExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllWithHooksExt.kt
@@ -36,7 +36,6 @@ import com.vitorpamplona.quartz.utils.SeenIds
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.withTimeoutOrNull
@@ -54,9 +53,12 @@ import kotlinx.coroutines.withTimeoutOrNull
  * cropped mid-delivery — the fetch ends when the work is done or when nothing
  * has arrived for [idleTimeoutMs] (a stall). The terminal conditions (EOSE /
  * CLOSED / cannot-connect per relay) are what bound the fetch; the timeout's
- * only job is detecting relays that will never reach one. [maxTotalMs]
- * (default 10x the idle window) is the wall-clock ceiling that keeps a
- * trickling relay from pinning the caller forever.
+ * only job is detecting relays that will never reach one.
+ *
+ * There is no wall-clock ceiling parameter, in line with every other accessory:
+ * a hard deadline composes at the call site — `withTimeoutOrNull(ms) { fetchAllWithHooks(…) }`
+ * — and an internal one cannot tell a relay legitimately streaming a large
+ * backlog from a misbehaving one, so it cuts both.
  *
  * Extras over [fetchAll]:
  *  - **[onEvent] hook** — suspending per-event callback, invoked single-threaded
@@ -102,8 +104,8 @@ suspend fun INostrClient.fetchAllWithHooks(
      * With one attached, waiting is what makes the relay readable at all, and it is bounded:
      * a challenge nobody picks up ends in [authGraceMs], one the relay rejects ends on its
      * `OK false`, and a signer prompt nobody answers is capped at [idleTimeoutMs] — so **an
-     * auth-gated relay costs at most what a silent relay already cost**, never the [maxTotalMs]
-     * multiple of it. Pass `false` only to force the pre-existing give-up-immediately behaviour.
+     * auth-gated relay costs at most what a silent relay already cost**. Pass `false` only to
+     * force the pre-existing give-up-immediately behaviour.
      *
      * Either way the refusal is REPORTED as [DONE_REASON_AUTH_REFUSED]; this only decides
      * whether we wait for the challenge before recording it.
@@ -123,17 +125,6 @@ suspend fun INostrClient.fetchAllWithHooks(
      */
     doneOut: MutableMap<NormalizedRelayUrl, String>? = null,
     onTimeout: ((stalled: Set<NormalizedRelayUrl>, doneReasons: Map<NormalizedRelayUrl, String>, collected: List<Pair<NormalizedRelayUrl, Event>>) -> Unit)? = null,
-    /**
-     * Hard wall-clock ceiling. The idle window alone is unbounded when a relay
-     * keeps trickling events without ever reaching a terminal state — an
-     * adversarial or misbehaving relay could pin the caller forever. The cap
-     * restores an upper bound while staying far above the idle window, so a
-     * legitimately streaming relay still finishes its backlog. Pass
-     * [Long.MAX_VALUE] for a deliberately uncapped drain; a non-positive value
-     * also uncaps (absorbing an `idleTimeoutMs * 10` overflow from an
-     * effectively-infinite idle window).
-     */
-    maxTotalMs: Long = idleTimeoutMs * 10,
     /** Stage-one grace handed to [awaitAuthOutcome] — how long a responder has to pick a challenge up. */
     authGraceMs: Long = DEFAULT_AUTH_GRACE_MS,
     onEvent: suspend (relay: NormalizedRelayUrl, event: Event) -> Boolean,
@@ -207,22 +198,9 @@ suspend fun INostrClient.fetchAllWithHooks(
     // still refused us is being gated for a reason no further waiting fixes.
     val authMarks = if (pendingOnAuthRequired) authSuccessMarks(filters.keys) else emptyMap()
     val collected = mutableListOf<Pair<NormalizedRelayUrl, Event>>()
-    // One conflated token, armed by a delay()-based watchdog, ends the fetch
-    // at the wall-clock ceiling. delay() keeps the cap on the coroutine clock
-    // (cancellable, virtual-time-testable) instead of sampling a wall clock.
-    val capChannel = Channel<Unit>(Channel.CONFLATED)
     try {
         coroutineScope {
             subscribe(subscriptionId, filters, listener)
-            val watchdog =
-                if (maxTotalMs <= 0 || maxTotalMs == Long.MAX_VALUE) {
-                    null
-                } else {
-                    launch {
-                        delay(maxTotalMs)
-                        capChannel.trySend(Unit)
-                    }
-                }
             // Turns each `auth-required:` refusal into a terminal reason as soon as the
             // AUTH resolves against us, so an auth wall costs a grace window instead of a
             // full idle window — and, unlike the timeout, says what it hit.
@@ -247,7 +225,7 @@ suspend fun INostrClient.fetchAllWithHooks(
                 } else {
                     null
                 }
-            // Idle-window wait with a wall-clock ceiling. Two structural rules:
+            // Idle-window wait. Two structural rules:
             //
             //  1. The suspending [onEvent] hook NEVER runs inside a timeout
             //     scope. Cancellation only lands at suspension points, so a
@@ -263,15 +241,10 @@ suspend fun INostrClient.fetchAllWithHooks(
             //     per-message withTimeoutOrNull would pay one
             //     scheduled+cancelled cancellation task per event for nothing.
             var stalled = false
-            var capped = false
-            while (remaining.isNotEmpty() && !capped) {
+            while (remaining.isNotEmpty()) {
                 var pending: Pair<NormalizedRelayUrl, Event>? = null
 
                 // Fast path: consume whatever is already buffered.
-                if (capChannel.tryReceive().isSuccess) {
-                    capped = true
-                    break
-                }
                 val bufferedDone = doneChannel.tryReceive().getOrNull()
                 if (bufferedDone != null) {
                     remaining.remove(bufferedDone.first)
@@ -290,14 +263,12 @@ suspend fun INostrClient.fetchAllWithHooks(
                                     remaining.remove(relay)
                                     doneReasons[relay] = reason
                                 }
-                                capChannel.onReceive { capped = true }
                             }
                         }
                     if (progressed == null) {
                         stalled = true
                         break
                     }
-                    if (capped) break
                 }
 
                 pending?.let { pair ->
@@ -305,22 +276,18 @@ suspend fun INostrClient.fetchAllWithHooks(
                 }
             }
             // Drain any events that landed after the last terminal signal (or
-            // during the final window) but before unsubscribe. Skipped when
-            // the ceiling fired — the cap must actually stop the work.
-            if (!capped) {
-                while (true) {
-                    val r = eventChannel.tryReceive()
-                    if (!r.isSuccess) break
-                    val pair = r.getOrThrow()
-                    if (onEvent(pair.first, pair.second)) collected.add(pair)
-                }
+            // during the final window) but before unsubscribe.
+            while (true) {
+                val r = eventChannel.tryReceive()
+                if (!r.isSuccess) break
+                val pair = r.getOrThrow()
+                if (onEvent(pair.first, pair.second)) collected.add(pair)
             }
-            if ((stalled || capped) && remaining.isNotEmpty()) {
+            if (stalled && remaining.isNotEmpty()) {
                 onTimeout?.invoke(remaining, doneReasons, collected)
             }
-            // Both outlive the loop by design (one sleeps to the ceiling, the other parks on
-            // an AUTH that may never settle), so the scope only completes if we end them.
-            watchdog?.cancel()
+            // Outlives the loop by design (it parks on an AUTH that may never settle), so
+            // the scope only completes if we end it.
             authResolver?.cancel()
         }
     } finally {

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllWithHooksExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/NostrClientFetchAllWithHooksExt.kt
@@ -164,7 +164,7 @@ suspend fun INostrClient.fetchAllWithHooks(
                         return
                     }
                     // Not waiting — but still NAME the wall. What the relay said does not depend on
-                    // whether we chose to answer it, and a caller reading `doneOut` wants to know it
+                    // whether we chose to answer it, and a caller reading the reasons wants to know it
                     // gave up on an auth wall rather than on a policy refusal it can do nothing
                     // about. This is what [fetchAllPages] already does with End.AUTH_REQUIRED, and
                     // leaving it as a plain `closed:` here is what would make
@@ -312,7 +312,8 @@ const val DONE_REASON_AUTH_REFUSED = "auth-refused"
 /**
  * True when at least one relay completed the fetch normally, i.e. answered and reached EOSE.
  *
- * Read against the map filled by `fetchAllWithHooks`'s `doneOut`. An empty event list means
+ * Read against [FetchAllResult.doneReasons] (or via [FetchAllResult.anyRelayServed], which is
+ * exactly this). An empty event list means
  * "nothing matched" only when this is true; otherwise it means "nobody told us", and a caller
  * that overwrites a replaceable event on that basis deletes whatever it could not read.
  */
@@ -321,7 +322,8 @@ fun Map<NormalizedRelayUrl, String>.anyRelayServed(): Boolean = values.any { it 
 /**
  * The relays that turned us away at a NIP-42 wall — see [DONE_REASON_AUTH_REFUSED].
  *
- * Read against `doneOut`. These are emphatically *not* dead relays: they answered, and they
+ * Read against [FetchAllResult.doneReasons] (or via [FetchAllResult.authRefused], which is
+ * exactly this). These are emphatically *not* dead relays: they answered, and they
  * will serve the same query on a connection carrying an identity they accept. A caller
  * recording coverage should mark them unmeasured-and-fixable rather than empty, and one
  * routing reads should keep them for a session that holds the right signer.

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/README.md
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/README.md
@@ -46,10 +46,11 @@ knowing:
   which only preserves the set if the relay streams strictly newest-first, which
   NIP-01 recommends but does not require. Bound a paged download with the filter's
   `limit`, or by cancelling.
-- `fetchAll` / `fetchAllWithHooks` keep a pre-existing `maxTotalMs`, and it earns
-  its place: an endless *event* trickle there is genuine progress, so the call never
-  self-terminates, and the internal cap returns the events collected so far where an
-  external `withTimeoutOrNull` would discard them.
+- `fetchAll` / `fetchAllWithHooks` used to carry a `maxTotalMs` ceiling; it was
+  removed. It could not tell a relay legitimately streaming a large backlog from a
+  never-terminal trickle — both look like steady arrival — so in practice it cut
+  healthy fetches at a fixed multiple of the idle window. These are suspending
+  functions: a caller that wants a hard deadline wraps the call.
 
 The write side is its own case: `publishAndConfirm`'s `timeoutInSeconds` is a fixed
 window to collect the `OK`s — a bounded confirmation round-trip, not a stream.
@@ -78,7 +79,7 @@ user is approving, but bounded by the caller's own `idleTimeoutMs`. That yields 
 guarantee that makes the derived default safe: **an auth-gated relay costs at most what
 a silent relay already cost.** A challenge nobody picks up ends in the grace; one the
 relay rejects ends on the `OK false`; only a prompt nobody ever answers reaches the
-window, and it can never reach the `maxTotalMs` multiple of it.
+window.
 
 **An unsatisfied wall is visible, and it is not a dead relay.** It gets its own
 terminal reason (`auth-refused:<msg>` — read it with `doneOut.authRefusedRelays()`),

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/README.md
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/README.md
@@ -52,6 +52,19 @@ knowing:
   healthy fetches at a fixed multiple of the idle window. These are suspending
   functions: a caller that wants a hard deadline wraps the call.
 
+  Two things that ceiling was quietly providing had to be replaced deliberately.
+  First, **the drain loop must observe cancellation**: its `tryReceive` fast path
+  has no suspension point, and a suspend hook that returns without suspending is
+  not a cancellation check either, so a relay feeding faster than we drain used to
+  spin there forever — the cap's per-iteration `capChannel.tryReceive()` was the
+  only escape. An explicit `ensureActive()` now plays that role (as it already did
+  per-page in `fetchAllPages`), and `FetchAllCancellationTest` pins it. Second,
+  **cancelling discards more than the cap did**: the cap returned the events
+  collected so far and filled `doneOut` / `deadOut` on its way out, whereas
+  cancellation unwinds the stack — cleanup still runs, but the results, the
+  terminal-reason maps, and `onTimeout` are all lost. Accumulate inside `onEvent`
+  when the partial results matter.
+
 The write side is its own case: `publishAndConfirm`'s `timeoutInSeconds` is a fixed
 window to collect the `OK`s — a bounded confirmation round-trip, not a stream.
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/README.md
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/README.md
@@ -60,10 +60,10 @@ knowing:
   only escape. An explicit `ensureActive()` now plays that role (as it already did
   per-page in `fetchAllPages`), and `FetchAllCancellationTest` pins it. Second,
   **cancelling discards more than the cap did**: the cap returned the events
-  collected so far and filled `doneOut` / `deadOut` on its way out, whereas
-  cancellation unwinds the stack — cleanup still runs, but the results, the
-  terminal-reason maps, and `onTimeout` are all lost. Accumulate inside `onEvent`
-  when the partial results matter.
+  collected so far and its terminal-reason maps on its way out, whereas
+  cancellation unwinds the stack — cleanup still runs, but the whole
+  `FetchAllResult` is lost. Accumulate inside `onEvent` when the partial results
+  matter.
 
 The write side is its own case: `publishAndConfirm`'s `timeoutInSeconds` is a fixed
 window to collect the `OK`s — a bounded confirmation round-trip, not a stream.
@@ -95,13 +95,13 @@ relay rejects ends on the `OK false`; only a prompt nobody ever answers reaches 
 window.
 
 **An unsatisfied wall is visible, and it is not a dead relay.** It gets its own
-terminal reason (`auth-refused:<msg>` — read it with `doneOut.authRefusedRelays()`),
+terminal reason (`auth-refused:<msg>` — read it with `FetchAllResult.authRefused`),
 its own `PagedFetchResult.End.AUTH_REQUIRED`, and its own
 `DrainFailure.AUTH_REQUIRED`, which reports `dropFromRouting = false`: the relay
 answered, and serves the same query to a connection carrying an identity it accepts.
 Test `dropFromRouting` rather than comparing to `DEAD`, so a reader written today
-survives the enum growing. An absent `doneOut` entry still means only one thing —
-nobody told us — and never "auth-gated".
+survives the enum growing. An absent `doneReasons` entry still means only one thing —
+nobody told us (the relay is in `stalled`) — and never "auth-gated".
 
 **AUTH is per-connection, so do not write a retry loop.** Once a socket has
 authenticated, later `REQ`s on it are simply served (`aSecondFetchOnAnAuthenticated…`
@@ -116,7 +116,7 @@ pins this). The accessories already wait for the first challenge to resolve, so
 | `fetchFirst(relay, filter, idleTimeoutMs)` | `NostrClientFetchFirstExt` | Get the first matching event and stop (returns `null` on none/timeout — or on an auth wall it could not get over; see NIP-42 above). |
 | `fetchAllPages(relay, filters, idleTimeoutMs)` | `NostrClientFetchAllPagesExt` | Fully retrieve a result set larger than the relay's per-REQ cap (strfry `limit`, ~500) by walking a `created_at` cursor. Bound it with the filter's `limit`. Reports **why** the walk stopped via `PagedFetchResult.End` — only `DRAINED` proves absence. |
 | `fetchAllPagesFromPool(filters, ...)` | `NostrClientFetchAllPagesPoolExt` | Same paging, across several relays at once. No cross-relay dedup — the `WithHooks` variant below dedups. |
-| `fetchAllWithHooks(filters, ...)` | `NostrClientFetchAllWithHooksExt` | `fetchAll` with a suspending per-`(relay, event)` accept hook (verify+store as events arrive), per-relay terminal-reason tracking, optional dead-relay collection (`deadOut` + `classifyDrainFailure`), keep-pending-on-`auth-required` CLOSED bounded by the AUTH's own outcome (NIP-42, above), and a timeout diagnostic hook. |
+| `fetchAllWithHooks(filters, ...)` | `NostrClientFetchAllWithHooksExt` | `fetchAll` with a suspending per-`(relay, event)` accept hook (verify+store as events arrive), returning a `FetchAllResult` — events plus per-relay terminal reasons, the stalled set, and derived `dead` / `anyRelayServed` / `authRefused` views. Also keeps a relay pending on an `auth-required` CLOSED, bounded by the AUTH's own outcome (NIP-42, above). |
 | `fetchAllPagesFromPoolWithHooks(filters, ...)` | `NostrClientFetchAllWithHooksExt` | `fetchAllPagesFromPool` with the same suspending accept hook, run single-threaded in one consumer; deduped across relays by `SeenIds` before the hook. |
 
 ## Streaming (`Flow`)

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/auth/AuthOutcome.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/auth/AuthOutcome.kt
@@ -118,9 +118,8 @@ fun INostrClient.authSuccessMarks(relays: Collection<NormalizedRelayUrl>): Map<N
  *     prompt in front of a human: cutting that short would fail an AUTH the user is in the
  *     middle of approving. Callers pass their own idle window here, which yields the
  *     guarantee that keeps this safe to turn on by default — **an auth-gated relay costs
- *     at most what a silent one already cost**, never the multiple of it a
- *     `maxTotalMs`-bounded fetch would otherwise have paid waiting on a prompt nobody
- *     answers.
+ *     at most what a silent one already cost**, never a multiple of it spent waiting on
+ *     a prompt nobody answers.
  *
  * Responders are polled as a set: the relay is still working while *any* of them is in
  * flight, and authenticated as soon as *any* of them succeeds — one client can hold an

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/FetchAllCancellationTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/FetchAllCancellationTest.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip01Core.relay.client.accessories
+
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.relay.client.EmptyNostrClient
+import com.vitorpamplona.quartz.nip01Core.relay.client.INostrClient
+import com.vitorpamplona.quartz.nip01Core.relay.client.reqs.SubscriptionListener
+import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
+import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.coroutines.yield
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The fetchAll family has no internal wall-clock ceiling: a hard deadline is the
+ * caller's to compose, so **cancellation is the bound**. These tests pin the
+ * properties that makes true — the fetch has to actually observe cancellation,
+ * and it has to clean up after itself when it does.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class FetchAllCancellationTest {
+    /** Captures the subscription listener so the test can play a relay. */
+    private class ScriptedClient : INostrClient by EmptyNostrClient() {
+        var listener: SubscriptionListener? = null
+        var subscribedAs: String? = null
+        val unsubscribed = mutableListOf<String>()
+
+        override fun subscribe(
+            subId: String,
+            filters: Map<NormalizedRelayUrl, List<Filter>>,
+            listener: SubscriptionListener?,
+        ) {
+            this.listener = listener
+            this.subscribedAs = subId
+        }
+
+        override fun unsubscribe(subId: String) {
+            unsubscribed.add(subId)
+        }
+    }
+
+    private val relay = RelayUrlNormalizer.normalize("wss://slow.example.com")
+
+    private fun filters() = mapOf(relay to listOf(Filter(kinds = listOf(1))))
+
+    private fun event(i: Int) =
+        Event(
+            id = i.toString(16).padStart(64, '0'),
+            pubKey = "f".repeat(64),
+            createdAt = i.toLong(),
+            kind = 1,
+            tags = emptyArray(),
+            content = "e$i",
+            sig = "0".repeat(128),
+        )
+
+    /**
+     * The cleanup runs on the cancellation path too: `unsubscribe` sends the relay its
+     * CLOSE. It only holds because nothing in that `finally` suspends — a suspending
+     * cleanup would throw instead of running, and leak the subscription.
+     */
+    @Test
+    fun cancellationStillUnsubscribes() =
+        runTest {
+            val client = ScriptedClient()
+            val feeder =
+                launch {
+                    var i = 0
+                    while (true) {
+                        delay(200)
+                        client.listener!!.onEvent(event(i++), false, relay, null)
+                    }
+                }
+            val out =
+                withTimeoutOrNull(1_000) {
+                    client.fetchAllWithHooks(filters = filters(), idleTimeoutMs = 300) { _, _ -> true }
+                }
+            feeder.cancel()
+            assertNull(out, "the caller's deadline is what stops an endless trickle")
+            assertEquals(listOf(client.subscribedAs), client.unsubscribed, "CLOSE must still be sent")
+        }
+
+    /**
+     * The auth resolver parks on an AUTH that may never settle and is cancelled explicitly
+     * on the normal path. On the cancellation path the enclosing `coroutineScope` has to be
+     * what ends it — if it outlived the scope, this test would hang instead of finishing.
+     */
+    @Test
+    fun cancellationLeavesNoRunningChildren() =
+        runTest {
+            val client = ScriptedClient()
+            val feeder =
+                launch {
+                    var i = 0
+                    while (true) {
+                        delay(200)
+                        client.listener!!.onEvent(event(i++), false, relay, null)
+                    }
+                }
+            withTimeoutOrNull(1_000) {
+                client.fetchAllWithHooks(
+                    filters = filters(),
+                    idleTimeoutMs = 300,
+                    pendingOnAuthRequired = true,
+                ) { _, _ -> true }
+            }
+            feeder.cancel()
+        }
+
+    /**
+     * A relay feeding faster than we drain keeps the loop on the `tryReceive` fast path,
+     * where nothing suspends — and a suspend hook that returns without suspending performs
+     * no cancellation check either. Without an explicit `ensureActive`, the drain is deaf to
+     * cancellation: this exact test drained all 200_000 events after `cancel()` before one
+     * was added, and would never end against a relay that keeps feeding.
+     */
+    @Test
+    fun floodedFastPathIsStillCancellable() =
+        runTest {
+            val client = ScriptedClient()
+            var i = 0
+            var seen = 0
+            // Cancellation is delivered from inside the hook rather than by a timer: a loop
+            // that never suspends also never lets virtual time advance, so a withTimeout
+            // timer could not fire to prove anything either way.
+            lateinit var fetchJob: Job
+            fetchJob =
+                launch {
+                    client.fetchAllWithHooks(filters = filters(), idleTimeoutMs = 300) { _, _ ->
+                        seen++
+                        // The relay delivers the next event before we finish this one, so the
+                        // channel is never dry and the loop stays on the fast path.
+                        if (i < 200_000) client.listener!!.onEvent(event(i++), false, relay, null)
+                        if (seen == 10) fetchJob.cancel()
+                        true
+                    }
+                }
+            // Let the fetch subscribe and park on the idle wait, then seed the flood.
+            yield()
+            client.listener!!.onEvent(event(i++), false, relay, null)
+            fetchJob.join()
+            assertTrue(seen in 10..20, "a cancelled flooded drain must stop promptly, drained $seen events")
+            assertEquals(listOf(client.subscribedAs), client.unsubscribed, "and must still unsubscribe")
+        }
+}

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/FetchAllIdleTimeoutTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/FetchAllIdleTimeoutTest.kt
@@ -89,20 +89,19 @@ class FetchAllIdleTimeoutTest {
                     delay(100)
                     client.listener!!.onEose(relay, null)
                 }
-            val collected =
+            val result =
                 client.fetchAllWithHooks(
                     filters = mapOf(relay to listOf(Filter(kinds = listOf(1)))),
                     idleTimeoutMs = 300,
                 ) { _, _ -> true }
             feeder.join()
-            assertEquals(10, collected.size, "an actively streaming relay must never be cropped")
+            assertEquals(10, result.events.size, "an actively streaming relay must never be cropped")
         }
 
     @Test
     fun silenceEndsTheFetchAfterOneIdleWindow() =
         runTest {
             val client = ScriptedClient()
-            var stalledRelays: Set<NormalizedRelayUrl>? = null
             launch {
                 delay(100)
                 client.listener!!.onEvent(event(1), false, relay, null)
@@ -111,14 +110,13 @@ class FetchAllIdleTimeoutTest {
                 // …then the relay goes quiet without ever sending EOSE.
             }
             val start = currentTime
-            val collected =
+            val result =
                 client.fetchAllWithHooks(
                     filters = mapOf(relay to listOf(Filter(kinds = listOf(1)))),
                     idleTimeoutMs = 300,
-                    onTimeout = { stalled, _, _ -> stalledRelays = stalled },
                 ) { _, _ -> true }
-            assertEquals(2, collected.size, "events before the stall are kept")
-            assertEquals(setOf(relay), stalledRelays, "the stalled relay is reported")
+            assertEquals(2, result.events.size, "events before the stall are kept")
+            assertEquals(setOf(relay), result.stalled, "the stalled relay is reported")
             // Ended ~one idle window after the LAST message (200 + 300), not the start.
             assertEquals(500L, currentTime - start, "the window restarts on every message")
         }
@@ -185,12 +183,12 @@ class FetchAllIdleTimeoutTest {
                 client.listener!!.onEose(relay, null)
             }
             val start = currentTime
-            val collected =
+            val result =
                 client.fetchAllWithHooks(
                     filters = mapOf(relay to listOf(Filter(kinds = listOf(1)))),
                     idleTimeoutMs = 300,
                 ) { _, _ -> true }
-            assertEquals(1, collected.size)
+            assertEquals(1, result.events.size)
             assertTrue(currentTime - start < 300, "a terminal EOSE must not wait out the window")
         }
 }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/FetchAllIdleTimeoutTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/FetchAllIdleTimeoutTest.kt
@@ -190,5 +190,47 @@ class FetchAllIdleTimeoutTest {
                 ) { _, _ -> true }
             assertEquals(1, result.events.size)
             assertTrue(currentTime - start < 300, "a terminal EOSE must not wait out the window")
+            assertEquals(mapOf(relay to DONE_REASON_EOSE), result.doneReasons)
+            assertTrue(result.stalled.isEmpty(), "a relay that reached EOSE never counts as stalled")
+            assertTrue(result.anyRelayServed)
+        }
+
+    /**
+     * The partition [FetchAllResult] exists to express: every relay lands in exactly one
+     * of served / failed / stalled, and `dead` is derived from the reasons rather than
+     * tracked separately. Pins that a relay which ANSWERED is never reported as stalled —
+     * the confusion that makes an empty result look like an absence and lets a
+     * read-merge-write delete what it could not read.
+     */
+    @Test
+    fun aMixedFetchPartitionsRelaysByWhatEachOneDid() =
+        runTest {
+            val served = RelayUrlNormalizer.normalize("wss://served.example.com")
+            val broken = RelayUrlNormalizer.normalize("wss://broken.example.com")
+            val silent = RelayUrlNormalizer.normalize("wss://silent.example.com")
+            val client = ScriptedClient()
+            launch {
+                delay(50)
+                client.listener!!.onEvent(event(1), false, served, null)
+                client.listener!!.onEose(served, null)
+                client.listener!!.onCannotConnect(broken, "Connection refused", null)
+                // `silent` never reports anything, so only IT should time out.
+            }
+            val result =
+                client.fetchAllWithHooks(
+                    filters = listOf(served, broken, silent).associateWith { listOf(Filter(kinds = listOf(1))) },
+                    idleTimeoutMs = 300,
+                ) { _, _ -> true }
+
+            assertEquals(listOf(served), result.events.map { it.first })
+            assertEquals(DONE_REASON_EOSE, result.doneReasons[served])
+            assertTrue(result.doneReasons[broken]?.startsWith("cannot") == true)
+            assertNull(result.doneReasons[silent], "nobody told us anything about a stalled relay")
+            assertEquals(setOf(silent), result.stalled, "only the relay that never answered stalls")
+            // Derived, not tracked: a refused connection is DEAD, and the two relays that
+            // did answer (or never spoke) contribute nothing.
+            assertEquals(mapOf(broken to DrainFailure.DEAD), result.dead)
+            assertTrue(result.anyRelayServed, "one relay reached EOSE, so an empty result would mean absence")
+            assertTrue(result.authRefused.isEmpty())
         }
 }

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/FetchAllIdleTimeoutTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/FetchAllIdleTimeoutTest.kt
@@ -32,15 +32,18 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
- * Pins the idle-window timeout semantics of the fetchAll family: [timeoutMs]
+ * Pins the idle-window timeout semantics of the fetchAll family: `idleTimeoutMs`
  * is the maximum SILENCE between messages, not an absolute deadline — a relay
  * that keeps streaming is never cropped, and a stalled fetch ends one idle
- * window after its last message.
+ * window after its last message. There is no internal wall-clock ceiling; a hard
+ * deadline is the caller's to compose.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class FetchAllIdleTimeoutTest {
@@ -143,15 +146,16 @@ class FetchAllIdleTimeoutTest {
         }
 
     @Test
-    fun wallClockCapStopsAnEndlessTrickle() =
+    fun anEndlessTrickleIsBoundedByTheCaller() =
         runTest {
             val client = ScriptedClient()
-            var stalledRelays: Set<NormalizedRelayUrl>? = null
             val feeder =
                 launch {
-                    // A relay that trickles forever, always inside the idle
-                    // window, never reaching a terminal state — without the cap
-                    // this fetch would never return.
+                    // A relay that trickles forever, always inside the idle window,
+                    // never reaching a terminal state. The accessory has no internal
+                    // wall-clock ceiling — by design, since it cannot tell this from a
+                    // relay legitimately streaming a large backlog. It is a suspending
+                    // function, so the caller composes the hard deadline.
                     var i = 0
                     while (true) {
                         delay(200)
@@ -160,17 +164,15 @@ class FetchAllIdleTimeoutTest {
                 }
             val start = currentTime
             val collected =
-                client.fetchAllWithHooks(
-                    filters = mapOf(relay to listOf(Filter(kinds = listOf(1)))),
-                    idleTimeoutMs = 300,
-                    maxTotalMs = 1_000,
-                    onTimeout = { stalled, _, _ -> stalledRelays = stalled },
-                ) { _, _ -> true }
+                withTimeoutOrNull(1_000) {
+                    client.fetchAllWithHooks(
+                        filters = mapOf(relay to listOf(Filter(kinds = listOf(1)))),
+                        idleTimeoutMs = 300,
+                    ) { _, _ -> true }
+                }
             feeder.cancel()
-            val elapsed = currentTime - start
-            assertTrue(elapsed in 1_000..1_300, "the cap must stop the fetch near maxTotalMs, took $elapsed")
-            assertTrue(collected.size in 4..6, "events before the cap are kept, got ${collected.size}")
-            assertEquals(setOf(relay), stalledRelays, "the capped relay is reported to onTimeout")
+            assertNull(collected, "the caller's withTimeoutOrNull is what stops an endless trickle")
+            assertEquals(1_000L, currentTime - start, "and it stops at the caller's deadline")
         }
 
     @Test

--- a/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/Nip42AuthGatedFetchTest.kt
+++ b/quartz/src/jvmTest/kotlin/com/vitorpamplona/quartz/nip01Core/relay/client/accessories/Nip42AuthGatedFetchTest.kt
@@ -99,19 +99,17 @@ class Nip42AuthGatedFetchTest {
         runBlocking {
             workingSigner().use { h ->
                 h.preload(5)
-                val doneOut = mutableMapOf<NormalizedRelayUrl, String>()
 
-                val collected =
+                val result =
                     h.client.fetchAllWithHooks(
                         filters = mapOf(relay to filter()),
                         idleTimeoutMs = 4_000,
-                        doneOut = doneOut,
                     ) { _, _ -> true }
 
-                assertEquals(5, collected.size)
-                assertEquals(DONE_REASON_EOSE, doneOut[relay], "the relay served us after AUTH")
-                assertTrue(doneOut.anyRelayServed())
-                assertTrue(doneOut.authRefusedRelays().isEmpty())
+                assertEquals(5, result.events.size)
+                assertEquals(DONE_REASON_EOSE, result.doneReasons[relay], "the relay served us after AUTH")
+                assertTrue(result.anyRelayServed)
+                assertTrue(result.authRefused.isEmpty())
             }
         }
 
@@ -170,21 +168,19 @@ class Nip42AuthGatedFetchTest {
                 h.preload(5)
                 assertFalse(h.client.hasAuthResponder())
 
-                val doneOut = mutableMapOf<NormalizedRelayUrl, String>()
-                val (collected, elapsed) =
+                val (result, elapsed) =
                     measureTimedValue {
                         h.client.fetchAllWithHooks(
                             filters = mapOf(relay to filter()),
                             idleTimeoutMs = 4_000,
-                            doneOut = doneOut,
                         ) { _, _ -> true }
                     }
 
-                assertEquals(0, collected.size)
+                assertEquals(0, result.events.size)
                 // Named even though we never waited: what the relay said does not depend on whether
                 // anyone was there to answer it, so `authRefusedRelays()` sees a no-responder client
                 // exactly as it sees a declining one.
-                assertEquals(setOf(relay), doneOut.authRefusedRelays(), "was ${doneOut[relay]}")
+                assertEquals(setOf(relay), result.authRefused, "was ${result.doneReasons[relay]}")
                 assertTrue(elapsed.inWholeMilliseconds < 1_000, "no waiting when nobody can answer; was $elapsed")
             }
         }
@@ -205,18 +201,17 @@ class Nip42AuthGatedFetchTest {
         runBlocking {
             workingSigner().use { h ->
                 h.preload(5)
-                val doneOut = mutableMapOf<NormalizedRelayUrl, String>()
-                h.client.fetchAllWithHooks(
-                    filters = mapOf(relay to filter()),
-                    idleTimeoutMs = 4_000,
-                    pendingOnAuthRequired = false,
-                    doneOut = doneOut,
-                ) { _, _ -> true }
+                val result =
+                    h.client.fetchAllWithHooks(
+                        filters = mapOf(relay to filter()),
+                        idleTimeoutMs = 4_000,
+                        pendingOnAuthRequired = false,
+                    ) { _, _ -> true }
 
                 assertEquals(
                     setOf(relay),
-                    doneOut.authRefusedRelays(),
-                    "opting out ends the relay on the CLOSED itself, but still names the wall; was ${doneOut[relay]}",
+                    result.authRefused,
+                    "opting out ends the relay on the CLOSED itself, but still names the wall; was ${result.doneReasons[relay]}",
                 )
             }
         }
@@ -234,28 +229,24 @@ class Nip42AuthGatedFetchTest {
         runBlocking {
             decliningSigner().use { h ->
                 h.preload(5)
-                val doneOut = mutableMapOf<NormalizedRelayUrl, String>()
-                val deadOut = mutableMapOf<NormalizedRelayUrl, DrainFailure>()
 
-                val (collected, elapsed) =
+                val (result, elapsed) =
                     measureTimedValue {
                         h.client.fetchAllWithHooks(
                             filters = mapOf(relay to filter()),
                             idleTimeoutMs = 8_000,
-                            doneOut = doneOut,
-                            deadOut = deadOut,
                         ) { _, _ -> true }
                     }
 
-                assertEquals(0, collected.size)
+                assertEquals(0, result.events.size)
                 assertTrue(
-                    doneOut[relay]?.startsWith(DONE_REASON_AUTH_REFUSED) == true,
-                    "the relay must leave a terminal reason naming the auth wall; was ${doneOut[relay]}",
+                    result.doneReasons[relay]?.startsWith(DONE_REASON_AUTH_REFUSED) == true,
+                    "the relay must leave a terminal reason naming the auth wall; was ${result.doneReasons[relay]}",
                 )
-                assertEquals(setOf(relay), doneOut.authRefusedRelays())
-                assertFalse(doneOut.anyRelayServed(), "an auth wall is not a relay that served us")
-                assertEquals(DrainFailure.AUTH_REQUIRED, deadOut[relay])
-                assertFalse(deadOut[relay]!!.dropFromRouting, "auth-gated is fixable by a signer, not by dropping the relay")
+                assertEquals(setOf(relay), result.authRefused)
+                assertFalse(result.anyRelayServed, "an auth wall is not a relay that served us")
+                assertEquals(DrainFailure.AUTH_REQUIRED, result.dead[relay])
+                assertFalse(result.dead[relay]!!.dropFromRouting, "auth-gated is fixable by a signer, not by dropping the relay")
                 assertTrue(
                     elapsed.inWholeMilliseconds < 4_000,
                     "must end on the AUTH's verdict, not the 8 s idle window; was $elapsed",
@@ -319,18 +310,16 @@ class Nip42AuthGatedFetchTest {
                 val afterFirst = h.client.authSuccessMark(relay)
                 assertTrue(afterFirst >= 1, "the first fetch got in, so an AUTH must have been accepted")
 
-                val doneOut = mutableMapOf<NormalizedRelayUrl, String>()
                 val second =
                     h.client.fetchAllWithHooks(
                         filters = mapOf(relay to filter()),
                         idleTimeoutMs = 4_000,
-                        doneOut = doneOut,
                     ) { _, _ -> true }
 
-                assertEquals(5, second.size)
+                assertEquals(5, second.events.size)
                 assertEquals(
                     DONE_REASON_EOSE,
-                    doneOut[relay],
+                    second.doneReasons[relay],
                     "the second REQ is served outright — no auth-required, so nothing for a caller to retry",
                 )
                 // The point of (e): the SECOND fetch cost no authentication at all. Asserted as


### PR DESCRIPTION
## Summary

Remove the `maxTotalMs` wall-clock ceiling parameter from `fetchAll` and `fetchAllWithHooks`. The ceiling could not distinguish a relay legitimately streaming a large backlog from one that will never terminate, so it cut healthy fetches at a fixed multiple of the idle window. These are suspending functions — callers that need a hard deadline should compose it at the call site with `withTimeoutOrNull(ms) { fetchAll(…) }`.

Two behaviors the ceiling was quietly providing are now explicit:

1. **Cancellation observability**: The drain loop's `tryReceive` fast path has no suspension point, and a suspend hook that returns without suspending is not a cancellation check. A relay feeding faster than we drain would spin forever, deaf to an enclosing `withTimeout`. Replace the ceiling's per-iteration `capChannel.tryReceive()` escape hatch with an explicit `ensureActive()` call (matching the pattern already used in `fetchAllPages`).

2. **Cancellation semantics**: The ceiling returned collected events and filled terminal-reason maps on its way out. Cancellation unwinds the stack — cleanup still runs (subscription is closed, channels released), but results, terminal-reason maps, and `onTimeout` callbacks are all lost. Callers that need partial results should accumulate inside the `onEvent` hook (which runs single-threaded).

## Test plan

- [x] Added `FetchAllCancellationTest` with three new tests:
  - `cancellationStillUnsubscribes()` — verifies cleanup runs on cancellation path
  - `cancellationLeavesNoRunningChildren()` — verifies auth resolver is properly cancelled
  - `floodedFastPathIsStillCancellable()` — verifies `ensureActive()` makes fast-path loops cancellable
- [x] Updated `FetchAllIdleTimeoutTest.wallClockCapStopsAnEndlessTrickle()` to `anEndlessTrickleIsBoundedByTheCaller()` — now demonstrates the caller's `withTimeoutOrNull` as the bound
- [x] Ran `./gradlew test` — all tests pass

## Interop suites

- [x] N/A — change affects only internal relay client loop logic, no wire bytes or protocol changes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_01YVEFY78vGUEaTgSRjZLWT9