### PR TITLE
feat: default new accounts to always AUTH with relays

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
@@ -1254,6 +1254,8 @@ private class InboxPrefs(
 
 private fun SharedPreferences.readInboxPrefs() =
     InboxPrefs(
+        // Missing key = an account saved before this setting existed. Those keep CUSTOM; only
+        // brand-new logins get the ALWAYS default from AccountSettings' constructor.
         defaultRelayAuthPolicy =
             getString(PrefKeys.DEFAULT_RELAY_AUTH_POLICY, null)
                 ?.let { runCatching { RelayAuthPolicy.valueOf(it) }.getOrNull() }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -338,7 +338,9 @@ class AccountSettings(
     var callVideoResolution: CallVideoResolution = CallVideoResolution.HD_720,
     var callMaxBitrateBps: Int = 1_500_000,
     val callsEnabled: MutableStateFlow<Boolean> = MutableStateFlow(true),
-    val defaultRelayAuthPolicy: MutableStateFlow<RelayAuthPolicy> = MutableStateFlow(RelayAuthPolicy.CUSTOM),
+    // New accounts authenticate with every relay that asks. Existing accounts keep whatever they
+    // had saved (LocalPreferences falls back to CUSTOM for prefs written before this key existed).
+    val defaultRelayAuthPolicy: MutableStateFlow<RelayAuthPolicy> = MutableStateFlow(RelayAuthPolicy.ALWAYS),
     val relayGroupViewMode: MutableStateFlow<RelayGroupViewMode> = MutableStateFlow(RelayGroupViewMode.DEFAULT),
     val concordViewMode: MutableStateFlow<ConcordViewMode> = MutableStateFlow(ConcordViewMode.DEFAULT),
     // Which conversation protocols the Messages inbox loads and shows. A disabled type is both hidden


### PR DESCRIPTION
New logins started on RelayAuthPolicy.CUSTOM, which auto-authenticates only
for own relays/venues and follows and prompts for everything else. Start them
on ALWAYS instead, so a fresh account answers every relay that asks (still
gated by the first-party check and the blocked-relay list).

Only the AccountSettings constructor default moves, so this applies to
accounts created from here on. Existing accounts keep their saved policy, and
prefs written before the key existed still fall back to CUSTOM.