### PR TITLE
perf: scan hashtags and #[n] references without ICU

### DIFF
--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip10Notes/content/ContentHashTags.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip10Notes/content/ContentHashTags.kt
@@ -23,18 +23,42 @@ package com.vitorpamplona.quartz.nip10Notes.content
 val hashtagSearch = Regex("(?:\\s|\\A)#([^\\s!@#\$%^&*()=+./,\\[{\\]};:'\"?><]+)")
 
 /**
+ * Characters that end a hashtag: the punctuation class spelled out in [hashtagSearch], plus ASCII
+ * whitespace. Everything else continues the tag — including every non-ASCII character, since the
+ * regex's class is ASCII-only, so accented letters, CJK and emoji are all valid tag content.
+ */
+private val HASHTAG_TERMINATORS =
+    BooleanArray(128).apply {
+        for (c in 0x09..0x0D) this[c] = true
+        this[' '.code] = true
+        for (c in "!@#\u0024%^&*()=+./,[{]};:'\"?><") this[c.code] = true
+    }
+
+/**
+ * True while [c] can still be part of a hashtag.
+ *
+ * Non-ASCII always continues the tag: [hashtagSearch]'s excluded set is entirely ASCII and its
+ * `\s` is ASCII-only, so nothing above 0x7F was ever excluded.
+ */
+private fun isHashtagChar(c: Char): Boolean = c.code >= 128 || !HASHTAG_TERMINATORS[c.code]
+
+/**
  * Collects the hashtags in [content].
  *
- * [hashtagSearch] requires `(?:\s|\A)` immediately before the `#`, so every match
- * starts either at position 0 or at a whitespace. That lets the scan jump between
- * `#` occurrences with `indexOf` — an intrinsified char search — and apply the
- * regex **anchored** at each, instead of letting `findAll` drive the regex engine
- * from every position in the string.
+ * Jumps between `#` occurrences with `indexOf` — an intrinsified char search — and then matches
+ * `#<tag>` directly, character by character, rather than anchoring a regex there.
  *
- * Measured on the production content distribution (median 529 B, tail to 767 KB):
- * ~68 MB/s -> ~1,240 MB/s on hashtag-dense text (18x) and ~19,000 MB/s when the
- * content has no `#` at all (up to 300x). Equivalence with the previous `findAll`
- * implementation is guarded by `RegexContentBenchmark` in `commons`.
+ * **Why not a regex.** On Android `java.util.regex` is ICU-backed, and `Matcher.region()` ->
+ * `reset()` -> `MatcherNative.setInput()` copies the *entire input* into native memory on every
+ * call. `Regex.matchAt` builds a fresh Matcher per call, so anchoring one at each candidate cost a
+ * full native UTF-16 copy of the note's content **per `#`** — the same defect that drove the app's
+ * native heap to ~1.9GB on a cold start via the NIP-19 scanner. This one is worse: measured over
+ * 2588 real notes it minted 43,626 Matchers copying 9.6GB in total, with a single 119KB note
+ * costing 279MB, because a whitespace-preceded `#` is far more common in prose than a NIP-19
+ * prefix. The Java `Matcher` object is tiny, so Java-heap-driven GC had no reason to reclaim them
+ * promptly while each pinned native memory.
+ *
+ * [hashtagSearch] is kept as the specification the scan is tested against, not used here.
  */
 fun findHashtags(
     content: String,
@@ -44,19 +68,17 @@ fun findHashtags(
 
     var h = content.indexOf('#')
     while (h >= 0) {
-        if (h == 0 || content[h - 1].isWhitespace()) {
-            val match =
-                try {
-                    hashtagSearch.matchAt(content, if (h == 0) 0 else h - 1)
-                } catch (e: Exception) {
-                    null
-                }
-            if (match != null) {
-                val tag = match.groups[1]?.value
-                if (tag != null && tag.isNotBlank()) {
-                    output.add(tag)
-                }
-                h = content.indexOf('#', match.range.last + 1)
+        // `(?:\s|\A)` — the `#` must open the string or follow one ASCII space character.
+        if (h == 0 || isAsciiRegexSpace(content[h - 1])) {
+            var end = h + 1
+            while (end < content.length && isHashtagChar(content[end])) end++
+            // The tag group is `+`, so it needs at least one character.
+            if (end > h + 1) {
+                val tag = content.substring(h + 1, end)
+                // Non-ASCII whitespace (U+00A0 and friends) is valid tag content to the regex but
+                // still blank to Kotlin, and the old code dropped those too.
+                if (tag.isNotBlank()) output.add(tag)
+                h = content.indexOf('#', end)
                 continue
             }
         }

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip10Notes/content/ContentScanChars.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip10Notes/content/ContentScanChars.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip10Notes.content
+
+/**
+ * `\s` as `java.util.regex` applies it *without* `UNICODE_CHARACTER_CLASS`: space plus the five
+ * control characters `\t \n \x0B \f \r`, which are contiguous at 0x09..0x0D — and nothing else.
+ *
+ * The scanners in this package hand-roll grammars that used to be regexes, so they must use this
+ * rather than [Char.isWhitespace], which is Unicode-aware and would accept U+00A0, U+2003 and
+ * friends that the regexes rejected.
+ */
+internal fun isAsciiRegexSpace(c: Char): Boolean = c == ' ' || c.code in 0x09..0x0D

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip10Notes/content/IndexedTags.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip10Notes/content/IndexedTags.kt
@@ -29,36 +29,36 @@ import com.vitorpamplona.quartz.nip01Core.core.TagArray
 val tagSearch = Regex("(?:\\s|\\A)\\#\\[([0-9]+)\\]")
 
 /**
- * Walks every `#[n]` reference in [content].
+ * Walks every `#[n]` reference in [content], handing each callback the digits between the brackets.
  *
- * [tagSearch] requires `(?:\s|\A)` immediately before the `#`, so every match
- * starts at position 0 or at a whitespace. That lets the scan jump between `#`
- * occurrences with `indexOf` — an intrinsified char search — and apply the regex
- * **anchored** at each, instead of letting `findAll` drive the regex engine from
- * every position in the string.
+ * Jumps between `#` occurrences with `indexOf` — an intrinsified char search — then matches
+ * `#[<digits>]` directly rather than anchoring a regex there.
  *
- * Measured on the production content distribution (median 529 B, tail to 767 KB):
- * ~63 MB/s -> multiple GB/s when the content has no `#`, and ~18x on reference-dense
- * text. Equivalence with the previous `findAll` implementation (both callers) is
- * guarded by `RegexContentBenchmark` in `commons`.
+ * **Why not a regex.** On Android `java.util.regex` is ICU-backed, and `Matcher.region()` ->
+ * `reset()` -> `MatcherNative.setInput()` copies the *entire input* into native memory per call,
+ * so anchoring a fresh Matcher at each candidate cost a full native UTF-16 copy of the content per
+ * `#`. See [findHashtags] for the measurements; this scanner shares the defect but never fires on
+ * real data, since `#[0]` is the legacy citation form that no current client emits.
+ *
+ * [tagSearch] is kept as the specification the scan is tested against, not used here.
  */
 private inline fun forEachIndexTag(
     content: String,
-    action: (MatchResult) -> Unit,
+    action: (digits: String) -> Unit,
 ) {
     var h = content.indexOf('#')
     while (h >= 0) {
-        if (h == 0 || content[h - 1].isWhitespace()) {
-            val match =
-                try {
-                    tagSearch.matchAt(content, if (h == 0) 0 else h - 1)
-                } catch (e: Exception) {
-                    null
+        // `(?:\s|\A)` — the `#` must open the string or follow one ASCII space character.
+        if (h == 0 || isAsciiRegexSpace(content[h - 1])) {
+            if (h + 1 < content.length && content[h + 1] == '[') {
+                var d = h + 2
+                while (d < content.length && content[d] in '0'..'9') d++
+                // `([0-9]+)` needs a digit, and the `]` must actually be there.
+                if (d > h + 2 && d < content.length && content[d] == ']') {
+                    action(content.substring(h + 2, d))
+                    h = content.indexOf('#', d + 1)
+                    continue
                 }
-            if (match != null) {
-                action(match)
-                h = content.indexOf('#', match.range.last + 1)
-                continue
             }
         }
         h = content.indexOf('#', h + 1)
@@ -73,10 +73,11 @@ fun findIndexTagsWithPeople(
     tags: TagArray,
     output: MutableSet<String> = mutableSetOf<String>(),
 ): List<String> {
-    forEachIndexTag(content) { index ->
+    forEachIndexTag(content) { digits ->
         try {
-            val tag = index.groups[1]?.value?.let { tags[it.toInt()] }
-            if (tag != null && tag.size > 1 && tag[0] == "p") {
+            // Out-of-range indexes and non-numeric digits land in the catch below.
+            val tag = tags[digits.toInt()]
+            if (tag.size > 1 && tag[0] == "p") {
                 output.add(tag[1])
             }
         } catch (e: Exception) {
@@ -94,13 +95,14 @@ fun findIndexTagsWithEventsOrAddresses(
     tags: TagArray,
     output: MutableSet<String> = mutableSetOf<String>(),
 ): Set<String> {
-    forEachIndexTag(content) { index ->
+    forEachIndexTag(content) { digits ->
         try {
-            val tag = index.groups[1]?.value?.let { tags[it.toInt()] }
-            if (tag != null && tag.size > 1 && tag[0] == "e") {
+            // Out-of-range indexes and non-numeric digits land in the catch below.
+            val tag = tags[digits.toInt()]
+            if (tag.size > 1 && tag[0] == "e") {
                 output.add(tag[1])
             }
-            if (tag != null && tag.size > 1 && tag[0] == "a") {
+            if (tag.size > 1 && tag[0] == "a") {
                 output.add(tag[1])
             }
         } catch (e: Exception) {

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip10Notes/content/ContentScanRegexEquivalenceTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip10Notes/content/ContentScanRegexEquivalenceTest.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.quartz.nip10Notes.content
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins the ICU-free content scanners to the regexes they replaced.
+ *
+ * [findHashtags] and the `#[n]` walker used to anchor a fresh `Regex.matchAt` at every candidate.
+ * On Android that goes through ICU, where `Matcher.region()` copies the whole input into native
+ * memory per call — over 2588 real notes that was 43,626 Matchers copying 9.6GB, worst single note
+ * 279MB. The scanners now match the grammars directly, so [hashtagSearch] and [tagSearch] survive
+ * only as the specification, and this asserts the two agree.
+ *
+ * The corpus targets where a hand-rolled matcher is most likely to drift: the exact punctuation
+ * set that ends a tag, ASCII-vs-Unicode whitespace before the `#`, non-ASCII inside the tag, and
+ * the `+`/`[0-9]+` minimum-one-character rules.
+ */
+class ContentScanRegexEquivalenceTest {
+    private fun referenceHashtags(content: String): List<String> {
+        if (content.isBlank()) return emptyList()
+        val out = mutableSetOf<String>()
+        hashtagSearch.findAll(content).forEach { m ->
+            val tag = m.groups[1]?.value
+            if (tag != null && tag.isNotBlank()) out.add(tag)
+        }
+        return out.toList()
+    }
+
+    private fun referenceIndexTags(
+        content: String,
+        tags: Array<Array<String>>,
+        wanted: String,
+    ): Set<String> {
+        val out = mutableSetOf<String>()
+        tagSearch.findAll(content).forEach { m ->
+            try {
+                val tag = m.groups[1]?.value?.let { tags[it.toInt()] }
+                if (tag != null && tag.size > 1 && tag[0] == wanted) out.add(tag[1])
+            } catch (e: Exception) {
+            }
+        }
+        return out
+    }
+
+    private val tagArray =
+        arrayOf(
+            arrayOf("p", "pubkey0"),
+            arrayOf("e", "event1"),
+            arrayOf("a", "addr2"),
+            arrayOf("p", "pubkey3"),
+            arrayOf("t", "topic4"),
+        )
+
+    private fun corpus(): List<String> =
+        buildList {
+            add("")
+            add("   ")
+            add("#")
+            add("#tag")
+            add("hello #tag world")
+            add("a#tag")
+            add("#tag#other")
+            add("#tag #other")
+            add("##tag")
+            add("#tag.")
+            add("#tag, and #more!")
+            add("#tag's")
+            add("#tag\"quoted\"")
+            add("#a")
+            add("#1")
+            add("#tag-with-dash")
+            add("#tag_with_underscore")
+            add("#tag~tilde|pipe\\back`tick")
+            // non-ASCII is valid tag content: the regex class and its \s are ASCII-only
+            add("#café")
+            add("#日本語")
+            add("#tagéè")
+            // ASCII vs Unicode whitespace BEFORE the # decides whether it matches at all
+            add("x\u00A0#tag")
+            add("x\u2003#tag")
+            add("x\t#tag")
+            add("x\n#tag")
+            add("x\r#tag")
+            // Unicode whitespace INSIDE the tag is valid to the regex but blank to Kotlin
+            add("#\u00A0")
+            add("#\u00A0x")
+            // every excluded char must terminate the tag
+            for (c in "!@#$%^&*()=+./,[{]};:'\"?><") add("#tag${c}more")
+            for (c in "!@#$%^&*()=+./,[{]};:'\"?><") add("#$c")
+            // index tags
+            add("#[0]")
+            add("#[1] and #[2]")
+            add("look #[3] here")
+            add("#[]")
+            add("#[abc]")
+            add("#[99]")
+            add("#[0")
+            add("#[0]]")
+            add("x#[0]")
+            add("x\u00A0#[0]")
+            add("#[0]#[1]")
+            add("#[00]")
+            // mixed
+            add("#tag #[0] #other #[1]")
+            add("lorem ipsum ".repeat(500) + "#tail")
+            add("#head" + " dolor sit ".repeat(500))
+            add("no hashes at all here ".repeat(200))
+        }
+
+    @Test
+    fun hashtagsMatchRegex() {
+        corpus().forEach { c ->
+            assertEquals(
+                referenceHashtags(c).sorted(),
+                findHashtags(c).sorted(),
+                "findHashtags diverged on: ${c.take(80)}",
+            )
+        }
+    }
+
+    @Test
+    fun indexTagsMatchRegex() {
+        corpus().forEach { c ->
+            assertEquals(
+                referenceIndexTags(c, tagArray, "p").sorted(),
+                findIndexTagsWithPeople(c, tagArray).sorted(),
+                "findIndexTagsWithPeople diverged on: ${c.take(80)}",
+            )
+            val refEv = referenceIndexTags(c, tagArray, "e") + referenceIndexTags(c, tagArray, "a")
+            assertEquals(
+                refEv.sorted(),
+                findIndexTagsWithEventsOrAddresses(c, tagArray).sorted(),
+                "findIndexTagsWithEventsOrAddresses diverged on: ${c.take(80)}",
+            )
+        }
+    }
+
+    @Test
+    fun hashtagsMatchRegexAtEveryOffset() {
+        val filler = "a b\tc\nd  "
+        for (i in 0..filler.length) {
+            val c = filler.substring(0, i) + "#tag" + filler.substring(i)
+            assertEquals(referenceHashtags(c).sorted(), findHashtags(c).sorted(), "offset $i")
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #3944, found while auditing for other instances of the same defect. **Independent of #3944** — this branches off `main` and touches different files.

## The defect

`findHashtags` and `forEachIndexTag` jump between `#` candidates with `indexOf` and then anchor `Regex.matchAt` at each. On Android `java.util.regex` is ICU-backed, and `Matcher.region()` → `reset()` → `MatcherNative.setInput()` copies the **entire input** into native memory on every call. So each candidate cost a full native UTF-16 copy of the note's content.

Same root cause as the NIP-19 scanner in #3944 — but measured over 2588 notes pulled off production relays with `amy fetch`, considerably worse, because a whitespace-preceded `#` is far more common in prose than a NIP-19 prefix:

| scanner | Matchers created | native bytes copied | worst single note |
|---|---|---|---|
| nip19 (fixed in #3944) | 7,871 | 1,752 MB | 62.8 MB |
| **findHashtags** | **43,626** | **9,639 MB** | **279.6 MB** (one 119 KB note) |
| findIndexTags | 0 | 0 MB | — |

Both are reached per ingested event via `BaseNoteEvent.citedUsers()` / `findCitations()`. This is very likely the rest of the "2,541 of 4,573 live Matchers" an earlier SM-T220 heap dump attributed to the NIP-19 regex — the other ~2,000 were these.

## The fix

Both grammars are small, so they're matched directly. `hashtagSearch` and `tagSearch` remain as the specification the scan is tested against.

Two case-handling details worth review, because they cut in opposite directions:

- **Before the `#`**, `(?:\s|\A)` is Java's `\s`, which without `UNICODE_CHARACTER_CLASS` is space plus `0x09..0x0D` and nothing else. So the new `isAsciiRegexSpace` is used rather than `Char.isWhitespace()` — the latter is Unicode-aware and would accept U+00A0 before a `#`, which the regex **rejected**.
- **Inside the tag**, the excluded punctuation class is entirely ASCII, so non-ASCII always *continues* a tag (accented letters, CJK, emoji are valid tag content). A tag made only of U+00A0 is non-empty to the regex but still dropped by `isNotBlank()`, matching the old behaviour.

## Speed

Medians of 5 `RegexContentBenchmark` runs (ns/op, lower better):

| case | bytes | regex | ICU-free | delta | ranges overlap |
|---|---|---|---|---|---|
| hashtags m=1 | 222 | 272 | 235 | −13.6% | yes |
| hashtags m=2 | 698 | 520 | 422 | −18.8% | yes |
| hashtags m=5 | 4050 | 3267 | 1035 | −68.3% | yes |
| hashtags m=40 | 68072 | 56956 | 16033 | −71.9% | yes |
| hashtags m=120 | 767072 | 656535 | 185675 | −71.7% | **no** |
| **hashtags TOTAL** | | 717550 | 203400 | **−71.7%** | |
| idxTags TOTAL | | 112932 | 99937 | −11.5% | |

## Correctness

- New `ContentScanRegexEquivalenceTest` runs **both original regexes** over a corpus covering the punctuation class, ASCII-vs-Unicode whitespace on either side of the `#`, non-ASCII tag content, and the minimum-one-character rules.
- Mutation-tested: dropping `.` from the terminator set, and swapping `isAsciiRegexSpace` for `Char.isWhitespace()`, both fail the new test **and** the pre-existing `ContentScanTest`.
- Against **2588 real production notes**: scanners agree with the regexes on every one, **32,075 hashtags parsed, 0 mismatches**.

## On device (SM-T220, release codegen)

This branch alone does **not** stop the OOM — NIP-19 from #3944 is still the dominant driver on this base, and the native heap still ran to 1342 MB with one lmkd kill. That's expected and worth stating plainly.

With **both** landed (measured on a temporary merge of the two branches), native heap plateaus at **~165 MB** across two cold starts, total RSS falls back to ~550 MB, the process survives past 40 s, and there are **zero lmkd kills**:

```
 t      TOTAL   Dalvik   Native
12.6s    616M     282M     104M
20.4s    878M     473M     154M
30.9s    608M     190M     169M
40.8s    551M     133M     169M
```

## Scope

`findIndexTags` shares the defect but never fires on real data — `#[0]` is the legacy citation form no current client emits — so it's fixed for consistency, not impact. Neither PR addresses the ~190-relay unthrottled connect fan-out that drives ingest volume in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
