### PR TITLE
feat(quartz): index trusted-list labels for NIP-50 search

### DIFF
--- a/.claude/skills/searchable-events/references/searchable-kinds.md
+++ b/.claude/skills/searchable-events/references/searchable-kinds.md
@@ -2,9 +2,9 @@
 
 Every concrete `SearchableEvent` implementor in Quartz, with the exact `indexableContent()`
 expression. **Update this file in the same PR as any change to the searchable set or to an
-`indexableContent()` body** (see SKILL.md). Verified against the code 2026-08-04.
+`indexableContent()` body** (see SKILL.md). Verified against the code 2026-08-04; kinds 30392-30395 added 2026-08-20.
 
-Counts: 126 concrete classes covering 129 kind values (`GitStatusEvent` spans 4 kinds;
+Counts: 130 concrete classes covering 133 kind values (`GitStatusEvent` spans 4 kinds;
 kind 30063 has a collision — see the footnote). File paths are under
 `quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/`.
 
@@ -100,6 +100,10 @@ Separator legend: **NL** = `joinToString("\n")`, **SP** = `joinToString(" ")`.
 | 30313 | MeetingRoomEvent | nip53LiveActivities/meetingSpaces | `listOfNotNull(title(), summary())` NL |
 | 30315 | StatusEvent | nip38UserStatus | `content` |
 | 30382 | ContactCardEvent | nip85TrustedAssertions/users | `(listOfNotNull(petName(), summary()) + topics())` NL — public tags only, never the NIP-44 content |
+| 30392 | UserTrustedListEvent | experimental/trustedLists/users | inherited `TrustedListEvent`: `listOfNotNull(title(), sourceTag()?.slug)` NL — labels only; the membership JSON in `content` is never indexed |
+| 30393 | EventTrustedListEvent | experimental/trustedLists/events | inherited `TrustedListEvent` (same as 30392) |
+| 30394 | AddressableTrustedListEvent | experimental/trustedLists/addressables | inherited `TrustedListEvent` (same as 30392) |
+| 30395 | ExternalIdTrustedListEvent | experimental/trustedLists/externalIds | inherited `TrustedListEvent` (same as 30392) |
 | 30402 | ClassifiedsEvent | nip99Classifieds | `listOfNotNull(title(), summary(), content)` NL |
 | 30617 | GitRepositoryEvent | nip34Git/repository | `listOfNotNull(name(), description(), content)` NL |
 | 30620 | WorkflowDefEvent | buzz/workflow | `listOfNotNull(name(), content)` NL |

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/trustedLists/README.md
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/trustedLists/README.md
@@ -80,6 +80,15 @@ build the member objects — these lists run to thousands of entries.
 - `content` is an optional JSON echo of the members with their computed values
   (`contentEcho()` → `TrustedListContent`).
 
+## Search
+
+All four kinds are `SearchableEvent`. Only the two human-written fields are
+indexed — the `title` and the `source-tag` slug (`"Podcaster\npodcaster"`).
+Everything else is machine data and stays out: `content` is the membership
+JSON (pubkeys, ids and counts), `d` embeds hex fragments, and `metric` is a
+constant across every list one publisher emits, so indexing it would only add
+generic tokens like `tag` and `membership` to every document in the family.
+
 ## Completeness and retraction
 
 A list an integrator relies on must be complete, or say that it isn't. The

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/trustedLists/TrustedListEvent.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/experimental/trustedLists/TrustedListEvent.kt
@@ -27,6 +27,7 @@ import com.vitorpamplona.quartz.nip01Core.core.BaseAddressableEvent
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
 import com.vitorpamplona.quartz.nip01Core.core.Tag
 import com.vitorpamplona.quartz.nip01Core.core.TagArray
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 
 /**
  * Base of the Tapestry Trusted List family: an addressable event that
@@ -58,7 +59,20 @@ abstract class TrustedListEvent(
     tags: TagArray,
     content: String,
     sig: HexKey,
-) : BaseAddressableEvent(id, pubKey, createdAt, kind, tags, content, sig) {
+) : BaseAddressableEvent(id, pubKey, createdAt, kind, tags, content, sig),
+    SearchableEvent {
+    /**
+     * Only the two fields a human wrote: the list's label and the slug of the
+     * tag its membership was computed from ("Podcaster" / "podcaster").
+     *
+     * Everything else on these events is machine data. `content` is the JSON
+     * echo of the membership -- pubkeys, ids and counts -- so it is never
+     * indexed; neither is `d`, which embeds hex fragments, nor `metric`, whose
+     * value is a constant across every list one publisher emits and would only
+     * add generic tokens to the index.
+     */
+    override fun indexableContent() = listOfNotNull(title(), sourceTag()?.slug).joinToString("\n")
+
     /** The addressable identity of this list. Deterministic per list. */
     fun listId() = dTag()
 

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/experimental/trustedLists/TrustedListEventTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/experimental/trustedLists/TrustedListEventTest.kt
@@ -29,6 +29,7 @@ import com.vitorpamplona.quartz.experimental.trustedLists.tags.ListStatus
 import com.vitorpamplona.quartz.experimental.trustedLists.users.UserTrustedListEvent
 import com.vitorpamplona.quartz.experimental.trustedLists.users.tags.PubKeyMemberTag
 import com.vitorpamplona.quartz.nip01Core.core.Event
+import com.vitorpamplona.quartz.nip50Search.SearchableEvent
 import com.vitorpamplona.quartz.utils.EventFactory
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -395,6 +396,59 @@ class TrustedListEventTest {
         assertEquals(event.members().size, event.memberCount())
         assertEquals(event.members().map { it.memberValue }, event.memberValues())
         assertEquals(1, event.memberCount(), "only the well-formed p tag is a member")
+    }
+
+    @Test
+    fun indexesOnlyTheHumanWrittenFields() {
+        val event = podcasterList()
+        assertIs<UserTrustedListEvent>(event)
+
+        assertEquals("Podcaster\npodcaster", event.indexableContent())
+    }
+
+    @Test
+    fun theMembershipJsonNeverReachesTheIndex() {
+        val event = podcasterList()
+        assertIs<UserTrustedListEvent>(event)
+
+        val indexed = event.indexableContent()
+        assertFalse(indexed.contains("b83a28b7"), "member pubkeys must not be indexed: $indexed")
+        assertFalse(indexed.contains("endorsements"), "the content echo must not be indexed: $indexed")
+        assertFalse(indexed.contains("pinned-tag-membership"), "the metric is a machine id: $indexed")
+        assertFalse(indexed.contains("tl-pin"), "the d tag embeds hex fragments: $indexed")
+        assertFalse(indexed.contains(observer), "the observer is a pubkey: $indexed")
+    }
+
+    @Test
+    fun indexingIsSafeOnAListWithNoHumanFields() {
+        // FullTextSearchModule probes kinds by constructing an empty event and
+        // reindex runs over whatever is already stored, so this must not throw
+        val event =
+            EventFactory.create<Event>(
+                id = "00".repeat(32),
+                pubKey = "a68dbf561cfe3da1b76f1e65c7d4d9cc116f79921b38a815fd75cb5460b4b599",
+                createdAt = 1_787_253_028L,
+                kind = ExternalIdTrustedListEvent.KIND,
+                tags = arrayOf(arrayOf("d", "tl")),
+                content = "",
+                sig = dummySig,
+            )
+        assertIs<ExternalIdTrustedListEvent>(event)
+
+        assertEquals("", event.indexableContent())
+    }
+
+    @Test
+    fun everyKindInTheFamilyIsSearchable() {
+        listOf(
+            UserTrustedListEvent.KIND,
+            EventTrustedListEvent.KIND,
+            AddressableTrustedListEvent.KIND,
+            ExternalIdTrustedListEvent.KIND,
+        ).forEach { kind ->
+            val probe = EventFactory.create<Event>("0", "0", 0L, kind, emptyArray(), "", "")
+            assertIs<SearchableEvent>(probe, "kind $kind must be searchable")
+        }
     }
 
     @Test

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/SearchTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip01Core/store/sqlite/SearchTest.kt
@@ -20,6 +20,13 @@
  */
 package com.vitorpamplona.quartz.nip01Core.store.sqlite
 
+import com.vitorpamplona.quartz.experimental.trustedLists.TrustedListContent
+import com.vitorpamplona.quartz.experimental.trustedLists.TrustedListContentMember
+import com.vitorpamplona.quartz.experimental.trustedLists.metric
+import com.vitorpamplona.quartz.experimental.trustedLists.sourceTag
+import com.vitorpamplona.quartz.experimental.trustedLists.title
+import com.vitorpamplona.quartz.experimental.trustedLists.users.UserTrustedListEvent
+import com.vitorpamplona.quartz.experimental.trustedLists.users.tags.PubKeyMemberTag
 import com.vitorpamplona.quartz.nip01Core.metadata.MetadataEvent
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
 import com.vitorpamplona.quartz.nip01Core.signers.NostrSignerSync
@@ -360,5 +367,38 @@ class SearchTest : BaseDBTest() {
             db.assertQuery(chan, Filter(search = "uniqchan")) // name
             db.assertQuery(chan, Filter(search = "uniqtopic")) // about
             db.assertQuery(chan, Filter(search = "uniqpic")) // picture URL
+        }
+
+    @Test
+    fun testTrustedListIndexesItsLabelsAndNothingElse() =
+        forEachDB { db ->
+            val memberKey = "b83a28b7e4e5d20bd960c5faeb6625f95529166b8bdb045d42634a2f35919450"
+            val list =
+                signer.sign(
+                    UserTrustedListEvent.build(
+                        listId = "tl-pin-2efaa715-e5272de9-uniqslug",
+                        members = listOf(PubKeyMemberTag(memberKey, score = 99)),
+                        content =
+                            TrustedListContent(
+                                members = listOf(TrustedListContentMember(pubkey = memberKey, endorsements = 4, score = 99)),
+                            ).toContent(),
+                    ) {
+                        title("Uniqpodcaster")
+                        metric("pinned-tag-membership")
+                        sourceTag("2f".repeat(32), "e5".repeat(32), "uniqslug")
+                    },
+                )
+            db.store.insertEvent(list)
+
+            // the human-written fields
+            db.assertQuery(list, Filter(search = "uniqpodcaster")) // title
+            db.assertQuery(list, Filter(search = "uniqslug")) // source-tag slug
+
+            // the machine fields must stay out of the index: the content echo
+            // is membership JSON, and the metric is a constant across every
+            // list one publisher emits
+            db.assertQuery(null, Filter(search = "endorsements"))
+            db.assertQuery(null, Filter(search = "membership"))
+            db.assertQuery(null, Filter(search = memberKey))
         }
 }


### PR DESCRIPTION
> **Stacked on #3959.** Base is `claude/quartz-trusted-list-1wggln`, not `main` — the
> Trusted List kinds this indexes don't exist on `main` yet. GitHub will retarget this to
> `main` automatically once #3959 merges. Review #3959 first; the diff here is 5 files.

## Summary

Makes the Trusted List family (kinds 30392–30395) searchable over NIP-50. `TrustedListEvent`
implements `SearchableEvent`, so all four kinds inherit it, and indexes the two fields a human
actually wrote: the list's `title` and the slug of the `source-tag` its membership was computed
from — `"Podcaster\npodcaster"` for the reference pinned-tag list.

```kotlin
override fun indexableContent() = listOfNotNull(title(), sourceTag()?.slug).joinToString("\n")
```

Everything else on these events is machine data and is deliberately kept out of the index:

- **`content`** is the JSON echo of the membership, so indexing it would put every member's
  pubkey and the literal words `endorsements`/`disputes` into FTS. This is exactly the case the
  `SearchableEvent` contract singles out for JSON-content kinds — parse and index the extracted
  fields, never the raw JSON. Here the parse yields no natural-language text at all, so nothing
  from `content` is indexed.
- **`d`** embeds hex fragments (`tl-pin-2efaa715-e5272de9-podcaster`).
- **`metric`** is a constant across every list one publisher emits, so it carries no
  discriminating power inside the family while adding generic tokens like `tag` and `membership`
  to every document in it. A `#metric` tag filter does that job without touching FTS. This one is
  a judgment call — say the word and it's a one-line change.

Also updates `references/searchable-kinds.md` (4 rows; counts 126/129 → 130/133), which the
searchable-events maintenance rule requires in the same PR because external search engines mirror
that table at version bumps.

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted, no reformats produced
- [x] Ran `./gradlew :quartz:jvmTest` — full quartz suite green (588 test classes)
- [x] Manually exercised the change — see below

Verified at both levels, since a unit test on `indexableContent()` alone would not prove the
store actually indexes it.

**Unit (`TrustedListEventTest`, 20 → 24 tests)** — asserts the exact extracted text
(`"Podcaster\npodcaster"`); negative assertions that member pubkeys, `endorsements`, the metric,
the `d` tag and the observer never appear; that a list with no human fields yields `""` rather
than throwing (both `reindexFullTextSearch` and `FullTextSearchModule`'s kind probe depend on
that); and that all four kinds resolve to `SearchableEvent` through `EventFactory`.

**Store (`SearchTest.testTrustedListIndexesItsLabelsAndNothingElse`, 10 → 11 tests)** — inserts a
signed list through SQLite FTS and queries it end to end:

```kotlin
db.assertQuery(list, Filter(search = "uniqpodcaster"))  // title
db.assertQuery(list, Filter(search = "uniqslug"))       // source-tag slug
db.assertQuery(null, Filter(search = "endorsements"))   // content echo stays out
db.assertQuery(null, Filter(search = "membership"))     // metric stays out
db.assertQuery(null, Filter(search = memberKey))        // member pubkeys stay out
```

```
> Task :quartz:jvmTest
BUILD SUCCESSFUL in 4m 26s
```

Flavour builds skipped deliberately: this is a pure `quartz/` change with no UI, no Android
dependency and no manifest impact, which `CONTRIBUTING-WITH-AI.md` § Build and install both
flavours explicitly allows ("If a change is conclusively flavour-irrelevant (a pure `quartz/`
protocol fix, a docs change, a translation), one flavour is enough — say which and why").

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

This changes only what text goes into the local full-text index. No event is built, parsed
differently, or published differently — `indexableContent()` is read by the stores, never by the
wire codec.

## Operational note

Existing stores do not reindex themselves. Any 30392–30395 event already persisted before this
change keeps its missing FTS row until `IEventStore.reindexFullTextSearch()` runs. For an
unreleased kind family that should be nothing, so nothing is scheduled app-side here — flagging
it in case these events are already flowing into a store you run.

## AI assistance

- [x] Drafted with AI assistance, manually reviewed and tested

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code
      I did not author personally carries its original license header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011f6dt4Zo3g8TAayhCU4tTD

---
_Generated by [Claude Code](https://claude.ai/code/session_011f6dt4Zo3g8TAayhCU4tTD)_