### PR TITLE
Fix nwc silent refusals

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountZapActions.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountZapActions.kt
@@ -99,7 +99,7 @@ class AccountZapActions(
 
     suspend fun sendNwcRequest(
         request: Request,
-        onTimeout: (() -> Unit)? = null,
+        onTimeout: () -> Unit = {},
         onResponse: (Response?) -> Unit,
     ) {
         val (event, relay) = account.nip47SignerState.sendNwcRequest(request, onTimeout, onResponse)
@@ -109,7 +109,7 @@ class AccountZapActions(
     suspend fun sendNwcRequestToWallet(
         walletUri: Nip47WalletConnect.Nip47URINorm,
         request: Request,
-        onTimeout: (() -> Unit)? = null,
+        onTimeout: () -> Unit = {},
         onResponse: (Response?) -> Unit,
     ): HexKey {
         val (event, relay) = account.nip47SignerState.sendNwcRequestToWallet(walletUri, request, onTimeout, onResponse)
@@ -138,7 +138,7 @@ class AccountZapActions(
     suspend fun sendZapPaymentRequestFor(
         bolt11: String,
         zappedNote: Note?,
-        onTimeout: (() -> Unit)? = null,
+        onTimeout: () -> Unit = {},
         onResponse: (Response?) -> Unit,
     ) {
         val (event, relay) = account.nip47SignerState.sendZapPaymentRequestFor(bolt11, zappedNote, onTimeout, onResponse)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountZapActions.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountZapActions.kt
@@ -99,18 +99,20 @@ class AccountZapActions(
 
     suspend fun sendNwcRequest(
         request: Request,
+        onTimeout: (() -> Unit)? = null,
         onResponse: (Response?) -> Unit,
     ) {
-        val (event, relay) = account.nip47SignerState.sendNwcRequest(request, onResponse)
+        val (event, relay) = account.nip47SignerState.sendNwcRequest(request, onTimeout, onResponse)
         account.client.publish(event, setOf(relay))
     }
 
     suspend fun sendNwcRequestToWallet(
         walletUri: Nip47WalletConnect.Nip47URINorm,
         request: Request,
+        onTimeout: (() -> Unit)? = null,
         onResponse: (Response?) -> Unit,
     ): HexKey {
-        val (event, relay) = account.nip47SignerState.sendNwcRequestToWallet(walletUri, request, onResponse)
+        val (event, relay) = account.nip47SignerState.sendNwcRequestToWallet(walletUri, request, onTimeout, onResponse)
         account.client.publish(event, setOf(relay))
         return event.id
     }
@@ -127,12 +129,19 @@ class AccountZapActions(
      */
     fun cleanupNwcRequest(requestId: HexKey) = LocalCache.paymentTracker.cleanup(requestId)
 
+    /**
+     * @param onTimeout invoked when no kind-23195 reply arrives before
+     *   [NwcSignerState.NWC_RESPONSE_TIMEOUT_MS]. Pass one on any path with a user
+     *   watching: without it a response lost in transit is indistinguishable from
+     *   the action never having happened.
+     */
     suspend fun sendZapPaymentRequestFor(
         bolt11: String,
         zappedNote: Note?,
+        onTimeout: (() -> Unit)? = null,
         onResponse: (Response?) -> Unit,
     ) {
-        val (event, relay) = account.nip47SignerState.sendZapPaymentRequestFor(bolt11, zappedNote, onResponse)
+        val (event, relay) = account.nip47SignerState.sendZapPaymentRequestFor(bolt11, zappedNote, onTimeout, onResponse)
         account.client.publish(event, setOf(relay))
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -3102,6 +3102,16 @@ object LocalCache : ILocalCache, ICacheProvider, Dao {
         wasVerified: Boolean,
     ): Boolean {
         val requestId = event.requestId()
+
+        // Duplicate delivery, checked before the tracker so the warnings below mean one
+        // thing each. Some NWC relays replay every cached kind-23195 whenever the REQ
+        // filter changes (see NWCPaymentFilterAssembler), so an already-answered response
+        // arrives again and again. Its first copy consumed the pending request, so the
+        // replays would otherwise be reported as "no pending request is registered" —
+        // the same line a genuinely late response produces, which made the two
+        // indistinguishable in the field.
+        if (getNoteIfExists(event.id)?.event != null) return false
+
         val pending =
             when (val match = paymentTracker.onResponseReceived(requestId, event.pubKey)) {
                 is NwcPaymentTracker.MatchResult.Matched -> {
@@ -3121,9 +3131,12 @@ object LocalCache : ILocalCache, ICacheProvider, Dao {
                 }
 
                 NwcPaymentTracker.MatchResult.NoMatch -> {
+                    // Not a replay — those are filtered above — so this is the first time we
+                    // have seen this response and nothing is waiting for it.
                     Log.w("LocalCache") {
                         "NWC response ${event.id} from ${event.pubKey} references request e=$requestId but no pending request is registered. " +
-                            "The response was either delivered after timeout, the user holds a stale subscription, or the wallet service set the wrong e tag."
+                            "The response arrived after the client gave up waiting, the user holds a stale subscription, " +
+                            "or the wallet service set the wrong e tag."
                     }
                     return false
                 }
@@ -3137,7 +3150,8 @@ object LocalCache : ILocalCache, ICacheProvider, Dao {
         val note = getOrCreateNote(event.id)
         val author = getOrCreateUser(event.pubKey)
 
-        // Already processed this event.
+        // Backstop for a concurrent delivery that loaded the event between the replay
+        // check above and here. Same outcome, no warning: it is not a protocol problem.
         if (note.event != null) return false
 
         if (wasVerified || justVerify(event)) {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcSignerState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcSignerState.kt
@@ -204,7 +204,7 @@ class NwcSignerState(
      */
     suspend fun sendNwcRequest(
         request: Request,
-        onTimeout: (() -> Unit)? = null,
+        onTimeout: () -> Unit = {},
         onResponse: (Response?) -> Unit,
     ): Pair<LnZapPaymentRequestEvent, NormalizedRelayUrl> = sendNwcRequestToWallet(defaultWalletUri.value, request, onTimeout, onResponse)
 
@@ -214,7 +214,7 @@ class NwcSignerState(
     suspend fun sendNwcRequestToWallet(
         walletUri: Nip47WalletConnect.Nip47URINorm?,
         request: Request,
-        onTimeout: (() -> Unit)? = null,
+        onTimeout: () -> Unit = {},
         onResponse: (Response?) -> Unit,
     ): Pair<LnZapPaymentRequestEvent, NormalizedRelayUrl> {
         val walletService = walletUri ?: throw IllegalArgumentException("No NIP47 setup")
@@ -237,15 +237,7 @@ class NwcSignerState(
         // be missed.
         assembler.subscribeAndFlush(filter)
 
-        // Safety net: drop the filter after the timeout if the wallet never replies.
-        // The happy path (response arrives) cancels this job and unsubscribes
-        // through assembler.unsubscribeSoon, which debounces.
-        val timeoutJob =
-            scope.launch(Dispatchers.IO) {
-                delay(NWC_RESPONSE_TIMEOUT_MS)
-                assembler.unsubscribe(filter)
-                giveUpWaiting(event.id, onTimeout)
-            }
+        val timeoutJob = launchGiveUpTimer(assembler, filter, event.id, onTimeout)
 
         val responseCache = NostrWalletConnectResponseCache(walletSigner)
         cache.consume(event, null, true, walletService.relayUri) {
@@ -263,7 +255,7 @@ class NwcSignerState(
     suspend fun sendZapPaymentRequestFor(
         bolt11: String,
         zappedNote: Note?,
-        onTimeout: (() -> Unit)? = null,
+        onTimeout: () -> Unit = {},
         onResponse: (Response?) -> Unit,
     ): Pair<LnZapPaymentRequestEvent, NormalizedRelayUrl> {
         val walletService = defaultWalletUri.value ?: throw IllegalArgumentException("No NIP47 setup")
@@ -283,15 +275,7 @@ class NwcSignerState(
         // See sendNwcRequestToWallet above for the rationale.
         assembler.subscribeAndFlush(filter)
 
-        // Safety net: drop the filter after the timeout if the wallet never replies.
-        // The happy path (response arrives) cancels this job and instead
-        // hands off to assembler.unsubscribeSoon, which debounces.
-        val timeoutJob =
-            scope.launch(Dispatchers.IO) {
-                delay(NWC_RESPONSE_TIMEOUT_MS)
-                assembler.unsubscribe(filter)
-                giveUpWaiting(event.id, onTimeout)
-            }
+        val timeoutJob = launchGiveUpTimer(assembler, filter, event.id, onTimeout)
 
         cache.consume(event, zappedNote, true, walletService.relayUri) {
             timeoutJob.cancel()
@@ -300,6 +284,22 @@ class NwcSignerState(
         }
 
         return Pair(event, walletService.relayUri)
+    }
+
+    /**
+     * Safety net for a wallet that never replies: drops the subscription filter and retires
+     * the request. The happy path cancels this job and unsubscribes through
+     * [NWCPaymentFilterAssembler.unsubscribeSoon] instead, which debounces.
+     */
+    private fun launchGiveUpTimer(
+        assembler: NWCPaymentFilterAssembler,
+        filter: NWCPaymentQueryState,
+        requestId: HexKey,
+        onTimeout: () -> Unit,
+    ) = scope.launch(Dispatchers.IO) {
+        delay(NWC_RESPONSE_TIMEOUT_MS)
+        assembler.unsubscribe(filter)
+        giveUpWaiting(requestId, onTimeout)
     }
 
     /**
@@ -313,24 +313,24 @@ class NwcSignerState(
      */
     private fun giveUpWaiting(
         requestId: HexKey,
-        onTimeout: (() -> Unit)?,
+        onTimeout: () -> Unit,
     ) {
         val wasStillPending = cache.paymentTracker.cleanup(requestId)
         if (wasStillPending) {
             Log.w("NwcSignerState") {
                 "No NIP-47 response for request $requestId after ${NWC_RESPONSE_TIMEOUT_MS}ms; giving up and dropping the subscription."
             }
-            onTimeout?.invoke()
+            onTimeout()
         }
     }
 
     companion object {
         /**
          * How long a NIP-47 request waits for its kind-23195 reply before the client
-         * gives up. Exposed so the UI can name the number it shows the user.
+         * gives up. Exposed in seconds so the UI can name the number it shows the user.
          */
-        const val NWC_RESPONSE_TIMEOUT_MS = 60000L
+        const val NWC_RESPONSE_TIMEOUT_SECONDS = 60
 
-        val NWC_RESPONSE_TIMEOUT_SECONDS = (NWC_RESPONSE_TIMEOUT_MS / 1000).toInt()
+        const val NWC_RESPONSE_TIMEOUT_MS = NWC_RESPONSE_TIMEOUT_SECONDS * 1000L
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcSignerState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip47WalletConnect/NwcSignerState.kt
@@ -42,6 +42,7 @@ import com.vitorpamplona.quartz.nip47WalletConnect.rpc.NwcTransaction
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.PaymentReceivedNotification
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Request
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Response
+import com.vitorpamplona.quartz.utils.Log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -203,8 +204,9 @@ class NwcSignerState(
      */
     suspend fun sendNwcRequest(
         request: Request,
+        onTimeout: (() -> Unit)? = null,
         onResponse: (Response?) -> Unit,
-    ): Pair<LnZapPaymentRequestEvent, NormalizedRelayUrl> = sendNwcRequestToWallet(defaultWalletUri.value, request, onResponse)
+    ): Pair<LnZapPaymentRequestEvent, NormalizedRelayUrl> = sendNwcRequestToWallet(defaultWalletUri.value, request, onTimeout, onResponse)
 
     /**
      * Sends a generic NIP-47 request to a specific wallet.
@@ -212,6 +214,7 @@ class NwcSignerState(
     suspend fun sendNwcRequestToWallet(
         walletUri: Nip47WalletConnect.Nip47URINorm?,
         request: Request,
+        onTimeout: (() -> Unit)? = null,
         onResponse: (Response?) -> Unit,
     ): Pair<LnZapPaymentRequestEvent, NormalizedRelayUrl> {
         val walletService = walletUri ?: throw IllegalArgumentException("No NIP47 setup")
@@ -234,13 +237,14 @@ class NwcSignerState(
         // be missed.
         assembler.subscribeAndFlush(filter)
 
-        // Safety net: drop the filter after 60s if the wallet never replies.
+        // Safety net: drop the filter after the timeout if the wallet never replies.
         // The happy path (response arrives) cancels this job and unsubscribes
         // through assembler.unsubscribeSoon, which debounces.
         val timeoutJob =
             scope.launch(Dispatchers.IO) {
-                delay(60000)
+                delay(NWC_RESPONSE_TIMEOUT_MS)
                 assembler.unsubscribe(filter)
+                giveUpWaiting(event.id, onTimeout)
             }
 
         val responseCache = NostrWalletConnectResponseCache(walletSigner)
@@ -259,6 +263,7 @@ class NwcSignerState(
     suspend fun sendZapPaymentRequestFor(
         bolt11: String,
         zappedNote: Note?,
+        onTimeout: (() -> Unit)? = null,
         onResponse: (Response?) -> Unit,
     ): Pair<LnZapPaymentRequestEvent, NormalizedRelayUrl> {
         val walletService = defaultWalletUri.value ?: throw IllegalArgumentException("No NIP47 setup")
@@ -278,13 +283,14 @@ class NwcSignerState(
         // See sendNwcRequestToWallet above for the rationale.
         assembler.subscribeAndFlush(filter)
 
-        // Safety net: drop the filter after 60s if the wallet never replies.
+        // Safety net: drop the filter after the timeout if the wallet never replies.
         // The happy path (response arrives) cancels this job and instead
         // hands off to assembler.unsubscribeSoon, which debounces.
         val timeoutJob =
             scope.launch(Dispatchers.IO) {
-                delay(60000) // waits 1 minute to complete payment.
+                delay(NWC_RESPONSE_TIMEOUT_MS)
                 assembler.unsubscribe(filter)
+                giveUpWaiting(event.id, onTimeout)
             }
 
         cache.consume(event, zappedNote, true, walletService.relayUri) {
@@ -294,5 +300,37 @@ class NwcSignerState(
         }
 
         return Pair(event, walletService.relayUri)
+    }
+
+    /**
+     * Retires a request whose response never arrived: removes the tracker entry so it
+     * does not leak, and tells the caller so the user hears about it. A silent give-up
+     * is the worst outcome for a payment UI — the action just appears not to have
+     * happened, which is indistinguishable from a refusal the wallet did send.
+     *
+     * A `cleanup` that returns false means a response beat us to the tracker entry,
+     * so the response path is already reporting and this must stay quiet.
+     */
+    private fun giveUpWaiting(
+        requestId: HexKey,
+        onTimeout: (() -> Unit)?,
+    ) {
+        val wasStillPending = cache.paymentTracker.cleanup(requestId)
+        if (wasStillPending) {
+            Log.w("NwcSignerState") {
+                "No NIP-47 response for request $requestId after ${NWC_RESPONSE_TIMEOUT_MS}ms; giving up and dropping the subscription."
+            }
+            onTimeout?.invoke()
+        }
+    }
+
+    companion object {
+        /**
+         * How long a NIP-47 request waits for its kind-23195 reply before the client
+         * gives up. Exposed so the UI can name the number it shows the user.
+         */
+        const val NWC_RESPONSE_TIMEOUT_MS = 60000L
+
+        val NWC_RESPONSE_TIMEOUT_SECONDS = (NWC_RESPONSE_TIMEOUT_MS / 1000).toInt()
     }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/V4VPaymentHandler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/V4VPaymentHandler.kt
@@ -25,11 +25,11 @@ import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.model.payments.PaymentSource
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.Note
-import com.vitorpamplona.amethyst.model.nip47WalletConnect.NwcSignerState
 import com.vitorpamplona.amethyst.service.lnurl.LightningAddressResolver
+import com.vitorpamplona.amethyst.ui.nwc.nwcFailureDetail
+import com.vitorpamplona.amethyst.ui.nwc.nwcTimeoutMessage
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.quartz.nip01Core.core.toHexKey
-import com.vitorpamplona.quartz.nip47WalletConnect.rpc.IErrorResponseLike
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.PayKeysendMethod
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Response
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.TlvRecord
@@ -163,23 +163,12 @@ class V4VPaymentHandler(
             account.zaps.sendNwcRequest(
                 request = request,
                 onResponse = { response: Response? ->
-                    if (response is IErrorResponseLike) {
-                        onError(
-                            stringRes(context, R.string.error_dialog_pay_invoice_error),
-                            response.errorMessage()
-                                ?: stringRes(context, R.string.error_parsing_error_message),
-                        )
+                    response.nwcFailureDetail(context)?.let { detail ->
+                        onError(stringRes(context, R.string.error_dialog_pay_invoice_error), detail)
                     }
                 },
                 onTimeout = {
-                    onError(
-                        stringRes(context, R.string.error_dialog_pay_invoice_error),
-                        stringRes(
-                            context,
-                            R.string.wallet_connect_no_response_error,
-                            NwcSignerState.NWC_RESPONSE_TIMEOUT_SECONDS,
-                        ),
-                    )
+                    onError(stringRes(context, R.string.error_dialog_pay_invoice_error), nwcTimeoutMessage(context))
                 },
             )
         }
@@ -268,23 +257,12 @@ class V4VPaymentHandler(
                         bolt11 = payable.invoice,
                         zappedNote = zappedNote,
                         onResponse = { response ->
-                            if (response is IErrorResponseLike) {
-                                onError(
-                                    stringRes(context, R.string.error_dialog_pay_invoice_error),
-                                    response.errorMessage()
-                                        ?: stringRes(context, R.string.error_parsing_error_message),
-                                )
+                            response.nwcFailureDetail(context)?.let { detail ->
+                                onError(stringRes(context, R.string.error_dialog_pay_invoice_error), detail)
                             }
                         },
                         onTimeout = {
-                            onError(
-                                stringRes(context, R.string.error_dialog_pay_invoice_error),
-                                stringRes(
-                                    context,
-                                    R.string.wallet_connect_no_response_error,
-                                    NwcSignerState.NWC_RESPONSE_TIMEOUT_SECONDS,
-                                ),
-                            )
+                            onError(stringRes(context, R.string.error_dialog_pay_invoice_error), nwcTimeoutMessage(context))
                         },
                     )
                     done++

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/V4VPaymentHandler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/V4VPaymentHandler.kt
@@ -25,6 +25,7 @@ import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.model.payments.PaymentSource
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.Note
+import com.vitorpamplona.amethyst.model.nip47WalletConnect.NwcSignerState
 import com.vitorpamplona.amethyst.service.lnurl.LightningAddressResolver
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.quartz.nip01Core.core.toHexKey
@@ -159,15 +160,28 @@ class V4VPaymentHandler(
                     tlvRecords = tlvRecords,
                 )
 
-            account.zaps.sendNwcRequest(request) { response: Response? ->
-                if (response is IErrorResponseLike) {
+            account.zaps.sendNwcRequest(
+                request = request,
+                onResponse = { response: Response? ->
+                    if (response is IErrorResponseLike) {
+                        onError(
+                            stringRes(context, R.string.error_dialog_pay_invoice_error),
+                            response.errorMessage()
+                                ?: stringRes(context, R.string.error_parsing_error_message),
+                        )
+                    }
+                },
+                onTimeout = {
                     onError(
                         stringRes(context, R.string.error_dialog_pay_invoice_error),
-                        response.errorMessage()
-                            ?: stringRes(context, R.string.error_parsing_error_message),
+                        stringRes(
+                            context,
+                            R.string.wallet_connect_no_response_error,
+                            NwcSignerState.NWC_RESPONSE_TIMEOUT_SECONDS,
+                        ),
                     )
-                }
-            }
+                },
+            )
         }
     }
 
@@ -250,15 +264,29 @@ class V4VPaymentHandler(
             is PaymentSource.Nwc -> {
                 var done = 0
                 payables.forEach { payable ->
-                    account.zaps.sendZapPaymentRequestFor(payable.invoice, zappedNote) { response ->
-                        if (response is IErrorResponseLike) {
+                    account.zaps.sendZapPaymentRequestFor(
+                        bolt11 = payable.invoice,
+                        zappedNote = zappedNote,
+                        onResponse = { response ->
+                            if (response is IErrorResponseLike) {
+                                onError(
+                                    stringRes(context, R.string.error_dialog_pay_invoice_error),
+                                    response.errorMessage()
+                                        ?: stringRes(context, R.string.error_parsing_error_message),
+                                )
+                            }
+                        },
+                        onTimeout = {
                             onError(
                                 stringRes(context, R.string.error_dialog_pay_invoice_error),
-                                response.errorMessage()
-                                    ?: stringRes(context, R.string.error_parsing_error_message),
+                                stringRes(
+                                    context,
+                                    R.string.wallet_connect_no_response_error,
+                                    NwcSignerState.NWC_RESPONSE_TIMEOUT_SECONDS,
+                                ),
                             )
-                        }
-                    }
+                        },
+                    )
                     done++
                     onProgress(done.toFloat() / payables.size)
                 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/ZapPaymentHandler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/ZapPaymentHandler.kt
@@ -28,11 +28,13 @@ import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
+import com.vitorpamplona.amethyst.model.nip47WalletConnect.NwcSignerState
 import com.vitorpamplona.amethyst.service.lnurl.LightningAddressResolver
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.quartz.experimental.clink.pointers.NDebit
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
-import com.vitorpamplona.quartz.nip47WalletConnect.rpc.PayInvoiceErrorResponse
+import com.vitorpamplona.quartz.nip47WalletConnect.rpc.IErrorResponseLike
+import com.vitorpamplona.quartz.nip47WalletConnect.rpc.PayInvoiceSuccessResponse
 import com.vitorpamplona.quartz.nip53LiveActivities.streaming.LiveActivitiesEvent
 import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
 import com.vitorpamplona.quartz.nip57Zaps.LnZapRequestEvent
@@ -419,18 +421,41 @@ class ZapPaymentHandler(
                     zappedNote = note,
                     onResponse = { response ->
                         progress.step()
-                        if (response is PayInvoiceErrorResponse) {
+                        // Matched on IErrorResponseLike rather than PayInvoiceErrorResponse:
+                        // a wallet that omits `result_type` on an error (NIP-47 does not
+                        // require it) deserializes to the generic NwcErrorResponse, and the
+                        // narrower check dropped those refusals without a word.
+                        if (response is IErrorResponseLike) {
                             onError(
                                 stringRes(context, R.string.error_dialog_pay_invoice_error),
                                 stringRes(
                                     context,
                                     R.string.wallet_connect_pay_invoice_error_error,
-                                    response.error?.message
-                                        ?: response.error?.code?.toString() ?: "Error parsing error message",
+                                    response.errorMessage()
+                                        ?: stringRes(context, R.string.error_parsing_error_message),
                                 ),
                                 payable.info.user,
                             )
+                        } else if (response !is PayInvoiceSuccessResponse) {
+                            // Undecryptable (null) or a shape we cannot read. Say so rather
+                            // than leaving the zap looking like it silently worked.
+                            onError(
+                                stringRes(context, R.string.error_dialog_pay_invoice_error),
+                                stringRes(context, R.string.wallet_connect_unreadable_response_error),
+                                payable.info.user,
+                            )
                         }
+                    },
+                    onTimeout = {
+                        onError(
+                            stringRes(context, R.string.error_dialog_pay_invoice_error),
+                            stringRes(
+                                context,
+                                R.string.wallet_connect_no_response_error,
+                                NwcSignerState.NWC_RESPONSE_TIMEOUT_SECONDS,
+                            ),
+                            payable.info.user,
+                        )
                     },
                 )
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/service/ZapPaymentHandler.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/service/ZapPaymentHandler.kt
@@ -28,13 +28,12 @@ import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
-import com.vitorpamplona.amethyst.model.nip47WalletConnect.NwcSignerState
 import com.vitorpamplona.amethyst.service.lnurl.LightningAddressResolver
+import com.vitorpamplona.amethyst.ui.nwc.nwcFailureDetail
+import com.vitorpamplona.amethyst.ui.nwc.nwcTimeoutMessage
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.quartz.experimental.clink.pointers.NDebit
 import com.vitorpamplona.quartz.nip01Core.relay.normalizer.NormalizedRelayUrl
-import com.vitorpamplona.quartz.nip47WalletConnect.rpc.IErrorResponseLike
-import com.vitorpamplona.quartz.nip47WalletConnect.rpc.PayInvoiceSuccessResponse
 import com.vitorpamplona.quartz.nip53LiveActivities.streaming.LiveActivitiesEvent
 import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
 import com.vitorpamplona.quartz.nip57Zaps.LnZapRequestEvent
@@ -421,27 +420,10 @@ class ZapPaymentHandler(
                     zappedNote = note,
                     onResponse = { response ->
                         progress.step()
-                        // Matched on IErrorResponseLike rather than PayInvoiceErrorResponse:
-                        // a wallet that omits `result_type` on an error (NIP-47 does not
-                        // require it) deserializes to the generic NwcErrorResponse, and the
-                        // narrower check dropped those refusals without a word.
-                        if (response is IErrorResponseLike) {
+                        response.nwcFailureDetail(context)?.let { detail ->
                             onError(
                                 stringRes(context, R.string.error_dialog_pay_invoice_error),
-                                stringRes(
-                                    context,
-                                    R.string.wallet_connect_pay_invoice_error_error,
-                                    response.errorMessage()
-                                        ?: stringRes(context, R.string.error_parsing_error_message),
-                                ),
-                                payable.info.user,
-                            )
-                        } else if (response !is PayInvoiceSuccessResponse) {
-                            // Undecryptable (null) or a shape we cannot read. Say so rather
-                            // than leaving the zap looking like it silently worked.
-                            onError(
-                                stringRes(context, R.string.error_dialog_pay_invoice_error),
-                                stringRes(context, R.string.wallet_connect_unreadable_response_error),
+                                stringRes(context, R.string.wallet_connect_pay_invoice_error_error, detail),
                                 payable.info.user,
                             )
                         }
@@ -449,11 +431,7 @@ class ZapPaymentHandler(
                     onTimeout = {
                         onError(
                             stringRes(context, R.string.error_dialog_pay_invoice_error),
-                            stringRes(
-                                context,
-                                R.string.wallet_connect_no_response_error,
-                                NwcSignerState.NWC_RESPONSE_TIMEOUT_SECONDS,
-                            ),
+                            nwcTimeoutMessage(context),
                             payable.info.user,
                         )
                     },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/invoice/InvoicePaymentDispatcher.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/invoice/InvoicePaymentDispatcher.kt
@@ -30,13 +30,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.model.payments.PaymentSource
-import com.vitorpamplona.amethyst.model.nip47WalletConnect.NwcSignerState
 import com.vitorpamplona.amethyst.ui.note.payViaIntent
+import com.vitorpamplona.amethyst.ui.nwc.nwcFailureDetail
+import com.vitorpamplona.amethyst.ui.nwc.nwcTimeoutMessage
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.quartz.lightning.LnInvoiceUtil
-import com.vitorpamplona.quartz.nip47WalletConnect.rpc.IErrorResponseLike
-import com.vitorpamplona.quartz.nip47WalletConnect.rpc.PayInvoiceSuccessResponse
 
 /**
  * Pays a single BOLT-11 from an in-post card (offer card, invoice card) through the
@@ -89,30 +88,12 @@ fun InvoicePaymentDispatcher(
                     accountViewModel.sendZapPaymentRequestFor(
                         bolt11 = bolt11,
                         zappedNote = null,
-                        onTimeout = {
-                            onError(
-                                stringRes(
-                                    context,
-                                    R.string.wallet_connect_no_response_error,
-                                    NwcSignerState.NWC_RESPONSE_TIMEOUT_SECONDS,
-                                ),
-                            )
+                        onTimeout = { onError(nwcTimeoutMessage(context)) },
+                        onResponse = { response ->
+                            val failure = response.nwcFailureDetail(context)
+                            if (failure == null) onSuccess() else onError(failure)
                         },
-                    ) { response ->
-                        when (response) {
-                            is PayInvoiceSuccessResponse -> onSuccess()
-                            // IErrorResponseLike, not PayInvoiceErrorResponse: a wallet that
-                            // omits `result_type` on an error still deserializes to something
-                            // renderable, and the narrower check dropped it silently.
-                            is IErrorResponseLike ->
-                                onError(
-                                    response.errorMessage()
-                                        ?: stringRes(context, R.string.error_parsing_error_message),
-                                )
-                            else ->
-                                onError(stringRes(context, R.string.wallet_connect_unreadable_response_error))
-                        }
-                    }
+                    )
 
                 is PaymentSource.ClinkDebit ->
                     accountViewModel.payInvoiceViaClinkDebit(source.wallet.pointer, bolt11) { response ->

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/invoice/InvoicePaymentDispatcher.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/invoice/InvoicePaymentDispatcher.kt
@@ -30,11 +30,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.model.payments.PaymentSource
+import com.vitorpamplona.amethyst.model.nip47WalletConnect.NwcSignerState
 import com.vitorpamplona.amethyst.ui.note.payViaIntent
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.quartz.lightning.LnInvoiceUtil
-import com.vitorpamplona.quartz.nip47WalletConnect.rpc.PayInvoiceErrorResponse
+import com.vitorpamplona.quartz.nip47WalletConnect.rpc.IErrorResponseLike
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.PayInvoiceSuccessResponse
 
 /**
@@ -85,16 +86,31 @@ fun InvoicePaymentDispatcher(
         onConfirm = {
             when (source) {
                 is PaymentSource.Nwc ->
-                    accountViewModel.sendZapPaymentRequestFor(bolt11, null) { response ->
+                    accountViewModel.sendZapPaymentRequestFor(
+                        bolt11 = bolt11,
+                        zappedNote = null,
+                        onTimeout = {
+                            onError(
+                                stringRes(
+                                    context,
+                                    R.string.wallet_connect_no_response_error,
+                                    NwcSignerState.NWC_RESPONSE_TIMEOUT_SECONDS,
+                                ),
+                            )
+                        },
+                    ) { response ->
                         when (response) {
                             is PayInvoiceSuccessResponse -> onSuccess()
-                            is PayInvoiceErrorResponse ->
+                            // IErrorResponseLike, not PayInvoiceErrorResponse: a wallet that
+                            // omits `result_type` on an error still deserializes to something
+                            // renderable, and the narrower check dropped it silently.
+                            is IErrorResponseLike ->
                                 onError(
-                                    response.error?.message
-                                        ?: response.error?.code?.toString()
+                                    response.errorMessage()
                                         ?: stringRes(context, R.string.error_parsing_error_message),
                                 )
-                            else -> {}
+                            else ->
+                                onError(stringRes(context, R.string.wallet_connect_unreadable_response_error))
                         }
                     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/nwc/NwcResponseMessages.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/nwc/NwcResponseMessages.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.ui.nwc
+
+import android.content.Context
+import com.vitorpamplona.amethyst.R
+import com.vitorpamplona.amethyst.model.nip47WalletConnect.NwcSignerState
+import com.vitorpamplona.amethyst.ui.stringRes
+import com.vitorpamplona.quartz.nip47WalletConnect.rpc.IErrorResponseLike
+import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Response
+
+// User-facing text for the ways a NIP-47 request can fail to settle. Every payment
+// surface needs the same sentences, and a surface that skips one shows the user
+// nothing at all — which is the failure mode these exist to prevent.
+
+/** Shown when no kind-23195 reply arrived before the client gave up waiting. */
+fun nwcTimeoutMessage(context: Context): String =
+    stringRes(
+        context,
+        R.string.wallet_connect_no_response_error,
+        NwcSignerState.NWC_RESPONSE_TIMEOUT_SECONDS,
+    )
+
+/**
+ * Why a NIP-47 request did not go through, or null when the wallet settled it.
+ *
+ * The three cases a payment surface has to tell apart:
+ * - **null receiver** — the reply could not be decrypted or parsed. `DecryptCache` swallows
+ *   both failures into null, so this is the only shape an unreadable reply ever takes, and
+ *   it needs a sentence: silence would leave a failed payment looking like one that worked.
+ * - **[IErrorResponseLike]** — the wallet refused, and said why. Matched on the interface
+ *   rather than the narrower `PayInvoiceErrorResponse` because NIP-47 does not require a
+ *   wallet to echo `result_type` on an error; those refusals deserialize to the generic
+ *   `NwcErrorResponse`, and checking the concrete type dropped them without a word.
+ * - **anything else** — a success shape, whichever method it belongs to. Deliberately not
+ *   matched against the *expected* success type: a wallet that omits `result_type` on a
+ *   settled payment is guessed into `PayInvoiceSuccessResponse` by the deserializer, so
+ *   demanding (say) `PayKeysendSuccessResponse` would report a real payment as unreadable.
+ */
+fun Response?.nwcFailureDetail(context: Context): String? =
+    when (this) {
+        null -> stringRes(context, R.string.wallet_connect_unreadable_response_error)
+        is IErrorResponseLike -> errorMessage() ?: stringRes(context, R.string.error_parsing_error_message)
+        else -> null
+    }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/nwc/NwcResponseMessages.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/nwc/NwcResponseMessages.kt
@@ -23,6 +23,7 @@ package com.vitorpamplona.amethyst.ui.nwc
 import android.content.Context
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.model.nip47WalletConnect.NwcSignerState
+import com.vitorpamplona.amethyst.ui.pluralStringRes
 import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.IErrorResponseLike
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Response
@@ -33,9 +34,10 @@ import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Response
 
 /** Shown when no kind-23195 reply arrived before the client gave up waiting. */
 fun nwcTimeoutMessage(context: Context): String =
-    stringRes(
+    pluralStringRes(
         context,
-        R.string.wallet_connect_no_response_error,
+        R.plurals.wallet_connect_no_response_error,
+        NwcSignerState.NWC_RESPONSE_TIMEOUT_SECONDS,
         NwcSignerState.NWC_RESPONSE_TIMEOUT_SECONDS,
     )
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -2788,7 +2788,7 @@ class AccountViewModel(
         bolt11: String,
         zappedNote: Note?,
         onSent: () -> Unit = {},
-        onTimeout: (() -> Unit)? = null,
+        onTimeout: () -> Unit = {},
         onResponse: (Response?) -> Unit,
     ) = launchSigner {
         account.zaps.sendZapPaymentRequestFor(bolt11, zappedNote, onTimeout, onResponse)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/AccountViewModel.kt
@@ -2788,9 +2788,10 @@ class AccountViewModel(
         bolt11: String,
         zappedNote: Note?,
         onSent: () -> Unit = {},
+        onTimeout: (() -> Unit)? = null,
         onResponse: (Response?) -> Unit,
     ) = launchSigner {
-        account.zaps.sendZapPaymentRequestFor(bolt11, zappedNote, onResponse)
+        account.zaps.sendZapPaymentRequestFor(bolt11, zappedNote, onTimeout, onResponse)
         onSent()
     }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/dvms/DvmContentDiscoveryScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/dvms/DvmContentDiscoveryScreen.kt
@@ -52,6 +52,7 @@ import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.model.payments.PaymentSource
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
+import com.vitorpamplona.amethyst.model.nip47WalletConnect.NwcSignerState
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.EventFinderFilterAssemblerSubscription
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.observeNoteAndMap
 import com.vitorpamplona.amethyst.ui.components.LoadNote
@@ -76,7 +77,8 @@ import com.vitorpamplona.amethyst.ui.theme.SimpleImage75Modifier
 import com.vitorpamplona.amethyst.ui.theme.Size35dp
 import com.vitorpamplona.quartz.lightning.LnInvoiceUtil
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
-import com.vitorpamplona.quartz.nip47WalletConnect.rpc.PayInvoiceErrorResponse
+import com.vitorpamplona.quartz.nip47WalletConnect.rpc.IErrorResponseLike
+import com.vitorpamplona.quartz.nip47WalletConnect.rpc.PayInvoiceSuccessResponse
 import com.vitorpamplona.quartz.nip89AppHandlers.definition.AppDefinitionEvent
 import com.vitorpamplona.quartz.nip89AppHandlers.definition.AppMetadata
 import com.vitorpamplona.quartz.nip90Dvms.contentDiscoveryResponse.NIP90ContentDiscoveryResponseEvent
@@ -402,17 +404,31 @@ fun DvmPaymentActions(
                         onSent = {
                             onStatusUpdate(nwcPaymentRequest)
                         },
+                        onTimeout = {
+                            onStatusUpdate(
+                                stringRes(
+                                    context,
+                                    R.string.wallet_connect_no_response_error,
+                                    NwcSignerState.NWC_RESPONSE_TIMEOUT_SECONDS,
+                                ),
+                            )
+                        },
                         onResponse = { response ->
                             onStatusUpdate(
-                                if (response is PayInvoiceErrorResponse) {
-                                    stringRes(
-                                        context,
-                                        R.string.wallet_connect_pay_invoice_error_error,
-                                        response.error?.message
-                                            ?: response.error?.code?.toString() ?: "Error parsing error message",
-                                    )
-                                } else {
-                                    thankYou
+                                when (response) {
+                                    is PayInvoiceSuccessResponse -> thankYou
+                                    // IErrorResponseLike, not PayInvoiceErrorResponse: a wallet
+                                    // that omits `result_type` on an error still deserializes to
+                                    // something renderable, and the narrower check thanked the
+                                    // user for a payment that had just been refused.
+                                    is IErrorResponseLike ->
+                                        stringRes(
+                                            context,
+                                            R.string.wallet_connect_pay_invoice_error_error,
+                                            response.errorMessage()
+                                                ?: stringRes(context, R.string.error_parsing_error_message),
+                                        )
+                                    else -> stringRes(context, R.string.wallet_connect_unreadable_response_error)
                                 },
                             )
                         },

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/dvms/DvmContentDiscoveryScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/dvms/DvmContentDiscoveryScreen.kt
@@ -52,7 +52,6 @@ import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.model.payments.PaymentSource
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.model.User
-import com.vitorpamplona.amethyst.model.nip47WalletConnect.NwcSignerState
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.EventFinderFilterAssemblerSubscription
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.observeNoteAndMap
 import com.vitorpamplona.amethyst.ui.components.LoadNote
@@ -66,6 +65,8 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.WatchNoteEvent
 import com.vitorpamplona.amethyst.ui.note.elements.BannerImage
 import com.vitorpamplona.amethyst.ui.note.payViaIntent
+import com.vitorpamplona.amethyst.ui.nwc.nwcFailureDetail
+import com.vitorpamplona.amethyst.ui.nwc.nwcTimeoutMessage
 import com.vitorpamplona.amethyst.ui.screen.RenderFeedState
 import com.vitorpamplona.amethyst.ui.screen.SaveableFeedState
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
@@ -77,8 +78,6 @@ import com.vitorpamplona.amethyst.ui.theme.SimpleImage75Modifier
 import com.vitorpamplona.amethyst.ui.theme.Size35dp
 import com.vitorpamplona.quartz.lightning.LnInvoiceUtil
 import com.vitorpamplona.quartz.nip01Core.relay.filters.Filter
-import com.vitorpamplona.quartz.nip47WalletConnect.rpc.IErrorResponseLike
-import com.vitorpamplona.quartz.nip47WalletConnect.rpc.PayInvoiceSuccessResponse
 import com.vitorpamplona.quartz.nip89AppHandlers.definition.AppDefinitionEvent
 import com.vitorpamplona.quartz.nip89AppHandlers.definition.AppMetadata
 import com.vitorpamplona.quartz.nip90Dvms.contentDiscoveryResponse.NIP90ContentDiscoveryResponseEvent
@@ -404,32 +403,12 @@ fun DvmPaymentActions(
                         onSent = {
                             onStatusUpdate(nwcPaymentRequest)
                         },
-                        onTimeout = {
-                            onStatusUpdate(
-                                stringRes(
-                                    context,
-                                    R.string.wallet_connect_no_response_error,
-                                    NwcSignerState.NWC_RESPONSE_TIMEOUT_SECONDS,
-                                ),
-                            )
-                        },
+                        onTimeout = { onStatusUpdate(nwcTimeoutMessage(context)) },
                         onResponse = { response ->
                             onStatusUpdate(
-                                when (response) {
-                                    is PayInvoiceSuccessResponse -> thankYou
-                                    // IErrorResponseLike, not PayInvoiceErrorResponse: a wallet
-                                    // that omits `result_type` on an error still deserializes to
-                                    // something renderable, and the narrower check thanked the
-                                    // user for a payment that had just been refused.
-                                    is IErrorResponseLike ->
-                                        stringRes(
-                                            context,
-                                            R.string.wallet_connect_pay_invoice_error_error,
-                                            response.errorMessage()
-                                                ?: stringRes(context, R.string.error_parsing_error_message),
-                                        )
-                                    else -> stringRes(context, R.string.wallet_connect_unreadable_response_error)
-                                },
+                                response.nwcFailureDetail(context)?.let { detail ->
+                                    stringRes(context, R.string.wallet_connect_pay_invoice_error_error, detail)
+                                } ?: thankYou,
                             )
                         },
                     )

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/payment/SendPaymentScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/payment/SendPaymentScreen.kt
@@ -52,7 +52,6 @@ import com.vitorpamplona.amethyst.model.DEFAULT_ONCHAIN_ZAP_SATS
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.MIN_ONCHAIN_ZAP_SATS
 import com.vitorpamplona.amethyst.model.User
-import com.vitorpamplona.amethyst.model.nip47WalletConnect.NwcSignerState
 import com.vitorpamplona.amethyst.service.ClinkOfferPayer
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinderFilterAssemblerSubscription
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserInfo
@@ -63,6 +62,8 @@ import com.vitorpamplona.amethyst.ui.note.UserPicture
 import com.vitorpamplona.amethyst.ui.note.UsernameDisplay
 import com.vitorpamplona.amethyst.ui.note.payViaIntent
 import com.vitorpamplona.amethyst.ui.note.showAmount
+import com.vitorpamplona.amethyst.ui.nwc.nwcFailureDetail
+import com.vitorpamplona.amethyst.ui.nwc.nwcTimeoutMessage
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.chats.rooms.LoadUser
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.wallet.FeeTier
@@ -75,8 +76,6 @@ import com.vitorpamplona.quartz.experimental.clink.offers.OfferErrorCode
 import com.vitorpamplona.quartz.experimental.clink.pointers.ClinkPointerParser
 import com.vitorpamplona.quartz.experimental.clink.pointers.NOffer
 import com.vitorpamplona.quartz.experimental.clink.pointers.OfferPriceType
-import com.vitorpamplona.quartz.nip47WalletConnect.rpc.IErrorResponseLike
-import com.vitorpamplona.quartz.nip47WalletConnect.rpc.PayInvoiceSuccessResponse
 import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
 import com.vitorpamplona.quartz.nipBCOnchainZaps.chain.FeeEstimates
 import com.vitorpamplona.quartz.nipBCOnchainZaps.taproot.SegwitAddress
@@ -355,13 +354,6 @@ private fun SendPaymentLoaded(
     val sentToWalletLabel = stringRes(R.string.send_payment_sent_to_wallet)
     val clinkNoResponseLabel = stringRes(R.string.clink_debit_no_response)
     val invoiceErrorLabel = stringRes(R.string.error_dialog_pay_invoice_error)
-    val parsingErrorLabel = stringRes(R.string.error_parsing_error_message)
-    val unreadableResponseLabel = stringRes(R.string.wallet_connect_unreadable_response_error)
-    val noResponseLabel =
-        stringRes(
-            R.string.wallet_connect_no_response_error,
-            NwcSignerState.NWC_RESPONSE_TIMEOUT_SECONDS,
-        )
 
     // Payment callbacks arrive on IO/relay threads. Snapshot state writes are
     // thread-safe, but every other payment flow in the app marshals UI state
@@ -392,20 +384,14 @@ private fun SendPaymentLoaded(
                 accountViewModel.sendZapPaymentRequestFor(
                     bolt11 = invoice,
                     zappedNote = null,
-                    onTimeout = { postStage(PaymentFlowStage.Failure(noResponseLabel)) },
-                ) { response ->
-                    when (response) {
-                        is PayInvoiceSuccessResponse -> postStage(PaymentFlowStage.Success(successTitle))
-                        // IErrorResponseLike, not PayInvoiceErrorResponse: a wallet that
-                        // omits `result_type` on an error still deserializes to something
-                        // renderable, and the narrower check dropped it silently.
-                        is IErrorResponseLike ->
-                            postStage(
-                                PaymentFlowStage.Failure(response.errorMessage() ?: parsingErrorLabel),
-                            )
-                        else -> postStage(PaymentFlowStage.Failure(unreadableResponseLabel))
-                    }
-                }
+                    onTimeout = { postStage(PaymentFlowStage.Failure(nwcTimeoutMessage(context))) },
+                    onResponse = { response ->
+                        val failure = response.nwcFailureDetail(context)
+                        postStage(
+                            if (failure == null) PaymentFlowStage.Success(successTitle) else PaymentFlowStage.Failure(failure),
+                        )
+                    },
+                )
             }
 
             is PaymentSource.ClinkDebit -> {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/payment/SendPaymentScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/profile/payment/SendPaymentScreen.kt
@@ -52,6 +52,7 @@ import com.vitorpamplona.amethyst.model.DEFAULT_ONCHAIN_ZAP_SATS
 import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.MIN_ONCHAIN_ZAP_SATS
 import com.vitorpamplona.amethyst.model.User
+import com.vitorpamplona.amethyst.model.nip47WalletConnect.NwcSignerState
 import com.vitorpamplona.amethyst.service.ClinkOfferPayer
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.UserFinderFilterAssemblerSubscription
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.user.observeUserInfo
@@ -74,7 +75,7 @@ import com.vitorpamplona.quartz.experimental.clink.offers.OfferErrorCode
 import com.vitorpamplona.quartz.experimental.clink.pointers.ClinkPointerParser
 import com.vitorpamplona.quartz.experimental.clink.pointers.NOffer
 import com.vitorpamplona.quartz.experimental.clink.pointers.OfferPriceType
-import com.vitorpamplona.quartz.nip47WalletConnect.rpc.PayInvoiceErrorResponse
+import com.vitorpamplona.quartz.nip47WalletConnect.rpc.IErrorResponseLike
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.PayInvoiceSuccessResponse
 import com.vitorpamplona.quartz.nip57Zaps.LnZapEvent
 import com.vitorpamplona.quartz.nipBCOnchainZaps.chain.FeeEstimates
@@ -355,6 +356,12 @@ private fun SendPaymentLoaded(
     val clinkNoResponseLabel = stringRes(R.string.clink_debit_no_response)
     val invoiceErrorLabel = stringRes(R.string.error_dialog_pay_invoice_error)
     val parsingErrorLabel = stringRes(R.string.error_parsing_error_message)
+    val unreadableResponseLabel = stringRes(R.string.wallet_connect_unreadable_response_error)
+    val noResponseLabel =
+        stringRes(
+            R.string.wallet_connect_no_response_error,
+            NwcSignerState.NWC_RESPONSE_TIMEOUT_SECONDS,
+        )
 
     // Payment callbacks arrive on IO/relay threads. Snapshot state writes are
     // thread-safe, but every other payment flow in the app marshals UI state
@@ -382,18 +389,21 @@ private fun SendPaymentLoaded(
         when (val source = pickedSource) {
             is PaymentSource.Nwc -> {
                 postStage(PaymentFlowStage.InProgress(stringRes(context, R.string.send_payment_paying_via, source.name)))
-                accountViewModel.sendZapPaymentRequestFor(invoice, null) { response ->
+                accountViewModel.sendZapPaymentRequestFor(
+                    bolt11 = invoice,
+                    zappedNote = null,
+                    onTimeout = { postStage(PaymentFlowStage.Failure(noResponseLabel)) },
+                ) { response ->
                     when (response) {
                         is PayInvoiceSuccessResponse -> postStage(PaymentFlowStage.Success(successTitle))
-                        is PayInvoiceErrorResponse ->
+                        // IErrorResponseLike, not PayInvoiceErrorResponse: a wallet that
+                        // omits `result_type` on an error still deserializes to something
+                        // renderable, and the narrower check dropped it silently.
+                        is IErrorResponseLike ->
                             postStage(
-                                PaymentFlowStage.Failure(
-                                    response.error?.message
-                                        ?: response.error?.code?.toString()
-                                        ?: parsingErrorLabel,
-                                ),
+                                PaymentFlowStage.Failure(response.errorMessage() ?: parsingErrorLabel),
                             )
-                        else -> {}
+                        else -> postStage(PaymentFlowStage.Failure(unreadableResponseLabel))
                     }
                 }
             }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletTransactionsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletTransactionsScreen.kt
@@ -41,7 +41,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -59,6 +58,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
 import com.vitorpamplona.amethyst.commons.icons.symbols.MaterialSymbols
+import com.vitorpamplona.amethyst.commons.ui.components.EmptyState
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.UserPicture
 import com.vitorpamplona.amethyst.ui.note.UsernameDisplay
@@ -154,31 +154,13 @@ fun WalletTransactionsScreen(
         } else if (currentError != null && transactions.isEmpty()) {
             // A wallet refusal (e.g. RESTRICTED) leaves the list empty. Without this
             // branch the screen would claim "no transactions yet" and hide the reason.
-            Column(
-                modifier =
-                    Modifier
-                        .padding(padding)
-                        .fillMaxSize()
-                        .padding(24.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center,
-            ) {
-                Text(
-                    text = stringRes(R.string.wallet_transactions_load_failed),
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.error,
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = currentError,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-                TextButton(onClick = { walletViewModel.fetchTransactions() }) {
-                    Text(stringRes(R.string.wallet_refresh))
-                }
-            }
+            EmptyState(
+                title = stringRes(R.string.wallet_transactions_load_failed),
+                modifier = Modifier.padding(padding).padding(24.dp),
+                description = currentError,
+                onRefresh = { walletViewModel.fetchTransactions() },
+                refreshLabel = stringRes(R.string.wallet_refresh),
+            )
         } else if (transactions.isEmpty()) {
             Column(
                 modifier =

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletTransactionsScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletTransactionsScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -89,6 +90,7 @@ fun WalletTransactionsScreen(
     val isLoadingMore by walletViewModel.isLoadingMore.collectAsState()
     val hasMore by walletViewModel.hasMoreTransactions.collectAsState()
     val currentFilter by walletViewModel.transactionFilter.collectAsState()
+    val error by walletViewModel.error.collectAsState()
 
     val listState = rememberLazyListState()
 
@@ -132,6 +134,7 @@ fun WalletTransactionsScreen(
             )
         },
     ) { padding ->
+        val currentError = error
         if (isLoading && transactions.isEmpty()) {
             Column(
                 modifier =
@@ -147,6 +150,34 @@ fun WalletTransactionsScreen(
                     stringRes(R.string.wallet_loading),
                     style = MaterialTheme.typography.bodyLarge,
                 )
+            }
+        } else if (currentError != null && transactions.isEmpty()) {
+            // A wallet refusal (e.g. RESTRICTED) leaves the list empty. Without this
+            // branch the screen would claim "no transactions yet" and hide the reason.
+            Column(
+                modifier =
+                    Modifier
+                        .padding(padding)
+                        .fillMaxSize()
+                        .padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Text(
+                    text = stringRes(R.string.wallet_transactions_load_failed),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.error,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = currentError,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                TextButton(onClick = { walletViewModel.fetchTransactions() }) {
+                    Text(stringRes(R.string.wallet_refresh))
+                }
             }
         } else if (transactions.isEmpty()) {
             Column(
@@ -168,6 +199,21 @@ fun WalletTransactionsScreen(
                 modifier = Modifier.padding(padding),
                 state = listState,
             ) {
+                if (currentError != null) {
+                    // Already-loaded transactions stay visible; the banner explains why
+                    // the latest refresh or page load did not land.
+                    item {
+                        Text(
+                            text = currentError,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                        )
+                    }
+                }
                 item {
                     TransactionFilterRow(currentFilter) { walletViewModel.setTransactionFilter(it) }
                 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletViewModel.kt
@@ -588,6 +588,7 @@ class WalletViewModel : ViewModel() {
         val currentOffset = allTransactions.value.size
         viewModelScope.launch(Dispatchers.IO) {
             _isLoadingMore.value = true
+            _error.value = null
             var requestId: HexKey? = null
             val timeoutJob = launchTimeout({ requestId }) { _isLoadingMore.value = false }
             try {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletViewModel.kt
@@ -20,13 +20,18 @@
  */
 package com.vitorpamplona.amethyst.ui.screen.loggedIn.wallet
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.vitorpamplona.amethyst.Amethyst
+import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.model.clink.ClinkDebitWalletEntryNorm
 import com.vitorpamplona.amethyst.commons.model.nip47WalletConnect.NwcWalletEntryNorm
 import com.vitorpamplona.amethyst.model.Account
 import com.vitorpamplona.amethyst.service.ClinkDebitPayer
+import com.vitorpamplona.amethyst.ui.pluralStringRes
 import com.vitorpamplona.amethyst.ui.screen.loggedIn.AccountViewModel
+import com.vitorpamplona.amethyst.ui.stringRes
 import com.vitorpamplona.quartz.experimental.clink.debits.DebitFrequency
 import com.vitorpamplona.quartz.experimental.clink.debits.DebitResponse
 import com.vitorpamplona.quartz.experimental.clink.pointers.ClinkPointerParser
@@ -105,9 +110,23 @@ data class WalletInfo(
 )
 
 private const val NWC_TIMEOUT_MS = 30_000L
-private const val PAYMENT_FAILED = "Payment failed"
 
 class WalletViewModel : ViewModel() {
+    // Error text is resolved here rather than in the screens because a single _error
+    // flow feeds several of them. WalletViewModel only ever runs in the main process,
+    // so Amethyst.instance is always initialised (see AccountViewModel for the same
+    // pattern); the :napplet process never builds a wallet screen.
+    private val appContext get() = Amethyst.instance.appContext
+
+    private fun text(
+        @StringRes id: Int,
+    ) = stringRes(appContext, id)
+
+    private fun text(
+        @StringRes id: Int,
+        vararg args: String?,
+    ) = stringRes(appContext, id, *args)
+
     private var account: Account? = null
     private var accountViewModel: AccountViewModel? = null
 
@@ -210,9 +229,9 @@ class WalletViewModel : ViewModel() {
     // something we can't read".
     private fun unreadableResponseError(response: Response?): String =
         if (response == null) {
-            "Could not decrypt the wallet's reply — the wallet may be using a different key"
+            text(R.string.wallet_connect_decrypt_failed)
         } else {
-            "Wallet returned an unrecognized reply for ${response.resultType}"
+            text(R.string.wallet_connect_unrecognized_reply, response.resultType)
         }
 
     private fun launchTimeout(
@@ -225,10 +244,9 @@ class WalletViewModel : ViewModel() {
             val spoofs = requestId?.let { account?.zaps?.nwcSpoofAttempts(it) ?: 0 } ?: 0
             _error.value =
                 if (spoofs > 0) {
-                    "Wallet request timed out — $spoofs ${if (spoofs == 1) "reply was" else "replies were"} rejected because " +
-                        "${if (spoofs == 1) "it was" else "they were"} signed by an unexpected key. Your relay may be untrusted."
+                    pluralStringRes(appContext, R.plurals.wallet_request_timed_out_spoofed, spoofs, spoofs)
                 } else {
-                    "Wallet request timed out"
+                    text(R.string.wallet_request_timed_out)
                 }
             requestId?.let { account?.zaps?.cleanupNwcRequest(it) }
             onTimeout()
@@ -415,7 +433,7 @@ class WalletViewModel : ViewModel() {
 
                         is NwcErrorResponse -> {
                             updateWalletInfo(walletId) {
-                                it.copy(error = response.error?.message ?: "Balance request failed", isLoading = false)
+                                it.copy(error = response.error?.message ?: text(R.string.wallet_balance_request_failed), isLoading = false)
                             }
                         }
 
@@ -427,7 +445,7 @@ class WalletViewModel : ViewModel() {
                     }
                 }
             } catch (e: Exception) {
-                updateWalletInfo(walletId) { it.copy(error = e.message, isLoading = false) }
+                updateWalletInfo(walletId) { it.copy(error = text(R.string.wallet_request_failed, e.message), isLoading = false) }
             }
         }
     }
@@ -489,7 +507,7 @@ class WalletViewModel : ViewModel() {
                             }
 
                             is NwcErrorResponse -> {
-                                _error.value = response.error?.message ?: "Balance request failed"
+                                _error.value = response.error?.message ?: text(R.string.wallet_balance_request_failed)
                             }
 
                             else -> {
@@ -500,7 +518,7 @@ class WalletViewModel : ViewModel() {
                     }
             } catch (e: Exception) {
                 timeoutJob.cancel()
-                _error.value = e.message
+                _error.value = text(R.string.wallet_request_failed, e.message)
                 _isLoading.value = false
             }
         }
@@ -563,7 +581,7 @@ class WalletViewModel : ViewModel() {
                             }
 
                             is NwcErrorResponse -> {
-                                _error.value = response.error?.message ?: "Failed to load transactions"
+                                _error.value = response.error?.message ?: text(R.string.wallet_transactions_load_failed)
                             }
 
                             else -> {
@@ -574,7 +592,7 @@ class WalletViewModel : ViewModel() {
                     }
             } catch (e: Exception) {
                 timeoutJob.cancel()
-                _error.value = e.message
+                _error.value = text(R.string.wallet_request_failed, e.message)
                 _isLoading.value = false
             }
         }
@@ -617,7 +635,7 @@ class WalletViewModel : ViewModel() {
                             }
 
                             is NwcErrorResponse -> {
-                                _error.value = response.error?.message ?: "Failed to load more transactions"
+                                _error.value = response.error?.message ?: text(R.string.wallet_transactions_load_more_failed)
                             }
 
                             else -> {
@@ -628,7 +646,7 @@ class WalletViewModel : ViewModel() {
                     }
             } catch (e: Exception) {
                 timeoutJob.cancel()
-                _error.value = e.message
+                _error.value = text(R.string.wallet_request_failed, e.message)
                 _isLoadingMore.value = false
             }
         }
@@ -654,17 +672,17 @@ class WalletViewModel : ViewModel() {
                             // same user-visible "payment failed" message.
                             _sendState.value =
                                 SendState.Error(
-                                    response.errorMessage() ?: PAYMENT_FAILED,
+                                    response.errorMessage() ?: text(R.string.send_payment_failed),
                                 )
                         }
 
                         else -> {
-                            _sendState.value = SendState.Error("Unexpected response")
+                            _sendState.value = SendState.Error(text(R.string.wallet_connect_unreadable_response_error))
                         }
                     }
                 }
             } catch (e: Exception) {
-                _sendState.value = SendState.Error(e.message ?: PAYMENT_FAILED)
+                _sendState.value = SendState.Error(e.message ?: text(R.string.send_payment_failed))
             }
         }
     }
@@ -692,24 +710,24 @@ class WalletViewModel : ViewModel() {
                             if (invoice != null) {
                                 _receiveState.value = ReceiveState.Created(invoice, amountSats)
                             } else {
-                                _receiveState.value = ReceiveState.Error("No invoice returned")
+                                _receiveState.value = ReceiveState.Error(text(R.string.wallet_no_invoice_returned))
                             }
                         }
 
                         is NwcErrorResponse -> {
                             _receiveState.value =
                                 ReceiveState.Error(
-                                    response.error?.message ?: "Invoice creation failed",
+                                    response.error?.message ?: text(R.string.wallet_invoice_creation_failed),
                                 )
                         }
 
                         else -> {
-                            _receiveState.value = ReceiveState.Error("Unexpected response")
+                            _receiveState.value = ReceiveState.Error(text(R.string.wallet_connect_unreadable_response_error))
                         }
                     }
                 }
             } catch (e: Exception) {
-                _receiveState.value = ReceiveState.Error(e.message ?: "Invoice creation failed")
+                _receiveState.value = ReceiveState.Error(e.message ?: text(R.string.wallet_invoice_creation_failed))
             }
         }
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/wallet/WalletViewModel.kt
@@ -533,6 +533,7 @@ class WalletViewModel : ViewModel() {
         val walletUri = getWalletUri(walletId) ?: return
         viewModelScope.launch(Dispatchers.IO) {
             _isLoading.value = true
+            _error.value = null
             _hasMoreTransactions.value = true
             var requestId: HexKey? = null
             val timeoutJob = launchTimeout({ requestId }) { _isLoading.value = false }
@@ -611,6 +612,7 @@ class WalletViewModel : ViewModel() {
                                     } else {
                                         newTxs.size >= pageSize
                                     }
+                                _error.value = null
                             }
 
                             is NwcErrorResponse -> {

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -3055,7 +3055,6 @@
     <string name="error_unable_to_fetch_invoice">Unable to fetch invoice from receiver\'s servers</string>
 
     <string name="wallet_connect_pay_invoice_error_error">Your wallet connect provider returned the following error: %1$s</string>
-    <string name="wallet_connect_no_response_error">Your wallet did not respond within %1$d seconds. The payment may or may not have gone through — check your wallet before retrying.</string>
     <string name="wallet_connect_unreadable_response_error">Your wallet connect provider sent a reply Amethyst could not read.</string>
 
     <string name="tor_connection_failed_title">Tor isn\'t connecting</string>
@@ -3213,6 +3212,14 @@
     <string name="wallet_outgoing">Sent</string>
     <string name="wallet_refresh">Refresh</string>
     <string name="wallet_transactions_load_failed">Could not load transactions</string>
+    <string name="wallet_transactions_load_more_failed">Could not load more transactions</string>
+    <string name="wallet_balance_request_failed">Could not load your balance</string>
+    <string name="wallet_invoice_creation_failed">Could not create the invoice</string>
+    <string name="wallet_no_invoice_returned">Your wallet did not return an invoice</string>
+    <string name="wallet_request_timed_out">Wallet request timed out</string>
+    <string name="wallet_request_failed">Could not reach your wallet: %1$s</string>
+    <string name="wallet_connect_unrecognized_reply">Your wallet replied with something Amethyst does not recognise (%1$s)</string>
+    <string name="wallet_connect_decrypt_failed">Amethyst could not decrypt your wallet\'s reply — the wallet may be using a different key</string>
     <string name="wallet_filter_all">All</string>
     <string name="wallet_filter_zaps">Zaps</string>
     <string name="wallet_filter_non_zaps">Non-Zaps</string>
@@ -5084,6 +5091,14 @@
     <plurals name="marmot_member_count">
         <item quantity="one">%1$d member</item>
         <item quantity="other">%1$d members</item>
+    </plurals>
+    <plurals name="wallet_connect_no_response_error">
+        <item quantity="one">Your wallet did not respond within %1$d second. The payment may or may not have gone through — check your wallet before retrying.</item>
+        <item quantity="other">Your wallet did not respond within %1$d seconds. The payment may or may not have gone through — check your wallet before retrying.</item>
+    </plurals>
+    <plurals name="wallet_request_timed_out_spoofed">
+        <item quantity="one">Wallet request timed out — %1$d reply was rejected because it was signed by an unexpected key. Your relay may be untrusted.</item>
+        <item quantity="other">Wallet request timed out — %1$d replies were rejected because they were signed by an unexpected key. Your relay may be untrusted.</item>
     </plurals>
     <string name="marmot_group_name">Group name</string>
     <string name="marmot_group_name_placeholder">Enter group name</string>

--- a/amethyst/src/main/res/values/strings.xml
+++ b/amethyst/src/main/res/values/strings.xml
@@ -3055,6 +3055,8 @@
     <string name="error_unable_to_fetch_invoice">Unable to fetch invoice from receiver\'s servers</string>
 
     <string name="wallet_connect_pay_invoice_error_error">Your wallet connect provider returned the following error: %1$s</string>
+    <string name="wallet_connect_no_response_error">Your wallet did not respond within %1$d seconds. The payment may or may not have gone through — check your wallet before retrying.</string>
+    <string name="wallet_connect_unreadable_response_error">Your wallet connect provider sent a reply Amethyst could not read.</string>
 
     <string name="tor_connection_failed_title">Tor isn\'t connecting</string>
     <string name="tor_connection_failed_body">Amethyst couldn\'t finish bootstrapping Tor. Use a regular (non-Tor) connection so the feed can load? We\'ll remember this choice for the next hour and re-try Tor after that.</string>
@@ -3210,6 +3212,7 @@
     <string name="wallet_incoming">Received</string>
     <string name="wallet_outgoing">Sent</string>
     <string name="wallet_refresh">Refresh</string>
+    <string name="wallet_transactions_load_failed">Could not load transactions</string>
     <string name="wallet_filter_all">All</string>
     <string name="wallet_filter_zaps">Zaps</string>
     <string name="wallet_filter_non_zaps">Non-Zaps</string>

--- a/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/service/nwc/NwcPaymentTracker.kt
+++ b/commons/src/jvmAndroid/kotlin/com/vitorpamplona/amethyst/commons/service/nwc/NwcPaymentTracker.kt
@@ -142,10 +142,13 @@ class NwcPaymentTracker {
 
     /**
      * Manually removes a pending request (e.g., on timeout).
+     *
+     * Returns true when this call is the one that removed it. Callers racing a
+     * response use that to decide who reports the outcome: the response path
+     * consumes the entry through [onResponseReceived], so a timeout that gets
+     * false must stay quiet rather than overwrite a real wallet answer.
      */
-    fun cleanup(requestId: HexKey) {
-        awaitingRequests.remove(requestId)
-    }
+    fun cleanup(requestId: HexKey): Boolean = awaitingRequests.remove(requestId) != null
 
     /**
      * Returns count of pending requests (for debugging/monitoring).

--- a/commons/src/jvmTest/kotlin/com/vitorpamplona/amethyst/commons/service/nwc/NwcPaymentTrackerTest.kt
+++ b/commons/src/jvmTest/kotlin/com/vitorpamplona/amethyst/commons/service/nwc/NwcPaymentTrackerTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2025 Vitor Pamplona
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.vitorpamplona.amethyst.commons.service.nwc
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * [NwcPaymentTracker.cleanup] is what decides who gets to tell the user how a NIP-47
+ * request ended. The give-up path and the response path race for the same entry, and
+ * exactly one of them must speak — otherwise the user either hears nothing (the bug
+ * that motivated this) or hears "timed out" over a refusal the wallet did send.
+ */
+class NwcPaymentTrackerTest {
+    private val requestId = "a".repeat(64)
+    private val walletPubkey = "b".repeat(64)
+    private val attackerPubkey = "c".repeat(64)
+
+    private fun trackerWithPendingRequest(): NwcPaymentTracker =
+        NwcPaymentTracker().apply {
+            registerRequest(requestId, walletPubkey, null) { }
+        }
+
+    @Test
+    fun cleanupReportsWhoRemovedTheEntry() {
+        val tracker = trackerWithPendingRequest()
+
+        assertTrue(tracker.cleanup(requestId), "the first give-up owns the entry and must report")
+        assertFalse(tracker.cleanup(requestId), "a second give-up must stay quiet")
+        assertEquals(0, tracker.pendingCount())
+    }
+
+    @Test
+    fun cleanupStaysQuietAfterAResponseConsumedTheRequest() {
+        val tracker = trackerWithPendingRequest()
+
+        assertIs<NwcPaymentTracker.MatchResult.Matched>(tracker.onResponseReceived(requestId, walletPubkey))
+        assertFalse(
+            tracker.cleanup(requestId),
+            "the response already reported; a timeout firing afterwards must not overwrite it",
+        )
+    }
+
+    @Test
+    fun cleanupStillReportsWhenOnlySpoofedRepliesArrived() {
+        val tracker = trackerWithPendingRequest()
+
+        // A wrong-author reply is dropped and deliberately leaves the request pending,
+        // so the give-up path is the only thing that can tell the user anything.
+        assertIs<NwcPaymentTracker.MatchResult.WrongAuthor>(tracker.onResponseReceived(requestId, attackerPubkey))
+        assertEquals(1, tracker.spoofAttemptsFor(requestId))
+        assertTrue(tracker.cleanup(requestId))
+    }
+
+    @Test
+    fun cleanupOfAnUnknownRequestReportsNothing() {
+        assertFalse(NwcPaymentTracker().cleanup(requestId))
+    }
+}

--- a/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/nwc/NwcPaymentHandler.kt
+++ b/desktopApp/src/jvmMain/kotlin/com/vitorpamplona/amethyst/desktop/nwc/NwcPaymentHandler.kt
@@ -32,9 +32,9 @@ import com.vitorpamplona.quartz.nip47WalletConnect.Nip47WalletConnect
 import com.vitorpamplona.quartz.nip47WalletConnect.events.LnZapPaymentRequestEvent
 import com.vitorpamplona.quartz.nip47WalletConnect.events.LnZapPaymentResponseEvent
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.GetBalanceSuccessResponse
+import com.vitorpamplona.quartz.nip47WalletConnect.rpc.IErrorResponseLike
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.MakeInvoiceSuccessResponse
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.NwcErrorResponse
-import com.vitorpamplona.quartz.nip47WalletConnect.rpc.PayInvoiceErrorResponse
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.PayInvoiceSuccessResponse
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.Response
 import kotlinx.coroutines.launch
@@ -181,8 +181,11 @@ class NwcPaymentHandler(
                 PaymentResult.Success(response.result?.preimage)
             }
 
-            is PayInvoiceErrorResponse -> {
-                PaymentResult.Error(response.error?.message ?: "Unknown error")
+            // IErrorResponseLike, not PayInvoiceErrorResponse: a wallet that omits
+            // `result_type` on an error deserializes to the generic shape, and the
+            // narrower check reported "unexpected response type" instead of the reason.
+            is IErrorResponseLike -> {
+                PaymentResult.Error(response.errorMessage() ?: "Unknown error")
             }
 
             else -> {

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/rpc/Response.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/rpc/Response.kt
@@ -31,6 +31,10 @@ abstract class Response(
  * NIP-47 responses that carry a human-readable error message. Lets UI
  * collapse generic NwcErrorResponse and method-specific *ErrorResponse
  * handling into one branch.
+ *
+ * [errorMessage] falls back to the machine-readable code name when the wallet
+ * omits `message`, because NIP-47 only requires `code`. Returning null there
+ * would leave the UI with nothing to show for a perfectly conforming refusal.
  */
 interface IErrorResponseLike {
     fun errorMessage(): String?
@@ -42,7 +46,7 @@ class NwcErrorResponse(
     val error: NwcError? = null,
 ) : Response(resultType),
     IErrorResponseLike {
-    override fun errorMessage() = error?.message
+    override fun errorMessage() = error?.message ?: error?.code?.name
 }
 
 // pay_invoice success response
@@ -65,7 +69,7 @@ class PayInvoiceErrorResponse(
         val message: String? = null,
     )
 
-    override fun errorMessage() = error?.message
+    override fun errorMessage() = error?.message ?: error?.code?.name
 }
 
 // pay success response (nostr-wallet-connect/nwc#2). For a settled BOLT12 payment

--- a/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/ResponseTest.kt
+++ b/quartz/src/commonTest/kotlin/com/vitorpamplona/quartz/nip47WalletConnect/ResponseTest.kt
@@ -26,6 +26,7 @@ import com.vitorpamplona.quartz.nip47WalletConnect.rpc.CreateConnectionSuccessRe
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.GetBalanceSuccessResponse
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.GetBudgetSuccessResponse
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.GetInfoSuccessResponse
+import com.vitorpamplona.quartz.nip47WalletConnect.rpc.IErrorResponseLike
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.ListTransactionsSuccessResponse
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.LookupInvoiceSuccessResponse
 import com.vitorpamplona.quartz.nip47WalletConnect.rpc.MakeHoldInvoiceSuccessResponse
@@ -442,6 +443,57 @@ class ResponseTest {
         val response = OptimizedJsonMapper.fromJsonTo<Response>(json)
         assertIs<PayInvoiceErrorResponse>(response)
         assertEquals(NwcErrorCode.EXPIRED, response.error?.code)
+    }
+
+    // --- Every refusal must be renderable (IErrorResponseLike) ---
+    //
+    // Field report, BrollyZapper 2026-08-25: a QUOTA_EXCEEDED on pay_invoice and a
+    // RESTRICTED on list_transactions both reached the phone and showed nothing.
+    // These pin the two payloads to a branch the UI can render.
+
+    @Test
+    fun testQuotaExceededPayInvoiceIsRenderable() {
+        val json =
+            """{"result_type":"pay_invoice","error":{"code":"QUOTA_EXCEEDED",""" +
+                """"message":"this payment would exceed the connection's budget for this period"}}"""
+        val response = OptimizedJsonMapper.fromJsonTo<Response>(json)
+        assertIs<PayInvoiceErrorResponse>(response)
+        assertIs<IErrorResponseLike>(response)
+        assertEquals(NwcErrorCode.QUOTA_EXCEEDED, response.error?.code)
+        assertEquals(
+            "this payment would exceed the connection's budget for this period",
+            (response as IErrorResponseLike).errorMessage(),
+        )
+    }
+
+    @Test
+    fun testRestrictedListTransactionsIsRenderable() {
+        val json = """{"result_type":"list_transactions","error":{"code":"RESTRICTED","message":"sending is disabled on this node"}}"""
+        val response = OptimizedJsonMapper.fromJsonTo<Response>(json)
+        // Not a pay_invoice, so the deserializer yields the generic shape. It must
+        // still be renderable, or the transactions screen shows "no transactions yet".
+        assertIs<NwcErrorResponse>(response)
+        assertIs<IErrorResponseLike>(response)
+        assertEquals("sending is disabled on this node", (response as IErrorResponseLike).errorMessage())
+    }
+
+    @Test
+    fun testErrorWithoutResultTypeIsRenderable() {
+        // NIP-47 does not require a wallet to echo result_type on an error.
+        val json = """{"error":{"code":"RESTRICTED","message":"sending is disabled on this node"}}"""
+        val response = OptimizedJsonMapper.fromJsonTo<Response>(json)
+        assertIs<NwcErrorResponse>(response)
+        assertEquals("sending is disabled on this node", (response as IErrorResponseLike).errorMessage())
+    }
+
+    @Test
+    fun testErrorMessageFallsBackToCodeNameWhenMessageMissing() {
+        // `message` is optional in NIP-47; `code` alone must still produce text.
+        val payInvoice = OptimizedJsonMapper.fromJsonTo<Response>("""{"result_type":"pay_invoice","error":{"code":"QUOTA_EXCEEDED"}}""")
+        assertEquals("QUOTA_EXCEEDED", (payInvoice as IErrorResponseLike).errorMessage())
+
+        val generic = OptimizedJsonMapper.fromJsonTo<Response>("""{"result_type":"list_transactions","error":{"code":"RESTRICTED"}}""")
+        assertEquals("RESTRICTED", (generic as IErrorResponseLike).errorMessage())
     }
 
     // --- Null/missing result ---


### PR DESCRIPTION
## Summary

Some NIP-47 wallet refusals reached the phone and showed the user nothing at all — no toast, no dialog, no error state. The action simply looked like it had never happened. This was reported from two field trips of a NIP-47 wallet service against Amethyst's built-in NWC wallet, a week apart, same phone, same pairing: `QUOTA_EXCEEDED` on `pay_invoice` and `RESTRICTED` on `list_transactions` were both silent, while a `PAYMENT_FAILED`/`NO_ROUTE` on the same `pay_invoice` method rendered its full text.

Three independent defects produce that symptom. All three are fixed here, and both original cases are verified on-device against a real wallet.

`QUOTA_EXCEEDED` is worth singling out: of the refusals a NIP-47 wallet returns, it is the only one the user can act on themselves — wait for the budget window, or ask for a raise. `RESTRICTED` and `UNAUTHORIZED` need the wallet operator whatever the user is told. So the failure mode was the inverse of what you would choose: the refusals only an operator can fix were shown, and the one the user could act on arrived as silence.

## What was wrong

**1. The zap path had no user-visible timeout.** `NwcSignerState`'s 60-second safety net only dropped the relay subscription. It never retired the pending tracker entry and never told anyone, so a response lost in transit was permanent silence. This turns out to be the actual cause of the reported `QUOTA_EXCEEDED` case — see Testing below.

**2. `WalletTransactionsScreen` never read `walletViewModel.error`.** The ViewModel set it correctly on both the refusal and timeout paths; the view branched on `isLoading`/`isEmpty` only and rendered "No transactions yet" straight over the top of a perfectly good error string.

**3. Consumers matched on `PayInvoiceErrorResponse`, which the deserializer only produces when `result_type == "pay_invoice"`.** NIP-47 does not require a wallet to echo `result_type` on an error, and an error for any other method takes the generic `NwcErrorResponse` branch — so those refusals were dropped without a word. The DVM screen went further and thanked the user for a payment that had just been refused.

## What changed

**Timeouts now reach the user.** The give-up path retires the tracker entry and invokes a new `onTimeout` callback, wired through `AccountZapActions` → `AccountViewModel` to every interactive surface: `ZapPaymentHandler`, `InvoicePaymentDispatcher`, `SendPaymentScreen`, `DvmContentDiscoveryScreen`, and both `V4VPaymentHandler` rails.

`NwcPaymentTracker.cleanup` now returns whether *it* removed the entry. Both the timeout and the response path bottom out in `ConcurrentHashMap.remove`, so exactly one of them ever gets the value — a timeout racing a real response stays quiet instead of overwriting the wallet's own answer. Four new tests pin that race.

**Every refusal is renderable.** Call sites match `IErrorResponseLike` rather than the concrete pay_invoice type, and `errorMessage()` falls back to the code name when a wallet sends `code` without `message` (which NIP-47 permits). The shared helpers live in a new `ui/nwc/NwcResponseMessages.kt`.

The classification deliberately does **not** check for an expected success type. `Nip47ResponseKSerializer` guesses a `result_type`-less success carrying a `preimage` into `PayInvoiceSuccessResponse`, so demanding (say) `PayKeysendSuccessResponse` would report a settled keysend as unreadable — a false failure on a real payment, which is worse than the gap it closes. Since `DecryptCache` funnels every decrypt *and* parse failure into `null`, the model is simply: null is unreadable, `IErrorResponseLike` is a refusal, anything else settled.

**The transactions screen renders its error state** through the existing shared `EmptyState` from `commons`, which wraps the description in a `SelectionContainer` — so the wallet's reason is selectable and copyable for reporting.

**One log line meant two things.** `LocalCache` checked the payment tracker before checking whether it had already processed the event, so a relay replaying a cached kind-23195 (which some NWC relays do on every REQ filter change, as `NWCPaymentFilterAssembler` already documents) produced the same "no pending request is registered" warning as a genuinely late response. Both appeared in the field capture and could not be told apart. The duplicate check now runs first.

**Wallet error text is localized.** Nothing new here was hardcoded, but promoting `_error` to a full-screen state gave top billing to English literals that had previously only appeared as a small line on `WalletDetailScreen`. Those now resolve through resources. `PAYMENT_FAILED` turned out to be an exact duplicate of the existing `send_payment_failed` and is gone; the spoofed-reply timeout built its own plural with two inline `if/else` switches and is now a real `<plurals>`.

## Testing

**On-device**, Pixel 9a, benchmark build, against a live NIP-47 wallet service with logcat captured throughout:

| Case | Before | After |
| --- | --- | --- |
| `QUOTA_EXCEEDED` on `pay_invoice`, over per-payment cap | nothing at all | "Your wallet connect provider returned the following error: this connection may not pay more than 30000 msat at once" |
| `RESTRICTED` on `list_transactions` | "No transactions yet" | "Could not load transactions" + "this connection may not use that method" + Refresh |
| Response lost in transit | nothing, forever | "Your wallet did not respond within 60 seconds. The payment may or may not have gone through — check your wallet before retrying." |

The over-limit zap was run twice on the same pairing and produced **both** outcomes: the timeout message on the first attempt, the wallet's actual reason on the second. Same code, same wallet, same limit — so the difference is transport, not client-side dispatch. That resolves the open question in the original report: the intermittent silence was never a rendering bug for that case, it was a lost response that the old client turned into nothing. The same capture shows two relays returning `ERROR: too many concurrent REQs` at the moment of the zap, and the reporter's own wallet-side logs recorded `no relay accepted an NWC response` with 40% of websocket upgrades to one relay failing.

The successful run shows no `NwcSignerState` give-up line and no `LocalCache` warning, which is the correct signature of a clean match — the response arrived, matched, and cancelled the timer.

**Automated:** 4 new tests in `NwcPaymentTrackerTest` (give-up wins, response wins, spoofed-then-give-up, unknown request) and 4 in `ResponseTest` pinning both field-observed payloads plus the no-`result_type` and no-`message` shapes. `:quartz:jvmTest`, `:commons:jvmTest` and `:amethyst:testPlayDebugUnitTest` all pass; play, fdroid and desktop all compile; spotless clean; Android lint reports 0 errors with no finding on any string added here.

## Known gaps, deliberately not addressed

These are pre-existing and out of scope for this fix, but worth recording since they sit next to it:

- **`WalletSendScreen` and `WalletReceiveScreen` still have no timeout.** They hang on "Sending payment…" / "Creating invoice…" indefinitely. Adding one is easy now that the parameter exists, but it is new behaviour rather than a fix to the reported bug.
- **Two timeout mechanisms for one request.** `WalletViewModel` retires its entries at 30s without dropping the subscription, while `NwcSignerState` does both at 60s. They compose only because 30 < 60, and the shorter one can tell the user "timed out" for a request the wallet answers at 40s. Consolidating them needs a product call on which duration is right.
- **`onTimeout` defaults to silence.** The default is still the old behaviour for any caller that omits it. A sealed outcome type would make omission a compile error — `desktopApp` already models this as `PaymentResult { Success | Error | Timeout }` — but that is ~20 call sites across three modules.
- **`errorMessage()` can surface an untranslated code name** such as `QUOTA_EXCEEDED` when a wallet omits `message`. It is wrapped in a localized sentence, and it beats the previous "Error parsing error message". Localizing all 15 `NwcErrorCode` values belongs in `amethyst`, not in protocol code.

## Review notes

Four commits, each self-contained: the fixes, a cleanup pass, findings from a Kotlin review, then the log disambiguation and localization. `desktopApp`'s `processResponse` had the same narrow type check and is fixed alongside; it reported "unexpected response type" instead of the wallet's reason.


## License

- [x] By submitting this PR, I agree to license my contribution under the
      MIT license. Any code I did not author personally carries its
      original license header.
