### PR TITLE
Add carmin777 to contributors list

### DIFF
--- a/docs/changelog/github.json
+++ b/docs/changelog/github.json
@@ -10,6 +10,7 @@
     "dskvr": "npub1uac67zc9er54ln0kl6e4qp2y6ta3enfcg7ywnayshvlw9r5w6ehsqq99rx",
     "alexgleason": "npub1q3sle0kvfsehgsuexttt3ugjd8xdklxfwwkh559wxckmzddywnws6cd26p",
     "believethehype": "npub1nxa4tywfz9nqp7z9zp7nr7d4nchhclsf58lcqt5y782rmf2hefjquaa6q8",
-    "dergigi": "npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc"
+    "dergigi": "npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc",
+    "carmin777": "npub1y9tpxsfnccnnvg7kanqa8wsyxuu2z72wxr2hd3m29psac3dkucdqmm7p4e"
   }
 }


### PR DESCRIPTION
## Summary

Add carmin777's Nostr public key to the contributors list in `docs/changelog/github.json`.

## Test plan

- [ ] N/A — documentation-only change

## Interop suites

- [ ] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

## License

- [ ] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

https://claude.ai/code/session_01St3rihb3T8PqW6USwo9zkt