### PR TITLE
fix: cache the painter on its first miss in painterRes

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/StringResourceCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/StringResourceCache.kt
@@ -151,21 +151,16 @@ fun painterRes(
     @DrawableRes resourceId: Int,
     sizeReference: Int,
 ): Painter {
-    val cached = iconCache.get(resourceId)
-    if (cached != null) {
-        val composition = cached.get(sizeReference)
-        if (composition != null) {
-            return composition
-        }
-    }
+    val bySize = iconCache.get(resourceId)
+    bySize?.get(sizeReference)?.let { return it }
 
     val loaded = painterResource(resourceId)
 
-    if (cached == null) {
-        iconCache.put(resourceId, LruCache<Int, Painter>(10))
-    } else {
-        cached.put(sizeReference, loaded)
-    }
+    // Store on the FIRST miss as well. This previously created the per-size cache but never
+    // put `loaded` into it, so a resource had to be requested three times before it could
+    // ever hit: once to install the (empty) inner cache, once to populate it, once to read it.
+    val sizes = bySize ?: LruCache<Int, Painter>(10).also { iconCache.put(resourceId, it) }
+    sizes.put(sizeReference, loaded)
 
     return loaded
 }


### PR DESCRIPTION
## The bug

`painterRes` keeps an `LruCache<Int, LruCache<Int, Painter>>` — per-size painters per drawable. On the **first** miss for a resource it installed the inner per-size cache but never put `loaded` into it:

```kotlin
if (cached == null) {
    iconCache.put(resourceId, LruCache<Int, Painter>(10))   // empty; `loaded` dropped
} else {
    cached.put(sizeReference, loaded)
}
```

So a drawable had to be requested **three** times before it could ever hit:

1. install the (empty) inner cache — miss, load, discard
2. inner cache exists but is empty — miss, load, store
3. hit

That's two wasted `painterResource` loads per `(resource, size)` pair.

## The fix

```kotlin
val bySize = iconCache.get(resourceId)
bySize?.get(sizeReference)?.let { return it }

val loaded = painterResource(resourceId)

val sizes = bySize ?: LruCache<Int, Painter>(10).also { iconCache.put(resourceId, it) }
sizes.put(sizeReference, loaded)

return loaded
```

Caches on the first miss, and drops the duplicated lookup. Net −5 lines.

## Scope — this is correctness, not performance

Found while profiling Home↔Notifications tab switching, but it is **not** a measurable win and shouldn't be read as one. Two extra loads per `(resource, size)` pair for the life of the process is nothing beside the GC and lock-contention costs that actually dominate that switch (main thread is ~87% blocked there, mostly on ART/GC internal locks).

## Testing

- `:amethyst:testPlayDebugUnitTest` — **1282 tests, 0 failures**
- compile + static analysis clean

**No new unit test, deliberately.** `painterRes` is `@Composable`, and this module has neither Robolectric nor `compose-ui-test`. On top of that `unitTests.isReturnDefaultValues = true` makes `android.util.LruCache` a no-op on the JVM, so a naive test would pass against a cache that never stores anything. Covering it would need either new test dependencies or a global `android/util/LruCache` stub in the test source set, which would change behaviour under the other 154 test files — disproportionate for a three-line fix. Verified by inspection instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
