### PR TITLE
Mute public chats

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/LocalPreferences.kt
@@ -214,6 +214,7 @@ private object PrefKeys {
     const val HAS_DONATED_IN_VERSION = "has_donated_in_version"
     const val DISMISSED_POLL_NOTE_IDS = "dismissed_poll_note_ids"
     const val DISMISSED_CHANNEL_INVITES = "dismissed_channel_invites"
+    const val MUTED_PUBLIC_CHATS = "muted_public_chats"
     const val VIEWED_POLL_RESULT_NOTE_IDS = "viewed_poll_result_note_ids"
     const val PENDING_ATTESTATIONS = "pending_attestations"
 
@@ -650,6 +651,7 @@ object LocalPreferences {
                     putStringSet(PrefKeys.HAS_DONATED_IN_VERSION, settings.hasDonatedInVersion.value)
                     putStringSet(PrefKeys.DISMISSED_POLL_NOTE_IDS, settings.dismissedPollNoteIds.value)
                     putStringSet(PrefKeys.DISMISSED_CHANNEL_INVITES, settings.dismissedChannelInvites.value)
+                    putStringSet(PrefKeys.MUTED_PUBLIC_CHATS, settings.mutedPublicChats.value)
                     putString(
                         PrefKeys.VIEWED_POLL_RESULT_NOTE_IDS,
                         JsonMapper.toJson(settings.viewedPollResultNoteIds.value),
@@ -789,6 +791,7 @@ object LocalPreferences {
                     val hasDonatedInVersion = getStringSet(PrefKeys.HAS_DONATED_IN_VERSION, null) ?: setOf()
                     val dismissedPollNoteIds = getStringSet(PrefKeys.DISMISSED_POLL_NOTE_IDS, null) ?: setOf()
                     val dismissedChannelInvites = getStringSet(PrefKeys.DISMISSED_CHANNEL_INVITES, null) ?: setOf()
+                    val mutedPublicChats = getStringSet(PrefKeys.MUTED_PUBLIC_CHATS, null) ?: setOf()
                     val viewedPollResultNoteIdsStr = getString(PrefKeys.VIEWED_POLL_RESULT_NOTE_IDS, null)
                     val localRelayServers = getStringSet(PrefKeys.LOCAL_RELAY_SERVERS, null) ?: setOf()
 
@@ -1048,6 +1051,7 @@ object LocalPreferences {
                         hasDonatedInVersion = MutableStateFlow(hasDonatedInVersion),
                         dismissedPollNoteIds = MutableStateFlow(dismissedPollNoteIds),
                         dismissedChannelInvites = MutableStateFlow(dismissedChannelInvites),
+                        mutedPublicChats = MutableStateFlow(mutedPublicChats),
                         viewedPollResultNoteIds = MutableStateFlow(viewedPollResultNoteIdsResolved),
                         pendingAttestations = MutableStateFlow(pendingAttestationsResolved),
                         backupNipA3PaymentTargets = latestPaymentTargetsResolved,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -1034,6 +1034,17 @@ class Account(
         sendNewAppSpecificData()
     }
 
+    /**
+     * Local state first, then publish. The local write is what every suppression point
+     * reads, so it must not wait on the signer — publishing is best-effort sync.
+     */
+    suspend fun toggleMutedPublicChat(channelId: String) {
+        settings.toggleMutedPublicChat(channelId)
+        sendNewAppSpecificData()
+    }
+
+    fun isPublicChatMuted(channelId: String): Boolean = settings.isPublicChatMuted(channelId)
+
     suspend fun updateZapAmounts(
         amountSet: List<Long>,
         selectedZapType: LnZapEvent.ZapType,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/Account.kt
@@ -1043,8 +1043,6 @@ class Account(
         sendNewAppSpecificData()
     }
 
-    fun isPublicChatMuted(channelId: String): Boolean = settings.isPublicChatMuted(channelId)
-
     suspend fun updateZapAmounts(
         amountSet: List<Long>,
         selectedZapType: LnZapEvent.ZapType,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -1525,9 +1525,11 @@ class AccountSettings(
 
             // Null means an older client rewrote the blob without this key — leave the
             // local set alone rather than treating "absent" as "unmute everything".
-            newSyncedSettings.chats.mutedPublicChats?.let { remote ->
-                mutedPublicChats.tryEmit(remote.toSet())
-            }
+            // The decision lives in mergeMutedPublicChats so it is unit-testable; this
+            // class cannot be constructed in a JVM test.
+            mutedPublicChats.tryEmit(
+                mergeMutedPublicChats(mutedPublicChats.value, newSyncedSettings.chats.mutedPublicChats),
+            )
 
             saveAccountSettings()
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -1632,8 +1632,6 @@ class AccountSettings(
     // muted public chats
     // ---
 
-    fun isPublicChatMuted(channelId: String) = mutedPublicChats.value.contains(channelId)
-
     fun toggleMutedPublicChat(channelId: String) {
         mutedPublicChats.update {
             if (channelId in it) it - channelId else it + channelId

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -330,6 +330,14 @@ class AccountSettings(
      * still lists you, and Leave (kind 9022) is the separate action that actually removes you.
      */
     val dismissedChannelInvites: MutableStateFlow<Set<String>> = MutableStateFlow(setOf()),
+    /**
+     * NIP-28 channel ids the user has silenced. Local device state ON PURPOSE, even
+     * though it also syncs via NIP-78: the push dispatcher must answer "is this muted?"
+     * during a cold start, before (or without) the settings blob having been decrypted —
+     * for a NIP-55 account that decrypt is an Amber IPC round-trip that may never
+     * complete in the background. See AppSpecificState.kt:70-75.
+     */
+    val mutedPublicChats: MutableStateFlow<Set<String>> = MutableStateFlow(setOf()),
     val viewedPollResultNoteIds: MutableStateFlow<Map<String, Long>> = MutableStateFlow(mapOf()),
     val pendingAttestations: MutableStateFlow<Map<HexKey, String>> = MutableStateFlow(mapOf()),
     var backupNipA3PaymentTargets: PaymentTargetsEvent? = null,
@@ -1515,6 +1523,12 @@ class AccountSettings(
             backupAppSpecificData = appSettings
             syncedSettings.updateFrom(newSyncedSettings)
 
+            // Null means an older client rewrote the blob without this key — leave the
+            // local set alone rather than treating "absent" as "unmute everything".
+            newSyncedSettings.chats.mutedPublicChats?.let { remote ->
+                mutedPublicChats.tryEmit(remote.toSet())
+            }
+
             saveAccountSettings()
         }
     }
@@ -1610,6 +1624,19 @@ class AccountSettings(
     fun toggleChatroomPin(room: ChatroomKey) {
         syncedSettings.chats.pinnedChatrooms.update {
             if (room in it) it - room else it + room
+        }
+        saveAccountSettings()
+    }
+
+    // ---
+    // muted public chats
+    // ---
+
+    fun isPublicChatMuted(channelId: String) = mutedPublicChats.value.contains(channelId)
+
+    fun toggleMutedPublicChat(channelId: String) {
+        mutedPublicChats.update {
+            if (channelId in it) it - channelId else it + channelId
         }
         saveAccountSettings()
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettings.kt
@@ -90,7 +90,7 @@ class AccountSyncedSettings(
             MutableStateFlow(DrawerItemVisibility.sanitize(navBarItemsFromNames(internalSettings.navigation.hiddenDrawerItems))),
         )
 
-    fun toInternal(): AccountSyncedSettingsInternal =
+    fun toInternal(mutedPublicChats: Set<String>): AccountSyncedSettingsInternal =
         AccountSyncedSettingsInternal(
             reactions = AccountReactionPreferencesInternal(reactions.reactionChoices.value, reactions.reactionRowItems.value),
             zaps =
@@ -120,7 +120,12 @@ class AccountSyncedSettings(
                 ),
             videoPlayer = AccountVideoPlayerPreferencesInternal(videoPlayer.buttonItems.value),
             media = AccountMediaPreferencesInternal(media.audioVisualizer.value.name),
-            chats = AccountChatPreferencesInternal(chats.pinnedChatrooms.value.map { it.users.sorted() }),
+            chats =
+                AccountChatPreferencesInternal(
+                    chats.pinnedChatrooms.value.map { it.users.sorted() },
+                    // sorted so the serialized form is deterministic
+                    mutedPublicChats.sorted(),
+                ),
             proofOfWork =
                 AccountPoWPreferencesInternal(
                     proofOfWork.difficulty.value,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettingsInternal.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSyncedSettingsInternal.kt
@@ -242,4 +242,14 @@ class AccountChatPreferencesInternal(
     // pubkeys (hex) sorted ascending, so the serialized form is deterministic
     // regardless of set iteration order.
     var pinnedRooms: List<List<String>> = emptyList(),
+    // NIP-28 channel ids (hex) whose notifications are silenced, sorted ascending
+    // for the same determinism reason as pinnedRooms.
+    //
+    // NULLABLE ON PURPOSE. The default has to tell two cases apart:
+    //   null = key absent — an older client rewrote the blob and dropped it, so
+    //          the local mute set must be left alone.
+    //   []   = an explicit "unmute everything" from a client that knows the field.
+    // A non-null default would collapse them and let an old client silently erase
+    // the user's mutes on every launch. See updateAppSpecificData.
+    var mutedPublicChats: List<String>? = null,
 )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/MutedPublicChats.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/MutedPublicChats.kt
@@ -62,3 +62,20 @@ fun isMutedPublicChatMessage(
     val channelId = publicChatChannelIdOf(event) ?: return false
     return channelId in mutedChannels
 }
+
+/**
+ * The inbound-sync decision for the mute set, kept separate from [AccountSettings] so it can be
+ * tested: [AccountSettings] builds a default `AccountSyncedSettingsInternal`, whose language
+ * preferences call `Resources.getSystem()`, so it cannot be constructed in a JVM unit test.
+ *
+ * [remote] is `null` when an older client rewrote the NIP-78 blob without the key. The local set
+ * must survive that — and because `AppSpecificState` replays the cached backup event on every app
+ * start, treating absent as empty would re-clear the user's mutes on every single launch.
+ *
+ * An explicitly empty list is different: it is a real "unmute everything" from a client that knows
+ * the field, and is adopted.
+ */
+fun mergeMutedPublicChats(
+    local: Set<HexKey>,
+    remote: List<HexKey>?,
+): Set<HexKey> = remote?.toSet() ?: local

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/MutedPublicChats.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/MutedPublicChats.kt
@@ -22,18 +22,36 @@ package com.vitorpamplona.amethyst.model
 
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelCreateEvent
+import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelMetadataEvent
 import com.vitorpamplona.quartz.nip28PublicChat.message.ChannelMessageEvent
 
 /**
- * The channel a mute decision applies to, or null when [event] is not a public-chat
- * message.
+ * The NIP-28 channel an event belongs to, or null when [event] is not one of the three
+ * public-chat event types a channel row's newest event can be.
+ *
+ * This is THE definition of "which event identifies a public-chat room" — the row dispatch
+ * (ChatroomHeaderCompose), the last-read route (ChatroomRowUnread.rowLastReadRoute), the
+ * feed's row de-duplication (ChatroomListKnownFeedFilter) and the mute predicate below all
+ * call it. It used to be copied into each of those by hand, and the copies drifted: one of
+ * them matched only [ChannelMessageEvent], so a channel whose latest activity was a topic
+ * edit silently lost its unread dot. Keep it a single function.
  *
  * Deliberately NOT `threadRootIdOrSelf()`. That returns the same channel id here — a
  * NIP-28 message's NIP-10 root marker IS its channel — but it means something else
  * (the NIP-51 "muted thread" key, which HIDES content). Keeping the two apart is what
  * stops "mute notifications" and "mute thread" from bleeding into each other.
+ *
+ * Matched on concrete types rather than the IsInPublicChatChannel interface, which the
+ * channel-admin events ChannelHideMessageEvent/ChannelMuteUserEvent also implement: those
+ * must fall through to null rather than be treated as room activity.
  */
-fun mutedChannelIdOf(event: Event?): HexKey? = (event as? ChannelMessageEvent)?.channelId()
+fun publicChatChannelIdOf(event: Event?): HexKey? =
+    when (event) {
+        is ChannelMessageEvent, is ChannelMetadataEvent -> event.channelId()
+        is ChannelCreateEvent -> event.id
+        else -> null
+    }
 
 /** True when [event] is a public-chat message in a channel the user has silenced. */
 fun isMutedPublicChatMessage(
@@ -41,6 +59,6 @@ fun isMutedPublicChatMessage(
     mutedChannels: Set<HexKey>,
 ): Boolean {
     if (mutedChannels.isEmpty()) return false
-    val channelId = mutedChannelIdOf(event) ?: return false
+    val channelId = publicChatChannelIdOf(event) ?: return false
     return channelId in mutedChannels
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/MutedPublicChats.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/MutedPublicChats.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.model
+
+import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip28PublicChat.message.ChannelMessageEvent
+
+/**
+ * The channel a mute decision applies to, or null when [event] is not a public-chat
+ * message.
+ *
+ * Deliberately NOT `threadRootIdOrSelf()`. That returns the same channel id here — a
+ * NIP-28 message's NIP-10 root marker IS its channel — but it means something else
+ * (the NIP-51 "muted thread" key, which HIDES content). Keeping the two apart is what
+ * stops "mute notifications" and "mute thread" from bleeding into each other.
+ */
+fun mutedChannelIdOf(event: Event?): HexKey? = (event as? ChannelMessageEvent)?.channelId()
+
+/** True when [event] is a public-chat message in a channel the user has silenced. */
+fun isMutedPublicChatMessage(
+    event: Event?,
+    mutedChannels: Set<HexKey>,
+): Boolean {
+    if (mutedChannels.isEmpty()) return false
+    val channelId = mutedChannelIdOf(event) ?: return false
+    return channelId in mutedChannels
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip78AppSpecific/AppSpecificState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip78AppSpecific/AppSpecificState.kt
@@ -53,7 +53,7 @@ class AppSpecificState(
     fun getAppSpecificDataFlow(): StateFlow<NoteState> = amethystSettingsNote.flow().metadata.stateFlow
 
     suspend fun saveNewAppSpecificData(): AppSpecificDataEvent {
-        val toInternal = settings.syncedSettings.toInternal()
+        val toInternal = settings.syncedSettings.toInternal(settings.mutedPublicChats.value)
         return signer.sign(
             AppSpecificDataEvent.build(
                 dTag = APP_SPECIFIC_DATA_D_TAG,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
@@ -219,11 +219,20 @@ class EventNotificationConsumer(
         // Don't push-notify events this account authored.
         if (event.pubKey == account.signer.pubKey) return
 
-        // Drop reactions/zaps/reposts whose target note lives on a muted thread
-        // (matches the in-app feed, which mutes all four).
+        // Drop reactions/zaps/reposts whose target note lives on a muted thread, or in a
+        // public chat the user has silenced (matches the in-app feed, which mutes all four).
+        // Without the second check, muting a channel still let a like on your own message
+        // there notify you — the row's glyph promises silence, so it has to mean it.
         if (event is ReactionEvent || event is LnZapEvent || event is RepostEvent || event is GenericRepostEvent) {
             val target = LocalCache.getNoteIfExists(event)?.replyTo?.lastOrNull()
-            if (target != null && account.isThreadMuted(account.resolveThreadRoot(target))) return
+            if (target != null &&
+                (
+                    account.isThreadMuted(account.resolveThreadRoot(target)) ||
+                        isMutedPublicChatMessage(target.event, account.settings.mutedPublicChats.value)
+                )
+            ) {
+                return
+            }
         }
 
         when (event) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/notifications/EventNotificationConsumer.kt
@@ -35,6 +35,7 @@ import com.vitorpamplona.amethyst.commons.nipACWebRtcCalls.CallManager
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
+import com.vitorpamplona.amethyst.model.isMutedPublicChatMessage
 import com.vitorpamplona.amethyst.service.call.notification.CallNotifier
 import com.vitorpamplona.amethyst.service.notifications.renderers.ArticleNotification
 import com.vitorpamplona.amethyst.service.notifications.renderers.BadgeNotification
@@ -315,6 +316,12 @@ class EventNotificationConsumer(
         event: ChannelMessageEvent,
         account: Account,
     ) {
+        // Reads local device state, NOT the NIP-78 blob: on a push-driven cold start
+        // AppSpecificState may not have decrypted yet (and for a NIP-55 account that is
+        // an Amber IPC round-trip that can fail outright in the background). Losing this
+        // race would post exactly the notification the mute exists to prevent.
+        if (isMutedPublicChatMessage(event, account.settings.mutedPublicChats.value)) return
+
         val note = LocalCache.getNoteIfExists(event.id) ?: return
 
         if (NotificationFeedFilter.isNotifiablePublicChatReply(note, account.signer.pubKey)) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteQuickActionMenu.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/NoteQuickActionMenu.kt
@@ -84,6 +84,7 @@ import com.vitorpamplona.amethyst.ui.theme.SmallestBorder
 import com.vitorpamplona.amethyst.ui.theme.isLight
 import com.vitorpamplona.amethyst.ui.theme.secondaryButtonBackground
 import com.vitorpamplona.quartz.experimental.bounties.bountyBaseReward
+import com.vitorpamplona.quartz.nip28PublicChat.message.ChannelMessageEvent
 import com.vitorpamplona.quartz.nip51Lists.followList.FollowListEvent
 import com.vitorpamplona.quartz.nip51Lists.peopleList.PeopleListEvent
 import kotlinx.coroutines.launch
@@ -369,22 +370,29 @@ fun CardBody(
                 VerticalDivider(color = primaryLight)
 
                 val isMuted = accountViewModel.isThreadMutedFor(note)
-                NoteQuickActionItem(
-                    MaterialSymbols.AutoMirrored.VolumeOff,
-                    stringRes(
+                // Every NIP-28 message shares one thread root — the channel — so "Mute thread" on a
+                // public chat can only ever hide that channel's ENTIRE content, and invisibly: the
+                // Messages row has no such check, so the room still lists while its messages vanish.
+                // "Mute notifications" owns silencing a public chat now. Unmute stays reachable so
+                // anyone already caught by a legacy mute can escape from the message in front of them.
+                if (note.event !is ChannelMessageEvent || isMuted) {
+                    NoteQuickActionItem(
+                        MaterialSymbols.AutoMirrored.VolumeOff,
+                        stringRes(
+                            if (isMuted) {
+                                R.string.quick_action_unmute_thread
+                            } else {
+                                R.string.quick_action_mute_thread
+                            },
+                        ),
+                    ) {
                         if (isMuted) {
-                            R.string.quick_action_unmute_thread
+                            accountViewModel.unmuteThread(note)
                         } else {
-                            R.string.quick_action_mute_thread
-                        },
-                    ),
-                ) {
-                    if (isMuted) {
-                        accountViewModel.unmuteThread(note)
-                    } else {
-                        accountViewModel.muteThread(note)
+                            accountViewModel.muteThread(note)
+                        }
+                        onDismiss()
                     }
-                    onDismiss()
                 }
             }
         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/NoteActionSections.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/elements/NoteActionSections.kt
@@ -43,6 +43,7 @@ import com.vitorpamplona.quartz.experimental.music.track.MusicTrackEvent
 import com.vitorpamplona.quartz.nip01Core.jackson.JacksonMapper
 import com.vitorpamplona.quartz.nip10Notes.TextNoteEvent
 import com.vitorpamplona.quartz.nip23LongContent.LongTextNoteEvent
+import com.vitorpamplona.quartz.nip28PublicChat.message.ChannelMessageEvent
 import com.vitorpamplona.quartz.nip30CustomEmoji.pack.EmojiPackEvent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -352,19 +353,26 @@ fun noteActionSections(
     val moderation =
         buildList {
             val isThreadMuted = accountViewModel.isThreadMutedFor(note)
-            add(
-                NoteAction(
-                    MaterialSymbols.AutoMirrored.VolumeOff,
-                    stringRes(if (isThreadMuted) R.string.quick_action_unmute_thread else R.string.quick_action_mute_thread),
-                ) {
-                    if (isThreadMuted) {
-                        accountViewModel.unmuteThread(note)
-                    } else {
-                        accountViewModel.muteThread(note)
-                    }
-                    handlers.onDismiss()
-                },
-            )
+            // Every NIP-28 message shares one thread root — the channel — so "Mute thread" on a
+            // public chat can only ever hide that channel's ENTIRE content, and invisibly: the
+            // Messages row has no such check, so the room still lists while its messages vanish.
+            // "Mute notifications" owns silencing a public chat now. Unmute stays reachable so
+            // anyone already caught by a legacy mute can escape from the message in front of them.
+            if (note.event !is ChannelMessageEvent || isThreadMuted) {
+                add(
+                    NoteAction(
+                        MaterialSymbols.AutoMirrored.VolumeOff,
+                        stringRes(if (isThreadMuted) R.string.quick_action_unmute_thread else R.string.quick_action_mute_thread),
+                    ) {
+                        if (isThreadMuted) {
+                            accountViewModel.unmuteThread(note)
+                        } else {
+                            accountViewModel.muteThread(note)
+                        }
+                        handlers.onDismiss()
+                    },
+                )
+            }
 
             // Own messages always get a delete affordance (the surface routes private
             // rumors through the gift-wrapped deletion); reporting yourself never

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -105,7 +105,7 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup.send.Marm
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup.send.MarmotGroupIconUpload
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup.send.MarmotGroupIconUploader
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.markRoomNoteAsRead
-import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.rowHasUnreadFlow
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.rowHasUnread
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications.CombinedZap
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.notifications.NOTIFICATION_LAST_READ_KEY
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.relays.eventsync.EventSync
@@ -444,7 +444,7 @@ class AccountViewModel(
     /**
      * The bottom-bar envelope dot: true when ANY Messages row is showing its blue dot.
      *
-     * Per-row via [rowHasUnreadFlow], which mirrors what each row composable computes for itself.
+     * Per-row via [rowHasUnread], which mirrors what each row composable computes for itself.
      * This used to call `unreadPrivateChatRoute` directly, which returns null for anything that is not
      * `ChatroomKeyable` — so only NIP-17/NIP-04 DMs counted, and a public chat, ephemeral room, geohash
      * cell, Marmot group, NIP-29/Buzz channel or Concord channel could sit there with a visible dot
@@ -460,7 +460,7 @@ class AccountViewModel(
                     MutableStateFlow(null)
                 }
             }.flatMapLatest { loadedFeedState ->
-                val flows = loadedFeedState?.list?.mapNotNull { chat -> rowHasUnreadFlow(chat, account) }
+                val flows = loadedFeedState?.list?.mapNotNull { chat -> rowHasUnread(chat, account)?.flow }
 
                 if (!flows.isNullOrEmpty()) {
                     combine(flows) { newItems ->

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -2036,6 +2036,13 @@ class AccountViewModel(
             account.toggleChatroomPin(room)
         }
 
+    fun mutedPublicChatsFlow(): StateFlow<Set<String>> = account.settings.mutedPublicChats
+
+    fun toggleMutedPublicChat(channelId: String) =
+        launchSigner {
+            account.toggleMutedPublicChat(channelId)
+        }
+
     fun updateZapAmounts(
         amountSet: List<Long>,
         selectedZapType: LnZapEvent.ZapType,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/nip28PublicChat/header/LongPublicChatChannelHeader.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/nip28PublicChat/header/LongPublicChatChannelHeader.kt
@@ -58,6 +58,7 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.nip28PublicChat.header.actions.EditButton
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.nip28PublicChat.header.actions.LeaveChatButton
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.nip28PublicChat.header.actions.LinkChatButton
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.nip28PublicChat.header.actions.MuteChatButton
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.nip28PublicChat.header.actions.OpenChatButton
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.nip28PublicChat.header.actions.ShareChatButton
 import com.vitorpamplona.amethyst.ui.stringRes
@@ -187,6 +188,8 @@ fun LongChannelActionOptions(
     LinkChatButton(channel, accountViewModel, nav)
 
     ShareChatButton(channel, accountViewModel, nav)
+
+    MuteChatButton(channel, accountViewModel)
 
     EditButtonIfIamCreator(channel, accountViewModel, nav)
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/nip28PublicChat/header/actions/MuteChatButton.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/publicChannels/nip28PublicChat/header/actions/MuteChatButton.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.nip28PublicChat.header.actions
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
+import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
+import com.vitorpamplona.amethyst.commons.model.nip28PublicChats.PublicChatChannel
+import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.amethyst.ui.theme.Size20Modifier
+import com.vitorpamplona.amethyst.ui.theme.ZeroPadding
+
+@Composable
+fun MuteChatButton(
+    channel: PublicChatChannel,
+    accountViewModel: AccountViewModel,
+) {
+    val mutedChats by accountViewModel.mutedPublicChatsFlow().collectAsStateWithLifecycle()
+    val isMuted = channel.idHex in mutedChats
+
+    val label =
+        stringRes(
+            if (isMuted) R.string.unmute_notifications else R.string.mute_notifications,
+        )
+
+    FilledTonalButton(
+        modifier =
+            Modifier
+                .padding(horizontal = 3.dp)
+                .width(50.dp),
+        onClick = { accountViewModel.toggleMutedPublicChat(channel.idHex) },
+        contentPadding = ZeroPadding,
+    ) {
+        Icon(
+            symbol = if (isMuted) MaterialSymbols.NotificationsOff else MaterialSymbols.Notifications,
+            contentDescription = label,
+            modifier = Size20Modifier,
+        )
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChatroomHeaderCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChatroomHeaderCompose.kt
@@ -119,6 +119,7 @@ import com.vitorpamplona.quartz.nip29RelayGroups.GroupId
 import com.vitorpamplona.quartz.nip29RelayGroups.groupId
 import com.vitorpamplona.quartz.nip29RelayGroups.isGroupScoped
 import com.vitorpamplona.quartz.nip37Drafts.DraftWrapEvent
+import kotlinx.coroutines.flow.MutableStateFlow
 
 @Composable
 fun ChatroomHeaderCompose(
@@ -292,7 +293,10 @@ private fun ChannelRoomCompose(
             noteEvent?.content?.take(200)
         }
 
-    val lastReadTime by accountViewModel.account.loadLastReadFlow("Channel/${channel.idHex}").collectAsStateWithLifecycle()
+    // One predicate for the row dot and the bottom-bar badge — see rowHasUnreadFlow.
+    val hasNewMessages by remember(lastMessage, channel.idHex) {
+        rowHasUnreadFlow(lastMessage, accountViewModel.account) ?: MutableStateFlow(false)
+    }.collectAsStateWithLifecycle(false)
 
     ChannelName(
         channelIdHex = channel.idHex,
@@ -300,7 +304,7 @@ private fun ChannelRoomCompose(
         channelTitle = { modifier -> ChannelTitleWithLabelInfo(channelName, MaterialSymbols.Public, R.string.public_chat, modifier) },
         channelLastTime = lastMessage.createdAt(),
         channelLastContent = "$authorName: $description",
-        hasNewMessages = (noteEvent?.createdAt ?: Long.MIN_VALUE) > lastReadTime,
+        hasNewMessages = hasNewMessages,
         loadProfilePicture = accountViewModel.settings.showProfilePictures(),
         loadRobohash = accountViewModel.settings.isNotPerformanceMode(),
         autoPlayGif =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChatroomHeaderCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChatroomHeaderCompose.kt
@@ -298,10 +298,22 @@ private fun ChannelRoomCompose(
         rowHasUnreadFlow(lastMessage, accountViewModel.account) ?: MutableStateFlow(false)
     }.collectAsStateWithLifecycle(false)
 
+    var menuOpen by remember { mutableStateOf(false) }
+    // Kept as a State (no `by`) so `.value` is read only inside the title and menu-text
+    // slots, confining mute-toggle invalidations to those scopes.
+    val mutedChats = accountViewModel.mutedPublicChatsFlow().collectAsStateWithLifecycle()
+
     ChannelName(
         channelIdHex = channel.idHex,
         channelPicture = channelPicture,
-        channelTitle = { modifier -> ChannelTitleWithLabelInfo(channelName, MaterialSymbols.Public, R.string.public_chat, modifier) },
+        channelTitle = { modifier ->
+            ChannelTitleWithLabelInfo(
+                channelName,
+                if (channel.idHex in mutedChats.value) MaterialSymbols.NotificationsOff else MaterialSymbols.Public,
+                R.string.public_chat,
+                modifier,
+            )
+        },
         channelLastTime = lastMessage.createdAt(),
         channelLastContent = "$authorName: $description",
         hasNewMessages = hasNewMessages,
@@ -312,7 +324,31 @@ private fun ChannelRoomCompose(
                 .collectAsStateWithLifecycle()
                 .value,
         onClick = { nav.nav(routeFor(channel)) },
+        onLongClick = { menuOpen = true },
     )
+
+    DropdownMenu(
+        expanded = menuOpen,
+        onDismissRequest = { menuOpen = false },
+    ) {
+        DropdownMenuItem(
+            text = {
+                Text(
+                    stringRes(
+                        if (channel.idHex in mutedChats.value) {
+                            R.string.unmute_notifications
+                        } else {
+                            R.string.mute_notifications
+                        },
+                    ),
+                )
+            },
+            onClick = {
+                accountViewModel.toggleMutedPublicChat(channel.idHex)
+                menuOpen = false
+            },
+        )
+    }
 }
 
 @Composable

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChatroomHeaderCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChatroomHeaderCompose.kt
@@ -119,7 +119,7 @@ import com.vitorpamplona.quartz.nip29RelayGroups.GroupId
 import com.vitorpamplona.quartz.nip29RelayGroups.groupId
 import com.vitorpamplona.quartz.nip29RelayGroups.isGroupScoped
 import com.vitorpamplona.quartz.nip37Drafts.DraftWrapEvent
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
 
 @Composable
 fun ChatroomHeaderCompose(
@@ -293,10 +293,12 @@ private fun ChannelRoomCompose(
             noteEvent?.content?.take(200)
         }
 
-    // One predicate for the row dot and the bottom-bar badge — see rowHasUnreadFlow.
-    val hasNewMessages by remember(lastMessage, channel.idHex) {
-        rowHasUnreadFlow(lastMessage, accountViewModel.account) ?: MutableStateFlow(false)
-    }.collectAsStateWithLifecycle(false)
+    // One predicate for the row dot and the bottom-bar badge — see rowHasUnread.
+    // `emptyFlow()` is a shared singleton, so a row that can never be unread allocates nothing.
+    // The seed matters: collection only starts after the first composition, so without it every
+    // row would paint dotless for a frame and then correct itself while scrolling.
+    val unread = remember(lastMessage) { rowHasUnread(lastMessage, accountViewModel.account) }
+    val hasNewMessages by (unread?.flow ?: emptyFlow()).collectAsStateWithLifecycle(unread?.initial ?: false)
 
     var menuOpen by remember { mutableStateOf(false) }
     // Kept as a State (no `by`) so `.value` is read only inside the title and menu-text
@@ -307,11 +309,13 @@ private fun ChannelRoomCompose(
         channelIdHex = channel.idHex,
         channelPicture = channelPicture,
         channelTitle = { modifier ->
+            val isMuted = channel.idHex in mutedChats.value
             ChannelTitleWithLabelInfo(
                 channelName,
-                if (channel.idHex in mutedChats.value) MaterialSymbols.NotificationsOff else MaterialSymbols.Public,
+                if (isMuted) MaterialSymbols.NotificationsOff else MaterialSymbols.Public,
                 R.string.public_chat,
                 modifier,
+                labelContentDescription = if (isMuted) stringRes(R.string.muted_chat_content_description) else null,
             )
         },
         channelLastTime = lastMessage.createdAt(),
@@ -793,6 +797,7 @@ private fun ChannelTitleWithLabelInfo(
     labelIcon: MaterialSymbol,
     label: Int,
     modifier: Modifier,
+    labelContentDescription: String? = null,
 ) {
     Row(verticalAlignment = Alignment.CenterVertically, modifier = modifier) {
         Text(
@@ -808,6 +813,7 @@ private fun ChannelTitleWithLabelInfo(
             symbol = labelIcon,
             text = stringRes(id = label),
             modifier = Modifier.widthIn(max = ChatLabelMaxWidth),
+            contentDescription = labelContentDescription,
         )
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChatroomRowUnread.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChatroomRowUnread.kt
@@ -26,6 +26,7 @@ import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupChatroom
 import com.vitorpamplona.amethyst.commons.model.nip29RelayGroups.RelayGroupChannel
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.Note
+import com.vitorpamplona.amethyst.model.mutedChannelIdOf
 import com.vitorpamplona.amethyst.model.unreadPrivateChatRoute
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup.marmotGroupLastReadRoute
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.concord.concordChannelLastReadRoute
@@ -38,6 +39,7 @@ import com.vitorpamplona.quartz.experimental.bitchat.geohash.GeohashChatEvent
 import com.vitorpamplona.quartz.experimental.ephemChat.chat.EphemeralChatEvent
 import com.vitorpamplona.quartz.nip28PublicChat.message.ChannelMessageEvent
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 
 /**
@@ -51,7 +53,12 @@ import kotlinx.coroutines.flow.map
  * silently skipped: their row could show a dot while the envelope stayed clean.
  *
  * Returns null when the row cannot be unread at all (no event, my own newest message in a DM, everyone
- * hidden), so callers can skip it rather than subscribe to a flow that is always false.
+ * hidden), so callers can skip it rather than subscribe to a flow that is always false. A muted public
+ * chat is deliberately NOT one of these cases: mute is a runtime-toggleable setting, not a structural
+ * fact about the row, so it is folded into the emitted `Flow<Boolean>` (via [mutedChannelIdOf] combined
+ * with the mute set) instead of being resolved as a one-shot snapshot at construction time. Early-return
+ * on a snapshot of the mute set would freeze the dot's mute state as of whenever the flow was built —
+ * do not "simplify" this back into an early return.
  *
  * The two collapsed rows are why this returns a `Flow<Boolean>` rather than a `(route, createdAt)`
  * pair: their dot is a fan-in over every child channel, not one timestamp against one marker, and
@@ -67,7 +74,17 @@ fun rowHasUnreadFlow(
 
     val route = rowLastReadRoute(row, account) ?: return null
     val createdAt = row.createdAt() ?: return null
-    return account.settings.getLastReadFlow(route).map { lastReadAt -> createdAt > lastReadAt }
+
+    val unread = account.settings.getLastReadFlow(route).map { lastReadAt -> createdAt > lastReadAt }
+
+    // Public chats can be silenced at runtime, so the mute set has to be part of the
+    // emitted signal rather than a snapshot taken when this flow was built — otherwise
+    // toggling mute would not move the dot until something else re-keyed the caller.
+    val mutedChannelId = mutedChannelIdOf(row.event) ?: return unread
+
+    return combine(unread, account.settings.mutedPublicChats) { hasUnread, muted ->
+        hasUnread && mutedChannelId !in muted
+    }
 }
 
 /**

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/RowUnread.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/RowUnread.kt
@@ -26,7 +26,7 @@ import com.vitorpamplona.amethyst.commons.model.marmotGroups.MarmotGroupChatroom
 import com.vitorpamplona.amethyst.commons.model.nip29RelayGroups.RelayGroupChannel
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.model.mutedChannelIdOf
+import com.vitorpamplona.amethyst.model.publicChatChannelIdOf
 import com.vitorpamplona.amethyst.model.unreadPrivateChatRoute
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.marmotGroup.marmotGroupLastReadRoute
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.concord.concordChannelLastReadRoute
@@ -37,9 +37,12 @@ import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.dal.ConcordServ
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.dal.RelayGroupServerRoomNote
 import com.vitorpamplona.quartz.experimental.bitchat.geohash.GeohashChatEvent
 import com.vitorpamplona.quartz.experimental.ephemChat.chat.EphemeralChatEvent
+import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelCreateEvent
+import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelMetadataEvent
 import com.vitorpamplona.quartz.nip28PublicChat.message.ChannelMessageEvent
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 
 /**
@@ -55,36 +58,69 @@ import kotlinx.coroutines.flow.map
  * Returns null when the row cannot be unread at all (no event, my own newest message in a DM, everyone
  * hidden), so callers can skip it rather than subscribe to a flow that is always false. A muted public
  * chat is deliberately NOT one of these cases: mute is a runtime-toggleable setting, not a structural
- * fact about the row, so it is folded into the emitted `Flow<Boolean>` (via [mutedChannelIdOf] combined
+ * fact about the row, so it is folded into the emitted `Flow<Boolean>` (via [publicChatChannelIdOf] combined
  * with the mute set) instead of being resolved as a one-shot snapshot at construction time. Early-return
  * on a snapshot of the mute set would freeze the dot's mute state as of whenever the flow was built —
  * do not "simplify" this back into an early return.
  *
- * The two collapsed rows are why this returns a `Flow<Boolean>` rather than a `(route, createdAt)`
+ * The two collapsed rows are why this carries a `Flow<Boolean>` rather than a `(route, createdAt)`
  * pair: their dot is a fan-in over every child channel, not one timestamp against one marker, and
  * approximating them by the newest child would miss an older channel that is still unread.
  */
-fun rowHasUnreadFlow(
+class RowUnread(
+    /**
+     * The answer as of right now, for the caller's FIRST frame.
+     *
+     * A composable collecting [flow] only starts collecting after its first composition, so without
+     * a seed every row would paint dotless and correct itself a frame later — a dot flash on every
+     * recycled row while scrolling. Before the row was routed through this helper it read a
+     * `StateFlow` directly and was right immediately; this keeps that property.
+     *
+     * `false` for the two collapsed rows, whose fan-in flows have no cheap synchronous answer. That
+     * matches what those rows already did before this type existed.
+     */
+    val initial: Boolean,
+    val flow: Flow<Boolean>,
+)
+
+fun rowHasUnread(
     row: Note,
     account: Account,
-): Flow<Boolean>? {
+): RowUnread? {
     // Collapsed rows own a fan-in flow across their children — reuse the row's own signal verbatim.
-    if (row is RelayGroupServerRoomNote) return relayGroupServerHasUnreadFlow(account, row.relay)
-    if (row is ConcordServerRoomNote) return concordCommunityHasUnreadFlow(account, row.communityId)
+    if (row is RelayGroupServerRoomNote) return RowUnread(false, relayGroupServerHasUnreadFlow(account, row.relay))
+    if (row is ConcordServerRoomNote) return RowUnread(false, concordCommunityHasUnreadFlow(account, row.communityId))
 
     val route = rowLastReadRoute(row, account) ?: return null
     val createdAt = row.createdAt() ?: return null
 
-    val unread = account.settings.getLastReadFlow(route).map { lastReadAt -> createdAt > lastReadAt }
+    val lastRead = account.settings.getLastReadFlow(route)
 
     // Public chats can be silenced at runtime, so the mute set has to be part of the
     // emitted signal rather than a snapshot taken when this flow was built — otherwise
     // toggling mute would not move the dot until something else re-keyed the caller.
-    val mutedChannelId = mutedChannelIdOf(row.event) ?: return unread
+    // Every other row type skips the mute flow entirely and stays a plain map.
+    val mutedChannelId = publicChatChannelIdOf(row.event)
 
-    return combine(unread, account.settings.mutedPublicChats) { hasUnread, muted ->
-        hasUnread && mutedChannelId !in muted
+    if (mutedChannelId == null) {
+        return RowUnread(
+            initial = createdAt > lastRead.value,
+            flow = lastRead.map { createdAt > it }.distinctUntilChanged(),
+        )
     }
+
+    val muted = account.settings.mutedPublicChats
+
+    // One expression feeds both the seed and the flow, so the first frame and every later
+    // frame cannot disagree — the drift this helper exists to prevent, in miniature.
+    val compute = { lastReadAt: Long, mutedSet: Set<String> ->
+        createdAt > lastReadAt && mutedChannelId !in mutedSet
+    }
+
+    return RowUnread(
+        initial = compute(lastRead.value, muted.value),
+        flow = combine(lastRead, muted) { read, mutedSet -> compute(read, mutedSet) }.distinctUntilChanged(),
+    )
 }
 
 /**
@@ -107,8 +143,12 @@ private fun rowLastReadRoute(
     }
 
     return when (val event = row.event) {
-        // Same route strings the row composables use — see ChatroomHeaderCompose.
-        is ChannelMessageEvent -> event.channelId()?.let { "Channel/$it" }
+        // Same route strings the row composables use — see ChatroomHeaderCompose. The channel
+        // id itself comes from [publicChatChannelIdOf], which is also what decides admin events
+        // (ChannelHideMessageEvent/ChannelMuteUserEvent) are not room activity — listing the
+        // three concrete types here keeps them falling through to `else`.
+        is ChannelMessageEvent, is ChannelMetadataEvent, is ChannelCreateEvent ->
+            publicChatChannelIdOf(event)?.let { "Channel/$it" }
         is EphemeralChatEvent -> event.roomId()?.let { "Channel/${it.toKey()}" }
         is GeohashChatEvent -> event.geohash()?.let { "Geohash/$it" }
         // DMs keep their own rule: a room whose newest message is mine counts as read.

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/dal/ChatroomListKnownFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/dal/ChatroomListKnownFeedFilter.kt
@@ -30,6 +30,7 @@ import com.vitorpamplona.amethyst.commons.util.replace
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
+import com.vitorpamplona.amethyst.model.publicChatChannelIdOf
 import com.vitorpamplona.amethyst.ui.dal.AdditiveFeedFilter
 import com.vitorpamplona.amethyst.ui.dal.sortedByDefaultFeedOrder
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.publicChannels.concord.isConcordTimelineMessage
@@ -45,8 +46,6 @@ import com.vitorpamplona.quartz.nip01Core.relay.normalizer.RelayUrlNormalizer
 import com.vitorpamplona.quartz.nip04Dm.messages.PrivateDmEvent
 import com.vitorpamplona.quartz.nip17Dm.base.ChatroomKey
 import com.vitorpamplona.quartz.nip17Dm.base.ChatroomKeyable
-import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelCreateEvent
-import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelMetadataEvent
 import com.vitorpamplona.quartz.nip28PublicChat.message.ChannelMessageEvent
 import com.vitorpamplona.quartz.nip29RelayGroups.GroupId
 import com.vitorpamplona.quartz.nip29RelayGroups.groupId
@@ -632,15 +631,9 @@ class ChatroomListKnownFeedFilter(
 
     // Maps a note that represents a public chat row to its channel id. The
     // representative note for a channel may be the channel's create event
-    // (id == channelId), a metadata update, or a message — match all three so
+    // (id == channelId), a metadata update, or a message — all three resolve so
     // an arriving ChannelMessageEvent replaces an existing placeholder
     // metadata/create note for the same channel instead of duplicating it
     // (which would yield the same LazyColumn key twice).
-    private fun publicChannelIdOf(note: Note): String? =
-        when (val event = note.event) {
-            is ChannelMessageEvent -> event.channelId()
-            is ChannelMetadataEvent -> event.channelId()
-            is ChannelCreateEvent -> event.id
-            else -> null
-        }
+    private fun publicChannelIdOf(note: Note): String? = publicChatChannelIdOf(note.event)
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationFeedFilter.kt
@@ -28,6 +28,7 @@ import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.TopFilter
 import com.vitorpamplona.amethyst.model.filterIntoSet
+import com.vitorpamplona.amethyst.model.isMutedPublicChatMessage
 import com.vitorpamplona.amethyst.model.topNavFeeds.IFeedTopNavFilter
 import com.vitorpamplona.amethyst.ui.dal.AdditiveFeedFilter
 import com.vitorpamplona.amethyst.ui.dal.FilterByListParams
@@ -487,6 +488,11 @@ class NotificationFeedFilter(
         }
 
         val noteEvent = it.event
+
+        // Muted public chats contribute nothing to Notifications. This feed is recomputed
+        // live from LocalCache rather than being an append-only store, so unmuting brings
+        // these entries back on its own — no replay needed.
+        if (isMutedPublicChatMessage(noteEvent, account.settings.mutedPublicChats.value)) return false
 
         // Buzz DM: a group chat message in a `t=dm` channel whose 39000 participants include me. A Buzz
         // relay carries DM messages as either kind-9 (NIP-29 chat) or kind-40002 (stream message v2), and

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationFeedFilter.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/dal/NotificationFeedFilter.kt
@@ -489,9 +489,12 @@ class NotificationFeedFilter(
 
         val noteEvent = it.event
 
-        // Muted public chats contribute nothing to Notifications. This feed is recomputed
-        // live from LocalCache rather than being an append-only store, so unmuting brings
-        // these entries back on its own — no replay needed.
+        // Muted public chats contribute nothing to Notifications.
+        //
+        // NOTE: this filter is one-way. NotificationFeedFilter is an AdditiveFeedFilter, so
+        // applyFilter only ever runs over newly-arriving items — nothing re-scans LocalCache
+        // when the mute set changes. Entries suppressed while muted therefore do NOT come
+        // back on unmute until the tab is refreshed. Device-confirmed; see the design doc.
         if (isMutedPublicChatMessage(noteEvent, account.settings.mutedPublicChats.value)) return false
 
         // Buzz DM: a group chat message in a `t=dm` channel whose 39000 participants include me. A Buzz
@@ -557,7 +560,12 @@ class NotificationFeedFilter(
             noteEvent is RepostEvent || noteEvent is GenericRepostEvent
         ) {
             val target = it.replyTo?.lastOrNull()
-            if (target != null && account.isThreadMuted(account.resolveThreadRoot(target))) {
+            if (target != null &&
+                (
+                    account.isThreadMuted(account.resolveThreadRoot(target)) ||
+                        isMutedPublicChatMessage(target.event, account.settings.mutedPublicChats.value)
+                )
+            ) {
                 return false
             }
         }

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -602,6 +602,9 @@
     <string name="quick_action_block">Block</string>
     <string name="quick_action_mute_thread">Mute thread</string>
     <string name="quick_action_unmute_thread">Unmute thread</string>
+    <string name="mute_notifications">Mute notifications</string>
+    <string name="unmute_notifications">Unmute notifications</string>
+    <string name="muted_chat_content_description">Notifications are muted for this chat</string>
     <string name="quick_action_report">Report</string>
     <string name="quick_action_dont_show_again_button">Don\'t show again</string>
     <string name="report_dialog_spam">Spam or scams</string>

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/model/MutedPublicChatsSyncTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/model/MutedPublicChatsSyncTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.model
+
+import com.vitorpamplona.quartz.nip01Core.core.JsonMapper
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Muted public chats ride inside the NIP-78 AppSpecificData blob so they reach the
+ * user's other devices.
+ *
+ * The nullable default is the load-bearing part. `updateFrom` overwrites local state
+ * whenever remote differs, and AppSpecificState replays the cached backup event on
+ * every app start — so if an older client rewrote the blob and dropped the key, a
+ * non-null `emptyList()` default would clear the local mute set on every single
+ * launch. `null` keeps "key absent" distinguishable from "explicitly empty".
+ */
+class MutedPublicChatsSyncTest {
+    private val channelA = "a".repeat(64)
+    private val channelB = "b".repeat(64)
+
+    @Test
+    fun blobWrittenWithoutTheFieldDecodesToNull() {
+        val json = """{"pinnedRooms":[]}"""
+        val decoded = JsonMapper.fromJson<AccountChatPreferencesInternal>(json)
+        assertNull(decoded.mutedPublicChats)
+    }
+
+    @Test
+    fun explicitlyEmptyListDecodesToEmptyNotNull() {
+        val json = """{"pinnedRooms":[],"mutedPublicChats":[]}"""
+        val decoded = JsonMapper.fromJson<AccountChatPreferencesInternal>(json)
+        assertEquals(emptyList<String>(), decoded.mutedPublicChats)
+    }
+
+    @Test
+    fun jsonRoundTripPreservesMutedChats() {
+        val internal = AccountChatPreferencesInternal(emptyList(), listOf(channelA, channelB))
+        val decoded = JsonMapper.fromJson<AccountChatPreferencesInternal>(JsonMapper.toJson(internal))
+        assertEquals(listOf(channelA, channelB), decoded.mutedPublicChats)
+    }
+
+    @Test
+    fun wireShapeIsSortedSoTheBlobIsStable() {
+        // Mirrors AccountSyncedSettings.toInternal(): mutedPublicChats.sorted().
+        // Two sets with the same members must serialize identically regardless of
+        // iteration order, or every settings save republishes a no-op event.
+        val oneOrder = setOf(channelB, channelA).sorted()
+        val otherOrder = setOf(channelA, channelB).sorted()
+        assertEquals(
+            JsonMapper.toJson(AccountChatPreferencesInternal(emptyList(), oneOrder)),
+            JsonMapper.toJson(AccountChatPreferencesInternal(emptyList(), otherOrder)),
+        )
+    }
+}

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/model/MutedPublicChatsSyncTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/model/MutedPublicChatsSyncTest.kt
@@ -72,4 +72,37 @@ class MutedPublicChatsSyncTest {
             JsonMapper.toJson(AccountChatPreferencesInternal(emptyList(), otherOrder)),
         )
     }
+
+    // ---
+    // The merge decision itself, not just the decode.
+    //
+    // The decode tests above prove `null` and `[]` arrive distinguishable. These prove the
+    // merge ACTS on that distinction. Without them, collapsing the guard to
+    // `remote ?: emptyList()` — exactly the mistake the nullable default exists to prevent —
+    // leaves every other test in this file green.
+    // ---
+
+    @Test
+    fun absentKeyLeavesTheLocalMuteSetAlone() {
+        // An older client rewrote the blob and dropped the field. The local set must survive:
+        // AppSpecificState replays the cached backup on every launch, so a wipe here would
+        // repeat on every start.
+        assertEquals(setOf(channelA), mergeMutedPublicChats(setOf(channelA), null))
+    }
+
+    @Test
+    fun absentKeyOnAnEmptyLocalSetStaysEmpty() {
+        assertEquals(emptySet<String>(), mergeMutedPublicChats(emptySet(), null))
+    }
+
+    @Test
+    fun explicitEmptyListClearsTheLocalMuteSet() {
+        // A client that knows the field saying "unmute everything" must be obeyed.
+        assertEquals(emptySet<String>(), mergeMutedPublicChats(setOf(channelA), emptyList()))
+    }
+
+    @Test
+    fun remoteListReplacesTheLocalMuteSet() {
+        assertEquals(setOf(channelB), mergeMutedPublicChats(setOf(channelA), listOf(channelB)))
+    }
 }

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/model/MutedPublicChatsTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/model/MutedPublicChatsTest.kt
@@ -22,6 +22,9 @@ package com.vitorpamplona.amethyst.model
 
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip17Dm.messages.ChatMessageEvent
+import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelCreateEvent
+import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelMetadataEvent
+import com.vitorpamplona.quartz.nip28PublicChat.admin.ChannelMuteUserEvent
 import com.vitorpamplona.quartz.nip28PublicChat.message.ChannelMessageEvent
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -56,20 +59,20 @@ class MutedPublicChatsTest {
 
     @Test
     fun topLevelMessageResolvesToItsChannel() {
-        assertEquals(channelId, mutedChannelIdOf(topLevel()))
+        assertEquals(channelId, publicChatChannelIdOf(topLevel()))
     }
 
     @Test
     fun replyResolvesToTheChannelNotItsParent() {
         // Every message in a NIP-28 channel shares one root, so mute is per-channel.
-        assertEquals(channelId, mutedChannelIdOf(reply()))
+        assertEquals(channelId, publicChatChannelIdOf(reply()))
     }
 
     @Test
     fun nonPublicChatEventHasNoChannel() {
         val dm = ChatMessageEvent("3".repeat(64), author, 1L, arrayOf(arrayOf("p", author)), "hi", sig)
-        assertNull(mutedChannelIdOf(dm))
-        assertNull(mutedChannelIdOf(null))
+        assertNull(publicChatChannelIdOf(dm))
+        assertNull(publicChatChannelIdOf(null))
     }
 
     @Test
@@ -93,5 +96,50 @@ class MutedPublicChatsTest {
         val dm = ChatMessageEvent("3".repeat(64), author, 1L, arrayOf(arrayOf("p", author)), "hi", sig)
         assertFalse(isMutedPublicChatMessage(dm, setOf(channelId)))
         assertFalse(isMutedPublicChatMessage(null, setOf(channelId)))
+    }
+
+    // --- Regression coverage: a channel row's newest event is not always a ChannelMessageEvent.
+    // ChannelMetadataEvent (kind 41, e.g. a topic/picture edit) and ChannelCreateEvent (kind 40,
+    // the channel's own creation event) are the other two event types a public-chat row can
+    // dispatch to ChannelRoomCompose — see ChatroomHeaderCompose's `when`. Both
+    // ChatroomRowUnread.rowLastReadRoute and ChatroomListKnownFeedFilter resolve the id
+    // through publicChatChannelIdOf, so this test covers all three sites at once.
+
+    private fun channelMetadata(tags: Array<Array<String>>) = ChannelMetadataEvent("7".repeat(64), author, 1778593701L, tags, "{}", sig)
+
+    @Test
+    fun metadataEventResolvesToItsChannel() {
+        val metadata = channelMetadata(arrayOf(arrayOf("e", channelId, relay, "root")))
+        assertEquals(channelId, publicChatChannelIdOf(metadata))
+    }
+
+    @Test
+    fun createEventResolvesToItsOwnId() {
+        val createId = "8".repeat(64)
+        val create = ChannelCreateEvent(createId, author, 1778593701L, arrayOf(), "{}", sig)
+        assertEquals(createId, publicChatChannelIdOf(create))
+    }
+
+    @Test
+    fun metadataEventInMutedChannelIsMuted() {
+        val metadata = channelMetadata(arrayOf(arrayOf("e", channelId, relay, "root")))
+        assertTrue(isMutedPublicChatMessage(metadata, setOf(channelId)))
+    }
+
+    @Test
+    fun channelAdminEventIsNotRecognisedAsChannelActivity() {
+        // ChannelMuteUserEvent (and ChannelHideMessageEvent) are channel-admin actions, not
+        // activity that should resolve to a channel id — they must keep falling through.
+        val muteUser = ChannelMuteUserEvent("9".repeat(64), author, 1778593701L, arrayOf(arrayOf("e", channelId, relay, "root")), "", sig)
+        assertNull(publicChatChannelIdOf(muteUser))
+        assertFalse(isMutedPublicChatMessage(muteUser, setOf(channelId)))
+    }
+
+    @Test
+    fun channelMessageWithNoTagsHasNoChannel() {
+        // Right type, but channelId() is null because there is no e-tag at all.
+        val untagged = channelMessage(arrayOf())
+        assertNull(publicChatChannelIdOf(untagged))
+        assertFalse(isMutedPublicChatMessage(untagged, setOf(channelId)))
     }
 }

--- a/amethyst/src/test/java/com/vitorpamplona/amethyst/model/MutedPublicChatsTest.kt
+++ b/amethyst/src/test/java/com/vitorpamplona/amethyst/model/MutedPublicChatsTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.model
+
+import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import com.vitorpamplona.quartz.nip17Dm.messages.ChatMessageEvent
+import com.vitorpamplona.quartz.nip28PublicChat.message.ChannelMessageEvent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The predicate behind every mute suppression point: the row dot, the bottom-bar
+ * badge, the push dispatcher and the Notifications feed all ask this one question,
+ * so they cannot drift apart.
+ */
+class MutedPublicChatsTest {
+    private val channelId: HexKey = "4".repeat(64)
+    private val otherChannel: HexKey = "5".repeat(64)
+    private val parentId: HexKey = "6".repeat(64)
+    private val author: HexKey = "b".repeat(64)
+    private val relay = "wss://relay.damus.io"
+    private val sig = "0".repeat(128)
+
+    private fun channelMessage(tags: Array<Array<String>>) = ChannelMessageEvent("3".repeat(64), author, 1778593701L, tags, "hi", sig)
+
+    private fun topLevel() = channelMessage(arrayOf(arrayOf("e", channelId, relay, "root")))
+
+    private fun reply() =
+        channelMessage(
+            arrayOf(
+                arrayOf("e", channelId, relay, "root"),
+                arrayOf("e", parentId, relay, "reply"),
+            ),
+        )
+
+    @Test
+    fun topLevelMessageResolvesToItsChannel() {
+        assertEquals(channelId, mutedChannelIdOf(topLevel()))
+    }
+
+    @Test
+    fun replyResolvesToTheChannelNotItsParent() {
+        // Every message in a NIP-28 channel shares one root, so mute is per-channel.
+        assertEquals(channelId, mutedChannelIdOf(reply()))
+    }
+
+    @Test
+    fun nonPublicChatEventHasNoChannel() {
+        val dm = ChatMessageEvent("3".repeat(64), author, 1L, arrayOf(arrayOf("p", author)), "hi", sig)
+        assertNull(mutedChannelIdOf(dm))
+        assertNull(mutedChannelIdOf(null))
+    }
+
+    @Test
+    fun messageInMutedChannelIsMuted() {
+        assertTrue(isMutedPublicChatMessage(topLevel(), setOf(channelId)))
+        assertTrue(isMutedPublicChatMessage(reply(), setOf(channelId)))
+    }
+
+    @Test
+    fun messageInAnotherChannelIsNotMuted() {
+        assertFalse(isMutedPublicChatMessage(topLevel(), setOf(otherChannel)))
+    }
+
+    @Test
+    fun emptyMuteSetMutesNothing() {
+        assertFalse(isMutedPublicChatMessage(topLevel(), emptySet()))
+    }
+
+    @Test
+    fun nonPublicChatEventIsNeverMuted() {
+        val dm = ChatMessageEvent("3".repeat(64), author, 1L, arrayOf(arrayOf("p", author)), "hi", sig)
+        assertFalse(isMutedPublicChatMessage(dm, setOf(channelId)))
+        assertFalse(isMutedPublicChatMessage(null, setOf(channelId)))
+    }
+}


### PR DESCRIPTION

<img width="300" alt="Screenshot_20260810-164625" src="https://github.com/user-attachments/assets/bb591771-b99f-4fed-9ef8-3f317a5ae82d" />

(PS: there is an issue with the amethyst users chat logo, the updated logo kind 41 is on nostr.wine and nowhere else)


## Mute a public chat
Long-press a public chat in Messages, or use the new button in the expanded channel header, and the chat stops driving notifications. The row keeps its place with a notifications-off glyph, and **the messages stay fully visible** — this silences alerts, it does not hide content.

## What muting suppresses

| Signal | Where it is gated |
| --- | --- |
| Row unread bubble | `rowHasUnread` (`RowUnread.kt`) |
| Bottom-nav envelope badge | `AccountViewModel.messagesHasNewItems` |
| Push notifications | `EventNotificationConsumer.notifyChannelMessage` |
| Notifications-tab entries | `NotificationFeedFilter.acceptableEvent` |
| Reactions/zaps/reposts on your messages there | both of the above |

Muting silences the channel completely, including `@`-mentions, matching Signal/Telegram "mute group".

All five decisions route through one pure predicate, `isMutedPublicChatMessage`, so they cannot drift apart.

## Storage

Two representations, and the split is deliberate.

**Local device state** (`AccountSettings.mutedPublicChats`) is the read path. Every consumer reads only this, because it needs no Nostr signer.

**NIP-78** (kind 30078, `d="AmethystSettings"`, beside the existing `pinnedRooms`) carries it across devices. No new event kind.

The split exists because `AppSpecificState` decrypts the settings blob asynchronously, and a push-driven cold start can reach `notifyChannelMessage` before that completes. For a NIP-55 external-signer account that decrypt is an IPC round-trip to Amber that may never complete in the background. A mute that loses that race posts exactly the notification the feature exists to kill, so NIP-78 never gates a read — it only feeds the local mirror.

The synced field is `List<String>? = null`, and the nullable default is load-bearing. `updateFrom` overwrites local state whenever remote differs, and `AppSpecificState` replays the cached backup on every app start. With a non-null `emptyList()` default, an older client that rewrote the blob without the key would clear the user's mutes on *every single launch*. `null` keeps "key absent" distinguishable from an explicit "unmute everything", and `mergeMutedPublicChats` acts on that distinction.

## Also fixed: "Mute thread" destroyed public chats

Verified by execution: `Event.threadRootIdOrSelf()` returns the **channel id** for every NIP-28 message, top-level and reply alike, because the channel *is* the NIP-10 root. So "Mute thread" on a public-chat message wrote the whole channel into the NIP-51 mute list, and `Account.isAcceptable` — which `ChannelFeedFilter` calls — then rejected every message in it.

The channel rendered empty while the Messages row kept listing it, and because the list is published to relays it survived restart, cache clear and reinstall. With every message filtered there was no message left to long-press, so Settings → Security Filters → Muted threads was the only escape, where the entry showed as an unnamed "unknown" thread.

A tester hit this during device testing of this branch and lost posts. The action is now hidden when the note is a `ChannelMessageEvent`; **unmute is still offered** when a legacy mute is already set, so anyone already caught can escape.

## Testing

**1279 unit tests pass.** 11 are new, covering the pure predicate and the whole serialization contract, including both arms of the null-vs-empty distinction.

The `mergeMutedPublicChats` guard is mutation-verified rather than assumed: changing `?: local` to `?: emptySet()` fails exactly one test, `absentKeyLeavesTheLocalMuteSetAlone`, and only that one.

`AccountSettings` cannot be constructed in a JVM unit test — `syncedSettings` is a property initializer that builds a default `AccountSyncedSettingsInternal`, whose language preferences call `Resources.getSystem()`, and there is no Robolectric in the project. Decisions are therefore extracted into pure functions, the same shape as the existing `unreadPrivateChatRoute`.

Verified on a Pixel 9a (Android 17):

- muted → no push, no unread dot, no envelope badge
- muted → messages still fully visible in the chat
- unmute → both dots return for messages that arrived while muted
- "Mute thread" absent on public chats in this build, still present in release

That third item only works because muting never advances the last-read marker.

## Known limitations

**Unmuting does not backfill the Notifications tab.** `NotificationFeedFilter` is an `AdditiveFeedFilter`: it only applies its filter to newly-arriving items and never re-scans the cache when an input changes. Entries suppressed while muted stay suppressed until the tab is refreshed. This is consistent with the rest of the app — unmuting a NIP-51 thread behaves the same — but it is a real gap and is commented at the call site.

**Push notifications suppressed while muted are gone permanently.** Android cannot replay a notification that was never posted, so "unmuting restores everything" holds for both dots and for chat content, not for system notifications.

**Older Amethyst builds can erase the synced copy.** `ignoreUnknownKeys = true` means they do not break, but any settings change republishes the blob without the field. The local copy survives, so only cross-device propagation is lost. `pinnedRooms` already carries the identical exposure.

**Android only.** Desktop never reads kind 30078, so it does not honour mutes. The stored form is a list, so the other Messages row types extend to it without a migration.

## Scope

20 files, +669/-58, `amethyst` module only. No new dependencies, no new event kind. `MaterialSymbols.NotificationsOff` was already in the bundled subset font, so it needs no regeneration — and it is deliberately not `VolumeOff`, which already labels the different "Mute thread" action.

`ChatroomRowUnread.kt` is renamed to `RowUnread.kt` for ktlint's single-class filename rule, after the helper gained a `RowUnread` type carrying an initial value alongside its flow. Without that seed, routing the row through the shared helper turned a `StateFlow` read into a cold-flow collection, and every row painted dotless for one frame before correcting itself.

## License

- [ ] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
