### PR TITLE
fix: reclaim memory under heap pressure and stop leaking sandbox Activities

### DIFF
--- a/amethyst/src/main/AndroidManifest.xml
+++ b/amethyst/src/main/AndroidManifest.xml
@@ -115,7 +115,7 @@
             android:exported="true"
             android:launchMode="singleInstance"
             android:windowSoftInputMode="adjustResize"
-            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize"
+            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|keyboardHidden|keyboard|navigation|uiMode|fontScale|density"
             android:supportsPictureInPicture="true"
             android:theme="@style/Theme.Amethyst">
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/AppModules.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/AppModules.kt
@@ -23,6 +23,7 @@ package com.vitorpamplona.amethyst
 import android.content.ComponentCallbacks2
 import android.content.Context
 import android.os.BatteryManager
+import android.os.SystemClock
 import androidx.security.crypto.EncryptedSharedPreferences
 import coil3.disk.DiskCache
 import coil3.memory.MemoryCache
@@ -189,6 +190,7 @@ import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.transform
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.io.File
@@ -333,6 +335,12 @@ class AppModules(
                 .drop(1)
                 .collect { surgeDns.staleAll() }
         }
+    }
+
+    // Runs for the whole process lifetime (main process only — the sandbox never builds AppModules).
+    // See [startHeapPressureWatchdog] for why the OS trim callbacks cannot be relied on.
+    init {
+        startHeapPressureWatchdog()
     }
 
     // Shared cache populated by OnionLocationInterceptor from any HTTP/WebSocket
@@ -1303,6 +1311,53 @@ class AppModules(
         accountsCache.clear()
     }
 
+    /**
+     * Self-triggered reclaim, because the OS-driven path cannot fire when we need it most.
+     *
+     * `onTrimMemory` is the ONLY caller of [trim], and since API 34 the OS delivers just two levels,
+     * both of which require the app to be backgrounded:
+     *  - `UI_HIDDEN(20)` — activities stopped. Only trims images; never touches [LocalCache].
+     *  - `BACKGROUND(40)` — the process is on the system LRU list, which is what gates every bulk
+     *    reclaim we have (Tier 2 pruning, feed trimming, the hard cache trims).
+     *
+     * Two independent situations therefore get NO reclaim at all:
+     *  1. **Foreground use.** The deprecated `RUNNING_*` levels are never delivered, so a long session
+     *     simply grows until the heap is full.
+     *  2. **The always-on notification service.** A process hosting a foreground service can never enter
+     *     the cached state, so `BACKGROUND` is unreachable *even while backgrounded* — ActivityManager
+     *     refuses it outright ("Unable to set a background trim level on a foreground process").
+     *
+     * Measured consequence: a 3.4-day session sat at 492 MB of a 512 MB heap (3% free), paying 685 ms
+     * mark-compact GCs every ~10 s with dozens of threads blocked in `WaitForGcToComplete`, until an
+     * input-dispatch ANR. Reproduced independently on a second device with no foreground service at all.
+     *
+     * So we watch our own occupancy instead of waiting to be told. Above [HEAP_HIGH_WATER] we run the
+     * app's existing `BACKGROUND` reclaim — deliberately the same path, not a parallel policy, because at
+     * this occupancy "real reclaim pressure" is simply true. [MIN_RECLAIM_INTERVAL_MS] keeps a prune that
+     * frees little from spinning.
+     */
+    private fun startHeapPressureWatchdog() {
+        applicationIOScope.launch {
+            var lastRunAt = 0L
+            while (isActive) {
+                delay(HEAP_CHECK_INTERVAL_MS)
+                val runtime = Runtime.getRuntime()
+                val max = runtime.maxMemory()
+                val used = runtime.totalMemory() - runtime.freeMemory()
+                val ratio = used.toDouble() / max
+                val now = SystemClock.elapsedRealtime()
+                if (ratio >= HEAP_HIGH_WATER && now - lastRunAt >= MIN_RECLAIM_INTERVAL_MS) {
+                    lastRunAt = now
+                    Log.w("AppModules") {
+                        "Heap at ${(ratio * 100).toInt()}% (${used / (1024 * 1024)}MB of ${max / (1024 * 1024)}MB) — " +
+                            "self-triggering BACKGROUND reclaim; the OS will not deliver one here."
+                    }
+                    trim(ComponentCallbacks2.TRIM_MEMORY_BACKGROUND)
+                }
+            }
+        }
+    }
+
     fun trim(level: Int) {
         _trimLevelEvents.tryEmit(level)
         // Backgrounding is a natural moment to flush the usage ledger too.
@@ -1346,5 +1401,24 @@ class AppModules(
                 }
             }
         }
+    }
+
+    companion object {
+        /**
+         * Fraction of `Runtime.maxMemory()` above which we stop waiting for an OS trim that is never
+         * coming and reclaim ourselves. 70% leaves real headroom: the ANR-producing session was pinned at
+         * 96% (492 MB of 512 MB, 3% free), where every allocation already stalls behind a GC.
+         */
+        private const val HEAP_HIGH_WATER = 0.70
+
+        /** Three `Runtime` reads; cheap enough to run often, slow enough to be invisible. */
+        private const val HEAP_CHECK_INTERVAL_MS = 60_000L
+
+        /**
+         * Floor between self-triggered reclaims. Pruning cannot free events the UI still holds, so a busy
+         * screen can sit above the high-water mark for a while; without this we would re-prune every
+         * check and burn CPU on a heap that has nothing left to give.
+         */
+        private const val MIN_RECLAIM_INTERVAL_MS = 120_000L
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/NappletBrokerService.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/NappletBrokerService.kt
@@ -154,6 +154,21 @@ class NappletBrokerService : Service() {
     private var foregroundLeaseWatchdog: Job? = null
 
     private fun handleMessage(msg: Message): Boolean {
+        // A sandbox surface is being destroyed: drop every reference we hold to its Messenger. Holding a
+        // client's Messenger keeps a binder alive, which pins that surface's whole Activity (and its
+        // WebView) in the `:napplet` process past onDestroy — reclaimable only by killing the process.
+        if (msg.what == NappletIpc.MSG_RELEASE_CLIENT) {
+            msg.replyTo?.let { incBus.removeAll(it) }
+            // Release its foreground lease too; otherwise a destroyed surface keeps the main process
+            // pinned resumed until the lease watchdog expires it.
+            msg.data?.getString(NappletIpc.KEY_LAUNCH_TOKEN)?.let { token ->
+                synchronized(foregroundLeases) {
+                    if (foregroundLeases.remove(token) != null) SandboxForegroundHold.release()
+                }
+            }
+            return true
+        }
+
         // A sandbox surface (full-screen :napplet host) entered, renewed, or left the foreground. Hold the
         // main process resumed while at least one is foreground, so opening it doesn't tear down Tor/relays.
         if (msg.what == NappletIpc.MSG_SET_FOREGROUND) {

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserActivity.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserActivity.kt
@@ -65,6 +65,7 @@ import com.vitorpamplona.amethyst.commons.browser.OmniboxInput
 import com.vitorpamplona.amethyst.commons.napplet.NappletWebContract
 import org.json.JSONObject
 import java.io.ByteArrayOutputStream
+import java.lang.ref.WeakReference
 import java.util.concurrent.Executor
 import com.vitorpamplona.amethyst.commons.R as CommonsR
 
@@ -107,7 +108,33 @@ class NappletBrowserActivity : ComponentActivity() {
 
     // ---- broker bridge (per-origin NIP-07 tokens; identical to NappletBrowserService) ----
     private var brokerMessenger: Messenger? = null
-    private val replyMessenger = Messenger(Handler(Looper.getMainLooper(), ::onBrokerReply))
+
+    /**
+     * Reply channel handed to the broker. It MUST NOT hold this Activity strongly.
+     *
+     * A [Messenger] sent over IPC is a binder: while the main process holds it, ART keeps a **JNI global
+     * reference** to the backing [Handler] here in `:napplet`. A `Handler(looper, ::onBrokerReply)` makes
+     * the Activity the handler's `mCallback` (a bound method reference captures `this`), so that one
+     * retained binder pinned Activity → PhoneWindow → DecorView → WebView past `onDestroy`, and no GC in
+     * this process could ever reclaim it — only killing the process could. Measured: one full-screen page
+     * opened and closed left a destroyed Activity plus its WebView alive through repeated forced GCs.
+     *
+     * Holding the Activity weakly severs that chain at the source, so even a broker that never processes
+     * [NappletIpc.MSG_RELEASE_CLIENT] (see [onDestroy]) cannot leak a surface. Messages arriving after
+     * destruction are dropped, which is correct: there is nothing left to deliver them to.
+     */
+    private val replyMessenger = Messenger(WeakBrokerReplyHandler(this))
+
+    private class WeakBrokerReplyHandler(
+        activity: NappletBrowserActivity,
+    ) : Handler(Looper.getMainLooper()) {
+        private val ref = WeakReference(activity)
+
+        override fun handleMessage(msg: Message) {
+            ref.get()?.onBrokerReply(msg)
+        }
+    }
+
     private val pendingBrokerRequests = mutableListOf<Message>()
     private var bridgeReplyProxy: JavaScriptReplyProxy? = null
     private var fireSeq = 0
@@ -259,6 +286,10 @@ class NappletBrowserActivity : ComponentActivity() {
     }
 
     override fun onDestroy() {
+        // Tell the broker to drop every reference to our reply Messenger BEFORE unbinding — a retained
+        // Messenger is a binder, and it would pin this Activity (and its WebView) in `:napplet` for the
+        // life of the process. `unbindService` alone does not release it. See [replyMessenger].
+        releaseFromBroker()
         runCatching { unbindService(brokerConnection) }
         if (this::webView.isInitialized) {
             // Detach from the view tree BEFORE destroy(). Destroying a WebView while it is still attached to
@@ -285,6 +316,21 @@ class NappletBrowserActivity : ComponentActivity() {
                     }
             }
         if (brokerMessenger != null) sendToBroker(msg)
+    }
+
+    /**
+     * Asks the broker to drop every reference it holds to [replyMessenger] (inc-bus subscriptions and this
+     * surface's foreground lease). Sent directly rather than through [sendToBroker] because that queues
+     * when the broker is unbound — and we are being destroyed, so a queued release would never be sent.
+     */
+    private fun releaseFromBroker() {
+        val broker = brokerMessenger ?: return
+        val msg =
+            Message.obtain(null, NappletIpc.MSG_RELEASE_CLIENT).apply {
+                replyTo = replyMessenger
+                data = Bundle().apply { putString(NappletIpc.KEY_LAUNCH_TOKEN, startUrl) }
+            }
+        runCatching { broker.send(msg) }
     }
 
     @Suppress("SetJavaScriptEnabled")

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletHostActivity.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletHostActivity.kt
@@ -78,6 +78,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
+import java.lang.ref.WeakReference
 import java.util.concurrent.Executor
 import com.vitorpamplona.amethyst.commons.R as CommonsR
 
@@ -140,7 +141,26 @@ class NappletHostActivity : ComponentActivity() {
 
     // Messenger to the main-process broker, bound lazily; requests queue until connected.
     private var brokerMessenger: Messenger? = null
-    private val replyMessenger = Messenger(Handler(Looper.getMainLooper(), ::onBrokerReply))
+
+    /**
+     * Reply channel handed to the broker. It MUST NOT hold this Activity strongly — a [Messenger] sent
+     * over IPC is a binder, so while the main process holds it ART keeps a JNI global reference to the
+     * backing [Handler] here in `:napplet`. With a bound method reference as the handler callback, that
+     * one retained binder pins Activity → window → WebView past `onDestroy`, reclaimable only by killing
+     * the process. See [NappletBrowserActivity.replyMessenger] for the measured case.
+     */
+    private val replyMessenger = Messenger(WeakBrokerReplyHandler(this))
+
+    private class WeakBrokerReplyHandler(
+        activity: NappletHostActivity,
+    ) : Handler(Looper.getMainLooper()) {
+        private val ref = WeakReference(activity)
+
+        override fun handleMessage(msg: Message) {
+            ref.get()?.onBrokerReply(msg)
+        }
+    }
+
     private val pendingRequests = mutableListOf<Message>()
     private var bridgeReplyProxy: JavaScriptReplyProxy? = null
 
@@ -389,7 +409,23 @@ class NappletHostActivity : ComponentActivity() {
         foregroundHeartbeat = null
     }
 
+    /**
+     * Asks the broker to drop every reference it holds to [replyMessenger] (inc-bus subscriptions and this
+     * surface's foreground lease). Sent directly rather than through [sendToBroker], which queues while
+     * unbound — we are being destroyed, so a queued release would never leave.
+     */
+    private fun releaseFromBroker() {
+        val broker = brokerMessenger ?: return
+        val msg =
+            Message.obtain(null, NappletIpc.MSG_RELEASE_CLIENT).apply {
+                replyTo = replyMessenger
+                data = Bundle().apply { putString(NappletIpc.KEY_LAUNCH_TOKEN, launchToken) }
+            }
+        runCatching { broker.send(msg) }
+    }
+
     /** Reports this surface's foreground state to the broker so it can hold the main process resumed. */
+
     private fun setBrokerForeground(foreground: Boolean) {
         val msg =
             Message.obtain(null, NappletIpc.MSG_SET_FOREGROUND).apply {
@@ -407,6 +443,9 @@ class NappletHostActivity : ComponentActivity() {
 
     override fun onDestroy() {
         uiScope.cancel()
+        // Drop the broker's references to our reply Messenger BEFORE unbinding — a retained Messenger is a
+        // binder and would pin this Activity (and its WebView) for the life of the `:napplet` process.
+        releaseFromBroker()
         // unbind is in runCatching: if the index never resolved we never bound the broker.
         runCatching { unbindService(brokerConnection) }
         keyActions.clear()

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletIpc.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletIpc.kt
@@ -106,6 +106,20 @@ object NappletIpc {
      */
     const val MSG_OPEN_PERMISSIONS = 12
 
+    /**
+     * Host → broker: this surface is being destroyed — drop every reference the broker holds to its
+     * `replyTo` [android.os.Messenger] (inc-bus topic subscriptions, and its foreground lease when
+     * [KEY_LAUNCH_TOKEN] is supplied).
+     *
+     * A `Messenger` handed to the broker is a **binder**, so the main process holding it keeps a JNI
+     * global reference alive in `:napplet`. Because the sandbox's reply handler is a bound method
+     * reference on the Activity, that one retained Messenger pins the whole Activity → window → WebView,
+     * and no GC in the sandbox can ever reclaim it (only process death can). Sending this on destroy is
+     * the release half of the fix; the reply handler holding the Activity weakly is the other half, so a
+     * missed or dropped release can never pin a surface again. Fire-and-forget; no reply needed.
+     */
+    const val MSG_RELEASE_CLIENT = 13
+
     const val KEY_REQUEST_ID = "requestId"
     const val KEY_PAYLOAD = "payload"
 


### PR DESCRIPTION
Three independent memory fixes found while investigating a Pixel 8 that had been running v1.13.1 for 3.4 days, pinned at 492MB of a 512MB heap with 685ms GCs every ~10s and input-dispatch ANRs.

> The relay-auth fix that was originally in this branch has been split out into #3937 — it is unrelated to the memory work.

Each commit stands alone and has its own detailed rationale.

## 1. Reclaim memory on heap pressure instead of waiting for the OS

`MemoryTrimmingService.run` has exactly one caller — `Application.onTrimMemory` — and since API 34 the OS delivers only `UI_HIDDEN(20)` and `BACKGROUND(40)`, both of which require the app to be backgrounded. Every bulk reclaim we have is gated on `BACKGROUND`, so two situations get **no reclaim at all**:

1. **Foreground use** — the deprecated `RUNNING_*` levels are never delivered, so a long session grows until the heap is full.
2. **The always-on notification service** — a process hosting a foreground service can never enter the cached state, so `BACKGROUND` is unreachable *even while backgrounded*. ActivityManager refuses it outright: `Unable to set a background trim level on a foreground process`.

Reproduced on two devices, including one with no foreground service at all (simply foregrounded, heap at 4–5% free with 5s GC cycles).

Added a watchdog on our own occupancy: above 70% of `maxMemory`, run the app's existing `BACKGROUND` reclaim — the same path, not a parallel policy — with a 120s floor between runs.

Verified by temporarily lowering the thresholds: the watchdog fires and drives the real Tier 2 functions (`pruneHiddenEvents`, `pruneOldMessages`, `pruneRepliesAndReactions`) that had never once executed on a foreground or always-on install.

## 2. Release the broker Messenger so a destroyed sandbox Activity can be freed

A full-screen napplet/browser surface ran `onDestroy` cleanly and left ActivityManager, yet `:napplet` kept the Activity, its window and its WebView alive through repeated forced GCs. Heap dump:

```
ROOT(JNI_GLOBAL) android.os.Handler$MessengerImpl
  -> MessengerImpl.this$0  = android.os.Handler
  -> Handler.mCallback     = <lambda>
  -> lambda.f$0            = NappletBrowserActivity
```

`Messenger(Handler(mainLooper, ::onBrokerReply))` makes the Activity the handler's callback, and a `Messenger` sent over IPC is a binder — so while the broker holds it, ART keeps a JNI global reference to that Handler in the sandbox, pinning Activity → PhoneWindow → DecorView → WebView. `onDestroy` only called `unbindService`, which releases none of the broker's references.

Both halves fixed: a new `MSG_RELEASE_CLIENT` sent first thing in `onDestroy`, and the reply handler now holds the Activity weakly so a missed release can't pin a surface again.

Verified: `Activities:1 WebViews:2` across three forced GCs before → `Activities:0 WebViews:1` after. Heap dump `NappletBrowserActivity` instances **13 → 1** (the survivor is the `Companion`, a static singleton).

## 3. Handle uiMode/fontScale/density in MainActivity instead of recreating

`MainActivity` declared only `orientation|screenSize|screenLayout|smallestScreenSize`, so a dark-mode toggle or font-size change destroyed and rebuilt it. Each rebuild strands one embedded browser session — privacysandbox holds the outgoing `SandboxedSdkView`'s `RemoteSessionClient` over binder, pinning the old Activity's `ViewRootImpl` and the provider's WebView + SurfaceControlViewHost + EGL surface.

Measured 1:1 on an emulator: 4 recreations → 4 leaked Activities and 4 leaked WebViews. On the 3.4-day device this showed as **15 retained Activity objects against only 3 ActivityRecords**, alongside **17 WebViews and 793MB of EGL** in `:napplet`.

Compose handles these config changes natively, and `NappletBrowserActivity` in this repo already declares the same wider set. The test goes from 1→5 to **flat at 1**, with zero session re-arms.

## Known limitation

Fix 3 removes the recreation *triggers* users actually hit, but does **not** fix the underlying privacysandbox retention. A session is still stranded by recreations it doesn't prevent (locale change, account switch). The root cause is proven by heap dump —

```
RemoteSessionClient.clientExecutor -> ViewRootImpl$ViewRootHandler -> ViewRootImpl
  -> .mContext -> DecorContext -> PhoneWindow.mContext = MainActivity
```

— i.e. `SandboxedSdkView` hands its ViewRootImpl handler to privacysandbox as the `clientExecutor`, which the sandbox holds over binder. Three fixes were attempted and **all failed**, so none are included here:

| attempt | result |
|---|---|
| explicit provider-side session close | sessions closed cleanly (`CLOSE found=true` every time), leak unchanged |
| `client.onSessionError(...)` on reap | instrumented and confirmed delivered (`ok=true`), leak unchanged |
| `SandboxedSdkView.preserveSessionOnWindowDetachment(false)` | leak unchanged |

This may be an `androidx.privacysandbox.ui 1.0.0-alpha17` defect — a client view that cannot release its session when its Activity dies. Worth pursuing separately.

## Testing

- `:amethyst:assemblePlayDebug` builds; `:commons:jvmTest` green.
- All three fixes verified on a Pixel emulator (SDK 36) with forced GCs and heap-dump analysis.
- **Not verified:** that dark mode still re-themes in place after fix 3 — the test account's theme is explicit DARK, so a system night-mode flip is a no-op for it. Worth a check with theme = SYSTEM before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)