### PR TITLE
fix: blank parent card above a top-level community post

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteCompose.kt
@@ -67,6 +67,7 @@ import com.vitorpamplona.amethyst.commons.ui.note.QuietMark
 import com.vitorpamplona.amethyst.commons.ui.note.RenderCashuMint
 import com.vitorpamplona.amethyst.commons.ui.note.RenderFedimint
 import com.vitorpamplona.amethyst.commons.ui.note.RenderMintRecommendation
+import com.vitorpamplona.amethyst.commons.ui.note.replyingDirectlyTo
 import com.vitorpamplona.amethyst.commons.ui.state.produceCachedStateAsync
 import com.vitorpamplona.amethyst.model.AddressableNote
 import com.vitorpamplona.amethyst.model.LocalCache
@@ -1995,14 +1996,7 @@ fun JumpToParentReplyButton(
 
     val parentNote =
         remember(baseNote) {
-            val noteEvent = baseNote.event as? BaseThreadedEvent ?: return@remember null
-            val direct =
-                noteEvent
-                    .replyingToAddressOrEvent()
-                    ?.let { accountViewModel.getNoteIfExists(it) }
-                    ?.takeIf { it.event !is CommunityDefinitionEvent && LocalCache.getAnyChannel(it) == null }
-            val resolved = direct ?: baseNote.replyTo?.lastOrNull { it.event !is CommunityDefinitionEvent }
-            resolved?.takeIf { LocalCache.getAnyChannel(it) == null }
+            replyingDirectlyTo(baseNote, LocalCache)?.takeIf { LocalCache.getAnyChannel(it) == null }
         } ?: return
 
     ClickableBox(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteCompose.kt
@@ -67,6 +67,7 @@ import com.vitorpamplona.amethyst.commons.ui.note.QuietMark
 import com.vitorpamplona.amethyst.commons.ui.note.RenderCashuMint
 import com.vitorpamplona.amethyst.commons.ui.note.RenderFedimint
 import com.vitorpamplona.amethyst.commons.ui.note.RenderMintRecommendation
+import com.vitorpamplona.amethyst.commons.ui.note.isCommunityDefinition
 import com.vitorpamplona.amethyst.commons.ui.note.replyingDirectlyTo
 import com.vitorpamplona.amethyst.commons.ui.state.produceCachedStateAsync
 import com.vitorpamplona.amethyst.model.AddressableNote
@@ -1708,7 +1709,7 @@ fun RenderRepost(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    note.replyTo?.lastOrNull { it.event !is CommunityDefinitionEvent }?.let {
+    note.replyTo?.lastOrNull { !it.isCommunityDefinition() }?.let {
         NoteCompose(
             it,
             modifier = Modifier,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/DisplayCommentScope.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/DisplayCommentScope.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.note.nip22Comments
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.theme.StdVertSpacer
+import com.vitorpamplona.quartz.nip22Comments.CommentEvent
+import com.vitorpamplona.quartz.nip72ModCommunities.topLevelCommunityAddress
+import com.vitorpamplona.quartz.nip73ExternalIds.scope
+
+/**
+ * The context card above a comment whose parent isn't a note.
+ *
+ * A NIP-22 comment can be scoped to something that never resolves to an in-cache parent: an
+ * external identifier (NIP-73 `I` tag -- a url, hashtag or geohash) or, for a top-level post in a
+ * NIP-72 community, the community itself. Both render here so the two call sites -- the feed row
+ * and the thread's own master note -- don't each repeat the choice.
+ *
+ * Renders nothing when the screen is already dedicated to this exact scope (see
+ * [LocalCurrentExternalScope]), which would otherwise repeat the same preview on every row.
+ */
+@Composable
+fun DisplayCommentScope(
+    noteEvent: CommentEvent,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    val community = remember(noteEvent) { noteEvent.topLevelCommunityAddress() }
+
+    if (community != null) {
+        val scopeKey = remember(community) { community.toValue() }
+        if (scopeKey != LocalCurrentExternalScope.current) {
+            DisplayCommunityScope(community, accountViewModel, nav)
+            Spacer(modifier = StdVertSpacer)
+        }
+        return
+    }
+
+    val scope = remember(noteEvent) { noteEvent.scope() }
+    if (scope != null && scope.toScope() != LocalCurrentExternalScope.current) {
+        DisplayExternalId(scope, accountViewModel, nav)
+        Spacer(modifier = StdVertSpacer)
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/DisplayCommunityScope.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/DisplayCommunityScope.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.note.nip22Comments
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.dp
+import com.vitorpamplona.amethyst.model.LocalCache
+import com.vitorpamplona.amethyst.ui.navigation.navs.INav
+import com.vitorpamplona.amethyst.ui.navigation.routes.Route
+import com.vitorpamplona.amethyst.ui.note.types.ShortCommunityHeaderNoActions
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.theme.replyModifier
+import com.vitorpamplona.quartz.nip01Core.core.Address
+
+/**
+ * The parent-context card for a top-level NIP-72 community post.
+ *
+ * Such a post answers the community itself, so there is no parent *note* to render -- without
+ * this the slot above the post is simply empty. [ShortCommunityHeaderNoActions] is reused because
+ * it degrades gracefully: it falls back to the address' `d` tag while the definition event is
+ * still in flight, and its `observeNoteEvent` is what asks the relays for that definition in the
+ * first place.
+ */
+@Composable
+fun DisplayCommunityScope(
+    community: Address,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
+    val communityNote = remember(community) { LocalCache.getOrCreateAddressableNote(community) }
+
+    Row(
+        modifier =
+            MaterialTheme.colorScheme.replyModifier
+                .clickable { nav.nav(Route.Community(community.kind, community.pubKeyHex, community.dTag)) }
+                .padding(10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        ShortCommunityHeaderNoActions(communityNote, accountViewModel, nav)
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/DisplayCommunityScope.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/DisplayCommunityScope.kt
@@ -21,12 +21,10 @@
 package com.vitorpamplona.amethyst.ui.note.nip22Comments
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -53,13 +51,13 @@ fun DisplayCommunityScope(
 ) {
     val communityNote = remember(community) { LocalCache.getOrCreateAddressableNote(community) }
 
-    Row(
+    ShortCommunityHeaderNoActions(
+        baseNote = communityNote,
+        accountViewModel = accountViewModel,
+        nav = nav,
         modifier =
             MaterialTheme.colorScheme.replyModifier
                 .clickable { nav.nav(Route.Community(community.kind, community.pubKeyHex, community.dTag)) }
                 .padding(10.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        ShortCommunityHeaderNoActions(communityNote, accountViewModel, nav)
-    }
+    )
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/DisplayExternalId.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/DisplayExternalId.kt
@@ -57,10 +57,10 @@ import com.vitorpamplona.quartz.nip73ExternalIds.topics.HashtagId
 import com.vitorpamplona.quartz.nip73ExternalIds.urls.UrlId
 
 /**
- * The normalized scope (e.g. [ExternalId.toScope]) of the external content a screen is
- * currently dedicated to, if any. A screen built entirely around one external scope (e.g.
- * the URL thread screen) provides this so nested comments sharing that same scope don't
- * redundantly repeat the preview the screen itself already shows.
+ * The scope a screen is currently dedicated to, if any: a normalized external id
+ * (e.g. [ExternalId.toScope]) for the URL thread screen, or a community address value for the
+ * community screen. A screen built entirely around one scope provides this so comments sharing
+ * that same scope don't redundantly repeat the preview the screen itself already shows.
  */
 val LocalCurrentExternalScope = staticCompositionLocalOf<String?> { null }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/CommunityHeader.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/CommunityHeader.kt
@@ -368,10 +368,11 @@ fun ShortCommunityHeaderNoActions(
     baseNote: AddressableNote,
     accountViewModel: AccountViewModel,
     nav: INav,
+    modifier: Modifier = Modifier,
 ) {
     val noteEvent by observeNoteEvent<CommunityDefinitionEvent>(baseNote, accountViewModel)
 
-    Row(verticalAlignment = Alignment.CenterVertically) {
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
         noteEvent?.image()?.let {
             RobohashFallbackAsyncImage(
                 robot = baseNote.idHex,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Text.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Text.kt
@@ -115,12 +115,12 @@ fun RenderTextEvent(
                 }
             }
 
-        val replyingDirectlyTo = remember(note) { replyingDirectlyTo(note, LocalCache) }
+        val parentNote = remember(note) { replyingDirectlyTo(note, LocalCache) }
 
-        if (replyingDirectlyTo != null && canShowReply) {
+        if (parentNote != null && canShowReply) {
             when (unPackReply) {
                 ReplyRenderType.FULL -> {
-                    ReplyNoteComposition(replyingDirectlyTo, backgroundColor, accountViewModel, nav)
+                    ReplyNoteComposition(parentNote, backgroundColor, accountViewModel, nav)
                     Spacer(modifier = StdVertSpacer)
                 }
 
@@ -128,12 +128,12 @@ fun RenderTextEvent(
                     // Zap receipts are signed by the recipient's lightning provider;
                     // label the reply with the zap sender instead of the service key.
                     val zapSender =
-                        if (replyingDirectlyTo.event is LnZapEvent) {
-                            observeZapSender(replyingDirectlyTo, accountViewModel).value
+                        if (parentNote.event is LnZapEvent) {
+                            observeZapSender(parentNote, accountViewModel).value
                         } else {
                             null
                         }
-                    val parentAuthor = zapSender ?: replyingDirectlyTo.author
+                    val parentAuthor = zapSender ?: parentNote.author
                     if (parentAuthor != null) {
                         ReplyToLabel(
                             parentAuthorDisplay = parentAuthor.toBestDisplayName(),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Text.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Text.kt
@@ -37,6 +37,7 @@ import com.vitorpamplona.amethyst.commons.model.EmptyTagList
 import com.vitorpamplona.amethyst.commons.model.toImmutableListOfLists
 import com.vitorpamplona.amethyst.commons.ui.components.GenericLoadable
 import com.vitorpamplona.amethyst.commons.ui.note.ReplyToLabel
+import com.vitorpamplona.amethyst.commons.ui.note.replyingDirectlyTo
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.components.SensitivityWarning
@@ -46,6 +47,7 @@ import com.vitorpamplona.amethyst.ui.navigation.routes.routeFor
 import com.vitorpamplona.amethyst.ui.note.LoadDecryptedContent
 import com.vitorpamplona.amethyst.ui.note.ReplyNoteComposition
 import com.vitorpamplona.amethyst.ui.note.elements.DisplayUncitedHashtags
+import com.vitorpamplona.amethyst.ui.note.nip22Comments.DisplayCommunityScope
 import com.vitorpamplona.amethyst.ui.note.nip22Comments.DisplayExternalId
 import com.vitorpamplona.amethyst.ui.note.nip22Comments.LocalCurrentExternalScope
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -60,7 +62,8 @@ import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
 import com.vitorpamplona.quartz.nip14Subject.subject
 import com.vitorpamplona.quartz.nip22Comments.CommentEvent
 import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
-import com.vitorpamplona.quartz.nip72ModCommunities.definition.CommunityDefinitionEvent
+import com.vitorpamplona.quartz.nip72ModCommunities.communityAddress
+import com.vitorpamplona.quartz.nip72ModCommunities.isTopLevelCommunityPost
 import com.vitorpamplona.quartz.nip73ExternalIds.scope
 
 enum class ReplyRenderType {
@@ -117,24 +120,7 @@ fun RenderTextEvent(
                 }
             }
 
-        val replyingDirectlyTo =
-            remember(note) {
-                if (noteEvent is BaseThreadedEvent) {
-                    val replyingTo = noteEvent.replyingToAddressOrEvent()
-                    if (replyingTo != null) {
-                        val newNote = accountViewModel.getNoteIfExists(replyingTo)
-                        if (newNote != null && LocalCache.getAnyChannel(newNote) == null && newNote.event?.kind != CommunityDefinitionEvent.KIND) {
-                            newNote
-                        } else {
-                            note.replyTo?.lastOrNull { it.event?.kind != CommunityDefinitionEvent.KIND }
-                        }
-                    } else {
-                        note.replyTo?.lastOrNull { it.event?.kind != CommunityDefinitionEvent.KIND }
-                    }
-                } else {
-                    note.replyTo?.lastOrNull { it.event?.kind != CommunityDefinitionEvent.KIND }
-                }
-            }
+        val replyingDirectlyTo = remember(note) { replyingDirectlyTo(note, LocalCache) }
 
         if (replyingDirectlyTo != null && canShowReply) {
             when (unPackReply) {
@@ -163,12 +149,20 @@ fun RenderTextEvent(
                 }
             }
         } else if (!makeItShort && noteEvent is CommentEvent) {
-            // A comment scoped to an external identifier (`I` tag) has no in-cache parent
-            // note. Show the scope itself as the reply context -- unless the screen we're
-            // in is already dedicated to this exact scope (e.g. the URL thread screen),
-            // in which case every row would otherwise redundantly repeat the same preview.
+            // A comment with no in-cache parent note is scoped to something that isn't a note:
+            // an external identifier (`I` tag) or, for a top-level community post, the community
+            // itself. Show that scope as the reply context -- unless the screen we're in is
+            // already dedicated to this exact scope (e.g. the URL or community screen), in which
+            // case every row would otherwise redundantly repeat the same preview.
+            val community = remember(note) { noteEvent.communityAddress()?.takeIf { noteEvent.isTopLevelCommunityPost() } }
             val scope = remember(note) { noteEvent.scope() }
-            if (scope != null && scope.toScope() != LocalCurrentExternalScope.current) {
+
+            if (community != null) {
+                if (community.toValue() != LocalCurrentExternalScope.current) {
+                    DisplayCommunityScope(community, accountViewModel, nav)
+                    Spacer(modifier = StdVertSpacer)
+                }
+            } else if (scope != null && scope.toScope() != LocalCurrentExternalScope.current) {
                 DisplayExternalId(scope, accountViewModel, nav)
                 Spacer(modifier = StdVertSpacer)
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Text.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/Text.kt
@@ -47,9 +47,7 @@ import com.vitorpamplona.amethyst.ui.navigation.routes.routeFor
 import com.vitorpamplona.amethyst.ui.note.LoadDecryptedContent
 import com.vitorpamplona.amethyst.ui.note.ReplyNoteComposition
 import com.vitorpamplona.amethyst.ui.note.elements.DisplayUncitedHashtags
-import com.vitorpamplona.amethyst.ui.note.nip22Comments.DisplayCommunityScope
-import com.vitorpamplona.amethyst.ui.note.nip22Comments.DisplayExternalId
-import com.vitorpamplona.amethyst.ui.note.nip22Comments.LocalCurrentExternalScope
+import com.vitorpamplona.amethyst.ui.note.nip22Comments.DisplayCommentScope
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.threadview.datasources.PreloadThreadForReply
 import com.vitorpamplona.amethyst.ui.theme.HalfVertSpacer
@@ -62,9 +60,6 @@ import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
 import com.vitorpamplona.quartz.nip14Subject.subject
 import com.vitorpamplona.quartz.nip22Comments.CommentEvent
 import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
-import com.vitorpamplona.quartz.nip72ModCommunities.communityAddress
-import com.vitorpamplona.quartz.nip72ModCommunities.isTopLevelCommunityPost
-import com.vitorpamplona.quartz.nip73ExternalIds.scope
 
 enum class ReplyRenderType {
     FULL,
@@ -149,23 +144,8 @@ fun RenderTextEvent(
                 }
             }
         } else if (!makeItShort && noteEvent is CommentEvent) {
-            // A comment with no in-cache parent note is scoped to something that isn't a note:
-            // an external identifier (`I` tag) or, for a top-level community post, the community
-            // itself. Show that scope as the reply context -- unless the screen we're in is
-            // already dedicated to this exact scope (e.g. the URL or community screen), in which
-            // case every row would otherwise redundantly repeat the same preview.
-            val community = remember(note) { noteEvent.communityAddress()?.takeIf { noteEvent.isTopLevelCommunityPost() } }
-            val scope = remember(note) { noteEvent.scope() }
-
-            if (community != null) {
-                if (community.toValue() != LocalCurrentExternalScope.current) {
-                    DisplayCommunityScope(community, accountViewModel, nav)
-                    Spacer(modifier = StdVertSpacer)
-                }
-            } else if (scope != null && scope.toScope() != LocalCurrentExternalScope.current) {
-                DisplayExternalId(scope, accountViewModel, nav)
-                Spacer(modifier = StdVertSpacer)
-            }
+            // No in-cache parent note: this comment answers a scope rather than a note.
+            DisplayCommentScope(noteEvent, accountViewModel, nav)
         }
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/ZapPoll.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/ZapPoll.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import com.vitorpamplona.amethyst.commons.model.EmptyTagList
 import com.vitorpamplona.amethyst.commons.model.toImmutableListOfLists
+import com.vitorpamplona.amethyst.commons.ui.note.replyingDirectlyTo
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.ui.components.SensitivityWarning
@@ -48,7 +49,6 @@ import com.vitorpamplona.amethyst.ui.theme.placeholderText
 import com.vitorpamplona.quartz.experimental.zapPolls.ZapPollEvent
 import com.vitorpamplona.quartz.nip01Core.tags.hashtags.hasHashtags
 import com.vitorpamplona.quartz.nip01Core.tags.people.hasAnyTaggedUser
-import com.vitorpamplona.quartz.nip72ModCommunities.definition.CommunityDefinitionEvent
 
 @Composable
 fun RenderZapPoll(
@@ -73,20 +73,7 @@ fun RenderZapPoll(
         }
 
     if (showReply) {
-        val replyingDirectlyTo =
-            remember(note) {
-                val replyingTo = noteEvent.replyingToAddressOrEvent()
-                if (replyingTo != null) {
-                    val newNote = accountViewModel.getNoteIfExists(replyingTo)
-                    if (newNote != null && LocalCache.getAnyChannel(newNote) == null && newNote.event?.kind != CommunityDefinitionEvent.KIND) {
-                        newNote
-                    } else {
-                        note.replyTo?.lastOrNull { it.event?.kind != CommunityDefinitionEvent.KIND }
-                    }
-                } else {
-                    note.replyTo?.lastOrNull { it.event?.kind != CommunityDefinitionEvent.KIND }
-                }
-            }
+        val replyingDirectlyTo = remember(note) { replyingDirectlyTo(note, LocalCache) }
         if (replyingDirectlyTo != null) {
             ReplyNoteComposition(replyingDirectlyTo, backgroundColor, accountViewModel, nav)
             Spacer(modifier = StdVertSpacer)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/ZapPoll.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/ZapPoll.kt
@@ -73,9 +73,9 @@ fun RenderZapPoll(
         }
 
     if (showReply) {
-        val replyingDirectlyTo = remember(note) { replyingDirectlyTo(note, LocalCache) }
-        if (replyingDirectlyTo != null) {
-            ReplyNoteComposition(replyingDirectlyTo, backgroundColor, accountViewModel, nav)
+        val parentNote = remember(note) { replyingDirectlyTo(note, LocalCache) }
+        if (parentNote != null) {
+            ReplyNoteComposition(parentNote, backgroundColor, accountViewModel, nav)
             Spacer(modifier = StdVertSpacer)
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/communities/CommunityScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/communities/CommunityScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.PagerState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -37,7 +36,6 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -134,25 +132,6 @@ fun CommunityScreen(
     val pagerState = rememberForeverPagerState(note.idHex + "CommunityScreenPagerState") { 2 }
     val expanded = remember { mutableStateOf(false) }
 
-    // This whole screen is dedicated to one community, and its header already shows it. Telling
-    // the rows which scope they are inside stops every post from repeating the same community
-    // card as its parent context.
-    CompositionLocalProvider(LocalCurrentExternalScope provides note.address.toValue()) {
-        CommunityScaffold(note, pagerState, expanded, feedViewModel, modFeedViewModel, accountViewModel, nav)
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun CommunityScaffold(
-    note: AddressableNote,
-    pagerState: PagerState,
-    expanded: MutableState<Boolean>,
-    feedViewModel: CommunityFeedViewModel,
-    modFeedViewModel: CommunityModerationFeedViewModel,
-    accountViewModel: AccountViewModel,
-    nav: INav,
-) {
     DisappearingScaffold(
         isInvertedLayout = false,
         isActive = { !expanded.value },
@@ -216,26 +195,31 @@ private fun CommunityScaffold(
         },
         accountViewModel = accountViewModel,
     ) {
-        HorizontalPager(
-            state = pagerState,
-        ) { page ->
-            when (page) {
-                0 -> {
-                    RefresheableFeedView(
-                        feedViewModel,
-                        null,
-                        accountViewModel = accountViewModel,
-                        nav = nav,
-                    )
-                }
+        // Every row here is a post in this one community, which the top bar already names. Telling
+        // the rows which scope they are inside stops each of them from repeating the same
+        // community card as its parent context.
+        CompositionLocalProvider(LocalCurrentExternalScope provides note.idHex) {
+            HorizontalPager(
+                state = pagerState,
+            ) { page ->
+                when (page) {
+                    0 -> {
+                        RefresheableFeedView(
+                            feedViewModel,
+                            null,
+                            accountViewModel = accountViewModel,
+                            nav = nav,
+                        )
+                    }
 
-                1 -> {
-                    RefresheableFeedView(
-                        modFeedViewModel,
-                        null,
-                        accountViewModel = accountViewModel,
-                        nav = nav,
-                    )
+                    1 -> {
+                        RefresheableFeedView(
+                            modFeedViewModel,
+                            null,
+                            accountViewModel = accountViewModel,
+                            nav = nav,
+                        )
+                    }
                 }
             }
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/communities/CommunityScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/communities/CommunityScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -35,6 +36,8 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -53,6 +56,7 @@ import com.vitorpamplona.amethyst.ui.navigation.topbars.ShorterTopAppBar
 import com.vitorpamplona.amethyst.ui.navigation.topbars.TitleIconModifier
 import com.vitorpamplona.amethyst.ui.note.ArrowBackIcon
 import com.vitorpamplona.amethyst.ui.note.LoadAddressableNote
+import com.vitorpamplona.amethyst.ui.note.nip22Comments.LocalCurrentExternalScope
 import com.vitorpamplona.amethyst.ui.note.types.LongCommunityHeader
 import com.vitorpamplona.amethyst.ui.note.types.ShortCommunityActionOptions
 import com.vitorpamplona.amethyst.ui.note.types.ShortCommunityHeaderNoActions
@@ -130,6 +134,25 @@ fun CommunityScreen(
     val pagerState = rememberForeverPagerState(note.idHex + "CommunityScreenPagerState") { 2 }
     val expanded = remember { mutableStateOf(false) }
 
+    // This whole screen is dedicated to one community, and its header already shows it. Telling
+    // the rows which scope they are inside stops every post from repeating the same community
+    // card as its parent context.
+    CompositionLocalProvider(LocalCurrentExternalScope provides note.address.toValue()) {
+        CommunityScaffold(note, pagerState, expanded, feedViewModel, modFeedViewModel, accountViewModel, nav)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CommunityScaffold(
+    note: AddressableNote,
+    pagerState: PagerState,
+    expanded: MutableState<Boolean>,
+    feedViewModel: CommunityFeedViewModel,
+    modFeedViewModel: CommunityModerationFeedViewModel,
+    accountViewModel: AccountViewModel,
+    nav: INav,
+) {
     DisappearingScaffold(
         isInvertedLayout = false,
         isActive = { !expanded.value },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/ThreadFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/ThreadFeedView.kt
@@ -133,6 +133,7 @@ import com.vitorpamplona.amethyst.ui.note.elements.Reward
 import com.vitorpamplona.amethyst.ui.note.elements.ShowForkInformation
 import com.vitorpamplona.amethyst.ui.note.elements.TimeAgo
 import com.vitorpamplona.amethyst.ui.note.elements.TimeAgoStyle
+import com.vitorpamplona.amethyst.ui.note.nip22Comments.DisplayCommunityScope
 import com.vitorpamplona.amethyst.ui.note.nip22Comments.DisplayExternalId
 import com.vitorpamplona.amethyst.ui.note.observeEdits
 import com.vitorpamplona.amethyst.ui.note.showAmount
@@ -333,6 +334,7 @@ import com.vitorpamplona.quartz.nip71Video.VideoEvent
 import com.vitorpamplona.quartz.nip72ModCommunities.approval.CommunityPostApprovalEvent
 import com.vitorpamplona.quartz.nip72ModCommunities.communityAddress
 import com.vitorpamplona.quartz.nip72ModCommunities.isACommunityPost
+import com.vitorpamplona.quartz.nip72ModCommunities.isTopLevelCommunityPost
 import com.vitorpamplona.quartz.nip73ExternalIds.scope
 import com.vitorpamplona.quartz.nip75ZapGoals.GoalEvent
 import com.vitorpamplona.quartz.nip78AppData.AppSpecificDataEvent
@@ -1137,12 +1139,17 @@ private fun FullBleedNoteCompose(
                         nav,
                     )
                 } else if (noteEvent is CommentEvent) {
-                    // A comment scoped to external content (NIP-73 `I` tag, e.g. a URL) has no
-                    // in-cache parent note, so it surfaces here as the thread's own "master" note.
-                    // Show its external scope for context, same as the reply-context branch in
-                    // RenderTextEvent does for non-root occurrences of the same comment.
+                    // A comment scoped to something that isn't a note -- external content (NIP-73
+                    // `I` tag, e.g. a URL) or, for a top-level community post, the community
+                    // itself -- has no in-cache parent note, so it surfaces here as the thread's
+                    // own "master" note. Show that scope for context, same as the reply-context
+                    // branch in RenderTextEvent does for non-root occurrences of the same comment.
+                    val community = remember(baseNote) { noteEvent.communityAddress()?.takeIf { noteEvent.isTopLevelCommunityPost() } }
                     val scope = remember(baseNote) { noteEvent.scope() }
-                    if (scope != null) {
+                    if (community != null) {
+                        DisplayCommunityScope(community, accountViewModel, nav)
+                        Spacer(modifier = StdVertSpacer)
+                    } else if (scope != null) {
                         DisplayExternalId(scope, accountViewModel, nav)
                         Spacer(modifier = StdVertSpacer)
                     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/ThreadFeedView.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/threadview/ThreadFeedView.kt
@@ -133,8 +133,7 @@ import com.vitorpamplona.amethyst.ui.note.elements.Reward
 import com.vitorpamplona.amethyst.ui.note.elements.ShowForkInformation
 import com.vitorpamplona.amethyst.ui.note.elements.TimeAgo
 import com.vitorpamplona.amethyst.ui.note.elements.TimeAgoStyle
-import com.vitorpamplona.amethyst.ui.note.nip22Comments.DisplayCommunityScope
-import com.vitorpamplona.amethyst.ui.note.nip22Comments.DisplayExternalId
+import com.vitorpamplona.amethyst.ui.note.nip22Comments.DisplayCommentScope
 import com.vitorpamplona.amethyst.ui.note.observeEdits
 import com.vitorpamplona.amethyst.ui.note.showAmount
 import com.vitorpamplona.amethyst.ui.note.types.AudioHeader
@@ -334,8 +333,6 @@ import com.vitorpamplona.quartz.nip71Video.VideoEvent
 import com.vitorpamplona.quartz.nip72ModCommunities.approval.CommunityPostApprovalEvent
 import com.vitorpamplona.quartz.nip72ModCommunities.communityAddress
 import com.vitorpamplona.quartz.nip72ModCommunities.isACommunityPost
-import com.vitorpamplona.quartz.nip72ModCommunities.isTopLevelCommunityPost
-import com.vitorpamplona.quartz.nip73ExternalIds.scope
 import com.vitorpamplona.quartz.nip75ZapGoals.GoalEvent
 import com.vitorpamplona.quartz.nip78AppData.AppSpecificDataEvent
 import com.vitorpamplona.quartz.nip7DThreads.ThreadEvent
@@ -1139,20 +1136,11 @@ private fun FullBleedNoteCompose(
                         nav,
                     )
                 } else if (noteEvent is CommentEvent) {
-                    // A comment scoped to something that isn't a note -- external content (NIP-73
-                    // `I` tag, e.g. a URL) or, for a top-level community post, the community
-                    // itself -- has no in-cache parent note, so it surfaces here as the thread's
-                    // own "master" note. Show that scope for context, same as the reply-context
-                    // branch in RenderTextEvent does for non-root occurrences of the same comment.
-                    val community = remember(baseNote) { noteEvent.communityAddress()?.takeIf { noteEvent.isTopLevelCommunityPost() } }
-                    val scope = remember(baseNote) { noteEvent.scope() }
-                    if (community != null) {
-                        DisplayCommunityScope(community, accountViewModel, nav)
-                        Spacer(modifier = StdVertSpacer)
-                    } else if (scope != null) {
-                        DisplayExternalId(scope, accountViewModel, nav)
-                        Spacer(modifier = StdVertSpacer)
-                    }
+                    // A comment that answers a scope rather than a note has no in-cache parent, so
+                    // it surfaces here as the thread's own "master" note. Show that scope for
+                    // context, same as the reply-context branch in RenderTextEvent does for
+                    // non-root occurrences of the same comment.
+                    DisplayCommentScope(noteEvent, accountViewModel, nav)
                     RenderTextEvent(
                         baseNote,
                         false,

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Note.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/Note.kt
@@ -396,6 +396,16 @@ open class Note(
 
     open fun address(): Address? = null
 
+    /**
+     * This note's kind, known even before its event arrives: an addressable note carries its kind
+     * in the address itself. Prefer this over `event?.kind` whenever a kind is being *excluded* --
+     * an uncached note has a null event, so `event?.kind != SOME_KIND` silently passes for every
+     * note that simply hasn't loaded yet.
+     */
+    fun kindOrNull(): Int? = address()?.kind ?: event?.kind
+
+    fun isKind(kind: Int) = kindOrNull() == kind
+
     open fun createdAt() = event?.createdAt
 
     fun isDraft() = event is DraftWrapEvent

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/ParentNote.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/ParentNote.kt
@@ -46,7 +46,7 @@ import com.vitorpamplona.quartz.nip72ModCommunities.isTopLevelCommunityPost
  */
 fun replyingDirectlyTo(
     note: Note,
-    cache: ICacheProvider?,
+    cache: ICacheProvider,
 ): Note? {
     val event = note.event
 
@@ -55,14 +55,14 @@ fun replyingDirectlyTo(
     val direct =
         (event as? BaseThreadedEvent)
             ?.replyingToAddressOrEvent()
-            ?.let { cache?.getNoteIfExists(it) }
-            ?.takeIf { cache?.getAnyChannel(it) == null && !it.isCommunityDefinition() }
+            ?.let { cache.getNoteIfExists(it) }
+            ?.takeIf { cache.getAnyChannel(it) == null && !it.isCommunityDefinition() }
 
     return direct ?: note.replyTo?.lastOrNull { !it.isCommunityDefinition() }
 }
 
 /**
- * True for a community definition whether or not its event has arrived -- an addressable note
- * knows its kind from the address alone, which an uncached note's null event cannot tell us.
+ * True for a community definition whether or not its event has arrived. See [Note.kindOrNull] for
+ * why the address has to be consulted instead of the event.
  */
-private fun Note.isCommunityDefinition() = address()?.kind == CommunityDefinitionEvent.KIND || event?.kind == CommunityDefinitionEvent.KIND
+fun Note.isCommunityDefinition() = isKind(CommunityDefinitionEvent.KIND)

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/ParentNote.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/ui/note/ParentNote.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.note
+
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+import com.vitorpamplona.quartz.nip10Notes.BaseThreadedEvent
+import com.vitorpamplona.quartz.nip22Comments.CommentEvent
+import com.vitorpamplona.quartz.nip72ModCommunities.definition.CommunityDefinitionEvent
+import com.vitorpamplona.quartz.nip72ModCommunities.isTopLevelCommunityPost
+
+/**
+ * The note to render as the "replying to" card above [note], or null when there is no parent to
+ * show. Prefers the parent the event itself names, falling back to the last resolved reply target.
+ *
+ * NIP-72 communities are deliberately never returned. A community is not a note a post replies
+ * to in any renderable sense: it is already named in the post's header and gets its own context
+ * card. Two shapes have to be caught for that to hold:
+ *
+ *  - the parent resolves to the community's [com.vitorpamplona.amethyst.commons.model.AddressableNote];
+ *  - the post is a top-level community post whose bridged tags point at the definition event by
+ *    *id* (mostr does this), which resolves to a plain [Note] that can never load, because
+ *    addressable events are cached by address and not by id.
+ *
+ * Both used to slip through a `note.event?.kind != CommunityDefinitionEvent.KIND` test, because an
+ * uncached note has a null event and `null != 34550`. The result was an empty card where the
+ * parent context belongs.
+ */
+fun replyingDirectlyTo(
+    note: Note,
+    cache: ICacheProvider?,
+): Note? {
+    val event = note.event
+
+    if (event is CommentEvent && event.isTopLevelCommunityPost()) return null
+
+    val direct =
+        (event as? BaseThreadedEvent)
+            ?.replyingToAddressOrEvent()
+            ?.let { cache?.getNoteIfExists(it) }
+            ?.takeIf { cache?.getAnyChannel(it) == null && !it.isCommunityDefinition() }
+
+    return direct ?: note.replyTo?.lastOrNull { !it.isCommunityDefinition() }
+}
+
+/**
+ * True for a community definition whether or not its event has arrived -- an addressable note
+ * knows its kind from the address alone, which an uncached note's null event cannot tell us.
+ */
+private fun Note.isCommunityDefinition() = address()?.kind == CommunityDefinitionEvent.KIND || event?.kind == CommunityDefinitionEvent.KIND

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/ui/note/ParentNoteTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/ui/note/ParentNoteTest.kt
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.note
+
+import com.vitorpamplona.amethyst.commons.model.AddressableNote
+import com.vitorpamplona.amethyst.commons.model.Channel
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheEventStream
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+import com.vitorpamplona.quartz.nip01Core.core.Address
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.hints.HintIndexer
+import com.vitorpamplona.quartz.nip22Comments.CommentEvent
+import kotlin.test.Test
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class ParentNoteTest {
+    private val communityOwner = "9ca0bd7450742d6a20319c0e3d4c679c9e046a9dc70e8ef55c2905e24052340b"
+    private val definitionEventId = "575117c37d66a698ddd81169f88fcdab5d5d63687f79da0c5c65f1d72cb99a57"
+    private val moviesAddress = Address(34550, communityOwner, "movies")
+    private val movies = moviesAddress.toValue()
+
+    private fun comment(vararg tags: Array<String>) =
+        CommentEvent(
+            id = "00".repeat(32),
+            pubKey = "11".repeat(32),
+            createdAt = 1_700_000_000L,
+            tags = arrayOf(*tags),
+            content = "Ciao a tutti",
+            sig = "22".repeat(64),
+        )
+
+    private fun noteOf(event: Event) = Note(event.id).apply { this.event = event }
+
+    /**
+     * The reported bug. A mostr-bridged top-level post in the "movies" community, viewed before
+     * the community definition has been fetched: the cache hands back an empty AddressableNote,
+     * which the old `event?.kind != KIND` test accepted (null != 34550) and rendered as a blank
+     * "replying to" card.
+     */
+    @Test
+    fun topLevelCommunityPostHasNoParentWhenTheDefinitionIsNotCachedYet() {
+        val event =
+            comment(
+                arrayOf("A", movies, "wss://relay.mostr.pub/"),
+                arrayOf("a", movies, "wss://relay.mostr.pub/"),
+                arrayOf("E", definitionEventId, "wss://relay.mostr.pub/", communityOwner),
+                arrayOf("K", "34550"),
+                arrayOf("e", definitionEventId, "wss://relay.mostr.pub/", communityOwner),
+                arrayOf("k", "34550"),
+            )
+
+        // An AddressableNote that exists in the cache but whose definition event has not arrived.
+        val unloadedCommunity = AddressableNote(moviesAddress)
+        val cache = StubCache(notesById = mapOf(movies to unloadedCommunity))
+
+        assertNull(replyingDirectlyTo(noteOf(event), cache))
+    }
+
+    /** Same post once the definition has loaded: still no parent card, via the address kind. */
+    @Test
+    fun topLevelCommunityPostHasNoParentOnceTheDefinitionLoads() {
+        val event =
+            comment(
+                arrayOf("A", movies),
+                arrayOf("a", movies),
+                arrayOf("K", "34550"),
+                arrayOf("k", "34550"),
+            )
+
+        val community = AddressableNote(moviesAddress)
+        val cache = StubCache(notesById = mapOf(movies to community))
+
+        assertNull(replyingDirectlyTo(noteOf(event), cache))
+    }
+
+    /**
+     * The bridged shape that points at the definition by *id*. That id can never resolve, because
+     * addressable events are cached by address -- so it must not be offered as a parent either.
+     */
+    @Test
+    fun bridgedCommunityPostPointingAtTheDefinitionByIdHasNoParent() {
+        val event =
+            comment(
+                arrayOf("E", definitionEventId, "", communityOwner),
+                arrayOf("K", "34550"),
+                arrayOf("e", definitionEventId, "", communityOwner),
+                arrayOf("k", "34550"),
+            )
+
+        val note = noteOf(event)
+        // What LocalCache builds for an `e` tag: a plain Note keyed by id that stays empty.
+        val neverLoads = Note(definitionEventId)
+        note.replyTo = listOf(neverLoads)
+        val cache = StubCache(notesById = mapOf(definitionEventId to neverLoads))
+
+        assertNull(replyingDirectlyTo(note, cache))
+    }
+
+    /**
+     * A reply to a post *inside* a community keeps `K` = 34550 but points `k` at the parent's
+     * kind. The real parent must still be resolved -- the fix must not swallow these.
+     */
+    @Test
+    fun nestedReplyInsideACommunityStillResolvesItsParent() {
+        val parentId = "33".repeat(32)
+        val event =
+            comment(
+                arrayOf("A", movies),
+                arrayOf("K", "34550"),
+                arrayOf("e", parentId),
+                arrayOf("k", "1111"),
+            )
+
+        val parent = Note(parentId)
+        val note = noteOf(event)
+        note.replyTo = listOf(AddressableNote(moviesAddress), parent)
+        val cache = StubCache(notesById = mapOf(parentId to parent, movies to AddressableNote(moviesAddress)))
+
+        assertSame(parent, replyingDirectlyTo(note, cache))
+    }
+
+    /** A post in a channel is rendered by the channel header, not as a parent note. */
+    @Test
+    fun noteInsideAChannelIsNotOfferedAsAParent() {
+        val parentId = "44".repeat(32)
+        val event = comment(arrayOf("e", parentId), arrayOf("k", "1111"))
+        val parent = Note(parentId)
+        val note = noteOf(event)
+        val cache = StubCache(notesById = mapOf(parentId to parent), channelFor = setOf(parentId))
+
+        assertNull(replyingDirectlyTo(note, cache))
+    }
+
+    private class StubCache(
+        private val notesById: Map<HexKey, Note>,
+        private val channelFor: Set<HexKey> = emptySet(),
+    ) : ICacheProvider {
+        override val relayHints = HintIndexer()
+
+        override fun getAnyChannel(note: Note): Channel? =
+            if (note.idHex in channelFor) {
+                object : Channel() {
+                    override fun toBestDisplayName() = "a channel"
+                }
+            } else {
+                null
+            }
+
+        override fun getUserIfExists(pubkey: HexKey): User? = null
+
+        override fun countUsers(predicate: (String, User) -> Boolean): Int = 0
+
+        override fun getNoteIfExists(hexKey: HexKey): Note? = notesById[hexKey]
+
+        override fun checkGetOrCreateNote(hexKey: HexKey): Note? = notesById[hexKey]
+
+        override fun getOrCreateAddressableNote(address: Address): AddressableNote = error("not used by replyingDirectlyTo")
+
+        override fun getEventStream(): ICacheEventStream = error("not used by replyingDirectlyTo")
+
+        override fun hasBeenDeleted(event: Any): Boolean = false
+
+        override fun getOrCreateUser(pubkey: HexKey): User? = null
+
+        override fun justConsumeMyOwnEvent(event: Event): Boolean = false
+    }
+}

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/ui/note/ParentNoteTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/ui/note/ParentNoteTest.kt
@@ -21,15 +21,9 @@
 package com.vitorpamplona.amethyst.commons.ui.note
 
 import com.vitorpamplona.amethyst.commons.model.AddressableNote
-import com.vitorpamplona.amethyst.commons.model.Channel
 import com.vitorpamplona.amethyst.commons.model.Note
-import com.vitorpamplona.amethyst.commons.model.User
-import com.vitorpamplona.amethyst.commons.model.cache.ICacheEventStream
-import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
 import com.vitorpamplona.quartz.nip01Core.core.Address
 import com.vitorpamplona.quartz.nip01Core.core.Event
-import com.vitorpamplona.quartz.nip01Core.core.HexKey
-import com.vitorpamplona.quartz.nip01Core.hints.HintIndexer
 import com.vitorpamplona.quartz.nip22Comments.CommentEvent
 import kotlin.test.Test
 import kotlin.test.assertNull
@@ -78,20 +72,25 @@ class ParentNoteTest {
         assertNull(replyingDirectlyTo(noteOf(event), cache))
     }
 
-    /** Same post once the definition has loaded: still no parent card, via the address kind. */
+    /**
+     * A reply whose own parent isn't tagged: `replyingToAddressOrEvent()` falls back to the root
+     * `A`, so the resolved candidate is the community. This is the path the top-level guard does
+     * *not* cover -- it reaches the address-kind exclusion, which has to hold even though the
+     * community's definition event has never loaded and its `event` is therefore null.
+     */
     @Test
-    fun topLevelCommunityPostHasNoParentOnceTheDefinitionLoads() {
+    fun replyFallingBackToTheCommunityRootHasNoParent() {
         val event =
             comment(
                 arrayOf("A", movies),
-                arrayOf("a", movies),
                 arrayOf("K", "34550"),
-                arrayOf("k", "34550"),
+                arrayOf("k", "1111"),
             )
 
-        val community = AddressableNote(moviesAddress)
-        val cache = StubCache(notesById = mapOf(movies to community))
+        val unloadedCommunity = AddressableNote(moviesAddress)
+        val cache = StubCache(notesById = mapOf(movies to unloadedCommunity))
 
+        assertNull(unloadedCommunity.event, "the exclusion must not depend on the definition being cached")
         assertNull(replyingDirectlyTo(noteOf(event), cache))
     }
 
@@ -151,39 +150,5 @@ class ParentNoteTest {
         val cache = StubCache(notesById = mapOf(parentId to parent), channelFor = setOf(parentId))
 
         assertNull(replyingDirectlyTo(note, cache))
-    }
-
-    private class StubCache(
-        private val notesById: Map<HexKey, Note>,
-        private val channelFor: Set<HexKey> = emptySet(),
-    ) : ICacheProvider {
-        override val relayHints = HintIndexer()
-
-        override fun getAnyChannel(note: Note): Channel? =
-            if (note.idHex in channelFor) {
-                object : Channel() {
-                    override fun toBestDisplayName() = "a channel"
-                }
-            } else {
-                null
-            }
-
-        override fun getUserIfExists(pubkey: HexKey): User? = null
-
-        override fun countUsers(predicate: (String, User) -> Boolean): Int = 0
-
-        override fun getNoteIfExists(hexKey: HexKey): Note? = notesById[hexKey]
-
-        override fun checkGetOrCreateNote(hexKey: HexKey): Note? = notesById[hexKey]
-
-        override fun getOrCreateAddressableNote(address: Address): AddressableNote = error("not used by replyingDirectlyTo")
-
-        override fun getEventStream(): ICacheEventStream = error("not used by replyingDirectlyTo")
-
-        override fun hasBeenDeleted(event: Any): Boolean = false
-
-        override fun getOrCreateUser(pubkey: HexKey): User? = null
-
-        override fun justConsumeMyOwnEvent(event: Event): Boolean = false
     }
 }

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/ui/note/ParentNoteTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/ui/note/ParentNoteTest.kt
@@ -26,8 +26,10 @@ import com.vitorpamplona.quartz.nip01Core.core.Address
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip22Comments.CommentEvent
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 class ParentNoteTest {
     private val communityOwner = "9ca0bd7450742d6a20319c0e3d4c679c9e046a9dc70e8ef55c2905e24052340b"
@@ -138,6 +140,36 @@ class ParentNoteTest {
         val cache = StubCache(notesById = mapOf(parentId to parent, movies to AddressableNote(moviesAddress)))
 
         assertSame(parent, replyingDirectlyTo(note, cache))
+    }
+
+    /**
+     * The predicate `RenderRepost` now shares (`note.replyTo?.lastOrNull { !it.isCommunityDefinition() }`).
+     * The composable itself needs an instrumented test, but the logic that changed is this
+     * predicate: it has to recognise the community from the address, with no event loaded.
+     */
+    @Test
+    fun communityIsRecognisedWithoutItsDefinitionEvent() {
+        val uncached = AddressableNote(moviesAddress)
+        assertNull(uncached.event, "precondition: the definition has not arrived")
+        assertTrue(uncached.isCommunityDefinition(), "an uncached community must still be excluded")
+
+        val article = AddressableNote(Address(30023, communityOwner, "some-article"))
+        assertFalse(article.isCommunityDefinition(), "other addressable kinds must not be excluded")
+
+        val plainNote = Note("55".repeat(32))
+        assertFalse(plainNote.isCommunityDefinition(), "a note with no event and no address is not a community")
+    }
+
+    /** The selection `RenderRepost` performs: skip the community, take the real boosted note. */
+    @Test
+    fun repostSelectionSkipsAnUncachedCommunityAndTakesTheRealNote() {
+        val boosted = Note("66".repeat(32))
+        val replyTo = listOf(AddressableNote(moviesAddress), boosted)
+
+        assertSame(boosted, replyTo.lastOrNull { !it.isCommunityDefinition() })
+
+        // Community-only: nothing to render, rather than the empty shell that produced the blank.
+        assertNull(listOf(AddressableNote(moviesAddress)).lastOrNull { !it.isCommunityDefinition() })
     }
 
     /** A post in a channel is rendered by the channel header, not as a parent note. */

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/ui/note/ReplyContextTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/ui/note/ReplyContextTest.kt
@@ -20,16 +20,8 @@
  */
 package com.vitorpamplona.amethyst.commons.ui.note
 
-import com.vitorpamplona.amethyst.commons.model.AddressableNote
-import com.vitorpamplona.amethyst.commons.model.Channel
 import com.vitorpamplona.amethyst.commons.model.Note
 import com.vitorpamplona.amethyst.commons.model.User
-import com.vitorpamplona.amethyst.commons.model.cache.ICacheEventStream
-import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
-import com.vitorpamplona.quartz.nip01Core.core.Address
-import com.vitorpamplona.quartz.nip01Core.core.Event
-import com.vitorpamplona.quartz.nip01Core.core.HexKey
-import com.vitorpamplona.quartz.nip01Core.hints.HintIndexer
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -106,32 +98,5 @@ class ReplyContextTest {
         val rawAddress = "30023:$parentAuthorPubKey:my-article"
         assertTrue(rawAddress.contains(":"))
         assertTrue(!parentEventId.contains(":"))
-    }
-
-    private class StubCache(
-        private val notesById: Map<HexKey, Note>,
-        private val users: Map<HexKey, User> = emptyMap(),
-    ) : ICacheProvider {
-        override fun getAnyChannel(note: Note): Channel? = null
-
-        override val relayHints = HintIndexer()
-
-        override fun getUserIfExists(pubkey: HexKey): User? = users[pubkey]
-
-        override fun countUsers(predicate: (String, User) -> Boolean): Int = 0
-
-        override fun getNoteIfExists(hexKey: HexKey): Note? = notesById[hexKey]
-
-        override fun checkGetOrCreateNote(hexKey: HexKey): Note? = notesById[hexKey]
-
-        override fun getOrCreateAddressableNote(address: Address): AddressableNote = error("not used by ReplyContext.from")
-
-        override fun getEventStream(): ICacheEventStream = error("not used by ReplyContext.from")
-
-        override fun hasBeenDeleted(event: Any): Boolean = false
-
-        override fun getOrCreateUser(pubkey: HexKey): User? = users[pubkey]
-
-        override fun justConsumeMyOwnEvent(event: Event): Boolean = false
     }
 }

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/ui/note/StubCache.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/ui/note/StubCache.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.ui.note
+
+import com.vitorpamplona.amethyst.commons.model.AddressableNote
+import com.vitorpamplona.amethyst.commons.model.Channel
+import com.vitorpamplona.amethyst.commons.model.Note
+import com.vitorpamplona.amethyst.commons.model.User
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheEventStream
+import com.vitorpamplona.amethyst.commons.model.cache.ICacheProvider
+import com.vitorpamplona.quartz.nip01Core.core.Address
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip01Core.hints.HintIndexer
+
+/**
+ * Minimal [ICacheProvider] for the pure reply-resolution tests in this package: a fixed set of
+ * notes and users, and an optional set of note ids that should report as living in a channel.
+ * Everything the resolvers never touch throws rather than returning a plausible-looking default.
+ */
+internal class StubCache(
+    private val notesById: Map<HexKey, Note> = emptyMap(),
+    private val users: Map<HexKey, User> = emptyMap(),
+    private val channelFor: Set<HexKey> = emptySet(),
+) : ICacheProvider {
+    override val relayHints = HintIndexer()
+
+    override fun getAnyChannel(note: Note): Channel? =
+        if (note.idHex in channelFor) {
+            object : Channel() {
+                override fun toBestDisplayName() = "a channel"
+            }
+        } else {
+            null
+        }
+
+    override fun getUserIfExists(pubkey: HexKey): User? = users[pubkey]
+
+    override fun countUsers(predicate: (String, User) -> Boolean): Int = 0
+
+    override fun getNoteIfExists(hexKey: HexKey): Note? = notesById[hexKey]
+
+    override fun checkGetOrCreateNote(hexKey: HexKey): Note? = notesById[hexKey]
+
+    override fun getOrCreateAddressableNote(address: Address): AddressableNote = error("unused by the reply resolvers")
+
+    override fun getEventStream(): ICacheEventStream = error("unused by the reply resolvers")
+
+    override fun hasBeenDeleted(event: Any): Boolean = false
+
+    override fun getOrCreateUser(pubkey: HexKey): User? = users[pubkey]
+
+    override fun justConsumeMyOwnEvent(event: Event): Boolean = false
+}

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip22Comments/CommentEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip22Comments/CommentEvent.kt
@@ -27,6 +27,7 @@ import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.TagArrayBuilder
 import com.vitorpamplona.quartz.nip01Core.core.any
+import com.vitorpamplona.quartz.nip01Core.core.fastAny
 import com.vitorpamplona.quartz.nip01Core.hints.AddressHintProvider
 import com.vitorpamplona.quartz.nip01Core.hints.EventHintBundle
 import com.vitorpamplona.quartz.nip01Core.hints.EventHintProvider
@@ -149,6 +150,9 @@ class CommentEvent(
     fun directReplies() = tags.filter { ReplyIdentifierTag.match(it) || ReplyAddressTag.match(it) || ReplyEventTag.match(it) }
 
     fun directKinds() = tags.filter(ReplyKindTag::match)
+
+    /** Whether a parent kind (`k`) is declared at all, without materialising [directKinds]. */
+    fun hasDirectKinds() = tags.fastAny(ReplyKindTag::match)
 
     fun rootAuthor() = tags.firstNotNullOfOrNull(RootAuthorTag::parse)
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip22Comments/CommentEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip22Comments/CommentEvent.kt
@@ -149,6 +149,9 @@ class CommentEvent(
 
     fun directReplies() = tags.filter { ReplyIdentifierTag.match(it) || ReplyAddressTag.match(it) || ReplyEventTag.match(it) }
 
+    /** Whether a parent is named at all, without materialising [directReplies]. */
+    fun hasDirectReplies() = tags.fastAny { ReplyIdentifierTag.match(it) || ReplyAddressTag.match(it) || ReplyEventTag.match(it) }
+
     fun directKinds() = tags.filter(ReplyKindTag::match)
 
     /** Whether a parent kind (`k`) is declared at all, without materialising [directKinds]. */

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip72ModCommunities/EventExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip72ModCommunities/EventExt.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.any
 import com.vitorpamplona.quartz.nip01Core.core.fastFirstNotNullOfOrNull
 import com.vitorpamplona.quartz.nip22Comments.CommentEvent
+import com.vitorpamplona.quartz.nip22Comments.tags.RootAddressTag
 import com.vitorpamplona.quartz.nip72ModCommunities.definition.CommunityDefinitionEvent
 import com.vitorpamplona.quartz.nip72ModCommunities.follow.tags.CommunityTag
 
@@ -44,8 +45,9 @@ fun Event.isForCommunity(communityAddressId: String): Boolean =
 
 fun Event.communityAddress(): Address? =
     if (this is CommentEvent) {
-        this.rootAddress().firstNotNullOfOrNull {
-            if (it.kind == CommunityDefinitionEvent.KIND) it else null
+        // Stops at the first community root address instead of parsing every `A` tag into a list.
+        this.tags.fastFirstNotNullOfOrNull { tag ->
+            RootAddressTag.parseAddress(tag)?.takeIf { it.kind == CommunityDefinitionEvent.KIND }
         }
     } else {
         this.tags.fastFirstNotNullOfOrNull(CommunityTag::parseAddress)
@@ -64,11 +66,17 @@ fun CommentEvent.isCommunityScoped() = hasRootScopeKind(CommunityDefinitionEvent
  * hence the fallback to the root kind when no `k` is present.
  */
 fun CommentEvent.isTopLevelCommunityPost() =
-    if (directKinds().isEmpty()) {
-        hasRootScopeKind(CommunityDefinitionEvent.KIND_STR)
-    } else {
+    if (hasDirectKinds()) {
         hasReplyScopeKind(CommunityDefinitionEvent.KIND_STR)
+    } else {
+        hasRootScopeKind(CommunityDefinitionEvent.KIND_STR)
     }
+
+/**
+ * The community this comment is a top-level post in, or null when it is a reply to another post
+ * (or not a community comment at all). Checks the cheap kind tags before parsing any address.
+ */
+fun CommentEvent.topLevelCommunityAddress(): Address? = if (isTopLevelCommunityPost()) communityAddress() else null
 
 fun CommentEvent.communityScope() = this.tags.fastFirstNotNullOfOrNull(CommunityTag::parseAddress)
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip72ModCommunities/EventExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip72ModCommunities/EventExt.kt
@@ -65,12 +65,18 @@ fun CommentEvent.isCommunityScoped() = hasRootScopeKind(CommunityDefinitionEvent
  * parent post's kind for the latter. Bridges (e.g. mostr) sometimes emit only the uppercase set,
  * hence the fallback to the root kind when no `k` is present.
  */
-fun CommentEvent.isTopLevelCommunityPost() =
-    if (hasDirectKinds()) {
-        hasReplyScopeKind(CommunityDefinitionEvent.KIND_STR)
-    } else {
-        hasRootScopeKind(CommunityDefinitionEvent.KIND_STR)
-    }
+fun CommentEvent.isTopLevelCommunityPost(): Boolean {
+    // An explicit parent kind (`k`) is authoritative: it names what this comment answers.
+    if (hasDirectKinds()) return hasReplyScopeKind(CommunityDefinitionEvent.KIND_STR)
+
+    // No `k`. Decide from what the comment actually points at rather than guessing: a parent
+    // *address* that is a community means top level; a parent *event* means it answers a post
+    // inside the community, not the community itself.
+    if (hasDirectReplies()) return replyAddressIds().any { Address.isOfKind(it, CommunityDefinitionEvent.KIND_STR) }
+
+    // Nothing names a parent at all -- the shape bridges emit, with only the uppercase root set.
+    return hasRootScopeKind(CommunityDefinitionEvent.KIND_STR)
+}
 
 /**
  * The community this comment is a top-level post in, or null when it is a reply to another post

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip72ModCommunities/EventExt.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip72ModCommunities/EventExt.kt
@@ -53,6 +53,23 @@ fun Event.communityAddress(): Address? =
 
 fun CommentEvent.isCommunityScoped() = hasRootScopeKind(CommunityDefinitionEvent.KIND_STR)
 
+/**
+ * True when this comment answers the community itself -- a top-level post in the community --
+ * as opposed to a nested reply to another post inside it.
+ *
+ * NIP-22 keeps the uppercase root tags (`A`/`E`/`K`) identical all the way down a thread, so
+ * [isCommunityScoped] is true for every comment in a community, however deep. What separates a
+ * top-level post from a reply is the lowercase parent kind (`k`): 34550 for the former, the
+ * parent post's kind for the latter. Bridges (e.g. mostr) sometimes emit only the uppercase set,
+ * hence the fallback to the root kind when no `k` is present.
+ */
+fun CommentEvent.isTopLevelCommunityPost() =
+    if (directKinds().isEmpty()) {
+        hasRootScopeKind(CommunityDefinitionEvent.KIND_STR)
+    } else {
+        hasReplyScopeKind(CommunityDefinitionEvent.KIND_STR)
+    }
+
 fun CommentEvent.communityScope() = this.tags.fastFirstNotNullOfOrNull(CommunityTag::parseAddress)
 
 fun CommentEvent.communityScopes() = this.tags.mapNotNull(CommunityTag::parseAddress)

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip72ModCommunities/CommunityCommentScopeTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip72ModCommunities/CommunityCommentScopeTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip72ModCommunities
+
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip22Comments.CommentEvent
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CommunityCommentScopeTest {
+    private fun comment(vararg tags: Array<String>) =
+        CommentEvent(
+            id = "00".repeat(32),
+            pubKey = "11".repeat(32),
+            createdAt = 1_700_000_000L,
+            tags = arrayOf(*tags),
+            content = "hello",
+            sig = "22".repeat(64),
+        )
+
+    private val communityOwner = "9ca0bd7450742d6a20319c0e3d4c679c9e046a9dc70e8ef55c2905e24052340b"
+    private val movies = "34550:$communityOwner:movies"
+
+    /**
+     * The report that motivated this: a mostr-bridged top-level post in the "movies" community.
+     * It carries the community both as `A`/`a` and -- unusually -- as an `E`/`e` pointing at the
+     * definition event's id, with `K`/`k` = 34550.
+     */
+    private fun bridgedTopLevelPost() =
+        comment(
+            arrayOf("A", movies, "wss://relay.mostr.pub/"),
+            arrayOf("a", movies, "wss://relay.mostr.pub/"),
+            arrayOf("E", "575117c37d66a698ddd81169f88fcdab5d5d63687f79da0c5c65f1d72cb99a57", "wss://relay.mostr.pub/", communityOwner),
+            arrayOf("K", "34550"),
+            arrayOf("P", communityOwner, "wss://nostr.wine/"),
+            arrayOf("e", "575117c37d66a698ddd81169f88fcdab5d5d63687f79da0c5c65f1d72cb99a57", "wss://relay.mostr.pub/", communityOwner),
+            arrayOf("k", "34550"),
+            arrayOf("p", communityOwner, "wss://nostr.wine/"),
+        )
+
+    @Test
+    fun bridgedTopLevelPostIsRecognisedAsAnswerToTheCommunity() {
+        val event = bridgedTopLevelPost()
+
+        assertTrue(event.isCommunityScoped())
+        assertTrue(event.isTopLevelCommunityPost())
+        assertEquals(movies, (event as Event).communityAddress()?.toValue())
+    }
+
+    /**
+     * The community must not become a "replying to" card: [tagsWithoutCitations] returning empty
+     * is what keeps it out of `Note.replyTo`, and the UI relies on that.
+     */
+    @Test
+    fun bridgedTopLevelPostHasNoReplyTargets() {
+        assertEquals(emptyList(), bridgedTopLevelPost().tagsWithoutCitations())
+    }
+
+    @Test
+    fun topLevelPostWithOnlyUppercaseRootTagsStillCounts() {
+        val event =
+            comment(
+                arrayOf("A", movies),
+                arrayOf("K", "34550"),
+            )
+
+        assertTrue(event.isTopLevelCommunityPost())
+    }
+
+    /**
+     * A reply to a post inside a community keeps `K` = 34550 but points `k` at the parent's kind,
+     * so it must still resolve to a real parent note rather than to the community.
+     */
+    @Test
+    fun nestedReplyInsideACommunityIsNotATopLevelPost() {
+        val parentId = "33".repeat(32)
+        val event =
+            comment(
+                arrayOf("A", movies),
+                arrayOf("K", "34550"),
+                arrayOf("e", parentId),
+                arrayOf("k", "1111"),
+            )
+
+        assertTrue(event.isCommunityScoped())
+        assertFalse(event.isTopLevelCommunityPost())
+        assertTrue(event.tagsWithoutCitations().contains(parentId))
+    }
+
+    @Test
+    fun commentOnSomethingOtherThanACommunityIsNotATopLevelPost() {
+        val event =
+            comment(
+                arrayOf("I", "https://example.com/article"),
+                arrayOf("K", "web"),
+            )
+
+        assertFalse(event.isCommunityScoped())
+        assertFalse(event.isTopLevelCommunityPost())
+    }
+}

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip72ModCommunities/CommunityCommentScopeTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip72ModCommunities/CommunityCommentScopeTest.kt
@@ -22,6 +22,7 @@ package com.vitorpamplona.quartz.nip72ModCommunities
 
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip22Comments.CommentEvent
+import com.vitorpamplona.quartz.nip72ModCommunities.definition.CommunityDefinitionEvent
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -106,6 +107,87 @@ class CommunityCommentScopeTest {
         assertFalse(event.isTopLevelCommunityPost())
         assertTrue(event.tagsWithoutCitations().contains(parentId))
     }
+
+    /**
+     * A nested reply that omits the parent kind (`k`) entirely -- malformed, but emitted in the
+     * wild. It must not be mistaken for a top-level post just because the root kind says 34550:
+     * it names a parent *event*, so it answers a post inside the community, not the community.
+     */
+    @Test
+    fun nestedReplyWithoutAParentKindIsNotATopLevelPost() {
+        val event =
+            comment(
+                arrayOf("A", movies),
+                arrayOf("K", "34550"),
+                arrayOf("e", "33".repeat(32)),
+            )
+
+        assertTrue(event.isCommunityScoped())
+        assertFalse(event.isTopLevelCommunityPost())
+    }
+
+    /** The mirror case: no `k`, but the parent *address* is the community, so it is top level. */
+    @Test
+    fun postNamingTheCommunityAsItsParentAddressIsATopLevelPost() {
+        val event =
+            comment(
+                arrayOf("A", movies),
+                arrayOf("a", movies),
+                arrayOf("K", "34550"),
+            )
+
+        assertTrue(event.isTopLevelCommunityPost())
+    }
+
+    /** A reply whose parent address is some other addressable event is not a top-level post. */
+    @Test
+    fun replyToANonCommunityAddressIsNotATopLevelPost() {
+        val event =
+            comment(
+                arrayOf("A", movies),
+                arrayOf("a", "30023:$communityOwner:some-article"),
+                arrayOf("K", "34550"),
+            )
+
+        assertFalse(event.isTopLevelCommunityPost())
+    }
+
+    /**
+     * [communityAddress] was rewritten to stop at the first community root address instead of
+     * parsing every `A` tag into a list. This pins it against the original algorithm as a
+     * reference oracle -- seven call sites outside this PR depend on it being unchanged.
+     */
+    @Test
+    fun communityAddressMatchesTheOriginalAlgorithmOnEveryShape() {
+        val other = "30023:$communityOwner:some-article"
+        val secondCommunity = "34550:$communityOwner:films"
+
+        val shapes =
+            listOf(
+                "no tags at all" to comment(),
+                "one community root" to comment(arrayOf("A", movies)),
+                "non-community root only" to comment(arrayOf("A", other)),
+                "non-community first, community second" to comment(arrayOf("A", other), arrayOf("A", movies)),
+                "two communities picks the first" to comment(arrayOf("A", movies), arrayOf("A", secondCommunity)),
+                "unparseable root" to comment(arrayOf("A", "not-an-address"), arrayOf("A", movies)),
+                "reply address only, no root" to comment(arrayOf("a", movies)),
+                "root without a value" to comment(arrayOf("A")),
+            )
+
+        shapes.forEach { (name, event) ->
+            assertEquals(
+                originalCommunityAddress(event)?.toValue(),
+                (event as Event).communityAddress()?.toValue(),
+                "communityAddress diverged from the original algorithm for: $name",
+            )
+        }
+    }
+
+    /** The pre-rewrite implementation, kept here purely as the oracle for the test above. */
+    private fun originalCommunityAddress(event: CommentEvent) =
+        event.rootAddress().firstNotNullOfOrNull {
+            if (it.kind == CommunityDefinitionEvent.KIND) it else null
+        }
 
     @Test
     fun commentOnSomethingOtherThanACommunityIsNotATopLevelPost() {


### PR DESCRIPTION
## Summary

A NIP-22 comment posted to a NIP-72 community answers the community itself, so it has no parent note — but the reply-context resolver rendered an empty card where the parent belongs. The resolver excluded the community with `note.event?.kind != CommunityDefinitionEvent.KIND`, which only holds once the community definition event is cached: an uncached `AddressableNote` has a null `event`, and `null != 34550`, so the empty shell was passed to `ReplyNoteComposition`. The same test also misrouted nested replies inside a community — `replyingToAddressOrEvent()` falls back to the root `A` tag, so it returned the community shell and the real parent comment was never shown.

The fix resolves the parent by *address* kind, which an `AddressableNote` knows without its event, and renders the community itself as the context card instead of leaving the slot blank. The resolver was triplicated across `Text.kt`, `ZapPoll.kt` and `JumpToParentReplyButton`; it now lives in `commons` as `replyingDirectlyTo(note, cache)` with unit tests.

Reported against `nevent1qqs9k0cfqv0f8u0kmlr3azzsgha2l84qh4fgk27fyh9yw6a5pkqmnq` — a mostr-bridged top-level post in the "movies" community, which tags the community both as `A`/`a` and as an `E`/`e` pointing at the definition event's *id*. That id can never resolve, because addressable events are cached by address, not by id.

### What changed

| Area | Change |
|--------------------------------|-----------------------------------------------------------------------------------------------------|
| `commons/model/Note.kt`        | New `kindOrNull()` / `isKind()` — an addressable note knows its kind from the address before its event arrives |
| `commons/ui/note/ParentNote.kt`| New shared `replyingDirectlyTo(note, cache)`, replacing three copies of the same resolution          |
| `quartz/nip72ModCommunities`   | New `CommentEvent.isTopLevelCommunityPost()` and `topLevelCommunityAddress()`; `communityAddress()` now stops at the first community root address instead of parsing every `A` tag into a list |
| `quartz/nip22Comments`         | New `hasDirectKinds()` (`fastAny`-backed) so the top-level check allocates nothing on the render path |
| `amethyst/ui/note/nip22Comments` | New `DisplayCommentScope` owning the community-vs-external-id choice for both call sites, and `DisplayCommunityScope` rendering the card |
| `amethyst` call sites          | `Text.kt`, `ZapPoll.kt`, `ThreadFeedView.kt`, `NoteCompose.kt` (`JumpToParentReplyButton`, `RenderRepost`) now share the resolver |

`RenderRepost` carried the same null hole one function away from the fix and is included.

No new event kind, tag form, or NIP interpretation — this only changes how existing NIP-22/NIP-72 events are rendered.

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted (`spotlessCheck` green)
- [x] Ran `./gradlew test` (`:quartz:jvmTest`, `:commons:jvmTest`, `:amethyst:testPlayDebugUnitTest` — all green)
- [x] Manually exercised the change (see notes below)

Device: **Pixel 9a, Android 17 (API 37)**, running the R8-minified `installPlayBenchmark` build (`com.vitorpamplona.amethyst.benchmark`, `1.13.1-BENCHMARK`).

### Feature test plan

- Open the reported note in the **home/profile feed** → the previously blank slot above the post now shows the community card (avatar + `movies`), and the community definition is fetched lazily at render time — the real avatar and name load rather than falling back to the bare `d` tag.
- Tap the post → **Thread screen** → the same card renders above the master note, via `ThreadFeedView`'s own call site.
- Card is tappable → navigates to the community screen.

Screenshots (dark theme): feed row, profile Notes tab, and Thread view — attached below.
<img width="300" alt="Screenshot_20260814-111946" src="https://github.com/user-attachments/assets/c5b7dbe4-ed1d-481c-91cb-2497eec169fe" /> <img width="300" alt="Screenshot_20260814-113934" src="https://github.com/user-attachments/assets/66c8d83b-90c8-4a76-87e1-01971f56aa3e" />

### Regression test plan

Touch points and verification:

- **Reply-context card on ordinary NIP-10 threads** — the extracted `replyingDirectlyTo` serves every note with a parent; a mistake here would blank or mis-target every reply card — verified: unit-tested (`ParentNoteTest.nestedReplyInsideACommunityStillResolvesItsParent`, `noteInsideAChannelIsNotOfferedAsAParent`), and the refactor is behaviour-preserving by construction (each call site's pre-existing asymmetry is retained — `JumpToParentReplyButton` still applies its extra channel filter, which the shared fallback deliberately does not).
- **Nested replies inside a community** — previously resolved to the community shell instead of the real parent; this PR fixes that, so it must not regress in the other direction — verified by unit test; **not yet exercised on-device** (see gaps below).
- **Community screen feed** — now publishes its own scope via `LocalCurrentExternalScope`, so rows don't repeat a card for the community they are already inside — **not yet exercised on-device**.
- **URL / hashtag / geohash comments** — `DisplayCommentScope` consolidated the external-id branch; a mistake would drop the URL preview chip — verified: the external-id path is unchanged apart from being moved, and `LocalCurrentExternalScope` has no provider above a thread destination, so honouring it at both call sites is behaviour-identical; **not exercised on-device**.
- **R8-minified build** — the whole manual plan above ran on `installPlayBenchmark`, not a debug build, so no keep-rule gap in the new Compose code.
- **KMP source sets** — new code in `commons/commonMain` and `quartz/commonMain` must stay Android-free — verified: no `android.*` imports, and `:quartz:compileKotlinIosSimulatorArm64` builds clean.
- **Render-path allocation** — this code runs per note in scrolling feeds — verified: the new predicates use the `fast*` operators (`fastAny`, `fastFirstNotNullOfOrNull`) per the quartz raw-array convention; the cheap kind check now gates the address parse, so non-community comments allocate nothing.

### Regression tests for the bug

Both suites were mutation-checked — reverting the fix makes them fail, so they are not passing for the wrong reason:

| Suite | Reverting | Result |
|------------------------------------|---------------------------------------------|--------------|
| `commons ParentNoteTest` (5 tests) | resolver back to `event?.kind` only         | 4 of 5 fail  |
| `commons ParentNoteTest` (5 tests) | `kindOrNull()` back to `event?.kind` only   | 2 of 5 fail  |
| `quartz CommunityCommentScopeTest` (6 tests) | n/a — new protocol predicate      | pass         |

### Known gaps

Stated explicitly rather than omitted:

- **F-Droid flavour not built.** Only `:amethyst:compileFdroidDebugKotlin` was compiled (clean); `installFdroidDebug` was not run. The change adds no Google-proprietary touch points — it is Compose + `quartz`/`commons` logic only — so it should be flavour-irrelevant, but the build was not exercised end-to-end.
- **Light-theme screenshots not captured** — dark only.
- **On-device coverage is partial.** Ordinary NIP-10 reply cards were confirmed working on device after the resolver extraction, alongside the community path. Zap-poll reply cards, reposts of community posts, URL/hashtag-scoped comments, and the community screen's own feed rest on unit tests rather than a click-through.
- **`ThreadFeedView` now honours `LocalCurrentExternalScope`** where it previously did not. This is behaviour-identical today because neither provider (`UrlScreen`, `CommunityScreen`) is an ancestor of a thread destination, but it is a structural assumption about the navigation graph, not something a unit test can pin. If a thread view is ever nested under either screen, the scope card would silently disappear.

And the ### Regression tests for the bug table, which is now understated:

### Regression tests for the bug

Every suite was mutation-checked — reverting the relevant code makes them fail, so none are passing for the wrong reason:

| Suite | Reverted change | Result |
|----------------------------------------------|---------------------------------------------------|-------------|
| `commons ParentNoteTest` (7 tests)            | resolver back to `event?.kind` only               | 4 fail      |
| `commons ParentNoteTest` (7 tests)            | `kindOrNull()` back to `event?.kind` only         | 2 fail      |
| `quartz CommunityCommentScopeTest` (9 tests)  | `isTopLevelCommunityPost()` back to the kind-only heuristic | 2 fail |
| `quartz CommunityCommentScopeTest` (9 tests)  | `communityAddress()` scan order reversed          | 1 fail      |

`communityAddress()` is additionally pinned against its pre-rewrite implementation as a reference oracle across eight tag shapes, because seven call sites outside this branch depend on it being unchanged.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

This PR only reads existing tags and changes rendering; no event is constructed or serialized differently.

## AI assistance

- [x] Drafted with AI assistance, manually reviewed and tested

Per `CONTRIBUTING-WITH-AI.md` § *Code review pass before opening the PR*, the diff was reviewed by agents other than the one that wrote it, and the tests plus the on-device plan were re-run afterwards:

| Pass | Outcome |
|--------------------------------|--------------------------------------------------------------------------------------------|
| `/simplify` (4 parallel agents: reuse, simplification, efficiency, altitude) | ~12 distinct findings; the substantive ones fixed in `b03af02` — see below |
| `/kotlin-review` (kotlin-reviewer agent) | 0 CRITICAL, 0 HIGH, 1 MEDIUM (a local shadowing the function it calls) — fixed in `1532707` |
| `./gradlew :amethyst:lintPlayDebug` | Exit 0; 0 new findings in touched files (the 4 hits there are pre-existing) |

Review findings acted on: the null-hole fix was generalized onto the model (`kindOrNull`) instead of staying a private community-specific helper, which is what let `RenderRepost` be fixed too; the duplicated scope dispatch was collapsed into one composable; three allocation sites on the feed render path were removed; an over-large `CommunityScaffold` extraction was reverted in favour of the `UrlScreen` precedent; and a test that passed for the wrong reason (the early return fired before it reached the branch it claimed to cover) was rewritten so the address-kind path is genuinely exercised.

Findings deliberately **not** acted on, with reasons:

- `CommentEvent.tagsWithoutCitations()` already decides "is this the root of a community post" from addresses, while the new `isTopLevelCommunityPost()` decides it from kind tags. Unifying them is the deeper fix, but it changes what enters `Note.replyTo` for every community comment, with blast radius into feed filters and thread assembly — that deserves its own PR with its own testing, not a quiet rider on a bug fix.
- `ReplyContext.from()` (the desktop reply-label resolver) has no community gate at all and shows "Replying to @owner" for these posts — the desktop twin of this bug. Left alone because it is a desktop behaviour change that was not verified here. **Worth a follow-up issue.**
- Outside the community screen a top-level community post now names the community twice: the `/n/<community>` chip in the header and the new context card. Left as-is; suppressing the chip for top-level community posts is a one-condition change if maintainers prefer it.

## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
