### PR TITLE
fix(browser): open a file picker for HTML file inputs

### DIFF
--- a/amethyst/src/main/AndroidManifest.xml
+++ b/amethyst/src/main/AndroidManifest.xml
@@ -588,6 +588,7 @@
             android:name=".napplet.WebFileChooserActivity"
             android:exported="false"
             android:excludeFromRecents="true"
+            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|keyboardHidden|keyboard|uiMode|navigation|fontScale|density"
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />
         <!-- First-connect "Connect to Nostr" dialog. -->
         <activity

--- a/amethyst/src/main/AndroidManifest.xml
+++ b/amethyst/src/main/AndroidManifest.xml
@@ -579,6 +579,16 @@
             android:excludeFromRecents="true"
             android:launchMode="singleTop"
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+        <!-- Invisible host that runs the system file picker for an embedded WebView surface. The
+             `:napplet` providers are windowless services with no Activity of their own, so the main
+             process collects the pick and relays the URIs back to the sandbox. -->
+        <!-- Standard launch mode on purpose: two embedded surfaces can each have a pick in flight, and
+             singleTop would collapse the second onto the first and strand its page's file input. -->
+        <activity
+            android:name=".napplet.WebFileChooserActivity"
+            android:exported="false"
+            android:excludeFromRecents="true"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
         <!-- First-connect "Connect to Nostr" dialog. -->
         <activity
             android:name=".connectedApps.consent.SignerConnectActivity"

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/WebFileChooserActivity.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/WebFileChooserActivity.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.napplet
+
+import android.os.Bundle
+import android.util.Log
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContracts
+import com.vitorpamplona.amethyst.napplethost.NappletFileChooser
+import com.vitorpamplona.amethyst.commons.R as CommonsR
+
+/**
+ * Invisible main-process host for one file pick made on behalf of an **embedded** WebView surface.
+ *
+ * The surface renders from the keyless `:napplet` process, which has no Activity to start a picker
+ * from, so [WebFileChooserCoordinator] launches this instead. It exists only long enough to run the
+ * picker and report the result, and it reports on every exit — a chosen file, a cancel, a system
+ * teardown — because the page's `<input type="file">` stays busy until it hears something back.
+ */
+class WebFileChooserActivity : ComponentActivity() {
+    private var token: String? = null
+    private var reported = false
+
+    private val picker =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            report(NappletFileChooser.parseResult(result.resultCode, result.data)?.map { it.toString() }?.toTypedArray())
+            finish()
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val token = intent.getStringExtra(WebFileChooserCoordinator.EXTRA_TOKEN)
+        this.token = token
+        val chooser = token?.let { WebFileChooserCoordinator.chooserFor(it) }
+        if (chooser == null) {
+            // No pending request under this token: the surface went away, or the process was restarted
+            // and the request died with it. Nothing to report to.
+            reported = true
+            finish()
+            return
+        }
+
+        // A recreated instance (rotation) already has its pick in flight; re-launching would stack a
+        // second picker on top of the first.
+        if (savedInstanceState != null) return
+
+        runCatching { picker.launch(chooser) }
+            .onFailure { e ->
+                Log.w(TAG, "No activity available to pick a file", e)
+                Toast.makeText(this, getString(CommonsR.string.browser_file_chooser_unavailable), Toast.LENGTH_LONG).show()
+                report(null)
+                finish()
+            }
+    }
+
+    /** Fail-open toward the page: any unreported teardown still releases its file input. */
+    override fun finish() {
+        report(null)
+        super.finish()
+    }
+
+    private fun report(uris: Array<String>?) {
+        if (reported) return
+        reported = true
+        token?.let { WebFileChooserCoordinator.complete(it, uris) }
+    }
+
+    private companion object {
+        private const val TAG = "WebFileChooser"
+    }
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/WebFileChooserActivity.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/WebFileChooserActivity.kt
@@ -58,9 +58,14 @@ class WebFileChooserActivity : ComponentActivity() {
             return
         }
 
-        // A recreated instance (rotation) already has its pick in flight; launching again would stack a
-        // second picker on top of the first.
-        if (savedInstanceState != null) return
+        // A recreated instance has lost the in-flight request that its result would be matched against
+        // (configChanges keeps this rare — a system kill, not a rotation), and relaunching would stack a
+        // second picker on the first. Release the page's input now rather than let it wait on a result
+        // that can no longer be routed anywhere.
+        if (savedInstanceState != null) {
+            finish()
+            return
+        }
 
         chooser.launch(
             acceptTypes = ask.acceptTypes,
@@ -74,6 +79,18 @@ class WebFileChooserActivity : ComponentActivity() {
     override fun finish() {
         report(null)
         super.finish()
+    }
+
+    /**
+     * The system can destroy this host without ever calling [finish] — a low-memory kill while the
+     * picker is on top. Without this the page's file input would wait on a result nobody is left to
+     * send, dead for the life of the page, and the coordinator would hold the reply callback (and the
+     * controller behind it) forever.
+     */
+    override fun onDestroy() {
+        chooser.teardown()
+        report(null)
+        super.onDestroy()
     }
 
     private fun report(uris: Array<String>?) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/WebFileChooserActivity.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/WebFileChooserActivity.kt
@@ -21,28 +21,26 @@
 package com.vitorpamplona.amethyst.napplet
 
 import android.os.Bundle
-import android.util.Log
-import android.widget.Toast
 import androidx.activity.ComponentActivity
-import androidx.activity.result.contract.ActivityResultContracts
-import com.vitorpamplona.amethyst.napplethost.NappletFileChooser
-import com.vitorpamplona.amethyst.commons.R as CommonsR
+import com.vitorpamplona.amethyst.napplethost.WebFileChooserLauncher
 
 /**
  * Invisible main-process host for one file pick made on behalf of an **embedded** WebView surface.
  *
- * The surface renders from the keyless `:napplet` process, which has no Activity to start a picker
- * from, so [WebFileChooserCoordinator] launches this instead. It exists only long enough to run the
- * picker and report the result, and it reports on every exit — a chosen file, a cancel, a system
- * teardown — because the page's `<input type="file">` stays busy until it hears something back.
+ * The surface renders from the keyless `:napplet` process, which has no Activity to start a picker or
+ * a permission prompt from, so [WebFileChooserCoordinator] launches this instead. It exists only long
+ * enough to run the pick and report the result, and it reports on every exit — a chosen file, a
+ * cancel, a system teardown — because the page's `<input type="file">` stays busy until it hears
+ * something back.
  */
 class WebFileChooserActivity : ComponentActivity() {
     private var token: String? = null
     private var reported = false
 
-    private val picker =
-        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-            report(NappletFileChooser.parseResult(result.resultCode, result.data)?.map { it.toString() }?.toTypedArray())
+    // Field, not a local: registerForActivityResult must run before this activity reaches STARTED.
+    private val chooser =
+        WebFileChooserLauncher(this) { uris ->
+            report(uris?.map { it.toString() }?.toTypedArray())
             finish()
         }
 
@@ -51,26 +49,25 @@ class WebFileChooserActivity : ComponentActivity() {
 
         val token = intent.getStringExtra(WebFileChooserCoordinator.EXTRA_TOKEN)
         this.token = token
-        val chooser = token?.let { WebFileChooserCoordinator.chooserFor(it) }
-        if (chooser == null) {
-            // No pending request under this token: the surface went away, or the process was restarted
-            // and the request died with it. Nothing to report to.
+        val ask = token?.let { WebFileChooserCoordinator.pendingFor(it) }
+        if (ask == null) {
+            // No pending request under this token: the surface went away, or the process restarted and
+            // the request died with it. Nothing to report to.
             reported = true
             finish()
             return
         }
 
-        // A recreated instance (rotation) already has its pick in flight; re-launching would stack a
+        // A recreated instance (rotation) already has its pick in flight; launching again would stack a
         // second picker on top of the first.
         if (savedInstanceState != null) return
 
-        runCatching { picker.launch(chooser) }
-            .onFailure { e ->
-                Log.w(TAG, "No activity available to pick a file", e)
-                Toast.makeText(this, getString(CommonsR.string.browser_file_chooser_unavailable), Toast.LENGTH_LONG).show()
-                report(null)
-                finish()
-            }
+        chooser.launch(
+            acceptTypes = ask.acceptTypes,
+            allowMultiple = ask.allowMultiple,
+            captureEnabled = ask.captureEnabled,
+            pageTitle = ask.pageTitle,
+        )
     }
 
     /** Fail-open toward the page: any unreported teardown still releases its file input. */
@@ -83,9 +80,5 @@ class WebFileChooserActivity : ComponentActivity() {
         if (reported) return
         reported = true
         token?.let { WebFileChooserCoordinator.complete(it, uris) }
-    }
-
-    private companion object {
-        private const val TAG = "WebFileChooser"
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/WebFileChooserCoordinator.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/WebFileChooserCoordinator.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.napplet
+
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.vitorpamplona.amethyst.napplethost.NappletFileChooser
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Runs the system file picker on behalf of an **embedded** WebView surface.
+ *
+ * The two embedded providers ([NappletBrowserService][com.vitorpamplona.amethyst.napplethost.NappletBrowserService]
+ * and [NappletHostService][com.vitorpamplona.amethyst.napplethost.NappletHostService]) host their
+ * WebView in the keyless `:napplet` process as a windowless Service, so when a page taps
+ * `<input type="file">` there is no Activity there to start a picker from. They send the *description*
+ * of the request over Messenger instead; this builds the Intent here in the main process, launches
+ * [WebFileChooserActivity] to collect the result, and hands the picked URIs back to the caller, which
+ * relays them to the sandbox.
+ *
+ * Mirrors [NappletConsentCoordinator]: the pending request is keyed by a one-time token so the
+ * throwaway Activity carries nothing but that token. Every request completes exactly once — a
+ * dismissed picker resolves to null, which is what releases the page's file input.
+ *
+ * URI read grants are per-UID, so the `content://` URIs granted to this process are readable by the
+ * WebView in `:napplet` without any re-granting.
+ */
+object WebFileChooserCoordinator {
+    private class Pending(
+        val chooser: Intent,
+        val onResult: (Array<String>?) -> Unit,
+    )
+
+    private val pending = ConcurrentHashMap<String, Pending>()
+
+    /**
+     * Shows a picker filtered by [acceptTypes] (raw HTML `accept` entries) and calls [onResult] with the
+     * picked URIs as strings, or null when the user cancelled. [onResult] always runs, including when no
+     * picker could be started at all — the page is waiting on it.
+     */
+    fun request(
+        context: Context,
+        acceptTypes: List<String>,
+        allowMultiple: Boolean,
+        pageTitle: String?,
+        onResult: (Array<String>?) -> Unit,
+    ) {
+        val token = UUID.randomUUID().toString()
+        pending[token] = Pending(NappletFileChooser.buildIntent(context, acceptTypes, allowMultiple, pageTitle), onResult)
+
+        val launch =
+            Intent(context, WebFileChooserActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                .putExtra(EXTRA_TOKEN, token)
+
+        runCatching { context.startActivity(launch) }
+            .onFailure { e ->
+                Log.w(TAG, "Could not start the file chooser host", e)
+                complete(token, null)
+            }
+    }
+
+    /** Called by [WebFileChooserActivity] to get the picker it should launch. */
+    fun chooserFor(token: String): Intent? = pending[token]?.chooser
+
+    /** Called by [WebFileChooserActivity] with the outcome; null = cancelled. Resolves at most once. */
+    fun complete(
+        token: String,
+        uris: Array<String>?,
+    ) {
+        pending.remove(token)?.onResult?.invoke(uris)
+    }
+
+    const val EXTRA_TOKEN = "web_file_chooser_token"
+
+    private const val TAG = "WebFileChooser"
+}

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/WebFileChooserCoordinator.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/napplet/WebFileChooserCoordinator.kt
@@ -23,7 +23,6 @@ package com.vitorpamplona.amethyst.napplet
 import android.content.Context
 import android.content.Intent
 import android.util.Log
-import com.vitorpamplona.amethyst.napplethost.NappletFileChooser
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
@@ -34,9 +33,9 @@ import java.util.concurrent.ConcurrentHashMap
  * and [NappletHostService][com.vitorpamplona.amethyst.napplethost.NappletHostService]) host their
  * WebView in the keyless `:napplet` process as a windowless Service, so when a page taps
  * `<input type="file">` there is no Activity there to start a picker from. They send the *description*
- * of the request over Messenger instead; this builds the Intent here in the main process, launches
- * [WebFileChooserActivity] to collect the result, and hands the picked URIs back to the caller, which
- * relays them to the sandbox.
+ * of the request over Messenger instead; this holds it here in the main process and launches
+ * [WebFileChooserActivity], which runs the picker (and the camera, and the CAMERA permission prompt
+ * that a `capture` input needs) and reports back to the caller, which relays the URIs to the sandbox.
  *
  * Mirrors [NappletConsentCoordinator]: the pending request is keyed by a one-time token so the
  * throwaway Activity carries nothing but that token. Every request completes exactly once — a
@@ -46,27 +45,32 @@ import java.util.concurrent.ConcurrentHashMap
  * WebView in `:napplet` without any re-granting.
  */
 object WebFileChooserCoordinator {
-    private class Pending(
-        val chooser: Intent,
+    /** The request as it arrived from the sandbox, plus where to send the answer. */
+    class Pending(
+        val acceptTypes: List<String>,
+        val allowMultiple: Boolean,
+        val captureEnabled: Boolean,
+        val pageTitle: String?,
         val onResult: (Array<String>?) -> Unit,
     )
 
     private val pending = ConcurrentHashMap<String, Pending>()
 
     /**
-     * Shows a picker filtered by [acceptTypes] (raw HTML `accept` entries) and calls [onResult] with the
-     * picked URIs as strings, or null when the user cancelled. [onResult] always runs, including when no
-     * picker could be started at all — the page is waiting on it.
+     * Shows a picker for [acceptTypes] and calls [onResult] with the picked URIs as strings, or null
+     * when nothing was chosen. [onResult] always runs, including when no picker host could be started
+     * at all — the page's file input is waiting on it.
      */
     fun request(
         context: Context,
         acceptTypes: List<String>,
         allowMultiple: Boolean,
+        captureEnabled: Boolean,
         pageTitle: String?,
         onResult: (Array<String>?) -> Unit,
     ) {
         val token = UUID.randomUUID().toString()
-        pending[token] = Pending(NappletFileChooser.buildIntent(context, acceptTypes, allowMultiple, pageTitle), onResult)
+        pending[token] = Pending(acceptTypes, allowMultiple, captureEnabled, pageTitle, onResult)
 
         val launch =
             Intent(context, WebFileChooserActivity::class.java)
@@ -80,10 +84,10 @@ object WebFileChooserCoordinator {
             }
     }
 
-    /** Called by [WebFileChooserActivity] to get the picker it should launch. */
-    fun chooserFor(token: String): Intent? = pending[token]?.chooser
+    /** Called by [WebFileChooserActivity] to learn what to ask the user for. */
+    fun pendingFor(token: String): Pending? = pending[token]
 
-    /** Called by [WebFileChooserActivity] with the outcome; null = cancelled. Resolves at most once. */
+    /** Called by [WebFileChooserActivity] with the outcome; null = nothing chosen. Resolves at most once. */
     fun complete(
         token: String,
         uris: Array<String>?,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/browser/EmbeddedWebAppController.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/browser/EmbeddedWebAppController.kt
@@ -40,6 +40,7 @@ import androidx.privacysandbox.ui.client.SandboxedUiAdapterFactory
 import androidx.privacysandbox.ui.client.view.SandboxedSdkView
 import androidx.privacysandbox.ui.core.SandboxedUiAdapter
 import com.vitorpamplona.amethyst.napplet.NappletWebViewProfiles
+import com.vitorpamplona.amethyst.napplet.WebFileChooserCoordinator
 import com.vitorpamplona.amethyst.napplethost.NappletBrowserContract
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.embed.ConsoleBridge
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.embed.ConsoleLogEntry
@@ -253,6 +254,24 @@ class EmbeddedWebAppController(
                 val line = msg.data?.getInt(NappletBrowserContract.KEY_CONSOLE_LINE, 0) ?: 0
                 if (consoleLogs.size >= MAX_CONSOLE_LOGS) consoleLogs.removeAt(0)
                 consoleLogs.add(ConsoleLogEntry(level, message, source, line))
+            }
+            NappletBrowserContract.MSG_FILE_CHOOSER_REQUEST -> {
+                val data = msg.data ?: return true
+                val requestId = data.getLong(NappletBrowserContract.KEY_FILE_CHOOSER_ID)
+                // The sandbox has no Activity to run a picker from, so the main process runs it here and
+                // ships the URIs back. The reply is sent on every outcome (a cancel included) — the page's
+                // file input stays busy until it hears something.
+                WebFileChooserCoordinator.request(
+                    context = appContext,
+                    acceptTypes = data.getStringArray(NappletBrowserContract.KEY_FILE_CHOOSER_ACCEPT)?.toList().orEmpty(),
+                    allowMultiple = data.getBoolean(NappletBrowserContract.KEY_FILE_CHOOSER_MULTIPLE, false),
+                    pageTitle = data.getString(NappletBrowserContract.KEY_FILE_CHOOSER_TITLE),
+                ) { uris ->
+                    send(NappletBrowserContract.MSG_FILE_CHOOSER_RESULT) {
+                        putLong(NappletBrowserContract.KEY_FILE_CHOOSER_ID, requestId)
+                        uris?.let { putStringArray(NappletBrowserContract.KEY_FILE_CHOOSER_URIS, it) }
+                    }
+                }
             }
             NappletBrowserContract.MSG_MAGNIFIER_FRAME -> {
                 val data = msg.data ?: return true

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/browser/EmbeddedWebAppController.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/browser/EmbeddedWebAppController.kt
@@ -265,6 +265,7 @@ class EmbeddedWebAppController(
                     context = appContext,
                     acceptTypes = data.getStringArray(NappletBrowserContract.KEY_FILE_CHOOSER_ACCEPT)?.toList().orEmpty(),
                     allowMultiple = data.getBoolean(NappletBrowserContract.KEY_FILE_CHOOSER_MULTIPLE, false),
+                    captureEnabled = data.getBoolean(NappletBrowserContract.KEY_FILE_CHOOSER_CAPTURE, false),
                     pageTitle = data.getString(NappletBrowserContract.KEY_FILE_CHOOSER_TITLE),
                 ) { uris ->
                     send(NappletBrowserContract.MSG_FILE_CHOOSER_RESULT) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/favorites/EmbeddedNostrAppController.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/favorites/EmbeddedNostrAppController.kt
@@ -39,6 +39,7 @@ import androidx.privacysandbox.ui.client.SandboxedUiAdapterFactory
 import androidx.privacysandbox.ui.client.view.SandboxedSdkView
 import androidx.privacysandbox.ui.core.SandboxedUiAdapter
 import com.vitorpamplona.amethyst.napplet.NappletWebViewProfiles
+import com.vitorpamplona.amethyst.napplet.WebFileChooserCoordinator
 import com.vitorpamplona.amethyst.napplethost.NappletEmbedContract
 import com.vitorpamplona.amethyst.napplethost.NappletHostContract
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.embed.EmbeddedImeBridge
@@ -245,6 +246,24 @@ class EmbeddedNostrAppController(
                 val isLoading = msg.data?.getBoolean(NappletEmbedContract.KEY_IS_LOADING, false) ?: false
                 val failed = msg.data?.getBoolean(NappletEmbedContract.KEY_LOAD_FAILED, false) ?: false
                 onLoadState(isLoading, failed)
+            }
+            NappletEmbedContract.MSG_FILE_CHOOSER_REQUEST -> {
+                val data = msg.data ?: return true
+                val requestId = data.getLong(NappletEmbedContract.KEY_FILE_CHOOSER_ID)
+                // The sandbox has no Activity to run a picker from, so the main process runs it here and
+                // ships the URIs back. The reply is sent on every outcome (a cancel included) — the page's
+                // file input stays busy until it hears something.
+                WebFileChooserCoordinator.request(
+                    context = appContext,
+                    acceptTypes = data.getStringArray(NappletEmbedContract.KEY_FILE_CHOOSER_ACCEPT)?.toList().orEmpty(),
+                    allowMultiple = data.getBoolean(NappletEmbedContract.KEY_FILE_CHOOSER_MULTIPLE, false),
+                    pageTitle = data.getString(NappletEmbedContract.KEY_FILE_CHOOSER_TITLE),
+                ) { uris ->
+                    send(NappletEmbedContract.MSG_FILE_CHOOSER_RESULT) {
+                        putLong(NappletEmbedContract.KEY_FILE_CHOOSER_ID, requestId)
+                        uris?.let { putStringArray(NappletEmbedContract.KEY_FILE_CHOOSER_URIS, it) }
+                    }
+                }
             }
             NappletEmbedContract.MSG_MAGNIFIER_FRAME -> {
                 val data = msg.data ?: return true

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/favorites/EmbeddedNostrAppController.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/favorites/EmbeddedNostrAppController.kt
@@ -257,6 +257,7 @@ class EmbeddedNostrAppController(
                     context = appContext,
                     acceptTypes = data.getStringArray(NappletEmbedContract.KEY_FILE_CHOOSER_ACCEPT)?.toList().orEmpty(),
                     allowMultiple = data.getBoolean(NappletEmbedContract.KEY_FILE_CHOOSER_MULTIPLE, false),
+                    captureEnabled = data.getBoolean(NappletEmbedContract.KEY_FILE_CHOOSER_CAPTURE, false),
                     pageTitle = data.getString(NappletEmbedContract.KEY_FILE_CHOOSER_TITLE),
                 ) { uris ->
                     send(NappletEmbedContract.MSG_FILE_CHOOSER_RESULT) {

--- a/commons/src/androidMain/res/values/strings.xml
+++ b/commons/src/androidMain/res/values/strings.xml
@@ -5,4 +5,8 @@
     <string name="browser_console_title">Console (%1$d)</string>
     <string name="browser_console_clear">Clear</string>
     <string name="napplet_untitled">Untitled nApplet</string>
+    <!-- Title of the system picker opened for an HTML file input inside the in-app browser. -->
+    <string name="browser_file_chooser_title">Choose a file</string>
+    <!-- Shown when the device has no app that can hand a file back to the page. -->
+    <string name="browser_file_chooser_unavailable">No app available to pick a file</string>
 </resources>

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/browser/FileChooserAccept.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/browser/FileChooserAccept.kt
@@ -84,6 +84,46 @@ object FileChooserAccept {
         return Resolved(primaryType = commonType(mimes), mimeTypes = mimes)
     }
 
+    /** A camera a file input can plausibly be satisfied by. */
+    enum class CaptureMedia {
+        IMAGE,
+        VIDEO,
+    }
+
+    /**
+     * Which cameras to offer for an input accepting [acceptTypes], mirroring what a mobile browser
+     * shows: a bare `<input type="file">` offers both stills and video, an image-only accept offers
+     * just the camera, and `accept="application/pdf"` offers neither.
+     *
+     * Unlike [resolve], an extension the platform can't name contributes nothing instead of widening —
+     * widening here would put a camera in front of a page that never asked for one. [extensionToMime]
+     * is the same lookup [resolve] takes.
+     */
+    fun captureMedia(
+        acceptTypes: List<String>,
+        extensionToMime: (String) -> String?,
+    ): Set<CaptureMedia> {
+        val tokens =
+            acceptTypes
+                .flatMap { it.split(',') }
+                .map { it.trim().lowercase() }
+                .filter { it.isNotEmpty() }
+
+        // No accept at all: the page takes anything, so both cameras are fair game.
+        if (tokens.isEmpty()) return setOf(CaptureMedia.IMAGE, CaptureMedia.VIDEO)
+
+        val media = mutableSetOf<CaptureMedia>()
+        for (token in tokens) {
+            if (token == ANY) return setOf(CaptureMedia.IMAGE, CaptureMedia.VIDEO)
+            val mime = if (token.contains('/')) token else extensionToMime(token.removePrefix("."))
+            when (mime?.substringBefore('/')) {
+                "image" -> media.add(CaptureMedia.IMAGE)
+                "video" -> media.add(CaptureMedia.VIDEO)
+            }
+        }
+        return media
+    }
+
     /**
      * The narrowest single type covering [mimes]: the type itself when there is only one, the shared
      * family's wildcard when they all belong to one family, and [ANY] when they span families (or the

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/browser/FileChooserAccept.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/browser/FileChooserAccept.kt
@@ -54,27 +54,32 @@ object FileChooserAccept {
      * Resolves [acceptTypes] (raw `accept` entries) into a picker filter.
      *
      * [extensionToMime] maps a lower-case extension with no leading dot (`"heic"`) to a MIME type, or
-     * null when the platform doesn't know it — an unknown extension simply contributes nothing rather
-     * than narrowing the picker to something the user can't satisfy.
+     * null when the platform doesn't know it. Android's `MimeTypeMap` is a fixed table and does not
+     * know every extension a page might list, so a token that fails to resolve widens the filter to
+     * [ANY] instead of being dropped: `accept` is a hint in HTML, never an enforced restriction, and a
+     * partially-resolved list would otherwise hide exactly the files the page cannot name — the user
+     * would see a picker with the wanted file missing and no way to reach it.
      */
     fun resolve(
         acceptTypes: List<String>,
         extensionToMime: (String) -> String?,
     ): Resolved {
-        val mimes =
+        val tokens =
             acceptTypes
                 // A page may write accept="image/*,video/*" and some WebView versions pass that through
                 // as ONE entry, so split again on the separator the attribute itself uses.
                 .flatMap { it.split(',') }
                 .map { it.trim().lowercase() }
                 .filter { it.isNotEmpty() }
-                .mapNotNull { token ->
-                    when {
-                        token.contains('/') -> token
-                        else -> extensionToMime(token.removePrefix("."))
-                    }
-                }.filter { it.isNotEmpty() }
-                .distinct()
+
+        val mimes = mutableListOf<String>()
+        for (token in tokens) {
+            val mime = if (token.contains('/')) token else extensionToMime(token.removePrefix("."))
+            // One name we can't translate means we cannot express this page's filter faithfully. Show
+            // everything rather than a filter that silently excludes part of what it asked for.
+            if (mime.isNullOrEmpty()) return Resolved(ANY, emptyList())
+            if (mime !in mimes) mimes.add(mime)
+        }
 
         return Resolved(primaryType = commonType(mimes), mimeTypes = mimes)
     }

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/browser/FileChooserAccept.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/browser/FileChooserAccept.kt
@@ -74,10 +74,9 @@ object FileChooserAccept {
 
         val mimes = mutableListOf<String>()
         for (token in tokens) {
-            val mime = if (token.contains('/')) token else extensionToMime(token.removePrefix("."))
             // One name we can't translate means we cannot express this page's filter faithfully. Show
             // everything rather than a filter that silently excludes part of what it asked for.
-            if (mime.isNullOrEmpty()) return Resolved(ANY, emptyList())
+            val mime = mimeOf(token, extensionToMime) ?: return Resolved(ANY, emptyList())
             if (mime !in mimes) mimes.add(mime)
         }
 
@@ -115,13 +114,30 @@ object FileChooserAccept {
         val media = mutableSetOf<CaptureMedia>()
         for (token in tokens) {
             if (token == ANY) return setOf(CaptureMedia.IMAGE, CaptureMedia.VIDEO)
-            val mime = if (token.contains('/')) token else extensionToMime(token.removePrefix("."))
-            when (mime?.substringBefore('/')) {
+            when (mimeOf(token, extensionToMime)?.substringBefore('/')) {
                 "image" -> media.add(CaptureMedia.IMAGE)
                 "video" -> media.add(CaptureMedia.VIDEO)
             }
         }
         return media
+    }
+
+    /**
+     * One `accept` entry as a MIME type, or null when it cannot be turned into one.
+     *
+     * A token with a slash is taken as a MIME type, but only when both halves are actually there: a
+     * page that writes `accept="image/"` would otherwise put that straight into `Intent.setType`, where
+     * it matches no provider and leaves the user staring at an empty picker with no way out. Everything
+     * else is an extension, with or without its leading dot.
+     */
+    private fun mimeOf(
+        token: String,
+        extensionToMime: (String) -> String?,
+    ): String? {
+        if (!token.contains('/')) return extensionToMime(token.removePrefix(".")).takeIf { !it.isNullOrEmpty() }
+        val type = token.substringBefore('/')
+        val subtype = token.substringAfter('/')
+        return token.takeIf { type.isNotEmpty() && subtype.isNotEmpty() && !subtype.contains('/') }
     }
 
     /**

--- a/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/browser/FileChooserAccept.kt
+++ b/commons/src/commonMain/kotlin/com/vitorpamplona/amethyst/commons/browser/FileChooserAccept.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.browser
+
+/**
+ * Translates an HTML `<input type="file" accept="…">` list into what an Android picker Intent needs:
+ * a single `type` plus an optional `EXTRA_MIME_TYPES` array.
+ *
+ * WebView hands us the `accept` attribute pre-split into `FileChooserParams.getAcceptTypes`, but the
+ * entries are whatever the page author wrote — exact MIME types, family wildcards, bare extensions
+ * (`.heic`), or several of those comma-joined into one entry. Android's own
+ * `FileChooserParams.createIntent()` keeps only the FIRST entry and drops multi-select entirely, so a
+ * page asking for `accept="image/png,image/jpeg" multiple` would offer PNGs only, one at a time. This
+ * resolves the whole list instead.
+ *
+ * Extension → MIME lookup is injected ([resolve]'s `extensionToMime`) rather than calling
+ * `android.webkit.MimeTypeMap` directly, which keeps this pure and unit-testable in commonMain; the
+ * Android callers pass the real map.
+ */
+object FileChooserAccept {
+    /** The any-type wildcard, used when the page asked for nothing or for types with no common family. */
+    const val ANY = "*/*"
+
+    /**
+     * [primaryType] goes in `Intent.setType` — the only thing pickers that predate `EXTRA_MIME_TYPES`
+     * (and plain `ACTION_GET_CONTENT` targets) look at, so it is widened to the narrowest wildcard that
+     * still covers everything asked for. [mimeTypes] is the exact list for `EXTRA_MIME_TYPES`, empty
+     * when nothing resolved (in which case [primaryType] is [ANY] and the picker shows everything).
+     */
+    data class Resolved(
+        val primaryType: String,
+        val mimeTypes: List<String>,
+    )
+
+    /**
+     * Resolves [acceptTypes] (raw `accept` entries) into a picker filter.
+     *
+     * [extensionToMime] maps a lower-case extension with no leading dot (`"heic"`) to a MIME type, or
+     * null when the platform doesn't know it — an unknown extension simply contributes nothing rather
+     * than narrowing the picker to something the user can't satisfy.
+     */
+    fun resolve(
+        acceptTypes: List<String>,
+        extensionToMime: (String) -> String?,
+    ): Resolved {
+        val mimes =
+            acceptTypes
+                // A page may write accept="image/*,video/*" and some WebView versions pass that through
+                // as ONE entry, so split again on the separator the attribute itself uses.
+                .flatMap { it.split(',') }
+                .map { it.trim().lowercase() }
+                .filter { it.isNotEmpty() }
+                .mapNotNull { token ->
+                    when {
+                        token.contains('/') -> token
+                        else -> extensionToMime(token.removePrefix("."))
+                    }
+                }.filter { it.isNotEmpty() }
+                .distinct()
+
+        return Resolved(primaryType = commonType(mimes), mimeTypes = mimes)
+    }
+
+    /**
+     * The narrowest single type covering [mimes]: the type itself when there is only one, the shared
+     * family's wildcard when they all belong to one family, and [ANY] when they span families (or the
+     * list is empty). Never narrower than the request — a picker filtered to `image/png` would hide a
+     * JPEG the page also accepts.
+     */
+    private fun commonType(mimes: List<String>): String {
+        if (mimes.isEmpty()) return ANY
+        if (mimes.size == 1) return mimes.first()
+        val families = mimes.map { it.substringBefore('/') }.distinct()
+        return if (families.size == 1) "${families.first()}/*" else ANY
+    }
+}

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/browser/FileChooserAcceptTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/browser/FileChooserAcceptTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.browser
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FileChooserAcceptTest {
+    /** Stands in for android.webkit.MimeTypeMap; only the extensions the tests use are known. */
+    private val map =
+        mapOf(
+            "png" to "image/png",
+            "jpg" to "image/jpeg",
+            "jpeg" to "image/jpeg",
+            "pdf" to "application/pdf",
+            "mp4" to "video/mp4",
+        )
+
+    private fun resolve(vararg accept: String) = FileChooserAccept.resolve(accept.toList(), map::get)
+
+    @Test
+    fun noAcceptMeansEverything() {
+        val resolved = resolve()
+        assertEquals(FileChooserAccept.ANY, resolved.primaryType)
+        assertEquals(emptyList(), resolved.mimeTypes)
+    }
+
+    @Test
+    fun blankEntriesAreIgnored() {
+        val resolved = resolve("", "   ")
+        assertEquals(FileChooserAccept.ANY, resolved.primaryType)
+        assertEquals(emptyList(), resolved.mimeTypes)
+    }
+
+    @Test
+    fun singleMimeTypeIsUsedVerbatim() {
+        val resolved = resolve("image/png")
+        assertEquals("image/png", resolved.primaryType)
+        assertEquals(listOf("image/png"), resolved.mimeTypes)
+    }
+
+    @Test
+    fun wildcardIsKept() {
+        val resolved = resolve("image/*")
+        assertEquals("image/*", resolved.primaryType)
+        assertEquals(listOf("image/*"), resolved.mimeTypes)
+    }
+
+    @Test
+    fun extensionsResolveToMimeTypes() {
+        val resolved = resolve(".png", ".pdf")
+        assertEquals(listOf("image/png", "application/pdf"), resolved.mimeTypes)
+    }
+
+    @Test
+    fun unknownExtensionContributesNothing() {
+        // Narrowing the picker to a type the platform can't name would hide every file the user has.
+        val resolved = resolve(".sqlite3")
+        assertEquals(FileChooserAccept.ANY, resolved.primaryType)
+        assertEquals(emptyList(), resolved.mimeTypes)
+    }
+
+    @Test
+    fun oneFamilyWidensToThatFamilysWildcard() {
+        // accept="image/png,image/jpeg" must still show JPEGs, so the Intent type can't be image/png.
+        val resolved = resolve("image/png", "image/jpeg")
+        assertEquals("image/*", resolved.primaryType)
+        assertEquals(listOf("image/png", "image/jpeg"), resolved.mimeTypes)
+    }
+
+    @Test
+    fun mixedFamiliesWidenToAny() {
+        val resolved = resolve("image/png", "application/pdf")
+        assertEquals(FileChooserAccept.ANY, resolved.primaryType)
+        assertEquals(listOf("image/png", "application/pdf"), resolved.mimeTypes)
+    }
+
+    @Test
+    fun commaJoinedEntryIsSplitAgain() {
+        // Some WebView versions hand the whole accept attribute back as a single entry.
+        val resolved = resolve("image/png,video/mp4")
+        assertEquals(FileChooserAccept.ANY, resolved.primaryType)
+        assertEquals(listOf("image/png", "video/mp4"), resolved.mimeTypes)
+    }
+
+    @Test
+    fun duplicatesCollapse() {
+        val resolved = resolve(".jpg", ".jpeg", "image/jpeg")
+        assertEquals("image/jpeg", resolved.primaryType)
+        assertEquals(listOf("image/jpeg"), resolved.mimeTypes)
+    }
+
+    @Test
+    fun caseAndWhitespaceAreNormalized() {
+        val resolved = resolve(" IMAGE/PNG ", ".PNG")
+        assertEquals("image/png", resolved.primaryType)
+        assertEquals(listOf("image/png"), resolved.mimeTypes)
+    }
+}

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/browser/FileChooserAcceptTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/browser/FileChooserAcceptTest.kt
@@ -126,6 +126,45 @@ class FileChooserAcceptTest {
         assertEquals(listOf("image/jpeg"), resolved.mimeTypes)
     }
 
+    private fun capture(vararg accept: String) = FileChooserAccept.captureMedia(accept.toList(), map::get)
+
+    @Test
+    fun bareFileInputOffersBothCameras() {
+        // A page that takes anything: a mobile browser offers stills and video there.
+        assertEquals(setOf(FileChooserAccept.CaptureMedia.IMAGE, FileChooserAccept.CaptureMedia.VIDEO), capture())
+        assertEquals(setOf(FileChooserAccept.CaptureMedia.IMAGE, FileChooserAccept.CaptureMedia.VIDEO), capture("*/*"))
+    }
+
+    @Test
+    fun imageAcceptOffersOnlyTheCamera() {
+        assertEquals(setOf(FileChooserAccept.CaptureMedia.IMAGE), capture("image/png"))
+        assertEquals(setOf(FileChooserAccept.CaptureMedia.IMAGE), capture(".jpg"))
+    }
+
+    @Test
+    fun videoAcceptOffersOnlyTheCamcorder() {
+        assertEquals(setOf(FileChooserAccept.CaptureMedia.VIDEO), capture(".mp4"))
+    }
+
+    @Test
+    fun bothMediaOfferBothCameras() {
+        assertEquals(setOf(FileChooserAccept.CaptureMedia.IMAGE, FileChooserAccept.CaptureMedia.VIDEO), capture("image/png", "video/mp4"))
+    }
+
+    @Test
+    fun documentAcceptOffersNoCamera() {
+        // Opening a PDF upload must never put a camera — or a camera permission prompt — in the way.
+        assertEquals(emptySet(), capture("application/pdf"))
+        assertEquals(emptySet(), capture(".pdf"))
+    }
+
+    @Test
+    fun unknownExtensionOffersNoCamera() {
+        // resolve() widens to */* here, but widening the CAMERA decision would show a camera to a page
+        // that never asked for one.
+        assertEquals(emptySet(), capture(".sqlite3"))
+    }
+
     @Test
     fun caseAndWhitespaceAreNormalized() {
         val resolved = resolve(" IMAGE/PNG ", ".PNG")

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/browser/FileChooserAcceptTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/browser/FileChooserAcceptTest.kt
@@ -126,6 +126,16 @@ class FileChooserAcceptTest {
         assertEquals(listOf("image/jpeg"), resolved.mimeTypes)
     }
 
+    @Test
+    fun malformedMimeTokenDoesNotBecomeTheFilter() {
+        // A half-written MIME would go straight into Intent.setType and match no provider at all, so the
+        // user gets an empty picker with no way out. Treat it as unnameable and show everything.
+        assertEquals(FileChooserAccept.ANY, resolve("image/").primaryType)
+        assertEquals(FileChooserAccept.ANY, resolve("/png").primaryType)
+        assertEquals(FileChooserAccept.ANY, resolve("/").primaryType)
+        assertEquals(emptyList(), resolve("image/").mimeTypes)
+    }
+
     private fun capture(vararg accept: String) = FileChooserAccept.captureMedia(accept.toList(), map::get)
 
     @Test

--- a/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/browser/FileChooserAcceptTest.kt
+++ b/commons/src/commonTest/kotlin/com/vitorpamplona/amethyst/commons/browser/FileChooserAcceptTest.kt
@@ -71,11 +71,29 @@ class FileChooserAcceptTest {
     }
 
     @Test
-    fun unknownExtensionContributesNothing() {
+    fun unknownExtensionShowsEverything() {
         // Narrowing the picker to a type the platform can't name would hide every file the user has.
         val resolved = resolve(".sqlite3")
         assertEquals(FileChooserAccept.ANY, resolved.primaryType)
         assertEquals(emptyList(), resolved.mimeTypes)
+    }
+
+    @Test
+    fun oneUnknownExtensionWidensTheWholeFilter() {
+        // MimeTypeMap is a fixed table and misses extensions pages do use. Filtering to just the half we
+        // could name would leave the user staring at a picker with the wanted file missing, and `accept`
+        // is only a hint in HTML — so an unnameable entry means show everything.
+        val resolved = resolve(".png", ".sqlite3")
+        assertEquals(FileChooserAccept.ANY, resolved.primaryType)
+        assertEquals(emptyList(), resolved.mimeTypes)
+    }
+
+    @Test
+    fun knownExtensionsStillFilterWhenAllResolve() {
+        // The widening above must not swallow the normal case.
+        val resolved = resolve(".png", ".jpg")
+        assertEquals("image/*", resolved.primaryType)
+        assertEquals(listOf("image/png", "image/jpeg"), resolved.mimeTypes)
     }
 
     @Test

--- a/nappletHost/src/main/AndroidManifest.xml
+++ b/nappletHost/src/main/AndroidManifest.xml
@@ -1,2 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!--
+      Android 11+ package visibility. Without these the sandbox cannot resolve the camera apps, which
+      it must do to name them in grantUriPermission before handing over the capture file. Launching an
+      implicit intent is unaffected; only querying is.
+    -->
+    <queries>
+        <intent>
+            <action android:name="android.media.action.IMAGE_CAPTURE" />
+        </intent>
+        <intent>
+            <action android:name="android.media.action.VIDEO_CAPTURE" />
+        </intent>
+    </queries>
+
+    <application>
+        <!--
+          Hands a camera app the single empty file a WebView capture will be written to. Its own
+          provider with its own authority rather than the app's general-purpose one, so the exposed
+          surface is one cache subdirectory instead of all of cache/ and external files.
+        -->
+        <provider
+            android:name="com.vitorpamplona.amethyst.napplethost.NappletCaptureFileProvider"
+            android:authorities="${applicationId}.napplethost.captures"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/napplet_capture_paths" />
+        </provider>
+    </application>
+
+</manifest>

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserActivity.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserActivity.kt
@@ -53,7 +53,6 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.scale
 import androidx.core.net.toUri
@@ -114,10 +113,7 @@ class NappletBrowserActivity : ComponentActivity() {
     // picker itself; the embedded surfaces have no Activity and route theirs through the main process.
     private val pendingFileChooser = PendingFileChooser()
 
-    private val fileChooserLauncher =
-        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-            pendingFileChooser.deliver(NappletFileChooser.parseResult(result.resultCode, result.data))
-        }
+    private val fileChooserLauncher = WebFileChooserLauncher(this) { uris -> pendingFileChooser.deliver(uris) }
 
     // ---- broker bridge (per-origin NIP-07 tokens; identical to NappletBrowserService) ----
     private var brokerMessenger: Messenger? = null
@@ -435,12 +431,12 @@ class NappletBrowserActivity : ComponentActivity() {
         params: WebChromeClient.FileChooserParams,
     ): Boolean {
         pendingFileChooser.start(filePathCallback)
-        runCatching { fileChooserLauncher.launch(NappletFileChooser.buildIntent(this, params)) }
-            .onFailure { e ->
-                Log.w(TAG, "No activity available to pick a file", e)
-                pendingFileChooser.cancel()
-                Toast.makeText(this, getString(CommonsR.string.browser_file_chooser_unavailable), Toast.LENGTH_LONG).show()
-            }
+        fileChooserLauncher.launch(
+            acceptTypes = params.acceptTypes?.toList().orEmpty(),
+            allowMultiple = NappletFileChooser.allowsMultiple(params.mode),
+            captureEnabled = params.isCaptureEnabled,
+            pageTitle = params.title,
+        )
         return true
     }
 

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserActivity.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserActivity.kt
@@ -302,6 +302,7 @@ class NappletBrowserActivity : ComponentActivity() {
         runCatching { unbindService(brokerConnection) }
         // A picker still up when the browser is torn down would otherwise leave its callback unanswered.
         pendingFileChooser.cancel()
+        fileChooserLauncher.teardown()
         if (this::webView.isInitialized) {
             // Detach from the view tree BEFORE destroy(). Destroying a WebView while it is still attached to
             // the window corrupts the SHARED multiprocess renderer/network state, which then breaks the OTHER

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserActivity.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserActivity.kt
@@ -38,6 +38,7 @@ import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.ConsoleMessage
+import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
@@ -52,6 +53,7 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.scale
 import androidx.core.net.toUri
@@ -105,6 +107,17 @@ class NappletBrowserActivity : ComponentActivity() {
     private var pendingMainFrameUrl: String? = null
     private var mainFrameLoadFailed = false
     private var lastIconHost: String? = null
+
+    // ---- HTML file input (`<input type="file">`) ----
+    // Registered as a field so it is in place before onCreate returns, which is what
+    // registerForActivityResult requires. This activity hosts its WebView directly, so it can run the
+    // picker itself; the embedded surfaces have no Activity and route theirs through the main process.
+    private val pendingFileChooser = PendingFileChooser()
+
+    private val fileChooserLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            pendingFileChooser.deliver(NappletFileChooser.parseResult(result.resultCode, result.data))
+        }
 
     // ---- broker bridge (per-origin NIP-07 tokens; identical to NappletBrowserService) ----
     private var brokerMessenger: Messenger? = null
@@ -291,6 +304,8 @@ class NappletBrowserActivity : ComponentActivity() {
         // life of the process. `unbindService` alone does not release it. See [replyMessenger].
         releaseFromBroker()
         runCatching { unbindService(brokerConnection) }
+        // A picker still up when the browser is torn down would otherwise leave its callback unanswered.
+        pendingFileChooser.cancel()
         if (this::webView.isInitialized) {
             // Detach from the view tree BEFORE destroy(). Destroying a WebView while it is still attached to
             // the window corrupts the SHARED multiprocess renderer/network state, which then breaks the OTHER
@@ -364,8 +379,19 @@ class NappletBrowserActivity : ComponentActivity() {
         wv.webChromeClient = BrowserChromeClient()
     }
 
-    /** Captures favicon and console output, and drives the top loading bar; all come from the WebChromeClient. */
+    /** Captures favicon and console output, drives the top loading bar, and opens the file picker. */
     private inner class BrowserChromeClient : WebChromeClient() {
+        /**
+         * Without this override the base implementation returns false and WebView shows nothing at all, so
+         * every `<input type="file">` in the browser is a dead tap. Always returns true: we take ownership
+         * of the callback, and [showFileChooser] guarantees it is answered on every path.
+         */
+        override fun onShowFileChooser(
+            webView: WebView,
+            filePathCallback: ValueCallback<Array<Uri>>,
+            fileChooserParams: FileChooserParams,
+        ): Boolean = showFileChooser(filePathCallback, fileChooserParams)
+
         override fun onProgressChanged(
             view: WebView,
             newProgress: Int,
@@ -396,6 +422,26 @@ class NappletBrowserActivity : ComponentActivity() {
             controlSheet?.updateConsoleCount(panel.entryCount)
             return true
         }
+    }
+
+    /**
+     * Opens the system picker for a page's file input and routes the pick back to it. Returns true
+     * unconditionally: the callback is ours from here on, and it is delivered on every path — a real
+     * pick, a cancel, or a device with no app that can return a file (the input is released with null so
+     * the user can tap it again after installing one).
+     */
+    private fun showFileChooser(
+        filePathCallback: ValueCallback<Array<Uri>>,
+        params: WebChromeClient.FileChooserParams,
+    ): Boolean {
+        pendingFileChooser.start(filePathCallback)
+        runCatching { fileChooserLauncher.launch(NappletFileChooser.buildIntent(this, params)) }
+            .onFailure { e ->
+                Log.w(TAG, "No activity available to pick a file", e)
+                pendingFileChooser.cancel()
+                Toast.makeText(this, getString(CommonsR.string.browser_file_chooser_unavailable), Toast.LENGTH_LONG).show()
+            }
+        return true
     }
 
     private inner class BrowserClient : WebViewClient() {

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserContract.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserContract.kt
@@ -94,6 +94,31 @@ object NappletBrowserContract {
      */
     const val MSG_MAGNIFIER_FRAME = 13
 
+    /**
+     * Provider → client: the page tapped an HTML file input and needs the system picker. The keyless
+     * `:napplet` process has no Activity of its own (this provider is windowless), and its streamed
+     * surface can't host one, so the main process runs the picker and sends the chosen URIs back.
+     *
+     * Carries the request description as data — [KEY_FILE_CHOOSER_ID], [KEY_FILE_CHOOSER_ACCEPT] (the raw `accept` entries),
+     * [KEY_FILE_CHOOSER_MULTIPLE] and [KEY_FILE_CHOOSER_TITLE] — never a ready-made Intent, so the sandbox can ask the trusted
+     * process for a file picker and for nothing else.
+     */
+    const val MSG_FILE_CHOOSER_REQUEST = 14
+
+    /**
+     * Client → provider: the picker for [KEY_FILE_CHOOSER_ID] finished. [KEY_FILE_CHOOSER_URIS] holds the picked
+     * `content://` URIs, or is absent when the user cancelled — the page's file input stays busy until
+     * one of the two arrives, so this is sent on every outcome. URI read grants are per-UID, so the URIs
+     * the main process was granted are readable by the WebView here without re-granting.
+     */
+    const val MSG_FILE_CHOOSER_RESULT = 15
+
+    const val KEY_FILE_CHOOSER_ID = "fileChooserId"
+    const val KEY_FILE_CHOOSER_ACCEPT = "fileChooserAccept"
+    const val KEY_FILE_CHOOSER_MULTIPLE = "fileChooserMultiple"
+    const val KEY_FILE_CHOOSER_TITLE = "fileChooserTitle"
+    const val KEY_FILE_CHOOSER_URIS = "fileChooserUris"
+
     const val KEY_MAG_X = "magX"
     const val KEY_MAG_Y = "magY"
     const val KEY_MAG_BOX_W = "magBoxW"

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserContract.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserContract.kt
@@ -116,6 +116,13 @@ object NappletBrowserContract {
     const val KEY_FILE_CHOOSER_ID = "fileChooserId"
     const val KEY_FILE_CHOOSER_ACCEPT = "fileChooserAccept"
     const val KEY_FILE_CHOOSER_MULTIPLE = "fileChooserMultiple"
+
+    /**
+     * The input's `capture` attribute: the page wants a camera, not a stored file. It decides
+     * whether the main process may ask for the CAMERA permission on this request, so it has to
+     * cross with it rather than being re-derived from the accept list.
+     */
+    const val KEY_FILE_CHOOSER_CAPTURE = "fileChooserCapture"
     const val KEY_FILE_CHOOSER_TITLE = "fileChooserTitle"
     const val KEY_FILE_CHOOSER_URIS = "fileChooserUris"
 

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserService.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserService.kt
@@ -419,7 +419,7 @@ class NappletBrowserService : Service() {
                     Bundle().apply {
                         putLong(NappletBrowserContract.KEY_FILE_CHOOSER_ID, id)
                         putStringArray(NappletBrowserContract.KEY_FILE_CHOOSER_ACCEPT, params.acceptTypes ?: emptyArray())
-                        putBoolean(NappletBrowserContract.KEY_FILE_CHOOSER_MULTIPLE, params.mode == WebChromeClient.FileChooserParams.MODE_OPEN_MULTIPLE)
+                        putBoolean(NappletBrowserContract.KEY_FILE_CHOOSER_MULTIPLE, NappletFileChooser.allowsMultiple(params.mode))
                         putString(NappletBrowserContract.KEY_FILE_CHOOSER_TITLE, params.title?.toString())
                     }
             }

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserService.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserService.kt
@@ -38,6 +38,7 @@ import android.os.Messenger
 import android.os.SystemClock
 import android.util.Log
 import android.webkit.ConsoleMessage
+import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
@@ -47,6 +48,7 @@ import android.webkit.WebViewClient
 import androidx.annotation.RequiresApi
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.scale
+import androidx.core.net.toUri
 import androidx.privacysandbox.ui.provider.toCoreLibInfo
 import androidx.webkit.JavaScriptReplyProxy
 import androidx.webkit.WebMessageCompat
@@ -94,6 +96,10 @@ class NappletBrowserService : Service() {
         var webView: WebView? = null
         var bridgeReplyProxy: JavaScriptReplyProxy? = null
         var fireSeq = 0
+
+        // The in-flight `<input type="file">` pick for this surface. The picker itself runs in the main
+        // process (this provider is windowless), so the callback waits here for MSG_FILE_CHOOSER_RESULT.
+        val fileChooser = PendingFileChooser()
 
         // Last main-frame error state, pushed to the client so it can show an error/retry overlay over
         // the surface (the embedded surface has no error page of its own).
@@ -146,7 +152,10 @@ class NappletBrowserService : Service() {
             runCatching { unbindService(brokerConnection) }
             brokerBound = false
         }
-        tabs.values.forEach { it.webView?.destroy() }
+        tabs.values.forEach {
+            it.fileChooser.cancel()
+            it.webView?.destroy()
+        }
         tabs.clear()
         super.onDestroy()
     }
@@ -195,6 +204,15 @@ class NappletBrowserService : Service() {
                 applyWebViewProxy(if (tab.useTor) tab.proxyPort else -1) { tab.webView?.reload() }
             }
             NappletBrowserContract.MSG_MAGNIFIER_REQUEST -> onMagnifierRequest(msg)
+            NappletBrowserContract.MSG_FILE_CHOOSER_RESULT -> {
+                val tab = tabFor(msg) ?: return true
+                val data = msg.data ?: return true
+                val id = data.getLong(NappletBrowserContract.KEY_FILE_CHOOSER_ID)
+                // Absent array = the user cancelled; PendingFileChooser turns that into the null the page
+                // needs to see so its file input becomes tappable again.
+                val uris = data.getStringArray(NappletBrowserContract.KEY_FILE_CHOOSER_URIS)?.map(String::toUri)
+                tab.fileChooser.deliver(id, uris?.toTypedArray())
+            }
             else -> return false
         }
         return true
@@ -295,6 +313,8 @@ class NappletBrowserService : Service() {
     fun onSessionClosed(sessionId: String) {
         val tab = tabs.remove(sessionId) ?: return
         tab.bridgeReplyProxy = null
+        // Release a picker still waiting on this surface before its WebView goes away.
+        tab.fileChooser.cancel()
         tab.webView?.destroy()
         tab.webView = null
     }
@@ -337,6 +357,17 @@ class NappletBrowserService : Service() {
         private val tab: BrowserTab?,
     ) : WebChromeClient() {
         /**
+         * Hands the page's `<input type="file">` to the main process, which owns the only Activity that
+         * can run a picker. Always returns true: the callback is ours now, and [requestFileChooser]
+         * answers it on every path — otherwise the input would stay dead for the life of the page.
+         */
+        override fun onShowFileChooser(
+            webView: WebView,
+            filePathCallback: ValueCallback<Array<Uri>>,
+            fileChooserParams: FileChooserParams,
+        ): Boolean = requestFileChooser(tab, filePathCallback, fileChooserParams)
+
+        /**
          * The embedded surface captures favicons just like the full-screen browser does — a site pinned
          * to a tab but never opened full-screen would otherwise never contribute an icon at all.
          */
@@ -363,6 +394,37 @@ class NappletBrowserService : Service() {
             )
             return true
         }
+    }
+
+    /**
+     * Asks the client (main process) to run the picker for [tab] and remembers the callback until the
+     * matching [NappletBrowserContract.MSG_FILE_CHOOSER_RESULT] comes back. A surface with no client to
+     * ask — a torn-down tab, a dead Messenger — releases the input immediately instead of leaving it
+     * stuck waiting for a reply that can never arrive.
+     */
+    private fun requestFileChooser(
+        tab: BrowserTab?,
+        filePathCallback: ValueCallback<Array<Uri>>,
+        params: WebChromeClient.FileChooserParams,
+    ): Boolean {
+        val client = tab?.clientMessenger
+        if (client == null) {
+            filePathCallback.onReceiveValue(null)
+            return true
+        }
+        val id = tab.fileChooser.start(filePathCallback)
+        val msg =
+            Message.obtain(null, NappletBrowserContract.MSG_FILE_CHOOSER_REQUEST).apply {
+                data =
+                    Bundle().apply {
+                        putLong(NappletBrowserContract.KEY_FILE_CHOOSER_ID, id)
+                        putStringArray(NappletBrowserContract.KEY_FILE_CHOOSER_ACCEPT, params.acceptTypes ?: emptyArray())
+                        putBoolean(NappletBrowserContract.KEY_FILE_CHOOSER_MULTIPLE, params.mode == WebChromeClient.FileChooserParams.MODE_OPEN_MULTIPLE)
+                        putString(NappletBrowserContract.KEY_FILE_CHOOSER_TITLE, params.title?.toString())
+                    }
+            }
+        if (runCatching { client.send(msg) }.isFailure) tab.fileChooser.cancel()
+        return true
     }
 
     private fun pushConsoleLog(

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserService.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletBrowserService.kt
@@ -420,6 +420,7 @@ class NappletBrowserService : Service() {
                         putLong(NappletBrowserContract.KEY_FILE_CHOOSER_ID, id)
                         putStringArray(NappletBrowserContract.KEY_FILE_CHOOSER_ACCEPT, params.acceptTypes ?: emptyArray())
                         putBoolean(NappletBrowserContract.KEY_FILE_CHOOSER_MULTIPLE, NappletFileChooser.allowsMultiple(params.mode))
+                        putBoolean(NappletBrowserContract.KEY_FILE_CHOOSER_CAPTURE, params.isCaptureEnabled)
                         putString(NappletBrowserContract.KEY_FILE_CHOOSER_TITLE, params.title?.toString())
                     }
             }

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletCaptureFileProvider.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletCaptureFileProvider.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.napplethost
+
+import androidx.core.content.FileProvider
+
+/**
+ * Serves the scratch files a camera writes WebView captures into (see [NappletCaptureFiles]).
+ *
+ * Exists as its own class purely so it can be its own `<provider>`: the manifest merger keys provider
+ * nodes by `android:name`, so declaring a second `androidx.core.content.FileProvider` alongside the
+ * app's general-purpose one collides on `authorities`. Subclassing gives this a separate node, a
+ * separate authority, and — the reason it is worth doing — a separate paths file, so the only thing
+ * reachable through it is one cache subdirectory rather than everything the app's provider exposes.
+ */
+class NappletCaptureFileProvider : FileProvider()

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletCaptureFiles.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletCaptureFiles.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.napplethost
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.util.Log
+import androidx.core.content.FileProvider
+import java.io.File
+
+/**
+ * The scratch files a camera app writes a WebView capture into, and the [FileProvider] URIs that
+ * expose them.
+ *
+ * `ACTION_IMAGE_CAPTURE` only returns a full-resolution photo when it is handed somewhere to put it
+ * (`EXTRA_OUTPUT`); without one it returns a thumbnail in the result extras, which is useless as an
+ * upload. So each capture option gets its own empty file here first.
+ *
+ * They live in `cacheDir`, which is one directory shared by the main and `:napplet` processes, so it
+ * does not matter which side ran the picker. They cannot be deleted as soon as the capture returns —
+ * the page may not read the file until the user submits the form, which can be minutes later — so
+ * [sweepStale] reclaims them on a later run instead, and the OS can evict the whole directory under
+ * storage pressure regardless.
+ */
+object NappletCaptureFiles {
+    private const val DIR = "webview-captures"
+    private const val TAG = "NappletCapture"
+
+    /** Files older than this are assumed read (or abandoned) and are deleted on the next request. */
+    private const val STALE_AFTER_MS = 24L * 60 * 60 * 1000
+
+    /** Authority of the dedicated provider declared in this module's manifest. */
+    private fun authority(context: Context) = "${context.packageName}.napplethost.captures"
+
+    /**
+     * Creates an empty capture file and its content URI, or null when the cache directory cannot be
+     * written — in which case the caller simply omits that camera option rather than offering one that
+     * would come back empty.
+     */
+    fun create(
+        context: Context,
+        extension: String,
+    ): Pair<File, Uri>? =
+        runCatching {
+            val dir = File(context.cacheDir, DIR).apply { mkdirs() }
+            // Not createTempFile's random name: a stable, sortable prefix makes the sweep below able to
+            // recognise our own files and nothing else.
+            val file = File(dir, "capture-${System.currentTimeMillis()}-${counter++}.$extension")
+            file.createNewFile()
+            file to FileProvider.getUriForFile(context, authority(context), file)
+        }.onFailure { Log.w(TAG, "Could not create a capture file", it) }
+            .getOrNull()
+
+    /** Deletes capture files left behind by earlier requests. Called before creating new ones. */
+    fun sweepStale(context: Context) {
+        runCatching {
+            val cutoff = System.currentTimeMillis() - STALE_AFTER_MS
+            File(context.cacheDir, DIR)
+                .listFiles()
+                ?.filter { it.isFile && it.lastModified() < cutoff }
+                ?.forEach { it.delete() }
+        }.onFailure { Log.w(TAG, "Could not sweep stale capture files", it) }
+    }
+
+    /**
+     * Grants every installed camera app write access to [uri].
+     *
+     * A chooser entry supplied through `EXTRA_INITIAL_INTENTS` is started by the system chooser, not by
+     * us, and the URI grant flags on that Intent are not reliably carried across the hop on every
+     * Android version — the camera then cannot open the output file and returns nothing. Granting each
+     * resolved package up front is the part that works everywhere.
+     *
+     * The cost is that the grant necessarily goes to every camera app, not just the one the user is
+     * about to choose (nobody knows that yet), so [releaseGrants] takes it all back the moment the
+     * outcome is known.
+     */
+    fun grantTo(
+        context: Context,
+        packages: Collection<String>,
+        uri: Uri,
+    ) {
+        packages.forEach { pkg ->
+            runCatching { context.grantUriPermission(pkg, uri, GRANT_FLAGS) }
+                .onFailure { Log.w(TAG, "Could not grant capture access to $pkg", it) }
+        }
+    }
+
+    /**
+     * Takes back the grants [grantTo] handed out, so no other app keeps a handle on a photo the user
+     * just took. Called for the kept capture as well as the discarded ones.
+     *
+     * Revokes per package rather than with the whole-URI overload, which is the point: this app reads
+     * the file back through its OWN provider, and same-UID access to a non-exported provider never went
+     * through a grant in the first place. Naming the packages makes it impossible for this to clip our
+     * own read on the way past.
+     */
+    fun releaseGrants(
+        context: Context,
+        packages: Collection<String>,
+        uri: Uri,
+    ) {
+        packages.forEach { pkg ->
+            runCatching { context.revokeUriPermission(pkg, uri, GRANT_FLAGS) }
+        }
+    }
+
+    /** Drops a capture file the user never filled — a cancelled camera, or the option they didn't take. */
+    fun discard(
+        context: Context,
+        file: File,
+    ) {
+        runCatching { file.delete() }
+    }
+
+    private const val GRANT_FLAGS = Intent.FLAG_GRANT_WRITE_URI_PERMISSION or Intent.FLAG_GRANT_READ_URI_PERMISSION
+
+    private var counter = 0
+}

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletCaptureFiles.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletCaptureFiles.kt
@@ -62,10 +62,12 @@ object NappletCaptureFiles {
     ): Pair<File, Uri>? =
         runCatching {
             val dir = File(context.cacheDir, DIR).apply { mkdirs() }
-            // Not createTempFile's random name: a stable, sortable prefix makes the sweep below able to
-            // recognise our own files and nothing else.
-            val file = File(dir, "capture-${System.currentTimeMillis()}-${counter++}.$extension")
-            file.createNewFile()
+            // createTempFile, not a name built from a clock and a per-object sequence: the main and
+            // `:napplet` processes each hold their OWN copy of this object, so those sequences run
+            // independently and two picks started in the same millisecond could name the same file —
+            // one capture would then silently overwrite the other. The extension is what FileProvider
+            // types the URI from, so it has to survive into the suffix.
+            val file = File.createTempFile("capture-", ".$extension", dir)
             file to FileProvider.getUriForFile(context, authority(context), file)
         }.onFailure { Log.w(TAG, "Could not create a capture file", it) }
             .getOrNull()
@@ -132,6 +134,4 @@ object NappletCaptureFiles {
     }
 
     private const val GRANT_FLAGS = Intent.FLAG_GRANT_WRITE_URI_PERMISSION or Intent.FLAG_GRANT_READ_URI_PERMISSION
-
-    private var counter = 0
 }

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletEmbedContract.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletEmbedContract.kt
@@ -118,6 +118,13 @@ object NappletEmbedContract {
     const val KEY_FILE_CHOOSER_ID = "fileChooserId"
     const val KEY_FILE_CHOOSER_ACCEPT = "fileChooserAccept"
     const val KEY_FILE_CHOOSER_MULTIPLE = "fileChooserMultiple"
+
+    /**
+     * The input's `capture` attribute: the page wants a camera, not a stored file. It decides
+     * whether the main process may ask for the CAMERA permission on this request, so it has to
+     * cross with it rather than being re-derived from the accept list.
+     */
+    const val KEY_FILE_CHOOSER_CAPTURE = "fileChooserCapture"
     const val KEY_FILE_CHOOSER_TITLE = "fileChooserTitle"
     const val KEY_FILE_CHOOSER_URIS = "fileChooserUris"
 

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletEmbedContract.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletEmbedContract.kt
@@ -96,6 +96,31 @@ object NappletEmbedContract {
     /** Provider → client: the captured loupe frame — [KEY_MAG_BYTES] PNG, [KEY_MAG_W]/[KEY_MAG_H], [KEY_MAG_CAPTURE_MS], echoed [KEY_MAG_REQ_T]. */
     const val MSG_MAGNIFIER_FRAME = 17
 
+    /**
+     * Provider → client: the page tapped an HTML file input and needs the system picker. The keyless
+     * `:napplet` process has no Activity of its own (this provider is windowless), and its streamed
+     * surface can't host one, so the main process runs the picker and sends the chosen URIs back.
+     *
+     * Carries the request description as data — [KEY_FILE_CHOOSER_ID], [KEY_FILE_CHOOSER_ACCEPT] (the raw `accept` entries),
+     * [KEY_FILE_CHOOSER_MULTIPLE] and [KEY_FILE_CHOOSER_TITLE] — never a ready-made Intent, so the sandbox can ask the trusted
+     * process for a file picker and for nothing else.
+     */
+    const val MSG_FILE_CHOOSER_REQUEST = 18
+
+    /**
+     * Client → provider: the picker for [KEY_FILE_CHOOSER_ID] finished. [KEY_FILE_CHOOSER_URIS] holds the picked
+     * `content://` URIs, or is absent when the user cancelled — the page's file input stays busy until
+     * one of the two arrives, so this is sent on every outcome. URI read grants are per-UID, so the URIs
+     * the main process was granted are readable by the WebView here without re-granting.
+     */
+    const val MSG_FILE_CHOOSER_RESULT = 19
+
+    const val KEY_FILE_CHOOSER_ID = "fileChooserId"
+    const val KEY_FILE_CHOOSER_ACCEPT = "fileChooserAccept"
+    const val KEY_FILE_CHOOSER_MULTIPLE = "fileChooserMultiple"
+    const val KEY_FILE_CHOOSER_TITLE = "fileChooserTitle"
+    const val KEY_FILE_CHOOSER_URIS = "fileChooserUris"
+
     const val KEY_MAG_X = "magX"
     const val KEY_MAG_Y = "magY"
     const val KEY_MAG_BOX_W = "magBoxW"

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletFileChooser.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletFileChooser.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.napplethost
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.webkit.MimeTypeMap
+import android.webkit.WebChromeClient.FileChooserParams
+import com.vitorpamplona.amethyst.commons.browser.FileChooserAccept
+import com.vitorpamplona.amethyst.commons.R as CommonsR
+
+/**
+ * The picker behind an HTML `<input type="file">` in any of Amethyst's WebViews.
+ *
+ * A WebView shows no picker of its own: unless the app overrides
+ * `WebChromeClient.onShowFileChooser`, tapping a file input is a silent no-op. Every host here does
+ * override it, and they all build their Intent through this so the browser, the full-screen napplet /
+ * nSite sandbox, and both embedded surfaces filter and multi-select identically.
+ *
+ * The request is described by plain data (accept list, multi-select, title) rather than by a
+ * ready-made Intent, because the two embedded hosts have no Activity of their own and must ask the
+ * main process to launch the picker for them. Shipping data keeps the keyless `:napplet` process
+ * unable to hand the trusted process an arbitrary Intent to start — it can only ask for a file picker.
+ */
+object NappletFileChooser {
+    /**
+     * Builds the picker for a request described by [acceptTypes] / [allowMultiple].
+     *
+     * `ACTION_GET_CONTENT` (rather than `ACTION_OPEN_DOCUMENT`) so gallery and camera-roll apps that
+     * are not document providers still show up — the same trade-off Chrome makes; the page only ever
+     * needs to read the bytes once, not to hold a persistable grant. [pageTitle] is the page-supplied
+     * chooser title, used when it set one.
+     */
+    fun buildIntent(
+        context: Context,
+        acceptTypes: List<String>,
+        allowMultiple: Boolean,
+        pageTitle: CharSequence? = null,
+    ): Intent {
+        val mimeMap = MimeTypeMap.getSingleton()
+        val resolved = FileChooserAccept.resolve(acceptTypes) { ext -> mimeMap.getMimeTypeFromExtension(ext) }
+
+        val pick =
+            Intent(Intent.ACTION_GET_CONTENT)
+                .addCategory(Intent.CATEGORY_OPENABLE)
+                .setType(resolved.primaryType)
+                // The provider sets this on the result too; asking for it up front makes the read grant
+                // explicit. Grants are per-UID, so a URI picked by the main process is readable by the
+                // WebView in `:napplet` without any re-granting.
+                .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+
+        // Only worth sending when it says more than `type` already does.
+        if (resolved.mimeTypes.size > 1) {
+            pick.putExtra(Intent.EXTRA_MIME_TYPES, resolved.mimeTypes.toTypedArray())
+        }
+        if (allowMultiple) pick.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+
+        val title = pageTitle?.takeIf { it.isNotBlank() } ?: context.getString(CommonsR.string.browser_file_chooser_title)
+        return Intent.createChooser(pick, title)
+    }
+
+    /** Convenience overload for the two Activity hosts, which hold the real [FileChooserParams]. */
+    fun buildIntent(
+        context: Context,
+        params: FileChooserParams,
+    ): Intent =
+        buildIntent(
+            context = context,
+            acceptTypes = params.acceptTypes?.toList().orEmpty(),
+            allowMultiple = params.mode == FileChooserParams.MODE_OPEN_MULTIPLE,
+            pageTitle = params.title,
+        )
+
+    /**
+     * Turns an activity result into the array the page's `filePathCallback` expects, or null when the
+     * user backed out. Handles both the single-URI and the `ClipData` multi-select shapes.
+     */
+    fun parseResult(
+        resultCode: Int,
+        data: Intent?,
+    ): Array<Uri>? = FileChooserParams.parseResult(resultCode, data)
+}

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletFileChooser.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletFileChooser.kt
@@ -162,6 +162,17 @@ object NappletFileChooser {
      * shape — where the result carries no URI at all and the evidence of a capture is a scratch file
      * that now has bytes in it. Every capture file this request created and did not return is deleted
      * here, so a cancelled or unused camera option leaves nothing behind.
+     *
+     * The URIs are read off the Intent here rather than through
+     * [FileChooserParams.parseResult][android.webkit.WebChromeClient.FileChooserParams.parseResult],
+     * which is a WebView *static*: calling it boots Chromium in whatever process calls it. This runs
+     * in the main process too — [com.vitorpamplona.amethyst.napplet.WebFileChooserActivity] is the
+     * chooser host for the embedded surfaces and declares no `android:process` — while `:napplet`
+     * already holds the WebView data directory. That second init throws
+     * `Using WebView from more than one process at once with the same data directory is not
+     * supported` out of `AwDataDirLock` and takes the whole app down on every completed embedded
+     * pick. The platform implementation reads exactly these two fields, so this is behaviour-for-
+     * behaviour identical without dragging WebView into a process that must not have it.
      */
     fun parseResult(
         context: Context,
@@ -169,7 +180,17 @@ object NappletFileChooser {
         resultCode: Int,
         data: Intent?,
     ): Array<Uri>? {
-        val picked = FileChooserParams.parseResult(resultCode, data)?.takeIf { it.isNotEmpty() }
+        val picked =
+            if (resultCode == Activity.RESULT_OK && data != null) {
+                val clip = data.clipData
+                if (clip != null && clip.itemCount > 0) {
+                    Array(clip.itemCount) { clip.getItemAt(it).uri }
+                } else {
+                    data.data?.let { arrayOf(it) }
+                }
+            } else {
+                null
+            }?.takeIf { it.isNotEmpty() }
 
         // A camera returns no URI at all — it reports success by filling the file we handed it, so an
         // empty one means it was dismissed. Only consulted when the picker returned nothing of its own.

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletFileChooser.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletFileChooser.kt
@@ -20,12 +20,16 @@
  */
 package com.vitorpamplona.amethyst.napplethost
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
+import android.provider.MediaStore
 import android.webkit.MimeTypeMap
 import android.webkit.WebChromeClient.FileChooserParams
 import com.vitorpamplona.amethyst.commons.browser.FileChooserAccept
+import java.io.File
 import com.vitorpamplona.amethyst.commons.R as CommonsR
 
 /**
@@ -33,29 +37,56 @@ import com.vitorpamplona.amethyst.commons.R as CommonsR
  *
  * A WebView shows no picker of its own: unless the app overrides
  * `WebChromeClient.onShowFileChooser`, tapping a file input is a silent no-op. Every host here does
- * override it, and they all build their Intent through this so the browser, the full-screen napplet /
- * nSite sandbox, and both embedded surfaces filter and multi-select identically.
+ * override it, and they all build their request through this so the browser, the full-screen napplet /
+ * nSite sandbox, and both embedded surfaces filter, multi-select and capture identically.
  *
- * The request is described by plain data (accept list, multi-select, title) rather than by a
+ * A request is described by plain data (accept list, multi-select, capture, title) rather than by a
  * ready-made Intent, because the two embedded hosts have no Activity of their own and must ask the
- * main process to launch the picker for them. Shipping data keeps the keyless `:napplet` process
- * unable to hand the trusted process an arbitrary Intent to start — it can only ask for a file picker.
+ * main process to run the picker for them. Shipping data keeps the keyless `:napplet` process unable
+ * to hand the trusted process an arbitrary Intent to start — it can only ask for a file picker.
  */
 object NappletFileChooser {
     /**
-     * Builds the picker for a request described by [acceptTypes] / [allowMultiple].
+     * A built picker, plus the capture files behind whatever camera options it offers.
      *
-     * `ACTION_GET_CONTENT` (rather than `ACTION_OPEN_DOCUMENT`) so gallery and camera-roll apps that
-     * are not document providers still show up — the same trade-off Chrome makes; the page only ever
-     * needs to read the bytes once, not to hold a persistable grant. [pageTitle] is the page-supplied
-     * chooser title, used when it set one.
+     * The capture files have to outlive the Intent: a camera writes to `EXTRA_OUTPUT` and returns a
+     * result with no data at all, so the only way to learn what was shot is to look at the files
+     * afterwards ([parseResult]).
      */
-    fun buildIntent(
+    class Request internal constructor(
+        val intent: Intent,
+        internal val captures: List<Capture>,
+    )
+
+    /** One camera option's output file, its content URI, and who was granted access to write it. */
+    class Capture internal constructor(
+        internal val file: File,
+        internal val uri: Uri,
+        internal val grantedTo: List<String>,
+    )
+
+    /**
+     * Builds the picker for a request described by [acceptTypes] / [allowMultiple] / [captureEnabled].
+     *
+     * `ACTION_GET_CONTENT` (rather than `ACTION_OPEN_DOCUMENT`) so gallery apps that are not document
+     * providers still show up — the same trade-off Chrome makes; the page only needs to read the bytes
+     * once, not hold a persistable grant. When the page accepts photos or video, the matching camera is
+     * offered alongside the file sources, which is what makes an image-accepting input behave the way it
+     * does in a mobile browser instead of only reaching already-saved files.
+     *
+     * [cameraAllowed] must be the caller's live CAMERA-permission state: `ACTION_IMAGE_CAPTURE` throws
+     * `SecurityException` for an app that declares the CAMERA permission without holding it, and
+     * Amethyst declares it. Callers request it first when the page asked for a camera outright
+     * ([captureEnabled]); see [wantsCamera].
+     */
+    fun buildRequest(
         context: Context,
         acceptTypes: List<String>,
         allowMultiple: Boolean,
+        captureEnabled: Boolean,
+        cameraAllowed: Boolean,
         pageTitle: CharSequence? = null,
-    ): Intent {
+    ): Request {
         val mimeMap = MimeTypeMap.getSingleton()
         val resolved = FileChooserAccept.resolve(acceptTypes) { ext -> mimeMap.getMimeTypeFromExtension(ext) }
 
@@ -74,21 +105,44 @@ object NappletFileChooser {
         }
         if (allowMultiple) pick.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
 
+        val captures = if (cameraAllowed) buildCaptureOptions(context, acceptTypes) else emptyList()
+
         val title = pageTitle?.takeIf { it.isNotBlank() } ?: context.getString(CommonsR.string.browser_file_chooser_title)
-        return Intent.createChooser(pick, title)
+        val chooser = Intent.createChooser(pick, title)
+
+        if (captures.isNotEmpty()) {
+            // At most two entries (stills + video), which is also all the system chooser will display
+            // from EXTRA_INITIAL_INTENTS — anything beyond that would be silently dropped.
+            chooser.putExtra(Intent.EXTRA_INITIAL_INTENTS, captures.map { it.first }.toTypedArray())
+        }
+
+        return Request(chooser, captures.map { it.second })
     }
 
     /** Convenience overload for the two Activity hosts, which hold the real [FileChooserParams]. */
-    fun buildIntent(
+    fun buildRequest(
         context: Context,
         params: FileChooserParams,
-    ): Intent =
-        buildIntent(
+        cameraAllowed: Boolean,
+    ): Request =
+        buildRequest(
             context = context,
             acceptTypes = params.acceptTypes?.toList().orEmpty(),
             allowMultiple = allowsMultiple(params.mode),
+            captureEnabled = params.isCaptureEnabled,
+            cameraAllowed = cameraAllowed,
             pageTitle = params.title,
         )
+
+    /**
+     * Whether a picker for [acceptTypes] would offer a camera at all — i.e. whether it is worth holding
+     * (or asking for) the CAMERA permission. False for a page that only accepts documents, so opening a
+     * PDF upload never triggers a camera prompt.
+     */
+    fun wantsCamera(acceptTypes: List<String>): Boolean {
+        val mimeMap = MimeTypeMap.getSingleton()
+        return FileChooserAccept.captureMedia(acceptTypes) { ext -> mimeMap.getMimeTypeFromExtension(ext) }.isNotEmpty()
+    }
 
     /**
      * Whether [mode] should let the user pick more than one file.
@@ -103,11 +157,74 @@ object NappletFileChooser {
     fun allowsMultiple(mode: Int): Boolean = mode == FileChooserParams.MODE_OPEN_MULTIPLE || mode == FileChooserParams.MODE_OPEN_FOLDER
 
     /**
-     * Turns an activity result into the array the page's `filePathCallback` expects, or null when the
-     * user backed out. Handles both the single-URI and the `ClipData` multi-select shapes.
+     * Turns an activity result into the array the page's `filePathCallback` expects, or null when
+     * nothing was chosen. Handles the single-URI and `ClipData` multi-select shapes, and the camera
+     * shape — where the result carries no URI at all and the evidence of a capture is a scratch file
+     * that now has bytes in it. Every capture file this request created and did not return is deleted
+     * here, so a cancelled or unused camera option leaves nothing behind.
      */
     fun parseResult(
+        context: Context,
+        request: Request,
         resultCode: Int,
         data: Intent?,
-    ): Array<Uri>? = FileChooserParams.parseResult(resultCode, data)
+    ): Array<Uri>? {
+        val picked = FileChooserParams.parseResult(resultCode, data)?.takeIf { it.isNotEmpty() }
+
+        // A camera returns no URI at all — it reports success by filling the file we handed it, so an
+        // empty one means it was dismissed. Only consulted when the picker returned nothing of its own.
+        val captured =
+            if (picked != null || resultCode != Activity.RESULT_OK) {
+                null
+            } else {
+                request.captures.firstOrNull { it.file.length() > 0 }
+            }
+
+        request.captures.forEach { capture ->
+            // Every camera app was granted write access up front because none of them could be ruled
+            // out yet. The outcome is known now, so none of them needs it any more — including for the
+            // photo being returned, which this app reads back through its own provider.
+            NappletCaptureFiles.releaseGrants(context, capture.grantedTo, capture.uri)
+            if (capture !== captured) NappletCaptureFiles.discard(context, capture.file)
+        }
+
+        return picked ?: captured?.let { arrayOf(it.uri) }
+    }
+
+    /**
+     * One camera option per medium the page accepts, each with its own output file. Media with no
+     * installed handler are skipped so the chooser never shows an entry that dead-ends.
+     */
+    private fun buildCaptureOptions(
+        context: Context,
+        acceptTypes: List<String>,
+    ): List<Pair<Intent, Capture>> {
+        val mimeMap = MimeTypeMap.getSingleton()
+        val media = FileChooserAccept.captureMedia(acceptTypes) { ext -> mimeMap.getMimeTypeFromExtension(ext) }
+        if (media.isEmpty()) return emptyList()
+
+        NappletCaptureFiles.sweepStale(context)
+
+        return media.mapNotNull { medium ->
+            val (action, extension) =
+                when (medium) {
+                    FileChooserAccept.CaptureMedia.IMAGE -> MediaStore.ACTION_IMAGE_CAPTURE to "jpg"
+                    FileChooserAccept.CaptureMedia.VIDEO -> MediaStore.ACTION_VIDEO_CAPTURE to "mp4"
+                }
+
+            val handlers = context.packageManager.queryIntentActivities(Intent(action), PackageManager.MATCH_DEFAULT_ONLY)
+            if (handlers.isEmpty()) return@mapNotNull null
+
+            val (file, uri) = NappletCaptureFiles.create(context, extension) ?: return@mapNotNull null
+            val packages = handlers.map { it.activityInfo.packageName }.distinct()
+            NappletCaptureFiles.grantTo(context, packages, uri)
+
+            val intent =
+                Intent(action)
+                    .putExtra(MediaStore.EXTRA_OUTPUT, uri)
+                    .addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION or Intent.FLAG_GRANT_READ_URI_PERMISSION)
+
+            intent to Capture(file, uri, packages)
+        }
+    }
 }

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletFileChooser.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletFileChooser.kt
@@ -192,24 +192,43 @@ object NappletFileChooser {
                 null
             }?.takeIf { it.isNotEmpty() }
 
-        // A camera returns no URI at all — it reports success by filling the file we handed it, so an
+        // Not every camera reports a capture the same way. `ACTION_IMAGE_CAPTURE` returns no URI and
+        // simply fills the file, but `ACTION_VIDEO_CAPTURE` on at least GoogleCamera echoes the
+        // EXTRA_OUTPUT URI straight back in the result — including when the recording was abandoned
+        // and nothing was ever written. Taken at face value that hands the page a 0-byte file and the
+        // upload silently succeeds with no content. An echoed URI is therefore only worth anything if
+        // the file behind it actually has bytes; when it does not, drop it and let the emptiness rules
+        // below treat the request as dismissed. URIs that are not ours are never second-guessed.
+        val usable =
+            picked
+                ?.filter { uri ->
+                    val own = request.captures.firstOrNull { it.uri == uri }
+                    own == null || own.file.length() > 0
+                }?.toTypedArray()
+                ?.takeIf { it.isNotEmpty() }
+
+        // A camera that returns no URI at all reports success by filling the file we handed it, so an
         // empty one means it was dismissed. Only consulted when the picker returned nothing of its own.
         val captured =
-            if (picked != null || resultCode != Activity.RESULT_OK) {
+            if (usable != null || resultCode != Activity.RESULT_OK) {
                 null
             } else {
                 request.captures.firstOrNull { it.file.length() > 0 }
             }
+
+        // A capture whose URI is being handed to the page has to outlive this call, whether it got
+        // there by being echoed back ([usable]) or by being the filled file ([captured]).
+        val returned = usable?.toSet().orEmpty()
 
         request.captures.forEach { capture ->
             // Every camera app was granted write access up front because none of them could be ruled
             // out yet. The outcome is known now, so none of them needs it any more — including for the
             // photo being returned, which this app reads back through its own provider.
             NappletCaptureFiles.releaseGrants(context, capture.grantedTo, capture.uri)
-            if (capture !== captured) NappletCaptureFiles.discard(context, capture.file)
+            if (capture !== captured && capture.uri !in returned) NappletCaptureFiles.discard(context, capture.file)
         }
 
-        return picked ?: captured?.let { arrayOf(it.uri) }
+        return usable ?: captured?.let { arrayOf(it.uri) }
     }
 
     /**

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletFileChooser.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletFileChooser.kt
@@ -86,9 +86,21 @@ object NappletFileChooser {
         buildIntent(
             context = context,
             acceptTypes = params.acceptTypes?.toList().orEmpty(),
-            allowMultiple = params.mode == FileChooserParams.MODE_OPEN_MULTIPLE,
+            allowMultiple = allowsMultiple(params.mode),
             pageTitle = params.title,
         )
+
+    /**
+     * Whether [mode] should let the user pick more than one file.
+     *
+     * `MODE_OPEN_FOLDER` is a `webkitdirectory` input. Android has no picker that hands a WebView the
+     * files of a directory — `ACTION_OPEN_DOCUMENT_TREE` returns a tree handle, not the file URIs the
+     * page's callback takes — so the closest honest answer is to let the user select the files
+     * themselves. They lose `webkitRelativePath`, but they can complete the upload instead of being
+     * limited to one file. The two embedded providers resolve this before sending the request, so all
+     * four surfaces agree on it.
+     */
+    fun allowsMultiple(mode: Int): Boolean = mode == FileChooserParams.MODE_OPEN_MULTIPLE || mode == FileChooserParams.MODE_OPEN_FOLDER
 
     /**
      * Turns an activity result into the array the page's `filePathCallback` expects, or null when the

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletHostActivity.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletHostActivity.kt
@@ -56,7 +56,6 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.webkit.JavaScriptReplyProxy
 import androidx.webkit.ProxyConfig
@@ -108,10 +107,7 @@ class NappletHostActivity : ComponentActivity() {
     // Registered as a field so it exists before onCreate returns (registerForActivityResult's contract).
     private val pendingFileChooser = PendingFileChooser()
 
-    private val fileChooserLauncher =
-        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-            pendingFileChooser.deliver(NappletFileChooser.parseResult(result.resultCode, result.data))
-        }
+    private val fileChooserLauncher = WebFileChooserLauncher(this) { uris -> pendingFileChooser.deliver(uris) }
 
     private val paths = mutableListOf<PathTag>()
     private val servers = mutableListOf<String>()
@@ -703,12 +699,12 @@ class NappletHostActivity : ComponentActivity() {
         params: WebChromeClient.FileChooserParams,
     ): Boolean {
         pendingFileChooser.start(filePathCallback)
-        runCatching { fileChooserLauncher.launch(NappletFileChooser.buildIntent(this, params)) }
-            .onFailure { e ->
-                Log.w(TAG, "No activity available to pick a file", e)
-                pendingFileChooser.cancel()
-                Toast.makeText(this, getString(CommonsR.string.browser_file_chooser_unavailable), Toast.LENGTH_LONG).show()
-            }
+        fileChooserLauncher.launch(
+            acceptTypes = params.acceptTypes?.toList().orEmpty(),
+            allowMultiple = NappletFileChooser.allowsMultiple(params.mode),
+            captureEnabled = params.isCaptureEnabled,
+            pageTitle = params.title,
+        )
         return true
     }
 

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletHostActivity.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletHostActivity.kt
@@ -40,6 +40,7 @@ import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.ConsoleMessage
+import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
@@ -55,6 +56,7 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.webkit.JavaScriptReplyProxy
 import androidx.webkit.ProxyConfig
@@ -98,6 +100,18 @@ import com.vitorpamplona.amethyst.commons.R as CommonsR
  */
 class NappletHostActivity : ComponentActivity() {
     private lateinit var webView: WebView
+
+    // ---- HTML file input (`<input type="file">`) ----
+    // The applet picks the file through the system picker, so the user names exactly which file crosses
+    // into the sandbox — the same user-mediated grant a browser gives a web page. Nothing extra is
+    // brokered: the applet gets the bytes of the one file that was chosen and no path around it.
+    // Registered as a field so it exists before onCreate returns (registerForActivityResult's contract).
+    private val pendingFileChooser = PendingFileChooser()
+
+    private val fileChooserLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            pendingFileChooser.deliver(NappletFileChooser.parseResult(result.resultCode, result.data))
+        }
 
     private val paths = mutableListOf<PathTag>()
     private val servers = mutableListOf<String>()
@@ -449,6 +463,8 @@ class NappletHostActivity : ComponentActivity() {
         // unbind is in runCatching: if the index never resolved we never bound the broker.
         runCatching { unbindService(brokerConnection) }
         keyActions.clear()
+        // A picker still up when the applet is torn down would otherwise leave its callback unanswered.
+        pendingFileChooser.cancel()
         if (this::webView.isInitialized) {
             // Detach before destroy(): destroying an attached WebView corrupts the shared multiprocess
             // renderer/network state and breaks the other (embedded) WebViews in this `:napplet` process
@@ -649,8 +665,19 @@ class NappletHostActivity : ComponentActivity() {
         }
     }
 
-    /** Drives the top loading bar and forwards the applet/site's `console.*` output to the console panel. */
+    /** Drives the top loading bar, opens the file picker, and forwards `console.*` output to the panel. */
     private inner class NappletWebChromeClient : WebChromeClient() {
+        /**
+         * Without this override WebView's base implementation returns false and shows no picker at all, so
+         * every `<input type="file">` in an applet or nSite is a dead tap. Always returns true: the
+         * callback is ours, and [showFileChooser] answers it on every path.
+         */
+        override fun onShowFileChooser(
+            webView: WebView,
+            filePathCallback: ValueCallback<Array<Uri>>,
+            fileChooserParams: FileChooserParams,
+        ): Boolean = showFileChooser(filePathCallback, fileChooserParams)
+
         override fun onProgressChanged(
             view: WebView,
             newProgress: Int,
@@ -664,6 +691,25 @@ class NappletHostActivity : ComponentActivity() {
             controlSheet?.updateConsoleCount(panel.entryCount)
             return true
         }
+    }
+
+    /**
+     * Opens the system picker for the applet's file input and routes the pick back to it. Returns true
+     * unconditionally: the callback is ours from here on, and it is answered on every path — a real pick,
+     * a cancel, or a device with no app that can return a file.
+     */
+    private fun showFileChooser(
+        filePathCallback: ValueCallback<Array<Uri>>,
+        params: WebChromeClient.FileChooserParams,
+    ): Boolean {
+        pendingFileChooser.start(filePathCallback)
+        runCatching { fileChooserLauncher.launch(NappletFileChooser.buildIntent(this, params)) }
+            .onFailure { e ->
+                Log.w(TAG, "No activity available to pick a file", e)
+                pendingFileChooser.cancel()
+                Toast.makeText(this, getString(CommonsR.string.browser_file_chooser_unavailable), Toast.LENGTH_LONG).show()
+            }
+        return true
     }
 
     /** Shows the thin top bar at [progress]% while loading, hiding it once the page is fully loaded. */

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletHostActivity.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletHostActivity.kt
@@ -461,6 +461,7 @@ class NappletHostActivity : ComponentActivity() {
         keyActions.clear()
         // A picker still up when the applet is torn down would otherwise leave its callback unanswered.
         pendingFileChooser.cancel()
+        fileChooserLauncher.teardown()
         if (this::webView.isInitialized) {
             // Detach before destroy(): destroying an attached WebView corrupts the shared multiprocess
             // renderer/network state and breaks the other (embedded) WebViews in this `:napplet` process

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletHostService.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletHostService.kt
@@ -38,6 +38,10 @@ import android.os.Messenger
 import android.os.SystemClock
 import android.util.Log
 import android.view.View
+import android.webkit.JsPromptResult
+import android.webkit.JsResult
+import android.webkit.ValueCallback
+import android.webkit.WebChromeClient
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
@@ -46,6 +50,7 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.annotation.RequiresApi
 import androidx.core.graphics.createBitmap
+import androidx.core.net.toUri
 import androidx.privacysandbox.ui.provider.toCoreLibInfo
 import androidx.webkit.JavaScriptReplyProxy
 import androidx.webkit.ProxyConfig
@@ -107,6 +112,10 @@ class NappletHostService : Service() {
         var bridgeReplyProxy: JavaScriptReplyProxy? = null
         var fireSeq = 0
 
+        // The in-flight `<input type="file">` pick for this surface. The picker itself runs in the main
+        // process (this provider is windowless), so the callback waits here for MSG_FILE_CHOOSER_RESULT.
+        val fileChooser = PendingFileChooser()
+
         // Last main-frame error state, pushed to the client so it can show an error/retry overlay over the
         // surface (the embedded surface has no error page of its own).
         var loadFailed = false
@@ -148,6 +157,7 @@ class NappletHostService : Service() {
             brokerBound = false
         }
         tabs.values.forEach {
+            it.fileChooser.cancel()
             it.contentServer?.close()
             it.webView?.destroy()
         }
@@ -183,6 +193,15 @@ class NappletHostService : Service() {
                 tab.bridgeReplyProxy?.postMessage(payload)
             }
             NappletEmbedContract.MSG_MAGNIFIER_REQUEST -> onMagnifierRequest(msg)
+            NappletEmbedContract.MSG_FILE_CHOOSER_RESULT -> {
+                val tab = tabFor(msg) ?: return true
+                val data = msg.data ?: return true
+                val id = data.getLong(NappletEmbedContract.KEY_FILE_CHOOSER_ID)
+                // Absent array = the user cancelled; PendingFileChooser turns that into the null the page
+                // needs to see so its file input becomes tappable again.
+                val uris = data.getStringArray(NappletEmbedContract.KEY_FILE_CHOOSER_URIS)?.map(String::toUri)
+                tab.fileChooser.deliver(id, uris?.toTypedArray())
+            }
             else -> return false
         }
         return true
@@ -328,6 +347,8 @@ class NappletHostService : Service() {
     fun onSessionClosed(sessionId: String) {
         val tab = tabs.remove(sessionId) ?: return
         tab.bridgeReplyProxy = null
+        // Release a picker still waiting on this surface before its WebView goes away.
+        tab.fileChooser.cancel()
         tab.contentServer?.close()
         tab.contentServer = null
         tab.webView?.destroy()
@@ -363,6 +384,90 @@ class NappletHostService : Service() {
         wv.overScrollMode = View.OVER_SCROLL_NEVER
         WebView.setWebContentsDebuggingEnabled(false)
         wv.webViewClient = HostClient(tab)
+        wv.webChromeClient = HostChromeClient(tab)
+    }
+
+    /**
+     * The applet's file picker. This surface has no other need for a chrome client — console output and
+     * the loading bar are drawn by the main process from [NappletEmbedContract.MSG_LOAD_STATE] — but
+     * without one WebView silently ignores every `<input type="file">`.
+     */
+    private inner class HostChromeClient(
+        private val tab: NappletTab,
+    ) : WebChromeClient() {
+        override fun onShowFileChooser(
+            webView: WebView,
+            filePathCallback: ValueCallback<Array<Uri>>,
+            fileChooserParams: FileChooserParams,
+        ): Boolean = requestFileChooser(tab, filePathCallback, fileChooserParams)
+
+        // Setting a chrome client at all is what opts this WebView into the default JS-dialog handling,
+        // and this one is built from a Service context — there is no window token to attach a dialog to,
+        // and an applet's alert() must not be able to draw over the main app's trusted chrome anyway.
+        // Dismiss all three so the page's JS resumes instead of blocking on a dialog that never appears.
+        override fun onJsAlert(
+            view: WebView,
+            url: String?,
+            message: String?,
+            result: JsResult,
+        ): Boolean {
+            result.cancel()
+            return true
+        }
+
+        override fun onJsConfirm(
+            view: WebView,
+            url: String?,
+            message: String?,
+            result: JsResult,
+        ): Boolean {
+            result.cancel()
+            return true
+        }
+
+        override fun onJsPrompt(
+            view: WebView,
+            url: String?,
+            message: String?,
+            defaultValue: String?,
+            result: JsPromptResult,
+        ): Boolean {
+            result.cancel()
+            return true
+        }
+    }
+
+    /**
+     * Asks the client (main process) to run the picker for [tab] and holds the callback until the
+     * matching [NappletEmbedContract.MSG_FILE_CHOOSER_RESULT] arrives. A surface with no client to ask
+     * releases the input immediately rather than leaving it stuck on a reply that can never come.
+     *
+     * The user names the one file that crosses into the sandbox by picking it, so this needs no
+     * capability of its own — same user-mediated grant a browser gives a page.
+     */
+    private fun requestFileChooser(
+        tab: NappletTab,
+        filePathCallback: ValueCallback<Array<Uri>>,
+        params: WebChromeClient.FileChooserParams,
+    ): Boolean {
+        val client = tab.clientMessenger
+        if (client == null) {
+            filePathCallback.onReceiveValue(null)
+            return true
+        }
+        val id = tab.fileChooser.start(filePathCallback)
+        val msg =
+            Message.obtain(null, NappletEmbedContract.MSG_FILE_CHOOSER_REQUEST).apply {
+                data =
+                    Bundle().apply {
+                        putLong(NappletEmbedContract.KEY_FILE_CHOOSER_ID, id)
+                        putStringArray(NappletEmbedContract.KEY_FILE_CHOOSER_ACCEPT, params.acceptTypes ?: emptyArray())
+                        putBoolean(NappletEmbedContract.KEY_FILE_CHOOSER_MULTIPLE, params.mode == WebChromeClient.FileChooserParams.MODE_OPEN_MULTIPLE)
+                        putString(NappletEmbedContract.KEY_FILE_CHOOSER_TITLE, params.title?.toString())
+                    }
+            }
+        if (runCatching { client.send(msg) }.isFailure) tab.fileChooser.cancel()
+        return true
     }
 
     private fun applyWebViewProxy(port: Int) {

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletHostService.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletHostService.kt
@@ -462,7 +462,7 @@ class NappletHostService : Service() {
                     Bundle().apply {
                         putLong(NappletEmbedContract.KEY_FILE_CHOOSER_ID, id)
                         putStringArray(NappletEmbedContract.KEY_FILE_CHOOSER_ACCEPT, params.acceptTypes ?: emptyArray())
-                        putBoolean(NappletEmbedContract.KEY_FILE_CHOOSER_MULTIPLE, params.mode == WebChromeClient.FileChooserParams.MODE_OPEN_MULTIPLE)
+                        putBoolean(NappletEmbedContract.KEY_FILE_CHOOSER_MULTIPLE, NappletFileChooser.allowsMultiple(params.mode))
                         putString(NappletEmbedContract.KEY_FILE_CHOOSER_TITLE, params.title?.toString())
                     }
             }

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletHostService.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/NappletHostService.kt
@@ -463,6 +463,7 @@ class NappletHostService : Service() {
                         putLong(NappletEmbedContract.KEY_FILE_CHOOSER_ID, id)
                         putStringArray(NappletEmbedContract.KEY_FILE_CHOOSER_ACCEPT, params.acceptTypes ?: emptyArray())
                         putBoolean(NappletEmbedContract.KEY_FILE_CHOOSER_MULTIPLE, NappletFileChooser.allowsMultiple(params.mode))
+                        putBoolean(NappletEmbedContract.KEY_FILE_CHOOSER_CAPTURE, params.isCaptureEnabled)
                         putString(NappletEmbedContract.KEY_FILE_CHOOSER_TITLE, params.title?.toString())
                     }
             }

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/PendingFileChooser.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/PendingFileChooser.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.napplethost
+
+import android.net.Uri
+import android.webkit.ValueCallback
+
+/**
+ * Holds the one in-flight `onShowFileChooser` callback for a WebView and guarantees it is invoked
+ * exactly once.
+ *
+ * This matters more than it looks. WebView treats a file input as busy until its `filePathCallback`
+ * fires, so a callback that is simply dropped — the user backed out of the picker, the session was
+ * torn down, no app could handle the Intent — leaves that `<input>` permanently dead for the life of
+ * the page: every later tap on it is ignored, with nothing logged. Cancelling with `null` is what
+ * releases it, so every exit path here ends in a delivery.
+ *
+ * [start] returns a request id. The embedded hosts round-trip it through the main process and hand it
+ * back to [deliver], so a result that outlived its request (a second tap while the picker was already
+ * up, a session rebuilt underneath) can be recognised and dropped instead of being fed to whichever
+ * input happens to be waiting now. Main-thread only, like the WebView callbacks it serves.
+ */
+class PendingFileChooser {
+    private var requestId = 0L
+    private var callback: ValueCallback<Array<Uri>>? = null
+
+    /**
+     * Registers [newCallback] as the pending request and returns its id. Any request still in flight is
+     * cancelled first — the page asked for a new pick, so the old input must be released rather than
+     * left waiting for a result that will never be routed to it.
+     */
+    fun start(newCallback: ValueCallback<Array<Uri>>): Long {
+        cancel()
+        requestId += 1
+        callback = newCallback
+        return requestId
+    }
+
+    /** Delivers [uris] (null = the user cancelled) to the pending request, if there still is one. */
+    fun deliver(uris: Array<Uri>?) {
+        val pending = callback ?: return
+        callback = null
+        pending.onReceiveValue(uris)
+    }
+
+    /** Delivers [uris] only if [id] is still the current request; a late or stale result is dropped. */
+    fun deliver(
+        id: Long,
+        uris: Array<Uri>?,
+    ) {
+        if (id != requestId) return
+        deliver(uris)
+    }
+
+    /** Releases the page's file input without a file. Safe to call when nothing is pending. */
+    fun cancel() = deliver(null)
+}

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/WebFileChooserLauncher.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/WebFileChooserLauncher.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.napplethost
+
+import android.Manifest
+import android.app.Activity
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.util.Log
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
+import com.vitorpamplona.amethyst.commons.R as CommonsR
+
+/**
+ * Runs one HTML file-input pick from [activity], camera options included, and reports the result to
+ * [onResult] — exactly once per [launch], with null meaning "nothing chosen".
+ *
+ * Every surface that can start an Activity uses this, so the full-screen browser, the full-screen
+ * napplet / nSite sandbox, and the main-process host that serves the two embedded surfaces cannot
+ * drift apart in how they filter, multi-select, or offer the camera.
+ *
+ * Must be constructed as a **field** of [activity]: it registers its activity-result contracts in the
+ * constructor, and `registerForActivityResult` has to run before the activity reaches STARTED.
+ */
+class WebFileChooserLauncher(
+    private val activity: ComponentActivity,
+    private val onResult: (Array<Uri>?) -> Unit,
+) {
+    /** What [launch] was asked for, held across a permission round-trip. */
+    private class Ask(
+        val acceptTypes: List<String>,
+        val allowMultiple: Boolean,
+        val captureEnabled: Boolean,
+        val pageTitle: CharSequence?,
+    )
+
+    private var ask: Ask? = null
+    private var request: NappletFileChooser.Request? = null
+
+    private val chooser =
+        activity.registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            val pending = request
+            request = null
+            val uris = pending?.let { NappletFileChooser.parseResult(activity, it, result.resultCode, result.data) }
+            onResult(uris)
+        }
+
+    private val cameraPermission =
+        activity.registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            // Denied is not a failure: the page still gets the file sources, it just cannot shoot a new
+            // photo. Falling back beats reporting nothing and leaving the input dead.
+            open(cameraAllowed = granted)
+        }
+
+    /**
+     * Opens the picker for a page's file input.
+     *
+     * When the page asked for a camera outright (`capture`) and CAMERA is not held yet, the permission
+     * is requested first — the user tapped a control whose whole purpose is to take a photo, so the
+     * prompt is expected. Without `capture` the camera is offered only if the permission is already
+     * held, so choosing a document never raises a camera prompt out of nowhere.
+     */
+    fun launch(
+        acceptTypes: List<String>,
+        allowMultiple: Boolean,
+        captureEnabled: Boolean,
+        pageTitle: CharSequence?,
+    ) {
+        ask = Ask(acceptTypes, allowMultiple, captureEnabled, pageTitle)
+
+        if (captureEnabled && !hasCameraPermission() && NappletFileChooser.wantsCamera(acceptTypes)) {
+            val requested = runCatching { cameraPermission.launch(Manifest.permission.CAMERA) }.isSuccess
+            if (requested) return
+        }
+        open(cameraAllowed = hasCameraPermission())
+    }
+
+    private fun open(cameraAllowed: Boolean) {
+        val pending = ask ?: return onResult(null)
+        ask = null
+
+        val built =
+            NappletFileChooser.buildRequest(
+                context = activity,
+                acceptTypes = pending.acceptTypes,
+                allowMultiple = pending.allowMultiple,
+                captureEnabled = pending.captureEnabled,
+                cameraAllowed = cameraAllowed,
+                pageTitle = pending.pageTitle,
+            )
+        request = built
+
+        runCatching { chooser.launch(built.intent) }
+            .onFailure { e ->
+                Log.w(TAG, "No activity available to pick a file", e)
+                request = null
+                // Runs the cancel path so the capture scratch files this request created are cleaned up.
+                NappletFileChooser.parseResult(activity, built, Activity.RESULT_CANCELED, null)
+                Toast.makeText(activity, activity.getString(CommonsR.string.browser_file_chooser_unavailable), Toast.LENGTH_LONG).show()
+                onResult(null)
+            }
+    }
+
+    private fun hasCameraPermission() = ContextCompat.checkSelfPermission(activity, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED
+
+    private companion object {
+        private const val TAG = "WebFileChooser"
+    }
+}

--- a/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/WebFileChooserLauncher.kt
+++ b/nappletHost/src/main/kotlin/com/vitorpamplona/amethyst/napplethost/WebFileChooserLauncher.kt
@@ -98,6 +98,10 @@ class WebFileChooserLauncher(
     private fun open(cameraAllowed: Boolean) {
         val pending = ask ?: return onResult(null)
         ask = null
+        // A second file input can ask before the first pick returns. The page's own callback is already
+        // released by PendingFileChooser, but the superseded request still owns scratch files and camera
+        // grants that nothing else would ever come back for.
+        abandonInFlight()
 
         val built =
             NappletFileChooser.buildRequest(
@@ -120,6 +124,19 @@ class WebFileChooserLauncher(
                 onResult(null)
             }
     }
+
+    /** Releases the scratch files and camera grants of a request whose result will never be read. */
+    private fun abandonInFlight() {
+        val stale = request ?: return
+        request = null
+        NappletFileChooser.parseResult(activity, stale, Activity.RESULT_CANCELED, null)
+    }
+
+    /**
+     * Called when the host is going away with a pick still open, so the request's scratch files and
+     * camera grants are not left behind for the stale sweep to find a day later.
+     */
+    fun teardown() = abandonInFlight()
 
     private fun hasCameraPermission() = ContextCompat.checkSelfPermission(activity, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED
 

--- a/nappletHost/src/main/res/xml/napplet_capture_paths.xml
+++ b/nappletHost/src/main/res/xml/napplet_capture_paths.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Scoped to the one cache subdirectory the camera writes WebView captures into. Deliberately NOT the
+  app-wide file_paths.xml (which exposes all of cache/ and external files) — the only thing a camera
+  app should ever be handed is the empty file it is about to fill.
+-->
+<paths>
+    <cache-path
+        name="webview_captures"
+        path="webview-captures/" />
+</paths>


### PR DESCRIPTION
Tapping `<input type="file">` anywhere in Amethyst was a silent no-op — no picker, no error, nothing logged. An Android WebView shows no chooser of its own; the app has to override `WebChromeClient.onShowFileChooser`, and none of the four WebView hosts did. Every file upload in the in-app browser, in nSites and in napplets was impossible.

All four hosts now open the picker. The two Activity-owning ones run it directly; the two windowless `:napplet` providers send the request's *description* to the main process over the existing Messenger contract, which builds the Intent and collects the result. Shipping data instead of a ready-made Intent keeps the sandbox able to ask the trusted process for a file picker and for nothing else.

Also here: `accept` is resolved as a whole list rather than Android's first-entry-only behaviour (widening rather than narrowing, since `accept` is a hint and showing less is unrecoverable), the camera is offered for inputs that accept photos or video, and `PendingFileChooser` guarantees the page's `filePathCallback` fires exactly once on every path — a dropped callback leaves that input dead for the life of the page.

## Two bugs found while testing on device, and fixed here

**The embedded pick killed the app** (`f11bdb8e49`). `FileChooserParams.parseResult` is a WebView *static*: it boots Chromium in whichever process calls it. `WebFileChooserActivity` — the main-process chooser host that exists precisely because the `:napplet` providers have no Activity — declares no `android:process`, so that call ran in main while `:napplet` already held the WebView data directory. `AwDataDirLock` threw `Using WebView from more than one process at once with the same data directory is not supported` as a FATAL on main. 100% reproducible: pick a file on an embedded surface, press Done, the process dies before the page is handed anything. The URIs are now read off the result Intent directly — same two fields the platform reads, no WebView in a process that must not have it.

The Activity-owning hosts never hit it because they are themselves `android:process=":napplet"`. Cancelling did not hit it either, which is why "the picker opened" was never sufficient evidence.

**Video capture delivered a 0-byte file** (`baae40e5fc`). The recording was fine — we deleted it. `parseResult` assumes a camera signals success by filling the `EXTRA_OUTPUT` file and returning no URI; `ACTION_IMAGE_CAPTURE` does that, but `ACTION_VIDEO_CAPTURE` on GoogleCamera writes the file *and* echoes the URI back. That echo made `captured` null, so the cleanup loop discarded every capture — including the one whose URI was on its way to the page. Captures being returned are now excluded from the sweep, and an echoed URI whose file is empty is no longer trusted on its face.

The second bug was only visible once the first was fixed; the crash happened before that code could run.

## Verified on device (Pixel 8, Android 17 / API 37)

| | |
|---|---|
| `FileChooserAccept` unit tests | 20/20 |
| `accept` matrix | bare → `*/*`; `image/*` → photo picker; `application/pdf` → documents, no camera; `.png,.sqlite3` and malformed `image/` both widen to `*/*` rather than narrowing or emptying the picker |
| Camera gating | prompts **only** on `capture`; a document upload never raises a camera prompt; denial still opens the picker, minus the camera |
| Callback | cancelling releases the input — re-tapping reopens |
| Pick, full-screen | 86,367-byte PNG read back, header intact |
| Pick, **embedded** | 94,976 bytes — a URI granted to the main process is readable by the WebView in `:napplet` with no re-granting, as designed |
| Multi-select (`ClipData`) | 3 files, 322,958 bytes total, all readable |
| Image capture | 781,853-byte JPEG with EXIF (full resolution, so `EXTRA_OUTPUT` is working) |
| Video capture | 28,135,304-byte MP4 — was 0 bytes |
| Grant/revoke | 0 outstanding grants on the capture authority, 1 while the camera holds it, 0 again once the result is in, for both media |
| `webkitdirectory` | opens a multi-select at `*/*` instead of falling through to a single-file pick |

## Not covered

Worth stating explicitly, since this branch had already been self-audited and device testing still turned up two real bugs:

- **`NappletHostActivity` and `NappletHostService`** — the napplet/nSite half of the four surfaces. Both architectural shapes are covered (Activity-owning, and Service-relayed-through-main), but these two specific hosts were never exercised; it needs a napplet or nSite containing a file input.
- **A superseding request** — a second input asking while the first is in flight. Attempted from one page, but the WebView suppresses a second `onShowFileChooser` while one is pending; the real scenario is two embedded surfaces each with a pick in flight, which was not staged.
- **A host destroyed without `finish()`** (low-memory kill while the picker is on top), and the JS alert/confirm/prompt dismissal added to `NappletHostService`.
