### PR TITLE
docs(homebrew): sync the reference cask to what actually merged upstream

### DIFF
--- a/desktopApp/packaging/homebrew/amethyst-nostr.rb
+++ b/desktopApp/packaging/homebrew/amethyst-nostr.rb
@@ -1,20 +1,49 @@
 # Reference Homebrew Cask for the Amethyst desktop app.
 #
-# This file is NOT consumed by any build in this repo. Submit it to
-# Homebrew/homebrew-cask (as `Casks/a/amethyst-nostr.rb`) or drop it into a
-# personal tap (`Casks/amethyst-nostr.rb`) for an instant
-# `brew install --cask <tap>/amethyst-nostr`.
+# THIS IS A MIRROR. The live cask is Homebrew/homebrew-cask
+# `Casks/a/amethyst-nostr.rb` (merged 2026-08-24). Keep this file byte-identical
+# to it below the header, so a diff against upstream is meaningful. Note that
+# `scripts/bump-homebrew-cask.sh` bumps upstream via `brew bump-cask-pr`, which
+# edits the upstream cask in place — it only reads version + sha256 from here,
+# so this file is documentation, not the thing that ships.
 #
 # The release matrix (.github/workflows/create-release.yml) builds an
 # Apple-Silicon DMG only (no Intel DMG), so this cask is arm64-only.
 #
-# version + sha256 below track the published
-# `amethyst-desktop-<version>-macos-arm64.dmg`. Once the cask exists upstream,
-# bump-homebrew.yml keeps the live copy current on each stable release. To
-# refresh this reference by hand:
+# version + sha256 track the published
+# `amethyst-desktop-<version>-macos-arm64.dmg`; bump-homebrew.yml keeps them
+# current on each stable release. To refresh by hand:
 #   curl -fsSL -o amethyst.dmg \
 #     https://github.com/vitorpamplona/amethyst/releases/download/vX.Y.Z/amethyst-desktop-X.Y.Z-macos-arm64.dmg
 #   shasum -a 256 amethyst.dmg
+#
+# ---------------------------------------------------------------------------
+# Why the cask body is this bare (review feedback on homebrew-cask#282745)
+# ---------------------------------------------------------------------------
+# The submitted version carried a `livecheck` block and two explanatory
+# comments. A maintainer removed all three. Do not add them back:
+#
+#   * `livecheck do url :url; strategy :github_latest end` — redundant.
+#     Homebrew infers the strategy from a GitHub release URL. Verified that
+#     `brew audit --new --cask` and `brew style` both still pass without it.
+#   * Inline comments — homebrew-cask house style is terse. The rationale
+#     lives here instead, where it is useful to us and invisible upstream.
+#
+# `conflicts_with cask: "amethyst"` is NOT optional: the unrelated tiling
+# window manager (cask `amethyst`, ianyh/Amethyst) installs its own
+# `Amethyst.app`, so the two cannot coexist in /Applications.
+#
+# The `zap` paths were verified against application source, not docs:
+#   ~/.amethyst                            AccountManager.kt -> File(homeDir, ".amethyst")
+#                                          (accounts + KEYS — destructive)
+#   ~/Library/Application Support/Amethyst DesktopTorManager.kt -> ".../Amethyst/tor"
+#   ~/Library/Caches/AmethystDesktop       DesktopImageLoaderSetup.kt -> cacheDir()
+#                                          (its macOS branch is ~/Library/Caches)
+#
+# Deliberately NOT zapped: ~/Library/Preferences/com.apple.java.util.prefs.plist.
+# The app uses the Java Preferences API (auth approvals, Namecoin settings),
+# which writes into that single SHARED plist — deleting it would wipe every
+# other Java application's preferences too.
 cask "amethyst-nostr" do
   version "1.14.0"
   sha256 "84a1bdaf3577ed7375ab65c48358efd3c609fa47b504de61f4e8fc436f6b3436"
@@ -24,27 +53,12 @@ cask "amethyst-nostr" do
   desc "Nostr client"
   homepage "https://github.com/vitorpamplona/amethyst"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
-  # The unrelated tiling window manager (cask `amethyst`, ianyh/Amethyst) also
-  # installs `Amethyst.app`, so the two cannot coexist in /Applications.
   conflicts_with cask: "amethyst"
   depends_on arch: :arm64
   depends_on :macos
 
   app "Amethyst.app"
 
-  # Verified against the source, not the docs:
-  #   ~/.amethyst                            DesktopAccountStorage (accounts + keys)
-  #   ~/Library/Application Support/Amethyst DesktopTorManager (tor/)
-  #   ~/Library/Caches/AmethystDesktop       Coil image cache
-  #
-  # Deliberately NOT zapped: ~/Library/Preferences/com.apple.java.util.prefs.plist.
-  # The app uses the Java Preferences API, which writes to that single SHARED
-  # plist — deleting it would wipe every other Java app's preferences too.
   zap trash: [
     "~/.amethyst",
     "~/Library/Application Support/Amethyst",


### PR DESCRIPTION
The `amethyst-nostr` cask [merged into Homebrew/homebrew-cask](https://github.com/Homebrew/homebrew-cask/pull/282745) on 2026-08-24 and is live — `brew install --cask amethyst-nostr` now works. During review a maintainer removed three things this reference copy still carried, so the file documented a shape Homebrew had rejected.

## Synced to upstream

Removed, per the review:

- the `livecheck do url :url; strategy :github_latest end` block — **redundant**, Homebrew infers the strategy from a GitHub release URL. Confirmed `brew audit --new --cask` and `brew style` both still pass without it.
- the inline `conflicts_with` comment
- the inline `zap` rationale comment

The body below the header is now byte-identical to upstream, so diffing the two is meaningful again.

## The rationale moves to the header

Worth keeping, just not upstream. Notably the `zap` paths, re-derived from source rather than copied from the old comment:

| Path | Source |
|---|---|
| `~/.amethyst` | `AccountManager.kt` — accounts and **keys** |
| `~/Library/Application Support/Amethyst` | `DesktopTorManager.kt` |
| `~/Library/Caches/AmethystDesktop` | `DesktopImageLoaderSetup.kt` — its macOS `cacheDir()` branch |

Plus why `~/Library/Preferences/com.apple.java.util.prefs.plist` is deliberately **not** zapped: `java.util.prefs` (auth approvals, Namecoin settings) writes every Java application's preferences into that single shared file.

The header also corrects a scope claim. It implied this file is what ships. It isn't — `scripts/bump-homebrew-cask.sh` bumps upstream through `brew bump-cask-pr`, which edits the upstream cask in place and reads only `version` + `sha256` from here.

## Test plan

- [x] Cask body byte-identical to the live upstream file (`diff`, no output)
- [x] `ruby -c` — Syntax OK
- [x] Both bumpers still parse it: `^  version "` and `^  sha256 "` match **exactly once** each
- [x] Replayed the workflow's `sed` against the file — only those two lines change; the enlarged header is untouched
- [x] `brew style` and `brew audit --new --cask` pass on the upstream-shaped body

## Interop suites

- [x] N/A — packaging reference file only; no wire bytes, decoded audio, MLS state or DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gs2gi3sZfQ7SHrVm2njLMw
