### PR TITLE
i18n fixes

### DIFF
--- a/amethyst/src/main/res/values-cs/strings.xml
+++ b/amethyst/src/main/res/values-cs/strings.xml
@@ -4175,12 +4175,6 @@
     <string name="poll_results_checking_completeness">Zjišťuje se, kolik hlasů existuje…</string>
     <string name="poll_results_partial">Načteno %1$d z %2$d odpovědí z %3$d relé.</string>
     <string name="poll_results_partial_approx">Načteno %1$d z přibližně %2$d odpovědí z %3$d relé.</string>
-    <plurals name="poll_results_voters">
-        <item quantity="one">hlasující</item>
-        <item quantity="few">hlasující</item>
-        <item quantity="many">hlasujícího</item>
-        <item quantity="other">hlasujících</item>
-    </plurals>
     <plurals name="poll_results_vote_count_link">
         <item quantity="one">%1$d hlas ›</item>
         <item quantity="few">%1$d hlasy ›</item>

--- a/amethyst/src/main/res/values-de-rDE/strings.xml
+++ b/amethyst/src/main/res/values-de-rDE/strings.xml
@@ -4017,10 +4017,6 @@
     <string name="poll_results_checking_completeness">Es wird geprüft, wie viele Stimmen existieren…</string>
     <string name="poll_results_partial">%1$d von %2$d Antworten von %3$d Relays geladen.</string>
     <string name="poll_results_partial_approx">%1$d von etwa %2$d Antworten von %3$d Relays geladen.</string>
-    <plurals name="poll_results_voters">
-        <item quantity="one">abstimmende Person</item>
-        <item quantity="other">abstimmende Personen</item>
-    </plurals>
     <plurals name="poll_results_vote_count_link">
         <item quantity="one">%1$d Stimme ›</item>
         <item quantity="other">%1$d Stimmen ›</item>

--- a/amethyst/src/main/res/values-hu-rHU/strings.xml
+++ b/amethyst/src/main/res/values-hu-rHU/strings.xml
@@ -4014,10 +4014,6 @@
     <string name="poll_results_checking_completeness">Szavazatok számának ellenőrzése…</string>
     <string name="poll_results_partial">%1$d válasz betöltve az %2$d közül, %3$d átjátszóról.</string>
     <string name="poll_results_partial_approx">%1$d válasz betöltve a körülbelül %2$d közül, %3$d átjátszóról.</string>
-    <plurals name="poll_results_voters">
-        <item quantity="one">szavazó</item>
-        <item quantity="other">szavazó</item>
-    </plurals>
     <plurals name="poll_results_vote_count_link">
         <item quantity="one">%1$d szavazó</item>
         <item quantity="other">%1$d szavazó</item>

--- a/amethyst/src/main/res/values-pl-rPL/strings.xml
+++ b/amethyst/src/main/res/values-pl-rPL/strings.xml
@@ -1247,7 +1247,7 @@ Zaplanowane posty z innych kont nie zostaną opublikowane, dopóki to konto jest
     <plurals name="nest_listener_count">
         <item quantity="one">%1$d słuchacz</item>
         <item quantity="few">%1$d słuchaczy</item>
-        <item quantity="many"></item>
+        <item quantity="many">%1$d słuchaczy</item>
         <item quantity="other">%1$d słuchacze</item>
     </plurals>
     <string name="nest_live_chip">NA ŻYWO</string>
@@ -4061,12 +4061,6 @@ Zaplanowane posty z innych kont nie zostaną opublikowane, dopóki to konto jest
     <string name="poll_results_checking_completeness">Sprawdzanie liczby oddanych głosów…</string>
     <string name="poll_results_partial">%1$d z %2$d odpowiedzi załadowanych z %3$d transmiterów.</string>
     <string name="poll_results_partial_approx">%1$d z około %2$d odpowiedzi załadowanych z %3$d transmiterów.</string>
-    <plurals name="poll_results_voters">
-        <item quantity="one">głosujący</item>
-        <item quantity="few">głosujących</item>
-        <item quantity="many">głosujących</item>
-        <item quantity="other">głosujący</item>
-    </plurals>
     <plurals name="poll_results_vote_count_link">
         <item quantity="one">%1$d głos &lt;unk&gt;</item>
         <item quantity="few">%1$d głosów &lt;unk&gt;</item>
@@ -4683,7 +4677,7 @@ Zaplanowane posty z innych kont nie zostaną opublikowane, dopóki to konto jest
     </plurals>
     <plurals name="pow_estimate_minutes">
         <item quantity="one">%1$d minutę</item>
-        <item quantity="few">%1$s minut</item>
+        <item quantity="few">%1$d minut</item>
         <item quantity="many">%1$d minut</item>
         <item quantity="other">%1$d minut</item>
     </plurals>

--- a/amethyst/src/main/res/values-pt-rBR/strings.xml
+++ b/amethyst/src/main/res/values-pt-rBR/strings.xml
@@ -4015,10 +4015,6 @@
     <string name="poll_results_checking_completeness">Verificando quantos votos existem…</string>
     <string name="poll_results_partial">%1$d de %2$d respostas carregadas de %3$d relays.</string>
     <string name="poll_results_partial_approx">%1$d de cerca de %2$d respostas carregadas de %3$d relays.</string>
-    <plurals name="poll_results_voters">
-        <item quantity="one">votante</item>
-        <item quantity="other">votantes</item>
-    </plurals>
     <plurals name="poll_results_vote_count_link">
         <item quantity="one">%1$d voto ›</item>
         <item quantity="other">%1$d votos ›</item>

--- a/amethyst/src/main/res/values-sl-rSI/strings.xml
+++ b/amethyst/src/main/res/values-sl-rSI/strings.xml
@@ -1060,7 +1060,7 @@ Za podpisovanje se je potrebno prijaviti s privatnim ključem</string>
         <item quantity="few">Poslušanje na %1$d vhodnih relejih, vsi povezani</item>
         <item quantity="other">Poslušanje na %1$d vhodnih relejih, vsi povezani</item>
     </plurals>
-    <string name="nip46_signer_relays_some_down">Povezan na %1$d od \%2$d relejev</string>
+    <string name="nip46_signer_relays_some_down">Povezan na %1$d od %2$d relejev</string>
     <string name="nip46_signer_bunker_uri_label">Vaš bunker naslov</string>
     <string name="nip46_signer_bunker_uri_hint">Prilepite to v drugo aplikacijo, da jo povežete s svojim ključem.</string>
     <string name="nip46_signer_copy">Kopiraj</string>

--- a/amethyst/src/main/res/values-sv-rSE/strings.xml
+++ b/amethyst/src/main/res/values-sv-rSE/strings.xml
@@ -4015,10 +4015,6 @@
     <string name="poll_results_checking_completeness">Kontrollerar hur många röster som finns…</string>
     <string name="poll_results_partial">%1$d av %2$d svar inlästa från %3$d reläer.</string>
     <string name="poll_results_partial_approx">%1$d av ungefär %2$d svar inlästa från %3$d reläer.</string>
-    <plurals name="poll_results_voters">
-        <item quantity="one">röstande</item>
-        <item quantity="other">röstande</item>
-    </plurals>
     <plurals name="poll_results_vote_count_link">
         <item quantity="one">%1$d röst ›</item>
         <item quantity="other">%1$d röster ›</item>

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -4381,10 +4381,6 @@
     <string name="poll_results_checking_completeness">Checking how many votes exist…</string>
     <string name="poll_results_partial">%1$d of %2$d responses loaded from %3$d relays.</string>
     <string name="poll_results_partial_approx">%1$d of about %2$d responses loaded from %3$d relays.</string>
-    <plurals name="poll_results_voters">
-        <item quantity="one">voter</item>
-        <item quantity="other">voters</item>
-    </plurals>
     <plurals name="poll_results_vote_count_link">
         <item quantity="one">%1$d vote ›</item>
         <item quantity="other">%1$d votes ›</item>

--- a/commons/src/commonMain/composeResources/values-de-rDE/strings.xml
+++ b/commons/src/commonMain/composeResources/values-de-rDE/strings.xml
@@ -131,8 +131,8 @@
     <string name="git_status_draft">Entwurf</string>
     <string name="git_diff_binary">Binärdatei wird nicht angezeigt.</string>
     <plurals name="git_diff_files_changed">
-        <item quantity="one">Datei geändert</item>
-        <item quantity="other">Dateien geändert</item>
+        <item quantity="one">%1$d Datei geändert</item>
+        <item quantity="other">%1$d Dateien geändert</item>
     </plurals>
     <string name="bird_detection_title">Vogelerkennung</string>
     <plurals name="birdex_species_count">


### PR DESCRIPTION
fix: drop the unused poll_results_voters plural
fix: unescape the second placeholder in the Slovenian relay-count string
fix: restore dropped count placeholders in de and pl plurals


## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
