### PR TITLE
fix(composer): restore GIF insertion on the comment reply screens

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/AppNavigation.kt
@@ -78,6 +78,7 @@ import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.navigation.navs.rememberNav
 import com.vitorpamplona.amethyst.ui.navigation.routes.MediaFeedRoute
 import com.vitorpamplona.amethyst.ui.navigation.routes.Route
+import com.vitorpamplona.amethyst.ui.navigation.routes.consumesSharesInPlace
 import com.vitorpamplona.amethyst.ui.navigation.routes.getRouteWithArguments
 import com.vitorpamplona.amethyst.ui.navigation.routes.isBaseRoute
 import com.vitorpamplona.amethyst.ui.navigation.routes.isSameRoute
@@ -1196,7 +1197,7 @@ private fun NavigateIfIntentRequested(
                             ShareTarget.VIDEO -> nav.navToSharedFeed(Route.Video(attachments = attachments, message = message))
 
                             ShareTarget.NEW_POST ->
-                                if (!isBaseRoute<Route.NewShortNote>(nav.controller) && (message != null || attachment != null)) {
+                                if (!consumesSharesInPlace(nav.controller) && (message != null || attachment != null)) {
                                     nav.newStack(Route.NewShortNote(message = message, attachment = attachment))
                                 }
                         }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/navigation/routes/Routes.kt
@@ -1092,6 +1092,24 @@ sealed class Route {
 
 inline fun <reified T : Route> isBaseRoute(navController: NavHostController): Boolean = navController.currentBackStackEntry?.destination?.hasRoute<T>() == true
 
+/**
+ * The composers that swallow a *redelivered* ACTION_SEND themselves: each registers its own
+ * onNewIntent listener and drops the shared text/media into the draft already on screen.
+ *
+ * Microsoft's SwiftKey delivers GIFs as fresh share intents, so without this the global share
+ * router would answer a GIF sent from one of these screens by starting a brand-new short-note
+ * composer — throwing away the reply the user was in the middle of writing.
+ *
+ * Only guards the onNewIntent path. A share that *launches* the activity has no composer
+ * listening yet, so it must still navigate.
+ */
+fun consumesSharesInPlace(navController: NavHostController): Boolean =
+    isBaseRoute<Route.NewShortNote>(navController) ||
+        isBaseRoute<Route.GenericCommentPost>(navController) ||
+        isBaseRoute<Route.HashtagPost>(navController) ||
+        isBaseRoute<Route.GeoPost>(navController) ||
+        isBaseRoute<Route.UrlPost>(navController)
+
 fun <T : Route> getRouteWithArguments(
     klazz: KClass<T>,
     navController: NavHostController,

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/messagefield/IMessageField.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/creators/messagefield/IMessageField.kt
@@ -21,9 +21,24 @@
 package com.vitorpamplona.amethyst.ui.note.creators.messagefield
 
 import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 
 interface IMessageField {
     val message: TextFieldState
 
     fun onMessageChanged()
+
+    /**
+     * Appends text that arrived from outside the composer to the end of the draft: a share intent
+     * dropped on the screen the user is already standing on (Microsoft's SwiftKey delivers GIFs
+     * that way) or the caption of a keyboard-inserted image.
+     *
+     * Defaulted here so every composer gets it for free — the copies that used to live in each
+     * view model drifted, and a composer that silently lacked it was how GIF replies went missing
+     * on the comment screens.
+     */
+    fun addToMessage(it: String) {
+        message.setTextAndPlaceCursorAtEnd(message.text.toString() + " " + it)
+        onMessageChanged()
+    }
 }

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/GenericCommentPostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/note/nip22Comments/GenericCommentPostScreen.kt
@@ -20,6 +20,8 @@
  */
 package com.vitorpamplona.amethyst.ui.note.nip22Comments
 
+import android.content.Intent
+import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
@@ -45,16 +47,20 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.core.content.IntentCompat
 import androidx.core.net.toUri
+import androidx.core.util.Consumer
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vitorpamplona.amethyst.R
 import com.vitorpamplona.amethyst.commons.icons.symbols.Icon
@@ -67,6 +73,7 @@ import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromGallery
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.actions.uploads.TakePictureButton
 import com.vitorpamplona.amethyst.ui.actions.uploads.TakeVideoButton
+import com.vitorpamplona.amethyst.ui.components.getActivity
 import com.vitorpamplona.amethyst.ui.insets.imePaddingSafe
 import com.vitorpamplona.amethyst.ui.navigation.navs.Nav
 import com.vitorpamplona.amethyst.ui.navigation.topbars.PostingTopBar
@@ -115,6 +122,7 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 @Composable
@@ -168,6 +176,33 @@ fun GenericCommentPostScreen(
     nav: Nav,
 ) {
     WatchAndLoadMyEmojiList(accountViewModel)
+
+    val context = LocalContext.current
+    val activity = context.getActivity()
+    val scope = rememberCoroutineScope()
+
+    DisposableEffect(nav, activity) {
+        // Microsoft's swift key sends Gifs as new actions
+        val consumer =
+            Consumer<Intent> { intent ->
+                if (intent.action == Intent.ACTION_SEND) {
+                    intent.getStringExtra(Intent.EXTRA_TEXT)?.ifBlank { null }?.let {
+                        postViewModel.addToMessage(it)
+                    }
+
+                    // Use the `intent` parameter (the new intent), not activity.intent (the launch intent).
+                    IntentCompat.getParcelableExtra(intent, Intent.EXTRA_STREAM, Uri::class.java)?.let { uri ->
+                        scope.launch(Dispatchers.IO) {
+                            val mediaType = context.contentResolver.getType(uri)
+                            postViewModel.selectImage(persistentListOf(SelectedMedia(uri, mediaType)))
+                        }
+                    }
+                }
+            }
+
+        activity.addOnNewIntentListener(consumer)
+        onDispose { activity.removeOnNewIntentListener(consumer) }
+    }
 
     // NIP-9B: when replying into a NIP-72 community, mount the community feed
     // subscription so the latest kind:34551 rules document is fetched and
@@ -364,6 +399,13 @@ private fun GenericCommentPostBody(
                     MessageField(
                         R.string.what_s_on_your_mind,
                         postViewModel,
+                        onContentReceived = { uri, mimeType ->
+                            postViewModel.selectImage(
+                                persistentListOf(
+                                    SelectedMedia(uri, mimeType),
+                                ),
+                            )
+                        },
                     )
                 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/ChatNewMessageViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/ChatNewMessageViewModel.kt
@@ -672,11 +672,6 @@ class ChatNewMessageViewModel :
         emojiSuggestions?.reset()
     }
 
-    fun addToMessage(it: String) {
-        message.setTextAndPlaceCursorAtEnd(message.text.toString() + " " + it)
-        onMessageChanged()
-    }
-
     override fun onMessageChanged() {
         urlPreviews.update(message.text.toString())
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/NewGroupDMScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/privateDM/send/NewGroupDMScreen.kt
@@ -234,7 +234,13 @@ fun GroupDMScreenContent(
             ) {
                 SendDirectMessageTo(postViewModel, accountViewModel)
 
-                MessageFieldRow(postViewModel, accountViewModel)
+                MessageFieldRow(
+                    postViewModel,
+                    accountViewModel,
+                    onContentReceived = { uri, mimeType ->
+                        postViewModel.pickedMedia(persistentListOf(SelectedMedia(uri, mimeType)))
+                    },
+                )
 
                 DisplayPreviews(postViewModel, accountViewModel, nav)
 
@@ -345,6 +351,7 @@ fun MessageFieldRow(
     postViewModel: IMessageField,
     accountViewModel: AccountViewModel,
     requestFocus: Boolean = false,
+    onContentReceived: ((Uri, String?) -> Unit)? = null,
 ) {
     Row {
         BaseUserPicture(
@@ -352,7 +359,7 @@ fun MessageFieldRow(
             Size35dp,
             accountViewModel,
         )
-        MessageField(R.string.write_a_message, postViewModel, requestFocus)
+        MessageField(R.string.write_a_message, postViewModel, requestFocus, onContentReceived)
     }
 }
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/NewProductScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip99Classifieds/NewProductScreen.kt
@@ -219,7 +219,17 @@ private fun NewProductBody(
                     Size35dp,
                     accountViewModel = accountViewModel,
                 )
-                MessageField(R.string.description, postViewModel)
+                MessageField(
+                    R.string.description,
+                    postViewModel,
+                    onContentReceived = { uri, mimeType ->
+                        postViewModel.selectImage(
+                            persistentListOf(
+                                SelectedMedia(uri, mimeType),
+                            ),
+                        )
+                    },
+                )
             }
 
             DisplayPreviews(postViewModel.urlPreviews, accountViewModel, nav)

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/home/ShortNotePostViewModel.kt
@@ -1511,11 +1511,6 @@ open class ShortNotePostViewModel :
         this.multiOrchestrator?.remove(selected)
     }
 
-    open fun addToMessage(it: String) {
-        message.setTextAndPlaceCursorAtEnd(message.text.toString() + " " + it)
-        onMessageChanged()
-    }
-
     override fun onMessageChanged() {
         urlPreviews.update(message.text.toString())
 

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/publicMessages/NewPublicMessageViewModel.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/publicMessages/NewPublicMessageViewModel.kt
@@ -552,11 +552,6 @@ class NewPublicMessageViewModel :
         this.multiOrchestrator?.remove(selected)
     }
 
-    fun addToMessage(it: String) {
-        message.setTextAndPlaceCursorAtEnd(message.text.toString() + " " + it)
-        onMessageChanged()
-    }
-
     override fun onMessageChanged() {
         urlPreviews.update(message.text.toString())
 


### PR DESCRIPTION
Replying to a kind-1 note opens ShortNotePostScreen, which wires both GIF
delivery paths. Replying to a comment (or a hashtag/geohash/url scope) opens
GenericCommentPostScreen, which wired neither, so GIFs silently did nothing:

- Gboard-style `commitContent` reaches the field only when the caller passes
  `onContentReceived`; ThinPaddingTextField attaches the `contentReceiver`
  modifier just for those, and MessageField defaults the parameter to null.
  The comment composer never passed one.

- SwiftKey delivers a GIF as a fresh ACTION_SEND. ShortNotePostScreen catches
  it with its own onNewIntent listener; the comment composer had none, so the
  global share router in AppNavigation handled it instead — and since its
  guard only recognised Route.NewShortNote, it answered a GIF by starting a
  brand-new short-note composer and discarding the reply in progress.

Wire both paths into GenericCommentPostScreen, which covers all four of its
entry points (comment, hashtag, geohash and url replies), and widen the
onNewIntent guard via consumesSharesInPlace() so a redelivered share no longer
throws away the draft. The launch-intent guard is left alone: a share that
starts the activity has no composer listening yet, so it must still navigate.

The root cause is copy-paste drift between composers, so also pull the four
identical addToMessage() bodies up into IMessageField as a default, and pass
onContentReceived on the other two composers with a working media pipeline
(new product, new group DM). NewHighlightScreen has no media pipeline and
EditPostView uses OutlinedThinPaddingTextField, which has no content receiver
— both left as-is.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CMyN6Y7DsXFdPxDxLfgo3g