### PR TITLE
fix(composer): wire keyboard GIF insertion into the last four composers

### DIFF
--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/minichat/MinichatScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/chats/minichat/MinichatScreen.kt
@@ -60,6 +60,7 @@ import com.vitorpamplona.amethyst.model.LocalCache
 import com.vitorpamplona.amethyst.model.Note
 import com.vitorpamplona.amethyst.service.relayClient.reqCommand.event.EventFinderFilterAssemblerSubscription
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromGallery
+import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.components.ThinPaddingTextField
 import com.vitorpamplona.amethyst.ui.insets.imePaddingSafe
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
@@ -81,6 +82,7 @@ import com.vitorpamplona.amethyst.ui.theme.EditFieldBorder
 import com.vitorpamplona.amethyst.ui.theme.EditFieldModifier
 import com.vitorpamplona.amethyst.ui.theme.EditFieldTrailingIconModifier
 import com.vitorpamplona.amethyst.ui.theme.placeholderText
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -255,6 +257,11 @@ fun MinichatScreen(
             Column(modifier = EditFieldModifier) {
                 ThinPaddingTextField(
                     state = composer,
+                    onContentReceived = { uri, mimeType ->
+                        uploadState.load(persistentListOf(SelectedMedia(uri, mimeType)))
+                        // Same encryption choice the gallery button makes below.
+                        uploadState.encryptFiles = isConcord
+                    },
                     modifier = Modifier.fillMaxWidth(),
                     shape = EditFieldBorder,
                     placeholder = {

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip23LongForm/LongFormPostScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/discover/nip23LongForm/LongFormPostScreen.kt
@@ -124,6 +124,7 @@ import com.vitorpamplona.amethyst.ui.theme.Size5dp
 import com.vitorpamplona.amethyst.ui.theme.SuggestionListDefaultHeightPage
 import com.vitorpamplona.amethyst.ui.theme.placeholderText
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import kotlinx.collections.immutable.persistentListOf
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -385,6 +386,9 @@ private fun MarkdownPostScreenBody(
                     ThinPaddingTextField(
                         state = postViewModel.message,
                         onTextChanged = postViewModel::onMessageChanged,
+                        onContentReceived = { uri, mimeType ->
+                            postViewModel.selectImage(persistentListOf(SelectedMedia(uri, mimeType)))
+                        },
                         inputTransformation = MentionPreservingInputTransformation,
                         modifier =
                             Modifier

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/chat/NestEditFieldRow.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/nests/room/chat/NestEditFieldRow.kt
@@ -41,6 +41,7 @@ import com.vitorpamplona.amethyst.ui.actions.MentionPreservingInputTransformatio
 import com.vitorpamplona.amethyst.ui.actions.StrippingFailureDialog
 import com.vitorpamplona.amethyst.ui.actions.UrlUserTagOutputTransformation
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromGallery
+import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.components.ThinPaddingTextField
 import com.vitorpamplona.amethyst.ui.navigation.navs.INav
 import com.vitorpamplona.amethyst.ui.note.creators.userSuggestions.ShowUserSuggestionList
@@ -53,6 +54,7 @@ import com.vitorpamplona.amethyst.ui.theme.EditFieldModifier
 import com.vitorpamplona.amethyst.ui.theme.EditFieldTrailingIconModifier
 import com.vitorpamplona.amethyst.ui.theme.SuggestionListDefaultHeightChat
 import com.vitorpamplona.amethyst.ui.theme.placeholderText
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.FlowPreview
 
 /**
@@ -125,6 +127,9 @@ fun NestEditFieldRow(
         ThinPaddingTextField(
             state = nestScreenModel.message,
             onTextChanged = { nestScreenModel.onMessageChanged() },
+            onContentReceived = { uri, mimeType ->
+                nestScreenModel.pickedMedia(persistentListOf(SelectedMedia(uri, mimeType)))
+            },
             inputTransformation = MentionPreservingInputTransformation,
             keyboardOptions =
                 KeyboardOptions.Default.copy(

--- a/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/publicMessages/NewPublicMessageScreen.kt
+++ b/amethyst/src/main/java/com/vitorpamplona/amethyst/ui/screen/loggedIn/notifications/publicMessages/NewPublicMessageScreen.kt
@@ -60,6 +60,7 @@ import com.vitorpamplona.amethyst.ui.actions.StrippingFailureDialog
 import com.vitorpamplona.amethyst.ui.actions.UrlUserTagOutputTransformation
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromFiles
 import com.vitorpamplona.amethyst.ui.actions.uploads.SelectFromGallery
+import com.vitorpamplona.amethyst.ui.actions.uploads.SelectedMedia
 import com.vitorpamplona.amethyst.ui.actions.uploads.TakePictureButton
 import com.vitorpamplona.amethyst.ui.actions.uploads.TakeVideoButton
 import com.vitorpamplona.amethyst.ui.components.ThinPaddingTextField
@@ -98,6 +99,7 @@ import com.vitorpamplona.amethyst.ui.theme.SuggestionListDefaultHeightPage
 import com.vitorpamplona.amethyst.ui.theme.imageModifier
 import com.vitorpamplona.amethyst.ui.theme.placeholderText
 import com.vitorpamplona.quartz.nip01Core.core.HexKey
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.delay
@@ -212,7 +214,14 @@ fun PublicMessageScreenContent(
                     }
                 }
 
-                MessageFieldRow(postViewModel, accountViewModel, postViewModel.toUsers.text.isNotBlank())
+                MessageFieldRow(
+                    postViewModel,
+                    accountViewModel,
+                    postViewModel.toUsers.text.isNotBlank(),
+                    onContentReceived = { uri, mimeType ->
+                        postViewModel.selectImage(persistentListOf(SelectedMedia(uri, mimeType)))
+                    },
+                )
 
                 DisplayPreviews(postViewModel.urlPreviews, accountViewModel, nav)
 


### PR DESCRIPTION
Follow-up to #4000, which fixed the comment reply composer. This finishes the sweep.

## Summary

After #4000 landed I audited every remaining text-field call site against the view models that can actually accept media. Four more composers had an upload button and a full media pipeline, but no `onContentReceived` — so a GIF inserted from the keyboard silently did nothing there too:

- **New public message** — already called `MessageFieldRow`, which gained the parameter in #4000; it simply never passed one.
- **Nests audio-room chat** (`NestEditFieldRow`)
- **Long-form markdown editor** (`LongFormPostScreen`)
- **Minichat** — routes through `ChatFileUploadState` rather than the view model, so it also mirrors the gallery button's `encryptFiles` choice.

## Root cause (recap)

`ThinPaddingTextField` attaches its `Modifier.contentReceiver` only when the caller passes a non-null `onContentReceived`, and `MessageField` defaults it to `null`. Keyboard GIF support is therefore opt-in per screen, and a composer that forgets it fails silently — no error, no warning, nothing visible at review time. #4000 removed one instance of that drift; this removes the rest.

## Deliberately not fixed

- `NewHighlightScreen` — its view model has no media pipeline at all, so a received GIF would have nowhere to go.
- `EditPostView` — uses `OutlinedThinPaddingTextField`, which has no `contentReceiver`. Supporting it means changing that component, not passing an argument.

Nine other call sites are subsidiary fields (`subject`, `toUsers`, `title`, `price`, `locationText`) where a GIF drop is meaningless.

## Out of scope, but worth knowing

Only the keyboard `commitContent` path is addressed here. The chat composers (Concord, public chat, Marmot, private DM, nests, minichat) still have no `onNewIntent` listener, so a **share-intent** GIF — how SwiftKey sends them — still navigates out of the chat to a new short-note composer. That needs a listener per screen plus a widened `consumesSharesInPlace()`, and it may well be intentional that a share leaves the chat given there's a dedicated "Send as DM" share target. Happy to take it as its own PR.

## Test plan

- [x] Ran `./gradlew spotlessApply` — repo is formatted
- [x] Ran the relevant module's tests
- [ ] Manually exercised the change (see notes below)

### Feature test plan

**Not verified on a device.** Developed in a headless container with no emulator or handset, so everything below is static verification, not observed behaviour. Both GIF paths are IME-driven and cannot be exercised by a unit test. **This needs an on-device pass before merge:**

- Gboard → GIF search → insert, on each of the four composers; expect the GIF to land in the attachment area rather than vanish.
- Minichat specifically: confirm a keyboard-inserted GIF encrypts on a Concord minichat and stays plaintext on a NIP-28/29 one.

What I did verify statically:

- Enumerated every call site of `ThinPaddingTextField` / `MessageField` / `MessageFieldRow` and cross-referenced against the view models exposing `selectImage` / `pickedMedia`, so the audit is exhaustive rather than spot-checked.
- Each new `onContentReceived` calls the same method the screen's own gallery button already calls, with the same argument shape.
- `./gradlew :amethyst:assemblePlayDebug :amethyst:assembleFdroidDebug` → `BUILD SUCCESSFUL in 3m 24s`.
- `:amethyst:testFdroidDebugUnitTest` — 1327 tests, 0 failures.
- Pre-commit static analysis and the pre-push suite (`quartz`, `commons`, `nestsClient`, `quic`, `amethyst`, `cli`) pass.

### Regression test plan

Touch points, failure mode, and how far I got:

- **Minichat `encryptFiles`** — the one with a real consequence. There's an ordering hazard: `ChatFileUploadState.load()` calls `reset()`, which forces `encryptFiles = true`, so the flag must be assigned *after* `load()` or it is silently overwritten. The new handler mirrors the gallery button exactly — same `isConcord` expression, same after-`load()` position. The reset default is `true` (encrypt), so the failure direction is fail-safe rather than a leak, but **this deserves explicit on-device attention** given the consequence of getting it backwards.
- **New public message** — passes a new argument to `MessageFieldRow`, whose other call site (new-group-DM) is unchanged and still relies on the `null` default. Compile-checked; no behaviour change for that caller.
- **Long-form editor** — `onContentReceived` sits on the markdown branch of a preview/edit toggle. A mistake would surface as the editor failing to compose; verified by reading that the preview branch is untouched.
- **Nests chat** — `pickedMedia` is the exact method reference the gallery button already uses (`onImageChosen = nestScreenModel::pickedMedia`).
- **Both flavours** — assembled Play and F-Droid (above). Assembled, not installed (no device). No new dependency, no manifest change, no Google-proprietary touch point.
- **Release-minified (`installPlayBenchmark`)** — not run; no device. The diff adds no reflection, ViewModel-factory, or serialization surface, so I judge R8 risk low, but stating it rather than omitting it.

## Interop suites

- [x] N/A — change can't affect wire bytes / decoded audio / MLS state / DM envelopes

UI wiring only; no event construction, encryption envelope, or transport code touched. The minichat path reuses the existing `ChatFileUploader` unchanged.

## AI assistance

- [x] Drafted with AI assistance — reviewed, but **not** manually tested on a device

Written by Claude Code. Two `CONTRIBUTING-WITH-AI.md` gates are **not** met, flagged here rather than omitted:

- **Manual on-device test plan** — no device available in this environment (see Test plan).
- **Cross-model code review pass** — not run; this session was constrained to a single agent. Please treat the diff as un-reviewed by a second model.

## License

- [x] By submitting this PR, I agree to license my contribution under the MIT license. Any code I did not author personally carries its original license header.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMyN6Y7DsXFdPxDxLfgo3g)_