### PR TITLE
fix(lists): stop deleted lists showing their UUID in the feed filter picker

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/AccountSettings.kt
@@ -788,6 +788,62 @@ class AccountSettings(
     // list names
     // ---
 
+    /**
+     * All per-screen persisted feed filters paired with their factory default.
+     * Deleting a list (NIP-51 people list / follow pack) must reset any screen whose
+     * filter still points at the deleted address — otherwise the screen keeps a
+     * dangling [TopFilter.PeopleList] that re-creates an empty AddressableNote shell
+     * on every start and shows the list's dTag/UUID in the top bar instead of a name.
+     */
+    private val feedFiltersWithDefaults: List<Pair<MutableStateFlow<TopFilter>, TopFilter>> =
+        listOf(
+            defaultHomeFollowList to TopFilter.AllFollows,
+            defaultStoriesFollowList to TopFilter.Global,
+            defaultNotificationFollowList to TopFilter.Selected,
+            defaultDiscoveryFollowList to TopFilter.Global,
+            defaultPollsFollowList to TopFilter.Global,
+            defaultPicturesFollowList to TopFilter.Global,
+            defaultNappletsFollowList to TopFilter.Global,
+            defaultNsitesFollowList to TopFilter.Global,
+            defaultWorkoutsFollowList to TopFilter.Global,
+            defaultGitRepositoriesFollowList to TopFilter.Global,
+            defaultHighlightsFollowList to TopFilter.Global,
+            defaultCalendarsFollowList to TopFilter.Global,
+            defaultProductsFollowList to TopFilter.AroundMe,
+            defaultShortsFollowList to TopFilter.Global,
+            defaultPublicChatsFollowList to TopFilter.Global,
+            defaultLiveStreamsFollowList to TopFilter.Global,
+            defaultNestsFollowList to TopFilter.Global,
+            defaultLongsFollowList to TopFilter.Global,
+            defaultArticlesFollowList to TopFilter.AllFollows,
+            defaultMusicTracksFollowList to TopFilter.Global,
+            defaultMusicPlaylistsFollowList to TopFilter.Global,
+            defaultPodcastEpisodesFollowList to TopFilter.Global,
+            defaultPodcastsFollowList to TopFilter.Global,
+            defaultSoftwareAppsFollowList to TopFilter.Global,
+            defaultBadgesFollowList to TopFilter.Mine,
+            defaultBrowseEmojiSetsFollowList to TopFilter.Global,
+            defaultCommunitiesFollowList to TopFilter.AllFollows,
+            defaultFollowPacksFollowList to TopFilter.Global,
+            defaultAppRecommendationsFollowList to TopFilter.Global,
+            defaultRelayGroupsDiscoveryFollowList to TopFilter.Mine,
+        )
+
+    /** Resets every persisted feed filter that points at the deleted list's address. */
+    fun resetFeedFiltersPointingTo(address: Address) {
+        var changed = false
+
+        feedFiltersWithDefaults.forEach { (flow, default) ->
+            val current = flow.value
+            if (current is TopFilter.AddressableTopFilter && current.address == address) {
+                flow.tryEmit(default)
+                changed = true
+            }
+        }
+
+        if (changed) saveAccountSettings()
+    }
+
     fun changeDefaultHomeFollowList(name: FeedDefinition) {
         changeDefaultHomeFollowList(name.code)
     }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/LocalCache.kt
@@ -825,6 +825,12 @@ object LocalCache : ILocalCache, ICacheProvider, Dao {
             false
         }
 
+    /**
+     * Checks if a kind-5 event from the addressable's own author has deleted this
+     * address. Works for empty addressable shells whose event is not loaded yet.
+     */
+    fun hasBeenDeleted(address: Address): Boolean = deletionIndex.hasBeenDeleted(address, address.pubKeyHex)
+
     fun getOrAddAliasNote(
         idHex: String,
         note: Note,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/peopleList/FollowListsState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/peopleList/FollowListsState.kt
@@ -71,7 +71,15 @@ class FollowListsState(
 ) {
     val user = cache.getOrCreateUser(signer.pubKey)
 
-    fun existingPeopleListNotes() = cache.addressables.filter(FollowListEvent.KIND, user.pubkeyHex)
+    // Hides shells that a kind-5 deletion event from the list's author has already
+    // deleted (e.g. a persisted TopFilter re-creates an empty shell for the deleted
+    // address after a restart, and its name falls back to the dTag/UUID). Shells that
+    // are merely not loaded yet stay in the list so the UI can subscribe and fetch
+    // them from relays.
+    fun existingPeopleListNotes() =
+        cache.addressables
+            .filter(FollowListEvent.KIND, user.pubkeyHex)
+            .filter { it.event != null || !cache.hasBeenDeleted(it.address) }
 
     val followListVersions = MutableStateFlow(0)
 
@@ -255,6 +263,10 @@ class FollowListsState(
         val followListEvent = getPeopleList(identifierTag)
         val deletionEvent = account.signer.sign(DeletionEvent.build(listOf(followListEvent)))
         account.sendMyPublicAndPrivateOutbox(deletionEvent)
+        // Any screen whose persisted feed filter still points at this follow pack would
+        // keep re-creating an empty shell for its address (and render the dTag/UUID in
+        // the top bar) — reset those filters to their default.
+        account.settings.resetFeedFiltersPointingTo(followListEvent.address())
     }
 
     suspend fun addUserToSet(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/peopleList/PeopleListsState.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/model/nip51Lists/peopleList/PeopleListsState.kt
@@ -69,10 +69,17 @@ class PeopleListsState(
 ) {
     val user = cache.getOrCreateUser(signer.pubKey)
 
+    // Hides the fixed-dTag block-list shell when it is not loaded (it has no
+    // meaningful name until it exists) and shells that a kind-5 deletion event from
+    // the list's author has already deleted (e.g. a persisted TopFilter re-creates an
+    // empty shell for the deleted address after a restart, and its name falls back to
+    // the dTag/UUID). Shells that are merely not loaded yet stay in the list so the UI
+    // can subscribe and fetch them from relays.
     fun existingPeopleListNotes() =
         cache.addressables
             .filter(PeopleListEvent.KIND, user.pubkeyHex)
             .filter { it.dTag() != PeopleListEvent.BLOCK_LIST_D_TAG || it.event != null }
+            .filter { it.event != null || !cache.hasBeenDeleted(it.address) }
 
     val peopleListVersions = MutableStateFlow(0)
 
@@ -262,6 +269,10 @@ class PeopleListsState(
         val followListEvent = getPeopleList(identifierTag)
         val deletionEvent = account.signer.sign(DeletionEvent.build(listOf(followListEvent)))
         account.sendMyPublicAndPrivateOutbox(deletionEvent)
+        // Any screen whose persisted feed filter still points at this list would keep
+        // re-creating an empty shell for its address (and render the dTag/UUID in the
+        // top bar) — reset those filters to their default.
+        account.settings.resetFeedFiltersPointingTo(followListEvent.address())
     }
 
     suspend fun addUserToSet(

--- a/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip09Deletions/DeletionIndex.kt
+++ b/quartz/src/commonMain/kotlin/com/vitorpamplona/quartz/nip09Deletions/DeletionIndex.kt
@@ -20,6 +20,7 @@
  */
 package com.vitorpamplona.quartz.nip09Deletions
 
+import com.vitorpamplona.quartz.nip01Core.core.Address
 import com.vitorpamplona.quartz.nip01Core.core.AddressableEvent
 import com.vitorpamplona.quartz.nip01Core.core.Event
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
@@ -114,6 +115,18 @@ class DeletionIndex {
 
         return false
     }
+
+    /**
+     * Checks if a kind-5 event signed by [pubKey] deleted the addressable at [address].
+     * Used when the addressable's event is not loaded yet (e.g. an empty shell
+     * re-created after a restart), so there is no event id or createdAt to compare
+     * against. A re-published version would arrive as a loaded event and is checked
+     * by [hasBeenDeleted] instead.
+     */
+    fun hasBeenDeleted(
+        address: Address,
+        pubKey: HexKey,
+    ): Boolean = hasBeenDeleted(DeletionRequest(address.toValue(), pubKey))
 
     private fun hasBeenDeleted(key: DeletionRequest) = deletedReferencesBefore.containsKey(key)
 


### PR DESCRIPTION
Fixes #3949

## Summary

Deleting a NIP-51 people list (kind 30000) or follow pack (kind 39089) left a null-event `AddressableNote` behind, and the persisted per-screen `TopFilter` that still pointed at the address re-created that empty shell on every app start via `getOrCreateAddressableNote`. With no event left, `PeopleListName.name()` fell back to `note.dTag()` — the raw UUID — so the deleted list kept showing in the top-bar feed filter ("Select an option to filter the feed"), even after a restart.

Four changes:

- **`DeletionIndex` (quartz)** — new `hasBeenDeleted(address, pubKey)` overload that checks the NIP-09 index by the `kind:pubkey:dTag` reference, so deletion status can be checked even when the addressable's event is not loaded (empty shell).
- **`LocalCache.hasBeenDeleted(address)`** — exposes that check for addressable shells.
- **`PeopleListsState.existingPeopleListNotes()` / `FollowListsState.existingPeopleListNotes()`** — hide a null-event shell **only when the deletion index shows its address was deleted by its own author** (`it.event != null || !cache.hasBeenDeleted(it.address)`). Shells that are merely not loaded yet stay in the list so the UI flow that opens the picker can still subscribe and fetch them from relays.
- **`deleteFollowSet()` (both states)** — after signing+sending the NIP-09 deletion, reset any persisted `default*FollowList` that still points at the deleted address back to that screen's factory default (new `AccountSettings.resetFeedFiltersPointingTo`), so no dangling filter survives a restart.

## Review history

The first revision filtered out every addressable without a loaded event (`it.event != null`). As pointed out in review, that is not a deletion check — it also removed legitimate not-yet-cached lists, blocking the UI flow that subscribes and loads addressables on demand. This revision only hides shells whose address has a matching NIP-09 deletion record in the `DeletionIndex`; unloaded ones stay loadable.

## Test plan

- `./gradlew :amethyst:compileFdroidDebugKotlin` — clean.
- `./gradlew :quartz:jvmTest :commons:jvmTest` and `./gradlew spotlessCheck :quartz:verifyKmpPurity :commons:verifyKmpPurity` — pass.
- Manual (reproduces #3949): create a list in My Lists → select it in the Home top-bar filter → delete it. Before: the picker keeps an entry whose name is a 32-char UUID, and it survives restarts. After: the entry disappears from the picker immediately and the screen's filter resets to its default (e.g. "Follows" on Home).

Note: substantial AI involvement — this PR was written with the help of an AI coding assistant.

No interop suites needed: the change only affects local cache filtering and per-screen persisted settings, not wire bytes or event handling.
