### PR TITLE
perf: scan NIP-19 entities without ICU to stop the cold-start native-heap OOM

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip19Bech32/Nip19Parser.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip19Bech32/Nip19Parser.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Immutable
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.hexToByteArray
 import com.vitorpamplona.quartz.nip01Core.core.toHexKey
+import com.vitorpamplona.quartz.nip19Bech32.bech32.Bech32
 import com.vitorpamplona.quartz.nip19Bech32.bech32.bechToBytes
 import com.vitorpamplona.quartz.nip19Bech32.entities.Entity
 import com.vitorpamplona.quartz.nip19Bech32.entities.NAddress
@@ -163,17 +164,6 @@ object Nip19Parser {
 
     private val EVENT_VARIABLE_PREFIXES = arrayOf("nevent1", "naddr1", "note1", "nrelay1", "nembed1")
 
-    /** bech32: digits except `1`, letters except `b`, `i`, `o`. ASCII-only, both cases. */
-    private val BECH32_CHARS =
-        BooleanArray(128).apply {
-            for (c in "qpzry9x8gf2tvdw0s3jn54khce6mua7l") {
-                this[c.code] = true
-                if (c in 'a'..'z') this[c.code - 32] = true
-            }
-        }
-
-    private fun isBech32(c: Char): Boolean = c.code < 128 && BECH32_CHARS[c.code]
-
     /**
      * `\S` in the trailing group. Java's `\s` is the six ASCII whitespace chars unless
      * `UNICODE_CHARACTER_CLASS` is set, so U+00A0 and friends count as NON-space here.
@@ -280,7 +270,7 @@ object Nip19Parser {
                         if (!matchesPrefixAt(content, i, prefix)) continue
                         val dataStart = i + prefix.length
                         var dataEnd = dataStart
-                        while (dataEnd < len && isBech32(content[dataEnd])) dataEnd++
+                        while (dataEnd < len && Bech32.isDataChar(content[dataEnd])) dataEnd++
                         // `+` needs at least one payload char.
                         if (dataEnd > dataStart) {
                             end = endOfTrailing(content, dataEnd)
@@ -310,7 +300,7 @@ object Nip19Parser {
         to: Int,
     ): Boolean {
         for (k in from until to) {
-            if (!isBech32(content[k])) return false
+            if (!Bech32.isDataChar(content[k])) return false
         }
         return true
     }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip19Bech32/Nip19Parser.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip19Bech32/Nip19Parser.kt
@@ -246,7 +246,25 @@ object Nip19Parser {
     ) {
         var i = 0
         val len = content.length
+        // Jump between 'n'/'N' with indexOf — an intrinsified, vectorised char search — instead of
+        // testing every character. Both cases are tracked separately so each is only re-searched
+        // once consumed, amortising to about one indexOf per candidate. Measured ~2x faster on
+        // content with no entity at all, which is 94% of real notes (2588-note production sample),
+        // and ~26% faster on the 767KB mention-heavy tail. Small mention-dense content (a ~700B
+        // note with 2 mentions) is a few microseconds slower; that trade is deliberate.
+        var nextLower = content.indexOf('n')
+        var nextUpper = content.indexOf('N')
         while (i < len) {
+            if (nextLower in 0..<i) nextLower = content.indexOf('n', i)
+            if (nextUpper in 0..<i) nextUpper = content.indexOf('N', i)
+            i =
+                when {
+                    nextLower < 0 && nextUpper < 0 -> return
+                    nextLower < 0 -> nextUpper
+                    nextUpper < 0 -> nextLower
+                    else -> if (nextLower < nextUpper) nextLower else nextUpper
+                }
+            if (i >= len) return
             if (isCandidateAt(content, i)) {
                 var end = -1
 

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip19Bech32/Nip19Parser.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip19Bech32/Nip19Parser.kt
@@ -133,6 +133,78 @@ object Nip19Parser {
 
     fun hasAny(content: String): Boolean = nip19regex.matches(content)
 
+    // ---------------------------------------------------------------------------------------
+    // ICU-free scanner for the ingest hot path.
+    //
+    // `java.util.regex` on Android is backed by ICU, and `Matcher.region()` -> `reset()` ->
+    // `MatcherNative.setInput()` copies the ENTIRE input into native memory on every call.
+    // `Regex.matchAt` builds a fresh Matcher per call, and [forEachNip19Match] calls it once per
+    // candidate position — so scanning one note allocated a full native UTF-16 copy of its content
+    // *per candidate*, with content running to 767KB in the tail. Because the Java Matcher object
+    // is tiny, Java-heap-driven GC had no reason to reclaim them promptly, so the native heap grew
+    // unbounded: measured 45MB -> 1372MB over a cold start, ending in an lmkd kill at ~1.9GB RSS.
+    // Disabling this one scan made the native heap plateau at ~257MB instead.
+    //
+    // The grammar is small enough to match directly, so nothing here touches ICU. Case folding is
+    // done ASCII-only on purpose: `RegexOption.IGNORE_CASE` maps to `Pattern.CASE_INSENSITIVE`,
+    // which is ASCII-only unless `UNICODE_CASE` is also set. Using Kotlin's `ignoreCase = true`
+    // would be Unicode-aware and would accept inputs the regex rejected (U+212A KELVIN SIGN folding
+    // to `k`, say).
+    // ---------------------------------------------------------------------------------------
+
+    /** Entities whose bech32 payload the regexes pin to exactly 58 chars. */
+    private val FIXED_58_PREFIXES = arrayOf("nsec1", "npub1", "note1")
+
+    /** Entities whose bech32 payload is `+` (one or more). */
+    private val VARIABLE_PREFIXES = arrayOf("nevent1", "naddr1", "nprofile1", "nrelay1", "nembed1")
+
+    /** [nip19regexEvents] has no fixed-58 branch — there `note1` takes a variable payload. */
+    private val EVENT_FIXED_58_PREFIXES = emptyArray<String>()
+
+    private val EVENT_VARIABLE_PREFIXES = arrayOf("nevent1", "naddr1", "note1", "nrelay1", "nembed1")
+
+    /** bech32: digits except `1`, letters except `b`, `i`, `o`. ASCII-only, both cases. */
+    private val BECH32_CHARS =
+        BooleanArray(128).apply {
+            for (c in "qpzry9x8gf2tvdw0s3jn54khce6mua7l") {
+                this[c.code] = true
+                if (c in 'a'..'z') this[c.code - 32] = true
+            }
+        }
+
+    private fun isBech32(c: Char): Boolean = c.code < 128 && BECH32_CHARS[c.code]
+
+    /**
+     * `\S` in the trailing group. Java's `\s` is the six ASCII whitespace chars unless
+     * `UNICODE_CHARACTER_CLASS` is set, so U+00A0 and friends count as NON-space here.
+     */
+    private fun isRegexSpace(c: Char): Boolean = c == ' ' || c == '\t' || c == '\n' || c == '\u000B' || c == '\u000C' || c == '\r'
+
+    /** ASCII-only case-insensitive prefix compare; [prefix] must be lowercase ASCII. */
+    private fun matchesPrefixAt(
+        content: String,
+        offset: Int,
+        prefix: String,
+    ): Boolean {
+        if (offset + prefix.length > content.length) return false
+        for (k in prefix.indices) {
+            val c = content[offset + k]
+            val folded = if (c in 'A'..'Z') c + 32 else c
+            if (folded != prefix[k]) return false
+        }
+        return true
+    }
+
+    /** End (exclusive) of the `[\S]*` run starting at [from]. */
+    private fun endOfTrailing(
+        content: String,
+        from: Int,
+    ): Int {
+        var j = from
+        while (j < content.length && !isRegexSpace(content[j])) j++
+        return j
+    }
+
     /**
      * True when one of the NIP-19 entity prefixes starts at [i].
      *
@@ -165,31 +237,82 @@ object Nip19Parser {
     }
 
     /**
-     * Applies [regex] anchored at every NIP-19 candidate position in [content].
+     * Matches `<prefix><bech32 payload><[\S]*>` at every NIP-19 candidate position in [content],
+     * without ICU — see the block comment above [FIXED_58_PREFIXES] for why that matters.
      *
-     * [isCandidateAt] covers the union of the prefixes across the three NIP-19
-     * regexes, so a narrower [regex] simply fails `matchAt` on a prefix it does
-     * not accept — still far cheaper than `findAll` restarting the engine at
-     * every position in the string.
+     * [isCandidateAt] covers the union of the prefixes across the three NIP-19 regexes, so a
+     * caller passing a narrower prefix set simply finds no match at a prefix it does not accept.
+     *
+     * The prefixes are mutually exclusive (none is a prefix of another), so the first one that
+     * matches decides the branch, exactly as the regex alternation did. A fixed-58 entity with
+     * fewer than 58 payload chars fails outright rather than falling through to the variable
+     * branch, again matching the regex: no variable prefix can equal a fixed-58 one.
      */
     private inline fun forEachNip19Match(
         content: String,
-        regex: Regex,
-        action: (MatchResult) -> Unit,
+        fixed58Prefixes: Array<String>,
+        variablePrefixes: Array<String>,
+        action: (type: String, key: String, additionalChars: String) -> Unit,
     ) {
         var i = 0
         val len = content.length
         while (i < len) {
             if (isCandidateAt(content, i)) {
-                val match = regex.matchAt(content, i)
-                if (match != null) {
-                    action(match)
-                    i = match.range.last + 1
+                var end = -1
+
+                for (prefix in fixed58Prefixes) {
+                    if (!matchesPrefixAt(content, i, prefix)) continue
+                    val dataStart = i + prefix.length
+                    val dataEnd = dataStart + 58
+                    if (dataEnd <= len && allBech32(content, dataStart, dataEnd)) {
+                        end = endOfTrailing(content, dataEnd)
+                        action(
+                            content.substring(i, dataStart),
+                            content.substring(dataStart, dataEnd),
+                            content.substring(dataEnd, end),
+                        )
+                    }
+                    break
+                }
+
+                if (end < 0) {
+                    for (prefix in variablePrefixes) {
+                        if (!matchesPrefixAt(content, i, prefix)) continue
+                        val dataStart = i + prefix.length
+                        var dataEnd = dataStart
+                        while (dataEnd < len && isBech32(content[dataEnd])) dataEnd++
+                        // `+` needs at least one payload char.
+                        if (dataEnd > dataStart) {
+                            end = endOfTrailing(content, dataEnd)
+                            action(
+                                content.substring(i, dataStart),
+                                content.substring(dataStart, dataEnd),
+                                content.substring(dataEnd, end),
+                            )
+                        }
+                        break
+                    }
+                }
+
+                // `end` is exclusive and always past `i`, so the scan still advances.
+                if (end >= 0) {
+                    i = end
                     continue
                 }
             }
             i++
         }
+    }
+
+    private fun allBech32(
+        content: String,
+        from: Int,
+        to: Int,
+    ): Boolean {
+        for (k in from until to) {
+            if (!isBech32(content[k])) return false
+        }
+        return true
     }
 
     /**
@@ -208,14 +331,8 @@ object Nip19Parser {
      */
     fun parseAll(content: String): List<Entity> {
         val returningList = mutableListOf<Entity>()
-        forEachNip19Match(content, nip19regex) { matcher ->
-            val type = matcher.groups[3]?.value ?: matcher.groups[5]?.value // npub1
-            val key = matcher.groups[4]?.value ?: matcher.groups[6]?.value // bech32
-            val additionalChars = matcher.groups[7]?.value // additional chars
-
-            if (type != null) {
-                parseComponents(type, key, additionalChars)?.entity?.let { returningList.add(it) }
-            }
+        forEachNip19Match(content, FIXED_58_PREFIXES, VARIABLE_PREFIXES) { type, key, additionalChars ->
+            parseComponents(type, key, additionalChars)?.entity?.let { returningList.add(it) }
         }
         return returningList
     }
@@ -223,14 +340,8 @@ object Nip19Parser {
     /** Same scan as [parseAll], restricted to the event-ish entities. */
     fun parseAllEvents(content: String): List<Entity> {
         val returningList = mutableListOf<Entity>()
-        forEachNip19Match(content, nip19regexEvents) { matcher ->
-            val type = matcher.groups[2]?.value // nevent1
-            val key = matcher.groups[3]?.value // bech32
-            val additionalChars = matcher.groups[4]?.value // additional chars
-
-            if (type != null) {
-                parseComponents(type, key, additionalChars)?.entity?.let { returningList.add(it) }
-            }
+        forEachNip19Match(content, EVENT_FIXED_58_PREFIXES, EVENT_VARIABLE_PREFIXES) { type, key, additionalChars ->
+            parseComponents(type, key, additionalChars)?.entity?.let { returningList.add(it) }
         }
         return returningList
     }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip19Bech32/bech32/Bech32Util.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip19Bech32/bech32/Bech32Util.kt
@@ -20,6 +20,8 @@
  */
 package com.vitorpamplona.quartz.nip19Bech32.bech32
 
+import kotlin.jvm.JvmField
+
 /*
  * Copyright 2020 ACINQ SAS
  *
@@ -81,14 +83,49 @@ object Bech32 {
     // char -> 5 bits value
     private val map = Array<Int5>(255) { -1 }
 
+    @PublishedApi
+    internal const val DATA_CHARS_SIZE = 128
+
+    /**
+     * Membership table for [isDataChar], kept separate from [map] because [map] is an
+     * `Array<Byte>` — a boxed `java.lang.Byte[]` — and [isDataChar] runs per character over whole
+     * note contents (up to ~767KB), where unboxing on every char would show up.
+     *
+     * `@JvmField` so callers of the inline [isDataChar] compile to a direct `getstatic` instead of
+     * a property-getter `invokevirtual` per character (the same reasoning as `PointTypes`).
+     * `@PublishedApi internal` because a public inline function cannot touch a private member.
+     */
+    @PublishedApi
+    @JvmField
+    internal val DATA_CHARS = BooleanArray(DATA_CHARS_SIZE)
+
     init {
         for (i in 0..ALPHABET.lastIndex) {
             map[ALPHABET[i].code] = i.toByte()
+            DATA_CHARS[ALPHABET[i].code] = true
         }
         for (i in 0..ALPHABET_UPPERCASE.lastIndex) {
             map[ALPHABET_UPPERCASE[i].code] = i.toByte()
+            DATA_CHARS[ALPHABET_UPPERCASE[i].code] = true
         }
     }
+
+    /**
+     * True when [c] is part of the bech32 data alphabet, in either case — i.e. everything except
+     * `1`, `b`, `i` and `o`, which BIP-173 excludes as visually ambiguous.
+     *
+     * Exposed so scanners can find where an encoded payload *ends* without decoding it. The NIP-19
+     * content scan needs exactly that on every ingested event, and cannot use a regex to do it:
+     * Android's `java.util.regex` is ICU-backed and `Matcher.region()` copies the entire input into
+     * native memory per call, which drove the app's native heap to ~1.9GB on a cold start.
+     *
+     * `inline` because it is called per character over whole note contents (up to ~767KB). As a
+     * normal member it compiled to an `invokevirtual` per char, which measured ~1-2% slower across
+     * the scan benchmark than the equivalent private lookup it replaced; inlining puts the constant
+     * compare and the `baload` straight into the caller's loop and closes that gap.
+     */
+    @Suppress("NOTHING_TO_INLINE")
+    inline fun isDataChar(c: Char): Boolean = c.code < DATA_CHARS_SIZE && DATA_CHARS[c.code]
 
     fun expand(hrp: String): Array<Int5> {
         val half = hrp.length + 1

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip19Bech32/Nip19ScannerRegexEquivalenceTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip19Bech32/Nip19ScannerRegexEquivalenceTest.kt
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip19Bech32
+
+import com.vitorpamplona.quartz.nip19Bech32.entities.Entity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins the ICU-free scanner in [Nip19Parser] to the regexes it replaced.
+ *
+ * The scan used to run `Regex.matchAt` at every candidate position. On Android that goes through
+ * ICU, and `Matcher.region()` copies the whole input into native memory on each call — one full
+ * native copy of a note's content *per candidate* — which drove the native heap to ~1.9GB on a
+ * cold start and got the process lmkd-killed. The scanner matches the grammar directly instead.
+ *
+ * [Nip19Parser.nip19regex] and [Nip19Parser.nip19regexEvents] are still the specification, so this
+ * runs both over the same corpus and requires identical entity lists. The corpus deliberately
+ * targets the places a hand-rolled matcher is most likely to drift from the regex: the exact-58
+ * payload boundary, the bech32 alphabet's excluded characters, ASCII-only case folding, and which
+ * characters `[\S]*` is willing to swallow.
+ */
+class Nip19ScannerRegexEquivalenceTest {
+    companion object {
+        const val NPUB = "npub1hv7k2s755n697sptva8vkh9jz40lzfzklnwj6ekewfmxp5crwdjs27007y"
+        const val NOTE = "note1stqea6wmwezg9x6yyr6qkukw95ewtdukyaztycws65l8wppjmtpscawevv"
+        const val NEVENT = "nevent1qqs0tsw8hjacs4fppgdg7f5yhgwwfkyua4xcs3re9wwkpkk2qeu6mhql22rcy"
+
+        /** 58 valid bech32 chars, so `npub1` + this is exactly the fixed-length branch. */
+        const val PAYLOAD58 = "qpzry9x8gf2tvdw0s3jn54khce6mua7lqpzry9x8gf2tvdw0s3jn54khce"
+    }
+
+    /** What `parseAll` did before: drive the regex from every position with `findAll`. */
+    private fun referenceParseAll(content: String): List<Entity> {
+        val out = mutableListOf<Entity>()
+        Nip19Parser.nip19regex.findAll(content).forEach { m ->
+            val type = m.groups[3]?.value ?: m.groups[5]?.value
+            val key = m.groups[4]?.value ?: m.groups[6]?.value
+            val additionalChars = m.groups[7]?.value
+            if (type != null) {
+                Nip19Parser.parseComponents(type, key, additionalChars)?.entity?.let { out.add(it) }
+            }
+        }
+        return out
+    }
+
+    private fun referenceParseAllEvents(content: String): List<Entity> {
+        val out = mutableListOf<Entity>()
+        Nip19Parser.nip19regexEvents.findAll(content).forEach { m ->
+            val type = m.groups[2]?.value
+            val key = m.groups[3]?.value
+            val additionalChars = m.groups[4]?.value
+            if (type != null) {
+                Nip19Parser.parseComponents(type, key, additionalChars)?.entity?.let { out.add(it) }
+            }
+        }
+        return out
+    }
+
+    private fun assertSameAsRegex(content: String) {
+        assertEquals(
+            referenceParseAll(content),
+            Nip19Parser.parseAll(content),
+            "parseAll diverged from nip19regex on: ${content.take(90)}",
+        )
+        assertEquals(
+            referenceParseAllEvents(content),
+            Nip19Parser.parseAllEvents(content),
+            "parseAllEvents diverged from nip19regexEvents on: ${content.take(90)}",
+        )
+    }
+
+    private fun corpus(): List<String> =
+        buildList {
+            // plain placement
+            add("")
+            add(NPUB)
+            add("hello $NPUB world")
+            add("nostr:$NPUB")
+            add("@$NPUB")
+            add("nostr:@$NPUB")
+            add("prefix-nostr:$NPUB-suffix")
+            add(NOTE)
+            add(NEVENT)
+
+            // adjacency and repetition — where scan-resume position matters
+            add(NPUB + NEVENT)
+            add("$NPUB $NEVENT")
+            add("$NPUB\n$NEVENT")
+            add("$NPUB,$NEVENT")
+            add(listOf(NPUB, NOTE, NEVENT).joinToString(" "))
+            add(NPUB.repeat(3))
+
+            // the exact-58 boundary for npub/nsec/note
+            add("npub1" + PAYLOAD58)
+            add("npub1" + PAYLOAD58.dropLast(1)) // 57 -> must not match
+            add("npub1" + PAYLOAD58 + "q") // 59 -> 58 key, trailing takes the rest
+            add("npub1" + PAYLOAD58 + " tail")
+            add("note1" + PAYLOAD58)
+            add("nsec1" + PAYLOAD58)
+
+            // bech32 alphabet: 1, b, i, o are excluded and must terminate the payload
+            add("nevent1qqs1qqs")
+            add("nevent1qqsbqqs")
+            add("nevent1qqsiqqs")
+            add("nevent1qqsoqqs")
+
+            // A *valid* variable-length entity butted straight against an excluded char. The
+            // payload has to stop there and still decode. These are the cases with teeth: a
+            // charset that wrongly accepted b/i/o/1 would swallow the extra char, fail the
+            // bech32 decode and silently drop the entity — whereas cases whose payload is
+            // invalid either way agree trivially and prove nothing.
+            for (excluded in listOf("b", "i", "o", "1")) {
+                add(NEVENT + excluded)
+                add(NEVENT + excluded + "xyz")
+                add("$NEVENT$excluded more text")
+            }
+            add("nevent1") // variable branch needs >= 1 payload char
+            add("nprofile1")
+            add("naddr1q")
+
+            // ASCII-only case folding
+            add(NPUB.uppercase())
+            add("NOSTR:" + NPUB.uppercase())
+            add(NEVENT.uppercase())
+            add("nPuB1" + PAYLOAD58)
+            // U+212A KELVIN SIGN folds to 'k' under Unicode rules but NOT under the regex's
+            // ASCII-only CASE_INSENSITIVE; both sides must reject it.
+            add("npub1" + PAYLOAD58.replaceFirst("k", "K"))
+
+            // what [\S]* may swallow: Java's \s is the six ASCII whitespace chars only,
+            // so U+00A0 and U+2003 are NON-space and belong to the trailing group.
+            add("$NPUB\u00A0more")
+            add("$NPUB\u2003more")
+            add("${NPUB}more")
+            add("${NPUB}1more")
+            add("$NPUB\tmore")
+            add("$NPUB\rmore")
+
+            // near-misses that must not be mistaken for entities
+            add("n")
+            add("nn")
+            add("np")
+            add("no")
+            add("nostr:")
+            add("nothing to see here")
+            add("a note about nothing")
+            add("nopqrstuvwxyz")
+            add("x$NPUB")
+            add("1$NPUB")
+
+            // long content with the entity at the far end (the 767KB-tail shape, scaled down)
+            add("lorem ipsum ".repeat(2000) + NPUB)
+            add(NPUB + " " + "dolor sit amet ".repeat(2000))
+            // many 'n' candidates but no entities — the scanner's rejection path
+            add("neither nor none never nothing ".repeat(500))
+        }
+
+    @Test
+    fun matchesRegexAcrossCorpus() {
+        corpus().forEach { assertSameAsRegex(it) }
+    }
+
+    @Test
+    fun matchesRegexWithEntityAtEveryOffset() {
+        // Slides the entity through a filler string so every start offset, including
+        // immediately after another candidate 'n', is exercised.
+        val filler = "n no non nost nostr "
+        for (i in 0..filler.length) {
+            assertSameAsRegex(filler.substring(0, i) + NPUB + filler.substring(i))
+        }
+    }
+
+    @Test
+    fun matchesRegexOnTruncatedPayloads() {
+        // Every truncation of a real entity: catches off-by-one at the 58 boundary and in `+`.
+        for (entity in listOf(NPUB, NOTE, NEVENT)) {
+            for (len in 1..entity.length) {
+                assertSameAsRegex(entity.substring(0, len))
+                assertSameAsRegex("text " + entity.substring(0, len) + " text")
+            }
+        }
+    }
+}

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip19Bech32/bech32/Bech32DataCharTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip19Bech32/bech32/Bech32DataCharTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip19Bech32.bech32
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * [Bech32.isDataChar] is the membership test the NIP-19 content scan uses to find where an encoded
+ * payload ends, so it has to agree with [Bech32.ALPHABET] exactly — a char wrongly accepted extends
+ * a payload past its real end and silently drops the entity when the decode then fails.
+ */
+class Bech32DataCharTest {
+    @Test
+    fun acceptsExactlyTheAlphabetInBothCases() {
+        for (c in Bech32.ALPHABET) assertTrue(Bech32.isDataChar(c), "expected '$c' to be a data char")
+        for (c in Bech32.ALPHABET_UPPERCASE) assertTrue(Bech32.isDataChar(c), "expected '$c' to be a data char")
+    }
+
+    @Test
+    fun rejectsTheAmbiguousFour() {
+        // BIP-173 leaves these out of the alphabet precisely because they are easy to misread.
+        for (c in "1bio1BIO") assertFalse(Bech32.isDataChar(c), "expected '$c' to be rejected")
+    }
+
+    @Test
+    fun agreesWithTheAlphabetAcrossEveryChar() {
+        // Sweeps the whole BMP so nothing outside the alphabet sneaks in — including the
+        // out-of-range guard for chars beyond the lookup table.
+        val expected = (Bech32.ALPHABET + Bech32.ALPHABET_UPPERCASE).toSet()
+        for (code in 0..0xFFFF) {
+            val c = code.toChar()
+            assertEquals(c in expected, Bech32.isDataChar(c), "disagreement at code $code")
+        }
+    }
+
+    @Test
+    fun countsMatchTheSpec() {
+        assertEquals(32, Bech32.ALPHABET.length)
+        // 32 symbols, but only the 23 letters have a distinct uppercase form — the 9 digits
+        // are the same char in both alphabets, so the accepted set is 23*2 + 9, not 64.
+        val letters = Bech32.ALPHABET.count { it.isLetter() }
+        val digits = Bech32.ALPHABET.count { it.isDigit() }
+        assertEquals(32, letters + digits)
+        assertEquals(letters * 2 + digits, (0..0xFFFF).count { Bech32.isDataChar(it.toChar()) })
+    }
+}


### PR DESCRIPTION
## The bug

On a 2.9 GB SM-T220 the **release** build grew to ~1.9 GB RSS during a cold start and was killed by lmkd about 32 s in:

```
lmkd: Reclaim 'com.vitorpamplona.amethyst.benchmark' … to free 1871628kB rss, 375492kB swap
      reason: min2x watermark is breached even after kill
ActivityManager: Process … has died: fg TOP
```

The growth is entirely in the **native** heap. The Java heap plateaus at its 512 MB `largeHeap` ceiling and GCs back down, while native runs away:

| t | TOTAL | Dalvik | **Native** |
|---|---|---|---|
| 9.2s | 309M | 93M | 45M |
| 13.8s | 1137M | 438M | 497M |
| 28.2s | 1884M | 334M | **1372M** |

That's why earlier Java-heap histograms (~350 MB) never explained it. It is also **not images** — Coil's memory cache held 2–11 MB of its 102 MB budget the whole time.

## Cause

`forEachNip19Match` called `Regex.matchAt` once per candidate position. On Android `java.util.regex` is ICU-backed, and `Regex.matchAt` builds a fresh `Matcher` whose `region()` → `reset()` → `MatcherNative.setInput()` **copies the entire input into native memory**. So scanning one note allocated a full native UTF-16 copy of its content **per candidate `n`**, and note content reaches **767 KB** in the tail. The Java `Matcher` object is tiny, so Java-heap-driven GC had no reason to reclaim them promptly and native memory grew unbounded.

heapprofd's top malloc stack is exactly this path:

```
LocalCache.justConsume → updateHintIndexes → TextNoteEvent.eventHints
  → Nip19Parser.parseAll → Regex.matchAt → Matcher.region → Matcher.reset
    → MatcherNative.setInput → libicu_jni MatcherState::updateInput → malloc
```

The file's own KDoc had already recorded the symptom from an earlier pass — *"2,541 of 4,573 live Matchers were running this regex"* — but that pass optimized **speed** (the 9–23× anchoring win) and left the native retention in place.

Confirmed causally before writing the fix, via a kill switch on the same build: with the scan disabled the native heap plateaued at ~257 MB; with it enabled it reached 882 MB by t=18 s and kept climbing.

## The fix

The grammar is prefix + bech32 payload + trailing non-space, so it's matched directly with char compares — no ICU.

Two details worth reviewing:

- **Case folding is ASCII-only on purpose.** `RegexOption.IGNORE_CASE` maps to `Pattern.CASE_INSENSITIVE`, which is ASCII-only unless `UNICODE_CASE` is also set. Kotlin's `ignoreCase = true` is Unicode-aware and would have *accepted inputs the regex rejected* (U+212A KELVIN SIGN folds to `k`).
- **Reusing a single Matcher would not have fixed this** — `region()` re-copies the input on every call. Removing ICU from this path was the only option.

Only the ingest hot path changes. `uriToRoute` (98 call sites), `tryParseAndClean` and `hasAny` still use the regexes: they run on short user input, not per ingested event.

## Measured on device (release codegen, 3 runs)

Native heap RSS:

| | t~9s | t~14s | t~22s | t~28s | t~43s |
|---|---|---|---|---|---|
| before | 45M | 497M | 626M | 1372M | *killed at 31.9s* |
| after | 48M | 127M | 170M | 175M | 172M |

Native now plateaus at **~170 MB**, total RSS falls back to ~500 MB instead of climbing to 1.88 GB, and the process survives past 45 s with **zero lmkd kills**. The feed renders with `@mention` NIP-19 entities resolving correctly.

Note this reproduces **only in release builds** — a debug build only reaches ~337 MB because the interpreter throttles ingest below the rate needed to outrun memory. Measure with `./gradlew :amethyst:installPlayBenchmark`.

## Testing

- New `Nip19ScannerRegexEquivalenceTest` runs **both original regexes** over a shared corpus and requires identical entity lists — targeting the exact-58 boundary, the excluded bech32 chars (`1`, `b`, `i`, `o`), ASCII-only case folding, and what `[\S]*` swallows (Java's `\s` is the six ASCII whitespace chars, so U+00A0/U+2003 belong to the trailing group).
- Mutation-tested: both `58 → 57` and admitting `b` into the alphabet fail the test.
  - Worth calling out — the first version of that test had **no teeth for charset bugs**. Admitting an extra char only produces *invalid* payloads that `parseComponents` rejects on both sides, so the lists matched trivially. The cases that catch it are a **valid** variable-length entity butted straight against an excluded char (`NEVENT + "b"` etc.), where a permissive charset swallows the char, fails the bech32 decode and silently drops a real entity.
- Pre-existing guards still pass: `Nip19ScanTest` (23), `NIP19ParserTest` (37), and commons' `nip19MatchesReferenceScan`.
- Full quartz suite: **4288 tests, 0 failures**.

## Scope

This fixes the dominant native-heap consumer. It does not address the ~190-relay unthrottled connect fan-out that drives ingest volume in the first place — that remains the structural item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
