### PR TITLE
feat: demote relay/ingest worker threads below the UI thread (~40% faster cold-start first paint)

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/Amethyst.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/Amethyst.kt
@@ -29,6 +29,7 @@ import com.vitorpamplona.amethyst.favorites.FavoriteAppsRegistry
 import com.vitorpamplona.amethyst.napplet.WebAppNetworkRegistry
 import com.vitorpamplona.amethyst.service.logging.Logging
 import com.vitorpamplona.amethyst.service.nests.AppForegroundRecycleHook
+import com.vitorpamplona.amethyst.service.priority.WorkerThreadPriorityGovernor
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.embed.EmbeddedTabHost
 import com.vitorpamplona.quartz.utils.Log
 import com.vitorpamplona.quartz.utils.LogLevel
@@ -118,6 +119,10 @@ class Amethyst : Application() {
         Log.i("AmethystApp") { "Amethyst ${BuildConfig.VERSION_NAME} starting in main process (log level ${Log.minLevel})" }
 
         instance = AppModules(this)
+
+        // Keeps the ~500 relay/ingest worker threads a cold start spawns from starving the UI
+        // thread out of its frames. Off unless the `amethyst_worker_nice` global setting is set.
+        WorkerThreadPriorityGovernor.startIfConfigured(this)
 
         // Hydrate the device-local favorite-apps list (main process only; the sandbox never reads it).
         FavoriteAppsRegistry.init(this)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/Amethyst.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/Amethyst.kt
@@ -120,9 +120,10 @@ class Amethyst : Application() {
 
         instance = AppModules(this)
 
-        // Keeps the ~500 relay/ingest worker threads a cold start spawns from starving the UI
-        // thread out of its frames. Off unless the `amethyst_worker_nice` global setting is set.
-        WorkerThreadPriorityGovernor.startIfConfigured(this)
+        // Keeps the ~650 relay/ingest worker threads a cold start spawns from starving the UI
+        // thread out of its frames — worth ~45% off time-to-first-paint on a release build.
+        // Override or disable with the `amethyst_worker_nice` global setting.
+        WorkerThreadPriorityGovernor.start(this)
 
         // Hydrate the device-local favorite-apps list (main process only; the sandbox never reads it).
         FavoriteAppsRegistry.init(this)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/priority/WorkerThreadPriorityGovernor.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/priority/WorkerThreadPriorityGovernor.kt
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.service.priority
+
+import android.content.Context
+import android.os.Process
+import android.provider.Settings
+import com.vitorpamplona.quartz.utils.Log
+import java.io.File
+
+/**
+ * Demotes the app's network/ingest worker threads below the UI thread so a cold-start relay storm
+ * cannot starve the main thread out of its frames.
+ *
+ * **Why this exists.** On a cold start the outbox model dials ~190 relays at once and the process
+ * grows to ~500 threads (OkHttp's TaskRunner pool, OkHttp dispatchers, the kotlinx scheduler and
+ * Arti's tokio workers). Every one of them is born at nice 0. The main thread is nice -10, but a
+ * single -10 thread against ~30 simultaneously-runnable nice-0 threads on 4 cores still loses about
+ * half of its schedulable time to the runqueue — long enough that the first feed frame takes
+ * multiple seconds and the "Loading account" screen stays on-screen well after the account itself
+ * has loaded.
+ *
+ * **Why a /proc sweep instead of thread factories.** The largest pool by far is OkHttp's
+ * `TaskRunner` backend, a process-wide singleton whose thread factory OkHttp does not expose per
+ * client, so there is no injection point to set a priority at creation time. Sweeping
+ * `/proc/self/task` catches every pool uniformly — including threads OkHttp renames after the host
+ * they are currently serving. A nice value is per-OS-thread and survives renaming, so seeing a
+ * thread once is enough; the sweep only has to be frequent enough to catch newly-spawned ones.
+ *
+ * Note that [Thread.setPriority] does NOT map to a Linux nice level on Android — only
+ * [Process.setThreadPriority] does. (`AudioTrackPlayer` documents the same trap for audio.)
+ *
+ * **Scope.** [DENYLIST] holds the threads that must keep their scheduling: the main thread,
+ * RenderThread (it draws the frames we are trying to protect), the ART daemons (demoting
+ * HeapTaskDaemon would make the GC pressure *worse*, not better) and binder threads (IPC replies
+ * the system waits on). Everything else is app work that should yield to the UI.
+ *
+ * **Runtime control.** The target nice level is read from a `Settings.Global` key so the effect can
+ * be A/B-measured on one build:
+ * ```
+ * adb shell settings put global amethyst_worker_nice 9    # demote workers (diagnostic only)
+ * adb shell settings delete global amethyst_worker_nice   # control (no-op)
+ * ```
+ *
+ * **Measured 2026-08-17 (4-round round-robin sweeps on two rigs) — this does NOT fix the stall on
+ * real hardware, which is why it ships disabled.** The mechanism works everywhere: starvation tracks
+ * the CFS weight monotonically and roughly halves (emulator 50.2% -> 24.8% at nice 9; SM-T220 15.2%
+ * -> 8.1%). But the user-visible time-to-first-paint does not reliably improve on device — the
+ * paired deltas were non-monotonic across nice levels, i.e. noise.
+ *
+ * The two rigs disagree because the bottleneck is not the same on both. On a 4-core emulator the
+ * main thread is only 27% busy and genuinely starved; on the SM-T220 it is **70% busy** and
+ * saturated with its own work (~42s of it), so scheduling was never the constraint. Raising priority
+ * there did hand main more CPU (41.9s -> 47.6s on-cpu) and the stall did not move. Treat an emulator
+ * as unable to answer scheduling questions: its shared cores manufacture contention real devices do
+ * not have.
+ *
+ * Kept as a diagnostic knob for the scheduling half of the problem. The larger, still-untested lever
+ * is bounding the ~190-relay connect fan-out.
+ *
+ * Despite AOSP's `androidSetThreadPriority` calling `set_sched_policy(SP_BACKGROUND)` at nice >= 10,
+ * no cpuset/schedtune move was observed on real hardware (SM-T220 / Android 14): at nice 5, 9 and 10
+ * every worker kept main's exact membership (`schedtune:/top-app`, `cpuset:/top-app`, `cpu:/`) and
+ * only the nice value changed. So there is no threshold at 10 to design around — pick the level off
+ * the weight/throughput curve above.
+ */
+object WorkerThreadPriorityGovernor {
+    /** `Settings.Global` key holding the target nice level. Absent/invalid = feature off. */
+    const val SETTING_KEY = "amethyst_worker_nice"
+
+    /** Sentinel for "not configured" — the governor stays off and costs nothing. */
+    private const val DISABLED = Int.MIN_VALUE
+
+    /** Sweep cadence while the cold-start storm is spawning threads. */
+    private const val BURST_INTERVAL_MS = 250L
+
+    /** How long to sweep aggressively before backing off to [IDLE_INTERVAL_MS]. */
+    private const val BURST_DURATION_MS = 120_000L
+
+    private const val IDLE_INTERVAL_MS = 2_000L
+
+    /**
+     * Threads whose scheduling must not be touched. Matched as prefixes against the kernel `comm`
+     * (which the kernel caps at 15 characters, so these are deliberately short).
+     */
+    private val DENYLIST =
+        listOf(
+            // Draws the frames this whole exercise is meant to protect.
+            "RenderThread",
+            "hwuiTask",
+            "GPU completion",
+            // ART daemons — demoting the GC would deepen the very stalls we are fixing.
+            "HeapTaskDaemon",
+            "ReferenceQueueD",
+            "FinalizerDaemon",
+            "FinalizerWatchd",
+            "Signal Catcher",
+            "Jit thread pool",
+            "Runtime worker",
+            "perfetto_hprof",
+            // Debugger/profiler plumbing.
+            "ADB-JDWP",
+            "JDWP",
+            // Synchronous IPC the system framework blocks on.
+            "binder:",
+        )
+
+    @Volatile private var started = false
+
+    fun startIfConfigured(context: Context) {
+        if (started) return
+        val targetNice = readTargetNice(context)
+        if (targetNice == DISABLED) {
+            Log.i("ThreadPriority") { "Worker thread governor off (no $SETTING_KEY setting)" }
+            return
+        }
+        started = true
+        Log.i("ThreadPriority") { "Worker thread governor ON, target nice=$targetNice" }
+
+        Thread({ sweepLoop(targetNice) }, "worker-nice-governor")
+            .apply {
+                isDaemon = true
+                start()
+            }
+    }
+
+    private fun readTargetNice(context: Context): Int =
+        runCatching {
+            Settings.Global.getInt(context.contentResolver, SETTING_KEY, DISABLED)
+        }.getOrDefault(DISABLED)
+
+    private fun sweepLoop(targetNice: Int) {
+        // The governor must keep running while the pools it polices saturate the CPU, so it runs
+        // slightly above default rather than as background work.
+        runCatching { Process.setThreadPriority(Process.THREAD_PRIORITY_FOREGROUND) }
+
+        val startedAt = System.currentTimeMillis()
+        val mainTid = Process.myPid()
+        // A thread's nice survives renaming, so once demoted it never needs revisiting.
+        // Seeding with our own tid keeps the sweep from demoting the governor itself.
+        val alreadyDemoted = HashSet<Int>().apply { add(Process.myTid()) }
+
+        while (true) {
+            val demoted = sweepOnce(mainTid, targetNice, alreadyDemoted)
+            val elapsed = System.currentTimeMillis() - startedAt
+            if (demoted > 0) {
+                Log.d("ThreadPriority") { "Demoted $demoted thread(s) to nice $targetNice" }
+            }
+            runCatching {
+                Thread.sleep(if (elapsed < BURST_DURATION_MS) BURST_INTERVAL_MS else IDLE_INTERVAL_MS)
+            }.onFailure { return }
+        }
+    }
+
+    private fun sweepOnce(
+        mainTid: Int,
+        targetNice: Int,
+        alreadyDemoted: MutableSet<Int>,
+    ): Int {
+        val tasks = File("/proc/self/task").listFiles() ?: return 0
+        var demoted = 0
+        for (task in tasks) {
+            val tid = task.name.toIntOrNull() ?: continue
+            if (tid == mainTid || tid in alreadyDemoted) continue
+
+            // A thread can exit between listing and reading; treat any failure as "skip".
+            val name = runCatching { File(task, "comm").readText().trim() }.getOrNull() ?: continue
+            if (DENYLIST.any { name.startsWith(it) }) continue
+
+            val ok = runCatching { Process.setThreadPriority(tid, targetNice) }.isSuccess
+            if (ok) {
+                alreadyDemoted.add(tid)
+                demoted++
+            }
+        }
+        return demoted
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/priority/WorkerThreadPriorityGovernor.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/priority/WorkerThreadPriorityGovernor.kt
@@ -22,6 +22,7 @@ package com.vitorpamplona.amethyst.service.priority
 
 import android.content.Context
 import android.os.Process
+import android.os.SystemClock
 import android.provider.Settings
 import com.vitorpamplona.quartz.utils.Log
 import java.io.File
@@ -31,12 +32,32 @@ import java.io.File
  * cannot starve the main thread out of its frames.
  *
  * **Why this exists.** On a cold start the outbox model dials ~190 relays at once and the process
- * grows to ~500 threads (OkHttp's TaskRunner pool, OkHttp dispatchers, the kotlinx scheduler and
+ * grows to ~650 threads (OkHttp's TaskRunner pool, OkHttp dispatchers, the kotlinx scheduler and
  * Arti's tokio workers). Every one of them is born at nice 0. The main thread is nice -10, but a
- * single -10 thread against ~30 simultaneously-runnable nice-0 threads on 4 cores still loses about
- * half of its schedulable time to the runqueue — long enough that the first feed frame takes
- * multiple seconds and the "Loading account" screen stays on-screen well after the account itself
- * has loaded.
+ * single -10 thread against dozens of simultaneously-runnable nice-0 threads still loses a large
+ * share of its schedulable time to the runqueue — long enough that the first feed frame takes
+ * seconds and the "Loading account" screen stays on-screen well after the account itself has
+ * loaded.
+ *
+ * **Measured on a release-codegen build** (`:amethyst:installPlayBenchmark`, i.e. R8-minified +
+ * baseline-profile AOT), SM-T220, 5-round round-robin, every run valid:
+ *
+ * | workers at | starvation | runqueue wait | time to first paint | spread |
+ * |---|---|---|---|---|
+ * | nice 0 (off) | 26.7% | 2300 ms | 11.1 s | 5.63 s |
+ * | nice 5 | 22.0% | 1774 ms | 8.0 s | 4.05 s |
+ * | nice 9 | 17.1% | 1280 ms | 8.4 s | 3.05 s |
+ * | **nice 10** | **14.6%** | **1234 ms** | **6.2 s** | **1.55 s** |
+ *
+ * nice 10 beat the control in 5 of 5 paired rounds (median 5.0 s faster, ~45%) and collapsed the
+ * run-to-run spread from 5.6 s to 1.6 s, so [DEFAULT_NICE] is 10.
+ *
+ * **This effect only exists in a release build, so never re-validate it on a debug one.** In a
+ * debug build the same sweep changes nothing measurable: there the main thread is ~70% busy,
+ * saturated with ART interpretation, so scheduling was never the constraint (starvation is 15% in
+ * debug vs 27% in release). R8 collapses main's own work while leaving the relay storm untouched,
+ * which is what promotes starvation to the binding constraint. An emulator is equally misleading
+ * for the opposite reason — its shared cores manufacture contention real hardware does not have.
  *
  * **Why a /proc sweep instead of thread factories.** The largest pool by far is OkHttp's
  * `TaskRunner` backend, a process-wide singleton whose thread factory OkHttp does not expose per
@@ -53,49 +74,40 @@ import java.io.File
  * HeapTaskDaemon would make the GC pressure *worse*, not better) and binder threads (IPC replies
  * the system waits on). Everything else is app work that should yield to the UI.
  *
- * **Runtime control.** The target nice level is read from a `Settings.Global` key so the effect can
- * be A/B-measured on one build:
+ * **Cost.** Each thread is touched once, not once per sweep, and the interval backs off whenever a
+ * sweep finds nothing new — the storm front-loads thread creation, so most sweeps after the first
+ * few seconds are empty. Threads that exit are pruned so a recycled tid is re-evaluated.
+ *
+ * **Runtime override.** [SETTING_KEY] overrides [DEFAULT_NICE] without a rebuild, and is also the
+ * off switch (any value <= 0 disables the governor entirely):
  * ```
- * adb shell settings put global amethyst_worker_nice 9    # demote workers (diagnostic only)
- * adb shell settings delete global amethyst_worker_nice   # control (no-op)
+ * adb shell settings put global amethyst_worker_nice 5    # demote to nice 5 instead
+ * adb shell settings put global amethyst_worker_nice 0    # disable
+ * adb shell settings delete global amethyst_worker_nice   # back to DEFAULT_NICE
  * ```
- *
- * **Measured 2026-08-17 (4-round round-robin sweeps on two rigs) — this does NOT fix the stall on
- * real hardware, which is why it ships disabled.** The mechanism works everywhere: starvation tracks
- * the CFS weight monotonically and roughly halves (emulator 50.2% -> 24.8% at nice 9; SM-T220 15.2%
- * -> 8.1%). But the user-visible time-to-first-paint does not reliably improve on device — the
- * paired deltas were non-monotonic across nice levels, i.e. noise.
- *
- * The two rigs disagree because the bottleneck is not the same on both. On a 4-core emulator the
- * main thread is only 27% busy and genuinely starved; on the SM-T220 it is **70% busy** and
- * saturated with its own work (~42s of it), so scheduling was never the constraint. Raising priority
- * there did hand main more CPU (41.9s -> 47.6s on-cpu) and the stall did not move. Treat an emulator
- * as unable to answer scheduling questions: its shared cores manufacture contention real devices do
- * not have.
- *
- * Kept as a diagnostic knob for the scheduling half of the problem. The larger, still-untested lever
- * is bounding the ~190-relay connect fan-out.
- *
  * Despite AOSP's `androidSetThreadPriority` calling `set_sched_policy(SP_BACKGROUND)` at nice >= 10,
  * no cpuset/schedtune move was observed on real hardware (SM-T220 / Android 14): at nice 5, 9 and 10
  * every worker kept main's exact membership (`schedtune:/top-app`, `cpuset:/top-app`, `cpu:/`) and
- * only the nice value changed. So there is no threshold at 10 to design around — pick the level off
- * the weight/throughput curve above.
+ * only the nice value changed — so 10 carries no hidden cgroup penalty over 9.
  */
 object WorkerThreadPriorityGovernor {
-    /** `Settings.Global` key holding the target nice level. Absent/invalid = feature off. */
+    /** `Settings.Global` key overriding [DEFAULT_NICE]; any value <= 0 disables the governor. */
     const val SETTING_KEY = "amethyst_worker_nice"
 
-    /** Sentinel for "not configured" — the governor stays off and costs nothing. */
-    private const val DISABLED = Int.MIN_VALUE
+    /** Best measured value on a release-codegen build — see the table in the class doc. */
+    const val DEFAULT_NICE = 10
 
-    /** Sweep cadence while the cold-start storm is spawning threads. */
-    private const val BURST_INTERVAL_MS = 250L
+    /** Sweep cadence while threads are still appearing. */
+    private const val MIN_INTERVAL_MS = 250L
 
-    /** How long to sweep aggressively before backing off to [IDLE_INTERVAL_MS]. */
+    /** Ceiling the interval backs off to while a sweep keeps finding nothing new. */
+    private const val MAX_BURST_INTERVAL_MS = 2_000L
+
+    /** How long to stay in the adaptive burst before settling at [IDLE_INTERVAL_MS]. */
     private const val BURST_DURATION_MS = 120_000L
 
-    private const val IDLE_INTERVAL_MS = 2_000L
+    /** Steady-state cadence; relay reconnects still spawn threads long after boot. */
+    private const val IDLE_INTERVAL_MS = 5_000L
 
     /**
      * Threads whose scheduling must not be touched. Matched as prefixes against the kernel `comm`
@@ -125,15 +137,15 @@ object WorkerThreadPriorityGovernor {
 
     @Volatile private var started = false
 
-    fun startIfConfigured(context: Context) {
+    fun start(context: Context) {
         if (started) return
-        val targetNice = readTargetNice(context)
-        if (targetNice == DISABLED) {
-            Log.i("ThreadPriority") { "Worker thread governor off (no $SETTING_KEY setting)" }
+        val targetNice = resolveTargetNice(context)
+        if (targetNice == null) {
+            Log.i("ThreadPriority") { "Worker thread governor disabled via $SETTING_KEY" }
             return
         }
         started = true
-        Log.i("ThreadPriority") { "Worker thread governor ON, target nice=$targetNice" }
+        Log.i("ThreadPriority") { "Worker thread governor on, target nice=$targetNice" }
 
         Thread({ sweepLoop(targetNice) }, "worker-nice-governor")
             .apply {
@@ -142,55 +154,88 @@ object WorkerThreadPriorityGovernor {
             }
     }
 
-    private fun readTargetNice(context: Context): Int =
-        runCatching {
-            Settings.Global.getInt(context.contentResolver, SETTING_KEY, DISABLED)
-        }.getOrDefault(DISABLED)
+    /** Returns the nice level to apply, or null when the governor should not run at all. */
+    private fun resolveTargetNice(context: Context): Int? {
+        val configured =
+            runCatching {
+                Settings.Global.getInt(context.contentResolver, SETTING_KEY, DEFAULT_NICE)
+            }.getOrDefault(DEFAULT_NICE)
+
+        // Only a demotion makes sense here; <= 0 is the documented off switch and anything above
+        // the nice ceiling is a typo we should not act on.
+        return configured.takeIf { it in 1..19 }
+    }
 
     private fun sweepLoop(targetNice: Int) {
         // The governor must keep running while the pools it polices saturate the CPU, so it runs
         // slightly above default rather than as background work.
         runCatching { Process.setThreadPriority(Process.THREAD_PRIORITY_FOREGROUND) }
 
-        val startedAt = System.currentTimeMillis()
+        val startedAt = SystemClock.elapsedRealtime()
         val mainTid = Process.myPid()
-        // A thread's nice survives renaming, so once demoted it never needs revisiting.
-        // Seeding with our own tid keeps the sweep from demoting the governor itself.
-        val alreadyDemoted = HashSet<Int>().apply { add(Process.myTid()) }
+        // Tids already dealt with — demoted, or skipped because they are on the denylist. Both are
+        // permanent decisions, so keeping them here means a thread costs one `comm` read for its
+        // whole life instead of one per sweep. Seeded with our own tid so the sweep can't demote
+        // the governor itself.
+        val handled = HashSet<Int>().apply { add(Process.myTid()) }
+        var interval = MIN_INTERVAL_MS
 
         while (true) {
-            val demoted = sweepOnce(mainTid, targetNice, alreadyDemoted)
-            val elapsed = System.currentTimeMillis() - startedAt
+            val demoted = sweepOnce(mainTid, targetNice, handled)
             if (demoted > 0) {
                 Log.d("ThreadPriority") { "Demoted $demoted thread(s) to nice $targetNice" }
             }
-            runCatching {
-                Thread.sleep(if (elapsed < BURST_DURATION_MS) BURST_INTERVAL_MS else IDLE_INTERVAL_MS)
-            }.onFailure { return }
+
+            // Thread creation is front-loaded into the connect storm, so once a sweep comes back
+            // empty the next one almost certainly will too — back off instead of spinning.
+            interval =
+                when {
+                    SystemClock.elapsedRealtime() - startedAt >= BURST_DURATION_MS -> IDLE_INTERVAL_MS
+                    demoted > 0 -> MIN_INTERVAL_MS
+                    else -> (interval * 2).coerceAtMost(MAX_BURST_INTERVAL_MS)
+                }
+
+            runCatching { Thread.sleep(interval) }.onFailure { return }
         }
     }
 
     private fun sweepOnce(
         mainTid: Int,
         targetNice: Int,
-        alreadyDemoted: MutableSet<Int>,
+        handled: MutableSet<Int>,
     ): Int {
-        val tasks = File("/proc/self/task").listFiles() ?: return 0
+        // list() rather than listFiles(): this runs hundreds of times over a boot and the File
+        // objects would be pure garbage on an already GC-pressured heap.
+        val tidNames = File("/proc/self/task").list() ?: return 0
+        val live = HashSet<Int>(tidNames.size * 2)
         var demoted = 0
-        for (task in tasks) {
-            val tid = task.name.toIntOrNull() ?: continue
-            if (tid == mainTid || tid in alreadyDemoted) continue
 
-            // A thread can exit between listing and reading; treat any failure as "skip".
-            val name = runCatching { File(task, "comm").readText().trim() }.getOrNull() ?: continue
-            if (DENYLIST.any { name.startsWith(it) }) continue
+        for (tidName in tidNames) {
+            val tid = tidName.toIntOrNull() ?: continue
+            live.add(tid)
+            if (tid == mainTid || tid in handled) continue
 
-            val ok = runCatching { Process.setThreadPriority(tid, targetNice) }.isSuccess
-            if (ok) {
-                alreadyDemoted.add(tid)
+            // A thread can exit between listing and reading; treat any failure as "skip" and let
+            // the next sweep retry, since it is not yet recorded in `handled`.
+            val name =
+                runCatching {
+                    File("/proc/self/task/$tidName/comm").readText().trim()
+                }.getOrNull() ?: continue
+
+            if (DENYLIST.any { name.startsWith(it) }) {
+                handled.add(tid)
+                continue
+            }
+
+            if (runCatching { Process.setThreadPriority(tid, targetNice) }.isSuccess) {
+                handled.add(tid)
                 demoted++
             }
         }
+
+        // Drop tids that have exited so the kernel recycling one into a new thread doesn't leave
+        // that thread permanently un-demoted.
+        handled.retainAll(live)
         return demoted
     }
 }


### PR DESCRIPTION
## What

Adds `WorkerThreadPriorityGovernor`, which demotes the app's ~650 network/ingest worker threads below the UI thread so the cold-start relay storm cannot starve `main` out of its frames. **Enabled by default at nice 10.**

## Why

A cold start dials ~190 relays at once and grows the process to ~650 threads — OkHttp's TaskRunner pool, OkHttp dispatchers, the kotlinx scheduler, Arti's tokio workers — and **every one of them is born at nice 0**. `main` is nice -10, but one thread against dozens of simultaneously-runnable nice-0 threads loses a large share of its schedulable time to the runqueue.

That surfaces as the "Loading account" screen persisting well after the account has loaded: the account state flips to `LoggedIn` in ~2s, but the screen is a **stale frame** because `main` cannot complete a repaint.

## Results (release-codegen build)

Measured on `:amethyst:installPlayBenchmark` (`initWith(release)` — R8-minified + baseline-profile AOT), SM-T220, 5-round round-robin, 22s window, **every run valid**:

| workers at | starvation | runqueue wait | first paint | spread |
|---|---|---|---|---|
| nice 0 (off) | 26.7% | 2300 ms | 11.1 s | 5.63 s |
| nice 5 | 22.0% | 1774 ms | 8.0 s | 4.05 s |
| nice 9 | 17.1% | 1280 ms | 8.4 s | 3.05 s |
| **nice 10** | **14.6%** | **1234 ms** | **6.2 s** | **1.55 s** |

nice 10 beat control in **5/5 paired rounds** (median 5.0 s faster) and collapsed the run-to-run spread from 5.6 s to 1.6 s.

Re-validated end-to-end in the **shipped** configuration (default-on vs explicitly disabled), 4 paired rounds:

| | disabled | default-on |
|---|---|---|
| first paint | 10.4 s | **6.4 s** |
| starvation | 31.3% | **20.5%** |
| runqueue wait | 2420 ms | **1408 ms** |

4/4 paired wins.

## ⚠️ This effect exists only in release — do not re-validate on a debug build

In a **debug** build the same sweep changes nothing measurable. There `main` is ~70% busy, saturated with ART interpretation, so scheduling was never the constraint — starvation is **15% in debug vs 27% in release**. R8 collapses main's *own* work while leaving the relay storm untouched, which is what promotes starvation to the binding constraint.

An emulator is misleading for the opposite reason: its shared cores manufacture contention real hardware doesn't have (starvation reads 50% there). Both traps are documented in the class KDoc so this isn't re-measured on the wrong rig.

## Governor's own cost

**3.6% of one core** over a cold start (930 ms / 26 s), measured from the sweep thread's own `utime+stime` — an on/off process-CPU diff can't isolate it, since enabling it also changes worker throughput. Halved from an initial 7.1% by:

- touching each thread once for its lifetime rather than once per sweep (denylisted threads are remembered instead of re-reading their `comm` every pass)
- backing the interval off when a sweep finds nothing new, resetting when it does
- `list()` instead of `listFiles()` — avoids ~650 `File` allocations per sweep on an already GC-pressured heap
- pruning exited tids so a recycled tid is re-evaluated

## Implementation notes

- **Sweeps `/proc/self/task` rather than installing thread factories** because the largest pool is OkHttp's `TaskRunner` backend — a process-wide singleton whose thread factory OkHttp 5.4 doesn't expose per client. A factory-only approach would cover ~50 of ~650 threads. A nice value is per-OS-thread and survives renaming, so seeing a thread once is enough.
- Uses `Process.setThreadPriority`, not `Thread.setPriority` — only the former maps to a Linux nice level on Android (`AudioTrackPlayer` documents the same trap).
- A denylist protects threads that must keep their scheduling: `main`, `RenderThread`, `hwuiTask`, the ART daemons (demoting `HeapTaskDaemon` would *deepen* the GC stalls this reduces) and binder threads. Verified on device — every protected thread untouched.
- `Settings.Global amethyst_worker_nice` is now an **override**, not the gate: it replaces the default nice level, and any value `<= 0` disables the governor entirely.
- Despite AOSP's `androidSetThreadPriority` calling `set_sched_policy(SP_BACKGROUND)` at nice >= 10, **no cpuset/schedtune move was observed on real hardware** (SM-T220 / Android 14): at nice 5, 9 and 10 every worker kept `main`'s exact membership (`schedtune:/top-app`, `cpuset:/top-app`, `cpu:/`). So 10 carries no hidden cgroup penalty over 9.

## Known limitation, and a separate bug found along the way

**This does not address the underlying problem** — the app dialing ~190 relays unthrottled on login. Bounding that fan-out is the structural fix; this reduces its collateral damage on the UI thread.

Separately, and **not fixed here**: the release build OOM-dies during cold start on the SM-T220 —

```
lmkd: Reclaim 'com.vitorpamplona.amethyst.benchmark' … to free 2011476kB rss
      reason: min2x watermark is breached even after kill
ActivityManager: Process … has died: fg TOP
```

~2.0 GB RSS at ~35–40 s in. It's arguably more severe than the issue this PR addresses and warrants its own investigation. It also forced the 22 s measurement window here: at longer windows survival was *arm-correlated* (nice 9 survived 5/5, nice 10 only 1/5), which is selection bias rather than a result, so those earlier sweeps were discarded.

## Testing

- `./gradlew test` green.
- ~90 instrumented cold starts across the Pixel emulator and SM-T220, debug and release-codegen builds, every run foreground-verified.
- Measured on one physical device; `benchmark` is release *codegen* but debug-signed, so it's close on R8/AOT but not identical to a Play release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
