### PR TITLE
fix: honour "always log in" for relays the account does not use itself

### DIFF
--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayauth/RelayAuthResolver.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/relayauth/RelayAuthResolver.kt
@@ -92,11 +92,14 @@ data class RelayAuthInputs(
  *      else fall through
  * 4. Fall-through → [RelayAuthVerdict.ASK] when the purpose is known, otherwise DENY.
  *
- * Both automatic grants in step 3 additionally require [RelayAuthInputs.isFirstParty]: an account
- * never reveals its identity *without being asked* on a relay it has no reason of its own to be on.
- * That is what keeps a bystander account off a relay only another account uses. It deliberately does
- * not suppress the question — a non-first-party challenge we can explain falls through to ASK, so
- * "decide per relay" means the user decides rather than a silent denial they never see.
+ * The [RelayAuthPolicy.CUSTOM] grant additionally requires [RelayAuthInputs.isFirstParty]: under
+ * "decide per relay" an account never reveals its identity *without being asked* on a relay it has no
+ * reason of its own to be on, which is what keeps a bystander account off a relay only another account
+ * uses. It deliberately does not suppress the question — a non-first-party challenge we can explain
+ * falls through to ASK, so the user decides rather than getting a silent denial they never see.
+ *
+ * [RelayAuthPolicy.ALWAYS] is NOT gated this way: it means what it says, every relay that asks. Users
+ * who want the narrower "only the relays I actually use" behaviour choose CUSTOM.
  */
 object RelayAuthResolver {
     fun resolve(inputs: RelayAuthInputs): RelayAuthVerdict {
@@ -111,7 +114,11 @@ object RelayAuthResolver {
 
         return when (inputs.policy) {
             RelayAuthPolicy.NEVER -> RelayAuthVerdict.DENY
-            RelayAuthPolicy.ALWAYS -> if (inputs.isFirstParty) RelayAuthVerdict.ALLOW else fallThrough(inputs)
+            // Unconditional, by design: "Always log in" means every relay that asks. Narrowing it to the
+            // relays this account uses is what CUSTOM ("decide per relay") is for — gating ALWAYS as well
+            // left the user no way to express "just authenticate everywhere" and, on a fresh install with
+            // a large follow list, produced a prompt for each of the 250+ third-party outbox relays.
+            RelayAuthPolicy.ALWAYS -> RelayAuthVerdict.ALLOW
             RelayAuthPolicy.CUSTOM ->
                 if (inputs.isFirstParty && customAllows(inputs)) RelayAuthVerdict.ALLOW else fallThrough(inputs)
         }

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/relayauth/RelayAuthResolverTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/relayauth/RelayAuthResolverTest.kt
@@ -146,11 +146,22 @@ class RelayAuthResolverTest {
     }
 
     @Test
-    fun nonFirstPartyNeverAutoAuthsUnderAlwaysPolicy() {
-        // "Always log in" is a statement about the relays this account uses. A relay it is only
-        // touching because of somebody else's traffic still has to be asked about.
+    fun alwaysPolicyAuthsEvenWhenNotFirstParty() {
+        // "Always log in" means every relay that asks, first-party or not — narrowing it to the relays
+        // this account uses is what CUSTOM is for. (This previously returned ASK for non-first-party,
+        // which left no way to express "authenticate everywhere" and prompted once per third-party
+        // outbox relay on a fresh install.)
         assertEquals(RelayAuthVerdict.ALLOW, resolve(inputs(policy = RelayAuthPolicy.ALWAYS, isFirstParty = true)))
-        assertEquals(RelayAuthVerdict.ASK, resolve(inputs(policy = RelayAuthPolicy.ALWAYS, isFirstParty = false)))
+        assertEquals(RelayAuthVerdict.ALLOW, resolve(inputs(policy = RelayAuthPolicy.ALWAYS, isFirstParty = false)))
+    }
+
+    @Test
+    fun customPolicyStillRequiresFirstParty() {
+        // The first-party gate belongs to CUSTOM: a toggle that matches is not enough if the only reason
+        // we are on this relay belongs to somebody else.
+        val allOn = RelayAuthCustomToggles(myRelaysAndVenues = true, readFollows = true, messageFollows = true, messageStrangers = true)
+        assertEquals(RelayAuthVerdict.ALLOW, resolve(inputs(toggles = allOn, isInMyRelayList = true, isFirstParty = true)))
+        assertEquals(RelayAuthVerdict.ASK, resolve(inputs(toggles = allOn, isInMyRelayList = true, isFirstParty = false)))
     }
 
     @Test


### PR DESCRIPTION
Split out of #3936 so it can be reviewed on its own — it is unrelated to the memory work there.

## The bug

`RelayAuthResolver` gated the `ALWAYS` policy behind `isFirstParty`:

```kotlin
RelayAuthPolicy.ALWAYS -> if (inputs.isFirstParty) ALLOW else fallThrough(inputs)   // -> ASK
```

So **"Always log in"** only auto-authenticated relays the account had its *own* reason to be on. Any relay reached only through somebody else's traffic — a followed author's outbox, another logged-in account — fell through to a prompt.

With the outbox model dialling 250+ relays and no stored per-relay decisions yet, that is **one prompt per third-party relay** on a fresh install. It is invisible on an established install only because those per-relay decisions have already accumulated.

## Why it is a bug and not a privacy feature

Narrowing to "only the relays I actually use" is exactly what the **"decide per relay"** option (`CUSTOM` + `RelayAuthCustomToggles`) exists to express. Applying the same narrowing to `ALWAYS` left the user no way to say *"just authenticate everywhere"* — and contradicted both the enum's own KDoc:

```kotlin
/** Authenticate with every relay that requests it. */
ALWAYS,
```

and the setting's user-facing description, `relay_auth_policy_always_desc` → **"Every relay that asks."**

## The change

`ALWAYS` is now unconditional. The first-party gate stays on `CUSTOM`, where it belongs.

Precedence is otherwise untouched: blocked relays (kind 10006) and explicit per-relay overrides are still resolved *before* the policy, so nothing the user has already decided is reopened.

## Tests

The old behaviour was pinned by a test that documented it as intentional:

```kotlin
fun nonFirstPartyNeverAutoAuthsUnderAlwaysPolicy() {
    // "Always log in" is a statement about the relays this account uses. ...
    assertEquals(RelayAuthVerdict.ASK, resolve(inputs(policy = ALWAYS, isFirstParty = false)))
}
```

Replaced with `alwaysPolicyAuthsEvenWhenNotFirstParty` (ALLOW either way), plus a new `customPolicyStillRequiresFirstParty` so the gate stays covered where it does apply.

`RelayAuthPermissionLedger.kt:122` is the only caller of `RelayAuthResolver.resolve`, so there is no duplicate policy logic to keep in sync.

## Verification

- `:commons:jvmTest` green; amethyst `AuthDecisionResolverTest` + `RelayAuthVenueCoverageTest` green.
- On device: a fresh install that previously produced a stream of "«relay» asks who you are" dialogs now launches straight into the feed with none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)