### PR TITLE
perf: memoize guestbook envelope opens so the Concord fold stops re-decrypting the buffer

### DIFF
--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/actions/ConcordActions.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/actions/ConcordActions.kt
@@ -560,11 +560,27 @@ object ConcordActions {
     fun guestbookMembers(
         wraps: List<Event>,
         guestbook: GroupKey,
-    ): Set<HexKey> {
+    ): Set<HexKey> = projectGuestbook(wraps.mapNotNull { guestbookEntry(it, guestbook) })
+
+    /**
+     * Opens a single guestbook [wrap] into its entry, or null when it doesn't belong to
+     * [guestbook] or isn't a guestbook rumor.
+     *
+     * Split out of [guestbookMembers] so a caller holding a growing wrap buffer can memoize the
+     * open per wrap id: opening is the expensive half (two NIP-44 decrypts plus the wrap and seal
+     * signature verifies), while [projectGuestbook] over the already-opened entries is trivial.
+     * Re-projecting a buffer of n wraps on every arrival without that memo is quadratic in
+     * decryptions — see [ConcordCommunitySession]'s guestbook cache.
+     */
+    fun guestbookEntry(
+        wrap: Event,
+        guestbook: GroupKey,
+    ): GuestbookEntry? = ConcordStreamEnvelope.openOrNull(wrap, guestbook)?.rumor?.let { Guestbook.parse(it) }
+
+    /** Last-writer-wins projection of already-opened [entries] down to the JOINed member set. */
+    fun projectGuestbook(entries: Collection<GuestbookEntry>): Set<HexKey> {
         val latest = HashMap<HexKey, GuestbookEntry>()
-        for (wrap in wraps) {
-            val rumor = ConcordStreamEnvelope.openOrNull(wrap, guestbook)?.rumor ?: continue
-            val entry = Guestbook.parse(rumor) ?: continue
+        for (entry in entries) {
             val prev = latest[entry.member.lowercase()]
             if (prev == null || entry.createdAt > prev.createdAt) latest[entry.member.lowercase()] = entry
         }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/concord/ConcordCommunitySession.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/concord/ConcordCommunitySession.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.amethyst.commons.util.KmpLock
 import com.vitorpamplona.amethyst.commons.util.withLock
 import com.vitorpamplona.quartz.concord.cord02Community.ConcordCommunityListEntry
 import com.vitorpamplona.quartz.concord.cord02Community.ConcordCommunityState
+import com.vitorpamplona.quartz.concord.cord02Community.GuestbookEntry
 import com.vitorpamplona.quartz.concord.cord03Channels.ChannelChat
 import com.vitorpamplona.quartz.concord.cord04Roles.ControlEdition
 import com.vitorpamplona.quartz.concord.cord04Roles.EditionFold
@@ -192,6 +193,26 @@ class ConcordCommunitySession(
      * lifetime exactly and needs no separate eviction.
      */
     private val editionByWrapId = HashMap<HexKey, ControlEdition?>()
+
+    /**
+     * Guestbook wraps opened into entries, memoized by wrap id — the guestbook analogue of
+     * [editionByWrapId]. [refoldGuestbook] runs on *every* arriving guestbook wrap and re-projects
+     * the whole buffer, so without this the nth arrival re-opens all n wraps and a boot costs
+     * O(n^2) envelope opens (each = two NIP-44 decrypts + two signature verifies). Measured on a
+     * cold start: 6,229 opens over 448 distinct wraps, ~all of the app's NIP-44 traffic.
+     *
+     * Safe to key on wrap id alone: [guestbookKey] is derived once at construction from the
+     * session's epoch and never rotates in place (a rekey builds a new session).
+     */
+    private val guestbookEntryByWrapId = HashMap<HexKey, GuestbookEntry?>()
+
+    /**
+     * Envelope opens [refoldGuestbook] actually performed (cache misses). Exposed so a test can
+     * assert the fold stays linear in arrivals; a regression to re-opening the buffer shows up here
+     * as O(n^2) long before it shows up as a slow boot.
+     */
+    internal var guestbookOpens = 0
+        private set
 
     // Prior-epoch Control Plane address -> (wrapId -> wrap). Kept apart from [controlWraps]: these
     // never join the live fold, they only produce the anti-rollback floor.
@@ -607,8 +628,16 @@ class ConcordCommunitySession(
 
     private fun refoldGuestbook() {
         lock.withLock {
-            val wraps = guestbookWraps.values.toList()
-            _members.value = ConcordActions.guestbookMembers(wraps, guestbookKey)
+            val entries =
+                guestbookWraps.values.mapNotNull { wrap ->
+                    if (guestbookEntryByWrapId.containsKey(wrap.id)) {
+                        guestbookEntryByWrapId[wrap.id]
+                    } else {
+                        guestbookOpens++
+                        ConcordActions.guestbookEntry(wrap, guestbookKey).also { guestbookEntryByWrapId[wrap.id] = it }
+                    }
+                }
+            _members.value = ConcordActions.projectGuestbook(entries)
         }
     }
 

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/concord/ConcordGuestbookFoldTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/model/concord/ConcordGuestbookFoldTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.model.concord
+
+import com.vitorpamplona.amethyst.commons.actions.ConcordActions
+import com.vitorpamplona.quartz.concord.cord02Community.ConcordCommunityFactory
+import com.vitorpamplona.quartz.concord.cord02Community.ConcordCommunityListEntry
+import com.vitorpamplona.quartz.nip01Core.core.toHexKey
+import com.vitorpamplona.quartz.nip01Core.crypto.KeyPair
+import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerInternal
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The guestbook re-folds on every arriving wrap, so opening the buffer each time is quadratic in
+ * NIP-44 decrypts (plus two signature verifies apiece). A cold start measured 6,229 envelope opens
+ * over 448 distinct wraps — ~13x redundant, and effectively all of the app's NIP-44 traffic.
+ */
+class ConcordGuestbookFoldTest {
+    private val owner = NostrSignerInternal(KeyPair())
+
+    @Test
+    fun opensEachGuestbookWrapOnceAcrossSequentialArrivals() =
+        runTest {
+            val community = ConcordCommunityFactory.create(owner, "Nostrichs", createdAt = 1L, relays = listOf("wss://r.example"))
+            val entry =
+                ConcordCommunityListEntry(
+                    id = community.communityIdHex,
+                    owner = community.ownerPubKey,
+                    ownerSalt = community.ownerSalt.toHexKey(),
+                    root = community.communityRoot.toHexKey(),
+                    rootEpoch = community.rootEpoch,
+                    controlPk = community.controlPkHex,
+                    controlRoot = community.controlRoot.toHexKey(),
+                    relays = listOf("wss://r.example"),
+                    name = "Nostrichs",
+                )
+            val session = ConcordCommunitySession(entry, owner.pubKey) { _, _, _, _ -> }
+            community.genesisWraps.forEach { session.ingest(it) }
+
+            val guestbook = ConcordActions.guestbookPlane(community.communityRoot, community.communityId, community.rootEpoch)
+            val members = List(12) { NostrSignerInternal(KeyPair()) }
+            val joins = members.mapIndexed { i, m -> ConcordActions.buildGuestbookJoin(m, guestbook, createdAt = 2L + i) }
+
+            // Arrivals land one at a time, exactly as the relay delivers them.
+            joins.forEach { session.ingest(it) }
+
+            // Linear, not 12*13/2 = 78.
+            assertEquals(joins.size, session.guestbookOpens, "guestbook wraps were re-decrypted on later folds")
+            assertEquals(members.mapTo(HashSet()) { it.pubKey.lowercase() }, session.members.value)
+
+            // A duplicate delivery re-folds nothing and opens nothing.
+            session.ingest(joins.first())
+            assertEquals(joins.size, session.guestbookOpens)
+            assertEquals(members.mapTo(HashSet()) { it.pubKey.lowercase() }, session.members.value)
+        }
+}


### PR DESCRIPTION
## What

`ConcordCommunitySession.refoldGuestbook()` re-projected the **entire** guestbook wrap buffer on **every** arriving guestbook wrap — and projecting means opening each envelope from scratch: two NIP-44 decrypts plus the wrap and seal signature verifies. So the nth arrival re-opened all n wraps, making a boot quadratic in decryptions.

The Control Plane already avoids exactly this via `editionByWrapId` (*"a wrap is only ever decrypted once no matter how many folds it participates in"*). The guestbook had no equivalent. This adds one, keyed on wrap id — safe because `guestbookKey` is derived once at construction from the session's epoch and never rotates in place (a rekey builds a new session).

## Measurement

Counted at `Nip44v2.decrypt(EncryptedInfo, key)` — the choke point every NIP-44 caller funnels through, so nothing escapes the count. Emulator cold start, real account, Soapbox Community (12 channels), 90 s window:

| | decrypts | bytes | envelope opens | distinct wraps | redundancy |
|---|---|---|---|---|---|
| before | 12,281 | 7,516 KB | 6,229 | 448 | **13x** |
| after | **724** | **705 KB** | 449 | 447 | 1x |

**94% fewer NIP-44 decrypts for the same set of envelopes**, and each avoided open also skips two signature verifies that don't even appear in those counters.

Worth noting what the same instrumentation ruled out — this was effectively *all* of the app's boot-time NIP-44 traffic:

- giftwrap / NIP-17 DMs (`GiftWrapEvent`, `SealedRumorEvent`): **0 calls**
- NIP-51 private-list "settings" (`PrivateTagsInContent`): **10 calls / 3 KB**

The `ChaCha20Core` samples in the ingest profile were Concord refolding, not DMs and not settings.

## Shape of the change

`guestbookMembers(wraps, key)` keeps its signature for existing callers (CLI, tests) and is now the composition of the two halves it was split into:

- `guestbookEntry(wrap, key)` — the expensive open
- `projectGuestbook(entries)` — the trivial last-writer-wins fold

## Testing

- New `ConcordGuestbookFoldTest` asserts the fold stays **linear** in arrivals (12 sequential arrivals → 12 opens, not 78) and that the member set is unchanged, including on a duplicate delivery. Mutation-tested: reverting the memo makes it fail.
- `:commons:jvmTest` 1,565 tests and `:quartz:jvmTest` 4,295 tests green.
- **On device** (emulator, real account): community still folds all 12 channels with unread counts, and the Members roster renders Owner / Admins / Moderators plus the plain guestbook members.

🤖 Generated with [Claude Code](https://claude.com/claude-code)