### PR TITLE
fix: collect buzzWorkspaces instead of reading .value in composition

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/ChannelInvite.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/types/ChannelInvite.kt
@@ -98,7 +98,12 @@ fun RenderChannelInvite(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    val workspaces = accountViewModel.account.buzzWorkspaces.flow.value
+    // Collected, not read as .value: the workspace set arrives asynchronously (a 13534 roster landing
+    // after this row is first drawn), and a plain .value read is a one-shot snapshot that never
+    // recomposes — so an invite drawn before its workspace was known would stay blank. This is what
+    // Compose's StateFlowValueCalledInComposition lint flags.
+    val workspaces by accountViewModel.account.buzzWorkspaces.flow
+        .collectAsStateWithLifecycle()
     val notice = remember(note, workspaces) { note.toMembershipNotice(workspaces) } ?: return
     // A withdrawn membership is not an invite. The projection already excludes these before a card is
     // built; re-checked here because this renderer is reachable from any NoteCompose over a 44100.

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChatroomHeaderCompose.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/rooms/ChatroomHeaderCompose.kt
@@ -644,7 +644,11 @@ private fun ChannelInviteRoomCompose(
     accountViewModel: AccountViewModel,
     nav: INav,
 ) {
-    val workspaces = accountViewModel.account.buzzWorkspaces.flow.value
+    // Collected rather than read as .value, for the same reason as RenderChannelInvite: the workspace
+    // set lands asynchronously, and a snapshot read never recomposes, so a row drawn before its
+    // workspace was known would never appear.
+    val workspaces by accountViewModel.account.buzzWorkspaces.flow
+        .collectAsStateWithLifecycle()
     val notice = remember(inviteNote, workspaces) { inviteNote.toMembershipNotice(workspaces) } ?: return
     val baseChannel =
         remember(notice) { LocalCache.getOrCreateRelayGroupChannel(GroupId(notice.channelId, notice.relay)) }


### PR DESCRIPTION
## Summary

`StateFlowValueCalledInComposition` is an **error** for lint here, so `:amethyst:lintFdroidBenchmark` aborts and takes `test-and-build-android` down with it. This is currently failing on `main`, which means every open PR inherits a red Android job regardless of its own contents.

Two `@Composable`s read the Buzz workspace set as a snapshot:

```kotlin
val workspaces = accountViewModel.account.buzzWorkspaces.flow.value
```

- `ChannelInvite.kt:101` — `RenderChannelInvite`
- `ChatroomHeaderCompose.kt:647` — `ChannelInviteRoomCompose`

Both now collect it instead.

## Why this is a real bug, not just a lint preference

The workspace set is populated asynchronously — the kind-13534 roster can land *after* the row is first drawn. A `.value` read subscribes to nothing, so the composable never recomposes when it arrives. Both call sites feed the result straight into `toMembershipNotice(workspaces)`, which returns `null` for an unknown workspace, and both then `?: return`. So an invite drawn before its workspace was known does not render a stale row — it renders **no row at all**, permanently. Collecting fixes the staleness as well as the lint.

## Notes

- Both files already imported `collectAsStateWithLifecycle` and `getValue`; it is also what the surrounding code uses (42 of 43 collections under `ui/note/types`).
- The other `buzzWorkspaces.flow.value` reads — `BuzzDmListViewModel`, `BuzzDmDiscovery`, `BuzzMembershipEoseManager` — are ViewModel/service code, not composition, and are correct as they are.
- CI only ever reported the **first** of the two: lint prints `First failure` and stops, so `ChatroomHeaderCompose` stayed invisible in the log until `ChannelInvite` was fixed. Worth knowing if this rule trips again — the reported count (`Lint found 2 errors`) is the number to trust, not the number of locations printed.

## Test plan

- [x] `./gradlew :amethyst:lintFdroidBenchmark` — was `Lint found 2 errors` on `main`, now `BUILD SUCCESSFUL` with 0 errors
- [x] `./gradlew spotlessApply` clean; pre-commit static analysis passes
- [ ] CI `test-and-build-android` green (this is the job the fix exists to unblock)

## Interop suites

- [x] N/A — UI-layer state read, no wire or protocol change

🤖 Generated with [Claude Code](https://claude.com/claude-code)