### PR TITLE
fix: give the invite roster line's member count its unit

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/ChannelInvite.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/ChannelInvite.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -315,12 +316,17 @@ private fun ChannelRosterLine(
             }
         }
 
+        // "24 members · relay.host". The count carries its unit through the same plural every other
+        // group surface uses (the workspace channel list, discovery, the parent picker), because a bare
+        // number sitting immediately after the faces reads as counting the faces — "3 people you
+        // follow" — which is the one thing it does not mean.
+        val host = channel.groupId.relayUrl.displayUrl()
         Text(
             text =
                 if (memberCount > 0) {
-                    "$memberCount · " + channel.groupId.relayUrl.displayUrl()
+                    pluralStringResource(R.plurals.relay_group_member_count, memberCount, memberCount) + " · " + host
                 } else {
-                    channel.groupId.relayUrl.displayUrl()
+                    host
                 },
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.placeholderText,


### PR DESCRIPTION
The channel-invite card's roster line read `5 · 10.0.2.2:7447`. Sitting immediately after the avatars of people you follow who are in the channel, a bare number reads as counting *those faces* — "5 people you follow" — which is the one thing it does not mean.

It now uses the same `relay_group_member_count` plural every other group surface uses (the workspace channel list, discovery, the parent picker), so the same channel reads the same way wherever it appears, and the singular falls out of the plural:

| roster | before | after |
|---|---|---|
| Design Guild, 5 members, 1 followed | `5 · 10.0.2.2:7447` | `5 members · 10.0.2.2:7447` |
| Just Us, 1 member | `1 · 10.0.2.2:7447` | `1 member · 10.0.2.2:7447` |

The faces stay unlabelled: they are already the visual answer to "is anyone I know in here", and a second "N people you follow" clause would restate them while pushing a one-line row toward truncation on real relay hostnames.

Verified on an emulator against a local Buzz workspace relay — both the plural and singular cases above are the rendered result, not a mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)