### PR TITLE
Replace mutable collection methods with immutable equivalents

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/authCommand/compose/RelayAuthPromptHost.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/authCommand/compose/RelayAuthPromptHost.kt
@@ -265,8 +265,8 @@ private fun RelayHeader(
         horizontalArrangement = Arrangement.spacedBy(11.dp),
     ) {
         RobohashFallbackAsyncImage(
-            robot = info?.id ?: prompt.relayUrl.displayUrl(),
-            model = info?.icon,
+            robot = info.id ?: prompt.relayUrl.displayUrl(),
+            model = info.icon,
             contentDescription = null,
             colorFilter = RelayIconFilter,
             modifier = Modifier.size(34.dp).clip(MaterialTheme.shapes.small),

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/authCommand/model/RelayAuthPurposeDeriver.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/relayClient/authCommand/model/RelayAuthPurposeDeriver.kt
@@ -140,13 +140,13 @@ object RelayAuthPurposeDeriver {
                     // `e` tags — take whichever we get so the prompt can say whose conversation.
                     AuthPurposeKind.THREAD -> {
                         readsThread = true
-                        explained?.entityIds?.let(readThreadNotes::addAll)
+                        explained.entityIds?.let(readThreadNotes::addAll)
                         filter.tags?.get("e")?.let(readThreadNotes::addAll)
                     }
                     // Declared, but the *who*/*what* still comes from the filter. Prefer the entity
                     // ids the assembler named over sniffing tags, and fall back when it named none.
                     AuthPurposeKind.READ_VENUE -> {
-                        val declared = explained?.entityIds.orEmpty()
+                        val declared = explained.entityIds.orEmpty()
                         if (declared.isNotEmpty()) readVenues.addAll(declared) else readVenues.addAll(filter.venueTags())
                     }
                     AuthPurposeKind.READ_OUTBOX -> {

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip88Polls/PollResponsesCache.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/model/nip88Polls/PollResponsesCache.kt
@@ -148,17 +148,17 @@ class PollResponsesCache : UserDependencies {
             ): Pair<PersistentMap<String, PersistentSet<User>>, PersistentSet<User>> {
                 var newTally = tally
                 accepted(event).forEach { code ->
-                    val remaining = newTally[code]?.remove(user)
+                    val remaining = newTally[code]?.removing(user)
                     newTally =
                         when {
                             remaining == null -> newTally
                             // Drop the key rather than leave an empty set: winning() and
                             // totalSelections() both read every entry.
-                            remaining.isEmpty() -> newTally.remove(code)
-                            else -> newTally.put(code, remaining)
+                            remaining.isEmpty() -> newTally.removing(code)
+                            else -> newTally.putting(code, remaining)
                         }
                 }
-                return newTally to countedVoters.remove(user)
+                return newTally to countedVoters.removing(user)
             }
 
             /**
@@ -168,7 +168,7 @@ class PollResponsesCache : UserDependencies {
             fun add(note: Note): ResponseTally {
                 if (note in allResponses) return this
 
-                val withNote = allResponses.add(note)
+                val withNote = allResponses.adding(note)
                 val event =
                     note.event as? PollResponseEvent
                         ?: return ResponseTally(withNote, policy, votes, tally, countedVoters, lateVotes, backdatedVotes)
@@ -201,13 +201,13 @@ class PollResponsesCache : UserDependencies {
 
                 val codes = accepted(event)
                 if (codes.isNotEmpty()) {
-                    newVoters = newVoters.add(author)
+                    newVoters = newVoters.adding(author)
                     codes.forEach { code ->
-                        newTally = newTally.put(code, (newTally[code] ?: persistentSetOf()).add(author))
+                        newTally = newTally.putting(code, (newTally[code] ?: persistentSetOf()).adding(author))
                     }
                 }
 
-                return ResponseTally(withNote, policy, votes.put(author, event), newTally, newVoters, lateVotes, backdatedVotes)
+                return ResponseTally(withNote, policy, votes.putting(author, event), newTally, newVoters, lateVotes, backdatedVotes)
             }
 
             /**
@@ -235,7 +235,7 @@ class PollResponsesCache : UserDependencies {
         // if it's not already there, quick exit
         if (deleteNote !in responses.value.allResponses) return
 
-        responses.update { it.rebuild(responses = it.allResponses.remove(deleteNote)) }
+        responses.update { it.rebuild(responses = it.allResponses.removing(deleteNote)) }
     }
 
     /**

--- a/commons/src/jvmTest/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/EventFinderFilterAssemblyTest.kt
+++ b/commons/src/jvmTest/kotlin/com/vitorpamplona/amethyst/commons/relayClient/event/EventFinderFilterAssemblyTest.kt
@@ -147,7 +147,7 @@ class EventFinderFilterAssemblyTest {
 
         override fun checkGetOrCreateNote(hexKey: HexKey): Note? = null
 
-        override fun getOrCreateAddressableNote(key: Address): AddressableNote = error("unused")
+        override fun getOrCreateAddressableNote(address: Address): AddressableNote = error("unused")
 
         override fun getEventStream(): ICacheEventStream = error("unused")
 


### PR DESCRIPTION
## Summary

Migrate from mutable collection mutation methods (`remove`, `put`, `add`) to their immutable equivalents (`removing`, `putting`, `adding`) throughout the codebase. This improves consistency with Kotlin's immutable collection patterns and reduces the risk of accidental mutations. Also fixes a parameter name inconsistency in a test mock.

## Changes

- **PollResponsesCache.kt**: Replace all `remove()`, `put()`, and `add()` calls on `PersistentMap` and `PersistentSet` with their immutable counterparts (`removing()`, `putting()`, `adding()`)
- **RelayAuthPromptHost.kt**: Remove unnecessary null-coalescing operators (`?.`) on non-nullable `info` object properties
- **RelayAuthPurposeDeriver.kt**: Remove unnecessary null-coalescing operators on non-nullable `explained` object properties  
- **EventFinderFilterAssemblyTest.kt**: Rename parameter `key` to `address` in mock method for consistency with the interface definition

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Ran `./gradlew test` — existing tests pass
- [ ] N/A — change is a straightforward refactor of collection method calls and parameter naming; no new functionality introduced

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license.

https://claude.ai/code/session_014B22CbhBupxD3DZcac8jMi